### PR TITLE
Packet.getlayer() method can work with string layer name

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -763,7 +763,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
             ccls,fld = cls.split(".",1)
         else:
             ccls,fld = cls,None
-        if cls is None or self.__class__ == cls or self.__class__.name == ccls:
+        if cls is None or self.__class__ == cls or self.__class__.__name__ == ccls:
             if nb == 1:
                 if fld is None:
                     return self


### PR DESCRIPTION
I found that Packet.getlayer() can't work when _cls_ param is string. For example, Packet.haslayer() can do it.
I created the fix, review it, please