### PR TITLE
Rename argument / attribute "set"

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -21,21 +21,21 @@ class Gen(object):
         return iter([])
     
 class SetGen(Gen):
-    def __init__(self, set, _iterpacket=1):
+    def __init__(self, values, _iterpacket=1):
         self._iterpacket=_iterpacket
-        if isinstance(set, (list, BasePacketList)):
-            self.set = list(set)
-        elif (type(set) is tuple) and (2 <= len(set) <= 3) and \
-             all(type(i) is int for i in set):
-            # We use set[1] + 1 as stop value for xrange to maintain
-            # the behavior of using tuples as field `set`
-            self.set = [xrange(*((set[0], set[1] + 1) + set[2:]))]
+        if isinstance(values, (list, BasePacketList)):
+            self.values = list(values)
+        elif (type(values) is tuple) and (2 <= len(values) <= 3) and \
+             all(type(i) is int for i in values):
+            # We use values[1] + 1 as stop value for xrange to maintain
+            # the behavior of using tuples as field `values`
+            self.values = [xrange(*((values[0], values[1] + 1) + values[2:]))]
         else:
-            self.set = [set]
+            self.values = [values]
     def transf(self, element):
         return element
     def __iter__(self):
-        for i in self.set:
+        for i in self.values:
             if (isinstance(i, Gen) and
                 (self._iterpacket or not isinstance(i,BasePacket))) or (
                     isinstance(i, (xrange, types.GeneratorType))):
@@ -44,7 +44,7 @@ class SetGen(Gen):
             else:
                 yield i
     def __repr__(self):
-        return "<SetGen %s>" % self.set.__repr__()
+        return "<SetGen %r>" % self.values
 
 class Net(Gen):
     """Generate a list of IPs from a network address or a name"""

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -138,15 +138,15 @@ class TestCampaign(TestClass):
 class TestSet(TestClass):
     def __init__(self, name):
         self.name = name
-        self.set = []
+        self.tests = []
         self.comments = ""
         self.keywords = []
         self.crc = None
         self.expand = 1
     def add_test(self, test):
-        self.set.append(test)
+        self.tests.append(test)
     def __iter__(self):
-        return self.set.__iter__()
+        return self.tests.__iter__()
 
 class UnitTest(TestClass):
     def __init__(self, name):
@@ -257,8 +257,9 @@ def compute_campaign_digests(test_campaign):
 def filter_tests_on_numbers(test_campaign, num):
     if num:
         for ts in test_campaign:
-            ts.set = filter(lambda t: t.num in num, ts.set)
-        test_campaign.campaign = filter(lambda ts: len(ts.set) > 0, test_campaign.campaign)
+            ts.tests = [t for t in ts.tests if t.num in num]
+        test_campaign.campaign = [ts for ts in test_campaign.campaign
+                                  if ts.tests]
 
 def filter_tests_keep_on_keywords(test_campaign, kw):
     def kw_match(lst, kw):
@@ -269,7 +270,7 @@ def filter_tests_keep_on_keywords(test_campaign, kw):
     
     if kw:
         for ts in test_campaign:
-            ts.set = filter(lambda t: kw_match(t.keywords, kw), ts.set)
+            ts.tests = [t for t in ts.tests if kw_match(t.keywords, kw)]
 
 def filter_tests_remove_on_keywords(test_campaign, kw):
     def kw_match(lst, kw):
@@ -280,11 +281,11 @@ def filter_tests_remove_on_keywords(test_campaign, kw):
     
     if kw:
         for ts in test_campaign:
-            ts.set = filter(lambda t: not kw_match(t.keywords, kw), ts.set)
+            ts.tests = [t for t in ts.tests if not kw_match(t.keywords, kw)]
 
 
 def remove_empty_testsets(test_campaign):
-    test_campaign.campaign = filter(lambda ts: len(ts.set) > 0, test_campaign.campaign)
+    test_campaign.campaign = [ts for ts in test_campaign.campaign if ts.tests]
 
 
 #### RUN CAMPAIGN #####

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -576,9 +576,8 @@ def main(argv):
                     try:
                         NUM.append(int(v))
                     except ValueError:
-                        v1,v2 = map(int, v.split("-"))
-                        for vv in xrange(v1, v2 + 1):
-                            NUM.append(vv)
+                        v1, v2 = map(int, v.split("-", 1))
+                        NUM.extend(xrange(v1, v2 + 1))
             elif opt == "-m":
                 MODULES.append(optarg)
             elif opt == "-k":

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -82,10 +82,12 @@ vzM985aHXOHAxQN2UQZbQkUv3D4Vc+lyvalAffv3Tyg4ks3a22kPXiyeCGweviNX
 0K8TKasyOhGsVamTUAZBXfQVw1zmdS4rHDnbHgtIjX3DcCt6UIr0BHTYjdV0JbPj
 r1APYgXihjQwM2M83AKIhwQQJv/F3JFOFCQNsEI0QA==""")
     def get_local_dict(cls):
-        return dict(map(lambda (x,y): (x, y.name),  filter(lambda (x,y): isinstance(y, File), cls.__dict__.items())))
+        return dict((x, y.name) for (x, y) in cls.__dict__.iteritems()
+                    if isinstance(y, File))
     get_local_dict = classmethod(get_local_dict)
     def get_URL_dict(cls):
-        return dict(map(lambda (x,y): (x, y.URL),  filter(lambda (x,y): isinstance(y, File), cls.__dict__.items())))
+        return dict((x, y.URL) for (x, y) in cls.__dict__.iteritems()
+                    if isinstance(y, File))
     get_URL_dict = classmethod(get_URL_dict)
 
 
@@ -570,7 +572,7 @@ def main(argv):
                 LOCAL = 1
             elif opt == "-n":
                 NUM = []
-                for v in map( lambda x: x.strip(), optarg.split(",") ):
+                for v in (x.strip() for x in optarg.split(",")):
                     try:
                         NUM.append(int(v))
                     except ValueError:


### PR DESCRIPTION
In two functions,`set` was used as an argument and class attribute. This PR replaces the name, and fixes some `filter`/`map` with `lambda` functions (see [Google Python style guide](https://google.github.io/styleguide/pyguide.html?showone=Deprecated_Language_Features#Deprecated_Language_Features)).