### PR TITLE
Sniff can accept a list of interfaces (+ fixed bug)

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -79,7 +79,7 @@ The ``/`` operator has been used as a composition operator between two layers. W
     <IP frag=0 proto=55 |<TCP |>>
 
 
-.. image:: graphics/fieldsmanagement.*
+.. image:: graphics/fieldsmanagement.png
    :scale: 90
 
 Each packet can be build or dissected (note: in Python ``_`` (underscore) is the latest result)::
@@ -520,7 +520,7 @@ Sniffing
 .. index::
    single: sniff()
 
-We can easily capture some packets or even clone tcpdump or tethereal. If no interface is given, sniffing will happen on every interfaces::
+We can easily capture some packets or even clone tcpdump or tshark. Either one interface or a list of interfaces to sniff on can be provided. If no interface is given, sniffing will happen on every interface::
 
     >>>  sniff(filter="icmp and host 66.35.250.151", count=2)
     <Sniffed: UDP:0 TCP:0 ICMP:2 Other:0>
@@ -607,6 +607,11 @@ We can easily capture some packets or even clone tcpdump or tethereal. If no int
              load      = 'B\xf7i\xa9\x00\x04\x149\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\x22#$%&\'()*+,-./01234567'
     ---[ Padding ]---
                 load      = '\n_\x00\x0b'
+    >>> sniff(iface=["eth1","eth2"], prn=lambda x: x.sniffed_on+": "+x.summary())
+    eth3: Ether / IP / ICMP 192.168.5.21 > 66.35.250.151 echo-request 0 / Raw  
+    eth3: Ether / IP / ICMP 66.35.250.151 > 192.168.5.21 echo-reply 0 / Raw    
+    eth2: Ether / IP / ICMP 192.168.5.22 > 66.35.250.152 echo-request 0 / Raw  
+    eth2: Ether / IP / ICMP 66.35.250.152 > 192.168.5.22 echo-reply 0 / Raw
 
 For even more control over displayed information we can use the ``sprintf()`` function::
 

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -65,6 +65,17 @@ SOL_SOCKET = 1
 RTF_UP = 0x0001  # Route usable
 RTF_REJECT = 0x0200
 
+# From if_packet.h
+PACKET_HOST = 0  # To us
+PACKET_BROADCAST = 1  # To all
+PACKET_MULTICAST = 2  # To group
+PACKET_OTHERHOST = 3  # To someone else
+PACKET_OUTGOING = 4  # Outgoing of any type
+PACKET_LOOPBACK = 5  # MC/BRD frame looped back
+PACKET_USER = 6  # To user space
+PACKET_KERNEL = 7  # To kernel space
+PACKET_FASTROUTE = 6  # Fastrouted frame
+# Unused, PACKET_FASTROUTE and PACKET_LOOPBACK are invisible to user space
 
 
 LOOPBACK_NAME="lo"
@@ -508,7 +519,9 @@ class L2ListenSocket(SuperSocket):
             cls = conf.l3types[sa_ll[1]]
         else:
             cls = conf.default_l2
-            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s" % (sa_ll[0],sa_ll[1],sa_ll[3],cls.name))
+            warning("Unable to guess type (interface=%s protocol=%#x "
+                    "family=%i). Using %s" % (sa_ll[0], sa_ll[1], sa_ll[3],
+                                              cls.name))
 
         try:
             pkt = cls(pkt)
@@ -519,6 +532,7 @@ class L2ListenSocket(SuperSocket):
                 raise
             pkt = conf.raw_layer(pkt)
         pkt.time = get_last_packet_timestamp(self.ins)
+        pkt.direction = sa_ll[2]
         return pkt
     
     def send(self, x):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -565,9 +565,9 @@ interfaces)
     """
     c = 0
     label = {}
-    ls = []
+    sniff_sockets = []
     if opened_socket is not None:
-        ls = [opened_socket]
+        sniff_sockets = [opened_socket]
     else:
         if offline is None:
             if L2socket is None:
@@ -576,24 +576,25 @@ interfaces)
                 for i in iface:
                     s = L2socket(type=ETH_P_ALL, iface=i, *arg, **karg)
                     label[s] = i
-                    ls.append(s)
+                    sniff_sockets.append(s)
             else:
-                ls = [L2socket(type=ETH_P_ALL, iface=iface, *arg, **karg)]
+                sniff_sockets = [L2socket(type=ETH_P_ALL, iface=iface, *arg,
+                                           **karg)]
         else:
-            ls = [PcapReader(offline)]
+            sniff_sockets = [PcapReader(offline)]
 
     lst = []
     if timeout is not None:
         stoptime = time.time()+timeout
     remain = None
     try:
-        stop_event = 0
+        stop_event = False
         while not stop_event:
             if timeout is not None:
                 remain = stoptime-time.time()
                 if remain <= 0:
                     break
-            sel = select(ls, [], [], remain)
+            sel = select(sniff_sockets, [], [], remain)
             for s in sel[0]:
                 p = s.recv()
                 if p is not None:
@@ -609,9 +610,11 @@ interfaces)
                         if r is not None:
                             print r
                     if stop_filter and stop_filter(p):
-                        stop_event = 1
+                        stop_event = True
+                        break
                     if count > 0 and c >= count:
-                        stop_event = 1
+                        stop_event = True
+                        break
     except KeyboardInterrupt:
         pass
     if opened_socket is None:
@@ -654,7 +657,7 @@ stop_filter: python function applied to each packet to determine
         stoptime = time.time()+timeout
     remain = None
     try:
-        stop_event = 0
+        stop_event = False
         while not stop_event:
             if timeout is not None:
                 remain = stoptime-time.time()
@@ -676,9 +679,11 @@ stop_filter: python function applied to each packet to determine
                         if r is not None:
                             print r
                     if stop_filter and stop_filter(p):
-                        stop_event = 1
+                        stop_event = True
+                        break
                     if count > 0 and c >= count:
-                        stop_event = 1
+                        stop_event = True
+                        break
     except KeyboardInterrupt:
         pass
     finally:


### PR DESCRIPTION
- Fixed bug in bridge_and_ sniff function. The count and stop_filter parameters where not considered
(because the "break" in the inner "for" was meant for exiting the external while).
- The sniff function can accept as "iface" parameter either one interface as string or a list of interfaces as list of strings. In this way it is still compatible with existing code.