### PR TITLE
TracerouteResult.world_trace() now uses Matplotlib Basemap Toolkit

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -375,7 +375,6 @@ extensions_paths: path or list of paths where extensions are to be looked for
     temp_files = []
     netcache = NetCache()
     geoip_city = '/usr/share/GeoIP/GeoLiteCity.dat'
-    gnuplot_world = "world.dat"
     load_layers = ["l2", "inet", "dhcp", "dns", "dot11", "gprs",
                    "hsrp", "inet6", "ir", "isakmp", "l2tp", "mgcp",
                    "mobileip", "netbios", "netflow", "ntp", "ppp",


### PR DESCRIPTION
Here is the final patch to remove the dependency on gnuplot. It works fine in a notebook.

The IPv6 version was not tested.