### PR TITLE
Fix crash when an unpriv user builds an Ether() packet without dst set

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -7,7 +7,8 @@
 Classes and functions for layer 2 protocols.
 """
 
-import os,struct,time
+import os, struct, time, socket
+
 from scapy.base_classes import Net
 from scapy.config import conf
 from scapy.packet import *
@@ -86,7 +87,10 @@ class DestMACField(MACField):
         MACField.__init__(self, name, None)
     def i2h(self, pkt, x):
         if x is None:
-            x = conf.neighbor.resolve(pkt,pkt.payload)
+            try:
+                x = conf.neighbor.resolve(pkt,pkt.payload)
+            except socket.error:
+                pass
             if x is None:
                 x = "ff:ff:ff:ff:ff:ff"
                 warning("Mac address to reach destination not found. Using broadcast.")


### PR DESCRIPTION
When an `Ether() / IP()` packet is built with `IP.dst` set and `Ether.dst`
not set, Scapy tries to fix `Ether.dst` by sending an ARP request. This
fails when the user cannot send packets.

Before:

    >>> p = str(Ether()/IP(dst="1.2.3.4"))
    Traceback (most recent call last):
      File "<console>", line 1, in <module>
      File "/usr/local/lib/python2.7/dist-packages/scapy/packet.py", line 272, in __str__
        return self.build()
      [...]
      File "/usr/local/lib/python2.7/dist-packages/scapy/arch/linux.py", line 414, in __init__
        self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))
      File "/usr/lib/python2.7/socket.py", line 187, in __init__
        _sock = _realsocket(family, type, proto)
    error: [Errno 1] Operation not permitted

After:

    >>> p = str(Ether()/IP(dst="1.2.3.4"))
    WARNING: Mac address to reach destination not found. Using broadcast.