### PR TITLE
Fix supercalls on BitMultiEnumField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -894,13 +894,13 @@ class MultiEnumField(_MultiEnumField, EnumField):
 class BitMultiEnumField(BitField, _MultiEnumField):
     __slots__ = EnumField.__slots__ + MultiEnumField.__slots__
     def __init__(self, name, default, size, enum, depends_on):
-        MultiEnumField.__init__(self, name, default, enum)
+        _MultiEnumField.__init__(self, name, default, enum, depends_on)
         self.rev = size < 0
         self.size = abs(size)
     def any2i(self, pkt, x):
-        return MultiEnumField.any2i(self, pkt, x)
+        return _MultiEnumField.any2i(self, pkt, x)
     def i2repr(self, pkt, x):
-        return MultiEnumField.i2repr(self, pkt, x)
+        return _MultiEnumField.i2repr(self, pkt, x)
 
 
 class ByteEnumKeysField(ByteEnumField):


### PR DESCRIPTION
The following code triggers an error in fields.py
```
import scapy.packet
import scapy.fields

class TestPacket(scapy.packet.Packet):
  name = "Test Packet"
  fields_desc = [
    scapy.fields.BitField('type', 0, 1),
    scapy.fields.BitMultiEnumField('flags', 0, 7, { 0: { 1: 'flagA1', 2: 'flagA2' }, 1: { 1: 'flagB1', 2: 'flagB2' } }, lambda pkt: pkt.type)
  ]
```

The exception looks like this:
```
Traceback (most recent call last):
  File "poc.py", line 4, in <module>
    class TestPacket(scapy.packet.Packet):
  File "poc.py", line 8, in TestPacket
    scapy.fields.BitMultiEnumField('flags', 0, 7, { 0: { 1: 'flagA1', 2: 'flagA2' }, 1: { 1: 'flagB1', 2: 'flagB2' } }, lambda pkt: pkt.type)
  File "/home/fmaury/scapy/scapy/fields.py", line 879, in __init__
    MultiEnumField.__init__(self, name, default, enum)
TypeError: unbound method __init__() must be called with MultiEnumField instance as first argument (got BitMultiEnumField instance instead)
```

The problem is that `MultiEnumField` is not a superclass of `BitMultiEnumField`. `_MultiEnumField` is.

At the same time, the `MultiEnumField.__init__(self, name, default, enum)` call is incorrect because it lacks the `depends_on` parameter.

This pull request fixes these issues, by fixing the super call, and adds the missing parameter.

Once patched, the following code runs flawlessly:
```
cat > poc.py <<<EOF
import scapy.packet
import scapy.fields

class TestPacket(scapy.packet.Packet):
  name = "Test Packet"
  fields_desc = [
    scapy.fields.BitField('type', 0, 1),
    scapy.fields.BitMultiEnumField('flags', 0, 7, { 0: { 1: 'flagA1', 2: 'flagA2' }, 1: { 1: 'flagB1', 2: 'flagB2' } }, lambda pkt: pkt.type)
  ]

TestPacket('\x01').show()
TestPacket('\x02').show()
TestPacket('\x81').show()
TestPacket('\x82').show()
EOF

python poc.py
###[ Test Packet ]###
  type      = 0L
  flags     = flagA1
###[ Test Packet ]###
  type      = 0L
  flags     = flagA2
###[ Test Packet ]###
  type      = 1L
  flags     = flagB1
###[ Test Packet ]###
  type      = 1L
  flags     = flagB2
```

These changes are not expected to break compatibility. A quick grep around scapy master branch code indicates that noone is currently using `BitMultiEnumField`.