### PR TITLE
Return Raw() when an exception occurs in .dispatch_hook()

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -210,7 +210,12 @@ class Packet_metaclass(type):
 
     def __call__(cls, *args, **kargs):
         if "dispatch_hook" in cls.__dict__:
-            cls =  cls.dispatch_hook(*args, **kargs)
+            try:
+                cls = cls.dispatch_hook(*args, **kargs)
+            except:
+                if conf.debug_dissector:
+                    raise
+                cls = Raw
         i = cls.__new__(cls, cls.__name__, cls.__bases__, cls.__dict__)
         i.__init__(*args, **kargs)
         return i


### PR DESCRIPTION
... if not conf.debug_dissector

Idea from @paaguti in pull request #10.