### PR TITLE
Allow L2pcapListenSocket to return None if where is no packets (issue #74)

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -203,7 +203,7 @@ if conf.use_winpcapy:
           else:
               cls = conf.default_l2
               warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
-  
+
           pkt = None
           while pkt is None:
               pkt = self.ins.next()
@@ -438,23 +438,20 @@ if conf.use_pcap:
                     cls = conf.default_l2
                     warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
         
-                pkt = None
-                while pkt is None:
-                    pkt = self.ins.next()
-                    if pkt is not None:
-                        ts,pkt = pkt
-                    if scapy.arch.WINDOWS and pkt is None:
+                pkt = self.ins.next()
+                if scapy.arch.WINDOWS and pkt is None:
                         raise PcapTimeoutElapsed
-                
-                try:
-                    pkt = cls(pkt)
-                except KeyboardInterrupt:
-                    raise
-                except:
-                    if conf.debug_dissector:
+                if pkt is not None:
+                    ts,pkt = pkt
+                    try:
+                        pkt = cls(pkt)
+                    except KeyboardInterrupt:
                         raise
-                    pkt = conf.raw_layer(pkt)
-                pkt.time = ts
+                    except:
+                        if conf.debug_dissector:
+                            raise
+                        pkt = conf.raw_layer(pkt)
+                    pkt.time = ts
                 return pkt
         
             def send(self, x):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -585,7 +585,7 @@ stop_filter: python function applied to each packet to determine
             if s in sel[0]:
                 p = s.recv(MTU)
                 if p is None:
-                    break
+                    continue
                 if lfilter and not lfilter(p):
                     continue
                 if store:


### PR DESCRIPTION
This PR solves [issue #74](https://github.com/secdev/scapy/issues/74) with 2 fixes:

L2pcapListenSocket.recv() waits until pcap's next() method return value that is not _None_. If there is no captured packets while loop will be endless. In this case sendrecv.sniff() timeout doesn't work.

Other functions from sendrecv.py can get _None_ from L2ListenSocket and try to recv() again, but sniff() breaks the while loop if _None_ was received. Now it is trying to recv() again