### PR TITLE
base_classes.py: dispatch_hook: conf variable is undefined in the global scope

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -216,7 +216,7 @@ class Packet_metaclass(type):
             try:
                 cls = cls.dispatch_hook(*args, **kargs)
             except:
-                if conf.debug_dissector:
+                if config.conf.debug_dissector:
                     raise
                 cls = Raw
         i = cls.__new__(cls, cls.__name__, cls.__bases__, cls.__dict__)

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -218,7 +218,7 @@ class Packet_metaclass(type):
             except:
                 if config.conf.debug_dissector:
                     raise
-                cls = Raw
+                cls = config.conf.raw_layer
         i = cls.__new__(cls, cls.__name__, cls.__bases__, cls.__dict__)
         i.__init__(*args, **kargs)
         return i


### PR DESCRIPTION
When triggering the code path that is modified in this patch, Scapy will crash, because the `conf` variable is not defined in the global scope. This comes from the fact that `import config` is used at the top of the file, and so the conf variable must be accessed within the "full" path `config.conf`

To reproduce the issue :
```
import scapy.packet
class Toto(scapy.packet.Packet):
  @classmethod
  def dispatch_hook(cls, *args, **kwargs):
    raise Exception()
Toto('titi')
```

Same goes for the next line because Raw is undefined in the global scope too.


Edit: removing mixed french/english from the pull request, and adding a word about the second commit to fix the Raw reference.