### PR TITLE
scapy/arch refactoring

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -40,7 +40,6 @@ def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
 
 
-    
 def get_if_addr(iff):
     return socket.inet_ntoa(get_if_raw_addr(iff))
     
@@ -52,13 +51,14 @@ def get_if_hwaddr(iff):
         raise Scapy_Exception("Unsupported address family (%i) for interface [%s]" % (addrfamily,iff))
 
 
-LINUX=sys.platform.startswith("linux")
-OPENBSD=sys.platform.startswith("openbsd")
-FREEBSD= "freebsd" in sys.platform
-NETBSD=sys.platform.startswith("netbsd")
-DARWIN=sys.platform.startswith("darwin")
-SOLARIS=sys.platform.startswith("sunos")
-WINDOWS=sys.platform.startswith("win32")
+LINUX = sys.platform.startswith("linux")
+OPENBSD = sys.platform.startswith("openbsd")
+FREEBSD = "freebsd" in sys.platform
+NETBSD = sys.platform.startswith("netbsd")
+DARWIN = sys.platform.startswith("darwin")
+SOLARIS = sys.platform.startswith("sunos")
+WINDOWS = sys.platform.startswith("win32")
+BSD = DARWIN or FREEBSD or OPENBSD or NETBSD
 
 X86_64 = not WINDOWS and (os.uname()[4] == 'x86_64')
 ARM_64 = not WINDOWS and (os.uname()[4] == 'aarch64')
@@ -81,8 +81,12 @@ if LINUX:
     from linux import *
     if scapy.config.conf.use_pcap or scapy.config.conf.use_dnet:
         from pcapdnet import *
-elif OPENBSD or FREEBSD or NETBSD or DARWIN:
-    from bsd import *
+elif BSD:
+    from bsd import LOOPBACK_NAME
+    from unix import read_routes, read_routes6, in6_getifaddr
+    scapy.config.conf.use_pcap = True
+    scapy.config.conf.use_dnet = True
+    from pcapdnet import *
 elif SOLARIS:
     from solaris import *
 elif WINDOWS:

--- a/scapy/arch/bsd.py
+++ b/scapy/arch/bsd.py
@@ -7,6 +7,4 @@
 Support for BSD-like operating systems such as FreeBSD, OpenBSD and Mac OS X.
 """
 
-LOOPBACK_NAME="lo0"
-
-from unix import *
+LOOPBACK_NAME = "lo0"

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -14,10 +14,7 @@ import scapy.config
 import scapy.utils
 import scapy.utils6
 import scapy.arch
-
-scapy.config.conf.use_pcap = 1
-scapy.config.conf.use_dnet = 1
-from pcapdnet import *
+from scapy.config import conf
 
 
 ##################


### PR DESCRIPTION
The current code prevents functions from the unix module to be imported without importing the pcapdnet module.

These functions must be used in the future BPF mode (that removes dependencies on pcap and dnet modules).