### PR TITLE
Packet().overload_fields can be overwritten

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -180,8 +180,11 @@ class Packet_metaclass(type):
 
         if "__slots__" not in dct:
             dct["__slots__"] = []
-        if "name" in dct:
-            dct["_name"] = dct.pop("name")
+        for attr in ["name", "overload_fields"]:
+            try:
+                dct["_%s" % attr] = dct.pop(attr)
+            except KeyError:
+                pass
         newcls = super(Packet_metaclass, cls).__new__(cls, name, bases, dct)
         newcls.__all_slots__ = set(
             attr

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -324,6 +324,7 @@ class ICMPTimeStampField(IntField):
 
 
 class IP(Packet, IPTools):
+    __slots__ = ["_defrag_pos"]
     name = "IP"
     fields_desc = [ BitField("version" , 4 , 4),
                     BitField("ihl", None, 4),

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -337,7 +337,7 @@ for i, payloadname in enumerate(ISAKMP_payload_type):
         ISAKMP_payload_type_overload[globals()[name]] = {"next_payload": i}
 
 del i, payloadname, name
-ISAKMP_class.overload_fields = ISAKMP_payload_type_overload.copy()
+ISAKMP_class._overload_fields = ISAKMP_payload_type_overload.copy()
 
 
 bind_layers( UDP,           ISAKMP,        dport=500, sport=500)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -36,7 +36,8 @@ class RawVal:
 class Packet(BasePacket):
     __slots__ = [
         "time", "sent_time", "name", "default_fields",
-        "overloaded_fields", "fields", "fieldtype", "packetfields",
+        "overload_fields", "overloaded_fields", "fields", "fieldtype",
+        "packetfields",
         "original", "explicit", "raw_packet_cache",
         "raw_packet_cache_fields", "_pkt", "post_transforms",
         # then payload and underlayer
@@ -64,7 +65,7 @@ class Packet(BasePacket):
 
     @classmethod
     def lower_bonds(self):
-        for lower,fval in self.overload_fields.iteritems():
+        for lower,fval in self._overload_fields.iteritems():
             print "%-20s  %s" % (lower.__name__, ", ".join("%-12s" % ("%s=%r"%i) for i in fval.iteritems()))
 
     def __init__(self, _pkt="", post_transform=None, _internal=0, _underlayer=None, **fields):
@@ -74,6 +75,7 @@ class Packet(BasePacket):
                      if self._name is None else
                      self._name)
         self.default_fields = {}
+        self.overload_fields = self._overload_fields
         self.overloaded_fields = {}
         self.fields = {}
         self.fieldtype = {}
@@ -1189,8 +1191,8 @@ def bind_bottom_up(lower, upper, __fval=None, **fval):
 def bind_top_down(lower, upper, __fval=None, **fval):
     if __fval is not None:
         fval.update(__fval)
-    upper.overload_fields = upper.overload_fields.copy()
-    upper.overload_fields[lower] = fval
+    upper._overload_fields = upper._overload_fields.copy()
+    upper._overload_fields[lower] = fval
     
 @conf.commands.register
 def bind_layers(lower, upper, __fval=None, **fval):
@@ -1215,13 +1217,13 @@ def split_bottom_up(lower, upper, __fval=None, **fval):
 def split_top_down(lower, upper, __fval=None, **fval):
     if __fval is not None:
         fval.update(__fval)
-    if lower in upper.overload_fields:
-        ofval = upper.overload_fields[lower]
+    if lower in upper._overload_fields:
+        ofval = upper._overload_fields[lower]
         for k in fval:
             if k not in ofval or ofval[k] != fval[k]:
                 return
-        upper.overload_fields = upper.overload_fields.copy()
-        del(upper.overload_fields[lower])
+        upper._overload_fields = upper._overload_fields.copy()
+        del(upper._overload_fields[lower])
 
 @conf.commands.register
 def split_layers(lower, upper, __fval=None, **fval):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4435,3 +4435,32 @@ assert pkt.dst == pkt.real_dst
 assert pkt.src == pkt.real_src
 assert pkt.tos == 0
 assert pkt.function == 0
+
+
+############
+############
++ Test fragment() / defragment() functions
+
+= fragment()
+payloadlen, fragsize = 100, 8
+assert fragsize % 8 == 0
+fragcount = (payloadlen / fragsize) + bool(payloadlen % fragsize)
+* create the packet
+pkt = IP() / ("X" * payloadlen)
+* create the fragments
+frags = fragment(pkt, fragsize)
+* count the fragments
+assert len(frags) == fragcount
+* each fragment except the last one should have MF set
+assert all(p.flags == 1 for p in frags[:-1])
+assert frags[-1].flags == 0
+* each fragment except the last one should have a payload of fragsize bytes
+assert all(len(p.payload) == 8 for p in frags[:-1])
+assert len(frags[-1].payload) == ((payloadlen % fragsize) or fragsize)
+
+= defragment()
+defrags = defragment(frags)
+* we should have one single packet
+assert len(defrags) == 1
+* which should be the same as pkt reconstructed
+assert defrags[0] == IP(str(pkt))


### PR DESCRIPTION
This is needed by fragment(), which has been broken since PR #11.