### PR TITLE
Update ls() to display more info about enum fields

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1259,21 +1259,26 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                     cur_fld = cur_fld.fld
                 if verbose and isinstance(cur_fld, EnumField) \
                    and hasattr(cur_fld, "i2s"):
-                    long_attrs.extend(
-                        "%s: %d" % (strval, numval)
-                        for numval, strval in sorted(cur_fld.i2s.iteritems())
-                    )
+                    if len(cur_fld.i2s) < 50:
+                        long_attrs.extend(
+                            "%s: %d" % (strval, numval)
+                            for numval, strval in
+                            sorted(cur_fld.i2s.iteritems())
+                        )
                 elif isinstance(cur_fld, MultiEnumField):
-                    fld_depend = cur_fld.depends_on(obj.__class__ if is_pkt else obj)
+                    fld_depend = cur_fld.depends_on(obj.__class__
+                                                    if is_pkt else obj)
                     attrs.append("Depends on %s" % fld_depend.name)
                     if verbose:
                         cur_i2s = cur_fld.i2s_multi.get(
                             cur_fld.depends_on(obj if is_pkt else obj()), {}
                         )
-                        long_attrs.extend(
-                            "%s: %d" % (strval, numval)
-                            for numval, strval in sorted(cur_i2s.iteritems())
-                        )
+                        if len(cur_i2s) < 50:
+                            long_attrs.extend(
+                                "%s: %d" % (strval, numval)
+                                for numval, strval in
+                                sorted(cur_i2s.iteritems())
+                            )
                 elif verbose and isinstance(cur_fld, FlagsField):
                     names = cur_fld.names
                     if isinstance(names, basestring):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1231,7 +1231,7 @@ def split_layers(lower, upper, __fval=None, **fval):
 
 
 @conf.commands.register
-def ls(obj=None, case_sensitive=False):
+def ls(obj=None, case_sensitive=False, verbose=False):
     """List  available layers, or infos on a given layer class or name"""
     is_string = isinstance(obj, basestring)
 
@@ -1253,9 +1253,27 @@ def ls(obj=None, case_sensitive=False):
             for f in obj.fields_desc:
                 cur_fld = f
                 attrs = []
+                long_attrs = []
                 while isinstance(cur_fld, (Emph, ConditionalField)):
                     attrs.append(cur_fld.__class__.__name__[:4])
                     cur_fld = cur_fld.fld
+                if verbose and isinstance(cur_fld, EnumField) \
+                   and hasattr(cur_fld, "i2s"):
+                    long_attrs.extend(
+                        "%s: %d" % (strval, numval)
+                        for numval, strval in sorted(cur_fld.i2s.iteritems())
+                    )
+                elif isinstance(cur_fld, MultiEnumField):
+                    fld_depend = cur_fld.depends_on(obj.__class__ if is_pkt else obj)
+                    attrs.append("Depends on %s" % fld_depend.name)
+                    if verbose:
+                        cur_i2s = cur_fld.i2s_multi.get(
+                            cur_fld.depends_on(obj if is_pkt else obj()), {}
+                        )
+                        long_attrs.extend(
+                            "%s: %d" % (strval, numval)
+                            for numval, strval in sorted(cur_i2s.iteritems())
+                        )
                 class_name = "%s (%s)" % (
                     cur_fld.__class__.__name__,
                     ", ".join(attrs)) if attrs else cur_fld.__class__.__name__
@@ -1263,10 +1281,12 @@ def ls(obj=None, case_sensitive=False):
                     class_name += " (%d bit%s)" % (cur_fld.size,
                                                    "s" if cur_fld.size > 1
                                                    else "")
-                print "%-10s : %-25s =" % (f.name, class_name),
+                print "%-10s : %-35s =" % (f.name, class_name),
                 if is_pkt:
                     print "%-15r" % getattr(obj,f.name),
                 print "(%r)" % f.default
+                for attr in long_attrs:
+                    print "%-15s%s" % ("", attr)
             if is_pkt and not isinstance(obj.payload, NoPayload):
                 print "--"
                 ls(obj.payload)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -10,9 +10,10 @@ Packet class. Binding mechanism. fuzz() method.
 import re
 import time,itertools
 import copy
-from fields import StrField,ConditionalField,Emph,PacketListField,BitField
+from fields import StrField, ConditionalField, Emph, PacketListField, BitField, \
+    MultiEnumField, EnumField, FlagsField
 from config import conf
-from base_classes import BasePacket,Gen,SetGen,Packet_metaclass,NewDefaultValues
+from base_classes import BasePacket, Gen, SetGen, Packet_metaclass
 from volatile import VolatileValue
 from utils import import_hexcap,tex_escape,colgen,get_temp_file
 from error import Scapy_Exception,log_runtime

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1274,6 +1274,12 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                             "%s: %d" % (strval, numval)
                             for numval, strval in sorted(cur_i2s.iteritems())
                         )
+                elif verbose and isinstance(cur_fld, FlagsField):
+                    names = cur_fld.names
+                    if isinstance(names, basestring):
+                        long_attrs.append(", ".join(names))
+                    else:
+                        long_attrs.append(", ".join(name[0] for name in names))
                 class_name = "%s (%s)" % (
                     cur_fld.__class__.__name__,
                     ", ".join(attrs)) if attrs else cur_fld.__class__.__name__


### PR DESCRIPTION
The objective is to be able to use Scapy's protocols implementation as a handy protocol documentation ;-), see some examples below.

Display "Depends on" for `MultiEnumField`s:
```
>>> ls(ICMP)
type       : ByteEnumField                       = (8)
code       : MultiEnumField (Depends on type)    = (0)
[...]
```

Show enum values with `verbose=True`:
```
>>> ls(ICMP, verbose=1)
type       : ByteEnumField                       = (8)
               echo-reply: 0
               dest-unreach: 3
               source-quench: 4
               redirect: 5
               echo-request: 8
               router-advertisement: 9
               router-solicitation: 10
               time-exceeded: 11
               parameter-problem: 12
               timestamp-request: 13
               timestamp-reply: 14
               information-request: 15
               information-response: 16
               address-mask-request: 17
               address-mask-reply: 18
code       : MultiEnumField (Depends on type)    = (0)
[...]
>>> ls(ICMP(type="dest-unreach"), verbose=True)
type       : ByteEnumField                       = 3               (8)
               echo-reply: 0
               dest-unreach: 3
               source-quench: 4
               redirect: 5
               echo-request: 8
               router-advertisement: 9
               router-solicitation: 10
               time-exceeded: 11
               parameter-problem: 12
               timestamp-request: 13
               timestamp-reply: 14
               information-request: 15
               information-response: 16
               address-mask-request: 17
               address-mask-reply: 18
code       : MultiEnumField (Depends on type)    = 0               (0)
               network-unreachable: 0
               host-unreachable: 1
               protocol-unreachable: 2
               port-unreachable: 3
                fragmentation-needed: 4
               source-route-failed: 5
               network-unknown: 6
               host-unknown: 7
               network-prohibited: 9
               host-prohibited: 10
               TOS-network-unreachable: 11
               TOS-host-unreachable: 12
               communication-prohibited: 13
               host-precedence-violation: 14
               precedence-cutoff: 15
[...]
```

Show possible flags with `verbose=True`:
```
>>> ls(TCP, verbose=1)
sport      : ShortEnumField                      = (20)
dport      : ShortEnumField                      = (80)
seq        : IntField                            = (0)
ack        : IntField                            = (0)
dataofs    : BitField (4 bits)                   = (None)
reserved   : BitField (3 bits)                   = (0)
flags      : FlagsField (9 bits)                 = (2)
               F, S, R, P, A, U, E, C, N
window     : ShortField                          = (8192)
chksum     : XShortField                         = (None)
urgptr     : ShortField                          = (0)
options    : TCPOptionsField                     = ({})
>>> ls(Dot11, verbose=1)
subtype    : BitField (4 bits)                   = (0)
type       : BitEnumField (2 bits)               = (0)
proto      : BitField (2 bits)                   = (0)
FCfield    : FlagsField (8 bits)                 = (0)
               to-DS, from-DS, MF, retry, pw-mgt, MD, wep, order
ID         : ShortField                          = (0)
addr1      : MACField                            = ('00:00:00:00:00:00')
addr2      : Dot11Addr2MACField                  = ('00:00:00:00:00:00')
addr3      : Dot11Addr3MACField                  = ('00:00:00:00:00:00')
SC         : Dot11SCField                        = (0)
addr4      : Dot11Addr4MACField                  = ('00:00:00:00:00:00')
```