### PR TITLE
Update scripts to call python2 instead of python

### DIFF
--- a/run_scapy
+++ b/run_scapy
@@ -1,3 +1,8 @@
 #! /bin/sh
 DIR=$(dirname $0)
-PYTHONPATH=$DIR exec python -m scapy.__init__
+if python --version | grep -q '^Python 2'; then
+    PYTHON=python
+else
+    PYTHON=python2
+fi
+PYTHONPATH=$DIR exec $PYTHON -m scapy.__init__

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,8 +1,13 @@
 #! /bin/bash
 DIR=$(dirname $0)/..
+if python --version | grep -q '^Python 2'; then
+    PYTHON=python
+else
+    PYTHON=python2
+fi
 if [ "$*" == "" ]
 then
-PYTHONPATH=$DIR exec python ${DIR}/scapy/tools/UTscapy.py -t regression.uts -f html -l -o /tmp/scapy_regression_test_$(date +%Y%m%d-%H%M%S).html
+PYTHONPATH=$DIR exec $PYTHON ${DIR}/scapy/tools/UTscapy.py -t regression.uts -f html -l -o /tmp/scapy_regression_test_$(date +%Y%m%d-%H%M%S).html
 else
-PYTHONPATH=$DIR exec python ${DIR}/scapy/tools/UTscapy.py "$@"
+PYTHONPATH=$DIR exec $PYTHON ${DIR}/scapy/tools/UTscapy.py "$@"
 fi


### PR DESCRIPTION
This will fix `run_scapy` and `run_tests` when Python 3 is the default (e.g., ArchLinux).