### PR TITLE
Add MultiFlagsField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -987,8 +987,49 @@ class FlagsField(BitField):
             r = "+".join(r)
         return r
 
-            
 
+class MultiFlagsField(BitField):
+    __slots__ = FlagsField.__slots__ + ["depends_on"]
+    def __init__(self, name, default, size, names, depends_on):
+        self.names = names
+        self.depends_on = depends_on
+        super(MultiFlagsField, self).__init__(name, default, size)
+
+    def any2i(self, pkt, x):
+        if type(x) is list:
+            v = self.depends_on(pkt)
+            y = 0
+            these_names = self.names[v]
+            for i in x:
+                for j in these_names.keys():
+                    if these_names[j]['short'] == i:
+                        shft_cnt = j
+                        break
+                else:
+                    assert False, 'Unknown flag "{}" with this dependency'.format(i)
+                    continue
+                y |= 1 << shft_cnt
+            x = y
+        return x
+
+    def i2repr(self, pkt, x):
+        v = self.depends_on(pkt)
+        if self.names.has_key(v):
+            these_names = self.names[v]
+        else:
+            these_names = {}
+
+        r = []
+        i = 0
+        while x:
+            if x & 1:
+                if these_names.has_key(i):
+                    r.append("{} ({})".format(these_names[i]['long'], these_names[i]['short']))
+                else:
+                    r.append('bit {}'.format(str(i)))
+            x >>= 1
+            i += 1
+        return r
 
 class FixedPointField(BitField):
     __slots__ = ['frac_bits']


### PR DESCRIPTION
I am currently writing a set of layers to add the support of HTTP/2 to scapy.
HTTP/2 is organized in such a way that some flags may have different meaning depending on the payload layer type.

While I could have defined a set of packets with a different `FlagsField` per packet, I thought it would be better to define a new `MultiFlagsField` class, acting similarly to `MultiEnumFields` and `BitMultiEnumFields`.

`MultiFlagsField`, as the other Multi*Fields, takes a dict of dict instead of a dict of names and uses a `depends_on` callback to select the right entry.
The `MultiFlagsField` also defined a concept of "short flags" and "long flags". Indeed, while it is possible to assign an integer to the field to set its value, I thought it could be more user-friendly to allow the user to assign a list of "short" names. On the contrary, displaying an integer or a list of short flags when calling "show" could be difficult to read. Instead, we display the "long flags" followed by the "short flags" inside parenthesis.

The following excerpt demonstrate how this new field works:
```
import scapy.fields
import scapy.packet

class TestPacket(scapy.packet.Packet):
    name = 'Test packet'
    fields_desc = [
        scapy.fields.IntField('type', 0),
        scapy.fields.MultiFlagsField('flags', 0, 8, {
                0: {
                    0: {'short': 'A', 'long': 'Option A'},
                    1: {'short': 'B', 'long': 'Option B'}
                },
                1: {
                    5: {'short': '+', 'long': 'Plus'},
                    6: {'short': '*', 'long': 'Star'}
                }
            }, depends_on=lambda pkt: pkt.type
        ),
    ]
    #... bind_layers to bind a type to a payload type

TestPacket(type=0, flags = [ 'A' ]).show()
TestPacket(type=0, flags = [ 'B' ]).show()
TestPacket(type=0, flags = 3).show()
TestPacket(type=0, flags = 7).show()
TestPacket(type=1, flags = ['+', '*']).show()
```

This will display the following output:
```
###[ Test packet ]### 
  type      = 0
  flags     = ['Option A (A)']

###[ Test packet ]### 
  type      = 0
  flags     = ['Option B (B)']

###[ Test packet ]### 
  type      = 0
  flags     = ['Option A (A)', 'Option B (B)']

###[ Test packet ]### 
  type      = 0
  flags     = ['Option A (A)', 'Option B (B)', 'bit 2']

###[ Test packet ]### 
  type      = 1
  flags     = ['Plus (+)', 'Star (*)']
```

When there is no name defined for a bit, at "show" time, the bit is called "bit X" where X is the power of 2 of the bit that is set. This behavior is exbited in the fourth TestPacket in the previous exemple.

I believe this new field to be generic enough to be integrated into fields.py, instead of remaining into the (to be commited) contrib/http2.py file.