### PR TITLE
Packet.copy(): copy the `time` property

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -166,6 +166,7 @@ class Packet(BasePacket):
         clone.post_transforms = self.post_transforms[:]
         clone.payload = self.payload.copy()
         clone.payload.add_underlayer(clone)
+        clone.time = self.time
         return clone
 
     def getfieldval(self, attr):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -92,6 +92,7 @@ TCP in a
 a[TCP]
 a[TCP].dport=[80,443]
 a
+assert(a.copy().time == a.time)
 a=3
 
 


### PR DESCRIPTION
Working with `scapy` has made my life a lot easier (thank you!), but I just recently spent quite a while tracking down a non-intuitive quirk about `Packet.copy()`: the cloned packet does not have the same `time` property as the original. These changes fix that and include a regression test.