### PR TITLE
Don't use /bin/bash in run_tests

### DIFF
--- a/test/run_tests
+++ b/test/run_tests
@@ -1,11 +1,11 @@
-#! /bin/bash
+#! /bin/sh
 DIR=$(dirname $0)/..
 if python --version 2>&1 | grep -q '^Python 2'; then
     PYTHON=python
 else
     PYTHON=python2
 fi
-if [ "$*" == "" ]
+if [ ! -n "$*" ]
 then
 PYTHONPATH=$DIR exec $PYTHON ${DIR}/scapy/tools/UTscapy.py -t regression.uts -f html -l -o /tmp/scapy_regression_test_$(date +%Y%m%d-%H%M%S).html
 else


### PR DESCRIPTION
At least FreeBSD and OpenBSD do not install bash by default. This patch aims at removing the dependency on bash to ease running regression tests.

It was tested on Debian, FreeBSD and OpenBSD.