### PR TITLE
Scapy can now use dumbnet

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -497,9 +497,8 @@ if conf.use_dnet:
                 l = dnet.intf().get(iff)
                 link_addr = l["link_addr"]
             except:
-                msg = "Error in attempting to get hw address for interface"
-                msg += " [%s]" % iff
-                raise Scapy_Exception(msg)
+                raise Scapy_Exception("Error in attempting to get hw address"
+                                      " for interface [%s]" % iff)
 
             if hasattr(link_addr, "type"):
                 # Legacy dnet module

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -24,6 +24,20 @@ lsc()
 ~ conf
 conf.debug_dissector = True
 
+
+############
+############
++ Scapy functions tests
+
+= Interface related functions
+
+get_if_raw_hwaddr(conf.iface)
+
+get_if_raw_addr(conf.iface).encode("hex")
+
+get_if_list()
+
+
 ############
 ############
 + Basic tests


### PR DESCRIPTION
This patch fixes #116. I choose to add some dummy calls to some important internal functions as I had to patch them, because they were failing.

It was tested on Debian (root and non-root regressions tests / with and without pcapdnet). Travis will do it on Ubuntu.

It can be tested easily with:
```python
from scapy.config import conf
conf.use_pcap = True
conf.use_dnet = True

from scapy.all import *

p = sr1(IP(dst="www.kame.net")/ICMP())
print p.summary()
```

As of today, there is no easy way to launch the regressions tests using pcapdnet. It could be interesting to trigger the use of pcapdnet using a environment variable (such as SCAPY_USE_PCAPDNET). I can modify this patch to implement this behavior.