### PR TITLE
Fixes crash when an interface has no ip

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -41,8 +41,12 @@ def str2mac(s):
 
 
 def get_if_addr(iff):
-    return socket.inet_ntoa(get_if_raw_addr(iff))
-    
+    addr = get_if_raw_addr(iff)
+    if addr:
+        return socket.inet_ntoa(addr)
+    else:
+        return None
+
 def get_if_hwaddr(iff):
     addrfamily, mac = get_if_raw_hwaddr(iff)
     if addrfamily in [ARPHDR_ETHER,ARPHDR_LOOPBACK]:

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -516,7 +516,19 @@ if conf.use_dnet:
 
         def get_if_raw_addr(ifname):
             i = dnet.intf()
-            return i.get(ifname)["addr"].data
+
+            try:
+                if_data = i.get(ifname)
+            except OSError, e:
+                if e.message == 'Device not configured':
+                    addr = None
+                else:
+                    raise
+            else:
+                addr = if_data["addr"].data
+
+            return addr
+
         def get_if_list():
             return [i.get("name", None) for i in dnet.intf()]
 

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -136,9 +136,10 @@ class Route:
         dst = atol(dst)
         pathes=[]
         for d,m,gw,i,a in self.routes:
-            aa = atol(a)
-            if aa == dst:
-                pathes.append((0xffffffffL,(LOOPBACK_NAME,a,"0.0.0.0")))
+            if a:
+                aa = atol(a)
+                if aa == dst:
+                    pathes.append((0xffffffffL,(LOOPBACK_NAME,a,"0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m,(i,a,gw)))
         if not pathes:


### PR DESCRIPTION
I couldn't use virtualbox and scapy at the same time because some of the bridges had no ip configured and that's not currently handled in scapy.