### PR TITLE
[cleanup] remove trailing whitespaces (pep8 W291, W293) with autopep8

### DIFF
--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -32,8 +32,8 @@ class AnsweringMachine(object):
     send_options = { "verbose":0 }
     send_options_list = ["iface", "inter", "loop", "verbose"]
     send_function = staticmethod(send)
-    
-    
+
+
     def __init__(self, **kargs):
         self.mode = 0
         if self.filter:
@@ -54,7 +54,7 @@ class AnsweringMachine(object):
             if attr in d:
                 return d[attr]
         raise AttributeError,attr
-                
+
     def __setattr__(self, attr, val):
         mode = self.__dict__.get("mode",0)
         if mode == 0:
@@ -82,7 +82,7 @@ class AnsweringMachine(object):
                 k = self.optam0.copy()
                 k.update(kargs)
                 self.parse_options(**k)
-                kargs = k 
+                kargs = k
             omode = self.__dict__.get("mode",0)
             self.__dict__["mode"] = mode
             self.parse_options(**kargs)
@@ -124,7 +124,7 @@ class AnsweringMachine(object):
             self.sniff()
         except KeyboardInterrupt:
             print "Interrupted by user"
-        
+
     def sniff(self):
         sniff(**self.optsniff)
 

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -37,12 +37,12 @@ except ImportError:
 
 
 def str2mac(s):
-    return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
+    return ("%02x:"*6)[:-1] % tuple(map(ord, s))
 
 
 def get_if_addr(iff):
     return socket.inet_ntoa(get_if_raw_addr(iff))
-    
+
 def get_if_hwaddr(iff):
     addrfamily, mac = get_if_raw_hwaddr(iff)
     if addrfamily in [ARPHDR_ETHER,ARPHDR_LOOPBACK]:
@@ -105,7 +105,7 @@ def get_if_addr6(iff):
     for x in in6_getifaddr():
         if x[2] == iff and x[1] == IPV6_ADDR_GLOBAL:
             return x[0]
-        
+
     return None
 
 def get_if_raw_addr6(iff):
@@ -117,5 +117,5 @@ def get_if_raw_addr6(iff):
     ip6= get_if_addr6(iff)
     if ip6 is not None:
         return inet_pton(socket.AF_INET6, ip6)
-    
+
     return None

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -24,14 +24,14 @@ from scapy.arch.common import get_if
 
 
 # From bits/ioctls.h
-SIOCGIFHWADDR  = 0x8927          # Get hardware address    
-SIOCGIFADDR    = 0x8915          # get PA address          
-SIOCGIFNETMASK = 0x891b          # get network PA mask     
-SIOCGIFNAME    = 0x8910          # get iface name          
-SIOCSIFLINK    = 0x8911          # set iface channel       
-SIOCGIFCONF    = 0x8912          # get iface list          
-SIOCGIFFLAGS   = 0x8913          # get flags               
-SIOCSIFFLAGS   = 0x8914          # set flags               
+SIOCGIFHWADDR  = 0x8927          # Get hardware address
+SIOCGIFADDR    = 0x8915          # get PA address
+SIOCGIFNETMASK = 0x891b          # get network PA mask
+SIOCGIFNAME    = 0x8910          # get iface name
+SIOCSIFLINK    = 0x8911          # set iface channel
+SIOCGIFCONF    = 0x8912          # get iface list
+SIOCGIFFLAGS   = 0x8913          # get flags
+SIOCSIFFLAGS   = 0x8914          # set flags
 SIOCGIFINDEX   = 0x8933          # name -> if_index mapping
 SIOCGIFCOUNT   = 0x8938          # get number of devices
 SIOCGSTAMP     = 0x8906          # get packet timestamp (as a timeval)
@@ -89,7 +89,7 @@ with os.popen("%s -V 2> /dev/null" % conf.prog.tcpdump) as _f:
     else:
         TCPDUMP=1
 del(_f)
-    
+
 
 def get_if_raw_hwaddr(iff):
     return struct.unpack("16xh6s8x",get_if(iff,SIOCGIFHWADDR))
@@ -115,7 +115,7 @@ def get_if_list():
     return lst
 def get_working_if():
     for i in get_if_list():
-        if i == LOOPBACK_NAME:                
+        if i == LOOPBACK_NAME:
             continue
         ifflags = struct.unpack("16xH14x",get_if(i,SIOCGIFFLAGS))[0]
         if ifflags & IFF_UP:
@@ -123,7 +123,7 @@ def get_working_if():
     return LOOPBACK_NAME
 
 def attach_filter(s, bpf_filter, iface):
-    # XXX We generate the filter on the interface conf.iface 
+    # XXX We generate the filter on the interface conf.iface
     # because tcpdump open the "any" interface and ppp interfaces
     # in cooked mode. As we use them in raw mode, the filter will not
     # work... one solution could be to use "any" interface and translate
@@ -153,7 +153,7 @@ def attach_filter(s, bpf_filter, iface):
     if scapy.arch.X86_64 or scapy.arch.ARM_64:
         bpfh = struct.pack("HL", nb, id(bpf)+36)
     else:
-        bpfh = struct.pack("HI", nb, id(bpf)+20)  
+        bpfh = struct.pack("HI", nb, id(bpf)+20)
     s.setsockopt(SOL_SOCKET, SO_ATTACH_FILTER, bpfh)
 
 def set_promisc(s,iff,val=1):
@@ -207,7 +207,7 @@ def read_routes():
                        socket.htonl(long(msk,16))&0xffffffffL,
                        scapy.utils.inet_ntoa(struct.pack("I",long(gw,16))),
                        iff, ifaddr))
-    
+
     f.close()
     return routes
 
@@ -227,7 +227,7 @@ def in6_getifaddr():
     ret = []
     try:
         f = open("/proc/net/if_inet6","r")
-    except IOError, err:    
+    except IOError, err:
         return ret
     l = f.readlines()
     for i in l:
@@ -258,8 +258,8 @@ def read_routes6():
         ret = struct.unpack('4s4s4s4s4s4s4s4s', p)
         ret = ':'.join(ret)
         return scapy.utils6.in6_ptop(ret)
-    
-    lifaddr = in6_getifaddr() 
+
+    lifaddr = in6_getifaddr()
     for l in f.readlines():
         d,dp,s,sp,nh,m,rc,us,fl,dev = l.split()
         fl = int(fl, 16)
@@ -281,11 +281,11 @@ def read_routes6():
         else:
             devaddrs = filter(lambda x: x[2] == dev, lifaddr)
             cset = scapy.utils6.construct_source_candidate_set(d, dp, devaddrs, LOOPBACK_NAME)
-        
+
         if len(cset) != 0:
             routes.append((d, dp, nh, dev, cset))
     f.close()
-    return routes   
+    return routes
 
 
 def get_if_index(iff):
@@ -381,11 +381,11 @@ class L3PacketSocket(SuperSocket):
             pkt = conf.raw_layer(pkt)
         if lvl == 2:
             pkt = pkt.payload
-            
+
         if pkt is not None:
             pkt.time = get_last_packet_timestamp(self.ins)
         return pkt
-    
+
     def send(self, x):
         iff,a,gw  = x.route()
         if iff is None:
@@ -419,7 +419,7 @@ class L2Socket(SuperSocket):
         self.iface = conf.iface if iface is None else iface
         self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))
         self.ins.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 0)
-        if not nofilter: 
+        if not nofilter:
             if conf.except_filter:
                 if filter:
                     filter = "(%s) and not (%s)" % (filter, conf.except_filter)
@@ -538,7 +538,7 @@ class L2ListenSocket(SuperSocket):
         pkt.time = get_last_packet_timestamp(self.ins)
         pkt.direction = sa_ll[2]
         return pkt
-    
+
     def send(self, x):
         raise Scapy_Exception("Can't send anything with L2ListenSocket")
 

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -56,7 +56,7 @@ if conf.use_winpcapy:
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
     ret = "\0\0\0\0\0\0"
-    
+
     if pcap_findalldevs(byref(devs), err) < 0:
       return ret
     try:
@@ -147,7 +147,7 @@ if conf.use_winpcapy:
           if sys.platform.startswith("win"):
             error("Cannot get selectable PCAP fd on Windows")
             return 0
-          return pcap_get_selectable_fd(self.pcap) 
+          return pcap_get_selectable_fd(self.pcap)
       def setfilter(self, f):
           filter_exp = create_string_buffer(f)
           if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:
@@ -192,10 +192,10 @@ if conf.use_winpcapy:
                       filter = "not (%s)" % conf.except_filter
               if filter:
                   self.ins.setfilter(filter)
-  
+
       def close(self):
           self.ins.close()
-          
+
       def recv(self, x=MTU):
           ll = self.ins.datalink()
           if ll in conf.l2types:
@@ -221,10 +221,10 @@ if conf.use_winpcapy:
               pkt = conf.raw_layer(pkt)
           pkt.time = ts
           return pkt
-  
+
       def send(self, x):
           raise Scapy_Exception("Can't send anything with L2pcapListenSocket")
-  
+
 
   conf.L2listen = L2pcapListenSocket
   class L2pcapSocket(SuperSocket):
@@ -269,13 +269,13 @@ if conf.use_winpcapy:
           else:
               cls = conf.default_l2
               warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
-  
+
           pkt = self.ins.next()
           if pkt is not None:
               ts,pkt = pkt
           if pkt is None:
               return
-          
+
           try:
               pkt = cls(pkt)
           except KeyboardInterrupt:
@@ -286,13 +286,13 @@ if conf.use_winpcapy:
               pkt = conf.raw_layer(pkt)
           pkt.time = ts
           return pkt
-  
+
       def nonblock_recv(self):
           self.ins.setnonblock(1)
           p = self.recv(MTU)
           self.ins.setnonblock(0)
           return p
-  
+
       def close(self):
           if hasattr(self, "ins"):
               self.ins.close()
@@ -303,7 +303,7 @@ if conf.use_winpcapy:
       #def __init__(self, iface = None, type = ETH_P_ALL, filter=None, nofilter=0):
       #    L2pcapSocket.__init__(self, iface, type, filter, nofilter)
       def recv(self, x = MTU):
-          r = L2pcapSocket.recv(self, x) 
+          r = L2pcapSocket.recv(self, x)
           if r:
             return r.payload
           else:
@@ -316,8 +316,8 @@ if conf.use_winpcapy:
           return self.ins.send(sx)
   conf.L2socket=L2pcapSocket
   conf.L3socket=L3pcapSocket
-    
-if conf.use_pcap:    
+
+if conf.use_pcap:
 
 
 
@@ -333,7 +333,7 @@ if conf.use_pcap:
             else:
                 raise
     if conf.use_pcap:
-        
+
         # From BSD net/bpf.h
         #BIOCIMMEDIATE=0x80044270
         BIOCIMMEDIATE=-2147204496
@@ -345,7 +345,7 @@ if conf.use_pcap:
                         self.pcap = pcap.pcap(device, snaplen, promisc, immediate=1, timeout_ms=to_ms)
                     except TypeError:
                         # Older pypcap versions do not support the timeout_ms argument
-                        self.pcap = pcap.pcap(device, snaplen, promisc, immediate=1)                    
+                        self.pcap = pcap.pcap(device, snaplen, promisc, immediate=1)
                 def __getattr__(self, attr):
                     return getattr(self.pcap, attr)
                 def __del__(self):
@@ -368,7 +368,7 @@ if conf.use_pcap:
                     c = self.pcap.next()
                     if c is None:
                         return
-                    l,pkt,ts = c 
+                    l,pkt,ts = c
                     return ts,pkt
                 def __getattr__(self, attr):
                     return getattr(self.pcap, attr)
@@ -398,10 +398,10 @@ if conf.use_pcap:
                     warning("__del__: don't know how to close the file descriptor. Bugs ahead ! Please report this bug.")
             open_pcap = lambda *args,**kargs: _PcapWrapper_pcapy(*args,**kargs)
 
-        
+
         class PcapTimeoutElapsed(Scapy_Exception):
             pass
-    
+
         class L2pcapListenSocket(SuperSocket):
             desc = "read packets at layer 2 using libpcap"
             def __init__(self, iface = None, type = ETH_P_ALL, promisc=None, filter=None):
@@ -426,10 +426,10 @@ if conf.use_pcap:
                             filter = "not (%s)" % conf.except_filter
                     if filter:
                         self.ins.setfilter(filter)
-        
+
             def close(self):
                 del(self.ins)
-                
+
             def recv(self, x=MTU):
                 ll = self.ins.datalink()
                 if ll in conf.l2types:
@@ -437,7 +437,7 @@ if conf.use_pcap:
                 else:
                     cls = conf.default_l2
                     warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
-        
+
                 pkt = self.ins.next()
                 if scapy.arch.WINDOWS and pkt is None:
                         raise PcapTimeoutElapsed
@@ -453,11 +453,11 @@ if conf.use_pcap:
                         pkt = conf.raw_layer(pkt)
                     pkt.time = ts
                 return pkt
-        
+
             def send(self, x):
                 raise Scapy_Exception("Can't send anything with L2pcapListenSocket")
-        
-    
+
+
         conf.L2listen = L2pcapListenSocket
 
 
@@ -582,13 +582,13 @@ if conf.use_pcap and conf.use_dnet:
             else:
                 cls = conf.default_l2
                 warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
-    
+
             pkt = self.ins.next()
             if pkt is not None:
                 ts,pkt = pkt
             if pkt is None:
                 return
-    
+
             try:
                 pkt = cls(pkt)
             except KeyboardInterrupt:
@@ -599,19 +599,19 @@ if conf.use_pcap and conf.use_dnet:
                 pkt = conf.raw_layer(pkt)
             pkt.time = ts
             return pkt.payload
-    
+
         def nonblock_recv(self):
             self.ins.setnonblock(1)
             p = self.recv()
             self.ins.setnonblock(0)
             return p
-    
+
         def close(self):
             if hasattr(self, "ins"):
                 del(self.ins)
             if hasattr(self, "outs"):
                 del(self.outs)
-    
+
     class L2dnetSocket(SuperSocket):
         desc = "read/write packets at layer 2 using libdnet and libpcap"
         def __init__(self, iface = None, type = ETH_P_ALL, filter=None, nofilter=0):
@@ -649,13 +649,13 @@ if conf.use_pcap and conf.use_dnet:
             else:
                 cls = conf.default_l2
                 warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
-    
+
             pkt = self.ins.next()
             if pkt is not None:
                 ts,pkt = pkt
             if pkt is None:
                 return
-            
+
             try:
                 pkt = cls(pkt)
             except KeyboardInterrupt:
@@ -666,13 +666,13 @@ if conf.use_pcap and conf.use_dnet:
                 pkt = conf.raw_layer(pkt)
             pkt.time = ts
             return pkt
-    
+
         def nonblock_recv(self):
             self.ins.setnonblock(1)
             p = self.recv(MTU)
             self.ins.setnonblock(0)
             return p
-    
+
         def close(self):
             if hasattr(self, "ins"):
                 del(self.ins)
@@ -682,5 +682,5 @@ if conf.use_pcap and conf.use_dnet:
     conf.L3socket=L3dnetSocket
     conf.L2socket=L2dnetSocket
 
-        
-    
+
+

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -61,7 +61,7 @@ def read_routes():
             dest,gw,flg = rt[:3]
             netif = rt[4 + mtu_present + prio_present + refs_present]
         if flg.find("Lc") >= 0:
-            continue                
+            continue
         if dest == "default":
             dest = 0L
             netmask = 0L
@@ -100,7 +100,7 @@ def read_routes():
             routes.append((dest,netmask,gw,gw_if,gw_if_addr))
         else:
             warning("Did not find output interface to reach gateway %s" % gw)
-            
+
     return routes
 
 ############
@@ -141,7 +141,7 @@ def _in6_getifaddr(ifname):
 
     return ret
 
-def in6_getifaddr():    
+def in6_getifaddr():
     """
     Returns a list of 3-tuples of the form (addr, scope, iface) where
     'addr' is the address of scope 'scope' associated to the interface
@@ -179,7 +179,7 @@ def in6_getifaddr():
     ret = []
     for i in splitted_line:
 	ret += _in6_getifaddr(i)
-    return ret	    
+    return ret
 
 def read_routes6():
     f = os.popen("netstat -rn -f inet6")
@@ -198,12 +198,12 @@ def read_routes6():
                 mtu_present = l.find("Mtu") >= 0
                 prio_present = l.find("Prio") >= 0
             continue
-        # gv 12/12/06: under debugging      
+        # gv 12/12/06: under debugging
         if scapy.arch.NETBSD or scapy.arch.OPENBSD:
             lspl = l.split()
             d,nh,fl = lspl[:3]
             dev = lspl[5+mtu_present+prio_present]
-        else:       # FREEBSD or DARWIN 
+        else:       # FREEBSD or DARWIN
             d,nh,fl,dev = l.split()[:4]
         if filter(lambda x: x[2] == dev, lifaddr) == []:
             continue
@@ -239,7 +239,7 @@ def read_routes6():
     return routes
 
 
-            
+
 
 
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -155,14 +155,14 @@ def win_find_exe(filename, installsubdir=None, env="ProgramFiles"):
         except IOError:
             path = filename
         else:
-            break        
+            break
     return path
 
 
 class WinProgPath(ConfClass):
     _default = "<System default>"
     # We try some magic to find the appropriate executables
-    pdfreader = win_find_exe("AcroRd32") 
+    pdfreader = win_find_exe("AcroRd32")
     psreader = win_find_exe("gsview32.exe", "Ghostgum/gsview")
     dot = win_find_exe("dot", "ATT/Graphviz/bin")
     tcpdump = win_find_exe("windump")
@@ -183,7 +183,7 @@ if conf.prog.powershell == "powershell":
     conf.prog.powershell = None
 
 class PcapNameNotFoundError(Scapy_Exception):
-    pass    
+    pass
 import platform
 
 def is_interface_valid(iface):
@@ -214,10 +214,10 @@ def get_ip_from_name(ifname, v6=False):
                                     ['Description', 'IPAddress']):
         if descr == ifname.strip():
             return ipaddr.split(",", 1)[v6].strip('{}').strip()
-        
+
 class NetworkInterface(object):
     """A network interface of your local host"""
-    
+
     def __init__(self, data=None):
         self.name = None
         self.ip = None
@@ -266,7 +266,7 @@ class NetworkInterface(object):
 from UserDict import UserDict
 
 class NetworkInterfaceDict(UserDict):
-    """Store information about network interfaces and convert between names""" 
+    """Store information about network interfaces and convert between names"""
     def load_from_powershell(self):
         for i in get_windows_if_list():
             try:
@@ -274,7 +274,7 @@ class NetworkInterfaceDict(UserDict):
                 self.data[interface.guid] = interface
             except (KeyError, PcapNameNotFoundError):
                 pass
-        
+
         if len(self.data) == 0:
             log_loading.warning("No match between your pcap and windows network interfaces found. "
                                 "You probably won't be able to send packets. "
@@ -314,7 +314,7 @@ class NetworkInterfaceDict(UserDict):
             if resolve_mac:
                 mac = conf.manufdb._resolve_MAC(mac)
             print "%s  %s  %s  %s" % (str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac)
-            
+
 IFACES = NetworkInterfaceDict()
 IFACES.load_from_powershell()
 
@@ -339,7 +339,7 @@ def dev_from_pcapname(pcap_name):
 def dev_from_index(if_index):
     """Return Windows adapter name for given Windows interface index"""
     return IFACES.dev_from_index(if_index)
-    
+
 def show_interfaces(resolve_mac=True):
     """Print list of available network interfaces"""
     return IFACES.show(resolve_mac)
@@ -401,13 +401,13 @@ def read_routes():
             routes = read_routes_xp()
         else:
             routes = read_routes_7()
-    except Exception as e:    
+    except Exception as e:
         log_loading.warning("Error building scapy routing table : %s"%str(e))
     else:
         if not routes:
             log_loading.warning("No default IPv4 routes found. Your Windows release may no be supported and you have to enter your routes manually")
     return routes
-       
+
 def read_routes_post2008():
     # XXX TODO: FIX THIS XXX
     routes = []
@@ -432,7 +432,7 @@ def read_routes_post2008():
             #     intf = pcapdnet.dnet.intf().get_dst(pcapdnet.dnet.addr(type=2, addrtxt=dest))
             # except OSError:
             #     log_loading.warning("Building Scapy's routing table: Couldn't get outgoing interface for destination %s" % dest)
-            #     continue               
+            #     continue
             routes.append((atol(match.group(2)), itom(int(match.group(3))),
                            match.group(4), iface, iface.ip))
     return routes
@@ -448,7 +448,7 @@ if conf.interactive_shell != 'ipython':
             import readline
             console = readline.GetOutputFile()
         except (ImportError, AttributeError):
-            log_loading.info("Could not get readline console. Will not interpret ANSI color codes.") 
+            log_loading.info("Could not get readline console. Will not interpret ANSI color codes.")
         else:
             conf.readfunc = readline.rl.readline
             orig_stdout = sys.stdout
@@ -457,7 +457,7 @@ if conf.interactive_shell != 'ipython':
 def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, multi=0):
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
-        
+
     if verbose is None:
         verbose = conf.verb
     debug.recv = plist.PacketList([],"Unanswered")
@@ -485,7 +485,7 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
 
     while retry >= 0:
         found=0
-    
+
         if timeout < 0:
             timeout = None
 
@@ -516,7 +516,7 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
                     except:
                         pass
             if WINDOWS or pid > 0:
-                # Timeout starts after last packet is sent (as in Unix version) 
+                # Timeout starts after last packet is sent (as in Unix version)
                 if timeout:
                     stoptime = time.time()+timeout
                 else:
@@ -571,15 +571,15 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
         remain = list(itertools.chain(*hsent.itervalues()))
         if multi:
             remain = [p for p in remain if not hasattr(p, '_answered')]
-            
+
         if autostop and len(remain) > 0 and len(remain) != len(tobesent):
             retry = autostop
-            
+
         tobesent = remain
         if len(tobesent) == 0:
             break
         retry -= 1
-        
+
     if conf.debug_match:
         debug.sent=plist.PacketList(remain[:],"Sent")
         debug.match=plist.SndRcvList(ans[:])
@@ -589,7 +589,7 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
         for s,r in ans:
             if hasattr(s, '_answered'):
                 del(s._answered)
-    
+
     if verbose:
         print "\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans)
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")

--- a/scapy/arch/winpcapy.py
+++ b/scapy/arch/winpcapy.py
@@ -51,7 +51,7 @@ class bpf_insn(Structure):
               ("jt",c_ubyte),
               ("jf",c_ubyte),
               ("k",bpf_u_int32)]
-    
+
 class bpf_program(Structure):
     pass
 bpf_program._fields_ = [('bf_len', u_int),
@@ -69,7 +69,7 @@ timeval._fields_ = [('tv_sec', c_long),
 
 ## sockaddr is used by pcap_addr.
 ## For exapmle if sa_family==socket.AF_INET then we need cast
-## with sockaddr_in 
+## with sockaddr_in
 if WIN32:
     class sockaddr(Structure):
         _fields_ = [("sa_family", c_ushort),
@@ -188,16 +188,16 @@ pcap_if._fields_ = [('next', POINTER(pcap_if)),
 
 ##define  PCAP_VERSION_MAJOR   2
 #   Major libpcap dump file version.
-PCAP_VERSION_MAJOR = 2 
+PCAP_VERSION_MAJOR = 2
 ##define  PCAP_VERSION_MINOR   4
 #   Minor libpcap dump file version.
-PCAP_VERSION_MINOR = 4 
+PCAP_VERSION_MINOR = 4
 ##define  PCAP_ERRBUF_SIZE   256
 #   Size to use when allocating the buffer that contains the libpcap errors.
-PCAP_ERRBUF_SIZE = 256 
+PCAP_ERRBUF_SIZE = 256
 ##define  PCAP_IF_LOOPBACK   0x00000001
 #   interface is loopback
-PCAP_IF_LOOPBACK = 1 
+PCAP_IF_LOOPBACK = 1
 ##define  MODE_CAPT   0
 #   Capture mode, to be used when calling pcap_setmode().
 MODE_CAPT = 0
@@ -243,7 +243,7 @@ pcap_addr_t = pcap_addr
 
 ##
 ## Unix-compatible Functions
-## These functions are part of the libpcap library, and therefore work both on Windows and on Linux. 
+## These functions are part of the libpcap library, and therefore work both on Windows and on Linux.
 ##
 
 #typedef void(* pcap_handler )(u_char *user, const struct pcap_pkthdr *pkt_header, const u_char *pkt_data)
@@ -499,7 +499,7 @@ pcap_dump_flush.restype = c_int
 pcap_dump_flush.argtypes = [POINTER(pcap_dumper_t)]
 
 #void pcap_dump_close (pcap_dumper_t *p)
-#   Closes a savefile. 
+#   Closes a savefile.
 pcap_dump_close = _lib.pcap_dump_close
 pcap_dump_close.restype = None
 pcap_dump_close.argtypes = [POINTER(pcap_dumper_t)]
@@ -507,7 +507,7 @@ pcap_dump_close.argtypes = [POINTER(pcap_dumper_t)]
 if not WIN32:
 
     pcap_get_selectable_fd = _lib.pcap_get_selectable_fd
-    pcap_get_selectable_fd.restype = c_int    
+    pcap_get_selectable_fd.restype = c_int
     pcap_get_selectable_fd.argtypes = [POINTER(pcap_t)]
 
 ###########################################
@@ -518,7 +518,7 @@ if not WIN32:
 ###########################################
 if WIN32:
     HANDLE = c_void_p
-    
+
     ##############
     ## Identifiers related to the new source syntax
     ##############
@@ -529,7 +529,7 @@ if WIN32:
     PCAP_SRC_FILE = 2
     PCAP_SRC_IFLOCAL = 3
     PCAP_SRC_IFREMOTE = 4
-    
+
     ##############
     ## Strings related to the new source syntax
     ##############
@@ -538,7 +538,7 @@ if WIN32:
     #String that will be used to determine the type of source in use (file, remote/local interface).
     PCAP_SRC_FILE_STRING="file://"
     PCAP_SRC_IF_STRING="rpcap://"
-    
+
     ##############
     ## Flags defined in the pcap_open() function
     ##############
@@ -556,7 +556,7 @@ if WIN32:
     # define  PCAP_OPENFLAG_MAX_RESPONSIVENESS   16
     #   This flag configures the adapter for maximum responsiveness.
     PCAP_OPENFLAG_MAX_RESPONSIVENESS=16
-    
+
     ##############
     ## Sampling methods defined in the pcap_setsampling() function
     ##############
@@ -569,7 +569,7 @@ if WIN32:
     #define   PCAP_SAMP_FIRST_AFTER_N_MS   2
     # It defines that we have to return 1 packet every N milliseconds.
     PCAP_SAMP_FIRST_AFTER_N_MS=2
-    
+
     ##############
     ## Authentication methods supported by the RPCAP protocol
     ##############
@@ -579,7 +579,7 @@ if WIN32:
     # define  RPCAP_RMTAUTH_PWD   1
     # It defines the username/password authentication.
     RPCAP_RMTAUTH_PWD=1
-    
+
 
     ##############
     ## Remote struct and defines
@@ -590,70 +590,70 @@ if WIN32:
     # define  RPCAP_HOSTLIST_SIZE   1024
     # Maximum lenght of an host name (needed for the RPCAP active mode).
     RPCAP_HOSTLIST_SIZE = 1024
-    
+
     class pcap_send_queue(Structure):
         _fields_=[("maxlen",c_uint),
                   ("len",c_uint),
                   ("buffer",c_char_p)]
-        
+
     ## struct   pcap_rmtauth
     ## This structure keeps the information needed to autheticate the user on a remote machine
     class pcap_rmtauth(Structure):
         _fields_=[("type",c_int),
                   ("username",c_char_p),
                   ("password",c_char_p)]
-    
+
     ## struct   pcap_samp
-    ## This structure defines the information related to sampling    
+    ## This structure defines the information related to sampling
     class pcap_samp(Structure):
         _fields_=[("method",c_int),
                   ("value",c_int)]
 
     #PAirpcapHandle   pcap_get_airpcap_handle (pcap_t *p)
     #   Returns the AirPcap handler associated with an adapter. This handler can be used to change the wireless-related settings of the CACE Technologies AirPcap wireless capture adapters.
-    
+
     #bool pcap_offline_filter (struct bpf_program *prog, const struct pcap_pkthdr *header, const u_char *pkt_data)
     #   Returns if a given filter applies to an offline packet.
     pcap_offline_filter = _lib.pcap_offline_filter
     pcap_offline_filter.restype = c_bool
     pcap_offline_filter.argtypes = [POINTER(bpf_program),POINTER(pcap_pkthdr),POINTER(u_char)]
-    
+
     #int pcap_live_dump (pcap_t *p, char *filename, int maxsize, int maxpacks)
     #   Save a capture to file.
     pcap_live_dump = _lib.pcap_live_dump
     pcap_live_dump.restype = c_int
     pcap_live_dump.argtypes = [POINTER(pcap_t), POINTER(c_char), c_int,c_int]
-    
+
     #int pcap_live_dump_ended (pcap_t *p, int sync)
     #   Return the status of the kernel dump process, i.e. tells if one of the limits defined with pcap_live_dump() has been reached.
     pcap_live_dump_ended = _lib.pcap_live_dump_ended
     pcap_live_dump_ended.restype = c_int
     pcap_live_dump_ended.argtypes = [POINTER(pcap_t), c_int]
-    
+
     #struct pcap_stat *  pcap_stats_ex (pcap_t *p, int *pcap_stat_size)
     #   Return statistics on current capture.
     pcap_stats_ex = _lib.pcap_stats_ex
     pcap_stats_ex.restype = POINTER(pcap_stat)
     pcap_stats_ex.argtypes = [POINTER(pcap_t), POINTER(c_int)]
-    
+
     #int pcap_setbuff (pcap_t *p, int dim)
     #   Set the size of the kernel buffer associated with an adapter.
     pcap_setbuff = _lib.pcap_setbuff
     pcap_setbuff.restype = c_int
     pcap_setbuff.argtypes = [POINTER(pcap_t), c_int]
-    
+
     #int pcap_setmode (pcap_t *p, int mode)
     #   Set the working mode of the interface p to mode.
     pcap_setmode = _lib.pcap_setmode
     pcap_setmode.restype = c_int
     pcap_setmode.argtypes = [POINTER(pcap_t), c_int]
-    
+
     #int pcap_setmintocopy (pcap_t *p, int size)
     #   Set the minumum amount of data received by the kernel in a single call.
     pcap_setmintocopy = _lib.pcap_setmintocopy
     pcap_setmintocopy.restype = c_int
     pcap_setmintocopy.argtype = [POINTER(pcap_t), c_int]
-    
+
     #HANDLE pcap_getevent (pcap_t *p)
     #   Return the handle of the event associated with the interface p.
     pcap_getevent = _lib.pcap_getevent
@@ -665,75 +665,75 @@ if WIN32:
     pcap_sendqueue_alloc = _lib.pcap_sendqueue_alloc
     pcap_sendqueue_alloc.restype = POINTER(pcap_send_queue)
     pcap_sendqueue_alloc.argtypes = [c_uint]
-    
+
     #void pcap_sendqueue_destroy (pcap_send_queue *queue)
     #   Destroy a send queue.
     pcap_sendqueue_destroy = _lib.pcap_sendqueue_destroy
     pcap_sendqueue_destroy.restype = None
     pcap_sendqueue_destroy.argtypes = [POINTER(pcap_send_queue)]
-    
+
     #int pcap_sendqueue_queue (pcap_send_queue *queue, const struct pcap_pkthdr *pkt_header, const u_char *pkt_data)
     #   Add a packet to a send queue.
     pcap_sendqueue_queue = _lib.pcap_sendqueue_queue
     pcap_sendqueue_queue.restype = c_int
     pcap_sendqueue_queue.argtypes = [POINTER(pcap_send_queue), POINTER(pcap_pkthdr), POINTER(u_char)]
-    
+
     #u_int pcap_sendqueue_transmit (pcap_t *p, pcap_send_queue *queue, int sync)
     #   Send a queue of raw packets to the network.
     pcap_sendqueue_transmit = _lib.pcap_sendqueue_transmit
     pcap_sendqueue_transmit.retype = u_int
     pcap_sendqueue_transmit.argtypes = [POINTER(pcap_t), POINTER(pcap_send_queue), c_int]
-    
+
     #int pcap_findalldevs_ex (char *source, struct pcap_rmtauth *auth, pcap_if_t **alldevs, char *errbuf)
     #   Create a list of network devices that can be opened with pcap_open().
     pcap_findalldevs_ex = _lib.pcap_findalldevs_ex
     pcap_findalldevs_ex.retype = c_int
     pcap_findalldevs_ex.argtypes = [STRING, POINTER(pcap_rmtauth), POINTER(POINTER(pcap_if_t)), STRING]
-    
+
     #int pcap_createsrcstr (char *source, int type, const char *host, const char *port, const char *name, char *errbuf)
     #   Accept a set of strings (host name, port, ...), and it returns the complete source string according to the new format (e.g. 'rpcap://1.2.3.4/eth0').
     pcap_createsrcstr = _lib.pcap_createsrcstr
     pcap_createsrcstr.restype = c_int
     pcap_createsrcstr.argtypes = [STRING, c_int, STRING, STRING, STRING, STRING]
-    
+
     #int pcap_parsesrcstr (const char *source, int *type, char *host, char *port, char *name, char *errbuf)
     #   Parse the source string and returns the pieces in which the source can be split.
     pcap_parsesrcstr = _lib.pcap_parsesrcstr
     pcap_parsesrcstr.retype = c_int
     pcap_parsesrcstr.argtypes = [STRING, POINTER(c_int), STRING, STRING, STRING, STRING]
-    
+
     #pcap_t *   pcap_open (const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *errbuf)
     #   Open a generic source in order to capture / send (WinPcap only) traffic.
     pcap_open = _lib.pcap_open
     pcap_open.restype = POINTER(pcap_t)
     pcap_open.argtypes = [STRING, c_int, c_int, c_int, POINTER(pcap_rmtauth), STRING]
-    
+
     #struct pcap_samp *  pcap_setsampling (pcap_t *p)
     #   Define a sampling method for packet capture.
     pcap_setsampling = _lib.pcap_setsampling
     pcap_setsampling.restype = POINTER(pcap_samp)
     pcap_setsampling.argtypes = [POINTER(pcap_t)]
-    
+
     #SOCKET pcap_remoteact_accept (const char *address, const char *port, const char *hostlist, char *connectinghost, struct pcap_rmtauth *auth, char *errbuf)
     #   Block until a network connection is accepted (active mode only).
     pcap_remoteact_accept = _lib.pcap_remoteact_accept
     pcap_remoteact_accept.restype = SOCKET
     pcap_remoteact_accept.argtypes = [STRING, STRING, STRING, STRING, POINTER(pcap_rmtauth), STRING]
-    
+
     #int pcap_remoteact_close (const char *host, char *errbuf)
     #   Drop an active connection (active mode only).
     pcap_remoteact_close = _lib.pcap_remoteact_close
     pcap_remoteact_close.restypes = c_int
     pcap_remoteact_close.argtypes = [STRING, STRING]
-    
+
     #void pcap_remoteact_cleanup ()
     #   Clean the socket that is currently used in waiting active connections.
     pcap_remoteact_cleanup = _lib.pcap_remoteact_cleanup
     pcap_remoteact_cleanup.restypes = None
     pcap_remoteact_cleanup.argtypes = []
-    
+
     #int pcap_remoteact_list (char *hostlist, char sep, int size, char *errbuf)
-    #   Return the hostname of the host that have an active connection with us (active mode only). 
+    #   Return the hostname of the host that have an active connection with us (active mode only).
     pcap_remoteact_list = _lib.pcap_remoteact_list
     pcap_remoteact_list.restype = c_int
     pcap_remoteact_list.argtypes = [STRING, c_char, c_int, STRING]

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -13,14 +13,14 @@ from config import conf
 
 class AS_resolver:
     server = None
-    options = "-k" 
+    options = "-k"
     def __init__(self, server=None, port=43, options=None):
         if server is not None:
             self.server = server
         self.port = port
         if options is not None:
             self.options = options
-        
+
     def _start(self):
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.connect((self.server,self.port))
@@ -29,7 +29,7 @@ class AS_resolver:
             self.s.recv(8192)
     def _stop(self):
         self.s.close()
-        
+
     def _parse_whois(self, txt):
         asn,desc = None,""
         for l in txt.splitlines():
@@ -68,7 +68,7 @@ class AS_resolver_riswhois(AS_resolver):
 class AS_resolver_radb(AS_resolver):
     server = "whois.ra.net"
     options = "-k -M"
-    
+
 
 class AS_resolver_cymru(AS_resolver):
     server = "whois.cymru.com"

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -67,7 +67,7 @@ class ASN1Codec(EnumElement):
         return cls._stem.safedec(s, context=context)
     def get_stem(cls):
         return cls.stem
-    
+
 
 class ASN1_Codecs_metaclass(Enum_metaclass):
     element_class = ASN1Codec
@@ -119,7 +119,7 @@ class ASN1_Class_metaclass(Enum_metaclass):
         rdict = {}
         for k,v in dct.iteritems():
             if type(v) is int:
-                v = ASN1Tag(k,v) 
+                v = ASN1Tag(k,v)
                 dct[k] = v
                 rdict[v] = v
             elif isinstance(v, ASN1Tag):
@@ -128,10 +128,10 @@ class ASN1_Class_metaclass(Enum_metaclass):
 
         cls = type.__new__(cls, name, bases, dct)
         for v in cls.__dict__.values():
-            if isinstance(v, ASN1Tag): 
+            if isinstance(v, ASN1Tag):
                 v.context = cls # overwrite ASN1Tag contexts, even cloned ones
         return cls
-            
+
 
 class ASN1_Class:
     __metaclass__ = ASN1_Class_metaclass
@@ -253,7 +253,7 @@ class ASN1_BOOLEAN(ASN1_INTEGER):
     # BER: 0 means False, anything else means True
     def __repr__(self):
         return str((not (self.val==0))) + " " + ASN1_Object.__repr__(self)
-    
+
 class ASN1_BIT_STRING(ASN1_Object):
     """
     /!\ ASN1_BIT_STRING values are bit strings like "011101".
@@ -361,7 +361,7 @@ class ASN1_SEQUENCE(ASN1_Object):
         for o in self.val:
             s += o.strshow(lvl=lvl+1)
         return s
-    
+
 class ASN1_SET(ASN1_SEQUENCE):
     tag = ASN1_Class_UNIVERSAL.SET
 
@@ -370,9 +370,9 @@ class ASN1_IPADDRESS(ASN1_STRING):
 
 class ASN1_COUNTER32(ASN1_INTEGER):
     tag = ASN1_Class_UNIVERSAL.COUNTER32
-    
+
 class ASN1_TIME_TICKS(ASN1_INTEGER):
     tag = ASN1_Class_UNIVERSAL.TIME_TICKS
-   
+
 
 conf.ASN1_default_codec = ASN1_Codecs.BER

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -79,7 +79,7 @@ def BER_len_dec(s):
             ll <<= 8L
             ll |= ord(c)
         return ll,s[l+1:]
-        
+
 def BER_num_enc(l, size=1):
         x=[]
         while l or size>0:
@@ -162,7 +162,7 @@ class BERcodec_Object:
     def check_string(cls, s):
         if not s:
             raise BER_Decoding_Error("%s: Got empty object while expecting tag %r" %
-                                     (cls.__name__,cls.tag), remaining=s)        
+                                     (cls.__name__,cls.tag), remaining=s)
     @classmethod
     def check_type(cls, s):
         cls.check_string(s)
@@ -263,7 +263,7 @@ class BERcodec_INTEGER(BERcodec_Object):
                 x <<= 8
                 x |= ord(c)
         return cls.asn1_object(x),t
-    
+
 class BERcodec_BOOLEAN(BERcodec_INTEGER):
     tag = ASN1_Class_UNIVERSAL.BOOLEAN
 
@@ -388,7 +388,7 @@ class BERcodec_SEQUENCE(BERcodec_Object):
                 if err.decoded is not None:
                     obj.append(err.decoded)
                 err.decoded = obj
-                raise 
+                raise
             obj.append(o)
         if len(st) < l:
             raise BER_Decoding_Error("Not enough bytes to decode sequence", decoded=obj)
@@ -404,7 +404,7 @@ class BERcodec_IPADDRESS(BERcodec_STRING):
         try:
             s = inet_aton(ipaddr_ascii)
         except Exception:
-            raise BER_Encoding_Error("IPv4 address could not be encoded") 
+            raise BER_Encoding_Error("IPv4 address could not be encoded")
         return chr(cls.tag)+BER_len_enc(len(s))+s
     @classmethod
     def do_dec(cls, s, context=None, safe=False):

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -48,7 +48,7 @@ class MIBDict(DADict):
             p -= 1
         if p != 0 or xl[p] not in self:
             return x
-        xl[p] = self[xl[p]] 
+        xl[p] = self[xl[p]]
         return ".".join(xl[p:])
     def _make_graph(self, other_keys=[], **kargs):
         nodes = [(k, self[k]) for k in self.iterkeys()]
@@ -107,7 +107,7 @@ def mib_register(ident, value, the_mib, unresolved):
                 i = 0
             else:
                 i += 1
-                    
+
         return True
 
 

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -33,7 +33,7 @@ class ASN1F_field(ASN1F_element):
     islist = 0
     ASN1_tag = ASN1_Class_UNIVERSAL.ANY
     context = ASN1_Class_UNIVERSAL
-    
+
     def __init__(self, name, default, context=None,
                  implicit_tag=None, explicit_tag=None):
         self.context = context
@@ -111,7 +111,7 @@ class ASN1F_field(ASN1F_element):
             return c,s
         else:
             return None,s
- 
+
     def build(self, pkt):
         return self.i2m(pkt, getattr(pkt, self.name))
     def dissect(self, pkt, s):
@@ -134,7 +134,7 @@ class ASN1F_field(ASN1F_element):
         return getattr(pkt, self.name) is None
     def get_fields_list(self):
         return [self]
-    
+
     def __hash__(self):
         return hash(self.name)
     def __str__(self):
@@ -182,7 +182,7 @@ class ASN1F_enum_INTEGER(ASN1F_INTEGER):
         if type(x) is list:
             return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
         else:
-            return self.any2i_one(pkt, x)        
+            return self.any2i_one(pkt, x)
     def i2repr_one(self, pkt, x):
         if x is not None:
             r = self.i2s.get(x)
@@ -206,7 +206,7 @@ class ASN1F_BIT_STRING(ASN1F_field):
                              explicit_tag=explicit_tag)
     def randval(self):
         return RandString(RandNum(0, 1000))
-    
+
 class ASN1F_STRING(ASN1F_field):
     ASN1_tag = ASN1_Class_UNIVERSAL.STRING
     def randval(self):
@@ -234,7 +234,7 @@ class ASN1F_T61_STRING(ASN1F_STRING):
 
 class ASN1F_IA5_STRING(ASN1F_STRING):
     ASN1_tag = ASN1_Class_UNIVERSAL.IA5_STRING
-   
+
 class ASN1F_UTC_TIME(ASN1F_STRING):
     ASN1_tag = ASN1_Class_UNIVERSAL.UTC_TIME
 
@@ -246,10 +246,10 @@ class ASN1F_ISO646_STRING(ASN1F_STRING):
 
 class ASN1F_UNIVERSAL_STRING(ASN1F_STRING):
     ASN1_tag = ASN1_Class_UNIVERSAL.UNIVERSAL_STRING
-   
+
 class ASN1F_BMP_STRING(ASN1F_STRING):
     ASN1_tag = ASN1_Class_UNIVERSAL.BMP_STRING
-   
+
 class ASN1F_SEQUENCE(ASN1F_field):
     ASN1_tag = ASN1_Class_UNIVERSAL.SEQUENCE
     holds_packets = 1
@@ -357,7 +357,7 @@ class ASN1F_SET_OF(ASN1F_SEQUENCE_OF):
     ASN1_tag = ASN1_Class_UNIVERSAL.SET
 
 class ASN1F_IPADDRESS(ASN1F_STRING):
-    ASN1_tag = ASN1_Class_UNIVERSAL.IPADDRESS    
+    ASN1_tag = ASN1_Class_UNIVERSAL.IPADDRESS
 
 class ASN1F_TIME_TICKS(ASN1F_INTEGER):
     ASN1_tag = ASN1_Class_UNIVERSAL.TIME_TICKS

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -18,12 +18,12 @@ class ASN1Packet_metaclass(Packet_metaclass):
 class ASN1_Packet(Packet):
     __metaclass__ = ASN1Packet_metaclass
     ASN1_root = None
-    ASN1_codec = None    
+    ASN1_codec = None
     def self_build(self):
         if self.raw_packet_cache is not None:
             return self.raw_packet_cache
-        return self.ASN1_root.build(self)    
+        return self.ASN1_root.build(self)
     def do_dissect(self, x):
         return self.ASN1_root.dissect(self, x)
-        
+
 

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -59,7 +59,7 @@ class _instance_state:
         return self.im_self.remove_breakpoints(self.im_func)
     def unintercepts(self):
         return self.im_self.remove_interception_points(self.im_func)
-        
+
 
 ##############
 ## Automata ##
@@ -232,7 +232,7 @@ class Automaton_metaclass(type):
 
         decorated = [v for v in members.itervalues()
                      if type(v) is types.FunctionType and hasattr(v, "atmt_type")]
-        
+
         for m in decorated:
             if m.atmt_type == ATMT.STATE:
                 s = m.atmt_state
@@ -245,7 +245,7 @@ class Automaton_metaclass(type):
                     cls.initial_states.append(m)
             elif m.atmt_type in [ATMT.CONDITION, ATMT.RECV, ATMT.TIMEOUT, ATMT.IOEVENT]:
                 cls.actions[m.atmt_condname] = []
-    
+
         for m in decorated:
             if m.atmt_type == ATMT.CONDITION:
                 cls.conditions[m.atmt_state].append(m)
@@ -261,7 +261,7 @@ class Automaton_metaclass(type):
             elif m.atmt_type == ATMT.ACTION:
                 for c in m.atmt_cond:
                     cls.actions[c].append(m)
-            
+
 
         for v in cls.timeout.itervalues():
             v.sort(lambda (t1,f1),(t2,f2): cmp(t1,t2))
@@ -280,7 +280,7 @@ class Automaton_metaclass(type):
 
     def graph(self, **kargs):
         s = 'digraph "%s" {\n'  % self.__class__.__name__
-        
+
         se = "" # Keep initial nodes at the begining for better rendering
         for st in self.states.itervalues():
             if st.atmt_initial:
@@ -295,7 +295,7 @@ class Automaton_metaclass(type):
             for n in st.atmt_origfunc.func_code.co_names+st.atmt_origfunc.func_code.co_consts:
                 if n in self.states:
                     s += '\t"%s" -> "%s" [ color=green ];\n' % (st.atmt_state,n)
-            
+
 
         for c,k,v in ([("purple",k,v) for k,v in self.conditions.items()]+
                       [("red",k,v) for k,v in self.recv_conditions.items()]+
@@ -313,13 +313,13 @@ class Automaton_metaclass(type):
                     continue
                 for n in f.func_code.co_names+f.func_code.co_consts:
                     if n in self.states:
-                        l = "%s/%.1fs" % (f.atmt_condname,t)                        
+                        l = "%s/%.1fs" % (f.atmt_condname,t)
                         for x in self.actions[f.atmt_condname]:
                             l += "\\l>[%s]" % x.func_name
                         s += '\t"%s" -> "%s" [label="%s",color=blue];\n' % (k,n,l)
         s += "}\n"
         return do_graph(s, **kargs)
-        
+
 
 
 class Automaton:
@@ -329,7 +329,7 @@ class Automaton:
     def parse_args(self, debug=0, store=1, **kargs):
         self.debug_level=debug
         self.socket_kargs = kargs
-        self.store_packets = store        
+        self.store_packets = store
 
     def master_filter(self, pkt):
         return True
@@ -354,7 +354,7 @@ class Automaton:
         def write(self, msg):
             return os.write(self.wr,msg)
         def recv(self, n=65535):
-            return self.read(n)        
+            return self.read(n)
         def send(self, msg):
             return self.write(msg)
 
@@ -369,7 +369,7 @@ class Automaton:
         def recv(self, n=None):
             return self.rd.recv(n)
         def read(self, n=None):
-            return self.rd.recv(n)        
+            return self.rd.recv(n)
         def send(self, msg):
             return self.wr.send(msg)
         def write(self, msg):
@@ -390,7 +390,7 @@ class Automaton:
         pass
     class AutomatonStopped(AutomatonException):
         pass
-    
+
     class Breakpoint(AutomatonStopped):
         pass
     class Singlestep(AutomatonStopped):
@@ -407,7 +407,7 @@ class Automaton:
     ## Services
     def debug(self, lvl, msg):
         if self.debug_level >= lvl:
-            log_interactive.debug(msg)            
+            log_interactive.debug(msg)
 
     def send(self, pkt):
         if self.state.state in self.interception_points:
@@ -429,7 +429,7 @@ class Automaton:
                 raise self.AutomatonError("INTERCEPT: unkown verdict: %r" % cmd.type)
         self.my_send(pkt)
         self.debug(3,"SENT : %s" % pkt.summary())
-        
+
         if self.store_packets:
             self.packets.append(pkt.copy())
 
@@ -458,7 +458,7 @@ class Automaton:
             extfd = external_fd.get(n)
             if type(extfd) is not tuple:
                 extfd = (extfd,extfd)
-            ioin,ioout = extfd                
+            ioin,ioout = extfd
             if ioin is None:
                 ioin = ObjectPipe()
             elif type(ioin) is not types.InstanceType:
@@ -469,22 +469,22 @@ class Automaton:
                 ioout = self._IO_fdwrapper(None,ioout)
 
             self.ioin[n] = ioin
-            self.ioout[n] = ioout 
+            self.ioout[n] = ioout
             ioin.ioname = n
             ioout.ioname = n
             setattr(self.io, n, self._IO_mixer(ioout,ioin))
             setattr(self.oi, n, self._IO_mixer(ioin,ioout))
 
         for stname in self.states:
-            setattr(self, stname, 
+            setattr(self, stname,
                     _instance_state(getattr(self, stname)))
-        
+
         self.parse_args(*args, **kargs)
 
         self.start()
 
     def __iter__(self):
-        return self        
+        return self
 
     def __del__(self):
         self.stop()
@@ -509,7 +509,7 @@ class Automaton:
             self.debug(2, "%s [%s] not taken" % (cond.atmt_type, cond.atmt_condname))
 
     def _do_start(self, *args, **kargs):
-        
+
         thread.start_new_thread(self._do_control, args, kargs)
 
 
@@ -522,7 +522,7 @@ class Automaton:
             k = self.init_kargs.copy()
             k.update(kargs)
             self.parse_args(*a,**k)
-    
+
             # Start the automaton
             self.state=self.initial_states[0](self)
             self.send_sock = self.send_sock_class()
@@ -563,49 +563,49 @@ class Automaton:
                 exc_info = sys.exc_info()
                 self.debug(3, "Transfering exception from tid=%i:\n%s"% (self.threadid, traceback.format_exc(exc_info)))
                 m = Message(type=_ATMT_Command.EXCEPTION, exception=e, exc_info=exc_info)
-                self.cmdout.send(m)        
+                self.cmdout.send(m)
             self.debug(3, "Stopping control thread (tid=%i)"%self.threadid)
             self.threadid = None
-    
+
     def _do_iter(self):
         while True:
             try:
                 self.debug(1, "## state=[%s]" % self.state.state)
-    
+
                 # Entering a new state. First, call new state function
-                if self.state.state in self.breakpoints and self.state.state != self.breakpointed: 
+                if self.state.state in self.breakpoints and self.state.state != self.breakpointed:
                     self.breakpointed = self.state.state
                     yield self.Breakpoint("breakpoint triggered on state %s" % self.state.state,
                                           state = self.state.state)
                 self.breakpointed = None
                 state_output = self.state.run()
                 if self.state.error:
-                    raise self.ErrorState("Reached %s: [%r]" % (self.state.state, state_output), 
+                    raise self.ErrorState("Reached %s: [%r]" % (self.state.state, state_output),
                                           result=state_output, state=self.state.state)
                 if self.state.final:
                     raise StopIteration(state_output)
-    
+
                 if state_output is None:
                     state_output = ()
                 elif type(state_output) is not list:
                     state_output = state_output,
-                
+
                 # Then check immediate conditions
                 for cond in self.conditions[self.state.state]:
                     self._run_condition(cond, *state_output)
-    
+
                 # If still there and no conditions left, we are stuck!
                 if ( len(self.recv_conditions[self.state.state]) == 0 and
                      len(self.ioevents[self.state.state]) == 0 and
                      len(self.timeout[self.state.state]) == 1 ):
                     raise self.Stuck("stuck in [%s]" % self.state.state,
                                      state=self.state.state, result=state_output)
-    
+
                 # Finally listen and pay attention to timeouts
                 expirations = iter(self.timeout[self.state.state])
                 next_timeout,timeout_func = expirations.next()
                 t0 = time.time()
-                
+
                 fds = [self.cmdin]
                 if len(self.recv_conditions[self.state.state]) > 0:
                     fds.append(self.listen_sock)
@@ -621,7 +621,7 @@ class Automaton:
                         remain = None
                     else:
                         remain = next_timeout-t
-    
+
                     self.debug(5, "Select on %r" % fds)
                     r,_,_ = select(fds,[],[],remain)
                     self.debug(5, "Selected %r" % r)
@@ -643,7 +643,7 @@ class Automaton:
                             for ioevt in self.ioevents[self.state.state]:
                                 if ioevt.atmt_ioname == fd.ioname:
                                     self._run_condition(ioevt, fd, *state_output)
-    
+
             except ATMT.NewStateRequested,state_req:
                 self.debug(2, "switching from [%s] to [%s]" % (self.state.state,state_req.state))
                 self.state = state_req
@@ -655,7 +655,7 @@ class Automaton:
             if hasattr(ipt,"atmt_state"):
                 ipt = ipt.atmt_state
             self.interception_points.add(ipt)
-        
+
     def remove_interception_points(self, *ipts):
         for ipt in ipts:
             if hasattr(ipt,"atmt_state"):
@@ -677,7 +677,7 @@ class Automaton:
     def start(self, *args, **kargs):
         if not self.started.locked():
             self._do_start(*args, **kargs)
-        
+
     def run(self, resume=None, wait=True):
         if resume is None:
             resume = Message(type = _ATMT_Command.RUN)
@@ -715,7 +715,7 @@ class Automaton:
                     break
                 for fd in r:
                     fd.recv()
-                
+
     def restart(self, *args, **kargs):
         self.stop()
         self.start(*args, **kargs)
@@ -733,5 +733,5 @@ class Automaton:
         rsm = Message(type = _ATMT_Command.REJECT)
         return self.run(resume=rsm, wait=wait)
 
-    
+
 

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -55,7 +55,7 @@ def autorun_commands(cmds,my_globals=None,verb=0):
                     sys.stderr.write(sys.__dict__.get("ps2","... "))
                 else:
                     sys.stderr.write(str(sys.__dict__.get("ps1",ColorPrompt())))
-                    
+
                 l = cmds.pop()
                 print l
                 cmd += "\n"+l
@@ -78,7 +78,7 @@ def autorun_get_interactive_session(cmds, **kargs):
             self.s = ""
         def write(self, x):
             self.s += x
-            
+
     sw = StringWriter()
     sstdout,sstderr = sys.stdout,sys.stderr
     try:
@@ -122,7 +122,7 @@ def autorun_get_html_interactive_session(cmds, **kargs):
             raise
     finally:
         conf.color_theme = ct
-    
+
     return to_html(s),res
 
 def autorun_get_latex_interactive_session(cmds, **kargs):

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -20,7 +20,7 @@ class Gen(object):
     __slots__ = []
     def __iter__(self):
         return iter([])
-    
+
 class SetGen(Gen):
     def __init__(self, values, _iterpacket=1):
         self._iterpacket=_iterpacket
@@ -79,7 +79,7 @@ class Net(Gen):
         self.parsed,self.netmask = self._parse_net(net)
 
 
-                                                                                               
+
     def __iter__(self):
         for d in xrange(*self.parsed[3]):
             for c in xrange(*self.parsed[2]):
@@ -90,8 +90,8 @@ class Net(Gen):
         ip = []
         for v in self.parsed:
             ip.append(str(random.randint(v[0],v[1]-1)))
-        return ".".join(ip) 
-                          
+        return ".".join(ip)
+
     def __repr__(self):
         return "Net(%r)" % self.repr
     def __eq__(self, other):
@@ -109,16 +109,16 @@ class Net(Gen):
             if a1 > a2 or b1 < b2:
                 return False
         return True
-    def __rcontains__(self, other):        
+    def __rcontains__(self, other):
         return self in self.__class__(other)
-        
+
 
 class OID(Gen):
     name = "OID"
     def __init__(self, oid):
-        self.oid = oid        
+        self.oid = oid
         self.cmpt = []
-        fmt = []        
+        fmt = []
         for i in oid.split("."):
             if "-" in i:
                 fmt.append("%i")
@@ -128,7 +128,7 @@ class OID(Gen):
         self.fmt = ".".join(fmt)
     def __repr__(self):
         return "OID(%r)" % self.oid
-    def __iter__(self):        
+    def __iter__(self):
         ii = [k[0] for k in self.cmpt]
         while 1:
             yield self.fmt % tuple(ii)
@@ -144,7 +144,7 @@ class OID(Gen):
                 i += 1
 
 
- 
+
 ######################################
 ## Packet abstract and base classes ##
 ######################################
@@ -236,7 +236,7 @@ class NewDefaultValues(Packet_metaclass):
     remove this:
         __metaclass__ = NewDefaultValues
     and it should still work.
-    """    
+    """
     def __new__(cls, name, bases, dct):
         from error import log_loading
         import traceback
@@ -249,7 +249,7 @@ class NewDefaultValues(Packet_metaclass):
             f,l="??",-1
             raise
         log_loading.warning("Deprecated (no more needed) use of NewDefaultValues  (%s l. %i)." % (f,l))
-        
+
         return super(NewDefaultValues, cls).__new__(cls, name, bases, dct)
 
 class BasePacket(Gen):

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -53,7 +53,7 @@ class Interceptor(object):
         setattr(obj, self.intname, val)
         self.hook(self.name, val, *self.args, **self.kargs)
 
-    
+
 class ProgPath(ConfClass):
     pdfreader = "acroread"
     psreader = "gv"
@@ -93,17 +93,17 @@ class Emphasize(ConfigFieldList):
 
 class Resolve(ConfigFieldList):
     pass
-    
+
 
 class Num2Layer:
     def __init__(self):
         self.num2layer = {}
         self.layer2num = {}
-        
+
     def register(self, num, layer):
         self.register_num2layer(num, layer)
         self.register_layer2num(num, layer)
-        
+
     def register_num2layer(self, num, layer):
         self.num2layer[num] = layer
     def register_layer2num(self, num, layer):
@@ -121,7 +121,7 @@ class Num2Layer:
         if item in self:
             return self[item]
         return default
-    
+
     def __repr__(self):
         lst = []
         for num,layer in self.num2layer.iteritems():
@@ -194,7 +194,7 @@ class CacheInstance(dict):
         if self.timeout is None:
             return dict.iteritems(self)
         t0=time.time()
-        return ((k,v) for (k,v) in dict.iteritems(self) if t0-self._timetable[k] < self.timeout) 
+        return ((k,v) for (k,v) in dict.iteritems(self) if t0-self._timetable[k] < self.timeout)
     def iterkeys(self):
         if self.timeout is None:
             return dict.iterkeys(self)
@@ -236,8 +236,8 @@ class CacheInstance(dict):
             for item in self.iteritems():
                 s.append(fmt % item)
         return "\n".join(s)
-            
-            
+
+
 
 
 class NetCache:
@@ -264,7 +264,7 @@ class NetCache:
             c.flush()
     def __repr__(self):
         return "\n".join(c.summary() for c in self._caches_list)
-        
+
 
 class LogLevel(object):
     def __get__(self, obj, otype):
@@ -272,7 +272,7 @@ class LogLevel(object):
     def __set__(self,obj,val):
         log_scapy.setLevel(val)
         obj._logLevel = val
-        
+
 
 
 def _prompt_changer(attr,val):
@@ -390,7 +390,7 @@ if not Conf.ipv6_enabled:
     for m in ["inet6","dhcp6"]:
         if m in Conf.load_layers:
             Conf.load_layers.remove(m)
-    
+
 
 conf=Conf()
 conf.logLevel=30 # 30=Warning

--- a/scapy/contrib/HomePlugAV.py
+++ b/scapy/contrib/HomePlugAV.py
@@ -62,7 +62,7 @@ DefaultVendor = "Qualcomm"
 # Qualcomm Vendor Specific Management Message Types;                    #
 # from https://github.com/qca/open-plc-utils/blob/master/mme/qualcomm.h #
 #########################################################################
-# Commented commands are already in HPAVTypeList, the other have to be implemted 
+# Commented commands are already in HPAVTypeList, the other have to be implemted
 QualcommTypeList = {  #0xA000 : "VS_SW_VER",
                     0xA004 : "VS_WR_MEM",
                     #0xA008 : "VS_RD_MEM",
@@ -140,7 +140,7 @@ def FragmentCond(pkt):
 class MACManagementHeader(Packet):
     name = "MACManagementHeader "
     if DefaultVendor == "Qualcomm":
-        HPAVTypeList.update(QualcommTypeList) 
+        HPAVTypeList.update(QualcommTypeList)
     fields_desc=[ ByteEnumField("version",0, HPAVversionList),
                 EnumField("HPtype" , 0xA000, HPAVTypeList, "<H") ]
 
@@ -154,7 +154,7 @@ class GetDeviceVersion(Packet):
                 ByteEnumField("DeviceID",0x20, HPAVDeviceIDList),
                 FieldLenField("VersionLen", None, count_of="DeviceVersion", fmt="B"),
                 StrLenField("DeviceVersion", "NoVersion\x00", length_from = lambda pkt: pkt.VersionLen),
-                StrLenField("DeviceVersion_pad", "\xcc\xcc\xcc\xcc\xcc"+"\x00"*59, length_from = lambda pkt: 64-pkt.VersionLen), 
+                StrLenField("DeviceVersion_pad", "\xcc\xcc\xcc\xcc\xcc"+"\x00"*59, length_from = lambda pkt: 64-pkt.VersionLen),
                 ByteEnumField("Upgradable", 0, {0:"False",1:"True"}) ]
 
 class NetworkInformationRequest(Packet):
@@ -185,7 +185,7 @@ class StationInfoV10(Packet):
     """
     name = "StationInfo"
     fields_desc=[ MACField("StationMAC", "00:00:00:00:00:00"),
-                XByteField("StationTerminalEID", 0x01), 
+                XByteField("StationTerminalEID", 0x01),
                 MACField("firstnodeMAC", "ff:ff:ff:ff:ff:ff"),
                 XByteField("TXaverage", 0x00),
                 XByteField("RXaverage", 0x00) ]
@@ -194,7 +194,7 @@ class StationInfoV10(Packet):
         return "", p
 
 #""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-#   Networks & Stations informations for MAC Management V1.1 
+#   Networks & Stations informations for MAC Management V1.1
 #""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 class NetworkInfoV11(Packet):
     """
@@ -210,7 +210,7 @@ class NetworkInfoV11(Packet):
                     MACField("CCoMACAdress", "00:00:00:00:00:00"),
                     XByteField("CCoTerminalEID", 0x01),
                     X3BytesField("reserved_3", 0x000000) ]
-    
+
     def extract_padding(self, p):
         return "", p
 
@@ -230,7 +230,7 @@ class StationInfoV11(Packet):
                 XByteField("reserved_s3", 0x00),
                 LEShortField("RXaverage", 0x0000),
                 XByteField("reserved_s4", 0x00) ]
-    
+
     def extract_padding(self, p):
         return "", p
 
@@ -280,7 +280,7 @@ class LoopbackRequest(Packet):
 
 class LoopbackConfirmation(Packet):
     name = "LoopbackConfirmation"
-    fields_desc=[ ByteEnumField("Status", 0x0, StatusCodes), 
+    fields_desc=[ ByteEnumField("Status", 0x0, StatusCodes),
                 ByteField("Duration", 0x01),
                 ShortField("LRlength", 0x0000) ]
 
@@ -291,13 +291,13 @@ class LoopbackConfirmation(Packet):
 class SetEncryptionKeyRequest(Packet):
     name = "SetEncryptionKeyRequest"
     fields_desc=[ XByteField("EKS", 0x00),
-                StrFixedLenField("NMK", 
+                StrFixedLenField("NMK",
                                 "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
                                 16),
                 XByteField("PayloadEncKeySelect", 0x00),
                 MACField("DestinationMAC", "ff:ff:ff:ff:ff:ff"),
-                StrFixedLenField("DAK", 
-                                "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 
+                StrFixedLenField("DAK",
+                                "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
                                 16) ]
 
 SetEncKey_Status = {    0x00 : "Success",
@@ -361,17 +361,17 @@ ANCodes = { 0x00 : "'In-home'",
 class SnifferIndicate(Packet):
     # TODO: Some bitfield have been regrouped for the moment => need more work on it
     name = "SnifferIndicate"
-    fields_desc=[ ByteEnumField("SnifferType", 0x0, SnifferTypeCodes), 
+    fields_desc=[ ByteEnumField("SnifferType", 0x0, SnifferTypeCodes),
                   ByteEnumField("Direction", 0x0, DirectionCodes),
                   LELongField("SystemTime", 0x0),
-                  LEIntField("BeaconTime", 0x0), 
+                  LEIntField("BeaconTime", 0x0),
                   XByteField("ShortNetworkID", 0x0),
                   ByteField("SourceTermEqID", 0),
                   ByteField("DestTermEqID", 0),
                   ByteField("LinkID", 0),
                   XByteField("PayloadEncrKeySelect", 0x0f),
                   ByteField("PendingPHYblock", 0),
-                  ByteField("BitLoadingEstim", 0), 
+                  ByteField("BitLoadingEstim", 0),
                   BitField("ToneMapIndex", 0, size=5),
                   BitField("NumberofSymbols", 0, size=2),
                   BitField("PHYblockSize", 0, size=1),
@@ -400,7 +400,7 @@ class SnifferIndicate(Packet):
 class ReadMACMemoryRequest(Packet):
     name = "ReadMACMemoryRequest"
     fields_desc=[ LEIntField("Address" , 0x00000000),
-                  LEIntField("Length", 0x00000400), 
+                  LEIntField("Length", 0x00000400),
                 ]
 
 ReadMACStatus = { 0x00 : "Success",
@@ -428,7 +428,7 @@ ModuleIDList = {    0x00 : "MAC Soft-Loader Image",
 def chksum32(data):
     cksum = 0
     for i in xrange(0, len(data), 4):
-        cksum = (cksum ^ struct.unpack('<I', data[i:i+4])[0]) & 0xffffffff   
+        cksum = (cksum ^ struct.unpack('<I', data[i:i+4])[0]) & 0xffffffff
     return (~cksum) & 0xffffffff
 
 class ReadModuleDataRequest(Packet):
@@ -446,7 +446,7 @@ class ReadModuleDataConfirmation(Packet):
                   XByteField("reserved_2", 0x00),
                   FieldLenField("DataLen", None, count_of="ModuleData", fmt="<H"),
                   LEIntField("Offset", 0x00000000),
-                  LEIntField("checksum", None), 
+                  LEIntField("checksum", None),
                   StrLenField("ModuleData", "\x00", length_from = lambda pkt: pkt.DataLen),
                 ]
 
@@ -495,18 +495,18 @@ class ClassifierPriorityMap(Packet):
                                 "\x00"*16,
                                 16),
                 ]
- 
+
     def extract_padding(self, p):
         return "", p
 
 class ClassifierObj(Packet):
     name = "ClassifierObj"
-    
+
     fields_desc=[ LEIntField("ClassifierPID", 0),
                   LEIntField("IndividualOperand", 0),
                   StrFixedLenField("ClassifierValue",
                                 "\x00"*16,
-                                16), 
+                                16),
                 ]
 
     def extract_padding(self, p):
@@ -515,7 +515,7 @@ class ClassifierObj(Packet):
 class AutoConnection(Packet):
     name = "AutoConnection"
 
-    fields_desc=[ XByteField("Action", 0x00), 
+    fields_desc=[ XByteField("Action", 0x00),
                   XByteField("ClassificationOperand", 0x00),
                   XShortField("NumClassifiers", 0x0000),
                   PacketListField("ClassifierObjs", "", ClassifierObj, length_from=lambda x: 24),
@@ -601,10 +601,10 @@ class ConfigBit(Packet):
                   BitField("DisableNetworkEventTrigger", 0, 1),
                   BitField("rsv1", 0, 6),
                 ]
-                
+
 class ContentionWindowTable(Packet):
     name = "ContentionWindowTable"
-    fields_desc=[ XShortField("element", 0), 
+    fields_desc=[ XShortField("element", 0),
                 ]
 
     def extract_padding(self, p):
@@ -731,7 +731,7 @@ class ModulePIB(Packet):
         ConditionalField(XByteField("NumOfPeerNodes", 0x00),
                          lambda pkt:(0x115 >= pkt.__offset and 0x116 <= pkt.__offset+pkt.__length)),
         ConditionalField(PacketListField("PeerNodes", "", PeerNode, length_from=lambda x: 56),
-                         lambda pkt:(0x116 >= pkt.__offset and 0x11C <= pkt.__offset+pkt.__length)), 
+                         lambda pkt:(0x116 >= pkt.__offset and 0x11C <= pkt.__offset+pkt.__length)),
         ConditionalField(StrFixedLenField("reserved_5",
                                           "\x00"*62,
                                           62),
@@ -827,7 +827,7 @@ class ModulePIB(Packet):
         ConditionalField(LEIntField("NumClassifierPriorityMaps" , 0),
                          lambda pkt:(0x228 >= pkt.__offset and 0x22C <= pkt.__offset+pkt.__length)),
         ConditionalField(LEIntField("NumAutoConnections" , 0),
-                         lambda pkt:(0x22C >= pkt.__offset and 0x230 <= pkt.__offset+pkt.__length)), 
+                         lambda pkt:(0x22C >= pkt.__offset and 0x230 <= pkt.__offset+pkt.__length)),
         ConditionalField(PacketListField("ClassifierPriorityMaps", "", ClassifierPriorityMap, length_from=lambda x: 224),
                          lambda pkt:(0x230 >= pkt.__offset and 0x244 <= pkt.__offset+pkt.__length)),
         ConditionalField(PacketListField("AutoConnections", "", AutoConnection, length_from=lambda x: 1600),
@@ -1079,7 +1079,7 @@ class ModulePIB(Packet):
 # Read MAC Memory
 #####################################################################
 
-StartMACCodes = { 0x00 : "Success" } 
+StartMACCodes = { 0x00 : "Success" }
 
 class StartMACRequest(Packet):
     name = "StartMACRequest"
@@ -1143,15 +1143,15 @@ CBImgTCodes = { 0x00 : "Generic Image",
 class ConfBlock(Packet):
     name = "ConfBlock"
     fields_desc=[ LEIntField("HeaderVersionNum", 0),
-                  LEIntField("ImgAddrNVM", 0), 
+                  LEIntField("ImgAddrNVM", 0),
                   LEIntField("ImgAddrSDRAM", 0),
                   LEIntField("ImgLength", 0),
                   LEIntField("ImgCheckSum", 0),
                   LEIntField("EntryPoint", 0),
                   XByteField("HeaderMinVersion", 0x00),
-                  ByteEnumField("HeaderImgType", 0x00, CBImgTCodes), 
-                  XShortField("HeaderIgnoreMask", 0x0000), 
-                  LEIntField("HeaderModuleID", 0), 
+                  ByteEnumField("HeaderImgType", 0x00, CBImgTCodes),
+                  XShortField("HeaderIgnoreMask", 0x0000),
+                  LEIntField("HeaderModuleID", 0),
                   LEIntField("HeaderModuleSubID", 0),
                   LEIntField("AddrNextHeaderNVM", 0),
                   LEIntField("HeaderChecksum", 0),
@@ -1213,8 +1213,8 @@ bind_layers( HomePlugAV, ReadMACMemoryRequest, { "HPtype" : 0xA008 } )
 bind_layers( HomePlugAV, ReadMACMemoryConfirmation, { "HPtype" : 0xA009 } )
 bind_layers( HomePlugAV, ReadModuleDataRequest, { "HPtype" : 0xA024 } )
 bind_layers( HomePlugAV, ReadModuleDataConfirmation, { "HPtype" : 0xA025 } )
-bind_layers( HomePlugAV, WriteModuleDataRequest, { "HPtype" : 0xA020 } ) 
-bind_layers( HomePlugAV, WriteModuleData2NVMRequest, { "HPtype" : 0xA028 } ) 
+bind_layers( HomePlugAV, WriteModuleDataRequest, { "HPtype" : 0xA020 } )
+bind_layers( HomePlugAV, WriteModuleData2NVMRequest, { "HPtype" : 0xA028 } )
 bind_layers( HomePlugAV, WriteModuleData2NVMConfirmation, { "HPtype" : 0xA029 } )
 bind_layers( HomePlugAV, NetworkInfoConfirmationV10, { "HPtype" : 0xA039, "version" : 0x00 } )
 bind_layers( HomePlugAV, NetworkInfoConfirmationV11, { "HPtype" : 0xA039, "version" : 0x01 } )
@@ -1226,7 +1226,7 @@ bind_layers( HomePlugAV, LoopbackConfirmation, { "HPtype" : 0xA049 } )
 bind_layers( HomePlugAV, SetEncryptionKeyRequest, { "HPtype" : 0xA050 } )
 bind_layers( HomePlugAV, SetEncryptionKeyConfirmation, { "HPtype" : 0xA051 } )
 bind_layers( HomePlugAV, ReadConfBlockRequest, { "HPtype" : 0xA058 } )
-bind_layers( HomePlugAV, ReadConfBlockConfirmation, { "HPtype" : 0xA059 } ) 
+bind_layers( HomePlugAV, ReadConfBlockConfirmation, { "HPtype" : 0xA059 } )
 bind_layers( HomePlugAV, QUAResetFactoryConfirm, { "HPtype" : 0xA07D } )
 bind_layers( HomePlugAV, GetNVMParametersRequest, { "HPtype" : 0xA010 } )
 bind_layers( HomePlugAV, GetNVMParametersConfirmation, { "HPtype" : 0xA011 } )
@@ -1236,4 +1236,4 @@ bind_layers( HomePlugAV, SnifferIndicate,  { "HPtype" : 0xA036 } )
 
 """
     Credit song : "Western Spaguetti - We are terrorists"
-""" 
+"""

--- a/scapy/contrib/avs.py
+++ b/scapy/contrib/avs.py
@@ -11,10 +11,10 @@ from scapy.layers.dot11 import *
 
 AVSWLANPhyType =  { 0 : "Unknown",
                     1 : "FHSS 802.11 '97",
-                    2 : "DSSS 802.11 '97", 
+                    2 : "DSSS 802.11 '97",
                     3 : "IR Baseband",
                     4 : "DSSS 802.11b",
-                    5 : "PBCC 802.11b", 
+                    5 : "PBCC 802.11b",
                     6 : "OFDM 802.11g",
                     7 : "PBCC 802.11g",
                     8 : "OFDM 802.11a" }

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python
 
 # http://trac.secdev.org/scapy/ticket/162
 
@@ -33,7 +33,7 @@ class BGPIPField(Field):
 		"""internal (ip as bytes, mask as int) to machine"""
 		mask, ip = i
 		ip = inet_aton( ip )
-		return struct.pack(">B",mask) + ip[:self.mask2iplen(mask)] 
+		return struct.pack(">B",mask) + ip[:self.mask2iplen(mask)]
 	def addfield(self, pkt, s, val):
 		return s+self.i2m(pkt, val)
 	def getfield(self, pkt, s):

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -35,7 +35,7 @@ class CARP(Packet):
 
 def build_hmac_sha1(pkt, pw = '\0' * 20, ip4l = [], ip6l = []):
     if not pkt.haslayer(CARP):
-        return None 
+        return None
 
     p = pkt[CARP]
     h = hmac.new(pw, digestmod = hashlib.sha1)

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -42,7 +42,7 @@ _cdp_tlv_cls = { 0x0001: "CDPMsgDeviceID",
                  0x0008: "CDPMsgProtoHello",
                  0x0009: "CDPMsgVTPMgmtDomain", # CDPv2
                  0x000a: "CDPMsgNativeVLAN",    # CDPv2
-                 0x000b: "CDPMsgDuplex",        # 
+                 0x000b: "CDPMsgDuplex",        #
 #                 0x000c: "CDPMsgGeneric",
 #                 0x000d: "CDPMsgGeneric",
                  0x000e: "CDPMsgVoIPVLANReply",
@@ -69,7 +69,7 @@ _cdp_tlv_types = { 0x0001: "Device ID",
                    0x0008: "Protocol Hello",
                    0x0009: "VTP Mangement Domain", # CDPv2
                    0x000a: "Native VLAN",    # CDPv2
-                   0x000b: "Duplex",        # 
+                   0x000b: "Duplex",        #
                    0x000c: "CDP Unknown command (send us a pcap file)",
                    0x000d: "CDP Unknown command (send us a pcap file)",
                    0x000e: "VoIP VLAN Reply",

--- a/scapy/contrib/gsm_um.py
+++ b/scapy/contrib/gsm_um.py
@@ -6341,7 +6341,7 @@ class CongestionLevelHdr(Packet):
     name = "Congestion Level"
     fields_desc = [
              XBitField("ieiCL", None, 4),
-             BitField("notDef", 0x0, 4) 
+             BitField("notDef", 0x0, 4)
              ]
 
 
@@ -11838,7 +11838,7 @@ class HighLayerCompatibility(Packet):
         return p + pay
 #
 # 10.5.4.16.1           Static conditions for the high layer
-# compatibility IE contents 
+# compatibility IE contents
 #
 
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -108,7 +108,7 @@ Selection_Mode = { 11111100: "MS or APN",
 
 TeardownInd_value = { 254: "False",
                       255: "True" }
- 
+
 class TBCDByteField(StrFixedLenField):
 
     def i2h(self, pkt, val):
@@ -247,7 +247,7 @@ class IE_NSAPI(Packet):
         return "",pkt
 
 class IE_ChargingCharacteristics(Packet):
-    # Way of informing both the SGSN and GGSN of the rules for 
+    # Way of informing both the SGSN and GGSN of the rules for
     name = "Charging Characteristics"
     fields_desc = [ ByteEnumField("ietype", 26, IEType),
                     # producing charging information based on operator configured triggers.
@@ -283,7 +283,7 @@ class IE_TraceType(Packet):
         return "",pkt
 
 class IE_EndUserAddress(Packet):
-    # Supply protocol specific information of the external packet 
+    # Supply protocol specific information of the external packet
     name = "End User Addresss"
     fields_desc = [ ByteEnumField("ietype", 128, IEType),
                     #         data network accessed by the GGPRS subscribers.
@@ -291,7 +291,7 @@ class IE_EndUserAddress(Packet):
                     #                1    Type (1byte)
                     #                2-3    Length (2bytes) - value 2
                     #                4    Spare + PDP Type Organization
-                    #                5    PDP Type Number    
+                    #                5    PDP Type Number
                     #            - Response
                     #                6-n    PDP Address
                     BitField("EndUserAddressLength", 2, 16),
@@ -310,7 +310,7 @@ class APNStrLenField(StrLenField):
             tmp_len = struct.unpack("!B", tmp_s[0])[0] + 1
             if tmp_len > len(tmp_s):
                 warning("APN prematured end of character-string (size=%i, remaining bytes=%i)" % (tmp_len, len(tmp_s)))
-            ret_s +=  tmp_s[1:tmp_len] 
+            ret_s +=  tmp_s[1:tmp_len]
             tmp_s = tmp_s[tmp_len:]
             if len(tmp_s) :
                 ret_s += "."
@@ -394,7 +394,7 @@ ietypecls = {   1: IE_Cause, 2: IE_IMSI, 3: IE_Routing, 14: IE_Recovery, 15: IE_
                17: IE_TEICP, 19: IE_Teardown, 20: IE_NSAPI, 26: IE_ChargingCharacteristics,
                27: IE_TraceReference, 28: IE_TraceType,
               128: IE_EndUserAddress, 131: IE_AccessPointName, 132: IE_ProtocolConfigurationOptions,
-              133: IE_GSNAddress, 134: IE_MSInternationalNumber, 152: IE_UserLocationInformation, 154: IE_IMEI } 
+              133: IE_GSNAddress, 134: IE_MSInternationalNumber, 152: IE_UserLocationInformation, 154: IE_IMEI }
 
 def IE_Dispatcher(s):
   """Choose the correct Information Element class."""
@@ -494,9 +494,9 @@ class GTPPDUNotificationRequest(Packet):
 class GTP_U_Header(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP-U Header"
-    # GTP-U protocol is used to transmit T-PDUs between GSN pairs (or between an SGSN and an RNC in UMTS), 
-    # encapsulated in G-PDUs. A G-PDU is a packet including a GTP-U header and a T-PDU. The Path Protocol 
-    # defines the path and the GTP-U header defines the tunnel. Several tunnels may be multiplexed on a single path. 
+    # GTP-U protocol is used to transmit T-PDUs between GSN pairs (or between an SGSN and an RNC in UMTS),
+    # encapsulated in G-PDUs. A G-PDU is a packet including a GTP-U header and a T-PDU. The Path Protocol
+    # defines the path and the GTP-U header defines the tunnel. Several tunnels may be multiplexed on a single path.
     fields_desc = [ BitField("version", 1,3),
                     BitField("PT", 1, 1),
                     BitField("Reserved", 0, 1),

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -39,7 +39,7 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
 
   """
   name = "IGMP"
-  
+
   igmptypes = { 0x11 : "Group Membership Query",
                 0x12 : "Version 1 - Membership Report",
                 0x16 : "Version 2 - Membership Report",
@@ -96,12 +96,12 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
     """
 
 # The rules are:
-#   1.  the Max Response time is meaningful only in Membership Queries and should be zero 
+#   1.  the Max Response time is meaningful only in Membership Queries and should be zero
 #       otherwise (RFC 2236, section 2.2)
 
     if (self.type != 0x11):         #rule 1
       self.mrtime = 0
-      
+
     if (self.adjust_ip(ip) == True):
       if (self.adjust_ether(ip, ether) == True): return True
     return False
@@ -118,7 +118,7 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
     if ip != None and ip.haslayer(IP) and ether != None and ether.haslayer(Ether):
       iplong = atol(ip.dst)
       ether.dst = "01:00:5e:%02x:%02x:%02x" % ( (iplong>>16)&0x7F, (iplong>>8)&0xFF, (iplong)&0xFF )
-      # print "igmpize ip " + ip.dst + " as mac " + ether.dst 
+      # print "igmpize ip " + ip.dst + " as mac " + ether.dst
       return True
     else:
       return False
@@ -141,7 +141,7 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
       if (self.type == 0x11):
         if (self.gaddr == "0.0.0.0"):
           ip.dst = "224.0.0.1"                   # IP rule 1
-          retCode = True                     
+          retCode = True
         elif isValidMCAddr(self.gaddr):
           ip.dst = self.gaddr                    # IP rule 3a
           retCode = True

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -13,7 +13,7 @@ from scapy.packet import *
 
 """
 
-#  TODO: Merge IGMPv3 packet Bindlayers correct for 
+#  TODO: Merge IGMPv3 packet Bindlayers correct for
 #        membership source/Group records
 #        ConditionalField parameters for IGMPv3 commented out
 #
@@ -100,21 +100,21 @@ class IGMPv3(Packet):
                     ]
                                           # use float_encode()
 
-    # if type = 0x11 (Membership Query), the next field is group address 
+    # if type = 0x11 (Membership Query), the next field is group address
     #   ConditionalField(IPField("gaddr", "0.0.0.0"), "type", lambda x:x==0x11),
-    # else if type = 0x22 (Membership Report), the next fields are 
+    # else if type = 0x22 (Membership Report), the next fields are
     #         reserved and number of group records
     #ConditionalField(ShortField("rsvd2", 0), "type", lambda x:x==0x22),
     #ConditionalField(ShortField("numgrp", 0), "type", lambda x:x==0x22),
 #                  FieldLenField("numgrp", None, "grprecs")]
-    # else if type = 0x30 (Multicast Router Advertisement), the next fields are 
+    # else if type = 0x30 (Multicast Router Advertisement), the next fields are
     #         query interval and robustness
     #ConditionalField(ShortField("qryIntvl", 0), "type", lambda x:x==0x30),
     #ConditionalField(ShortField("robust", 0), "type", lambda x:x==0x30),
 #  The following are only present for membership queries
        #   ConditionalField(BitField("resv", 0, 4), "type", lambda x:x==0x11),
        #   ConditionalField(BitField("s", 0, 1), "type", lambda x:x==0x11),
-       #   ConditionalField(BitField("qrv", 0, 3), "type", lambda x:x==0x11), 
+       #   ConditionalField(BitField("qrv", 0, 3), "type", lambda x:x==0x11),
        #  ConditionalField(ByteField("qqic",0), "type", lambda x:x==0x11),
     # ConditionalField(FieldLenField("numsrc", None, "srcaddrs"), "type", lambda x:x==0x11),
     # ConditionalField(FieldListField("srcaddrs", None, IPField("sa", "0.0.0.0"), "numsrc"), "type", lambda x:x==0x11),
@@ -194,12 +194,12 @@ class IGMPv3(Packet):
 #               (IP, IGMPv3, { "proto": 2 , "ttl": 1, "tos":0xc0 }),
 #               (IGMPv3, IGMPv3gr, { }) ]
 # The rules are:
-#   1.  the Max Response time is meaningful only in Membership Queries and should be zero 
+#   1.  the Max Response time is meaningful only in Membership Queries and should be zero
 #       otherwise (RFC 2236, section 2.2)
 
     if (self.type != 0x11):         #rule 1
       self.mrtime = 0
-      
+
     if (self.adjust_ip(ip) == True):
       if (self.adjust_ether(ip, ether) == True): return True
     return False
@@ -216,7 +216,7 @@ class IGMPv3(Packet):
     if ip != None and ip.haslayer(IP) and ether != None and ether.haslayer(Ether):
       iplong = atol(ip.dst)
       ether.dst = "01:00:5e:%02x:%02x:%02x" % ( (iplong>>16)&0x7F, (iplong>>8)&0xFF, (iplong)&0xFF )
-      # print "igmpize ip " + ip.dst + " as mac " + ether.dst 
+      # print "igmpize ip " + ip.dst + " as mac " + ether.dst
       return True
     else:
       return False
@@ -239,7 +239,7 @@ class IGMPv3(Packet):
       if (self.type == 0x11):
         if (self.gaddr == "0.0.0.0"):
           ip.dst = "224.0.0.1"                   # IP rule 1
-          retCode = True                     
+          retCode = True
         elif isValidMCAddr(self.gaddr):
           ip.dst = self.gaddr                    # IP rule 3a
           retCode = True

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -23,9 +23,9 @@ IKEv2AttributeTypes= { "Encryption":    (1, { "DES-IV64"  : 1,
                                                 "DES" : 2,
                                                 "3DES" : 3,
                                                 "RC5" : 4,
-                                                "IDEA" : 5, 
-                                                "CAST" : 6, 
-                                                "Blowfish" : 7, 
+                                                "IDEA" : 5,
+                                                "CAST" : 6,
+                                                "Blowfish" : 7,
                                                 "3IDEA" : 8,
                                                 "DES-IV32" : 9,
                                                 "AES-CBC" : 12,
@@ -67,13 +67,13 @@ IKEv2AttributeTypes= { "Encryption":    (1, { "DES-IV64"  : 1,
                                                 "SHA2-512-256": 14,
                                         }, 0),
                          "GroupDesc":     (4, { "768MODPgr"  : 1,
-                                                "1024MODPgr" : 2, 
-                                                "1536MODPgr" : 5, 
-                                                "2048MODPgr" : 14, 
-                                                "3072MODPgr" : 15, 
-                                                "4096MODPgr" : 16, 
-                                                "6144MODPgr" : 17, 
-                                                "8192MODPgr" : 18, 
+                                                "1024MODPgr" : 2,
+                                                "1536MODPgr" : 5,
+                                                "2048MODPgr" : 14,
+                                                "3072MODPgr" : 15,
+                                                "4096MODPgr" : 16,
+                                                "6144MODPgr" : 17,
+                                                "8192MODPgr" : 18,
                                                 "256randECPgr" : 19,
                                                 "384randECPgr" : 20,
                                                 "521randECPgr" : 21,
@@ -87,8 +87,8 @@ IKEv2AttributeTypes= { "Encryption":    (1, { "DES-IV64"  : 1,
                                                  "ESN":   1,  }, 0),
                          }
 
-# the name 'IKEv2TransformTypes' is actually a misnomer (since the table 
-# holds info for all IKEv2 Attribute types, not just transforms, but we'll 
+# the name 'IKEv2TransformTypes' is actually a misnomer (since the table
+# holds info for all IKEv2 Attribute types, not just transforms, but we'll
 # keep it for backwards compatibility... for now at least
 IKEv2TransformTypes = IKEv2AttributeTypes
 
@@ -110,7 +110,7 @@ del(tmp)
 del(val)
 
 # Note: Transform and Proposal can only be used inside the SA payload
-IKEv2_payload_type = ["None", "", "Proposal", "Transform"] 
+IKEv2_payload_type = ["None", "", "Proposal", "Transform"]
 
 IKEv2_payload_type.extend([""] * 29)
 IKEv2_payload_type.extend(["SA","KE","IDi","IDr", "CERT","CERTREQ","AUTH","Nonce","Notify","Delete",
@@ -163,17 +163,17 @@ class IKEv2(IKEv2_class): # rfc4306
         if self.length is None:
             p = p[:24]+struct.pack("!I",len(p))+p[28:]
         return p
-       
+
 
 class IKEv2_Key_Length_Attribute(IntField):
 	# We only support the fixed-length Key Length attribute (the only
 	# one currently defined)
 	def __init__(self, name):
 		IntField.__init__(self, name, "0x800E0000")
-		
+
 	def i2h(self, pkt, x):
 		return IntField.i2h(self, pkt, x & 0xFFFF)
-		
+
 	def h2i(self, pkt, x):
 		return IntField.h2i(self, pkt, struct.pack("!I", 0x800E0000 | int(x, 0)))
 
@@ -185,7 +185,7 @@ class IKEv2_Transform_ID(ShortField):
 		else:
 			map = IKEv2TransformNum[pkt.transform_type][1]
 			return map[x]
-		
+
 	def h2i(self, pkt, x):
 		if pkt == None:
 			return None
@@ -195,7 +195,7 @@ class IKEv2_Transform_ID(ShortField):
 				if map[k] == x:
 					return k
 			return None
-		
+
 class IKEv2_payload_Transform(IKEv2_class):
     name = "IKE Transform"
     fields_desc = [
@@ -207,7 +207,7 @@ class IKEv2_payload_Transform(IKEv2_class):
         IKEv2_Transform_ID("transform_id", 0),
         ConditionalField(IKEv2_Key_Length_Attribute("key_length"), lambda pkt: pkt.length > 8),
     ]
-            
+
 class IKEv2_payload_Proposal(IKEv2_class):
     name = "IKEv2 Proposal"
     fields_desc = [

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -218,7 +218,7 @@ class ISIS_CircuitTypeField(FlagsField):
 #######################################################################
 ##  ISIS TLVs                                                        ##
 #######################################################################
-_isis_tlv_classes = { 
+_isis_tlv_classes = {
     1: "ISIS_AreaTlv",
     2: "ISIS_IsReachabilityTlv",
     6: "ISIS_IsNeighbourTlv",
@@ -248,7 +248,7 @@ _isis_tlv_names = {
     9: "LSP Entries TLV",
    10: "Authentication TLV",
    12: "Optional Checksum TLV",
-   13: "Purge Originator Identification TLV", 
+   13: "Purge Originator Identification TLV",
    14: "LSP Buffer Size TLV",
    22: "Extended IS-Reachability TLV",
    23: "IS Neighbour Attribute TLV",
@@ -373,14 +373,14 @@ class ISIS_ExtendedIpPrefix(Packet):
         BitField("subtlvindicator", 0, 1),
         BitFieldLenField("pfxlen", None, 6, length_of="pfx"),
         IPPrefixField("pfx", None, wordbytes=1, length_from=lambda x: x.pfxlen),
-        ConditionalField(FieldLenField("subtlvslen", None, length_of=lambda x: x.subtlvs, fmt= "B"), lambda pkt: pkt.subtlvindicator == 1), 
+        ConditionalField(FieldLenField("subtlvslen", None, length_of=lambda x: x.subtlvs, fmt= "B"), lambda pkt: pkt.subtlvindicator == 1),
         ConditionalField(PacketListField("subtlvs", [], _isis_guess_subtlv_cls, length_from=lambda x: x.subtlvslen), lambda pkt: pkt.subtlvindicator == 1)
     ]
 
     def extract_padding(self, s):
         return "", s
 
- 
+
 class ISIS_ExtendedIpReachabilityTlv(ISIS_GenericTlv):
     name = "ISIS Extended IP Reachability TLV"
     fields_desc = [ByteEnumField("type", 135, _isis_tlv_names),
@@ -398,7 +398,7 @@ class ISIS_ExtendedIsNeighbourEntry(Packet):
     def extract_padding(self, s):
         return "", s
 
-    
+
 class ISIS_ExtendedIsReachabilityTlv(ISIS_GenericTlv):
     name = "ISIS Extended IS Reachability TLV"
     fields_desc = [ByteEnumField("type", 22, _isis_tlv_names),
@@ -432,7 +432,7 @@ class ISIS_Ipv6Prefix(Packet):
         BitField("reserved", 0, 5),
         FieldLenField("pfxlen", None, length_of="pfx", fmt="B"),
         IP6PrefixField("pfx", None, wordbytes=1, length_from=lambda x: x.pfxlen),
-        ConditionalField(FieldLenField("subtlvslen", None, length_of=lambda x: x.subtlvs, fmt= "B"), lambda pkt: pkt.subtlvindicator == 1), 
+        ConditionalField(FieldLenField("subtlvslen", None, length_of=lambda x: x.subtlvs, fmt= "B"), lambda pkt: pkt.subtlvindicator == 1),
         ConditionalField(PacketListField("subtlvs", [], _isis_guess_subtlv_cls, length_from=lambda x: x.subtlvslen), lambda pkt: pkt.subtlvindicator == 1)
     ]
 

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -101,7 +101,7 @@ class FecTLVField(StrField):
     def getfield(self, pkt, s):
         l = self.size(s)
         return s[l:],self.m2i(pkt, s[:l])
-        
+
 
 # 3.4.2.1. Generic Label TLV
 
@@ -255,7 +255,7 @@ class CommonSessionTLVField(StrField):
     def getfield(self, pkt, s):
         l = 18
         return s[l:],self.m2i(pkt, s[:l])
-    
+
 
 
 ## Messages ##
@@ -272,7 +272,7 @@ class LDPNotification(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -289,7 +289,7 @@ class LDPHello(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -306,7 +306,7 @@ class LDPInit(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -322,7 +322,7 @@ class LDPKeepAlive(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -377,7 +377,7 @@ class LDPLabelMM(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -394,7 +394,7 @@ class LDPLabelReqM(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -413,7 +413,7 @@ class LDPLabelARM(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -432,7 +432,7 @@ class LDPLabelWM(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 
@@ -451,7 +451,7 @@ class LDPLabelRelM(Packet):
         if self.len is None:
             l = len(p) - 4
             p = p[:2]+struct.pack("!H", l)+p[4:]
-        return p+pay  
+        return p+pay
     def guess_payload_class(self, p):
         return guess_payload(p)
 

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -141,7 +141,7 @@ class OFPMatch(Packet):
             w1 = binrepr(self.wildcards1)
             l+="0"*(2-len(w1))
             l+=w1
-                    
+
         # ip masks use 6 bits each
         if self.nw_dst_mask is None:
             if self.nw_dst is "0": l+="111111"

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -228,9 +228,9 @@ ofp_oxm_constr = {  0: ["OFBInPort", "in_port", 4],
                    16: ["OFBUDPDst", "udp_dst", 2],
                    17: ["OFBSCTPSrc", "sctp_src", 2],
                    18: ["OFBSCTPDst", "sctp_dst", 2],
-                   19: ["OFBICMPv4Type", "icmpv4_type", 1],    
-                   20: ["OFBICMPv4Code", "icmpv4_code", 1],    
-                   21: ["OFBARPOP", "arp_op", 2],    
+                   19: ["OFBICMPv4Type", "icmpv4_type", 1],
+                   20: ["OFBICMPv4Code", "icmpv4_code", 1],
+                   21: ["OFBARPOP", "arp_op", 2],
                    22: ["OFBARPSPA", "arp_spa", 4],
                    23: ["OFBARPTPA", "arp_tpa", 4],
                    24: ["OFBARPSHA", "arp_sha", 6],
@@ -507,14 +507,14 @@ need_prereq = { 14: [12, 0x1000],
                 21: [10, 0x86dd],
                 22: [10, 0x0800],
                 24: [10, 0x0800],
-                26: [20, 6],    
-                28: [20, 6],    
-                30: [20, 17],    
-                32: [20, 17],    
-                34: [20, 132],    
-                36: [20, 132],    
-                38: [20, 1],    
-                40: [20, 1],    
+                26: [20, 6],
+                28: [20, 6],
+                30: [20, 17],
+                32: [20, 17],
+                34: [20, 132],
+                36: [20, 132],
+                38: [20, 1],
+                40: [20, 1],
                 42: [10, 0x0806],
                 44: [10, 0x0806],
                 46: [10, 0x0806],
@@ -542,7 +542,7 @@ class OXMPacketListField(PacketListField):
         PacketListField.__init__(self, name, default, cls, length_from=length_from)
         self.autocomplete = autocomplete
         self.index = []
-    
+
     def i2m(self, pkt, val):
             ### this part makes for a faster writing of specs-compliant matches
             ### expect some unwanted behaviour if you try incoherent associations
@@ -2614,7 +2614,7 @@ class OFPMPReplyGroupDesc(_ofp_header):
                     GroupDescPacketListField("group_descs", [], Packet,
                                              length_from=lambda pkt:pkt.len-16) ]
     overload_fields = {TCP: {"dport": 6653}}
-                    
+
 class OFPMPRequestGroupFeatures(_ofp_header):
     name = "OFPMP_REQUEST_GROUP_FEATURES"
     fields_desc = [ ByteEnumField("version", 0x04, ofp_version),
@@ -3009,7 +3009,7 @@ class TableFeaturesPropPacketListField(PacketListField):
     def getfield(self, pkt, s):
         lst = []
         remain = s
-    
+
         while remain and len(remain) >= 4:
             l = TableFeaturesPropPacketListField._get_table_features_prop_length(remain)
             # add padding !
@@ -3072,7 +3072,7 @@ class OFPMPRequestTableFeatures(_ofp_header):
                     FlagsField("flags", 0, 16, ofpmp_request_flags),
                     XIntField("pad1", 0),
                     TableFeaturesPacketListField("table_features", [], Packet,
-                                                 length_from=lambda pkt:pkt.len-16) ] 
+                                                 length_from=lambda pkt:pkt.len-16) ]
     overload_fields = {TCP: {"sport": 6653}}
 
 class OFPMPReplyTableFeatures(_ofp_header):

--- a/scapy/contrib/ppi.py
+++ b/scapy/contrib/ppi.py
@@ -56,7 +56,7 @@ def _PPIGuessPayloadClass(p, **kargs):
                 out.payload.payload = conf.padding_layer(p[pfh_len:])
         elif (len(p) > pfh_len):
             out.payload = conf.padding_layer(p[pfh_len:])
-        
+
     else:
         out = conf.raw_layer(p, **kargs)
     return out

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -420,7 +420,7 @@ SENS_Fields = [  LEShortEnumField('SensorType', None, sensor_types),
               HCSIDescField("DescString", None),  XLEIntField("AppId", None),
               HCSIAppField("AppData", None),      HCSINullField("Extended", None)]
 
-              
+
 
 class Sensor(HCSIPacket):
     name = "PPI Sensor"

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -17,7 +17,7 @@ rsvpmsgtypes = { 0x01 : "Path",
                  0x06 : "Reservation teardown",
                  0x07 : "Reservation request acknowledgment"
 }
-        
+
 class RSVP(Packet):
     name = "RSVP"
     fields_desc = [ BitField("Version",1,4),
@@ -36,7 +36,7 @@ class RSVP(Packet):
             ck = checksum(p)
             p = p[:2]+chr(ck>>8)+chr(ck&0xff)+p[4:]
         return p
-                    
+
 rsvptypes = { 0x01 : "Session",
               0x03 : "HOP",
               0x04 : "INTEGRITY",
@@ -52,7 +52,7 @@ rsvptypes = { 0x01 : "Session",
               0x0E   : "POLICY_DATA",
               0x0F   : "RESV_CONFIRM",
               0x10   : "RSVP_LABEL",
-              0x11   : "HOP_COUNT",        
+              0x11   : "HOP_COUNT",
               0x12   : "STRICT_SOURCE_ROUTE",
               0x13   : "LABEL_REQUEST",
               0x14   : "EXPLICIT_ROUTE",
@@ -86,13 +86,13 @@ rsvptypes = { 0x01 : "Session",
               0x83  : "RESTART_CA",
               0x84  : "SESSION-OF-INTEREST",
               0x85  : "LINK_CAPABILITY",
-              0x86  : "Capability Object", 
+              0x86  : "Capability Object",
               0xA1  : "RSVP_HOP_L2",
-              0xA2  : "LAN_NHOP_L2",    
-              0xA3  : "LAN_NHOP_L3",    
-              0xA4  : "LAN_LOOPBACK",    
+              0xA2  : "LAN_NHOP_L2",
+              0xA3  : "LAN_NHOP_L3",
+              0xA4  : "LAN_LOOPBACK",
               0xA5  : "TCLASS",
-              0xC0  : "TUNNEL", 
+              0xC0  : "TUNNEL",
               0xC1  : "LSP_TUNNEL_INTERFACE_ID",
               0xC2  : "USER_ERROR_SPEC",
               0xC3  : "NOTIFY_REQUEST",
@@ -101,7 +101,7 @@ rsvptypes = { 0x01 : "Session",
               0xC6  : "ALARM_SPEC",
               0xC7  : "ASSOCIATION",
               0xC8  : "SECONDARY_EXPLICIT_ROUTE",
-              0xC9  : "SECONDARY_RECORD_ROUTE",                
+              0xC9  : "SECONDARY_RECORD_ROUTE",
               0xCD  : "FAST_REROUTE",
               0xCF  : "SESSION_ATTRIBUTE",
               0xE1  : "DCLASS",
@@ -112,7 +112,7 @@ rsvptypes = { 0x01 : "Session",
               0xE6  : "CALL_ID",
               0xE7  : "3GPP2_Object",
               0xE8  : "EXCLUDE_ROUTE"
-}      
+}
 
 class RSVP_Object(Packet):
     name = "RSVP_Object"
@@ -132,8 +132,8 @@ class RSVP_Object(Packet):
             return RSVP_SessionAttrb
         else:
             return RSVP_Data
-    
-    
+
+
 
 class RSVP_Data(Packet):
     name = "Data"
@@ -180,7 +180,7 @@ class RSVP_SessionAttrb(Packet):
                      ByteField("flags",1),
                      ByteField("Name_length",1),
                      StrLenField("Name","",length_from= lambda pkt:pkt.underlayer.Length - 8),
-                     ]  
+                     ]
     def default_payload_class(self, payload):
       return RSVP_Object
 

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -29,7 +29,7 @@ import __builtin__
 # Helpers and constants
 #####################################################################
 
-skinny_messages_cls = { 
+skinny_messages_cls = {
 # Station -> Callmanager
   0x0000: "SkinnyMessageKeepAlive",
   0x0001: "SkinnyMessageRegister",
@@ -204,7 +204,7 @@ class SkinnyDateTimeField(StrFixedLenField):
     def m2i(self, pkt, s):
         year,month,dow,day,hour,min,sec,milisecond=struct.unpack('<8I', s)
         return (year, month, day, hour, min, sec)
-    
+
     def i2m(self, pkt, val):
         if type(val) is str:
             val = self.h2i(pkt, val)
@@ -219,7 +219,7 @@ class SkinnyDateTimeField(StrFixedLenField):
 
     def i2repr(self, pkt, x):
         return self.i2h(pkt, x)
-    
+
     def h2i(self, pkt, s):
         t = ()
         if type(s) is str:
@@ -251,10 +251,10 @@ class SkinnyMessageOffHook(Packet):
     name = 'Off Hook'
     fields_desc = [ LEIntField("unknown1", 0),
                     LEIntField("unknown2", 0),]
-        
+
 class SkinnyMessageOnHook(SkinnyMessageOffHook):
     name = 'On Hook'
-    
+
 class SkinnyMessageCallState(Packet):
     name='Skinny Call state message'
     fields_desc = [ LEIntEnumField("state", 1, skinny_callstates),
@@ -297,7 +297,7 @@ class SkinnyMessageStopTone(SkinnyMessageGeneric):
     fields_desc = [ LEIntField("instance", 1),
                     LEIntField("callid", 0)]
 
-    
+
 class SkinnyMessageSpeakerMode(Packet):
     name='Speaker mdoe'
     fields_desc = [ LEIntEnumField("ring", 0x1, skinny_speaker_modes) ]
@@ -314,7 +314,7 @@ class SkinnyMessageSoftKeyEvent(Packet):
                     LEIntField("callid", 0),
                     LEIntField("set", 0),
                     LEIntField("map", 0xffff)]
-    
+
 class SkinnyMessagePromptStatus(Packet):
     name='Prompt status'
     fields_desc = [ LEIntField("timeout", 0),
@@ -325,7 +325,7 @@ class SkinnyMessagePromptStatus(Packet):
 class SkinnyMessageCallPlane(Packet):
     name='Activate/Desactivate Call Plane Message'
     fields_desc = [ LEIntField("instance", 1)]
-    
+
 class SkinnyMessageTimeDate(Packet):
     name='Setting date and time'
     fields_desc = [ SkinnyDateTimeField("settime", None),
@@ -451,7 +451,7 @@ class SkinnyMessageStartMediaTransmission(Packet):
 
     def guess_payload_class(self, p):
         return conf.padding_layer
-    
+
 class SkinnyMessageCloseReceiveChannel(Packet):
     name='close receive channel'
     fields_desc = [LEIntField('conference', 0),
@@ -469,7 +469,7 @@ class SkinnyMessageStopMultiMediaTransmission(Packet):
     fields_desc = [LEIntField('conference', 0),
                    LEIntField('passthru', 0),
                    LEIntField('callid', 0)]
-    
+
 class Skinny(Packet):
     name="Skinny"
     fields_desc = [ LEIntField("len", None),
@@ -482,7 +482,7 @@ class Skinny(Packet):
             pkt=struct.pack('@I', l)+pkt[4:]
         return pkt+p
 
-# An helper 
+# An helper
 def get_cls(name, fallback_cls):
     return globals().get(name, fallback_cls)
     #return __builtin__.__dict__.get(name, fallback_cls)

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -5,7 +5,7 @@
 #
 #############################################################
 # Example SPB Frame Creation
-# 
+#
 # Note the outer Dot1Q Ethertype marking (0x88e7)
 #############################################################
 # backboneEther     = Ether(dst='00:bb:00:00:90:00', src='00:bb:00:00:40:00', type=0x8100)

--- a/scapy/contrib/ubberlogger.py
+++ b/scapy/contrib/ubberlogger.py
@@ -70,12 +70,12 @@ class Uberlogger_open_data(Packet):
     name  = "Uberlogger open_data"
     fields_desc = [IntField("flags", 0),
                    IntField("mode", 0)]
-                   
+
 class Uberlogger_read_data(Packet):
     name  = "Uberlogger read_data"
     fields_desc = [IntField("fd", 0),
                    IntField("count", 0)]
-                   
+
 class Uberlogger_setuid_data(Packet):
     name  = "Uberlogger setuid_data"
     fields_desc = [IntField("uid", 0)]

--- a/scapy/contrib/vqp.py
+++ b/scapy/contrib/vqp.py
@@ -41,9 +41,9 @@ class VQPEntry(Packet):
                 ConditionalField(MACField("data", "00:00:00:00:00:00"),
                         lambda p:p.datatype==3078),
                 ConditionalField(MACField("data", "00:00:00:00:00:00"),
-                        lambda p:p.datatype==3080), 
+                        lambda p:p.datatype==3080),
                 ConditionalField(StrLenField("data", None,
-                        length_from=lambda p:p.len), 
+                        length_from=lambda p:p.len),
                         lambda p:p.datatype not in [3073, 3078, 3080]),
         ]
         def post_build(self, p, pay):

--- a/scapy/contrib/vxlan.py
+++ b/scapy/contrib/vxlan.py
@@ -10,7 +10,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import UDP
 from scapy.fields import FlagsField, XByteField, ThreeBytesField
 
-_VXLAN_FLAGS = ['R' for _ in xrange(0, 24)] + ['R', 'R', 'R', 'I', 'R', 'R', 'R', 'R', 'R'] 
+_VXLAN_FLAGS = ['R' for _ in xrange(0, 24)] + ['R', 'R', 'R', 'I', 'R', 'R', 'R', 'R', 'R']
 
 
 class VXLAN(Packet):

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -16,7 +16,7 @@ class WPA_key(Packet):
                     StrFixedLenField("replay_counter", "", 8),
                     StrFixedLenField("nonce", "", 32),
                     StrFixedLenField("key_iv", "", 16),
-                    StrFixedLenField("wpa_key_rsc", "", 8), 
+                    StrFixedLenField("wpa_key_rsc", "", 8),
                     StrFixedLenField("wpa_key_id", "", 8),
                     StrFixedLenField("wpa_key_mic", "", 16),
                     LenField("wpa_key_length", None, "H"),
@@ -30,6 +30,6 @@ class WPA_key(Packet):
         if isinstance(other,WPA_key):
                return 1
         return 0
-             
+
 
 bind_layers( EAPOL,         WPA_key,       type=3)

--- a/scapy/crypto/cert.py
+++ b/scapy/crypto/cert.py
@@ -72,7 +72,7 @@ def pkcs_os2ip(x):
 
     Reverse function is pkcs_i2osp()
     """
-    return number.bytes_to_long(x) 
+    return number.bytes_to_long(x)
 
 # IP2OS function defined in RFC 3447 for octet string to integer conversion
 def pkcs_i2osp(x,xLen):
@@ -92,53 +92,53 @@ def pkcs_i2osp(x,xLen):
     padlen = max(0, xLen-len(z))
     return '\x00'*padlen + z
 
-# for every hash function a tuple is provided, giving access to 
+# for every hash function a tuple is provided, giving access to
 # - hash output length in byte
 # - associated hash function that take data to be hashed as parameter
 #   XXX I do not provide update() at the moment.
 # - DER encoding of the leading bits of digestInfo (the hash value
 #   will be concatenated to create the complete digestInfo).
-# 
+#
 # Notes:
-# - MD4 asn.1 value should be verified. Also, as stated in 
+# - MD4 asn.1 value should be verified. Also, as stated in
 #   PKCS#1 v2.1, MD4 should not be used.
 # - hashlib is available from http://code.krypto.org/python/hashlib/
 # - 'tls' one is the concatenation of both md5 and sha1 hashes used
 #   by SSL/TLS when signing/verifying things
 _hashFuncParams = {
-    "md2"    : (16, 
-                lambda x: MD2.new(x).digest(), 
+    "md2"    : (16,
+                lambda x: MD2.new(x).digest(),
                 '\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x02\x05\x00\x04\x10'),
-    "md4"    : (16, 
-                lambda x: MD4.new(x).digest(), 
+    "md4"    : (16,
+                lambda x: MD4.new(x).digest(),
                 '\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x04\x05\x00\x04\x10'), # is that right ?
-    "md5"    : (16, 
-                lambda x: MD5.new(x).digest(), 
+    "md5"    : (16,
+                lambda x: MD5.new(x).digest(),
                 '\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10'),
     "sha1"   : (20,
-                lambda x: SHA.new(x).digest(), 
+                lambda x: SHA.new(x).digest(),
                 '\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14'),
     "tls"    : (36,
                 lambda x: MD5.new(x).digest() + SHA.new(x).digest(),
                 '') }
 
 if HAS_HASHLIB:
-    _hashFuncParams["sha224"] = (28, 
+    _hashFuncParams["sha224"] = (28,
                 lambda x: hashlib.sha224(x).digest(),
                 '\x30\x2d\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x04\x05\x00\x04\x1c')
-    _hashFuncParams["sha256"] = (32, 
-                lambda x: hashlib.sha256(x).digest(), 
+    _hashFuncParams["sha256"] = (32,
+                lambda x: hashlib.sha256(x).digest(),
                 '\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20')
-    _hashFuncParams["sha384"] = (48, 
+    _hashFuncParams["sha384"] = (48,
                 lambda x: hashlib.sha384(x).digest(),
                '\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30')
-    _hashFuncParams["sha512"] = (64, 
+    _hashFuncParams["sha512"] = (64,
                lambda x: hashlib.sha512(x).digest(),
                '\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40')
 else:
     warning("hashlib support is not available. Consider installing it")
     warning("if you need sha224, sha256, sha384 and sha512 algs.")
-    
+
 def pkcs_mgf1(mgfSeed, maskLen, h):
     """
     Implements generic MGF1 Mask Generation function as described in
@@ -165,7 +165,7 @@ def pkcs_mgf1(mgfSeed, maskLen, h):
     hLen = _hashFuncParams[h][0]
     hFunc = _hashFuncParams[h][1]
     if maskLen > 2**32 * hLen:                               # 1)
-        warning("pkcs_mgf1: maskLen > 2**32 * hLen")         
+        warning("pkcs_mgf1: maskLen > 2**32 * hLen")
         return None
     T = ""                                                   # 2)
     maxCounter = math.ceil(float(maskLen) / float(hLen))     # 3)
@@ -177,7 +177,7 @@ def pkcs_mgf1(mgfSeed, maskLen, h):
     return T[:maskLen]
 
 
-def pkcs_emsa_pss_encode(M, emBits, h, mgf, sLen): 
+def pkcs_emsa_pss_encode(M, emBits, h, mgf, sLen):
     """
     Implements EMSA-PSS-ENCODE() function described in Sect. 9.1.1 of RFC 3447
 
@@ -241,7 +241,7 @@ def pkcs_emsa_pss_verify(M, EM, emBits, h, mgf, sLen):
     Output:
        True if the verification is ok, False otherwise.
     """
-    
+
     # 1) is not done
     hLen = _hashFuncParams[h][0]                             # 2)
     hFunc = _hashFuncParams[h][1]
@@ -385,7 +385,7 @@ def create_temporary_ca_path(anchor_list, folder):
             os.makedirs(folder)
     except:
         return None
-    
+
     l = len(anchor_list)
     if l == 0:
         return None
@@ -529,7 +529,7 @@ class _EncryptAndVerify:
         if mLen > k - 2*hLen - 2:                   # 1.b)
             warning("Key._rsaes_oaep_encrypt(): message too long.")
             return None
-        
+
         # 2) EME-OAEP encoding
         if L is None:                               # 2.a)
             L = ""
@@ -591,10 +591,10 @@ class _EncryptAndVerify:
             m = pkcs_os2ip(m)
             c = self._rsaep(m)
             return pkcs_i2osp(c, self.modulusLen/8)
-        
+
         elif t == "pkcs":
             return self._rsaes_pkcs1_v1_5_encrypt(m)
-        
+
         elif t == "oaep":
             return self._rsaes_oaep_encrypt(m, h, mgf, L)
 
@@ -661,7 +661,7 @@ class _EncryptAndVerify:
         s = pkcs_os2ip(S)                           # 2.a)
         m = self._rsavp1(s)                         # 2.b)
         emLen = math.ceil((modBits - 1) / 8.)       # 2.c)
-        EM = pkcs_i2osp(m, emLen) 
+        EM = pkcs_i2osp(m, emLen)
 
         # 3) EMSA-PSS verification
         Result = pkcs_emsa_pss_verify(M, EM, modBits - 1, h, mgf, sLen)
@@ -767,7 +767,7 @@ class _EncryptAndVerify:
         else:
             warning("Key.verify(): Unknown signature type (%s) provided" % t)
             return None
-    
+
 class _DecryptAndSignMethods(OSSLHelper):
     ### Below are decryption related methods. Encryption ones are inherited
     ### from PubKey
@@ -793,12 +793,12 @@ class _DecryptAndSignMethods(OSSLHelper):
 
         n = self.modulus
         if type(c) is int:
-            c = long(c)        
+            c = long(c)
         if type(c) is not long or c > n-1:
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
 
-        return self.key.decrypt(c)    
+        return self.key.decrypt(c)
 
 
     def _rsaes_pkcs1_v1_5_decrypt(self, C):
@@ -815,7 +815,7 @@ class _DecryptAndSignMethods(OSSLHelper):
 
         on error, None is returned.
         """
-        
+
         # 1) Length checking
         cLen = len(C)
         k = self.modulusLen / 8
@@ -834,7 +834,7 @@ class _DecryptAndSignMethods(OSSLHelper):
         # I am aware of the note at the end of 7.2.2 regarding error
         # conditions reporting but the one provided below are for _local_
         # debugging purposes. --arno
-        
+
         if EM[0] != '\x00':
             warning("Key._rsaes_pkcs1_v1_5_decrypt(): decryption error "
                     "(first byte is not 0x00)")
@@ -946,7 +946,7 @@ class _DecryptAndSignMethods(OSSLHelper):
         if lHash != lHashPrime:
             warning("Key._rsaes_oaep_decrypt(): decryption error. "
                     "(invalid hash)")
-            return None            
+            return None
         return M                                    # 4)
 
 
@@ -1081,7 +1081,7 @@ class _DecryptAndSignMethods(OSSLHelper):
         Output:
            the signature, an octet string.
         """
-        
+
         # 1) EMSA-PKCS1-v1_5 encoding
         k = self.modulusLen / 8
         EM = pkcs_emsa_pkcs1_v1_5_encode(M, k, h)
@@ -1141,12 +1141,12 @@ class _DecryptAndSignMethods(OSSLHelper):
             if s is None:
                 return None
             return pkcs_i2osp(s, self.modulusLen/8)
-        
+
         elif t == "pkcs": # RSASSA-PKCS1-v1_5-SIGN
             if h is None:
                 h = "sha1"
             return self._rsassa_pkcs1_v1_5_sign(M, h)
-        
+
         elif t == "pss": # RSASSA-PSS-SIGN
             return self._rsassa_pss_sign(M, h, mgf, sLen)
 
@@ -1167,7 +1167,7 @@ class PubKey(OSSLHelper, _EncryptAndVerify):
     possible_fields = [ "Modulus (",
                         "Exponent:" ]
     possible_fields_count = len(possible_fields)
-    
+
     def __init__(self, keypath):
         error_msg = "Unable to import key."
 
@@ -1196,7 +1196,7 @@ class PubKey(OSSLHelper, _EncryptAndVerify):
                 rawkey = f.read()
                 f.close()
             except:
-                raise Exception(error_msg)     
+                raise Exception(error_msg)
         else:
             rawkey = keypath
 
@@ -1245,7 +1245,7 @@ class PubKey(OSSLHelper, _EncryptAndVerify):
                 cmd = openssl_convert_RSA_cmd("DER", "PEM")
                 self.pemkey = self._apply_ossl_cmd(cmd, rawkey)
                 cmd = openssl_convert_RSA_cmd("DER", "DER")
-                self.derkey = self._apply_ossl_cmd(cmd, rawkey)                
+                self.derkey = self._apply_ossl_cmd(cmd, rawkey)
             else:
                 try: # Perhaps it is a cert
                     c = Cert(keypath)
@@ -1303,7 +1303,7 @@ class PubKey(OSSLHelper, _EncryptAndVerify):
             self.modulus = long(rem, 16)
         if self.modulus is None:
             raise Exception(error_msg)
-        
+
         # public exponent
         v = fields_dict["Exponent:"]
         self.pubExp = None
@@ -1332,7 +1332,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
                         "exponent2:",
                         "coefficient:" ]
     possible_fields_count = len(possible_fields)
-    
+
     def __init__(self, keypath):
         error_msg = "Unable to import key."
 
@@ -1353,7 +1353,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
                 rawkey = f.read()
                 f.close()
             except:
-                raise Exception(error_msg)     
+                raise Exception(error_msg)
         else:
             rawkey = keypath
 
@@ -1407,7 +1407,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
                 cmd = (convertstr % ("DER", "DER")).split(" ")
                 self.derkey = self._apply_ossl_cmd(cmd, rawkey)
             else:
-                raise Exception(error_msg)     
+                raise Exception(error_msg)
 
         self.osslcmdbase = ['openssl', 'rsa', '-inform', self.format]
 
@@ -1460,7 +1460,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
             self.modulusLen = int(v.split(' bit', 1)[0])
         if self.modulusLen is None:
             raise Exception(error_msg)
-        
+
         # public exponent
         v = fields_dict["publicExponent:"]
         self.pubExp = None
@@ -1482,7 +1482,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
         self.modulus     = tmp["modulus:"]
         self.privExp     = tmp["privateExponent:"]
         self.prime1      = tmp["prime1:"]
-        self.prime2      = tmp["prime2:"] 
+        self.prime2      = tmp["prime2:"]
         self.exponent1   = tmp["exponent1:"]
         self.exponent2   = tmp["exponent2:"]
         self.coefficient = tmp["coefficient:"]
@@ -1494,7 +1494,7 @@ class Key(OSSLHelper, _DecryptAndSignMethods, _EncryptAndVerify):
 
 
 # We inherit from PubKey to get access to all encryption and verification
-# methods. To have that working, we simply need Cert to provide 
+# methods. To have that working, we simply need Cert to provide
 # modulusLen and key attribute.
 # XXX Yes, it is a hack.
 class Cert(OSSLHelper, _EncryptAndVerify):
@@ -1523,7 +1523,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
                         "            Authority Information Access:",
                         "    Signature Algorithm:" ]
     possible_fields_count = len(possible_fields)
-    
+
     def __init__(self, certpath):
         error_msg = "Unable to import certificate."
 
@@ -1544,10 +1544,10 @@ class Cert(OSSLHelper, _EncryptAndVerify):
                 rawcert = f.read()
                 f.close()
             except:
-                raise Exception(error_msg)     
+                raise Exception(error_msg)
         else:
             rawcert = certpath
-            
+
         if rawcert is None:
             raise Exception(error_msg)
 
@@ -1595,13 +1595,13 @@ class Cert(OSSLHelper, _EncryptAndVerify):
                 self.textcert = textcert
                 cmd = (convertstr % ("DER", "PEM")).split(" ")
                 self.pemcert = self._apply_ossl_cmd(cmd, rawcert)
-                cmd = (convertstr % ("DER", "DER")).split(" ")     
+                cmd = (convertstr % ("DER", "DER")).split(" ")
                 self.dercert = self._apply_ossl_cmd(cmd, rawcert)
             else:
                 raise Exception(error_msg)
 
         self.osslcmdbase = ['openssl', 'x509', '-inform', self.format]
-                                                  
+
         r,w,e = popen3('openssl asn1parse -inform DER'.split(' '))
         w.write(self.dercert)
         w.close()
@@ -1611,7 +1611,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         e.close()
         if res != '':
             raise Exception(error_msg)
-        
+
         # Grab _raw_ X509v3 Authority Key Identifier, if any.
         tmp = self.asn1parsecert.split(":X509v3 Authority Key Identifier", 1)
         self.authorityKeyID = None
@@ -1626,13 +1626,13 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         if len(tmp) == 2:
             tmp = tmp[1]
             tmp = tmp.split("[HEX DUMP]:", 1)[1]
-            self.subjectKeyID=tmp.split('\n',1)[0]            
+            self.subjectKeyID=tmp.split('\n',1)[0]
 
         # Get tbsCertificate using the worst hack. output of asn1parse
         # looks like that:
         #
-        # 0:d=0  hl=4 l=1298 cons: SEQUENCE          
-        # 4:d=1  hl=4 l=1018 cons: SEQUENCE          
+        # 0:d=0  hl=4 l=1298 cons: SEQUENCE
+        # 4:d=1  hl=4 l=1018 cons: SEQUENCE
         # ...
         #
         l1,l2 = self.asn1parsecert.split('\n', 2)[:2]
@@ -1696,7 +1696,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         if self.serial is None:
             raise Exception(error_msg)
 
-        # Signature Algorithm        
+        # Signature Algorithm
         v = fields_dict["        Signature Algorithm:"]
         self.sigAlg = None
         if v:
@@ -1705,7 +1705,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             self.sigAlg = v
         if self.sigAlg is None:
             raise Exception(error_msg)
-        
+
         # issuer
         v = fields_dict["        Issuer:"]
         self.issuer = None
@@ -1732,7 +1732,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             self.notBefore = time.strptime(self.notBefore_str,
                                            "%b %d %H:%M:%S %Y")
         self.notBefore_str_simple = time.strftime("%x", self.notBefore)
-        
+
         # not after
         v = fields_dict["            Not After :"]
         self.notAfter_str = None
@@ -1747,9 +1747,9 @@ class Cert(OSSLHelper, _EncryptAndVerify):
                                           "%b %d %H:%M:%S %Y %Z")
         except:
             self.notAfter = time.strptime(self.notAfter_str,
-                                          "%b %d %H:%M:%S %Y")            
+                                          "%b %d %H:%M:%S %Y")
         self.notAfter_str_simple = time.strftime("%x", self.notAfter)
-        
+
         # subject
         v = fields_dict["        Subject:"]
         self.subject = None
@@ -1759,7 +1759,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             self.subject = v
         if self.subject is None:
             raise Exception(error_msg)
-        
+
         # Public Key Algorithm
         v = fields_dict["            Public Key Algorithm:"]
         self.pubKeyAlg = None
@@ -1769,7 +1769,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             self.pubKeyAlg = v
         if self.pubKeyAlg is None:
             raise Exception(error_msg)
-        
+
         # Modulus
         v = fields_dict["                Modulus ("]
         self.modulus = None
@@ -1793,7 +1793,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
 
         # Public Key instance
         self.key = RSA.construct((self.modulus, self.exponent, ))
-        
+
         # Subject Key Identifier
 
         # Authority Key Identifier: keyid, dirname and serial
@@ -1814,7 +1814,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             if v:
                 v = v.split('\n',1)[0]
                 v = v.strip().replace(':', '')
-                self.authorityKeyID_serial = v                
+                self.authorityKeyID_serial = v
 
         # Basic constraints
         self.basicConstraintsCritical = False
@@ -1833,7 +1833,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         # X509v3 Key Usage
         self.keyUsage = []
         v = fields_dict["            X509v3 Key Usage:"]
-        if v:   
+        if v:
             # man 5 x509v3_config
             ku_mapping = {"Digital Signature": "digitalSignature",
                           "Non Repudiation": "nonRepudiation",
@@ -1858,7 +1858,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         # X509v3 Extended Key Usage
         self.extKeyUsage = []
         v = fields_dict["            X509v3 Extended Key Usage:"]
-        if v:   
+        if v:
             # man 5 x509v3_config:
             eku_mapping = {"TLS Web Server Authentication": "serverAuth",
                            "TLS Web Client Authentication": "clientAuth",
@@ -1892,7 +1892,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             v = v.split("\n\n", 1)[0]
             v = v.split("URI:")[1:]
             self.CRLDistributionPoints = map(lambda x: x.strip(), v)
-            
+
         # Authority Information Access: list of tuples ("method", "location")
         self.authorityInfoAccess = []
         v = fields_dict["            Authority Information Access:"]
@@ -1947,7 +1947,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         if not found:
             return False
         hlen, hfunc, digestInfo =  _hashFuncParams[k]
-        
+
         if len(unenc) != (hlen+len(digestInfo)):
             return False
 
@@ -2033,7 +2033,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         while i<l: # get a string version of modulus
             res.append(struct.pack("B", int(m[i:i+2], 16)))
             i += 2
-        return sha.new("".join(res)).digest()    
+        return sha.new("".join(res)).digest()
 
     def output(self, fmt="DER"):
         if fmt == "DER":
@@ -2097,7 +2097,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
             if not untrusted_file:
                 os.unlink(cafile)
                 return False
-        res = self.verifychain_from_cafile(cafile, 
+        res = self.verifychain_from_cafile(cafile,
                                            untrusted_file=untrusted_file)
         os.unlink(cafile)
         if untrusted_file:
@@ -2162,7 +2162,7 @@ class Cert(OSSLHelper, _EncryptAndVerify):
         Cert. Otherwise, the issuers are simply compared.
         """
         for c in crl_list:
-            if (self.authorityKeyID is not None and 
+            if (self.authorityKeyID is not None and
                 c.authorityKeyID is not None and
                 self.authorityKeyID == c.authorityKeyID):
                 return self.serial in map(lambda x: x[0], c.revoked_cert_serials)
@@ -2208,11 +2208,11 @@ class CRL(OSSLHelper):
                         "        Next Update:",
                         "        CRL extensions:",
                         "            X509v3 Issuer Alternative Name:",
-                        "            X509v3 Authority Key Identifier:", 
+                        "            X509v3 Authority Key Identifier:",
                         "                keyid:",
                         "                DirName:",
                         "                serial:",
-                        "            X509v3 CRL Number:", 
+                        "            X509v3 CRL Number:",
                         "Revoked Certificates:",
                         "No Revoked Certificates.",
                         "    Signature Algorithm:" ]
@@ -2238,7 +2238,7 @@ class CRL(OSSLHelper):
                 rawcrl = f.read()
                 f.close()
             except:
-                raise Exception(error_msg)     
+                raise Exception(error_msg)
         else:
             rawcrl = crlpath
 
@@ -2398,7 +2398,7 @@ class CRL(OSSLHelper):
         self.nextUpdate = time.strptime(self.nextUpdate_str,
                                        "%b %d %H:%M:%S %Y %Z")
         self.nextUpdate_str_simple = time.strftime("%x", self.nextUpdate)
-        
+
         # XXX Do something for Issuer Alternative Name
 
         # Authority Key Identifier: keyid, dirname and serial
@@ -2455,7 +2455,7 @@ class CRL(OSSLHelper):
 
     def __str__(self):
         return self.dercrl
-        
+
     # Print main informations stored in CRL
     def show(self):
         print "Version: %d" % self.version
@@ -2482,4 +2482,4 @@ class CRL(OSSLHelper):
         return "verify OK" in cmdres
 
 
-    
+

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -32,7 +32,7 @@ class DADict:
         return val in self.__dict__
     def __getitem__(self, attr):
         return getattr(self, attr)
-    def __setitem__(self, attr, val):        
+    def __setitem__(self, attr, val):
         return setattr(self, self.fixname(attr), val)
     def __iter__(self):
         return iter(map(lambda (x,y):y,filter(lambda (x,y):x and x[0]!="_", self.__dict__.items())))
@@ -55,7 +55,7 @@ class DADict:
             if k not in self or self[k] != kargs[k]:
                 return False
         return True
-    
+
     def _find(self, *args, **kargs):
          return self._recurs_find((), *args, **kargs)
     def _recurs_find(self, path, *args, **kargs):

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -52,7 +52,7 @@ MTU = 0xffff # a.k.a give me all you have
 
 WINDOWS=sys.platform.startswith("win")
 
- 
+
 # file parsing to get some values :
 
 def load_protocols(filename):
@@ -145,9 +145,9 @@ class ManufDA(DADict):
         if oui in self:
             return ":".join([self[oui][0]]+ mac.split(":")[3:])
         return mac
-        
-        
-        
+
+
+
 
 def load_manuf(filename):
     try:
@@ -170,7 +170,7 @@ def load_manuf(filename):
         #log_loading.warning("Couldn't open [%s] file" % filename)
         pass
     return manufdb
-    
+
 
 
 if WINDOWS:
@@ -211,5 +211,5 @@ class KnowledgeBase:
         if self.base is None:
             self.lazy_init()
         return self.base
-    
+
 

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -20,7 +20,7 @@ class ScapyFreqFilter(logging.Filter):
     def __init__(self):
         logging.Filter.__init__(self)
         self.warning_table = {}
-    def filter(self, record):        
+    def filter(self, record):
         from config import conf
         wt = conf.warning_threshold
         if wt > 0:
@@ -43,7 +43,7 @@ class ScapyFreqFilter(logging.Filter):
                 else:
                     return 0
             self.warning_table[caller] = (tm,nb)
-        return 1    
+        return 1
 
 log_scapy = logging.getLogger("scapy")
 console_handler = logging.StreamHandler()

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -99,7 +99,7 @@ class Field(object):
             return RandBin(l)
         else:
             warning("no random class for [%s] (fmt=%s)." % (self.name, self.fmt))
-            
+
 
 
 
@@ -113,7 +113,7 @@ class Emph(object):
         return hash(self.fld)
     def __eq__(self, other):
         return self.fld == other
-    
+
 
 class ActionField(object):
     __slots__ = ["_fld", "_action_method", "_privdata"]
@@ -171,10 +171,10 @@ class PadField(object):
     def addfield(self, pkt, s, val):
         sval = self._fld.addfield(pkt, "", val)
         return s+sval+struct.pack("%is" % (self.padlen(len(sval))), self._padwith)
-    
+
     def __getattr__(self, attr):
         return getattr(self._fld,attr)
-        
+
 
 class DestField(Field):
     __slots__ = ["defaultdst"]
@@ -229,7 +229,7 @@ class IPField(Field):
             except socket.error:
                 x = Net(x)
         elif type(x) is list:
-            x = [self.h2i(pkt, n) for n in x] 
+            x = [self.h2i(pkt, n) for n in x]
         return x
     def resolve(self, x):
         if self in conf.resolve:
@@ -276,13 +276,13 @@ class SourceIPField(IPField):
                 iff,x,gw = conf.route.route(dst)
         return IPField.i2h(self, pkt, x)
 
-    
+
 
 
 class ByteField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "B")
-        
+
 class XByteField(ByteField):
     def i2repr(self, pkt, x):
         return lhex(self.i2h(pkt, x))
@@ -370,7 +370,7 @@ class StrField(Field):
     __slots__ = ["remain"]
     def __init__(self, name, default, fmt="H", remain=0):
         Field.__init__(self,name,default,fmt)
-        self.remain = remain        
+        self.remain = remain
     def i2len(self, pkt, i):
         return len(i)
     def i2m(self, pkt, x):
@@ -407,7 +407,7 @@ class PacketField(StrField):
             del(r.underlayer.payload)
             remain = r.load
         return remain,i
-    
+
 class PacketLenField(PacketField):
     __slots__ = ["length_from"]
     def __init__(self, name, default, cls, length_from=None):
@@ -457,7 +457,7 @@ class PacketListField(PacketField):
             l = self.length_from(pkt)
         elif self.count_from is not None:
             c = self.count_from(pkt)
-            
+
         lst = []
         ret = ""
         remain = s
@@ -550,7 +550,7 @@ class StrLenField(StrField):
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
         return s[l:], self.m2i(pkt,s[:l])
-    
+
 class StrLenFieldUtf16(StrLenField):
     def h2i(self, pkt, x):
         return x.encode('utf-16')[2:]
@@ -563,7 +563,7 @@ class BoundStrLenField(StrLenField):
         StrLenField.__init__(self, name, default, fld, length_from)
         self.minlen = minlen
         self.maxlen = maxlen
-    
+
     def randval(self):
         return RandBin(RandNum(self.minlen, self.maxlen))
 
@@ -577,14 +577,14 @@ class FieldListField(Field):
         Field.__init__(self, name, default)
         self.count_from = count_from
         self.length_from = length_from
-            
+
     def i2count(self, pkt, val):
         if type(val) is list:
             return len(val)
         return 1
     def i2len(self, pkt, val):
         return sum( self.field.i2len(pkt,v) for v in val )
-    
+
     def i2m(self, pkt, val):
         if val is None:
             val = []
@@ -612,7 +612,7 @@ class FieldListField(Field):
         ret=""
         if l is not None:
             s,ret = s[:l],s[l:]
-            
+
         while s:
             if c is not None:
                 if c <= 0:
@@ -687,7 +687,7 @@ class BitField(Field):
     __slots__ = ["rev", "size"]
     def __init__(self, name, default, size):
         Field.__init__(self, name, default)
-        self.rev = size < 0 
+        self.rev = size < 0
         self.size = abs(size)
     def reverse(self, val):
         if self.size == 16:
@@ -695,7 +695,7 @@ class BitField(Field):
         elif self.size == 32:
             val = socket.ntohl(val)
         return val
-        
+
     def addfield(self, pkt, s, val):
         val = self.i2m(pkt, val)
         if type(s) is tuple:
@@ -791,12 +791,12 @@ class _EnumField(Field):
         if self not in conf.noenum and not isinstance(x,VolatileValue) and x in self.i2s:
             return self.i2s[x]
         return repr(x)
-    
+
     def any2i(self, pkt, x):
         if type(x) is list:
             return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
         else:
-            return self.any2i_one(pkt,x)        
+            return self.any2i_one(pkt,x)
     def i2repr(self, pkt, x):
         if type(x) is list:
             return map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x)
@@ -862,7 +862,7 @@ class XShortEnumField(ShortEnumField):
 
 class _MultiEnumField(_EnumField):
     def __init__(self, name, default, enum, depends_on, fmt = "H"):
-        
+
         self.depends_on = depends_on
         self.i2s_multi = enum
         self.s2i_multi = {}
@@ -967,7 +967,7 @@ class FlagsField(BitField):
             r = "+".join(r)
         return r
 
-            
+
 
 
 class FixedPointField(BitField):
@@ -1003,11 +1003,11 @@ class _IPPrefixFieldBase(Field):
         self.ntoa = ntoa
         Field.__init__(self, name, default, "%is" % self.maxbytes)
         self.length_from = length_from
-    
+
     def _numbytes(self, pfxlen):
         wbits= self.wordbytes * 8
         return ((pfxlen + (wbits - 1)) / wbits) * self.wordbytes
-    
+
     def h2i(self, pkt, x):
         # "fc00:1::1/64" -> ("fc00:1::1", 64)
         [pfx,pfxlen]= x.split('/')
@@ -1025,30 +1025,30 @@ class _IPPrefixFieldBase(Field):
         (pfx,pfxlen)= x
         s= self.aton(pfx);
         return (s[:self._numbytes(pfxlen)], pfxlen)
-    
+
     def m2i(self, pkt, x):
         # ("\xfc\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 64) -> ("fc00:1::1", 64)
         (s,pfxlen)= x
-        
+
         if len(s) < self.maxbytes:
             s= s + ("\0" * (self.maxbytes - len(s)))
         return (self.ntoa(s), pfxlen)
-    
+
     def any2i(self, pkt, x):
         if x is None:
             return (self.ntoa("\0"*self.maxbytes), 1)
-        
+
         return self.h2i(pkt,x)
-    
+
     def i2len(self, pkt, x):
         (_,pfxlen)= x
         return pfxlen
-        
+
     def addfield(self, pkt, s, val):
         (rawpfx,pfxlen)= self.i2m(pkt,val)
         fmt= "!%is" % self._numbytes(pfxlen)
         return s+struct.pack(fmt, rawpfx)
-    
+
     def getfield(self, pkt, s):
         pfxlen= self.length_from(pkt)
         numbytes= self._numbytes(pfxlen)

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -122,7 +122,7 @@ DHCPOptions = {
     59: IntField("rebinding_time", 37800),
     60: "vendor_class_id",
     61: "client_id",
-    
+
     64: "NISplus_domain",
     65: IPField("NISplus_server","0.0.0.0"),
     69: IPField("SMTP_server","0.0.0.0"),
@@ -151,8 +151,8 @@ for k,v in DHCPOptions.iteritems():
 del(n)
 del(v)
 del(k)
-    
-    
+
+
 
 
 class RandDHCPOptions(RandField):
@@ -193,7 +193,7 @@ class DHCPOptionsField(StrField):
             else:
                 s.append(sane(v))
         return "[%s]" % (" ".join(s))
-        
+
     def getfield(self, pkt, s):
         return "", self.m2i(pkt, s)
     def m2i(self, pkt, x):
@@ -262,7 +262,7 @@ class DHCPOptionsField(StrField):
                 s += chr(len(oval))
                 s += oval
 
-            elif (type(o) is str and DHCPRevOptions.has_key(o) and 
+            elif (type(o) is str and DHCPRevOptions.has_key(o) and
                   DHCPRevOptions[o][1] == None):
                 s += chr(DHCPRevOptions[o][0])
             elif type(o) is int:
@@ -330,7 +330,7 @@ class BOOTP_am(AnsweringMachine):
     def print_reply(self, req, reply):
         print "Reply %s to %s" % (reply.getlayer(IP).dst,reply.dst)
 
-    def make_reply(self, req):        
+    def make_reply(self, req):
         mac = req.src
         if type(self.pool) is list:
             if not self.leases.has_key(mac):
@@ -338,7 +338,7 @@ class BOOTP_am(AnsweringMachine):
             ip = self.leases[mac]
         else:
             ip = self.pool
-            
+
         repb = req.getlayer(BOOTP).copy()
         repb.op="BOOTREPLY"
         repb.yiaddr = ip
@@ -365,10 +365,10 @@ class DHCP_am(BOOTP_am):
                              ("broadcast_address", self.broadcast),
                              ("subnet_mask", self.netmask),
                              ("renewal_time", self.renewal_time),
-                             ("lease_time", self.lease_time), 
+                             ("lease_time", self.lease_time),
                              "end"
                              ]
             resp /= DHCP(options=dhcp_options)
         return resp
-    
+
 

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -31,10 +31,10 @@ def get_cls(name, fallback_cls):
 #############################################################################
 #############################################################################
 
-All_DHCP_Relay_Agents_and_Servers = "ff02::1:2" 
+All_DHCP_Relay_Agents_and_Servers = "ff02::1:2"
 All_DHCP_Servers = "ff05::1:3"  # Site-Local scope : deprecated by 3879
 
-dhcp6opts = { 1: "CLIENTID",  
+dhcp6opts = { 1: "CLIENTID",
               2: "SERVERID",
               3: "IA_NA",
               4: "IA_TA",
@@ -65,14 +65,14 @@ dhcp6opts = { 1: "CLIENTID",
              30: "OPTION_NISP_DOMAIN_NAME",          #RFC3898
              31: "OPTION_SNTP_SERVERS",              #RFC4075
              32: "OPTION_INFORMATION_REFRESH_TIME",  #RFC4242
-             33: "OPTION_BCMCS_SERVER_D",            #RFC4280         
+             33: "OPTION_BCMCS_SERVER_D",            #RFC4280
              34: "OPTION_BCMCS_SERVER_A",            #RFC4280
              36: "OPTION_GEOCONF_CIVIC",             #RFC-ietf-geopriv-dhcp-civil-09.txt
              37: "OPTION_REMOTE_ID",                 #RFC4649
              38: "OPTION_SUBSCRIBER_ID",             #RFC4580
              39: "OPTION_CLIENT_FQDN" }              #RFC4704
 
-dhcp6opts_by_code = {  1: "DHCP6OptClientId", 
+dhcp6opts_by_code = {  1: "DHCP6OptClientId",
                        2: "DHCP6OptServerId",
                        3: "DHCP6OptIA_NA",
                        4: "DHCP6OptIA_TA",
@@ -103,7 +103,7 @@ dhcp6opts_by_code = {  1: "DHCP6OptClientId",
                        30: "DHCP6OptNISPDomain",          #RFC3898
                        31: "DHCP6OptSNTPServers",         #RFC4075
                        32: "DHCP6OptInfoRefreshTime",     #RFC4242
-                       33: "DHCP6OptBCMCSDomains",        #RFC4280         
+                       33: "DHCP6OptBCMCSDomains",        #RFC4280
                        34: "DHCP6OptBCMCSServers",        #RFC4280
                        #36: "DHCP6OptGeoConf",            #RFC-ietf-geopriv-dhcp-civil-09.txt
                        37: "DHCP6OptRemoteID",            #RFC4649
@@ -141,12 +141,12 @@ dhcp6types = {   1:"SOLICIT",
 ###                  DHCPv6 DUID related stuff                    ###
 #####################################################################
 
-duidtypes = { 1: "Link-layer address plus time", 
+duidtypes = { 1: "Link-layer address plus time",
               2: "Vendor-assigned unique ID based on Enterprise Number",
               3: "Link-layer Address",
               4: "UUID" }
 
-# DUID hardware types - RFC 826 - Extracted from 
+# DUID hardware types - RFC 826 - Extracted from
 # http://www.iana.org/assignments/arp-parameters on 31/10/06
 # We should add the length of every kind of address.
 duidhwtypes = {  0: "NET/ROM pseudo", # Not referenced by IANA
@@ -197,16 +197,16 @@ class UTCTimeField(IntField):
 class _LLAddrField(MACField):
     pass
 
-# XXX We only support Ethernet addresses at the moment. _LLAddrField 
+# XXX We only support Ethernet addresses at the moment. _LLAddrField
 #     will be modified when needed. Ask us. --arno
 class DUID_LLT(Packet):  # sect 9.2 RFC 3315
     name = "DUID - Link-layer address plus time"
     fields_desc = [ ShortEnumField("type", 1, duidtypes),
-                    XShortEnumField("hwtype", 1, duidhwtypes), 
+                    XShortEnumField("hwtype", 1, duidhwtypes),
                     UTCTimeField("timeval", 0), # i.e. 01 Jan 2000
                     _LLAddrField("lladdr", ETHER_ANY) ]
 
-# In fact, IANA enterprise-numbers file available at 
+# In fact, IANA enterprise-numbers file available at
 # http//www.iana.org/asignments/enterprise-numbers)
 # is simply huge (more than 2Mo and 600Ko in bz2). I'll
 # add only most common vendors, and encountered values.
@@ -225,12 +225,12 @@ class DUID_EN(Packet):  # sect 9.3 RFC 3315
     name = "DUID - Assigned by Vendor Based on Enterprise Number"
     fields_desc = [ ShortEnumField("type", 2, duidtypes),
                     IntEnumField("enterprisenum", 311, iana_enterprise_num),
-                    StrField("id","") ] 
+                    StrField("id","") ]
 
 class DUID_LL(Packet):  # sect 9.4 RFC 3315
     name = "DUID - Based on Link-layer Address"
     fields_desc = [ ShortEnumField("type", 3, duidtypes),
-                    XShortEnumField("hwtype", 1, duidhwtypes), 
+                    XShortEnumField("hwtype", 1, duidhwtypes),
                     _LLAddrField("lladdr", ETHER_ANY) ]
 
 class DUID_UUID(Packet):  # RFC 6355
@@ -257,7 +257,7 @@ class _DHCP6OptGuessPayload(Packet):
 
 class DHCP6OptUnknown(_DHCP6OptGuessPayload): # A generic DHCPv6 Option
     name = "Unknown DHCPv6 Option"
-    fields_desc = [ ShortEnumField("optcode", 0, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 0, dhcp6opts),
                     FieldLenField("optlen", None, length_of="data", fmt="!H"),
                     StrLenField("data", "",
                                 length_from = lambda pkt: pkt.optlen)]
@@ -281,11 +281,11 @@ class _DUIDField(PacketField):
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
         return s[l:], self.m2i(pkt,s[:l])
- 
+
 
 class DHCP6OptClientId(_DHCP6OptGuessPayload):     # RFC sect 22.2
     name = "DHCP6 Client Identifier Option"
-    fields_desc = [ ShortEnumField("optcode", 1, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 1, dhcp6opts),
                     FieldLenField("optlen", None, length_of="duid", fmt="!H"),
                     _DUIDField("duid", "",
                                length_from = lambda pkt: pkt.optlen) ]
@@ -300,7 +300,7 @@ class DHCP6OptServerId(DHCP6OptClientId):     # RFC sect 22.3
 # TODO : last field IAaddr-options is not defined in the reference document
 class DHCP6OptIAAddress(_DHCP6OptGuessPayload):    # RFC sect 22.6
     name = "DHCP6 IA Address Option (IA_TA or IA_NA suboption)"
-    fields_desc = [ ShortEnumField("optcode", 5, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 5, dhcp6opts),
                     FieldLenField("optlen", None, length_of="iaaddropts",
                                   fmt="!H", adjust = lambda pkt,x: x+24),
                     IP6Field("addr", "::"),
@@ -335,7 +335,7 @@ class _IANAOptField(PacketListField):
 
 class DHCP6OptIA_NA(_DHCP6OptGuessPayload):         # RFC sect 22.4
     name = "DHCP6 Identity Association for Non-temporary Addresses Option"
-    fields_desc = [ ShortEnumField("optcode", 3, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 3, dhcp6opts),
                     FieldLenField("optlen", None, length_of="ianaopts",
                                   fmt="!H", adjust = lambda pkt,x: x+12),
                     XIntField("iaid", None),
@@ -349,7 +349,7 @@ class _IATAOptField(_IANAOptField):
 
 class DHCP6OptIA_TA(_DHCP6OptGuessPayload):         # RFC sect 22.5
     name = "DHCP6 Identity Association for Temporary Addresses Option"
-    fields_desc = [ ShortEnumField("optcode", 4, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 4, dhcp6opts),
                     FieldLenField("optlen", None, length_of="iataopts",
                                   fmt="!H", adjust = lambda pkt,x: x+4),
                     XIntField("iaid", None),
@@ -379,7 +379,7 @@ class _OptReqListField(StrLenField):
                 s.append(dhcp6opts[y])
             else:
                 s.append("%d" % y)
-        return "[%s]" % ", ".join(s) 
+        return "[%s]" % ", ".join(s)
 
     def m2i(self, pkt, x):
         r = []
@@ -390,7 +390,7 @@ class _OptReqListField(StrLenField):
             r.append(struct.unpack("!H", x[:2])[0])
             x = x[2:]
         return r
-    
+
     def i2m(self, pkt, x):
         return "".join(map(lambda y: struct.pack("!H", y), x))
 
@@ -410,7 +410,7 @@ class DHCP6OptOptReq(_DHCP6OptGuessPayload):       # RFC sect 22.7
 # les messages Advertise, a priori
 class DHCP6OptPref(_DHCP6OptGuessPayload):       # RFC sect 22.8
     name = "DHCP6 Preference Option"
-    fields_desc = [ ShortEnumField("optcode", 7, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 7, dhcp6opts),
                     ShortField("optlen", 1 ),
                     ByteField("prefval",255) ]
 
@@ -425,7 +425,7 @@ class _ElapsedTimeField(ShortField):
 
 class DHCP6OptElapsedTime(_DHCP6OptGuessPayload):# RFC sect 22.9
     name = "DHCP6 Elapsed Time Option"
-    fields_desc = [ ShortEnumField("optcode", 8, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 8, dhcp6opts),
                     ShortField("optlen", 2),
                     _ElapsedTimeField("elapsedtime", 0) ]
 
@@ -435,11 +435,11 @@ class DHCP6OptElapsedTime(_DHCP6OptGuessPayload):# RFC sect 22.9
 # Relayed message is seen as a payload.
 class DHCP6OptRelayMsg(_DHCP6OptGuessPayload):# RFC sect 22.10
     name = "DHCP6 Relay Message Option"
-    fields_desc = [ ShortEnumField("optcode", 9, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 9, dhcp6opts),
                     ShortField("optlen", None ) ]
     def post_build(self, p, pay):
         if self.optlen is None:
-            l = len(pay) 
+            l = len(pay)
             p = p[:2]+struct.pack("!H", l)
         return p + pay
 
@@ -482,7 +482,7 @@ class DHCP6OptRelayMsg(_DHCP6OptGuessPayload):# RFC sect 22.10
 # TODO : Decoding only at the moment
 class DHCP6OptAuth(_DHCP6OptGuessPayload):    # RFC sect 22.11
     name = "DHCP6 Option - Authentication"
-    fields_desc = [ ShortEnumField("optcode", 11, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 11, dhcp6opts),
                     FieldLenField("optlen", None, length_of="authinfo",
                                   adjust = lambda pkt,x: x+11),
                     ByteField("proto", 3), # TODO : XXX
@@ -499,13 +499,13 @@ class _SrvAddrField(IP6Field):
         if x is None:
             return "::"
         return x
-    
+
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, self.i2h(pkt,x))
 
 class DHCP6OptServerUnicast(_DHCP6OptGuessPayload):# RFC sect 22.12
     name = "DHCP6 Server Unicast Option"
-    fields_desc = [ ShortEnumField("optcode", 12, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 12, dhcp6opts),
                     ShortField("optlen", 16 ),
                     _SrvAddrField("srvaddr",None) ]
 
@@ -522,7 +522,7 @@ dhcp6statuscodes = { 0:"Success",      # sect 24.4
 
 class DHCP6OptStatusCode(_DHCP6OptGuessPayload):# RFC sect 22.13
     name = "DHCP6 Status Code Option"
-    fields_desc = [ ShortEnumField("optcode", 13, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 13, dhcp6opts),
                     FieldLenField("optlen", None, length_of="statusmsg",
                                   fmt="!H", adjust = lambda pkt,x:x+2),
                     ShortEnumField("statuscode",None,dhcp6statuscodes),
@@ -572,7 +572,7 @@ class USER_CLASS_DATA(Packet):
 
 class DHCP6OptUserClass(_DHCP6OptGuessPayload):# RFC sect 22.15
     name = "DHCP6 User Class Option"
-    fields_desc = [ ShortEnumField("optcode", 15, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 15, dhcp6opts),
                     FieldLenField("optlen", None, fmt="!H",
                                   length_of="userclassdata"),
                     _UserClassDataField("userclassdata", [], USER_CLASS_DATA,
@@ -589,7 +589,7 @@ class VENDOR_CLASS_DATA(USER_CLASS_DATA):
 
 class DHCP6OptVendorClass(_DHCP6OptGuessPayload):# RFC sect 22.16
     name = "DHCP6 Vendor Class Option"
-    fields_desc = [ ShortEnumField("optcode", 16, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 16, dhcp6opts),
                     FieldLenField("optlen", None, length_of="vcdata", fmt="!H",
                                   adjust = lambda pkt,x: x+4),
                     IntEnumField("enterprisenum",None , iana_enterprise_num ),
@@ -610,7 +610,7 @@ class VENDOR_SPECIFIC_OPTION(_DHCP6OptGuessPayload):
 # The third one that will be used for nothing interesting
 class DHCP6OptVendorSpecificInfo(_DHCP6OptGuessPayload):# RFC sect 22.17
     name = "DHCP6 Vendor-specific Information Option"
-    fields_desc = [ ShortEnumField("optcode", 17, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 17, dhcp6opts),
                     FieldLenField("optlen", None, length_of="vso", fmt="!H",
                                   adjust = lambda pkt,x: x+4),
                     IntEnumField("enterprisenum",None , iana_enterprise_num),
@@ -637,9 +637,9 @@ class DHCP6OptIfaceId(_DHCP6OptGuessPayload):# RFC sect 22.18
 # renew message or an Informatiion-request message.
 class DHCP6OptReconfMsg(_DHCP6OptGuessPayload):       # RFC sect 22.19
     name = "DHCP6 Reconfigure Message Option"
-    fields_desc = [ ShortEnumField("optcode", 19, dhcp6opts), 
+    fields_desc = [ ShortEnumField("optcode", 19, dhcp6opts),
                     ShortField("optlen", 1 ),
-                    ByteEnumField("msgtype", 11, {  5:"Renew Message", 
+                    ByteEnumField("msgtype", 11, {  5:"Renew Message",
                                                    11:"Information Request"}) ]
 
 
@@ -657,7 +657,7 @@ class DHCP6OptReconfAccept(_DHCP6OptGuessPayload):   # RFC sect 22.20
     fields_desc = [ ShortEnumField("optcode", 20, dhcp6opts),
                     ShortField("optlen", 0)]
 
-# As required in Sect 8. of RFC 3315, Domain Names must be encoded as 
+# As required in Sect 8. of RFC 3315, Domain Names must be encoded as
 # described in section 3.1 of RFC 1035
 # XXX Label should be at most 63 octets in length : we do not enforce it
 #     Total length of domain should be 255 : we do not enforce it either
@@ -719,7 +719,7 @@ class DHCP6OptSIPServers(_DHCP6OptGuessPayload):          #RFC3319
     name = "DHCP6 Option - SIP Servers IPv6 Address List"
     fields_desc = [ ShortEnumField("optcode", 22, dhcp6opts),
                     FieldLenField("optlen", None, length_of="sipservers"),
-                    IP6ListField("sipservers", [], 
+                    IP6ListField("sipservers", [],
                                  length_from = lambda pkt: pkt.optlen) ]
 
 class DHCP6OptDNSServers(_DHCP6OptGuessPayload):          #RFC3646
@@ -736,7 +736,7 @@ class DHCP6OptDNSDomains(_DHCP6OptGuessPayload): #RFC3646
                     DomainNameListField("dnsdomains", [],
                                         length_from = lambda pkt: pkt.optlen) ]
 
-# TODO: Implement iaprefopts correctly when provided with more 
+# TODO: Implement iaprefopts correctly when provided with more
 #       information about it.
 class DHCP6OptIAPrefix(_DHCP6OptGuessPayload):                    #RFC3633
     name = "DHCP6 Option - IA_PD Prefix option"
@@ -827,7 +827,7 @@ class DHCP6OptInfoRefreshTime(_DHCP6OptGuessPayload):    #RFC4242
                     ShortField("optlen", 4),
                     IntField("reftime", IRT_DEFAULT)] # One day
 
-class DHCP6OptBCMCSDomains(_DHCP6OptGuessPayload):              #RFC4280         
+class DHCP6OptBCMCSDomains(_DHCP6OptGuessPayload):              #RFC4280
     name = "DHCP6 Option - BCMCS Domain Name List"
     fields_desc = [ ShortEnumField("optcode", 33, dhcp6opts),
                     FieldLenField("optlen", None, length_of="bcmcsdomains"),
@@ -890,7 +890,7 @@ class DHCP6OptRelayAgentERO(_DHCP6OptGuessPayload):       # RFC4994
 ###                        DHCPv6 messages                        ###
 #####################################################################
 
-# Some state parameters of the protocols that should probably be 
+# Some state parameters of the protocols that should probably be
 # useful to have in the configuration (and keep up-to-date)
 DHCP6RelayAgentUnicastAddr=""
 DHCP6RelayHopCount=""
@@ -972,9 +972,9 @@ class DHCP6_Advertise(DHCP6):
     name = "DHCPv6 Advertise Message"
     msgtype = 2
     overload_fields = { UDP: {"sport": 547, "dport": 546} }
-    
+
     def answers(self, other):
-        return (isinstance(other,DHCP6_Solicit) and 
+        return (isinstance(other,DHCP6_Solicit) and
                 other.msgtype == 1 and
                 self.trid == other.trid)
 
@@ -1010,7 +1010,7 @@ class DHCP6_Request(DHCP6):
 class DHCP6_Confirm(DHCP6):
     name = "DHCPv6 Confirm Message"
     msgtype = 4
-    
+
 #####################################################################
 # Renew Message
 # - sent by clients
@@ -1031,7 +1031,7 @@ class DHCP6_Confirm(DHCP6):
 class DHCP6_Renew(DHCP6):
     name = "DHCPv6 Renew Message"
     msgtype = 5
-    
+
 #####################################################################
 # Rebind Message
 # - sent by clients
@@ -1041,7 +1041,7 @@ class DHCP6_Renew(DHCP6):
 class DHCP6_Rebind(DHCP6):
     name = "DHCPv6 Rebind Message"
     msgtype = 6
-    
+
 #####################################################################
 # Reply Message
 # - sent by servers
@@ -1070,7 +1070,7 @@ class DHCP6_Reply(DHCP6):
     msgtype = 7
 
     overload_fields = { UDP: {"sport": 547, "dport": 546} }
-    
+
     def answers(self, other):
 
         types = (DHCP6_InfoRequest, DHCP6_Confirm, DHCP6_Rebind, DHCP6_Decline, DHCP6_Request, DHCP6_Release, DHCP6_Renew)
@@ -1087,7 +1087,7 @@ class DHCP6_Reply(DHCP6):
 class DHCP6_Release(DHCP6):
     name = "DHCPv6 Release Message"
     msgtype = 8
-    
+
 #####################################################################
 # Decline Message
 # - sent by clients
@@ -1096,12 +1096,12 @@ class DHCP6_Release(DHCP6):
 # - The addresses to be declined must be included in the IAs. Any
 # addresses for the IAs the client wishes to continue to use should
 # not be in added to the IAs.
-# - cf p54 
+# - cf p54
 
 class DHCP6_Decline(DHCP6):
     name = "DHCPv6 Decline Message"
     msgtype = 9
-    
+
 #####################################################################
 # Reconfigure Message
 # - sent by servers
@@ -1120,11 +1120,11 @@ class DHCP6_Reconf(DHCP6):
     msgtype = 10
     overload_fields = { UDP: { "sport": 547, "dport": 546 } }
 
-    
+
 #####################################################################
 # Information-Request Message
 # - sent by clients when needs configuration information but no
-# addresses. 
+# addresses.
 # - client should include a client identifier option to identify
 # itself. If it doesn't the server is not able to return client
 # specific options or the server can choose to not respond to the
@@ -1134,11 +1134,11 @@ class DHCP6_Reconf(DHCP6):
 # (can include hints)
 
 class DHCP6_InfoRequest(DHCP6):
-    name = "DHCPv6 Information Request Message"    
-    msgtype = 11 
-    
+    name = "DHCPv6 Information Request Message"
+    msgtype = 11
+
 #####################################################################
-# sent between Relay Agents and Servers 
+# sent between Relay Agents and Servers
 #
 # Normalement, doit inclure une option "Relay Message Option"
 # peut en inclure d'autres.
@@ -1148,7 +1148,7 @@ class DHCP6_InfoRequest(DHCP6):
 # - sent by relay agents to servers
 # If the relay agent relays messages to the All_DHCP_Servers multicast
 # address or other multicast addresses, it sets the Hop Limit field to
-# 32. 
+# 32.
 
 class DHCP6_RelayForward(_DHCP6OptGuessPayload,Packet):
     name = "DHCPv6 Relay Forward Message (Relay Agent/Server Message)"
@@ -1160,7 +1160,7 @@ class DHCP6_RelayForward(_DHCP6OptGuessPayload,Packet):
         return inet_pton(socket.AF_INET6, self.peeraddr)
 
 #####################################################################
-# sent between Relay Agents and Servers 
+# sent between Relay Agents and Servers
 # Normalement, doit inclure une option "Relay Message Option"
 # peut en inclure d'autres.
 # Les valeurs des champs hop-count, link-addr et peer-addr
@@ -1216,7 +1216,7 @@ bind_bottom_up(UDP, _dhcp6_dispatcher, { "dport": 546 } )
 
 class DHCPv6_am(AnsweringMachine):
     function_name = "dhcp6d"
-    filter = "udp and port 546 and port 547" 
+    filter = "udp and port 546 and port 547"
     send_function = staticmethod(send)
     def usage(self):
         msg = """
@@ -1286,7 +1286,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
     def parse_options(self, dns="2001:500::1035", domain="localdomain, local",
                       startip="2001:db8::1", endip="2001:db8::20", duid=None,
-                      sntpservers=None, sipdomains=None, sipservers=None, 
+                      sntpservers=None, sipdomains=None, sipservers=None,
                       nisdomain=None, nisservers=None, nispdomain=None,
                       nispservers=None, bcmcsservers=None, bcmcsdomains=None,
                       iface=None, debug=0, advpref=255):
@@ -1305,20 +1305,20 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
         if iface is None:
             iface = conf.iface6
-        
+
         self.debug = debug
 
         # Dictionary of provided DHCPv6 options, keyed by option type
         self.dhcpv6_options={}
 
-        for o in [(dns, "dns", 23, lambda x: DHCP6OptDNSServers(dnsservers=x)), 
-                  (domain, "domain", 24, lambda x: DHCP6OptDNSDomains(dnsdomains=x)), 
+        for o in [(dns, "dns", 23, lambda x: DHCP6OptDNSServers(dnsservers=x)),
+                  (domain, "domain", 24, lambda x: DHCP6OptDNSDomains(dnsdomains=x)),
                   (sntpservers, "sntpservers", 31, lambda x: DHCP6OptSNTPServers(sntpservers=x)),
                   (sipservers, "sipservers", 22, lambda x: DHCP6OptSIPServers(sipservers=x)),
                   (sipdomains, "sipdomains", 21, lambda x: DHCP6OptSIPDomains(sipdomains=x)),
                   (nisservers, "nisservers", 27, lambda x: DHCP6OptNISServers(nisservers=x)),
                   (nisdomain, "nisdomain", 29, lambda x: DHCP6OptNISDomain(nisdomain=(x+[""])[0])),
-                  (nispservers, "nispservers", 28, lambda x: DHCP6OptNISPServers(nispservers=x)), 
+                  (nispservers, "nispservers", 28, lambda x: DHCP6OptNISPServers(nispservers=x)),
                   (nispdomain, "nispdomain", 30, lambda x: DHCP6OptNISPDomain(nispdomain=(x+[""])[0])),
                   (bcmcsservers, "bcmcsservers", 33, lambda x: DHCP6OptBCMCSServers(bcmcsservers=x)),
                   (bcmcsdomains, "bcmcsdomains", 34, lambda x: DHCP6OptBCMCSDomains(bcmcsdomains=x))]:
@@ -1338,7 +1338,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             for i in opts:
                 print "    %d: %s" % (i, repr(self.dhcpv6_options[i]))
 
-        # Preference value used in Advertise. 
+        # Preference value used in Advertise.
         self.advpref = advpref
 
         # IP Pool
@@ -1350,7 +1350,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
         # The interface we are listening/replying on
         self.iface = iface
 
-        ####        
+        ####
         # Generate a server DUID
         if duid is not None:
             self.duid = duid
@@ -1366,28 +1366,28 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             mac = ":".join(map(lambda x: "%.02x" % ord(x), list(rawmac)))
 
             self.duid = DUID_LLT(timeval = timeval, lladdr = mac)
-            
+
         if self.debug:
-            print "\n[+] Our server DUID:" 
+            print "\n[+] Our server DUID:"
             self.duid.show(label_lvl=" "*4)
 
         ####
         # Find the source address we will use
-        l = filter(lambda x: x[2] == iface and in6_islladdr(x[0]), 
+        l = filter(lambda x: x[2] == iface and in6_islladdr(x[0]),
                    in6_getifaddr())
         if not l:
             warning("Unable to get a Link-Local address")
-            return 
-        
+            return
+
         self.src_addr = l[0][0]
 
         ####
         # Our leases
         self.leases = {}
-        
+
 
         if self.debug:
-            print "\n[+] Starting DHCPv6 service on %s:" % self.iface 
+            print "\n[+] Starting DHCPv6 service on %s:" % self.iface
 
     def is_request(self, p):
         if not IPv6 in p:
@@ -1396,7 +1396,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
         src = p[IPv6].src
         dst = p[IPv6].dst
 
-        p = p[IPv6].payload 
+        p = p[IPv6].payload
         if not isinstance(p, UDP) or p.sport != 546 or p.dport != 547 :
             return False
 
@@ -1412,7 +1412,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
         # Message validation following section 15 of RFC 3315
 
-        if ((p.msgtype == 1) or # Solicit 
+        if ((p.msgtype == 1) or # Solicit
             (p.msgtype == 6) or # Rebind
             (p.msgtype == 4)):  # Confirm
             if ((not DHCP6OptClientId in p) or
@@ -1420,15 +1420,15 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                 return False
 
             if (p.msgtype == 6 or # Rebind
-                p.msgtype == 4):  # Confirm   
-                # XXX We do not reply to Confirm or Rebind as we 
-                # XXX do not support address assignment            
+                p.msgtype == 4):  # Confirm
+                # XXX We do not reply to Confirm or Rebind as we
+                # XXX do not support address assignment
                 return False
 
         elif (p.msgtype == 3 or # Request
               p.msgtype == 5 or # Renew
               p.msgtype == 8):  # Release
-        
+
             # Both options must be present
             if ((not DHCP6OptServerId in p) or
                 (not DHCP6OptClientId in p)):
@@ -1442,8 +1442,8 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
             if (p.msgtype == 5 or # Renew
                 p.msgtype == 8):  # Release
-                # XXX We do not reply to Renew or Release as we 
-                # XXX do not support address assignment            
+                # XXX We do not reply to Renew or Release as we
+                # XXX do not support address assignment
                 return False
 
         elif p.msgtype == 9: # Decline
@@ -1477,10 +1477,10 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                 a=map(lambda x: x.addr,  opsaddr)
                 addrs += a
                 it = it.payload
-                    
+
             addrs = map(lambda x: bo + x + n, addrs)
             if debug:
-                msg = r + "[DEBUG]" + n + " Received " + g + "Decline" + n 
+                msg = r + "[DEBUG]" + n + " Received " + g + "Decline" + n
                 msg += " from " + bo + src + vendor + " for "
                 msg += ", ".join(addrs)+ n
                 print msg
@@ -1494,7 +1494,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             # be sent in return.
 
             # - Message must include a Server identifier option
-            # - the content of the Server identifier option must 
+            # - the content of the Server identifier option must
             #   match the server's identifier
             # - the message must include a Client Identifier option
             return False
@@ -1506,7 +1506,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                     return False
                 if str(duid) != str(self.duid):
                     return False
-            if ((DHCP6OptIA_NA in p) or 
+            if ((DHCP6OptIA_NA in p) or
                 (DHCP6OptIA_TA in p) or
                 (DHCP6OptIA_PD in p)):
                     return False
@@ -1522,7 +1522,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             if s.endswith(" Message"):
                 s = s[:-8]
             return s
-        
+
         if reply is None:
             return
 
@@ -1556,23 +1556,23 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
         trid = p.trid
 
         if msgtype == 1: # SOLICIT (See Sect 17.1 and 17.2 of RFC 3315)
-            
+
             # XXX We don't support address or prefix assignment
             # XXX We also do not support relay function           --arno
 
             client_duid = p[DHCP6OptClientId].duid
             resp  = IPv6(src=self.src_addr, dst=req_src)
             resp /= UDP(sport=547, dport=546)
-            
+
             if p.haslayer(DHCP6OptRapidCommit):
-                # construct a Reply packet 
+                # construct a Reply packet
                 resp /= DHCP6_Reply(trid=trid)
                 resp /= DHCP6OptRapidCommit() # See 17.1.2
                 resp /= DHCP6OptServerId(duid = self.duid)
                 resp /= DHCP6OptClientId(duid = client_duid)
-                
-            else: # No Rapid Commit in the packet. Reply with an Advertise                
-                
+
+            else: # No Rapid Commit in the packet. Reply with an Advertise
+
                 if (p.haslayer(DHCP6OptIA_NA) or
                     p.haslayer(DHCP6OptIA_TA)):
                     # XXX We don't assign addresses at the moment
@@ -1580,7 +1580,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                     resp /= DHCP6_Advertise(trid = trid)
                     resp /= DHCP6OptStatusCode(statuscode=2, statusmsg=msg)
                     resp /= DHCP6OptServerId(duid = self.duid)
-                    resp /= DHCP6OptClientId(duid = client_duid)                  
+                    resp /= DHCP6OptClientId(duid = client_duid)
 
                 elif p.haslayer(DHCP6OptIA_PD):
                     # XXX We don't assign prefixes at the moment
@@ -1588,7 +1588,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                     resp /= DHCP6_Advertise(trid = trid)
                     resp /= DHCP6OptStatusCode(statuscode=6, statusmsg=msg)
                     resp /= DHCP6OptServerId(duid = self.duid)
-                    resp /= DHCP6OptClientId(duid = client_duid)                  
+                    resp /= DHCP6OptClientId(duid = client_duid)
 
                 else: # Usual case, no request for prefixes or addresse
                     resp /= DHCP6_Advertise(trid = trid)
@@ -1596,7 +1596,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                     resp /= DHCP6OptServerId(duid = self.duid)
                     resp /= DHCP6OptClientId(duid = client_duid)
                     resp /= DHCP6OptReconfAccept()
-                    
+
                     # See which options should be included
                     reqopts = []
                     if p.haslayer(DHCP6OptOptReq): # add only asked ones
@@ -1606,7 +1606,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                                 resp /= self.dhcpv6_options[o]
                     else: # advertise everything we have available
                         for o in self.dhcpv6_options.keys():
-                            resp /= self.dhcpv6_options[o]                    
+                            resp /= self.dhcpv6_options[o]
 
             return resp
 
@@ -1625,18 +1625,18 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                 for o in self.dhcpv6_options.keys():
                     if o in reqopts:
                         resp /= self.dhcpv6_options[o]
-            else: 
+            else:
                 # advertise everything we have available.
-                # Should not happen has clients MUST include 
+                # Should not happen has clients MUST include
                 # and ORO in requests (sec 18.1.1)   -- arno
                 for o in self.dhcpv6_options.keys():
-                    resp /= self.dhcpv6_options[o]          
+                    resp /= self.dhcpv6_options[o]
 
-            return resp            
-        
+            return resp
+
         elif msgtype == 4: # CONFIRM
             # see Sect 18.1.2
-            
+
             # Client want to check if addresses it was assigned
             # are still appropriate
 
@@ -1651,7 +1651,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
         elif msgtype == 5: # RENEW
             # see Sect 18.1.3
-            
+
             # Clients want to extend lifetime of assigned addresses
             # and update configuration parameters. This message is sent
             # specifically to the server that provided her the info
@@ -1663,15 +1663,15 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             # - the message must include a Client identifier option
 
             pass
-        
+
         elif msgtype == 6: # REBIND
             # see Sect 18.1.4
-            
+
             # Same purpose as the Renew message but sent to any
             # available server after he received no response
             # to its previous Renew message.
 
-            
+
             # - Message must include a Client Identifier Option
             # - Message can't include a Server identifier option
 
@@ -1683,7 +1683,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
         elif msgtype == 8: # RELEASE
             # See section 18.1.6
 
-            # Message is sent to the server to indicate that 
+            # Message is sent to the server to indicate that
             # she will no longer use the addresses that was assigned
             # We should parse the message and verify our dictionary
             # to log that fact.
@@ -1697,7 +1697,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
             pass
 
         elif msgtype == 9: # DECLINE
-            # See section 18.1.7            
+            # See section 18.1.7
             pass
 
         elif msgtype == 11: # INFO-REQUEST
@@ -1715,7 +1715,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
             if client_duid:
                 resp /= DHCP6OptClientId(duid = client_duid)
-                
+
             # Stack requested options if available
             reqopts = []
             if p.haslayer(DHCP6OptOptReq):

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -64,7 +64,7 @@ class DNSRRCountField(ShortField):
             x = x.payload
             i += 1
         return i
-        
+
     def i2m(self, pkt, x):
         if x is None:
             x = self._countRR(pkt)
@@ -73,7 +73,7 @@ class DNSRRCountField(ShortField):
         if x is None:
             x = self._countRR(pkt)
         return x
-    
+
 
 def DNSgetstr(s,p):
     name = ""
@@ -105,7 +105,7 @@ def DNSgetstr(s,p):
     if q:
         p = q
     return name,p
-        
+
 
 class DNSRRField(StrField):
     __slots__ = ["countfld", "passon"]
@@ -130,9 +130,9 @@ class DNSRRField(StrField):
             rr = DNSRR_DISPATCHER[type]("\x00"+ret+s[p:p+rdlen])
 	else:
           del(rr.rdlen)
-        
+
         p += rdlen
-        
+
         rr.rrname = name
         return rr,p
     def getfield(self, pkt, s):
@@ -157,8 +157,8 @@ class DNSRRField(StrField):
             return (s,p),ret
         else:
             return s[p:],ret
-            
-            
+
+
 class DNSQRField(DNSRRField):
     def decodeRR(self, name, s, p):
         ret = s[p:p+4]
@@ -166,8 +166,8 @@ class DNSQRField(DNSRRField):
         rr = DNSQR("\x00"+ret)
         rr.qname = name
         return rr,p
-        
-        
+
+
 
 class RDataField(StrLenField):
     def m2i(self, pkt, s):
@@ -190,7 +190,7 @@ class RDataField(StrLenField):
             s = ret_s
         elif pkt.type == 28: # AAAA
             family = socket.AF_INET6
-        if family is not None:    
+        if family is not None:
             s = inet_ntop(family, s)
         return s
     def i2m(self, pkt, s):
@@ -209,7 +209,7 @@ class RDataField(StrLenField):
                 while len(s) >= 255:
                     ret_s += "\xff" + s[:255]
                     s = s[255:]
-                # The remaining string is less than 255 bytes long    
+                # The remaining string is less than 255 bytes long
                 if len(s):
                     ret_s += struct.pack("!B", len(s)) + s
                 s = ret_s
@@ -231,7 +231,7 @@ class RDLenField(Field):
             rdataf = pkt.get_field("rdata")
             x = len(rdataf.i2m(pkt, pkt.rdata))
         return x
-    
+
 
 class DNS(Packet):
     name = "DNS"
@@ -260,7 +260,7 @@ class DNS(Packet):
                 and self.id == other.id
                 and self.qr == 1
                 and other.qr == 0)
-        
+
     def mysummary(self):
         type = ["Qry","Ans"][self.qr]
         name = ""
@@ -292,8 +292,8 @@ class DNSQR(Packet):
     fields_desc = [ DNSStrField("qname",""),
                     ShortEnumField("qtype", 1, dnsqtypes),
                     ShortEnumField("qclass", 1, dnsclasses) ]
-                    
-                    
+
+
 
 # RFC 2671 - Extension Mechanisms for DNS (EDNS0)
 
@@ -322,7 +322,7 @@ class DNSRROPT(Packet):
 # RFC 4034 - Resource Records for the DNS Security Extensions
 
 # 09/2013 from http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
-dnssecalgotypes = { 0:"Reserved", 1:"RSA/MD5", 2:"Diffie-Hellman", 3:"DSA/SHA-1", 
+dnssecalgotypes = { 0:"Reserved", 1:"RSA/MD5", 2:"Diffie-Hellman", 3:"DSA/SHA-1",
                     4:"Reserved", 5:"RSA/SHA-1", 6:"DSA-NSEC3-SHA1",
                     7:"RSASHA1-NSEC3-SHA1", 8:"RSA/SHA-256", 9:"Reserved",
                    10:"RSA/SHA-512", 11:"Reserved", 12:"GOST R 34.10-2001",
@@ -347,7 +347,7 @@ class TimeField(IntField):
 	import time
 	x = self.i2h(pkt, x)
 	t = time.strftime("%Y%m%d%H%M%S", time.gmtime(x))
-	return "%s (%d)" % (t ,x) 
+	return "%s (%d)" % (t ,x)
 
 
 def bitmap2RRlist(bitmap):
@@ -364,7 +364,7 @@ def bitmap2RRlist(bitmap):
 	if len(bitmap) < 2:
 	    warning("bitmap too short (%i)" % len(bitmap))
 	    return
-   
+
 	window_block = ord(bitmap[0]) # window number
 	offset = 256*window_block # offset of the Ressource Record
 	bitmap_len = ord(bitmap[1]) # length of the bitmap in bytes
@@ -381,9 +381,9 @@ def bitmap2RRlist(bitmap):
 	    for i in xrange(8):
 		if ord(tmp_bitmap[b]) & v:
 		    # each of the RR is encoded as a bit
-		    RRlist += [ offset + b*8 + i ] 
+		    RRlist += [ offset + b*8 + i ]
 		v = v >> 1
-	
+
 	# Next block if any
 	bitmap = bitmap[2+bitmap_len:]
 
@@ -402,7 +402,7 @@ def RRlist2bitmap(lst):
     bitmap = ""
     lst = list(set(lst))
     lst.sort()
-    
+
     lst = filter(lambda x: x <= 65535, lst)
     lst = map(lambda x: abs(x), lst)
 
@@ -419,7 +419,7 @@ def RRlist2bitmap(lst):
         rrlist.sort()
         if rrlist == []:
             continue
-     
+
         # Compute the number of bytes used to store the bitmap
         if rrlist[-1] == 0: # only one element in the list
 	    bytes = 1
@@ -445,7 +445,7 @@ def RRlist2bitmap(lst):
                 # 3. sum everything
                 v = reduce(lambda x,y: x+y, tmp_rrlist)
             bitmap += struct.pack("B", v)
-   
+
     return bitmap
 
 
@@ -470,7 +470,7 @@ class _DNSRRdummy(Packet):
         lrrname = len(self.fields_desc[0].i2m("", self.getfieldval("rrname")))
         l = len(pkt) - lrrname - 10
         pkt = pkt[:lrrname+8] + struct.pack("!H", l) + pkt[lrrname+8+2:]
-        
+
         return pkt
 
 class DNSRRSOA(_DNSRRdummy):
@@ -566,9 +566,9 @@ class DNSRRNSEC3(_DNSRRdummy):
                     ShortEnumField("rclass", 1, dnsclasses),
                     IntField("ttl", 0),
                     ShortField("rdlen", None),
-		    ByteField("hashalg", 0), 
+		    ByteField("hashalg", 0),
                     BitEnumField("flags", 0, 8, {1:"Opt-Out"}),
-		    ShortField("iterations", 0), 
+		    ShortField("iterations", 0),
 		    FieldLenField("saltlength", 0, fmt="!B", length_of="salt"),
 		    StrLenField("salt", "", length_from=lambda x: x.saltlength),
 		    FieldLenField("hashlength", 0, fmt="!B", length_of="nexthashedownername"),
@@ -584,9 +584,9 @@ class DNSRRNSEC3PARAM(_DNSRRdummy):
                     ShortEnumField("rclass", 1, dnsclasses),
                     IntField("ttl", 0),
                     ShortField("rdlen", None),
-		    ByteField("hashalg", 0), 
-		    ByteField("flags", 0), 
-		    ShortField("iterations", 0), 
+		    ByteField("hashalg", 0),
+		    ByteField("flags", 0),
+		    ShortField("iterations", 0),
 		    FieldLenField("saltlength", 0, fmt="!B", length_of="salt"),
 		    StrLenField("salt", "", length_from=lambda pkt: pkt.saltlength)
 		  ]
@@ -645,9 +645,9 @@ RFC2136
         return r.getlayer(DNS).rcode
     else:
         return -1
-    
-    
-    
+
+
+
 
 @conf.commands.register
 def dyndns_del(nameserver, name, type="ALL", ttl=10):
@@ -667,7 +667,7 @@ RFC2136
         return r.getlayer(DNS).rcode
     else:
         return -1
-    
+
 
 class DNS_am(AnsweringMachine):
     function_name="dns_spoof"
@@ -682,7 +682,7 @@ class DNS_am(AnsweringMachine):
 
     def is_request(self, req):
         return req.haslayer(DNS) and req.getlayer(DNS).qr == 0
-    
+
     def make_reply(self, req):
         ip = req.getlayer(IP)
         dns = req.getlayer(DNS)

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -30,7 +30,7 @@ class Dot11AddrMACField(MACField):
         if self.is_applicable(pkt):
             return MACField.addfield(self, pkt, s, val)
         else:
-            return s        
+            return s
     def getfield(self, pkt, s):
         if self.is_applicable(pkt):
             return MACField.getfield(self, pkt, s)
@@ -55,7 +55,7 @@ class Dot11Addr4MACField(Dot11AddrMACField):
             if pkt.FCfield & 0x3 == 0x3: # To-DS and From-DS are set
                 return 1
         return 0
-    
+
 
 ### Layers
 
@@ -162,7 +162,7 @@ class Dot11(Packet):
                     Dot11Addr2MACField("addr2", ETHER_ANY),
                     Dot11Addr3MACField("addr3", ETHER_ANY),
                     Dot11SCField("SC", 0),
-                    Dot11Addr4MACField("addr4", ETHER_ANY) 
+                    Dot11Addr4MACField("addr4", ETHER_ANY)
                     ]
     def mysummary(self):
         return self.sprintf("802.11 %Dot11.type% %Dot11.subtype% %Dot11.addr2% > %Dot11.addr1%")
@@ -240,7 +240,7 @@ class Dot11Beacon(Packet):
     fields_desc = [ LELongField("timestamp", 0),
                     LEShortField("beacon_interval", 0x0064),
                     FlagsField("cap", 0, 16, capability_list) ]
-    
+
 
 class Dot11Elt(Packet):
     name = "802.11 Information Element"
@@ -285,13 +285,13 @@ class Dot11ReassoResp(Dot11AssoResp):
 
 class Dot11ProbeReq(Packet):
     name = "802.11 Probe Request"
-    
+
 class Dot11ProbeResp(Packet):
     name = "802.11 Probe Response"
     fields_desc = [ LELongField("timestamp", 0),
                     LEShortField("beacon_interval", 0x0064),
                     FlagsField("cap", 0, 16, capability_list) ]
-    
+
 class Dot11Auth(Packet):
     name = "802.11 Authentication"
     fields_desc = [ LEShortEnumField("algo", 0, ["open", "sharedkey"]),
@@ -339,7 +339,7 @@ class Dot11WEP(Packet):
             else:
                 warning("No WEP key set (conf.wepkey).. strange results expected..")
         return p
-            
+
 
     def decrypt(self,key=None):
         if key is None:
@@ -347,7 +347,7 @@ class Dot11WEP(Packet):
         if key:
             c = ARC4.new(self.iv+key)
             self.add_payload(LLC(c.decrypt(self.wepdata)))
-                    
+
 
 bind_layers( PrismHeader,   Dot11,         )
 bind_layers( RadioTap,      Dot11,         )
@@ -404,13 +404,13 @@ iwconfig wlan0 mode managed
 """
     function_name = "airpwn"
     filter = None
-    
+
     def parse_options(self, iffrom, ifto, replace, pattern="", ignorepattern=""):
         self.iffrom = iffrom
         self.ifto = ifto
         ptrn = re.compile(pattern)
         iptrn = re.compile(ignorepattern)
-        
+
     def is_request(self, pkt):
         if not isinstance(pkt,Dot11):
             return 0
@@ -443,7 +443,7 @@ iwconfig wlan0 mode managed
         q.getlayer(TCP).flags="RA"
         q.getlayer(TCP).seq+=len(replace)
         return [p,q]
-    
+
     def print_reply(self):
         print p.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%")
 
@@ -471,9 +471,9 @@ def get_toDS():
 #        print "iwpriv %s hostapd 1" % ifto
 #        os.system("iwpriv %s hostapd 1" % ifto)
 #        ifto += "ap"
-#        
+#
 #    os.system("iwconfig %s mode monitor" % iffrom)
-#    
+#
 
 def airpwn(iffrom, ifto, replace, pattern="", ignorepattern=""):
     """Before using this, initialize "iffrom" and "ifto" interfaces:
@@ -492,7 +492,7 @@ iwconfig wlan0 channel 11
 iwconfig wlan0 essid dontexist
 iwconfig wlan0 mode managed
 """
-    
+
     ptrn = re.compile(pattern)
     iptrn = re.compile(ignorepattern)
     def do_airpwn(p, ifto=ifto, replace=replace, ptrn=ptrn, iptrn=iptrn):
@@ -525,20 +525,20 @@ iwconfig wlan0 mode managed
         q.ID += 1
         q.getlayer(TCP).flags="RA"
         q.getlayer(TCP).seq+=len(replace)
-        
+
         sendp([p,q], iface=ifto, verbose=0)
-#        print "send",repr(p)        
+#        print "send",repr(p)
 #        print "send",repr(q)
         print p.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%")
 
     sniff(iface=iffrom,prn=do_airpwn)
 
-            
-        
+
+
 conf.stats_dot11_protocols += [Dot11WEP, Dot11Beacon, ]
 
 
-        
+
 
 
 class Dot11PacketList(PacketList):
@@ -555,5 +555,5 @@ class Dot11PacketList(PacketList):
             q.unwep()
             r2.append(Ether()/q.payload.payload.payload) #Dot11/LLC/SNAP/IP
         return PacketList(r2,name="Ether from %s"%self.listname)
-        
-        
+
+

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -39,7 +39,7 @@ class IPTools(object):
         t.sort()
         return t[t.index(self.ttl)+1]
     def hops(self):
-        return self.ottl()-self.ttl-1 
+        return self.ottl()-self.ttl-1
 
 
 _ip_options_names = { 0: "end_of_list",
@@ -67,22 +67,22 @@ _ip_options_names = { 0: "end_of_list",
                       23: "dynamic_packet_state",
                       24: "upstream_multicast_packet",
                       25: "quick_start",
-                      30: "rfc4727_experiment", 
+                      30: "rfc4727_experiment",
                       }
-                      
+
 
 class _IPOption_HDR(Packet):
     fields_desc = [ BitField("copy_flag",0, 1),
                     BitEnumField("optclass",0,2,{0:"control",2:"debug"}),
                     BitEnumField("option",0,5, _ip_options_names) ]
-    
+
 class IPOption(Packet):
     name = "IP Option"
     fields_desc = [ _IPOption_HDR,
                     FieldLenField("length", None, fmt="B",  # Only option 0 and 1 have no length and value
                                   length_of="value", adjust=lambda pkt,l:l+2),
                     StrLenField("value", "",length_from=lambda pkt:pkt.length-2) ]
-    
+
     def extract_padding(self, p):
         return "",p
 
@@ -102,7 +102,7 @@ class IPOption_EOL(IPOption):
     name = "IP Option End of Options List"
     option = 0
     fields_desc = [ _IPOption_HDR ]
-    
+
 
 class IPOption_NOP(IPOption):
     name = "IP Option No Operation"
@@ -120,7 +120,7 @@ class IPOption_Security(IPOption):
                     ShortField("handling_restrictions",0),
                     StrFixedLenField("transmission_control_code","xxx",3),
                     ]
-    
+
 class IPOption_LSRR(IPOption):
     name = "IP Option Loose Source and Record Route"
     copy_flag = 1
@@ -129,7 +129,7 @@ class IPOption_LSRR(IPOption):
                     FieldLenField("length", None, fmt="B",
                                   length_of="routers", adjust=lambda pkt,l:l+3),
                     ByteField("pointer",4), # 4 is first IP
-                    FieldListField("routers",[],IPField("","0.0.0.0"), 
+                    FieldListField("routers",[],IPField("","0.0.0.0"),
                                    length_from=lambda pkt:pkt.length-3)
                     ]
     def get_current_router(self):
@@ -149,7 +149,7 @@ class IPOption_Stream_Id(IPOption):
     fields_desc = [ _IPOption_HDR,
                     ByteField("length", 4),
                     ShortField("security",0), ]
-                    
+
 class IPOption_MTU_Probe(IPOption):
     name = "IP Option MTU Probe"
     option = 11
@@ -197,10 +197,10 @@ class IPOption_SDBM(IPOption):
     fields_desc = [ _IPOption_HDR,
                     FieldLenField("length", None, fmt="B",
                                   length_of="addresses", adjust=lambda pkt,l:l+2),
-                    FieldListField("addresses",[],IPField("","0.0.0.0"), 
+                    FieldListField("addresses",[],IPField("","0.0.0.0"),
                                    length_from=lambda pkt:pkt.length-2)
                     ]
-    
+
 
 
 TCPOptions = (
@@ -267,7 +267,7 @@ class TCPOptionsField(StrField):
                 opt.append((onum, oval))
             x = x[olen:]
         return opt
-    
+
     def i2m(self, pkt, x):
         opt = ""
         for oname,oval in x:
@@ -299,7 +299,7 @@ class TCPOptionsField(StrField):
         return opt+"\x00"*(3-((len(opt)+3)%4))
     def randval(self):
         return [] # XXX
-    
+
 
 class ICMPTimeStampField(IntField):
     re_hmsm = re.compile("([0-2]?[0-9])[Hh:](([0-5]?[0-9])([Mm:]([0-5]?[0-9])([sS:.]([0-9]{0,3}))?)?)?$")
@@ -419,7 +419,7 @@ class IP(Packet, IPTools):
         if self.frag:
             s += " frag:%i" % self.frag
         return s
-                 
+
     def fragment(self, fragsize=1480):
         """Fragment IP datagrams"""
         fragsize = (fragsize+7)/8*8
@@ -429,11 +429,11 @@ class IP(Packet, IPTools):
         while fl.underlayer is not None:
             fnb += 1
             fl = fl.underlayer
-        
+
         for p in fl:
             s = str(p[fnb].payload)
             nb = (len(s)+fragsize-1)/fragsize
-            for i in xrange(nb):            
+            for i in xrange(nb):
                 q = p.copy()
                 del(q[fnb].payload)
                 del(q[fnb].chksum)
@@ -441,7 +441,7 @@ class IP(Packet, IPTools):
                 if i == nb-1:
                     q[IP].flags &= ~1
                 else:
-                    q[IP].flags |= 1 
+                    q[IP].flags |= 1
                 q[IP].frag = i*fragsize/8
                 r = conf.raw_layer(load=s[i*fragsize:(i+1)*fragsize])
                 r.overload_fields = p[IP].payload.overload_fields.copy()
@@ -573,7 +573,7 @@ class UDP(Packet):
         elif isinstance(self.underlayer, scapy.layers.inet6.IPv6):
             return self.underlayer.sprintf("UDP %IPv6.src%:%UDP.sport% > %IPv6.dst%:%UDP.dport%")
         else:
-            return self.sprintf("UDP %UDP.sport% > %UDP.dport%")    
+            return self.sprintf("UDP %UDP.sport% > %UDP.dport%")
 
 icmptypes = { 0 : "echo-reply",
               3 : "dest-unreach",
@@ -614,8 +614,8 @@ icmpcodes = { 3 : { 0  : "network-unreachable",
                      1 : "ttl-zero-during-reassembly", },
               12 : { 0 : "ip-header-bad",
                      1 : "required-option-missing", }, }
-                         
-                   
+
+
 
 
 class ICMP(Packet):
@@ -643,7 +643,7 @@ class ICMP(Packet):
             ck = checksum(p)
             p = p[:2]+chr(ck>>8)+chr(ck&0xff)+p[4:]
         return p
-    
+
     def hashret(self):
         if self.type in [0,8,13,14,15,16,17,18]:
             return struct.pack("HH",self.id,self.seq)+self.payload.hashret()
@@ -667,8 +667,8 @@ class ICMP(Packet):
             return self.underlayer.sprintf("ICMP %IP.src% > %IP.dst% %ICMP.type% %ICMP.code%")
         else:
             return self.sprintf("ICMP %ICMP.type% %ICMP.code%")
-    
-        
+
+
 
 
 
@@ -723,7 +723,7 @@ class UDPerror(UDP):
     def mysummary(self):
         return Packet.mysummary(self)
 
-                    
+
 
 class ICMPerror(ICMP):
     name = "ICMP in ICMP"
@@ -781,7 +781,7 @@ def fragment(pkt, fragsize=1480):
     for p in pkt:
         s = str(p[IP].payload)
         nb = (len(s)+fragsize-1)/fragsize
-        for i in xrange(nb):            
+        for i in xrange(nb):
             q = p.copy()
             del(q[IP].payload)
             del(q[IP].chksum)
@@ -789,7 +789,7 @@ def fragment(pkt, fragsize=1480):
             if i == nb-1:
                 q[IP].flags &= ~1
             else:
-                q[IP].flags |= 1 
+                q[IP].flags |= 1
             q[IP].frag = i*fragsize/8
             r = conf.raw_layer(load=s[i*fragsize:(i+1)*fragsize])
             r.overload_fields = p[IP].payload.overload_fields.copy()
@@ -865,7 +865,7 @@ def defrag(plist):
     for p in defrag:
         defrag2.append(p.__class__(str(p)))
     return nofrag,defrag2,missfrag
-            
+
 @conf.commands.register
 def defragment(plist):
     """defrag(plist) -> plist defragmented as much as possible """
@@ -938,10 +938,10 @@ def defragment(plist):
         name = "Defragmented %s" % plist.listname
     else:
         name = "Defragmented"
-    
+
     return PacketList(final, name=name)
-            
-        
+
+
 
 ### Add timeskew_graph() method to PacketList
 def _packetlist_timeskew_graph(self, ip, **kargs):
@@ -1084,7 +1084,7 @@ class TracerouteResult(SndRcvList):
                     col = visual.color.green
                 else:
                     col = visual.color.blue
-                
+
                 s = IPsphere(pos=((l-1)*visual.cos(2*i*visual.pi/l),(l-1)*visual.sin(2*i*visual.pi/l),2*t),
                              ip = r[i][0],
                              color = col)
@@ -1099,7 +1099,7 @@ class TracerouteResult(SndRcvList):
             for ip in trlst:
                 visual.cylinder(pos=start,axis=ip.pos-start,color=col,radius=0.2)
                 start = ip.pos
-        
+
         movcenter=None
         while 1:
             visual.rate(50)
@@ -1136,8 +1136,8 @@ class TracerouteResult(SndRcvList):
             if movcenter:
                 visual.scene.center -= visual.scene.mouse.pos-movcenter
                 movcenter = visual.scene.mouse.pos
-                
-                
+
+
     def world_trace(self, **kargs):
         """Display traceroute results on a world map."""
 
@@ -1212,7 +1212,7 @@ class TracerouteResult(SndRcvList):
         # Plot the traceroute measurement as lines in the map
         lines = [bmap.plot(*bmap(lons, lats)) for lons, lats in locations]
 
-        # Draw countries   
+        # Draw countries
         bmap.drawcoastlines()
 
         # Call show() if matplotlib is not inlined
@@ -1266,7 +1266,7 @@ class TracerouteResult(SndRcvList):
             else:
                 trace[ttl] = r.sprintf('"%r,src%"')
             rt[trace_id] = trace
-    
+
         # Fill holes with unk%i nodes
         unknown_label = incremental_label("unk%i")
         blackholes = []
@@ -1281,23 +1281,23 @@ class TracerouteResult(SndRcvList):
                     bh = "%s %i/icmp" % (rtk[1],rtk[3])
                 elif rtk[2] == 6: #TCP
                     bh = "%s %i/tcp" % (rtk[1],rtk[3])
-                elif rtk[2] == 17: #UDP                    
+                elif rtk[2] == 17: #UDP
                     bh = '%s %i/udp' % (rtk[1],rtk[3])
                 else:
-                    bh = '%s %i/proto' % (rtk[1],rtk[2]) 
+                    bh = '%s %i/proto' % (rtk[1],rtk[2])
                 ips[bh] = None
                 bhip[rtk[1]] = bh
                 bh = '"%s"' % bh
                 trace[max(k)+1] = bh
                 blackholes.append(bh)
-    
+
         # Find AS numbers
         ASN_query_list = set(x.rsplit(" ",1)[0] for x in ips)
-        if ASres is None:            
+        if ASres is None:
             ASNlist = []
         else:
-            ASNlist = ASres.resolve(*ASN_query_list)            
-    
+            ASNlist = ASres.resolve(*ASN_query_list)
+
         ASNs = {}
         ASDs = {}
         for ip,asn,desc, in ASNlist:
@@ -1312,15 +1312,15 @@ class TracerouteResult(SndRcvList):
                 iplist.append(ip)
             ASNs[asn] = iplist
             ASDs[asn] = desc
-    
-    
+
+
         backcolorlist=colgen("60","86","ba","ff")
         forecolorlist=colgen("a0","70","40","20")
-    
+
         s = "digraph trace {\n"
-    
+
         s += "\n\tnode [shape=ellipse,color=black,style=solid];\n\n"
-    
+
         s += "\n#ASN clustering\n"
         for asn in ASNs:
             s += '\tsubgraph cluster_%s {\n' % asn
@@ -1330,17 +1330,17 @@ class TracerouteResult(SndRcvList):
             s += '\t\tfontsize = 10;'
             s += '\t\tlabel = "%s\\n[%s]"\n' % (asn,ASDs[asn])
             for ip in ASNs[asn]:
-    
+
                 s += '\t\t"%s";\n'%ip
             s += "\t}\n"
-    
-    
-    
-    
+
+
+
+
         s += "#endpoints\n"
         for p in ports:
             s += '\t"%s" [shape=record,color=black,fillcolor=green,style=filled,label="%s|%s"];\n' % (p,p,"|".join(ports[p]))
-    
+
         s += "\n#Blackholes\n"
         for bh in blackholes:
             s += '\t%s [shape=octagon,color=black,fillcolor=red,style=filled];\n' % bh
@@ -1355,12 +1355,12 @@ class TracerouteResult(SndRcvList):
                         pad[rcv.src]=None
             for rcv in pad:
                 s += '\t"%s" [shape=triangle,color=black,fillcolor=red,style=filled];\n' % rcv
-    
-    
-            
+
+
+
         s += "\n\tnode [shape=ellipse,color=black,style=solid];\n\n"
-    
-    
+
+
         for rtk in rt:
             s += "#---[%s\n" % `rtk`
             s += '\t\tedge [color="#%s%s%s"];\n' % forecolorlist.next()
@@ -1369,10 +1369,10 @@ class TracerouteResult(SndRcvList):
             for n in xrange(min(trace), maxtrace):
                 s += '\t%s ->\n' % trace[n]
             s += '\t%s;\n' % trace[maxtrace]
-    
+
         s += "}\n";
         self.graphdef = s
-    
+
     def graph(self, ASres=None, padding=0, **kargs):
         """x.graph(ASres=conf.AS_resolver, other args):
         ASres=None          : no AS resolver => no clustering
@@ -1426,7 +1426,7 @@ traceroute(target, [maxttl=30,] [dport=80,] [sport=80,] [verbose=conf.verb]) -> 
 #############################
 
 class TCP_client(Automaton):
-    
+
     def parse_args(self, ip, port, *args, **kargs):
         self.dst = iter(Net(ip)).next()
         self.dport = port
@@ -1445,7 +1445,7 @@ class TCP_client(Automaton):
 #        bpf=None
         Automaton.parse_args(self, filter=bpf, **kargs)
 
-    
+
     def master_filter(self, pkt):
         return (IP in pkt and
                 pkt[IP].src == self.dst and
@@ -1464,7 +1464,7 @@ class TCP_client(Automaton):
     @ATMT.state()
     def SYN_SENT(self):
         pass
-    
+
     @ATMT.state()
     def ESTABLISHED(self):
         pass
@@ -1477,7 +1477,7 @@ class TCP_client(Automaton):
     def CLOSED(self):
         pass
 
-    
+
     @ATMT.condition(START)
     def connect(self):
         raise self.SYN_SENT()
@@ -1513,7 +1513,7 @@ class TCP_client(Automaton):
             if pkt[TCP].flags & 8 != 0: #PUSH
                 self.oi.tcp.send(self.rcvbuf)
                 self.rcvbuf = ""
-    
+
     @ATMT.ioevent(ESTABLISHED,name="tcp", as_supersocket="tcplink")
     def outgoing_data_received(self, fd):
         raise self.ESTABLISHED().action_parameters(fd.recv())
@@ -1522,8 +1522,8 @@ class TCP_client(Automaton):
         self.l4[TCP].flags = "PA"
         self.send(self.l4/d)
         self.l4[TCP].seq += len(d)
-        
-    
+
+
     @ATMT.receive_condition(ESTABLISHED)
     def reset_received(self, pkt):
         if pkt[TCP].flags & 4 != 0:
@@ -1584,8 +1584,8 @@ def IPID_count(lst, funcID=lambda x:x[1].id, funcpres=lambda x:x[1].summary()):
     print "Probably %i classes:" % len(classes), classes
     for id,pr in lst:
         print "%5i" % id, pr
-    
-    
+
+
 def fragleak(target,sport=123, dport=123, timeout=0.2, onlyasc=0):
     load = "XXXXYYYYYYYYYY"
 #    getmacbyip(target)
@@ -1619,9 +1619,9 @@ def fragleak(target,sport=123, dport=123, timeout=0.2, onlyasc=0):
                 if not ans.haslayer(conf.padding_layer):
                     continue
 
-                
+
 #                print repr(ans.payload.payload.payload.payload)
-                
+
 #                if not isinstance(ans.payload.payload.payload.payload, conf.raw_layer):
 #                    continue
 #                leak = ans.payload.payload.payload.payload.load[len(load):]
@@ -1650,7 +1650,7 @@ def fragleak2(target, timeout=0.4, onlyasc=0):
                     linehexdump(leak,onlyasc=onlyasc)
     except:
         pass
-    
+
 
 conf.stats_classic_protocols += [TCP,UDP,ICMP]
 conf.stats_dot11_protocols += [TCP,UDP,ICMP]

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -20,9 +20,9 @@ ISAKMPAttributeTypes= { "Encryption":    (1, { "DES-CBC"  : 1,
                                                 "IDEA-CBC" : 2,
                                                 "Blowfish-CBC" : 3,
                                                 "RC5-R16-B64-CBC" : 4,
-                                                "3DES-CBC" : 5, 
-                                                "CAST-CBC" : 6, 
-                                                "AES-CBC" : 7, 
+                                                "3DES-CBC" : 5,
+                                                "CAST-CBC" : 6,
+                                                "AES-CBC" : 7,
                                                 "CAMELLIA-CBC" : 8, }, 0),
                          "Hash":          (2, { "MD5": 1,
                                                 "SHA": 2,
@@ -30,7 +30,7 @@ ISAKMPAttributeTypes= { "Encryption":    (1, { "DES-CBC"  : 1,
                                                 "SHA2-256": 4,
                                                 "SHA2-384": 5,
                                                 "SHA2-512": 6,}, 0),
-                         "Authentication":(3, { "PSK": 1, 
+                         "Authentication":(3, { "PSK": 1,
                                                 "DSS": 2,
                                                 "RSA Sig": 3,
                                                 "RSA Encryption": 4,
@@ -53,14 +53,14 @@ ISAKMPAttributeTypes= { "Encryption":    (1, { "DES-CBC"  : 1,
                                                 "XAUTHInitRSARevisedEncryption": 65009,
                                                 "XAUTHRespRSARevisedEncryptio": 65010, }, 0),
                          "GroupDesc":     (4, { "768MODPgr"  : 1,
-                                                "1024MODPgr" : 2, 
+                                                "1024MODPgr" : 2,
                                                 "EC2Ngr155"  : 3,
                                                 "EC2Ngr185"  : 4,
-                                                "1536MODPgr" : 5, 
-                                                "2048MODPgr" : 14, 
-                                                "3072MODPgr" : 15, 
-                                                "4096MODPgr" : 16, 
-                                                "6144MODPgr" : 17, 
+                                                "1536MODPgr" : 5,
+                                                "2048MODPgr" : 14,
+                                                "3072MODPgr" : 15,
+                                                "4096MODPgr" : 16,
+                                                "6144MODPgr" : 17,
                                                 "8192MODPgr" : 18, }, 0),
                          "GroupType":      (5,  {"MODP":       1,
                                                  "ECP":        2,
@@ -79,8 +79,8 @@ ISAKMPAttributeTypes= { "Encryption":    (1, { "DES-CBC"  : 1,
                          "GroupOrder":     (16, {}, 1),
                          }
 
-# the name 'ISAKMPTransformTypes' is actually a misnomer (since the table 
-# holds info for all ISAKMP Attribute types, not just transforms, but we'll 
+# the name 'ISAKMPTransformTypes' is actually a misnomer (since the table
+# holds info for all ISAKMP Attribute types, not just transforms, but we'll
 # keep it for backwards compatibility... for now at least
 ISAKMPTransformTypes = ISAKMPAttributeTypes
 
@@ -136,7 +136,7 @@ class ISAKMPTransformSetField(StrLenField):
             is_tlv = not (trans_type & 0x8000)
             if is_tlv:
                 # We should probably check to make sure the attribute type we
-                # are looking at is allowed to have a TLV format and issue a 
+                # are looking at is allowed to have a TLV format and issue a
                 # warning if we're given an TLV on a basic attribute.
                 value_len, = struct.unpack("!H", m[2:4])
                 if value_len+4 > len(m):
@@ -201,7 +201,7 @@ class ISAKMP(ISAKMP_class): # rfc2408
         if self.length is None:
             p = p[:24]+struct.pack("!I",len(p))+p[28:]
         return p
-       
+
 
 
 
@@ -230,10 +230,10 @@ class ISAKMP_payload_Transform(ISAKMP_class):
             p = p[:2]+chr((l>>8)&0xff)+chr(l&0xff)+p[4:]
         p += pay
         return p
-            
 
 
-        
+
+
 class ISAKMP_payload_Proposal(ISAKMP_class):
     name = "IKE proposal"
 #    ISAKMP_payload_type = 0

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -97,7 +97,7 @@ class DestMACField(MACField):
         return MACField.i2h(self, pkt, x)
     def i2m(self, pkt, x):
         return MACField.i2m(self, pkt, self.i2h(pkt, x))
-        
+
 class SourceMACField(MACField):
     def __init__(self, name):
         MACField.__init__(self, name, None)
@@ -116,7 +116,7 @@ class SourceMACField(MACField):
         return MACField.i2h(self, pkt, x)
     def i2m(self, pkt, x):
         return MACField.i2m(self, pkt, self.i2h(pkt, x))
-        
+
 class ARPSourceMACField(MACField):
     def __init__(self, name):
         MACField.__init__(self, name, None)
@@ -201,8 +201,8 @@ class CookedLinux(Packet):
                     ShortField("lladdrlen",0),
                     StrFixedLenField("src","",8),
                     XShortEnumField("proto",0x800,ETHER_TYPES) ]
-                    
-                                   
+
+
 
 class SNAP(Packet):
     name = "SNAP"
@@ -241,7 +241,7 @@ class Dot1Q(Packet):
         else:
             return self.sprintf("802.1q (%Dot1Q.type%) vlan %Dot1Q.vlan%")
 
-            
+
 conf.neighbor.register_l3(Ether, Dot1Q, lambda l2,l3: conf.neighbor.resolve(l2,l3.payload))
 
 class STP(Packet):
@@ -267,7 +267,7 @@ class EAPOL(Packet):
     fields_desc = [ ByteField("version", 1),
                     ByteEnumField("type", 0, ["EAP_PACKET", "START", "LOGOFF", "KEY", "ASF"]),
                     LenField("len", None, "H") ]
-    
+
     EAP_PACKET= 0
     START = 1
     LOGOFF = 2
@@ -286,7 +286,7 @@ class EAPOL(Packet):
         return 0
     def mysummary(self):
         return self.sprintf("EAPOL %EAPOL.type%")
-             
+
 
 class EAP(Packet):
     name = "EAP"
@@ -296,7 +296,7 @@ class EAP(Packet):
                     ConditionalField(ByteEnumField("type",0, {1:"ID",4:"MD5"}), lambda pkt:pkt.code not in [EAP.SUCCESS, EAP.FAILURE])
 
                                      ]
-    
+
     REQUEST = 1
     RESPONSE = 2
     SUCCESS = 3
@@ -314,13 +314,13 @@ class EAP(Packet):
             elif other.code == self.RESPONSE:
                 return 1
         return 0
-    
+
     def post_build(self, p, pay):
         if self.len is None:
             l = len(p)+len(pay)
             p = p[:2]+chr((l>>8)&0xff)+chr(l&0xff)+p[4:]
         return p+pay
-             
+
 
 class ARP(Packet):
     name = "ARP"
@@ -356,7 +356,7 @@ class ARP(Packet):
             return self.sprintf("ARP who has %pdst% says %psrc%")
         else:
             return self.sprintf("ARP %op% %psrc% > %pdst%")
-                 
+
 conf.neighbor.register_l3(Ether, ARP, lambda l2,l3: getmacbyip(l3.pdst))
 
 class GRErouting(Packet):
@@ -536,7 +536,7 @@ class ARP_am(AnsweringMachine):
         return (req.haslayer(ARP) and
                 req.getlayer(ARP).op == 1 and
                 (self.IP_addr == None or self.IP_addr == req.getlayer(ARP).pdst))
-    
+
     def make_reply(self, req):
         ether = req.getlayer(Ether)
         arp = req.getlayer(ARP)
@@ -575,7 +575,7 @@ class ARP_am(AnsweringMachine):
 @conf.commands.register
 def etherleak(target, **kargs):
     """Exploit Etherleak flaw"""
-    return srpflood(Ether()/ARP(pdst=target), 
+    return srpflood(Ether()/ARP(pdst=target),
                     prn=lambda (s,r): conf.padding_layer in r and hexstr(r[conf.padding_layer].load),
                     filter="arp", **kargs)
 

--- a/scapy/layers/mgcp.py
+++ b/scapy/layers/mgcp.py
@@ -25,8 +25,8 @@ class MGCP(Packet):
                     StrStopField("version","MGCP 1.0 NCS 1.0","\x0a", -1),
                     StrFixedLenField("sep4","\x0a",1),
                     ]
-                    
-    
+
+
 #class MGCP(Packet):
 #    name = "MGCP"
 #    longname = "Media Gateway Control Protocol"

--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -34,7 +34,7 @@ class NetBIOS_DS(Packet):
             l = len(p)-14
             p = p[:10]+struct.pack("!H", l)+p[12:]
         return p
-        
+
 #        ShortField("length",0),
 #        ShortField("Delimitor",0),
 #        ByteField("command",0),
@@ -44,7 +44,7 @@ class NetBIOS_DS(Packet):
 #        ShortField("RSPCor",0),
 #        StrFixedLenField("dest","",16),
 #        StrFixedLenField("source","",16),
-#        
+#
 #        ]
 #
 
@@ -117,7 +117,7 @@ class NBNSQueryResponse(Packet):
 # Name Release Response
 class NBNSQueryResponseNegative(Packet):
     name="NBNS query response (negative)"
-    fields_desc = [ShortField("NAME_TRN_ID",0), 
+    fields_desc = [ShortField("NAME_TRN_ID",0),
                    ShortField("FLAGS", 0x8506),
                    ShortField("QDCOUNT",0),
                    ShortField("ANCOUNT",1),
@@ -134,11 +134,11 @@ class NBNSQueryResponseNegative(Packet):
                    BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",01:"P node",02:"M node",03:"H node"}),
                    BitEnumField("UNUSED",0,13,{0:"Unused"}),
                    IPField("NB_ADDRESS", "127.0.0.1")]
-    
+
 # Node Status Response
 class NBNSNodeStatusResponse(Packet):
     name="NBNS Node Status Response"
-    fields_desc = [ShortField("NAME_TRN_ID",0), 
+    fields_desc = [ShortField("NAME_TRN_ID",0),
                    ShortField("FLAGS", 0x8500),
                    ShortField("QDCOUNT",0),
                    ShortField("ANCOUNT",1),
@@ -200,7 +200,7 @@ class NBTDatagram(Packet):
                   NetBIOSNameField("DestinationName","windows"),
                   ShortEnumField("SUFFIX2",0x4141,{0x4141:"workstation",0x4141+0x03:"messenger service",0x4141+0x200:"file server service",0x4141+0x10b:"domain master browser",0x4141+0x10c:"domain controller", 0x4141+0x10e:"browser election service"}),
                   ByteField("NULL",0)]
-    
+
 
 class NBTSession(Packet):
     name="NBT Session Packet"

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -35,18 +35,18 @@ class TimeStampField(FixedPointField):
         elif isinstance(val, datetime.datetime):
             val = int(val.strftime("%s")) + _NTP_BASETIME
         return FixedPointField.any2i(self, pkt, val)
-    
+
     def i2m(self, pkt, val):
         if val is None:
             val = FixedPointField.any2i(self, pkt, time.time()+_NTP_BASETIME)
         return FixedPointField.i2m(self, pkt, val)
-        
+
 
 
 class NTP(Packet):
     # RFC 1769
     name = "NTP"
-    fields_desc = [ 
+    fields_desc = [
          BitEnumField('leap', 0, 2,
                       { 0: 'nowarning',
                         1: 'longminute',
@@ -71,7 +71,7 @@ class NTP(Packet):
          TimeStampField('ref', 0),
          TimeStampField('orig', None),  # None means current time
          TimeStampField('recv', 0),
-         TimeStampField('sent', None) 
+         TimeStampField('sent', None)
          ]
     def mysummary(self):
         return self.sprintf("NTP v%ir,NTP.version%, %NTP.mode%")

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -226,7 +226,7 @@ _PPP_conftypes = { 1:"Configure-Request",
 
 ### PPP IPCP stuff (RFC 1332)
 
-# All IPCP options are defined below (names and associated classes) 
+# All IPCP options are defined below (names and associated classes)
 _PPP_ipcpopttypes = {     1:"IP-Addresses (Deprecated)",
                           2:"IP-Compression-Protocol",
                           3:"IP-Address",
@@ -330,7 +330,7 @@ class PPP_ECP_Option_OUI(PPP_ECP_Option):
                     StrFixedLenField("oui","",3),
                     ByteField("subtype",0),
                     StrLenField("data", "", length_from=lambda p:p.len-6) ]
-                    
+
 
 
 class PPP_ECP(Packet):

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -13,7 +13,7 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *
 
-class RadiusAttribute(Packet): 
+class RadiusAttribute(Packet):
     name = "Radius Attribute"
     fields_desc = [
         ByteEnumField("type",1,{ 1:"User-Name",
@@ -87,7 +87,7 @@ class RadiusAttribute(Packet):
             l = len(p)
             p = p[:2]+struct.pack("!B",l)+p[4:]
         return p
-        
+
     def extract_padding(self, pay):
         return "",pay
 

--- a/scapy/layers/rtp.py
+++ b/scapy/layers/rtp.py
@@ -37,4 +37,4 @@ class RTP(Packet):
                     IntField('timestamp', 0),
                     IntField('sourcesync', 0),
                     FieldListField('sync', [], IntField("id",0), count_from=lambda pkt:pkt.numsync) ]
-    
+

--- a/scapy/layers/skinny.py
+++ b/scapy/layers/skinny.py
@@ -12,7 +12,7 @@ from scapy.fields import *
 from scapy.layers.inet import TCP
 
 # shamelessly ripped from Ethereal dissector
-skinny_messages = { 
+skinny_messages = {
 # Station -> Callmanager
   0x0000: "KeepAliveMessage",
   0x0001: "RegisterMessage",
@@ -150,7 +150,7 @@ skinny_messages = {
   }
 
 
-        
+
 class Skinny(Packet):
     name="Skinny"
     fields_desc = [ LEIntField("len",0),

--- a/scapy/layers/smb.py
+++ b/scapy/layers/smb.py
@@ -99,7 +99,7 @@ class SMBNetlogon_Protocol_Response_Tail_SAM(Packet):
                    ShortField("Data38", 0x0),
                    ShortField("Data39", 0x0d00),
                    ShortField("Data40", 0x0),
-                   ShortField("Data41", 0xffff)]                   
+                   ShortField("Data41", 0xffff)]
 
 # SMB NetLogon Protocol Response Tail LM2.0
 class SMBNetlogon_Protocol_Response_Tail_LM20(Packet):
@@ -217,7 +217,7 @@ class SMBNegociate_Protocol_Response_No_Security(Packet):
                    BitField("EncryptionKey",0,64),
                    StrNullField("DomainName","WORKGROUP"),
                    StrNullField("ServerName","RMFF1")]
-    
+
 # SMBNegociate Protocol Response No Security No Key
 class SMBNegociate_Protocol_Response_No_Security_No_Key(Packet):
     namez="SMBNegociate Protocol Response No Security No Key"
@@ -257,7 +257,7 @@ class SMBNegociate_Protocol_Response_No_Security_No_Key(Packet):
                    LEShortField("ByteCount",16),
                    StrNullField("DomainName","WORKGROUP"),
                    StrNullField("ServerName","RMFF1")]
-    
+
 # Session Setup AndX Request
 class SMBSession_Setup_AndX_Request(Packet):
     name="Session Setup AndX Request"

--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -180,7 +180,7 @@ class SNMPset(ASN1_Packet):
                                     ASN1F_INTEGER("error_index",0),
                                     ASN1F_SEQUENCE_OF("varbindlist", [], SNMPvarbind)
                                     )
-    
+
 class SNMPtrapv1(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SNMP_PDU_TRAPv1( ASN1F_OID("enterprise", "1.3"),
@@ -198,7 +198,7 @@ class SNMPbulk(ASN1_Packet):
                                      ASN1F_INTEGER("max_repetitions",0),
                                      ASN1F_SEQUENCE_OF("varbindlist", [], SNMPvarbind)
                                      )
-    
+
 class SNMPinform(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SNMP_PDU_INFORM( ASN1F_INTEGER("id",0),
@@ -206,7 +206,7 @@ class SNMPinform(ASN1_Packet):
                                        ASN1F_INTEGER("error_index",0),
                                        ASN1F_SEQUENCE_OF("varbindlist", [], SNMPvarbind)
                                        )
-    
+
 class SNMPtrapv2(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SNMP_PDU_TRAPv2( ASN1F_INTEGER("id",0),
@@ -214,7 +214,7 @@ class SNMPtrapv2(ASN1_Packet):
                                        ASN1F_INTEGER("error_index",0),
                                        ASN1F_SEQUENCE_OF("varbindlist", [], SNMPvarbind)
                                        )
-    
+
 
 class SNMP(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
@@ -234,8 +234,8 @@ class SNMP(ASN1_Packet):
 
 bind_layers( UDP,           SNMP,          sport=161)
 bind_layers( UDP,           SNMP,          dport=161)
-bind_layers( UDP,           SNMP,          sport=162) 
-bind_layers( UDP,           SNMP,          dport=162) 
+bind_layers( UDP,           SNMP,          sport=162)
+bind_layers( UDP,           SNMP,          dport=162)
 
 def snmpwalk(dst, oid="1", community="public"):
     try:
@@ -249,7 +249,7 @@ def snmpwalk(dst, oid="1", community="public"):
                 break
             print "%-40s: %r" % (r[SNMPvarbind].oid.val,r[SNMPvarbind].value)
             oid = r[SNMPvarbind].oid
-            
+
     except KeyboardInterrupt:
         pass
 

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -528,7 +528,7 @@ class X509_AccessDescription(ASN1_Packet):
 
 class X509_ExtAuthInfoAccess(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
-    ASN1_root = ASN1F_SEQUENCE_OF("authorityInfoAccess", 
+    ASN1_root = ASN1F_SEQUENCE_OF("authorityInfoAccess",
                                   [X509_AccessDescription()],
                                   X509_AccessDescription)
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -13,7 +13,7 @@ import glob
 import __builtin__
 from error import *
 import utils
-    
+
 
 def _probe_config_file(cf):
     cf_path = os.path.join(os.path.expanduser("~"), cf)
@@ -32,7 +32,7 @@ def _read_config_file(cf):
         log_loading.warning("Cannot read config file [%s] [%s]" % (cf,e))
     except Exception,e:
         log_loading.exception("Error during evaluation of config file [%s]" % cf)
-        
+
 
 DEFAULT_PRESTART_FILE = _probe_config_file(".scapy_prestart.py")
 DEFAULT_STARTUP_FILE = _probe_config_file(".scapy_startup.py")
@@ -92,10 +92,10 @@ def list_contrib(name=None):
                 desc[key] = value
         print "%(name)-20s: %(description)-40s status=%(status)s" % desc
 
-                        
 
 
-    
+
+
 
 ##############################
 ## Session saving/restoring ##
@@ -112,7 +112,7 @@ def save_session(fname=None, session=None, pickleProto=-1):
         session = __builtin__.__dict__["scapy_session"]
 
     to_be_saved = session.copy()
-        
+
     if to_be_saved.has_key("__builtins__"):
         del(to_be_saved["__builtins__"])
 
@@ -233,12 +233,12 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
                     if word[:n] == attr and word != "__builtins__":
                         matches.append("%s.%s" % (expr, word))
                 return matches
-    
+
         readline.set_completer(ScapyCompleter().complete)
         readline.parse_and_bind("C-o: operate-and-get-next")
         readline.parse_and_bind("tab: complete")
-    
-    
+
+
     session=None
     session_name=""
     STARTUP_FILE = DEFAULT_STARTUP_FILE
@@ -263,7 +263,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
                 PRESTART_FILE = None
             elif opt == "-d":
                 conf.logLevel = max(1,conf.logLevel-10)
-        
+
         if len(opts[1]) > 0:
             raise getopt.GetoptError("Too many parameters : [%s]" % " ".join(opts[1]))
 
@@ -283,12 +283,12 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
     if mydict is not None:
         __builtin__.__dict__.update(mydict)
         globkeys += mydict.keys()
-    
+
 
     conf.color_theme = DefaultTheme()
     if STARTUP_FILE:
         _read_config_file(STARTUP_FILE)
-        
+
     if session_name:
         try:
             os.stat(session_name)
@@ -313,7 +313,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
         else:
             conf.session = session_name
             session={"conf":conf}
-            
+
     else:
         session={"conf": conf}
 
@@ -327,9 +327,9 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
             except IOError:
                 pass
         atexit.register(scapy_write_history_file,readline)
-    
+
     atexit.register(scapy_delete_temp_files)
-    
+
     IPYTHON=False
     if conf.interactive_shell.lower() == "ipython":
         try:
@@ -338,7 +338,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
         except ImportError, e:
             log_loading.warning("IPython not available. Using standard Python shell instead.")
             IPYTHON=False
-        
+
     if IPYTHON:
         banner = the_banner % (conf.version) + " using IPython %s" % IPython.__version__
 

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -106,7 +106,7 @@ def nmap_udppacket_sig(S,T):
         r["ULEN"] = "%X" % T.getlayer(UDPerror).len
         r["DAT"] = T.getlayer(conf.raw_layer) is None and "E" or S.getlayer(conf.raw_layer).load == T.getlayer(conf.raw_layer).load and "E" or "F"
     return r
-    
+
 
 
 def nmap_match_one_sig(seen, ref):
@@ -161,7 +161,7 @@ def nmap_probes2sig(tests):
     for k in tests:
         res[k] = nmap_tcppacket_sig(tests[k])
     return res
-        
+
 
 def nmap_search(sigs):
     guess = 0,[]
@@ -176,8 +176,8 @@ def nmap_search(sigs):
         elif c == guess[0]:
             guess[1].append(os)
     return guess
-    
-    
+
+
 @conf.commands.register
 def nmap_fp(target, oport=80, cport=81):
     """nmap fingerprinting
@@ -185,7 +185,7 @@ nmap_fp(target, [oport=80,] [cport=81,]) -> list of best guesses with accuracy
 """
     sigs = nmap_sig(target, oport, cport)
     return nmap_search(sigs)
-        
+
 
 @conf.commands.register
 def nmap_sig2txt(sig):
@@ -209,7 +209,7 @@ def nmap_sig2txt(sig):
             s.append("%s=%s"%(k,v))
         txt.append("%s(%s)" % (t, "%".join(s)))
     return "\n".join(txt)
-            
-        
+
+
 
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -28,7 +28,7 @@ conf.p0fo_base ="/etc/p0f/p0fo.fp"
 #
 # wwww    - window size
 # ttt     - initial TTL
-# D       - don't fragment bit  (0=unset, 1=set) 
+# D       - don't fragment bit  (0=unset, 1=set)
 # ss      - overall SYN packet size
 # OOO     - option value and order specification
 # QQ      - quirks list
@@ -97,20 +97,20 @@ def packet2p0f(pkt):
         if isinstance(pkt.payload, TCP):
             break
         pkt = pkt.payload
-    
+
     if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
         raise TypeError("Not a TCP/IP packet")
     #if pkt.payload.flags & 0x7 != 0x02: #S,!F,!R
     #    raise TypeError("Not a SYN or SYN/ACK packet")
-    
+
     db = p0f_selectdb(pkt.payload.flags)
-    
+
     #t = p0f_kdb.ttl_range[:]
     #t += [pkt.ttl]
     #t.sort()
     #ttl=t[t.index(pkt.ttl)+1]
     ttl = pkt.ttl
-    
+
     df = (pkt.flags & 2) / 2
     ss = len(pkt)
     # from p0f/config.h : PACKET_BIG = 100
@@ -125,7 +125,7 @@ def packet2p0f(pkt):
     if db == p0fo_kdb:
         # p0fo.fp: "Packet size MUST be wildcarded."
         ss = '*'
-    
+
     ooo = ""
     mss = -1
     qqT = False
@@ -168,7 +168,7 @@ def packet2p0f(pkt):
             # FIXME: ilen
     ooo = ooo[:-1]
     if ooo == "": ooo = "."
-    
+
     win = pkt.payload.window
     if mss != -1:
         if mss != 0 and win % mss == 0:
@@ -176,9 +176,9 @@ def packet2p0f(pkt):
         elif win % (mss + 40) == 0:
             win = "T" + str(win/(mss+40))
     win = str(win)
-    
+
     qq = ""
-    
+
     if db == p0fr_kdb:
         if pkt.payload.flags & 0x10 == 0x10:
             # p0fr.fp: "A new quirk, 'K', is introduced to denote
@@ -341,13 +341,13 @@ Some specifications of the p0f.fp file are not (yet) implemented."""
         if isinstance(pkt.payload, TCP):
             break
         pkt = pkt.payload
-    
+
     if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
         raise TypeError("Not a TCP/IP packet")
-    
+
     if uptime is None:
         uptime = random.randint(120,100*60*60*24*365)
-    
+
     db = p0f_selectdb(pkt.payload.flags)
     if osgenre:
         pb = db.get_base()
@@ -369,7 +369,7 @@ Some specifications of the p0f.fp file are not (yet) implemented."""
     if not pb:
         raise Scapy_Exception("No match in the p0f database")
     pers = pb[random.randint(0, len(pb) - 1)]
-    
+
     # options (we start with options because of MSS)
     ## TODO: let the options already set if they are valid
     options = []
@@ -434,7 +434,7 @@ Some specifications of the p0f.fp file are not (yet) implemented."""
             else:
                 warning("unhandled TCP option " + opt)
             pkt.payload.options = options
-    
+
     # window size
     if pers[0] == '*':
         pkt.payload.window = RandShort()
@@ -453,7 +453,7 @@ Some specifications of the p0f.fp file are not (yet) implemented."""
         pkt.payload.window = filter(lambda x: x[0] == 'MSS', options)[0][1] * int(pers[0][1:])
     else:
         raise Scapy_Exception('Unhandled window size specification')
-    
+
     # ttl
     pkt.ttl = pers[1]-extrahops
     # DF flag
@@ -484,7 +484,7 @@ Some specifications of the p0f.fp file are not (yet) implemented."""
         pkt.payload.seq = 0
     elif pkt.payload.seq == 0:
         pkt.payload.seq = RandInt()
-    
+
     while pkt.underlayer:
         pkt = pkt.underlayer
     return pkt

--- a/scapy/modules/queso.py
+++ b/scapy/modules/queso.py
@@ -10,7 +10,7 @@ Clone of queso OS fingerprinting
 from scapy.data import KnowledgeBase
 from scapy.config import conf
 from scapy.layers.inet import IP,TCP
-#from 
+#from
 
 conf.queso_base ="/etc/queso.conf"
 
@@ -62,11 +62,11 @@ class QuesoKnowledgeBase(KnowledgeBase):
             self.base = None
             warning("Can't load queso base [%s]", self.filename)
         f.close()
-            
-        
+
+
 queso_kdb = QuesoKnowledgeBase(conf.queso_base)
 
-    
+
 def queso_sig(target, dport=80, timeout=3):
     p = queso_kdb.get_base()
     ret = []
@@ -88,7 +88,7 @@ def queso_sig(target, dport=80, timeout=3):
             rs += " %x" % r.payload.flags
         ret.append(rs)
     return ret
-            
+
 def queso_search(sig):
     p = queso_kdb.get_base()
     sig.reverse()
@@ -102,7 +102,7 @@ def queso_search(sig):
     except KeyError:
         pass
     return ret
-        
+
 
 @conf.commands.register
 def queso(*args,**kargs):

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -36,23 +36,23 @@ def voip_play(s1,list=None,**kargs):
     FIFO=get_temp_file()
     FIFO1=FIFO % 1
     FIFO2=FIFO % 2
-    
+
     os.mkfifo(FIFO1)
     os.mkfifo(FIFO2)
     try:
         os.system("soxmix -t .ul %s -t .ul %s -t ossdsp /dev/dsp &" % (FIFO1,FIFO2))
-        
+
         c1=open(FIFO1,"w", 4096)
         c2=open(FIFO2,"w", 4096)
         fcntl.fcntl(c1.fileno(),fcntl.F_SETFL, os.O_NONBLOCK)
         fcntl.fcntl(c2.fileno(),fcntl.F_SETFL, os.O_NONBLOCK)
-    
+
     #    dsp,rd = os.popen2("sox -t .ul -c 2 - -t ossdsp /dev/dsp")
         def play(pkt,last=[]):
             if not pkt:
-                return 
+                return
             if not pkt.haslayer(UDP):
-                return 
+                return
             ip=pkt.getlayer(IP)
             if s1 in [ip.src, ip.dst]:
                 if not last:
@@ -69,7 +69,7 @@ def voip_play(s1,list=None,**kargs):
     #                x2 = pkt.load[:12]
                     c2.write(pkt.load[12:])
     #            dsp.write(merge(x1,x2))
-    
+
         if list is None:
             sniff(store=0, prn=play, **kargs)
         else:
@@ -83,13 +83,13 @@ def voip_play(s1,list=None,**kargs):
 
 def voip_play1(s1,list=None,**kargs):
 
-    
+
     dsp,rd = os.popen2("sox -t .ul - -t ossdsp /dev/dsp")
     def play(pkt):
         if not pkt:
-            return 
+            return
         if not pkt.haslayer(UDP):
-            return 
+            return
         ip=pkt.getlayer(IP)
         if s1 in [ip.src, ip.dst]:
             dsp.write(pkt.getlayer(conf.raw_layer).load[12:])
@@ -107,9 +107,9 @@ def voip_play2(s1,**kargs):
     dsp,rd = os.popen2("sox -t .ul -c 2 - -t ossdsp /dev/dsp")
     def play(pkt,last=[]):
         if not pkt:
-            return 
+            return
         if not pkt.haslayer(UDP):
-            return 
+            return
         ip=pkt.getlayer(IP)
         if s1 in [ip.src, ip.dst]:
             if not last:
@@ -126,7 +126,7 @@ def voip_play2(s1,**kargs):
                 x2 = pkt.load[:12]
 #                c2.write(pkt.load[12:])
             dsp.write(merge(x1,x2))
-            
+
     sniff(store=0, prn=play, **kargs)
 
 def voip_play3(lst=None,**kargs):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -112,12 +112,12 @@ class Packet(BasePacket):
             self.fieldtype[f.name] = f
             if f.holds_packets:
                 self.packetfields.append(f)
-            
+
     def dissection_done(self,pkt):
         """DEV: will be called after a dissection is completed"""
         self.post_dissection(pkt)
         self.payload.dissection_done(pkt)
-        
+
     def post_dissection(self, pkt):
         """DEV: is called after the dissection of the whole packet"""
         pass
@@ -125,7 +125,7 @@ class Packet(BasePacket):
     def get_field(self, fld):
         """DEV: returns the field instance from the name of the field"""
         return self.fieldtype[fld]
-        
+
     def add_payload(self, payload):
         if payload is None:
             return
@@ -176,7 +176,7 @@ class Packet(BasePacket):
         if attr in self.default_fields:
             return self.default_fields[attr]
         return self.payload.getfieldval(attr)
-    
+
     def getfield_and_val(self, attr):
         if attr in self.fields:
             return self.get_field(attr),self.fields[attr]
@@ -185,7 +185,7 @@ class Packet(BasePacket):
         if attr in self.default_fields:
             return self.get_field(attr),self.default_fields[attr]
         return self.payload.getfield_and_val(attr)
-    
+
     def __getattr__(self, attr):
         fld,v = self.getfield_and_val(attr)
         if fld is not None:
@@ -241,7 +241,7 @@ class Packet(BasePacket):
         except AttributeError:
             pass
         return object.__delattr__(self, attr)
-            
+
     def __repr__(self):
         s = ""
         ct = conf.color_theme
@@ -261,7 +261,7 @@ class Packet(BasePacket):
                 ncol = ct.field_name
                 vcol = ct.field_value
 
-                
+
             s += " %s%s%s" % (ncol(f.name),
                               ct.punct("="),
                               vcol(val))
@@ -297,7 +297,7 @@ class Packet(BasePacket):
             raise TypeError
     def __rmul__(self,other):
         return self.__mul__(other)
-    
+
     def __nonzero__(self):
         return True
     def __len__(self):
@@ -344,7 +344,7 @@ class Packet(BasePacket):
             return self.post_build(pkt, pay)
         else:
             return pkt + pay
-    
+
     def build_padding(self):
         return self.payload.build_padding()
 
@@ -353,7 +353,7 @@ class Packet(BasePacket):
         p += self.build_padding()
         p = self.build_done(p)
         return p
-    
+
     def post_build(self, pkt, pay):
         """DEV: called right after the current layer is build."""
         return pkt+pay
@@ -375,13 +375,13 @@ class Packet(BasePacket):
             else:
                 r = ""
             pl.append( (f, f.i2repr(self,self.getfieldval(f.name)), r) )
-            
+
         pkt,lst = self.payload.build_ps(internal=1)
         p += pkt
         lst.append( (self, pl) )
-        
+
         return p,lst
-    
+
     def build_ps(self,internal=0):
         p,lst = self.do_build_ps()
 #        if not internal:
@@ -416,7 +416,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
         else:
             canvas.writePDFfile(filename)
 
-        
+
     def canvas_dump(self, layer_shift=0, rebuild=1):
         canvas = pyx.canvas.canvas()
         if rebuild:
@@ -433,22 +433,22 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
         XDSTART = 10
         y = 0.0
         yd = 0.0
-        xd = 0 
+        xd = 0
         XMUL= 0.55
         YMUL = 0.4
-    
+
         backcolor=colgen(0.6, 0.8, 1.0, trans=pyx.color.rgb)
         forecolor=colgen(0.2, 0.5, 0.8, trans=pyx.color.rgb)
 #        backcolor=makecol(0.376, 0.729, 0.525, 1.0)
-        
-        
+
+
         def hexstr(x):
             s = []
             for c in x:
                 s.append("%02x" % ord(c))
             return " ".join(s)
 
-                
+
         def make_dump_txt(x,y,txt):
             return pyx.text.text(XDSTART+x*XMUL, (YDUMP-y)*YMUL, r"\tt{%s}"%hexstr(txt), [pyx.text.size.Large])
 
@@ -491,7 +491,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
                                          pyx.path.lineto(lb.left(), gb.top()),
                                          pyx.path.lineto(fb.left(), gb.top()),
                                          pyx.path.closepath(),)
-                                         
+
 
         def make_dump(s, shift=0, y=0, col=None, bkcol=None, larg=16):
             c = pyx.canvas.canvas()
@@ -512,7 +512,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
             for txt in tlist:
                 c.insert(txt)
             return c, tlist[-1].bbox(), shift, y
-                            
+
 
         last_shift,last_y=0,0.0
         while t:
@@ -553,13 +553,13 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
                         pass
                     else:
                         canvas.stroke(cnx,[pyx.style.linewidth.thin,pyx.deco.earrow.small,col])
-                        
+
                     canvas.insert(dt)
-                
+
                 canvas.insert(ft)
                 canvas.insert(vt)
             last_y += layer_shift
-    
+
         return canvas
 
 
@@ -617,7 +617,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
         s = self.do_dissect(s)
 
         s = self.post_dissect(s)
-            
+
         payl,pad = self.extract_padding(s)
         self.do_dissect_payload(payl)
         if pad and conf.padding:
@@ -636,7 +636,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
                 if ok:
                     return cls
         return self.default_payload_class(payload)
-    
+
     def default_payload_class(self, payload):
         """DEV: Returns the default payload class if nothing has been found by the guess_payload_class() method."""
         return conf.raw_layer
@@ -820,7 +820,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
 
     def __setitem__(self, cls, val):
         self[cls].underlayer.payload = val
-    
+
     def __contains__(self, cls):
         """"cls in self" returns true if self has a layer which is an instance of cls."""
         return self.haslayer(cls)
@@ -830,7 +830,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
 
     def fragment(self, *args, **kargs):
         return self.payload.fragment(*args, **kargs)
-    
+
 
     def display(self,*args,**kargs):  # Deprecated. Use show()
         """Deprecated. Use show() method."""
@@ -902,7 +902,7 @@ A side effect is that, to obtain "{" and "}" characters, you must use
                    ")": "}" }
 
 
-        # Evaluate conditions 
+        # Evaluate conditions
         while "{" in fmt:
             i = fmt.rindex("{")
             j = fmt[i+1:].index("}")
@@ -974,7 +974,7 @@ A side effect is that, to obtain "{" and "}" characters, you must use
                     val = self.payload.sprintf("%%%s%%" % sfclsfld, relax)
                     f = "s"
                 s += ("%"+f) % val
-            
+
         s += fmt
         return s
 
@@ -1014,7 +1014,7 @@ A side effect is that, to obtain "{" and "}" characters, you must use
         found,s,needed = self._do_summary()
         return s
 
-    
+
     def lastlayer(self,layer=None):
         """Returns the uppest layer of the packet"""
         return self.payload.lastlayer(self)
@@ -1058,7 +1058,7 @@ A side effect is that, to obtain "{" and "}" characters, you must use
         pc = self.payload.command()
         if pc:
             c += "/"+pc
-        return c                    
+        return c
 
 class NoPayload(Packet):
     def __new__(cls, *args, **kargs):
@@ -1124,7 +1124,7 @@ class NoPayload(Packet):
             _track.append(nb)
         return None
     def fragment(self, *args, **kargs):
-        raise Scapy_Exception("cannot fragment this packet")        
+        raise Scapy_Exception("cannot fragment this packet")
     def show(self, indent=3, lvl="", label_lvl=""):
         pass
     def sprintf(self, fmt, relax):
@@ -1138,12 +1138,12 @@ class NoPayload(Packet):
         return layer
     def command(self):
         return ""
-    
+
 ####################
 ## packet classes ##
 ####################
 
-            
+
 class Raw(Packet):
     name = "Raw"
     fields_desc = [ StrField("load", "") ]
@@ -1161,7 +1161,7 @@ class Raw(Packet):
             else:
                 return "Raw %r" % self.load
         return Packet.mysummary(self)
-        
+
 class Padding(Raw):
     name = "Padding"
     def self_build(self):
@@ -1185,14 +1185,14 @@ def bind_bottom_up(lower, upper, __fval=None, **fval):
         fval.update(__fval)
     lower.payload_guess = lower.payload_guess[:]
     lower.payload_guess.append((fval, upper))
-    
+
 
 def bind_top_down(lower, upper, __fval=None, **fval):
     if __fval is not None:
         fval.update(__fval)
     upper._overload_fields = upper._overload_fields.copy()
     upper._overload_fields[lower] = fval
-    
+
 @conf.commands.register
 def bind_layers(lower, upper, __fval=None, **fval):
     """Bind 2 layers on some specific fields' values"""
@@ -1212,7 +1212,7 @@ def split_bottom_up(lower, upper, __fval=None, **fval):
                 return True
         return False
     lower.payload_guess = filter(do_filter, lower.payload_guess)
-        
+
 def split_top_down(lower, upper, __fval=None, **fval):
     if __fval is not None:
         fval.update(__fval)
@@ -1309,7 +1309,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
             print "Not a packet class or name. Type 'ls()' to list packet classes."
 
 
-    
+
 #############
 ## Fuzzing ##
 #############

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -33,7 +33,7 @@ class PipeEngine:
                 print "###### %s\n %s" % (pn ,pc.__doc__)
             else:
                 print "###### %s" % pn
-    
+
     def __init__(self, *pipes):
         self.active_pipes = set()
         self.active_sources = set()
@@ -83,7 +83,7 @@ class PipeEngine:
         for q in pl:
             self.add_one_pipe(q)
         return pl
-            
+
 
     def run(self):
         log_interactive.info("Pipe engine thread started.")
@@ -156,7 +156,7 @@ class PipeEngine:
                 for p in pipes:
                     p.start()
                 os.write(self.__fdw, "A")
-    
+
     def graph(self,**kargs):
         g=['digraph "pipe" {',"\tnode [shape=rectangle];",]
         for p in self.active_pipes:
@@ -173,7 +173,7 @@ class PipeEngine:
                 g.append('\t"%i" -> "%i" [color="red"];' % (id(p), id(q)))
         g.append('}')
         graph = "\n".join(g)
-        scapy.utils.do_graph(graph, **kargs) 
+        scapy.utils.do_graph(graph, **kargs)
 
 
 class _ConnectorLogic(object):
@@ -343,7 +343,7 @@ class ThreadGenSource(AutoSource):
         self.RUN = False
 
 
-        
+
 class ConsoleSink(Sink):
     """Print messages on low and high entries
      +-------+
@@ -428,7 +428,7 @@ class PeriodicSource(ThreadGenSource):
                 self.is_exhausted = True
                 self._wake_up()
             time.sleep(self.period2)
-        
+
 class TermSink(Sink):
     """Print messages on low and high entries on a separate terminal
      +-------+
@@ -468,12 +468,12 @@ class TermSink(Sink):
         if self.newlines:
             s+="\n"
         os.write(self.__w, s)
-            
+
     def push(self, msg):
         self._print(str(msg))
     def high_push(self, msg):
         self._print(str(msg))
-    
+
 
 class QueueSink(Sink):
     """Collect messages from high and low entries and queue them. Messages are unqueued with the .recv() method.
@@ -539,7 +539,7 @@ class DownDrain(Drain):
         pass
     def high_push(self, msg):
         self._send(msg)
-        
+
 
 def _testmain():
     s = PeriodicSource("hello", 1, name="src")

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -119,7 +119,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
     def show(self, *args, **kargs):
         """Best way to display the packet list. Defaults to nsummary() method"""
         return self.nsummary(*args, **kargs)
-    
+
     def filter(self, func):
         """Returns a packet list filtered by a truth function"""
         return self.__class__(filter(func,self.res),
@@ -279,7 +279,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                         p.sprintf("%.time%"),
                                         self._elt2sum(res))
                     hexdump(p.getlayer(conf.padding_layer).load)
-        
+
 
     def conversations(self, getsrcdst=None,**kargs):
         """Graphes a conversations between sources and destinations and display it
@@ -319,7 +319,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             gr += '\t "%s" -> "%s" [label="%s"]\n' % (
                 s, d, ', '.join(str(x) for x in l) if isinstance(l, set) else l
             )
-        gr += "}\n"        
+        gr += "}\n"
         return do_graph(gr, **kargs)
 
     def afterglow(self, src=None, event=None, dst=None, **kargs):
@@ -374,7 +374,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         mins, maxs = minmax(x for x, _ in sl.itervalues())
         mine, maxe = minmax(x for x, _ in el.itervalues())
         mind, maxd = minmax(dl.itervalues())
-    
+
         gr = 'digraph "afterglow" {\n\tedge [len=2.5];\n'
 
         gr += "# src nodes\n"
@@ -393,12 +393,12 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         for s in sl:
             n,l = sl[s]
             for e in l:
-                gr += ' "src.%s" -> "evt.%s";\n' % (`s`,`e`) 
+                gr += ' "src.%s" -> "evt.%s";\n' % (`s`,`e`)
         for e in el:
             n,l = el[e]
             for d in l:
-                gr += ' "evt.%s" -> "dst.%s";\n' % (`e`,`d`) 
-            
+                gr += ' "evt.%s" -> "dst.%s";\n' % (`e`,`d`)
+
         gr += "}"
         return do_graph(gr, **kargs)
 
@@ -418,8 +418,8 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                        margin=1*pyx.unit.t_cm,
                                        fittosize=1))
         return d
-                     
-                 
+
+
 
     def psdump(self, filename = None, **kargs):
         """Creates a multipage poscript file with a psdump of every packet
@@ -433,7 +433,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         else:
             d.writePSfile(filename)
         print
-        
+
     def pdfdump(self, filename = None, **kargs):
         """Creates a PDF file with a psdump of every packet
         filename: name of the file to write to. If empty, a temporary file is used and
@@ -498,7 +498,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             sess = session_extractor(self._elt2pkt(p))
             sessions[sess].append(p)
         return dict(sessions)
-    
+
     def replace(self, *args, **kargs):
         """
         lst.replace(<field>,[<oldvalue>,]<newvalue>)
@@ -531,11 +531,11 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                             setattr(p[o], fld.name, new)
             x.append(p)
         return x
-                
-            
-        
-    
-        
+
+
+
+
+
 
 
 class SndRcvList(PacketList):
@@ -545,11 +545,11 @@ class SndRcvList(PacketList):
     def _elt2pkt(self, elt):
         return elt[1]
     def _elt2sum(self, elt):
-        return "%s ==> %s" % (elt[0].summary(),elt[1].summary()) 
+        return "%s ==> %s" % (elt[0].summary(),elt[1].summary())
 
 
 
-    
 
-        
-                                                                               
+
+
+

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -18,17 +18,17 @@ def inet_pton(af, addr):
         return inet_aton(addr)
     elif af == socket.AF_INET6:
         # IPv6: The use of "::" indicates one or more groups of 16 bits of zeros.
-        # We deal with this form of wildcard using a special marker. 
+        # We deal with this form of wildcard using a special marker.
         JOKER = "*"
         while "::" in addr:
             addr = addr.replace("::", ":" + JOKER + ":")
-        joker_pos = None 
-        
+        joker_pos = None
+
         # The last part of an IPv6 address can be an IPv4 address
         ipv4_addr = None
         if "." in addr:
             ipv4_addr = addr.split(":")[-1]
-           
+
         result = ""
         parts = addr.split(":")
         for part in parts:
@@ -39,23 +39,23 @@ def inet_pton(af, addr):
                 else:
                    raise Exception("Illegal syntax for IP address")
             elif part == ipv4_addr: # FIXME: Make sure IPv4 can only be last part
-                # FIXME: inet_aton allows IPv4 addresses with less than 4 octets 
+                # FIXME: inet_aton allows IPv4 addresses with less than 4 octets
                 result += socket.inet_aton(ipv4_addr)
             else:
-                # Each part must be 16bit. Add missing zeroes before decoding. 
+                # Each part must be 16bit. Add missing zeroes before decoding.
                 try:
                     result += part.rjust(4, "0").decode("hex")
                 except TypeError:
                     raise Exception("Illegal syntax for IP address")
-                    
-        # If there's a wildcard, fill up with zeros to reach 128bit (16 bytes) 
+
+        # If there's a wildcard, fill up with zeros to reach 128bit (16 bytes)
         if JOKER in addr:
             result = (result[:joker_pos] + "\x00" * (16 - len(result))
                       + result[joker_pos:])
-    
+
         if len(result) != 16:
             raise Exception("Illegal syntax for IP address")
-        return result 
+        return result
     else:
         raise Exception("Address family not supported")
 
@@ -70,7 +70,7 @@ def inet_ntop(af, addr):
             raise Exception("Illegal syntax for IP address")
         parts = []
         for left in [0, 2, 4, 6, 8, 10, 12, 14]:
-            try: 
+            try:
                 value = struct.unpack("!H", addr[left:left+2])[0]
                 hexstr = hex(value)[2:]
             except TypeError:
@@ -86,4 +86,4 @@ def inet_ntop(af, addr):
             result = "0" + result
         return result
     else:
-        raise Exception("Address family not supported yet")        
+        raise Exception("Address family not supported yet")

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -67,7 +67,7 @@ class Route:
         self.invalidate_cache()
         self.routes.append(self.make_route(*args,**kargs))
 
-        
+
     def delt(self,  *args, **kargs):
         """delt(host|net, gw|dev)"""
         self.invalidate_cache()
@@ -77,15 +77,15 @@ class Route:
             del(self.routes[i])
         except ValueError:
             warning("no matching route found")
-             
+
     def ifchange(self, iff, addr):
         self.invalidate_cache()
         the_addr,the_msk = (addr.split("/")+["32"])[:2]
         the_msk = itom(int(the_msk))
         the_rawaddr = atol(the_addr)
         the_net = the_rawaddr & the_msk
-        
-        
+
+
         for i, route in enumerate(self.routes):
             net, msk, gw, iface, addr = route
             if iface != iff:
@@ -95,8 +95,8 @@ class Route:
             else:
                 self.routes[i] = (net,msk,gw,iface,the_addr)
         conf.netcache.flush()
-        
-                
+
+
 
     def ifdel(self, iff):
         self.invalidate_cache()
@@ -105,7 +105,7 @@ class Route:
             if rt[3] != iff:
                 new_routes.append(rt)
         self.routes=new_routes
-        
+
     def ifadd(self, iff, addr):
         self.invalidate_cache()
         the_addr,the_msk = (addr.split("/")+["32"])[:2]
@@ -124,7 +124,7 @@ class Route:
             verbose=conf.verb
         # Transform "192.168.*.1-5" to one IP of the set
         dst = dest.split("/")[0]
-        dst = dst.replace("*","0") 
+        dst = dst.replace("*","0")
         while 1:
             l = dst.find("-")
             if l < 0:
@@ -132,7 +132,7 @@ class Route:
             m = (dst[l:]+".").find(".")
             dst = dst[:l]+dst[l+m:]
 
-            
+
         dst = atol(dst)
         pathes=[]
         for d,m,gw,i,a in self.routes:
@@ -151,7 +151,7 @@ class Route:
         ret = pathes[-1][1]
         self.cache[dest] = ret
         return ret
-            
+
     def get_if_bcast(self, iff):
         for net, msk, gw, iface, addr in self.routes:
             if (iff == iface and net != 0L):

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -42,7 +42,7 @@ class Route6:
 	self.routes = read_routes6()
 	if self.routes == []:
 	     log_loading.info("No IPv6 support in kernel")
-        
+
     def __repr__(self):
         rtlst = [('Destination', 'Next Hop', "iface", "src candidates")]
 
@@ -57,7 +57,7 @@ class Route6:
 
 
     # Unlike Scapy's Route.make_route() function, we do not have 'host' and 'net'
-    # parameters. We only have a 'dst' parameter that accepts 'prefix' and 
+    # parameters. We only have a 'dst' parameter that accepts 'prefix' and
     # 'prefix/prefixlen' values.
     # WARNING: Providing a specific device will at the moment not work correctly.
     def make_route(self, dst, gw=None, dev=None):
@@ -73,13 +73,13 @@ class Route6:
         else:
             # TODO: do better than that
             # replace that unique address by the list of all addresses
-            lifaddr = in6_getifaddr()             
+            lifaddr = in6_getifaddr()
             devaddrs = filter(lambda x: x[2] == dev, lifaddr)
             ifaddr = construct_source_candidate_set(prefix, plen, devaddrs, LOOPBACK_NAME)
 
         return (prefix, plen, gw, dev, ifaddr)
 
-    
+
     def add(self, *args, **kargs):
         """Ex:
         add(dst="2001:db8:cafe:f000::/56")
@@ -112,7 +112,7 @@ class Route6:
             i=self.routes.index(l[0])
             self.invalidate_cache()
             del(self.routes[i])
-        
+
     def ifchange(self, iff, addr):
         the_addr, the_plen = (addr.split("/")+["128"])[:2]
         the_plen = int(the_plen)
@@ -120,7 +120,7 @@ class Route6:
         naddr = inet_pton(socket.AF_INET6, the_addr)
         nmask = in6_cidr2mask(the_plen)
         the_net = inet_ntop(socket.AF_INET6, in6_and(nmask,naddr))
-        
+
         for i, route in enumerate(self.routes):
             net,plen,gw,iface,addr = route
             if iface != iff:
@@ -181,14 +181,14 @@ class Route6:
         """
         # Transform "2001:db8:cafe:*::1-5:0/120" to one IPv6 address of the set
         dst = dst.split("/")[0]
-        savedst = dst # In case following inet_pton() fails 
+        savedst = dst # In case following inet_pton() fails
         dst = dst.replace("*","0")
         l = dst.find("-")
         while l >= 0:
             m = (dst[l:]+":").find(":")
             dst = dst[:l]+dst[l+m:]
             l = dst.find("-")
-            
+
         try:
             inet_pton(socket.AF_INET6, dst)
         except socket.error:
@@ -205,7 +205,7 @@ class Route6:
         pathes = []
 
         # TODO : review all kinds of addresses (scope and *cast) to see
-        #        if we are able to cope with everything possible. I'm convinced 
+        #        if we are able to cope with everything possible. I'm convinced
         #        it's not the case.
         # -- arnaud
         for p, plen, gw, iface, cset in self.routes:
@@ -215,7 +215,7 @@ class Route6:
                 pathes.append((plen, (iface, cset, gw)))
             elif (in6_ismlladdr(dst) and in6_islladdr(p) and in6_islladdr(cset[0])):
                 pathes.append((plen, (iface, cset, gw)))
-                
+
         if not pathes:
             warning("No route found for IPv6 destination %s (no default route?)" % dst)
             return (LOOPBACK_NAME, "::", "::") # XXX Linux specific
@@ -238,8 +238,8 @@ class Route6:
             return (LOOPBACK_NAME, "::", "::") # XXX Linux specific
 
         # Symptom  : 2 routes with same weight (our weight is plen)
-        # Solution : 
-        #  - dst is unicast global. Check if it is 6to4 and we have a source 
+        # Solution :
+        #  - dst is unicast global. Check if it is 6to4 and we have a source
         #    6to4 address in those available
         #  - dst is link local (unicast or multicast) and multiple output
         #    interfaces are available. Take main one (conf.iface6)
@@ -259,7 +259,7 @@ class Route6:
 
             if tmp:
                 res = tmp
-                
+
         # Fill the cache (including dev-specific request)
         k = dst
         if dev is not None:

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -49,7 +49,7 @@ class RdpcapSource(Source):
         self.f.close()
     def fileno(self):
         return self.f.fileno()
-    def deliver(self):    
+    def deliver(self):
         p = self.f.recv()
         print "deliver %r" % p
         if p is None:
@@ -81,8 +81,8 @@ class InjectSink(Sink):
 class Inject3Sink(InjectSink):
     def start(self):
         self.s = conf.L3socket(iface=self.iface)
-    
-    
+
+
 class WrpcapSink(Sink):
     """Packets received on low input are written to PCA file
      +----------+
@@ -98,7 +98,7 @@ class WrpcapSink(Sink):
         self.f.flush()
     def push(self, msg):
         self.f.write(msg)
-        
+
 
 class UDPDrain(Drain):
     """Apply a function to messages on low and high entry
@@ -120,4 +120,4 @@ class UDPDrain(Drain):
     def high_push(self, msg):
         p = IP(dst=self.ip)/UDP(sport=1234,dport=self.port)/msg
         self._send(p)
-        
+

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -40,7 +40,7 @@ class debug:
 def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0, multi=0):
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
-        
+
     if verbose is None:
         verbose = conf.verb
     debug.recv = plist.PacketList([],"Unanswered")
@@ -68,10 +68,10 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
 
     while retry >= 0:
         found=0
-    
+
         if timeout < 0:
             timeout = None
-            
+
         rdpipe,wrpipe = os.pipe()
         rdpipe=os.fdopen(rdpipe)
         wrpipe=os.fdopen(wrpipe,"w")
@@ -193,12 +193,12 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
 
         if autostop and len(remain) > 0 and len(remain) != len(tobesent):
             retry = autostop
-            
+
         tobesent = remain
         if len(tobesent) == 0:
             break
         retry -= 1
-        
+
     if conf.debug_match:
         debug.sent=plist.PacketList(remain[:],"Sent")
         debug.match=plist.SndRcvList(ans[:])
@@ -208,7 +208,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
         for s,r in ans:
             if hasattr(s, '_answered'):
                 del(s._answered)
-    
+
     if verbose:
         print "\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans)
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")
@@ -256,7 +256,7 @@ def __gen_send(s, x, inter=0, loop=0, count=None, verbose=None, realtime=None, r
         print "\nSent %i packets." % n
     if return_packets:
         return sent_packets
-        
+
 @conf.commands.register
 def send(x, inter=0, loop=0, count=None, verbose=None, realtime=None, return_packets=False, *args, **kargs):
     """Send packets at layer 3
@@ -312,10 +312,10 @@ def sendpfast(x, pps=None, mbps=None, realtime=None, loop=0, file_cache=False, i
     finally:
         os.unlink(f)
 
-        
 
-        
-    
+
+
+
 @conf.commands.register
 def sr(x,filter=None, iface=None, nofilter=0, *args,**kargs):
     """Send and receive packets at layer 3
@@ -440,7 +440,7 @@ def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summ
                 time.sleep(inter+start-end)
     except KeyboardInterrupt:
         pass
- 
+
     if verbose and n>0:
         print ct.normal("\nSent %i packets, received %i packets. %3.1f%% hits." % (n,r,100.0*r/n))
     return plist.SndRcvList(ans),plist.PacketList(unans)
@@ -487,7 +487,7 @@ def sndrcvflood(pks, pkt, prn=lambda (s,r):r.summary(), chainCC=0, store=1, uniq
             readyr,readys,_ = select([rsock],[ssock],[])
             if ssock in readys:
                 pks.send(packets_to_send.next())
-                
+
             if rsock in readyr:
                 p = pks.recv(MTU)
                 if p is None:
@@ -535,13 +535,13 @@ nofilter: put 1 to avoid use of bpf filters
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface"""
     if iface is None and iface_hint is not None:
-        iface = conf.route.route(iface_hint)[0]    
+        iface = conf.route.route(iface_hint)[0]
     s = conf.L2socket(filter=filter, iface=iface, nofilter=nofilter)
     r=sndrcvflood(s,x,*args,**kargs)
     s.close()
     return r
 
-           
+
 
 
 @conf.commands.register
@@ -631,7 +631,7 @@ interfaces)
 
 
 @conf.commands.register
-def bridge_and_sniff(if1, if2, count=0, store=1, offline=None, prn=None, 
+def bridge_and_sniff(if1, if2, count=0, store=1, offline=None, prn=None,
                      lfilter=None, L2socket=None, timeout=None,
                      stop_filter=None, *args, **kargs):
     """Forward traffic between two interfaces and sniff packets exchanged
@@ -659,7 +659,7 @@ stop_filter: python function applied to each packet to determine
     s2 = L2socket(iface=if2)
     peerof={s1:s2,s2:s1}
     label={s1:if1, s2:if2}
-    
+
     lst = []
     if timeout is not None:
         stoptime = time.time()+timeout

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -48,7 +48,7 @@ class SuperSocket:
             self.ins.close()
     def sr(self, *args, **kargs):
         return sendrecv.sndrcv(self, *args, **kargs)
-    def sr1(self, *args, **kargs):        
+    def sr1(self, *args, **kargs):
         a,b = sendrecv.sndrcv(self, *args, **kargs)
         if len(a) > 0:
             return a[0][1]
@@ -90,7 +90,7 @@ class L3RawSocket(SuperSocket):
             pkt = conf.raw_layer(pkt)
         if lvl == 2:
             pkt = pkt.payload
-            
+
         if pkt is not None:
             from arch import get_last_packet_timestamp
             pkt.time = get_last_packet_timestamp(self.ins)
@@ -117,7 +117,7 @@ class StreamSocket(SimpleSocket):
             basecls = conf.raw_layer
         SimpleSocket.__init__(self, sock)
         self.basecls = basecls
-        
+
     def recv(self, x=MTU):
         pkt = self.ins.recv(x, socket.MSG_PEEK)
         x = len(pkt)
@@ -132,7 +132,7 @@ class StreamSocket(SimpleSocket):
             pad = pad.payload
         self.ins.recv(x)
         return pkt
-        
+
 
 
 if conf.L3socket is None:

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -26,7 +26,7 @@ class Color:
     uline = "\033[4m"
     blink = "\033[5m"
     invert = "\033[7m"
-        
+
 
 def create_styler(fmt=None, before="", after="", fmt2="%s"):
     def do_style(val, fmt=fmt, before=before, after=after, fmt2=fmt2):
@@ -43,7 +43,7 @@ class ColorTheme:
         return "<%s>" % self.__class__.__name__
     def __getattr__(self, attr):
         return create_styler()
-        
+
 
 class NoTheme(ColorTheme):
     pass
@@ -53,7 +53,7 @@ class AnsiColorTheme(ColorTheme):
     def __getattr__(self, attr):
         if attr.startswith("__"):
             raise AttributeError(attr)
-        s = "style_%s" % attr 
+        s = "style_%s" % attr
         if s in self.__class__.__dict__:
             before = getattr(self, s)
             after = self.style_normal
@@ -61,8 +61,8 @@ class AnsiColorTheme(ColorTheme):
             before = after = ""
 
         return create_styler(before=before, after=after)
-        
-        
+
+
     style_normal = ""
     style_prompt = ""
     style_punct = ""
@@ -112,7 +112,7 @@ class DefaultTheme(AnsiColorTheme):
     style_closed = Color.grey
     style_left = Color.blue+Color.invert
     style_right = Color.red+Color.invert
-    
+
 class BrightTheme(AnsiColorTheme):
     style_normal = Color.normal
     style_punct = Color.normal
@@ -185,7 +185,7 @@ class FormatTheme(ColorTheme):
         if attr.startswith("__"):
             raise AttributeError(attr)
         colfmt = self.__class__.__dict__.get("style_%s" % attr, "%s")
-        return create_styler(fmt2 = colfmt)       
+        return create_styler(fmt2 = colfmt)
 
 class LatexTheme(FormatTheme):
     style_prompt = r"\textcolor{blue}{%s}"
@@ -211,8 +211,8 @@ class LatexTheme2(FormatTheme):
     style_layer_name = r"@`@textcolor@[@red@]@@[@@`@bfseries@[@@]@%s@]@"
     style_field_name = r"@`@textcolor@[@blue@]@@[@%s@]@"
     style_field_value = r"@`@textcolor@[@purple@]@@[@%s@]@"
-    style_emph_field_name = r"@`@textcolor@[@blue@]@@[@@`@underline@[@%s@]@@]@" 
-    style_emph_field_value = r"@`@textcolor@[@purple@]@@[@@`@underline@[@%s@]@@]@" 
+    style_emph_field_name = r"@`@textcolor@[@blue@]@@[@@`@underline@[@%s@]@@]@"
+    style_emph_field_value = r"@`@textcolor@[@purple@]@@[@@`@underline@[@%s@]@@]@"
     style_packetlist_name = r"@`@textcolor@[@red@]@@[@@`@bfseries@[@@]@%s@]@"
     style_packetlist_proto = r"@`@textcolor@[@blue@]@@[@%s@]@"
     style_packetlist_value = r"@`@textcolor@[@purple@]@@[@%s@]@"

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -20,7 +20,7 @@ def import_module(name):
     if name.endswith(".py"):
         name = name[:-3]
     f,path,desc = imp.find_module(name,[thepath])
-    
+
     try:
         return imp.load_module(name, f, path, desc)
     finally:
@@ -44,7 +44,7 @@ class File:
             dir += "/"
         open(dir+self.name,"w").write(self.get_local())
 
-        
+
 # Embed a base64 encoded bziped version of js and css files
 # to work if you can't reach Internet.
 class External_Files:
@@ -97,7 +97,7 @@ class EnumClass:
     def from_string(cls,x):
         return cls.__dict__[x.upper()]
     from_string = classmethod(from_string)
-    
+
 class Format(EnumClass):
     TEXT  = 1
     ANSI  = 2
@@ -193,7 +193,7 @@ def parse_campaign_file(campaign_file):
             testset.add_test(test)
         elif l[0] == "*":
             if test is not None:
-                
+
                 test.comments += l[1:]
             elif testset is not None:
                 testset.comments += l[1:]
@@ -230,7 +230,7 @@ def dump_campaign(test_campaign):
             if t.crc:
                 c = "[%(crc)s] " % t
             if c or k:
-                print "    %s%s" % (c,k) 
+                print "    %s%s" % (c,k)
 
 #### COMPUTE CAMPAIGN DIGESTS ####
 
@@ -269,7 +269,7 @@ def filter_tests_keep_on_keywords(test_campaign, kw):
             if k in kw:
                 return True
         return False
-    
+
     if kw:
         for ts in test_campaign:
             ts.tests = [t for t in ts.tests if kw_match(t.keywords, kw)]
@@ -280,7 +280,7 @@ def filter_tests_remove_on_keywords(test_campaign, kw):
             if k not in lst:
                 return False
         return True
-    
+
     if kw:
         for ts in test_campaign:
             ts.tests = [t for t in ts.tests if not kw_match(t.keywords, kw)]
@@ -348,7 +348,7 @@ def campaign_to_TEXT(test_campaign):
     output="%(title)s\n" % test_campaign
     output += "-- "+info_line(test_campaign)+"\n\n"
     output += "Passed=%(passed)i\nFailed=%(failed)i\n\n%(headcomments)s\n" % test_campaign
-    
+
     for testset in test_campaign:
         if any(t.expand for t in testset):
             output += "######\n## %(name)s\n######\n%(comments)s\n\n" % testset
@@ -357,12 +357,12 @@ def campaign_to_TEXT(test_campaign):
                     output += "###(%(num)03i)=[%(result)s] %(name)s\n%(comments)s\n%(output)s\n\n" % t
 
     return output
- 
+
 def campaign_to_ANSI(test_campaign):
     output="%(title)s\n" % test_campaign
     output += "-- "+info_line(test_campaign)+"\n\n"
     output += "Passed=%(passed)i\nFailed=%(failed)i\n\n%(headcomments)s\n" % test_campaign
-    
+
     for testset in test_campaign:
         if any(t.expand for t in testset):
             output += "######\n## %(name)s\n######\n%(comments)s\n\n" % testset
@@ -419,7 +419,7 @@ def campaign_to_HTML(test_campaign, local=0):
         for t in ts:
             output += """<span class=button%(result)s onClick="goto_id('tst%(num)il')">%(num)03i</span>\n""" % t
     output += "\n\n"
-    
+
     for testset in test_campaign:
         output += "<h2>" % testset
         if testset.crc is not None:
@@ -474,7 +474,7 @@ def campaign_to_LATEX(test_campaign):
 
 """ % test_campaign
     output %= info_line(test_campaign)
-    
+
     for testset in test_campaign:
         output += "\\chapter{%(name)s}\n\n%(comments)s\n\n" % testset
         for t in testset:
@@ -496,7 +496,7 @@ def campaign_to_LATEX(test_campaign):
 
 
 #### USAGE ####
-                      
+
 def usage():
     print >>sys.stderr,"""Usage: UTscapy [-m module] [-f {text|ansi|HTML|LaTeX}] [-o output_file] 
                [-t testfile] [-k keywords [-k ...]] [-K keywords [-K ...]]
@@ -525,7 +525,7 @@ def main(argv):
     import __builtin__
 
     # Parse arguments
-    
+
     FORMAT = Format.ANSI
     TESTFILE = sys.stdin
     OUTPUTFILE = sys.stdout
@@ -585,7 +585,7 @@ def main(argv):
             elif opt == "-K":
                 KW_KO.append(optarg.split(","))
 
-        
+
         try:
             from scapy import all as scapy
         except ImportError,e:
@@ -597,7 +597,7 @@ def main(argv):
                 __builtin__.__dict__.update(mod.__dict__)
             except ImportError,e:
                 raise getopt.GetoptError("cannot import [%s]: %s" % (m,e))
-                
+
     except getopt.GetoptError,msg:
         print >>sys.stderr,"ERROR:",msg
         raise SystemExit
@@ -616,7 +616,7 @@ def main(argv):
     # Report parameters
     if PREEXEC:
         test_campaign.preexec = PREEXEC
-    
+
 
     # Compute campaign CRC and SHA
     if CRC:

--- a/scapy/tools/check_asdis.py
+++ b/scapy/tools/check_asdis.py
@@ -34,16 +34,16 @@ def main(argv):
                 APPEND = True
             elif opt == "-z":
                 COMPRESS = True
-                
-                
+
+
         if PCAP_IN is None:
             raise getopt.GetoptError("Missing pcap file (-i)")
-    
+
     except getopt.GetoptError,e:
         print >>sys.stderr,"ERROR: %s" % e
         raise SystemExit
-    
-    
+
+
 
     from scapy.config import conf
     from scapy.utils import RawPcapReader,RawPcapWriter,hexdiff
@@ -60,8 +60,8 @@ def main(argv):
     if LLcls is None:
         print >>sys.stderr," Unknown link type [%i]. Can't test anything!" % pcap.linktype
         raise SystemExit
-    
-    
+
+
     i=-1
     differ=0
     failed=0
@@ -93,8 +93,8 @@ def main(argv):
     correct = i-differ-failed
     print "%i total packets. %i ok, %i differed, %i failed. %.2f%% correct." % (i, correct, differ,
                                                                                 failed, i and 100.0*(correct)/i)
-    
-        
+
+
 if __name__ == "__main__":
     import sys
     try:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -96,13 +96,13 @@ def linehexdump(x, onlyasc=0, onlyhex=0):
 def chexdump(x):
     x=str(x)
     print ", ".join(map(lambda x: "%#04x"%ord(x), x))
-    
+
 def hexstr(x, onlyasc=0, onlyhex=0):
     s = []
     if not onlyasc:
         s.append(" ".join(map(lambda x:"%02x"%ord(x), x)))
     if not onlyhex:
-        s.append(sane(x)) 
+        s.append(sane(x))
     return "  ".join(s)
 
 
@@ -125,7 +125,7 @@ def hexdiff(x,y):
             d[i,j] = min( ( d[i-1,j-1][0]+SUBST*(x[i] != y[j]), (i-1,j-1) ),
                           ( d[i-1,j][0]+INSERT, (i-1,j) ),
                           ( d[i,j-1][0]+INSERT, (i,j-1) ) )
-                          
+
 
     backtrackx = []
     backtracky = []
@@ -137,13 +137,13 @@ def hexdiff(x,y):
         backtracky.append(y[j2+1:j+1])
         i,j = i2,j2
 
-        
+
 
     x = y = i = 0
     colorize = { 0: lambda x:x,
                 -1: conf.color_theme.left,
                  1: conf.color_theme.right }
-    
+
     dox=1
     doy=0
     l = len(backtrackx)
@@ -158,7 +158,7 @@ def hexdiff(x,y):
             doy = 1
         if dox and linex == liney:
             doy=1
-            
+
         if dox:
             xd = y
             j = 0
@@ -181,9 +181,9 @@ def hexdiff(x,y):
             line=liney
         else:
             print "    ",
-            
+
         print " ",
-        
+
         cl = ""
         for j in xrange(16):
             if i+j < l:
@@ -216,7 +216,7 @@ def hexdiff(x,y):
             else:
                 i += 16
 
-    
+
 crc32 = zlib.crc32
 
 if struct.pack("H",1) == "\x00\x01": # big endian
@@ -272,7 +272,7 @@ def fletcher16_checkbytes(binbuf, offset):
         
         For details on the algorithm, see RFC 2328 chapter 12.1.7 and RFC 905 Annex B.
     """
-    
+
     # This is based on the GPLed C implementation in Zebra <http://www.zebra.org/>
     if len(binbuf) < offset:
         raise Exception("Packet too short for checkbytes %d" % len(binbuf))
@@ -299,7 +299,7 @@ def mac2str(mac):
     return "".join(map(lambda x: chr(int(x,16)), mac.split(":")))
 
 def str2mac(s):
-    return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
+    return ("%02x:"*6)[:-1] % tuple(map(ord, s))
 
 def strxor(x,y):
     return "".join(map(lambda x,y:chr(ord(x)^ord(y)),x,y))
@@ -346,7 +346,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
     target: filename or redirect. Defaults pipe to Imagemagick's display program
     prog: which graphviz program to use
     options: options to be passed to prog"""
-        
+
     if format is None:
         if WINDOWS:
             format = "png" # use common format to make sure a viewer is installed
@@ -379,7 +379,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
             if time.time() - waiting_start > 3:
                 warning("Temporary file '%s' could not be written. Graphic will not be displayed." % tempfile)
                 break
-        else:  
+        else:
             if conf.prog.display == conf.prog._default:
                 os.startfile(tempfile)
             else:
@@ -401,7 +401,7 @@ _TEX_TR = {
     "<":"{\\tt\\char60}",
     ">":"{\\tt\\char62}",
     }
-    
+
 def tex_escape(x):
     s = ""
     for c in x:
@@ -716,7 +716,7 @@ class PcapReader(RawPcapReader):
         if rp is None:
             return None
         s,(sec,usec,wirelen) = rp
-        
+
         try:
             p = self.LLcls(s)
         except KeyboardInterrupt:
@@ -848,7 +848,7 @@ append: append packets to the capture file instead of truncating it
 sync: do not bufferize writes to the capture file
 
         """
-        
+
         self.linktype = linktype
         self.header_present = 0
         self.append = append
@@ -882,11 +882,11 @@ sync: do not bufferize writes to the capture file
             g = [open,gzip.open][self.gz](self.filename,"rb")
             if g.read(16):
                 return
-            
+
         self.f.write(struct.pack(self.endian+"IHHIIII", 0xa1b2c3d4L,
                                  2, 4, 0, 0, MTU, self.linktype))
         self.f.flush()
-    
+
 
     def write(self, pkt):
         """accepts either a single packet or a list of packets to be
@@ -975,10 +975,10 @@ def import_hexcap():
                 continue
     except EOFError:
         pass
-    
+
     p = p.replace(" ","")
     return p.decode("hex")
-        
+
 
 
 @conf.commands.register
@@ -999,8 +999,8 @@ def hexedit(x):
     return x
 
 def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None, seplinefunc=None):
-    vx = {} 
-    vy = {} 
+    vx = {}
+    vy = {}
     vz = {}
     vxf = {}
     vyf = {}
@@ -1058,7 +1058,7 @@ def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None,
 
 def make_table(*args, **kargs):
     __make_table(lambda l:"%%-%is" % l, lambda l:"%%-%is" % l, "", *args, **kargs)
-    
+
 def make_lined_table(*args, **kargs):
     __make_table(lambda l:"%%-%is |" % l, lambda l:"%%-%is |" % l, "",
                  seplinefunc=lambda a,x:"+".join(map(lambda y:"-"*(y+2), [a-1]+x+[-2])),

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -62,7 +62,7 @@ def construct_source_candidate_set(addr, plen, laddr, loname):
         cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
     cset = map(lambda x: x[0], cset)
     cset.sort(cmp=cset_sort) # Sort with global addresses first
-    return cset            
+    return cset
 
 def get_source_addr_from_candidate_set(dst, candidate_set):
     """
@@ -127,7 +127,7 @@ def get_source_addr_from_candidate_set(dst, candidate_set):
         # Rule 5: does not make sense here
         # Rule 6: cannot be implemented
         # Rule 7: cannot be implemented
-        
+
         # Rule 8: Longest prefix match
         tmp1 = in6_get_common_plen(source_a, dst)
         tmp2 = in6_get_common_plen(source_b, dst)
@@ -136,23 +136,23 @@ def get_source_addr_from_candidate_set(dst, candidate_set):
         elif tmp2 > tmp1:
             return -1
         return 0
-    
+
     if not candidate_set:
         # Should not happen
         return None
 
     candidate_set.sort(cmp=rfc3484_cmp, reverse=True)
-    
+
     return candidate_set[0]
 
 
 def find_ifaddr2(addr, plen, laddr):
     dstAddrType = in6_getAddrType(addr)
-    
+
     if dstAddrType == IPV6_ADDR_UNSPECIFIED: # Shouldn't happen as dst addr
         return None
 
-    if dstAddrType == IPV6_ADDR_LOOPBACK: 
+    if dstAddrType == IPV6_ADDR_LOOPBACK:
         return None
 
     tmp = [[]] + map(lambda (x,y,z): (in6_getAddrType(x), x, y, z), laddr)
@@ -161,8 +161,8 @@ def find_ifaddr2(addr, plen, laddr):
             l.append(t)
         return l
     sameScope = reduce(filterSameScope, tmp)
-    
-    l =  len(sameScope) 
+
+    l =  len(sameScope)
     if l == 1:  # Only one address for our scope
         return sameScope[0][1]
 
@@ -305,7 +305,7 @@ def in6_getLinkScopedMcastAddr(addr, grpid=None, scope=2):
     Multicast address, or if another error occurs, None is returned.
     """
     if not scope in [0, 1, 2]:
-        return None    
+        return None
     try:
         if not in6_islladdr(addr):
             return None
@@ -366,7 +366,7 @@ def in6_6to4ExtractAddr(addr):
     if addr[:2] != " \x02":
         return None
     return inet_ntop(socket.AF_INET, addr[2:6])
-    
+
 
 def in6_getLocalUniquePrefix():
     """
@@ -375,11 +375,11 @@ def in6_getLocalUniquePrefix():
     generation.
     """
     # Extracted from RFC 1305 (NTP) :
-    # NTP timestamps are represented as a 64-bit unsigned fixed-point number, 
-    # in seconds relative to 0h on 1 January 1900. The integer part is in the 
+    # NTP timestamps are represented as a 64-bit unsigned fixed-point number,
+    # in seconds relative to 0h on 1 January 1900. The integer part is in the
     # first 32 bits and the fraction part in the last 32 bits.
 
-    # epoch = (1900, 1, 1, 0, 0, 0, 5, 1, 0) 
+    # epoch = (1900, 1, 1, 0, 0, 0, 5, 1, 0)
     # x = time.time()
     # from time import gmtime, strftime, gmtime, mktime
     # delta = mktime(gmtime(0)) - mktime(self.epoch)
@@ -394,7 +394,7 @@ def in6_getLocalUniquePrefix():
     rawmac = get_if_raw_hwaddr(conf.iface6)[1]
     mac = ":".join(map(lambda x: "%.02x" % ord(x), list(rawmac)))
     # construct modified EUI-64 ID
-    eui64 = inet_pton(socket.AF_INET6, '::' + in6_mactoifaceid(mac))[8:] 
+    eui64 = inet_pton(socket.AF_INET6, '::' + in6_mactoifaceid(mac))[8:]
     import sha
     globalid = sha.new(tod+eui64).digest()[:5]
     return inet_ntop(socket.AF_INET6, '\xfd' + globalid + '\x00'*10)
@@ -430,9 +430,9 @@ def in6_getRandomizedIfaceId(ifaceid, previous=None):
     import md5
     s = md5.new(s).digest()
     s1,s2 = s[:8],s[8:]
-    s1 = chr(ord(s1[0]) | 0x04) + s1[1:]  
+    s1 = chr(ord(s1[0]) | 0x04) + s1[1:]
     s1 = inet_ntop(socket.AF_INET6, "\xff"*8 + s1)[20:]
-    s2 = inet_ntop(socket.AF_INET6, "\xff"*8 + s2)[20:]    
+    s2 = inet_ntop(socket.AF_INET6, "\xff"*8 + s2)[20:]
     return (s1, s2)
 
 
@@ -449,7 +449,7 @@ def in6_ctop(addr):
     (RFC 1924) to printable representation ;-)
     Returns None on error.
     """
-    if len(addr) != 20 or not reduce(lambda x,y: x and y, 
+    if len(addr) != 20 or not reduce(lambda x,y: x and y,
                                      map(lambda x: x in _rfc1924map, addr)):
         return None
     i = 0
@@ -468,7 +468,7 @@ def in6_ptoc(addr):
     Converts an IPv6 address in printable representation to RFC 
     1924 Compact Representation ;-) 
     Returns None on error.
-    """    
+    """
     try:
         d=struct.unpack("!IIII", inet_pton(socket.AF_INET6, addr))
     except:
@@ -485,7 +485,7 @@ def in6_ptoc(addr):
     res.reverse()
     return "".join(res)
 
-    
+
 def in6_isaddr6to4(x):
     """
     Return True if provided address (in printable format) is a 6to4
@@ -518,7 +518,7 @@ def teredoAddrExtractInfo(x):
     addr = inet_pton(socket.AF_INET6, x)
     server = inet_ntop(socket.AF_INET, addr[4:8])
     flag = struct.unpack("!H",addr[8:10])[0]
-    mappedport = struct.unpack("!H",strxor(addr[10:12],'\xff'*2))[0] 
+    mappedport = struct.unpack("!H",strxor(addr[10:12],'\xff'*2))[0]
     mappedaddr = inet_ntop(socket.AF_INET, strxor(addr[12:16],'\xff'*4))
     return server, flag, mappedaddr, mappedport
 
@@ -538,10 +538,10 @@ def in6_isanycast(x): # RFC 2526
         s = '::fdff:ffff:ffff:ff80'
         packed_x = inet_pton(socket.AF_INET6, x)
         packed_s = inet_pton(socket.AF_INET6, s)
-        x_and_s = in6_and(packed_x, packed_s) 
+        x_and_s = in6_and(packed_x, packed_s)
         return x_and_s == packed_s
     else:
-        # not EUI-64 
+        # not EUI-64
         #|              n bits             |    121-n bits    |   7 bits   |
         #+---------------------------------+------------------+------------+
         #|           subnet prefix         | 1111111...111111 | anycast ID |
@@ -556,7 +556,7 @@ def _in6_bitops(a1, a2, operator=0):
     fop = [ lambda x,y: x | y,
             lambda x,y: x & y,
             lambda x,y: x ^ y
-          ]  
+          ]
     ret = map(fop[operator%len(fop)], a1, a2)
     t = ''.join(map(lambda x: struct.pack('I', x), ret))
     return t
@@ -602,7 +602,7 @@ def in6_cidr2mask(m):
 
     return ''.join(map(lambda x: struct.pack('!I', x), t))
 
-def in6_getnsma(a): 
+def in6_getnsma(a):
     """
     Return link-local solicited-node multicast address for given
     address. Passed address must be provided in network format.
@@ -624,7 +624,7 @@ def in6_getnsmac(a): # return multicast Ethernet address associated with multica
     mac += ':'.join(map(lambda x: '%.2x' %x, a))
     return mac
 
-def in6_getha(prefix): 
+def in6_getha(prefix):
     """
     Return the anycast address associated with all home agents on a given
     subnet.
@@ -633,7 +633,7 @@ def in6_getha(prefix):
     r = in6_or(r, inet_pton(socket.AF_INET6, '::fdff:ffff:ffff:fffe'))
     return inet_ntop(socket.AF_INET6, r)
 
-def in6_ptop(str): 
+def in6_ptop(str):
     """
     Normalizes IPv6 addresses provided in printable format, returning the 
     same address in printable format. (2001:0db8:0:0::1 -> 2001:db8::1)
@@ -692,7 +692,7 @@ def in6_isuladdr(str):
 
 # TODO : we should see the status of Unique Local addresses against
 #        global address space.
-#        Up-to-date information is available through RFC 3587. 
+#        Up-to-date information is available through RFC 3587.
 #        We should review function behavior based on its content.
 def in6_isgladdr(str):
     """
@@ -792,7 +792,7 @@ def in6_get_common_plen(a, b):
             if (byte1 & cur_mask) != (byte2 & cur_mask):
                 return i
         return 8
-        
+
     tmpA = inet_pton(socket.AF_INET6, a)
     tmpB = inet_pton(socket.AF_INET6, b)
     for i in xrange(16):

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -29,7 +29,7 @@ class RandomEnumeration:
         self.sbox_size = 256
 
         self.top = sup-inf+1
-    
+
         n=0
         while (1<<n) < self.top:
             n += 1
@@ -58,7 +58,7 @@ class RandomEnumeration:
                     ct >>= self.fs
                     lsb ^= self.sbox[ct%self.sbox_size]
                     ct |= lsb << (self.n-self.fs)
-                
+
                 if ct < self.top:
                     return self.inf+ct
             self.i = 0
@@ -205,7 +205,7 @@ class RandChoice(RandField):
         self._choice = args
     def _fix(self):
         return random.choice(self._choice)
-    
+
 class RandString(RandField):
     def __init__(self, size=None, chars="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"):
         if size is None:
@@ -229,8 +229,8 @@ class RandTermString(RandString):
         self.term = term
     def _fix(self):
         return RandString._fix(self)+self.term
-    
-    
+
+
 
 class RandIP(RandString):
     def __init__(self, iptemplate="0.0.0.0/0"):
@@ -254,7 +254,7 @@ class RandMAC(RandString):
             self.mac += (v,)
     def _fix(self):
         return "%02x:%02x:%02x:%02x:%02x:%02x" % self.mac
-    
+
 class RandIP6(RandString):
     def __init__(self, ip6template="**"):
         self.tmpl = ip6template
@@ -336,7 +336,7 @@ class RandOID(RandString):
                 else:
                     oid.append(i)
             return ".".join(oid)
-            
+
 
 class RandRegExp(RandField):
     def __init__(self, regexp, lambda_=0.3,):
@@ -415,7 +415,7 @@ class RandRegExp(RandField):
         while i < ln:
             c = self._regexp[i]
             i+=1
-            
+
             if c == '(':
                 current = [current]
                 current[0].append(current)
@@ -493,19 +493,19 @@ class RandRegExp(RandField):
 
 class RandSingularity(RandChoice):
     pass
-                
+
 class RandSingNum(RandSingularity):
     @staticmethod
     def make_power_of_two(end):
         sign = 1
-        if end == 0: 
+        if end == 0:
             end = 1
         if end < 0:
             end = -end
             sign = -1
         end_n = int(math.log(end)/math.log(2))+1
-        return set([sign*2**i for i in xrange(end_n)])            
-        
+        return set([sign*2**i for i in xrange(end_n)])
+
     def __init__(self, mn, mx):
         sing = set([0, mn, mx, int((mn+mx)/2)])
         sing |= self.make_power_of_two(mn)
@@ -517,7 +517,7 @@ class RandSingNum(RandSingularity):
             if not mn <= i <= mx:
                 sing.remove(i)
         self._choice = list(sing)
-        
+
 
 class RandSingByte(RandSingNum):
     def __init__(self):
@@ -607,7 +607,7 @@ class RandSingString(RandSingularity):
                          r"\\myserver\share",
                          "foo.exe:",
                          "foo.exe\\", ]
-                             
+
 
 class RandPool(RandField):
     def __init__(self, *args):
@@ -633,7 +633,7 @@ class AutoTime(VolatileValue):
             self.diff = time.time()-base
     def _fix(self):
         return time.time()-self.diff
-            
+
 class IntAutoTime(AutoTime):
     def _fix(self):
         return int(time.time()-self.diff)


### PR DESCRIPTION
The source code of scapy is littered with many trailing whitespaces.

This can be especially annoying if you have your text editor configured to automatically strip trailing whitespaces when you save a file as it leads you to potentially inadvertently committing whitespace fixes.

In this commit I clean up all the scapy source tree from spurious whitespaces.

The command used for this is:
    autopep8 --in-place --recursive --select="W291,W293" scapy

It may be useful also in the future to run some other automatic cleanup option of autopep8 to fix other style issues.