### PR TITLE
"Add" support for mDNS

### DIFF
--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -726,6 +726,7 @@ bind_layers(OSPF_Hdr, OSPF_DBDesc, type=2)
 bind_layers(OSPF_Hdr, OSPF_LSReq, type=3)
 bind_layers(OSPF_Hdr, OSPF_LSUpd, type=4)
 bind_layers(OSPF_Hdr, OSPF_LSAck, type=5)
+DestIPField.bind_addr(OSPF_Hdr, "224.0.0.5")
 
 bind_layers(IPv6, OSPFv3_Hdr, nh=89)
 bind_layers(OSPFv3_Hdr, OSPFv3_Hello, type=1)
@@ -733,6 +734,7 @@ bind_layers(OSPFv3_Hdr, OSPFv3_DBDesc, type=2)
 bind_layers(OSPFv3_Hdr, OSPFv3_LSReq, type=3)
 bind_layers(OSPFv3_Hdr, OSPFv3_LSUpd, type=4)
 bind_layers(OSPFv3_Hdr, OSPFv3_LSAck, type=5)
+DestIP6Field.bind_addr(OSPFv3_Hdr, "ff02::5")
 
 
 if __name__ == "__main__":

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -176,6 +176,26 @@ class PadField(object):
         return getattr(self._fld,attr)
         
 
+class DestField(Field):
+    __slots__ = ["defaultdst"]
+    # Each subclass must have its own bindings attribute
+    # bindings = {}
+    def __init__(self, name, default):
+        self.defaultdst = default
+    def dst_from_pkt(self, pkt):
+        for addr, condition in self.bindings.get(pkt.payload.__class__, []):
+            try:
+                if all(pkt.payload.getfieldval(field) == value
+                       for field, value in condition.iteritems()):
+                    return addr
+            except AttributeError:
+                pass
+        return self.defaultdst
+    @classmethod
+    def bind_addr(cls, layer, addr, **condition):
+        cls.bindings.setdefault(layer, []).append((addr, condition))
+
+
 class MACField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "6s")

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -12,7 +12,8 @@ import socket,struct
 from scapy.packet import *
 from scapy.fields import *
 from scapy.ansmachine import *
-from scapy.layers.inet import IP, UDP
+from scapy.layers.inet import IP, DestIPField, UDP
+from scapy.layers.inet6 import DestIP6Field
 
 class DNSStrField(StrField):
 
@@ -622,6 +623,8 @@ bind_layers(UDP, DNS, dport=5353)
 bind_layers(UDP, DNS, sport=5353)
 bind_layers(UDP, DNS, dport=53)
 bind_layers(UDP, DNS, sport=53)
+DestIPField.bind_addr(UDP, "224.0.0.251", dport=5353)
+DestIP6Field.bind_addr(UDP, "ff02::fb", dport=5353)
 
 
 @conf.commands.register

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -617,8 +617,11 @@ class DNSRR(Packet):
                     RDLenField("rdlen"),
                     RDataField("rdata", "", length_from=lambda pkt:pkt.rdlen) ]
 
-bind_layers( UDP,           DNS,           dport=53)
-bind_layers( UDP,           DNS,           sport=53)
+
+bind_layers(UDP, DNS, dport=5353)
+bind_layers(UDP, DNS, sport=5353)
+bind_layers(UDP, DNS, dport=53)
+bind_layers(UDP, DNS, sport=53)
 
 
 @conf.commands.register

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -34,7 +34,8 @@ HSRP (Hot Standby Router Protocol): proprietary redundancy protocol for Cisco ro
 
 from scapy.fields import *
 from scapy.packet import *
-from scapy.layers.inet import UDP
+from scapy.layers.inet import DestIPField, UDP
+from scapy.layers.inet6 import DestIP6Field
 
 
 class HSRP(Packet):
@@ -77,3 +78,6 @@ class HSRPmd5(Packet):
         return p
 
 bind_layers(UDP, HSRP, dport=1985, sport=1985)
+bind_layers(UDP, HSRP, dport=2029, sport=2029)
+DestIPField.bind_addr(UDP, "224.0.0.2", dport=1985)
+DestIP6Field.bind_addr(UDP, "ff02::66", dport=2029)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -325,16 +325,11 @@ class ICMPTimeStampField(IntField):
         return val
 
 
-class DestIPField(IPField):
-    __slots__ = ["defaultdst"]
+class DestIPField(IPField, DestField):
+    bindings = {}
     def __init__(self, name, default):
         IPField.__init__(self, name, None)
-        self.defaultdst = default
-    def dst_from_pkt(self, pkt):
-        if isinstance(pkt.payload, UDP):
-            if pkt.payload.dport == 5353:
-                return "224.0.0.251"
-        return self.defaultdst
+        DestField.__init__(self, name, default)
     def i2m(self, pkt, x):
         if x is None:
             x = self.dst_from_pkt(pkt)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -325,6 +325,26 @@ class ICMPTimeStampField(IntField):
         return val
 
 
+class DestIPField(IPField):
+    __slots__ = ["defaultdst"]
+    def __init__(self, name, default):
+        IPField.__init__(self, name, None)
+        self.defaultdst = default
+    def dst_from_pkt(self, pkt):
+        if isinstance(pkt.payload, UDP):
+            if pkt.payload.dport == 5353:
+                return "224.0.0.251"
+        return self.defaultdst
+    def i2m(self, pkt, x):
+        if x is None:
+            x = self.dst_from_pkt(pkt)
+        return IPField.i2m(self, pkt, x)
+    def i2h(self, pkt, x):
+        if x is None:
+            x = self.dst_from_pkt(pkt)
+        return IPField.i2h(self, pkt, x)
+
+
 class IP(Packet, IPTools):
     __slots__ = ["_defrag_pos"]
     name = "IP"
@@ -340,7 +360,7 @@ class IP(Packet, IPTools):
                     XShortField("chksum", None),
                     #IPField("src", "127.0.0.1"),
                     Emph(SourceIPField("src","dst")),
-                    Emph(IPField("dst", "127.0.0.1")),
+                    Emph(DestIPField("dst", "127.0.0.1")),
                     PacketListField("options", [], IPOption, length_from=lambda p:p.ihl*4-20) ]
     def post_build(self, p, pay):
         ihl = self.ihl

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -247,16 +247,11 @@ class SourceIP6Field(IP6Field):
                 iff,x,nh = conf.route6.route(dst)
         return IP6Field.i2h(self, pkt, x)
 
-class DestIP6Field(IP6Field):
-    __slots__ = ["defaultdst"]
+class DestIP6Field(IP6Field, DestField):
+    bindings = {}
     def __init__(self, name, default):
         IP6Field.__init__(self, name, None)
-        self.defaultdst = default
-    def dst_from_pkt(self, pkt):
-        if isinstance(pkt.payload, UDP):
-            if pkt.payload.dport == 5353:
-                return "ff02::fb"
-        return self.defaultdst
+        DestField.__init__(self, name, default)
     def i2m(self, pkt, x):
         if x is None:
             x = self.dst_from_pkt(pkt)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -247,6 +247,25 @@ class SourceIP6Field(IP6Field):
                 iff,x,nh = conf.route6.route(dst)
         return IP6Field.i2h(self, pkt, x)
 
+class DestIP6Field(IP6Field):
+    __slots__ = ["defaultdst"]
+    def __init__(self, name, default):
+        IP6Field.__init__(self, name, None)
+        self.defaultdst = default
+    def dst_from_pkt(self, pkt):
+        if isinstance(pkt.payload, UDP):
+            if pkt.payload.dport == 5353:
+                return "ff02::fb"
+        return self.defaultdst
+    def i2m(self, pkt, x):
+        if x is None:
+            x = self.dst_from_pkt(pkt)
+        return IP6Field.i2m(self, pkt, x)
+    def i2h(self, pkt, x):
+        if x is None:
+            x = self.dst_from_pkt(pkt)
+        return IP6Field.i2h(self, pkt, x)
+
 ipv6nh = { 0:"Hop-by-Hop Option Header",
            4:"IP",
            6:"TCP",
@@ -358,7 +377,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                     ByteEnumField("nh", 59, ipv6nh),
                     ByteField("hlim", 64),
                     SourceIP6Field("src", "dst"), # dst is for src @ selection
-                    IP6Field("dst", "::1") ]
+                    DestIP6Field("dst", "::1") ]
 
     def route(self):
         dst = self.dst

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4495,3 +4495,25 @@ assert bpkt.chksum == 0xf0bc and bpkt.payload.chksum == 0xbb17
 pkt = IP(len=42, ihl=6, options=[IPOption_RR()]) / UDP() / ("A" * 10)
 bpkt = IP(str(pkt))
 assert bpkt.chksum == 0xf0bc and bpkt.payload.chksum == 0xbb17
+
+= Layer binding
+
+* Test DestMACField & DestIPField
+pkt = Ether(str(Ether()/IP()/UDP(dport=5353)/DNS()))
+assert isinstance(pkt, Ether) and pkt.dst == '01:00:5e:00:00:fb'
+pkt = pkt.payload
+assert isinstance(pkt, IP) and pkt.dst == '224.0.0.251'
+pkt = pkt.payload
+assert isinstance(pkt, UDP) and pkt.dport == 5353
+pkt = pkt.payload
+assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)
+
+* Same with IPv6
+pkt = Ether(str(Ether()/IPv6()/UDP(dport=5353)/DNS()))
+assert isinstance(pkt, Ether) and pkt.dst == '33:33:00:00:00:fb'
+pkt = pkt.payload
+assert isinstance(pkt, IPv6) and pkt.dst == 'ff02::fb'
+pkt = pkt.payload
+assert isinstance(pkt, UDP) and pkt.dport == 5353
+pkt = pkt.payload
+assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -119,7 +119,7 @@ else:
 = equality
 ~ basic
 w=Ether()/IP()/UDP(dport=53)
-x=Ether()/IP(dst="127.0.0.1")/UDP()
+x=Ether()/IP(version=4)/UDP()
 y=Ether()/IP()/UDP(dport=4)
 z=Ether()/IP()/UDP()/NTP()
 t=Ether()/IP()/TCP()


### PR DESCRIPTION
This PR introduces DestIPField and DestIPv6Field, similar to DestMACField, to be used when a default destination address can be guessed based on the payload. The only use I can see for that for now is multicast protocols (such as mDNS), but it might as well be useful in other situations.