### PR TITLE
Fix DHCP6 DomainNameField parsing

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -785,7 +785,7 @@ class DomainNameField(StrLenField):
 
     def m2i(self, pkt, x):
         cur = []
-        while x:
+        while x != '\x00' and len(x) > 0:
             l = ord(x[0])
             cur.append(x[1:1+l])
             x = x[l+1:]


### PR DESCRIPTION
At the moment the parsing of the field continues when the null byte at the end of the string is reached, adding an empty string to the list, which results in an extra dot at the end of the domain name.
Checking whether the remaining part is a null byte and the length of the packet is larger than zero (in case the string does not end with a null byte for some reason) fixes this issue.