### PR TITLE
add TCP User Timeout Option (RFC 5482)

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -213,7 +213,8 @@ TCPOptions = (
                 8 : ("Timestamp","!II"),
                 14 : ("AltChkSum","!BH"),
                 15 : ("AltChkSumOpt",None),
-                25 : ("Mood","!p")
+                25 : ("Mood","!p"),
+                28 : ("UTO", "!H")
                 },
               { "EOL":0,
                 "NOP":1,
@@ -224,7 +225,8 @@ TCPOptions = (
                 "Timestamp":8,
                 "AltChkSum":14,
                 "AltChkSumOpt":15,
-                "Mood":25
+                "Mood":25,
+                "UTO":28
                 } )
 
 class TCPOptionsField(StrField):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4396,3 +4396,14 @@ defrags = defragment(frags)
 assert len(defrags) == 1
 * which should be the same as pkt reconstructed
 assert defrags[0] == IP(str(pkt))
+
+############
+############
++ Test TCP options
+
+= TCP options: UTO - basic build
+str(TCP(options=[("UTO", 0xffff)])) == "\x00\x14\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\x60\x02\x20\x00\x00\x00\x00\x00\x1c\x04\xff\xff"
+
+= TCP options: UTO - basic dissection
+uto = TCP("\x00\x14\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\x60\x02\x20\x00\x00\x00\x00\x00\x1c\x04\xff\xff")
+uto[TCP].options[0][0] == "UTO" and uto[TCP].options[0][1] == 0xffff


### PR DESCRIPTION
Allow one to send the TCP User Timeout Option described in RFC 5482 in
a crafted TCP segment.