### PR TITLE
Missing import in packet.py

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -12,6 +12,7 @@ import time,itertools
 import copy
 from fields import StrField, ConditionalField, Emph, PacketListField, BitField, \
     MultiEnumField, EnumField, FlagsField
+from themes import AnsiColorTheme
 from config import conf
 from base_classes import BasePacket, Gen, SetGen, Packet_metaclass
 from volatile import VolatileValue


### PR DESCRIPTION
Some regression tests are failing due to a missing import in packet.py