### PR TITLE
Fix IPv6 support on OpenBSD

### DIFF
--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -155,14 +155,30 @@ def in6_getifaddr():
     """
 
     # List all network interfaces
-    try:
-	f = os.popen("%s -l" % conf.prog.ifconfig)
-    except OSError,msg:
-	log_interactive.warning("Failed to execute ifconfig.")
-	return []
+    if scapy.arch.OPENBSD:
+        try:
+            f = os.popen("%s" % conf.prog.ifconfig)
+        except OSError,msg:
+	    log_interactive.warning("Failed to execute ifconfig.")
+	    return []
 
-    # Get the list of network interfaces
-    splitted_line = f.readline().rstrip().split()
+        # Get the list of network interfaces
+        splitted_line = []
+        for l in f:
+            if "flags" in l:
+                iface = l.split()[0].rstrip(':')
+                splitted_line.append(iface)
+
+    else: # FreeBSD, NetBSD or Darwin
+        try:
+	    f = os.popen("%s -l" % conf.prog.ifconfig)
+        except OSError,msg:
+	    log_interactive.warning("Failed to execute ifconfig.")
+	    return []
+
+        # Get the list of network interfaces
+        splitted_line = f.readline().rstrip().split()
+
     ret = []
     for i in splitted_line:
 	ret += _in6_getifaddr(i)


### PR DESCRIPTION
Hi,

Before

$ scapy
INFO: Can't import PyX. Won't be able to use psdump() or pdfdump().
usage: ifconfig [-AaC] [interface] [address_family] [address [dest_address]]
                [parameters]
INFO: No IPv6 support in kernel
WARNING: No route found for IPv6 destination :: (no default route?)
Welcome to Scapy (2.3.2)

$ python2.7 scapy/tools/UTscapy.py -t test/regression.uts -f html -l -o /tmp/scapy_regression_test.html
[...]
PASSED=739 FAILED=28

After

$ scapy
INFO: Can't import PyX. Won't be able to use psdump() or pdfdump().
Welcome to Scapy (2.3.2)

$ python2.7 scapy/tools/UTscapy.py -t test/regression.uts -f html -l -o /tmp/scapy_regression_test.html
[...]
PASSED=750 FAILED=17

It seems to start normally on FreeBSD.