### PR TITLE
Move get_if() to scapy/arch/common.py

### DIFF
--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -1,0 +1,21 @@
+## This file is part of Scapy
+## See http://www.secdev.org/projects/scapy for more informations
+## Copyright (C) Philippe Biondi <phil@secdev.org>
+## This program is published under a GPLv2 license
+
+"""
+Functions common to different architectures
+"""
+
+import socket
+from fcntl import ioctl
+import struct
+
+
+def get_if(iff, cmd):
+    """Ease SIOCGIF* ioctl calls"""
+
+    sck = socket.socket()
+    ifreq = ioctl(sck, cmd, struct.pack("16s16x", iff))
+    sck.close()
+    return ifreq

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -19,6 +19,7 @@ from scapy.data import *
 from scapy.supersocket import SuperSocket
 import scapy.arch
 from scapy.error import warning, Scapy_Exception
+from scapy.arch.common import get_if
 
 
 
@@ -274,15 +275,6 @@ def read_routes6():
             routes.append((d, dp, nh, dev, cset))
     f.close()
     return routes   
-
-
-
-
-def get_if(iff,cmd):
-    s=socket.socket()
-    ifreq = ioctl(s, cmd, struct.pack("16s16x",iff))
-    s.close()
-    return ifreq
 
 
 def get_if_index(iff):


### PR DESCRIPTION
The (future) BPF mode needs to call get_if(). Importing the function does not work on OS X. As discussed in Issue #100, this patch moves the function to a new file common.py