### PR TITLE
Fix scapy init when gtk is not available

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -21,7 +21,8 @@ try:
     else:
         MATPLOTLIB_INLINED = 0
     MATPLOTLIB_DEFAULT_PLOT_KARGS = {"marker": "+"}
-except ImportError:
+# RuntimeError to catch gtk "Cannot open display" error
+except (ImportError, RuntimeError) as e:
     plt = None
     MATPLOTLIB = 0
     MATPLOTLIB_INLINED = 0


### PR DESCRIPTION
matplotlib.pyplot inits gtk, which may not be available.
If so, handles this as if the import failed.