### PR TITLE
fix unicode problem for IPField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -203,7 +203,7 @@ class IPField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "4s")
     def h2i(self, pkt, x):
-        if type(x) is str:
+        if isinstance(x, basestring):
             try:
                 inet_aton(x)
             except socket.error:


### PR DESCRIPTION
When create packets with a changed IP address, code will report error.

`>>> p1 = IP(dst=u'10.158.200.34-35')/ICMP()
>>> p1
<IP  frag=0 proto=icmp dst=10.158.200.34-35 |<ICMP  |>>
>>> sr(p1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/scapy/sendrecv.py", line 326, in sr
    a,b=sndrcv(s,x,*args,**kargs)
  File "/usr/local/lib/python2.7/dist-packages/scapy/sendrecv.py", line 55, in sndrcv
    h = i.hashret()
  File "/usr/local/lib/python2.7/dist-packages/scapy/layers/inet.py", line 377, in hashret
    return strxor(inet_aton(self.src),inet_aton(self.dst))+struct.pack("B",self.proto)+self.payload.hashret()
socket.error: illegal IP address string passed to inet_aton
>>> 
`

I found it is because in "IPField", "if type(x) is str:", and unicode is not supported.

After modify the problem code to "if isinstance(x, basestring)", looks ok

`>>> p1 = IP(dst=u'10.158.200.34-35')/ICMP()
>>> p1
<IP  frag=0 proto=icmp dst=Net(u'10.158.200.34-35') |<ICMP  |>>
>>> sr(p1)
Begin emission:
.*Finished to send 2 packets.
*
Received 3 packets, got 2 answers, remaining 0 packets
(<Results: TCP:0 UDP:0 ICMP:2 Other:0>, <Unanswered: TCP:0 UDP:0 ICMP:0 Other:0>)
>>> 
`