### PR TITLE
Fix support and add test for ASN.1 (unknown) high-tag-number

### DIFF
--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -15,8 +15,6 @@ from volatile import *
 from base_classes import BasePacket
 from utils import binrepr
 
-FLEXIBLE_TAGS = False
-
 class ASN1F_badsequence(Exception):
     pass
 
@@ -35,7 +33,8 @@ class ASN1F_field(ASN1F_element):
     context = ASN1_Class_UNIVERSAL
     
     def __init__(self, name, default, context=None,
-                 implicit_tag=None, explicit_tag=None):
+                 implicit_tag=None, explicit_tag=None,
+                 flexible_tag=False):
         self.context = context
         self.name = name
         if default is None:
@@ -44,7 +43,7 @@ class ASN1F_field(ASN1F_element):
             self.default = default
         else:
             self.default = self.ASN1_tag.asn1_object(default)
-        self.flexible_tag = False or FLEXIBLE_TAGS
+        self.flexible_tag = flexible_tag
         if (implicit_tag is not None) and (explicit_tag is not None):
             err_msg = "field cannot be both implicitly and explicitly tagged"
             raise ASN1_Error(err_msg)
@@ -70,13 +69,18 @@ class ASN1F_field(ASN1F_element):
 
         Regarding other fields, we might need to know whether encoding went
         as expected or not. Noticeably, input methods from cert.py expect
-        certain exceptions to be raised. Hence default flexible_tag is False,
-        but we provide a FLEXIBLE_TAGS switch for debugging purposes.
+        certain exceptions to be raised. Hence default flexible_tag is False.
         """
-        s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
-                            implicit_tag=self.implicit_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        diff_tag, s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
+                                      implicit_tag=self.implicit_tag,
+                                      explicit_tag=self.explicit_tag,
+                                      safe=self.flexible_tag)
+        if diff_tag is not None:
+            # this implies that flexible_tag was True
+            if self.implicit_tag is not None:
+                self.implicit_tag = diff_tag
+            elif self.explicit_tag is not None:
+                self.explicit_tag = diff_tag
         codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
         if self.flexible_tag:
             return codec.safedec(s, context=self.context)
@@ -251,19 +255,32 @@ class ASN1F_BMP_STRING(ASN1F_STRING):
     ASN1_tag = ASN1_Class_UNIVERSAL.BMP_STRING
    
 class ASN1F_SEQUENCE(ASN1F_field):
+# Here is how you could decode a SEQUENCE
+# with an unknown, private high-tag prefix :
+# class PrivSeq(ASN1_Packet):
+#     ASN1_codec = ASN1_Codecs.BER
+#     ASN1_root = ASN1F_SEQUENCE(
+#                       <asn1 field #0>,
+#                       ...
+#                       <asn1 field #N>,
+#                       explicit_tag=0,
+#                       flexible_tag=True)
+# Because we use flexible_tag, the value of the explicit_tag does not matter.
     ASN1_tag = ASN1_Class_UNIVERSAL.SEQUENCE
     holds_packets = 1
     def __init__(self, *seq, **kwargs):
         name = "dummy_seq_name"
         default = [field.default for field in seq]
-        for kwarg in ["context", "implicit_tag", "explicit_tag"]:
+        for kwarg in ["context", "implicit_tag",
+                      "explicit_tag", "flexible_tag"]:
             if kwarg in kwargs:
                 setattr(self, kwarg, kwargs[kwarg])
             else:
                 setattr(self, kwarg, None)
         ASN1F_field.__init__(self, name, default, context=self.context,
                              implicit_tag=self.implicit_tag,
-                             explicit_tag=self.explicit_tag)
+                             explicit_tag=self.explicit_tag,
+                             flexible_tag=self.flexible_tag)
         self.seq = seq
         self.islist = len(seq) > 1
     def __repr__(self):
@@ -284,10 +301,15 @@ class ASN1F_SEQUENCE(ASN1F_field):
         Thus m2i returns an empty list (along with the proper remainder).
         It is discarded by dissect() and should not be missed elsewhere.
         """
-        s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
-                            implicit_tag=self.implicit_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        diff_tag, s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
+                                      implicit_tag=self.implicit_tag,
+                                      explicit_tag=self.explicit_tag,
+                                      safe=self.flexible_tag)
+        if diff_tag is not None:
+            if self.implicit_tag is not None:
+                self.implicit_tag = diff_tag
+            elif self.explicit_tag is not None:
+                self.explicit_tag = diff_tag
         codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
         i,s,remain = codec.check_type_check_len(s)
         if len(s) == 0:
@@ -325,10 +347,15 @@ class ASN1F_SEQUENCE_OF(ASN1F_field):
     def is_empty(self, pkt):
         return ASN1F_field.is_empty(self, pkt)
     def m2i(self, pkt, s):
-        s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
-                            implicit_tag=self.implicit_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        diff_tag, s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
+                                      implicit_tag=self.implicit_tag,
+                                      explicit_tag=self.explicit_tag,
+                                      safe=self.flexible_tag)
+        if diff_tag is not None:
+            if self.implicit_tag is not None:
+                self.implicit_tag = diff_tag
+            elif self.explicit_tag is not None:
+                self.explicit_tag = diff_tag
         codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
         i,s,remain = codec.check_type_check_len(s)
         lst = []
@@ -368,7 +395,7 @@ class ASN1F_TIME_TICKS(ASN1F_INTEGER):
 #############################
 
 class ASN1F_optional(ASN1F_element):
-    def __init__(self, field, by_default=False):
+    def __init__(self, field):
         field.flexible_tag = False
         self._field = field
     def __getattr__(self, attr):
@@ -440,9 +467,8 @@ class ASN1F_CHOICE(ASN1F_field):
         """
         if len(s) == 0:
             raise ASN1_Error("ASN1F_CHOICE: got empty string")
-        s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        _,s = BER_tagging_dec(s, hidden_tag=self.ASN1_tag,
+                              explicit_tag=self.explicit_tag)
         tag,_ = BER_id_dec(s)
         if tag not in self.choices:
             if self.flexible_tag:
@@ -484,10 +510,15 @@ class ASN1F_PACKET(ASN1F_field):
                 self.network_tag = 16|0x20
         self.default = default
     def m2i(self, pkt, s):
-        s = BER_tagging_dec(s, hidden_tag=self.cls.ASN1_root.ASN1_tag,
-                            implicit_tag=self.implicit_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        diff_tag, s = BER_tagging_dec(s, hidden_tag=self.cls.ASN1_root.ASN1_tag,
+                                      implicit_tag=self.implicit_tag,
+                                      explicit_tag=self.explicit_tag,
+                                      safe=self.flexible_tag)
+        if diff_tag is not None:
+            if self.implicit_tag is not None:
+                self.implicit_tag = diff_tag
+            elif self.explicit_tag is not None:
+                self.explicit_tag = diff_tag
         p,s = self.extract_packet(self.cls, s)
         return p,s
     def i2m(self, pkt, x):

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -19,6 +19,16 @@ class ASN1P_INTEGER(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_INTEGER("number", 0)
 
+class ASN1P_PRIVSEQ(ASN1_Packet):
+    # This class gets used in x509.uts
+    # It showcases the private high-tag decoding capacities of scapy.
+    ASN1_codec = ASN1_Codecs.BER
+    ASN1_root = ASN1F_SEQUENCE(
+            ASN1F_IA5_STRING("str", ""),
+            ASN1F_STRING("int", 0),
+            explicit_tag=0,
+            flexible_tag=True)
+
 
 #######################
 ##### RSA packets #####
@@ -36,7 +46,7 @@ class RSAPublicKey(ASN1_Packet):
                     ASN1F_INTEGER("publicExponent", 3))
 
 class RSAOtherPrimeInfo(ASN1_Packet):
-    ASN1_codec = ASN1_Codecs.DER
+    ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SEQUENCE(
                     ASN1F_INTEGER("prime", 0),
                     ASN1F_INTEGER("exponent", 0),
@@ -610,9 +620,9 @@ class ASN1F_EXT_SEQUENCE(ASN1F_SEQUENCE):
                    explicit_tag=0x04)]
         ASN1F_SEQUENCE.__init__(self, *seq, **kargs)
     def dissect(self, pkt, s):
-        s = BER_tagging_dec(s, implicit_tag=self.implicit_tag,
-                            explicit_tag=self.explicit_tag,
-                            safe=self.flexible_tag)
+        _,s = BER_tagging_dec(s, implicit_tag=self.implicit_tag,
+                              explicit_tag=self.explicit_tag,
+                              safe=self.flexible_tag)
         codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
         i,s,remain = codec.check_type_check_len(s)
         extnID = self.seq[0]

--- a/test/x509.uts
+++ b/test/x509.uts
@@ -1,7 +1,15 @@
 % Tests for X.509 objects
 # 
-# Launch me with:
-# sudo bash test/run_tests -t test/x509.uts -F
+# Try me with:
+# bash test/run_tests -t test/x509.uts -F
+
+########### ASN.1 border case #######################################
+
++ General BER decoding tests
+= Decoding an ASN.1 SEQUENCE with an unknown, high-tag identifier
+s = '\xff\x84\x92\xb9\x86H\x1e0\x1c\x16\x04BNCH\x04\x14\xb7\xca\x01wO\x9b\xbaz\xbb\xb5\x92\x87>T\xb2\xc3g\xc1]\xfb'
+p = ASN1P_PRIVSEQ(s)
+
 
 ########### Key class ###############################################
 
@@ -136,7 +144,7 @@ str(x) == c
 tbs = x.tbsCertList
 tbs.version == None
 
-= CRL class : Signature algorithm (as advertised by TBSCRLificate)
+= CRL class : Signature algorithm (as advertised by TBSCertList)
 assert(type(tbs.signature) is X509_AlgorithmIdentifier)
 tbs.signature.algorithm == ASN1_OID("sha1-with-rsa-signature")
 
@@ -178,6 +186,7 @@ x.signatureAlgorithm.algorithm == ASN1_OID("sha1-with-rsa-signature")
 x.signatureValue == ASN1_BIT_STRING('"\xc9\xf6\xbb\x1d\xa1\xa5=$\xc7\xff\xb0"\x11\xb3p\x06[\xc5U\xdd3v\xa0\x98"\x08cDi\xcfOG%w\x99\x12\x84\xd2\x19\xae \x94\xca,T\x9ak\x81\xd2\x038\xa6Z\x95\x8d*\xe2a\xce\xdb\x19\xcdu\'Y&|V\xe1\xe4\x80q\x1aI\xb2\xaa\xcdI[\xda\x0f\xa8\xff\xce<\n\xfc\xc9\xad\xc6\xde\xc8@d\x0c&\t#\x90\xb7\x9c\xb9P\x03\x8fK\x18\x9f\xb0\xe0e\x0f`\x1c\x1ag\xe5\x85\xc4%\xf5\x0b\xc93\x82R\xe6', readable=True)
 
 = CRL class : Default X509_CRL from scratch
-str(X509_CRL(str(X509_CRL()))) == str(X509_CRL())
+s = str(X509_CRL())
+str(X509_CRL(s)) == s
 
 


### PR DESCRIPTION
This commit relates to the ASN.1 high-tag-number support. It comes with an example for the dissection of an ASN1F_SEQUENCE with a (previously) unknown high-tag.

BER_tagging_dec now returns the tag value along with the string stripped of its tag, and replaces the explicit_tag or implicit_tag we provided when defining the class. This is needed in order to restore the tag once we want to rebuild the packet.

Code below raised a TypeError before this commit.

```python
class asn1test(ASN1_Packet):
    ASN1_codec = ASN1_Codecs.BER
    ASN1_root = ASN1F_INTEGER("int", "", explicit_tag=0, flexible_tag=True)

s = '\xff\x01\x03\x02\x01\x03'
# the first two bytes represent the explicit_tag
# (class private + type constructed + real tag 0x01)
# then comes length 0x03 of the ASN1-encoded integer
a = asn1test(s)
print s == str(a)
```

It also works with implicit tags :

```python
class asn1test(ASN1_Packet):
    ASN1_codec = ASN1_Codecs.BER
    ASN1_root = ASN1F_INTEGER("int", "", implicit_tag=0, flexible_tag=True)

s = '\xff\x01\x01\x03'
# the first two bytes represent the implicit_tag
# (class private + type constructed + real tag 0x01)
# then comes length 0x01 of the integer
a = asn1test(s)
print s == str(a)
```
