### PR TITLE
Run unit tests on Linux and OS X - root and non-root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,42 @@
-sudo: false
-
 language: python
 
-python:
-  - 2.6
-  - 2.7
-  - pypy
+matrix:
+    include:
+        # Run as a regular user
+        - os: linux
+          python: 2.6
 
-install:
-  - pip install pycrypto
+        - os: linux
+          python: 2.7
 
-script: cd test/; for f in *.uts; do ./run_tests -q -F -t $f -K netaccess || exit $?; done; for f in ../scapy/contrib/*.uts ; do ./run_tests -q -F -t $f -K netaccess -P "load_contrib('$(basename ${f/.uts})')" || exit $?; done
+        - os: linux
+          python: pypy
+
+        - os: osx
+          language: generic
+          env:
+            - SCAPY_USE_PCAPDNET=true
+
+        # Run as root
+        - os: linux
+          sudo: required
+          python: 2.7
+          env:
+            - TRAVIS_SUDO=sudo
+
+        - os: linux
+          sudo: required
+          python: 2.7
+          env:
+            - TRAVIS_SUDO=sudo
+            - SCAPY_USE_PCAPDNET=true
+
+        - os: osx
+          language: generic
+          env:
+            - TRAVIS_SUDO=sudo
+            - SCAPY_USE_PCAPDNET=true
+
+install: bash .travis/install.sh
+
+script: bash .travis/test.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,23 @@
+# Install dependencies using pip
+if [ -z $TRAVIS_SUDO ] && [ "$TRAVIS_OS_NAME" = "osx" ]
+then 
+  PIP_INSTALL_FLAGS="--user"
+fi
+$TRAVIS_SUDO pip install $PIP_INSTALL_FLAGS pycrypto mock
+
+# Install pcap & dnet
+if [ ! -z $SCAPY_USE_PCAPDNET ]
+then
+  if [ "$TRAVIS_OS_NAME" = "linux" ]
+  then
+    $TRAVIS_SUDO apt-get install python-pcapy python-dumbnet
+  elif [ "$TRAVIS_OS_NAME" = "osx" ]
+  then
+    mkdir -p /Users/travis/Library/Python/2.7/lib/python/site-packages
+    echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/travis/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+ 
+    brew update
+    brew install --with-python libdnet
+    brew install .travis/pylibpcap.rb
+  fi
+fi

--- a/.travis/pylibpcap.rb
+++ b/.travis/pylibpcap.rb
@@ -1,0 +1,10 @@
+class Pylibpcap <Formula
+  url "http://downloads.sourceforge.net/project/pylibpcap/pylibpcap/0.6.4/pylibpcap-0.6.4.tar.gz"
+  homepage "http://pylibpcap.sourceforge.net/"
+  sha256 "cfc365f2707a7986496acacf71789fef932a5ddbeaa36274cc8f9834831ca3b1"
+ 
+  def install
+    system "python", *Language::Python.setup_install_args(prefix)
+  end
+end
+

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,18 @@
+# Don't run tests that requires root privileges
+if [ -z $TRAVIS_SUDO ]
+then
+  UT_FLAGS="-K netaccess"
+fi
+
+# Run unit tests
+cd test/
+
+for f in *.uts
+do
+  $TRAVIS_SUDO ./run_tests -q -F -t $f $UT_FLAGS || exit $?
+done
+
+for f in ../scapy/contrib/*.uts
+do
+  $TRAVIS_SUDO ./run_tests -q -F -t $f $UT_FLAGS -P "load_contrib('$(basename ${f/.uts})')" || exit $?
+done


### PR DESCRIPTION
This PR introduces a new Travis-CI build matrix, as well as helpers in the `.travis/` directory. The goal is to run unit tests on Linux on OS X and Linux as a regular and as root.

@p-l- I don't understand with Travis-CI is not launched on this PR ...