### PR TITLE
LLTD: remove class decorators (not supported by Python 2.5)

### DIFF
--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -21,7 +21,6 @@ from scapy.plist import PacketList
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IPField
 from scapy.layers.inet6 import IP6Field
-from scapy.config import conf
 from scapy.data import ETHER_ANY
 
 # Protocol layers
@@ -220,8 +219,7 @@ class LLTDQueryResp(Packet):
     def mysummary(self):
         return self.sprintf("%d response%s" % (
             self.descs_count,
-            "s" if self.descs_count > 1 else ""),
-        ), [LLTD]
+            "s" if self.descs_count > 1 else "")), [LLTD]
 
 
 class LLTDQueryLargeTlv(Packet):

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -303,7 +303,23 @@ class LLTDAttribute(Packet):
 SPECIFIC_CLASSES = {}
 
 
-def register_lltd_specific_class(*attr_types):
+def _register_lltd_specific_class(*attr_types):
+    """This can be used as a class decorator, but since we want to
+    support Python 2.5, we have to replace
+
+@_register_lltd_specific_class(x[, y[, ...]])
+class LLTDAttributeSpecific(LLTDAttribute):
+[...]
+
+by
+
+class LLTDAttributeSpecific(LLTDAttribute):
+[...]
+LLTDAttributeSpecific = _register_lltd_specific_class(x[, y[, ...]])(
+    LLTDAttributeSpecific
+)
+
+    """
     def _register(cls):
         for attr_type in attr_types:
             SPECIFIC_CLASSES[attr_type] = cls
@@ -314,13 +330,14 @@ def register_lltd_specific_class(*attr_types):
     return _register
 
 
-@register_lltd_specific_class(0)
 class LLTDAttributeEOP(LLTDAttribute):
     name = "LLTD Attribute - End Of Property"
     fields_desc = []
 
 
-@register_lltd_specific_class(1)
+LLTDAttributeEOP = _register_lltd_specific_class(0)(LLTDAttributeEOP)
+
+
 class LLTDAttributeHostID(LLTDAttribute):
     name = "LLTD Attribute - Host ID"
     fields_desc = [
@@ -332,7 +349,9 @@ class LLTDAttributeHostID(LLTDAttribute):
         return "ID: %s" % self.mac, [LLTD, LLTDAttributeMachineName]
 
 
-@register_lltd_specific_class(2)
+LLTDAttributeHostID = _register_lltd_specific_class(1)(LLTDAttributeHostID)
+
+
 class LLTDAttributeCharacteristics(LLTDAttribute):
     name = "LLTD Attribute - Characteristics"
     fields_desc = [
@@ -347,7 +366,11 @@ class LLTDAttributeCharacteristics(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(3)
+LLTDAttributeCharacteristics = _register_lltd_specific_class(2)(
+    LLTDAttributeCharacteristics
+)
+
+
 class LLTDAttributePhysicalMedium(LLTDAttribute):
     name = "LLTD Attribute - Physical Medium"
     fields_desc = [
@@ -633,7 +656,11 @@ class LLTDAttributePhysicalMedium(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(7)
+LLTDAttributePhysicalMedium = _register_lltd_specific_class(3)(
+    LLTDAttributePhysicalMedium
+)
+
+
 class LLTDAttributeIPv4Address(LLTDAttribute):
     name = "LLTD Attribute - IPv4 Address"
     fields_desc = [
@@ -642,7 +669,11 @@ class LLTDAttributeIPv4Address(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(8)
+LLTDAttributeIPv4Address = _register_lltd_specific_class(7)(
+    LLTDAttributeIPv4Address
+)
+
+
 class LLTDAttributeIPv6Address(LLTDAttribute):
     name = "LLTD Attribute - IPv6 Address"
     fields_desc = [
@@ -651,7 +682,11 @@ class LLTDAttributeIPv6Address(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(9)
+LLTDAttributeIPv6Address = _register_lltd_specific_class(8)(
+    LLTDAttributeIPv6Address
+)
+
+
 class LLTDAttribute80211MaxRate(LLTDAttribute):
     name = "LLTD Attribute - 802.11 Max Rate"
     fields_desc = [
@@ -660,7 +695,11 @@ class LLTDAttribute80211MaxRate(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(10)
+LLTDAttribute80211MaxRate = _register_lltd_specific_class(9)(
+    LLTDAttribute80211MaxRate
+)
+
+
 class LLTDAttributePerformanceCounterFrequency(LLTDAttribute):
     name = "LLTD Attribute - Performance Counter Frequency"
     fields_desc = [
@@ -669,7 +708,11 @@ class LLTDAttributePerformanceCounterFrequency(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(12)
+LLTDAttributePerformanceCounterFrequency = _register_lltd_specific_class(10)(
+    LLTDAttributePerformanceCounterFrequency
+)
+
+
 class LLTDAttributeLinkSpeed(LLTDAttribute):
     name = "LLTD Attribute - Link Speed"
     fields_desc = [
@@ -678,7 +721,11 @@ class LLTDAttributeLinkSpeed(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(14, 24, 26)
+LLTDAttributeLinkSpeed = _register_lltd_specific_class(12)(
+    LLTDAttributeLinkSpeed
+)
+
+
 class LLTDAttributeLargeTLV(LLTDAttribute):
     name = "LLTD Attribute - Large TLV"
     fields_desc = [
@@ -686,7 +733,11 @@ class LLTDAttributeLargeTLV(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(15)
+LLTDAttributeLargeTLV = _register_lltd_specific_class(14, 24, 26)(
+    LLTDAttributeLargeTLV
+)
+
+
 class LLTDAttributeMachineName(LLTDAttribute):
     name = "LLTD Attribute - Machine Name"
     fields_desc = [
@@ -699,7 +750,11 @@ class LLTDAttributeMachineName(LLTDAttribute):
                 [LLTD, LLTDAttributeHostID])
 
 
-@register_lltd_specific_class(18)
+LLTDAttributeMachineName = _register_lltd_specific_class(15)(
+    LLTDAttributeMachineName
+)
+
+
 class LLTDAttributeDeviceUUID(LLTDAttribute):
     name = "LLTD Attribute - Device UUID"
     fields_desc = [
@@ -708,7 +763,11 @@ class LLTDAttributeDeviceUUID(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(20)
+LLTDAttributeDeviceUUID = _register_lltd_specific_class(18)(
+    LLTDAttributeDeviceUUID
+)
+
+
 class LLTDAttributeQOSCharacteristics(LLTDAttribute):
     name = "LLTD Attribute - QoS Characteristics"
     fields_desc = [
@@ -719,7 +778,11 @@ class LLTDAttributeQOSCharacteristics(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(21)
+LLTDAttributeQOSCharacteristics = _register_lltd_specific_class(20)(
+    LLTDAttributeQOSCharacteristics
+)
+
+
 class LLTDAttribute80211PhysicalMedium(LLTDAttribute):
     name = "LLTD Attribute - 802.11 Physical Medium"
     fields_desc = [
@@ -736,13 +799,23 @@ class LLTDAttribute80211PhysicalMedium(LLTDAttribute):
     ]
 
 
-@register_lltd_specific_class(25)
+LLTDAttribute80211PhysicalMedium = _register_lltd_specific_class(21)(
+    LLTDAttribute80211PhysicalMedium
+)
+
+
 class LLTDAttributeSeesList(LLTDAttribute):
     name = "LLTD Attribute - Sees List Working Set"
     fields_desc = [
         ByteField("len", 2),
         ShortField("max_entries", 0),
     ]
+
+
+LLTDAttributeSeesList = _register_lltd_specific_class(25)(
+    LLTDAttributeSeesList
+)
+
 
 bind_layers(Ether, LLTD, type=0x88d9)
 bind_layers(LLTD, LLTDDiscover, tos=0, function=0)


### PR DESCRIPTION
This makes the code less readable, but we have to keep it that way as long as we want to maintain Python 2.5 support.

This PR also includes minor fixes.