### PR TITLE
Accept generators and xrange objects as field values

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -14,6 +14,7 @@ Generators and packet meta classes.
 import re,random,socket
 import config
 import error
+import types
 
 class Gen(object):
     def __iter__(self):
@@ -36,7 +37,9 @@ class SetGen(Gen):
                     while j <= i[1]:
                         yield j
                         j += 1
-            elif isinstance(i, Gen) and (self._iterpacket or not isinstance(i,BasePacket)):
+            elif (isinstance(i, Gen) and
+                  (self._iterpacket or not isinstance(i,BasePacket))) or (
+                  isinstance(i, (xrange, types.GeneratorType))):
                 for j in i:
                     yield j
             else:

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -25,21 +25,18 @@ class SetGen(Gen):
         self._iterpacket=_iterpacket
         if isinstance(set, (list, BasePacketList)):
             self.set = list(set)
+        elif (type(set) is tuple) and (2 <= len(set) <= 3) and \
+             all(type(i) is int for i in set):
+            self.set = [xrange(*set)]
         else:
             self.set = [set]
     def transf(self, element):
         return element
     def __iter__(self):
         for i in self.set:
-            if (type(i) is tuple) and (len(i) == 2) and type(i[0]) is int and type(i[1]) is int:
-                if  (i[0] <= i[1]):
-                    j=i[0]
-                    while j <= i[1]:
-                        yield j
-                        j += 1
-            elif (isinstance(i, Gen) and
-                  (self._iterpacket or not isinstance(i,BasePacket))) or (
-                  isinstance(i, (xrange, types.GeneratorType))):
+            if (isinstance(i, Gen) and
+                (self._iterpacket or not isinstance(i,BasePacket))) or (
+                    isinstance(i, (xrange, types.GeneratorType))):
                 for j in i:
                     yield j
             else:

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -27,7 +27,9 @@ class SetGen(Gen):
             self.set = list(set)
         elif (type(set) is tuple) and (2 <= len(set) <= 3) and \
              all(type(i) is int for i in set):
-            self.set = [xrange(*set)]
+            # We use set[1] + 1 as stop value for xrange to maintain
+            # the behavior of using tuples as field `set`
+            self.set = [xrange(*((set[0], set[1] + 1) + set[2:]))]
         else:
             self.set = [set]
     def transf(self, element):


### PR DESCRIPTION
With this PR, we can use `xrange()` objects and generators as field values. It makes it possible to:

- Send TCP packets to `"target"`, ports 10 to 100 (included) with an increment of 10 (10 packets). Before this PR, one had to build a list (e.g., using `range()`), which wastes memory, either using a (three-element) tuple, or an `xrange()` object:
```python
>>> sr(IP(dst="target") / TCP(sport=1234, dport=(10, 100, 10)))
>>> sr(IP(dst="target") / TCP(sport=1234, dport=(10, 101, 10)))
```

- Use custom generators, e.g., based on a `file` object:
```python
>>> print open("domains.txt").read(),
github.com
secdev.org
google.com
>>> ans, unans = sr(IP(dst="8.8.8.8") / UDP(sport=RandShort()) / DNS(
... rd=1, qd=DNSQR(qname=(x.strip() for x in open("domains.txt")))))
Begin emission:
*......Finished to send 3 packets.
.**
Received 10 packets, got 3 answers, remaining 0 packets
>>> ans.show()
0000 IP / UDP / DNS Qry "github.com"  ==> IP / UDP / DNS Ans "192.30.252.131" 
0001 IP / UDP / DNS Qry "google.com"  ==> IP / UDP / DNS Ans "216.58.208.78" 
0002 IP / UDP / DNS Qry "secdev.org"  ==> IP / UDP / DNS Ans "217.25.178.5" 
```