### PR TITLE
mDNS support

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -238,60 +238,36 @@ Some optional packages:
 Mac OS X
 --------
 
-Here's how to install Scapy on Mac OS 10.4 (Tiger) or 10.5 (Leopard).
+On Mac OS X, Scapy does not work natively. You need to install Python bindings
+to use libdnet and libpcap. You can choose to install using either Homebrew or
+MacPorts. They both work fine, yet Homebrew is used to run unit tests with
+`Travis CI <https://travis-ci.org>`_. 
 
-Set up a development environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. Install X11. 
-   On the Mac OS X DVD, it is located in the "Optional Installs.mpkg" package.
- 
-2. Install SDK.
-   On the Mac OS X DVD, it is located in the "Xcode Tools/Packages" directory.
+Install using Homebrew
+^^^^^^^^^^^^^^^^^^^^^^
 
-3. Install Python 2.5 from Python.org.
-   Using Apple's Python version will lead to some problems.
-   Get it from http://www.python.org/ftp/python/2.5.2/python-2.5.2-macosx.dmg
+1. Update Homebrew::
+
+   $ sudo brew update
+
+2. Install Python bindings::
+
+   $ sudo brew install --with-python libdnet
+   $ sudo brew install https://raw.githubusercontent.com/secdev/scapy/master/.travis/pylibpcap.r
+
 
 Install using MacPorts
 ^^^^^^^^^^^^^^^^^^^^^^
 
-3. Install MacPorts
-   Download the dmg from macports.org and install it.
-     
-4. Update MacPorts::
+1. Update MacPorts::
 
    $ sudo port -d selfupdate
 
-5. Install Scapy::
+2. Install Python bindings::
 
-   $ sudo port install scapy
+   $ sudo port install py-libdnet py-pylibpcap
 
-You can then update to the latest version as shown in the generic installation above. 
-
-Install from original sources
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Install libdnet and its Python wrapper::
-
- $ wget http://libdnet.googlecode.com/files/libdnet-1.12.tgz
- $ tar xfz libdnet-1.12.tgz 
- $ ./configure
- $ make
- $ sudo make install
- $ cd python
- $ python2.5 setup.py install
-
-Install libpcap and its Python wrapper::
-
- $ wget http://dfn.dl.sourceforge.net/sourceforge/pylibpcap/pylibpcap-0.6.2.tar.gz
- $ tar xfz pylibpcap-0.6.2.tar.gz
- $ cd pylibpcap-0.6.2
- $ python2.5 setup.py install
-
-Optionally: Install readline::
-
- $ python `python -c "import pimp; print pimp.__file__"` -i readline
 
 OpenBSD
 -------

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -436,10 +436,10 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                 nh = self.payload.nh # XXX what if another extension follows ?
                 ss = foundhao.hoa
 
-        if conf.checkIPsrc and conf.checkIPaddr:
+        if conf.checkIPsrc and conf.checkIPaddr and not in6_ismaddr(sd):
             sd = inet_pton(socket.AF_INET6, sd)
             ss = inet_pton(socket.AF_INET6, self.src)
-            return struct.pack("B",nh)+self.payload.hashret()
+            return strxor(sd, ss) + struct.pack("B", nh) + self.payload.hashret()
         else:
             return struct.pack("B", nh)+self.payload.hashret()
 


### PR DESCRIPTION
This PR provides two different yet related patches:
1. mDNS support added for IPv4
2. fix IPv6.hashret() that was not working as expected (i.e. IPv6 addresses were never involved in hashret() results). It might break some behaviours, therefore I wonder if I could be better to create a separated PR