### PR TITLE
Added a stop condition to PacketListField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -425,15 +425,15 @@ class PacketLenField(PacketField):
 
 
 class PacketListField(PacketField):
-    __slots__ = ["count_from", "length_from"]
+    __slots__ = ["count_from", "length_from", "stop"]
     islist = 1
-    def __init__(self, name, default, cls, count_from=None, length_from=None):
+    def __init__(self, name, default, cls, count_from=None, length_from=None, stop=None):
         if default is None:
             default = []  # Create a new list for each instance
         PacketField.__init__(self, name, default, cls)
         self.count_from = count_from
         self.length_from = length_from
-
+        self.stop = stop
 
     def any2i(self, pkt, x):
         if type(x) is not list:
@@ -483,6 +483,9 @@ class PacketListField(PacketField):
                 else:
                     remain = ""
             lst.append(p)
+            # Evaluate the stop condition
+            if self.stop and self.stop(p):
+                break
         return remain+ret,lst
     def addfield(self, pkt, s, val):
         return s+"".join(map(str, val))

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -502,6 +502,33 @@ hexdiff(a,b)
 assert( str(a) == str(b) )
 
 
+############
+############
++ PacketListField stop condition tests
+
+= Test the PacketListField stop condition
+
+class TestPktStop(Packet):
+    fields_desc = [ ByteField("f1", 0x33) ]
+    def extract_padding(self, p):
+        return "", p
+
+class TestPLFStop(Packet):
+    name="test"
+    fields_desc=[PacketListField("plist", None, TestPktStop, stop=lambda x:x.f1 == 0xff)]
+
+a=TestPLFStop()
+assert(str(a) == "")
+
+a.plist=[TestPktStop(), TestPktStop()]
+str(a)
+assert(_ == "\x33\x33")
+
+a = TestPLFStop("\x33\xff\x33")
+str(a)
+assert(_ == "\x33\xff\x33")
+assert(Raw in a)
+assert(str(a.payload) == "\x33")
 
 
 ############


### PR DESCRIPTION
Added a stop parameter to PacketListField. This parameter is a callable that would be evaluated after each packet is identified, and used as a condition to keep adding more packets to the list field. This enables the implementation of protocols who uses a "sentinel" or some property of an inner packet to mark the end of the packet list, in addition or instead of providing the count/length.