### PR TITLE
Introducing the SCAPY_USE_PCAPDNET environment variable

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -363,8 +363,8 @@ extensions_paths: path or list of paths where extensions are to be looked for
     resolve = Resolve()
     noenum = Resolve()
     emph = Emphasize()
-    use_pcap = False
-    use_dnet = False
+    use_pcap = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
+    use_dnet = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
     use_winpcapy = False
     ipv6_enabled = socket.has_ipv6
     ethertypes = ETHER_TYPES


### PR DESCRIPTION
This patch introduces the SCAPY_USE_PCAPDNET environment variable that can be used to easily force the use of the pcap and dnet modules. It is [yolo](https://bitbucket.org/secdev/yolo) compliant by default =)

So far, the only way to control this behavior was to patch manually the source, or write a wrapper to set conf.use_pcap and conf.use_dnet before importing Scapy. 

```shell
$ SCAPY_USE_PCAPDNET=YoLo ./run_scapy 
Welcome to Scapy (2.3.2-dev)
>>> conf.L3socket
<L3dnetSocket: read/write packets at layer 3 using libdnet and libpcap>
```

This PR is a preliminary step to test pcap & dnet modules using Travis-CI.