### PR TITLE
Python 2.5: fallback implementation for gcd() without pycrypto

### DIFF
--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -41,7 +41,22 @@ True
 
 import socket
 import struct
-from Crypto.Util.number import GCD as gcd
+try:
+    from Crypto.Util.number import GCD as gcd
+except ImportError:
+    try:
+        from fractions import gcd
+    except ImportError:
+        def gcd(a, b):
+            """Fallback implementation when Crypto is missing, and fractions does
+            not exist (Python 2.5)
+
+            """
+            if b > a:
+                a, b = b, a
+            c = a % b
+            return b if c == 0 else gcd(c, b)
+
 
 from scapy.data import IP_PROTOS
 


### PR DESCRIPTION
This was reported by @AmedeoSapio in #68