### PR TITLE
ls() can now filter by layer name or description

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -256,7 +256,7 @@ class _DHCP6OptGuessPayload(Packet):
         return cls
 
 class DHCP6OptUnknown(_DHCP6OptGuessPayload): # A generic DHCPv6 Option
-    name = "Unknown DHCPv6 OPtion"
+    name = "Unknown DHCPv6 Option"
     fields_desc = [ ShortEnumField("optcode", 0, dhcp6opts), 
                     FieldLenField("optlen", None, length_of="data", fmt="!H"),
                     StrLenField("data", "",
@@ -921,7 +921,7 @@ DHCP6PrefVal="" # la valeur de preference a utiliser dans
 # a chaque emission et doivent matcher dans les reponses faites par
 # les clients
 class DHCP6(_DHCP6OptGuessPayload):
-    name = "DHCPv6 Generic Message)"
+    name = "DHCPv6 Generic Message"
     fields_desc = [ ByteEnumField("msgtype",None,dhcp6types),
                     X3BytesField("trid",0x000000) ]
     overload_fields = { UDP: {"sport": 546, "dport": 547} }

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -7,7 +7,8 @@
 Packet class. Binding mechanism. fuzz() method.
 """
 
-import time,itertools,os
+import re
+import time,itertools
 import copy
 from fields import StrField,ConditionalField,Emph,PacketListField,BitField
 from config import conf
@@ -1230,16 +1231,22 @@ def split_layers(lower, upper, __fval=None, **fval):
 
 
 @conf.commands.register
-def ls(obj=None):
-    """List  available layers, or infos on a given layer"""
-    if obj is None:
-        
-        import __builtin__
-        all = __builtin__.__dict__.copy()
-        all.update(globals())
-        objlst = sorted(conf.layers, key=lambda x: x.__name__)
-        for o in objlst:
-            print "%-10s : %s" %(o.__name__, o._name)
+def ls(obj=None, case_sensitive=False):
+    """List  available layers, or infos on a given layer class or name"""
+    is_string = isinstance(obj, basestring)
+
+    if obj is None or is_string:
+        if obj is None:
+            all_layers = sorted(conf.layers, key=lambda x: x.__name__)
+        else:
+            pattern = re.compile(obj, 0 if case_sensitive else re.I)
+            all_layers = sorted((layer for layer in conf.layers
+                                if (pattern.search(layer.__name__ or '')
+                                    or pattern.search(layer.name or ''))),
+                                key=lambda x: x.__name__)
+        for layer in all_layers:
+            print "%-10s : %s" % (layer.__name__, layer.name)
+
     else:
         is_pkt = isinstance(obj, Packet)
         if (isinstance(obj, type) and issubclass(obj, Packet)) or is_pkt:
@@ -1265,7 +1272,7 @@ def ls(obj=None):
                 ls(obj.payload)
 
         else:
-            print "Not a packet class. Type 'ls()' to list packet classes."
+            print "Not a packet class or name. Type 'ls()' to list packet classes."
 
 
     


### PR DESCRIPTION
Additional behaviour for ls() : passing a string filters by layer name, case insensitive. Also added argument `case_sensitive` (default to False). Example:

`ls('dhcp')` will print all the layers whose names or descriptions match "dhcp" (case insensitive)
`ls('DHCP', case_sensitive=True)` will print all the layers whose names or descriptions match "dhcp" (case insensitive)