### PR TITLE
0b0000 is not supported in Python 2.5

### DIFF
--- a/scapy/contrib/HomePlugAV.py
+++ b/scapy/contrib/HomePlugAV.py
@@ -225,8 +225,8 @@ class StationInfoV11(Packet):
                 X3BytesField("reserved_s2", 0x000000),
                 MACField("firstnodeMAC", "ff:ff:ff:ff:ff:ff"),
                 LEShortField("TXaverage", 0x0000),
-                BitField("RxCoupling", 0b0000, 4),
-                BitField("TxCoupling", 0b0000, 4),
+                BitField("RxCoupling", 0, 4),
+                BitField("TxCoupling", 0, 4),
                 XByteField("reserved_s3", 0x00),
                 LEShortField("RXaverage", 0x0000),
                 XByteField("reserved_s4", 0x00) ]


### PR DESCRIPTION
Here is another patch to make Scapy work better with Python 2.5.