### PR TITLE
Matplotlib support

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -13,11 +13,20 @@ from scapy.error import *
 import scapy.config
 
 try:
-    import Gnuplot
-    GNUPLOT=1
+    from matplotlib import get_backend as matplotlib_get_backend
+    import matplotlib.pyplot as plt
+    MATPLOTLIB = 1
+    if "inline" in matplotlib_get_backend():
+        MATPLOTLIB_INLINED = 1
+    else:
+        MATPLOTLIB_INLINED = 0
+    MATPLOTLIB_DEFAULT_PLOT_KARGS = { "color": "r", "marker": "+", "ls": "" }
 except ImportError:
-    log_loading.info("Can't import python gnuplot wrapper . Won't be able to plot.")
-    GNUPLOT=0
+    plt = None
+    MATPLOTLIB = 0
+    MATPLOTLIB_INLINED = 0
+    MATPLOTLIB_DEFAULT_PLOT_KARGS = dict()
+    log_loading.info("Can't import matplotlib. Won't be able to plot.")
 
 try:
     import pyx

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -15,9 +15,7 @@ from collections import defaultdict
 
 from utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table,get_temp_file
 
-import arch
-if arch.GNUPLOT:
-    Gnuplot=arch.Gnuplot
+from scapy.arch import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 
 
 
@@ -136,31 +134,47 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         """Same as make_table, but print a table with LaTeX syntax"""
         return make_tex_table(self.res, *args, **kargs)
 
-    def plot(self, f, lfilter=None,**kargs):
-        """Applies a function to each packet to get a value that will be plotted with GnuPlot. A gnuplot object is returned
+    def plot(self, f, lfilter=None, **kargs):
+        """Applies a function to each packet to get a value that will be plotted
+        with matplotlib. A list of matplotlib.lines.Line2D is returned
         lfilter: a truth function that decides whether a packet must be ploted"""
-        g=Gnuplot.Gnuplot()
         l = self.res
         if lfilter is not None:
             l = filter(lfilter, l)
         l = map(f,l)
-        g.plot(Gnuplot.Data(l, **kargs))
-        return g
+
+        # Mimic the default gnuplot output
+        if kargs == {}:
+            kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
+        lines = plt.plot(l, **kargs)
+
+        # Call show() if matplotlib is not inlined
+        if not MATPLOTLIB_INLINED:
+            plt.show()
+
+        return lines
 
     def diffplot(self, f, delay=1, lfilter=None, **kargs):
         """diffplot(f, delay=1, lfilter=None)
         Applies a function to couples (l[i],l[i+delay])"""
-        g = Gnuplot.Gnuplot()
         l = self.res
         if lfilter is not None:
             l = filter(lfilter, l)
         l = map(f,l[:-delay],l[delay:])
-        g.plot(Gnuplot.Data(l, **kargs))
-        return g
+
+        # Mimic the default gnuplot output
+        if kargs == {}:
+            kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
+        lines = plt.plot(l, **kargs)
+
+        # Call show() if matplotlib is not inlined
+        if not MATPLOTLIB_INLINED:
+            plt.show()
+
+        return lines
 
     def multiplot(self, f, lfilter=None, **kargs):
         """Uses a function that returns a label and a value for this label, then plots all the values label by label"""
-        g=Gnuplot.Gnuplot()
         l = self.res
         if lfilter is not None:
             l = filter(lfilter, l)
@@ -172,13 +186,17 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                 d[k].append(v)
             else:
                 d[k] = [v]
-        data=[]
-        for k in d:
-            data.append(Gnuplot.Data(d[k], title=k, **kargs))
 
-        g.plot(*data)
-        return g
-        
+        lines = []
+        for k in d:
+            lines += plt.plot(d[k], label=k, **kargs)
+        plt.legend(loc="center right", bbox_to_anchor=(1.5, 0.5))
+
+        # Call show() if matplotlib is not inlined
+        if not MATPLOTLIB_INLINED:
+            plt.show()
+
+        return lines
 
     def rawhexdump(self):
         """Prints an hexadecimal dump of each packet in the list"""

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -136,12 +136,20 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
 
     def plot(self, f, lfilter=None, **kargs):
         """Applies a function to each packet to get a value that will be plotted
-        with matplotlib. A list of matplotlib.lines.Line2D is returned
-        lfilter: a truth function that decides whether a packet must be ploted"""
+        with matplotlib. A list of matplotlib.lines.Line2D is returned.
+
+        lfilter: a truth function that decides whether a packet must be ploted
+        """
+
+        # Get the list of packets
         l = self.res
+
+        # Apply the filter
         if lfilter is not None:
             l = filter(lfilter, l)
-        l = map(f,l)
+
+        # Apply the function f to the packets
+        l = map(f, l)
 
         # Mimic the default gnuplot output
         if kargs == {}:
@@ -156,11 +164,20 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
 
     def diffplot(self, f, delay=1, lfilter=None, **kargs):
         """diffplot(f, delay=1, lfilter=None)
-        Applies a function to couples (l[i],l[i+delay])"""
+        Applies a function to couples (l[i],l[i+delay])
+
+        A list of matplotlib.lines.Line2D is returned.
+        """
+
+        # Get the list of packets
         l = self.res
+
+        # Apply the filter
         if lfilter is not None:
             l = filter(lfilter, l)
-        l = map(f,l[:-delay],l[delay:])
+
+        # Apply the function f to compute the difference
+        l = map(f, l[:-delay],l[delay:])
 
         # Mimic the default gnuplot output
         if kargs == {}:

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -191,22 +191,34 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         return lines
 
     def multiplot(self, f, lfilter=None, **kargs):
-        """Uses a function that returns a label and a value for this label, then plots all the values label by label"""
+        """Uses a function that returns a label and a value for this label, then
+        plots all the values label by label.
+
+        A list of matplotlib.lines.Line2D is returned.
+        """
+
+        # Get the list of packets
         l = self.res
+
+        # Apply the filter
         if lfilter is not None:
             l = filter(lfilter, l)
 
-        d={}
-        for e in l:
-            k,v = f(e)
-            if k in d:
-                d[k].append(v)
-            else:
-                d[k] = [v]
+        # Apply the function f to the packets
+        d_x = {}
+        d_y = {}
+        for k, v in map(f, l):
+            x,y = v
+            d_x[k] = d_x.get(k, []) + [x]
+            d_y[k] = d_y.get(k, []) + [y]
+
+        # Mimic the default gnuplot output
+        if kargs == {}:
+            kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
 
         lines = []
-        for k in d:
-            lines += plt.plot(d[k], label=k, **kargs)
+        for k in d_x:
+            lines += plt.plot(d_x[k], d_y[k], label=k, **kargs)
         plt.legend(loc="center right", bbox_to_anchor=(1.5, 0.5))
 
         # Call show() if matplotlib is not inlined


### PR DESCRIPTION
Hi,

Here is a modified version of the PR submitted on bitbucket. It aims to replace the dependency on gnuplot-py with maplotlib.

The main focus was on compatibility. Therefore, most of the time, old plot() commands will seamlessly work with this PR. Moreover, Scapy can now be used in IPython notebooks: plots are inlined.

Besides the documentation that still refers to gnuplot, there is still one call to gnuplot in TracerouteResult.world_trace() which is broken since 2008, according to git blame (that is issue #28). 

Guillaume