### PR TITLE
PROFINET RPC

### DIFF
--- a/scapy/contrib/dce_rpc.py
+++ b/scapy/contrib/dce_rpc.py
@@ -1,0 +1,234 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016 Gauthier Sebaux
+
+# scapy.contrib.description = DCE/RPC
+# scapy.contrib.status = loads
+
+"""
+A basic dissector for DCE/RPC. Isn't reliable for all packets and for building
+"""
+
+# external imports
+import re
+import struct
+
+# Scapy imports
+from scapy.all import Packet, bind_layers, Field, RandField, RandNum, \
+        RandInt, RandShort, RandByte
+from scapy.fields import BitEnumField, ByteEnumField, ByteField,\
+        FlagsField,\
+        IntField,\
+        LenField,\
+        ShortField,\
+        XByteField, XShortField
+
+
+############
+## Fields ##
+############
+
+class EndiannessField(object):
+    """Field which change the endianess of a sub-field"""
+    __slots__ = ["fld", "endianess_from"]
+    def __init__(self, fld, endianess_from):
+        self.fld = fld
+        self.endianess_from = endianess_from
+
+    def set_endianess(self, pkt):
+        """Add the endianess to the format"""
+        end = self.endianess_from(pkt)
+        if isinstance(end, str) and len(end) > 0:
+            # fld.fmt should always start with a order specifier, cf field init
+            self.fld.fmt = end[0] + self.fld.fmt[1:]
+
+    def getfield(self, pkt, buf):
+        """retrieve the field with endianess"""
+        self.set_endianess(pkt)
+        return self.fld.getfield(pkt, buf)
+
+    def addfield(self, pkt, buf, val):
+        """add the field with endianess to the buffer"""
+        self.set_endianess(pkt)
+        return self.fld.addfield(pkt, buf, val)
+
+    def __getattr__(self, attr):
+        return getattr(self.fld, attr)
+
+class UUIDField(Field):
+    """UUID Field"""
+    __slots__ = ["reg"]
+    def __init__(self, name, default):
+        # create and compile the regex used to extract the uuid values from str
+        reg = r"^\s*{0}-{1}-{1}-{2}{2}-{2}{2}{2}{2}{2}{2}\s*$".format(
+            "([0-9a-f]{8})", "([0-9a-f]{4})", "([0-9a-f]{2})"
+            )
+        self.reg = re.compile(reg, re.I)
+
+        Field.__init__(self, name, default, fmt="I2H8B")
+
+    def i2m(self, pkt, val):
+        if val is None:
+            return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+        if isinstance(val, str):
+            # use the regex to extract the values
+            match = self.reg.match(val)
+            if match:
+                # we return a tuple of values after parsing them to integer
+                return tuple([int(i, 16) for i in match.groups()])
+            else:
+                return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        else:
+            return val
+
+    def m2i(self, pkt, val):
+        return ("%08x-%04x-%04x-%02x%02x-" + "%02x"*6) % val
+
+    def any2i(self, pkt, val):
+        if isinstance(val, str) and len(val) == 16:
+            return self.getfield(pkt, val)[1]
+        elif isinstance(val, str):
+            return val.lower()
+        return val
+
+    def addfield(self, pkt, s, val):
+        return s + struct.pack(self.fmt, *self.i2m(pkt, val))
+    def getfield(self, pkt, s):
+        return s[16:], \
+                self.m2i(pkt, struct.unpack(self.fmt, s[:16]))
+
+    @staticmethod
+    def randval():
+        return RandUUID()
+
+class RandUUID(RandField):
+    """generate a random UUID"""
+    def __init__(self, template="*-*-*-**-******"):
+        base = "([0-9a-f]{{{0}}}|\\*|[0-9a-f]{{{0}}}:[0-9a-f]{{{0}}})"
+        reg = re.compile(
+            r"^\s*{0}-{1}-{1}-{2}{2}-{2}{2}{2}{2}{2}{2}\s*$".format(
+                base.format(8), base.format(4), base.format(2)
+            ),
+            re.I
+            )
+
+        tmp = reg.match(template)
+        if tmp:
+            template = tmp.groups()
+        else:
+            template = ["*"] * 11
+
+        rnd_f = [RandInt] + [RandShort] * 2 + [RandByte] * 8
+        self.uuid = ()
+        for i in xrange(11):
+            if template[i] == "*":
+                val = rnd_f[i]()
+            elif ":" in template[i]:
+                mini, maxi = template[i].split(":")
+                val = RandNum(int(mini, 16), int(maxi, 16))
+            else:
+                val = int(template[i], 16)
+            self.uuid += (val,)
+
+    def _fix(self):
+        return ("%08x-%04x-%04x-%02x%02x-" + "%02x"*6) % self.uuid
+
+
+####################
+## DCE/RPC Packet ##
+####################
+
+DCE_RPC_TYPE = ["request", "ping", "response", "fault", "working", "no_call",
+                "reject", "acknowledge", "connectionless_cancel", "frag_ack",
+                "cancel_ack"]
+DCE_RPC_FLAGS1 = ["reserved_0", "last_frag", "frag", "no_frag_ack", "maybe",
+                  "idempotent", "broadcast", "reserved_7"]
+DCE_RPC_FLAGS2 = ["reserved_0", "cancel_pending", "reserved_2", "reserved_3",
+                  "reserved_4", "reserved_5", "reserved_6", "reserved_7"]
+
+def dce_rpc_endianess(pkt):
+    """Determine the right endianess sign for a given DCE/RPC packet"""
+    if pkt.endianess == 0:  # big endian
+        return ">"
+    elif pkt.endianess == 1:  # little endian
+        return "<"
+    else:
+        return "!"
+
+class DceRpc(Packet):
+    """DCE/RPC packet"""
+    name = "DCE/RPC"
+    fields_desc = [
+        ByteField("version", 4),
+        ByteEnumField("type", 0, DCE_RPC_TYPE),
+        FlagsField("flags1", 0, 8, DCE_RPC_FLAGS1),
+        FlagsField("flags2", 0, 8, DCE_RPC_FLAGS2),
+        BitEnumField("endianess", 0, 4, ["big", "little"]),
+        BitEnumField("encoding", 0, 4, ["ASCII", "EBCDIC"]),
+        ByteEnumField("float", 0, ["IEEE", "VAX", "CRAY", "IBM"]),
+        ByteField("DataRepr_reserved", 0),
+        XByteField("serial_high", 0),
+        EndiannessField(UUIDField("object_uuid", None), endianess_from=dce_rpc_endianess),
+        EndiannessField(UUIDField("interface_uuid", None), endianess_from=dce_rpc_endianess),
+        EndiannessField(UUIDField("activity", None), endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("boot_time", 0), endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("interface_version", 1), endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("sequence_num", 0), endianess_from=dce_rpc_endianess),
+        EndiannessField(ShortField("opnum", 0), endianess_from=dce_rpc_endianess),
+        EndiannessField(XShortField("interface_hint", 0xffff), endianess_from=dce_rpc_endianess),
+        EndiannessField(XShortField("activity_hint", 0xffff), endianess_from=dce_rpc_endianess),
+        EndiannessField(LenField("frag_len", None, fmt="H"), endianess_from=dce_rpc_endianess),
+        EndiannessField(ShortField("frag_num", 0), endianess_from=dce_rpc_endianess),
+        ByteEnumField("auth", 0, ["none"]), # TODO other auth ?
+        XByteField("serial_low", 0),
+        ]
+
+### Heuristical way to find the payload class
+#
+# To add a possible payload to a DCE/RPC packet, one must first create the
+# packet class, then instead of binding layers using bind_layers, he must
+# call DceRpcPayload.register_possible_payload() with the payload class as
+# parameter.
+#
+# To be able to decide if the payload class is capable of handling the rest of
+# the dissection, the classmethod can_handle() should be implemented in the
+# payload class. This method is given the rest of the string to dissect as
+# first argument, and the DceRpc packet instance as second argument. Based on
+# this information, the method must return True if the class is capable of
+# handling the dissection, False otherwise
+class DceRpcPayload(Packet):
+    """Dummy class which use the dispatch_hook to find the payload class"""
+    _payload_class = []
+
+    @classmethod
+    def dispatch_hook(cls, _pkt, _underlayer=None, *args, **kargs):
+        """dispatch_hook to choose among different registered payloads"""
+        for klass in cls._payload_class:
+            if hasattr(klass, "can_handle") and \
+                    klass.can_handle(_pkt, _underlayer):
+                return klass
+
+        # Raise an exception for debug. If debug is not set, it falls back to
+        # Raw packet
+        raise Exception("DCE/RPC payload class not found")
+
+    @classmethod
+    def register_possible_payload(cls, pay):
+        """Method to call from possible DCE/RPC endpoint to register it as
+        possible payload"""
+        cls._payload_class.append(pay)
+
+bind_layers(DceRpc, DceRpcPayload)

--- a/scapy/contrib/dce_rpc.uts
+++ b/scapy/contrib/dce_rpc.uts
@@ -1,0 +1,122 @@
+% DCE/RPC layer test campaign
+
++ Syntax check
+= Import the DCE/RPC layer
+import re
+from scapy.contrib.dce_rpc import *
+
+
++ Check EndiannessField
+
+= Little Endian IntField getfield
+f = EndiannessField(IntField('f', 0), lambda p: '<')
+f.getfield(None, '0102030405'.decode('hex')) == ('\x05', 0x04030201)
+
+= Little Endian IntField addfield
+f = EndiannessField(IntField('f', 0), lambda p: '<')
+f.addfield(None, '\x01', 0x05040302) == '0102030405'.decode('hex')
+
+= Big Endian IntField getfield
+f = EndiannessField(IntField('f', 0), lambda p: '>')
+f.getfield(None, '0102030405'.decode('hex')) == ('\x05', 0x01020304)
+
+= Big Endian IntField addfield
+f = EndiannessField(IntField('f', 0), lambda p: '>')
+f.addfield(None, '\x01', 0x02030405) == '0102030405'.decode('hex')
+
+= Little Endian StrField getfield
+f = EndiannessField(StrField('f', 0), lambda p: '<')
+f.getfield(None, '0102030405') == ('', '0102030405')
+
+= Little Endian StrField addfield
+f = EndiannessField(StrField('f', 0), lambda p: '<')
+f.addfield(None, '01', '02030405') == '0102030405'
+
+= Big Endian StrField getfield
+f = EndiannessField(StrField('f', 0), lambda p: '>')
+f.getfield(None, '0102030405') == ('', '0102030405')
+
+= Big Endian StrField addfield
+f = EndiannessField(StrField('f', 0), lambda p: '>')
+f.addfield(None, '01', '02030405') == '0102030405'
+
+
+
++ Check UUIDField
+
+= Parsing a human-readable UUID
+f = UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef')
+f.addfield(None, '', f.default) == '0123456789abcdef0123456789abcdef'.decode('hex')
+
+= Parsing a machine-encoded UUID
+f = UUIDField('f', '0123456789abcdef0123456789abcdef'.decode('hex'))
+f.addfield(None, '', f.default) == '0123456789abcdef0123456789abcdef'.decode('hex')
+
+= Parsing a tuple of values
+f = UUIDField('f', (0x01234567, 0x89ab, 0xcdef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef))
+f.addfield(None, '', f.default) == '0123456789abcdef0123456789abcdef'.decode('hex')
+
+= Handle None valuse
+f = UUIDField('f', None)
+f.addfield(None, '', f.default) == '00000000000000000000000000000000'.decode('hex')
+
+= Get a UUID for dissection
+f = UUIDField('f', None)
+f.getfield(None, '0123456789abcdef0123456789abcdef01'.decode('hex')) == ('\x01', '01234567-89ab-cdef-0123-456789abcdef')
+
+= Verify little endianess of UUIDField
+* The endianess of a UUIDField should be apply by block on each block in parenthesis '(01234567)-(89ab)-(cdef)-(01)(23)-(45)(67)(89)(ab)(cd)(ef)'
+f = EndiannessField(UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef'), lambda p: '<')
+f.addfield(None, '', f.default) == '67452301ab89efcd0123456789abcdef'.decode('hex')
+
+= Verify RandUUID
+re.match(r'[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}', str(RandUUID()), re.I) is not None
+
+= Verify RandUUID with a static part
+* RandUUID template can contain static part such a 01234567-89ab-*-01*-*****ef
+re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{10}ef', str(RandUUID('01234567-89ab-*-01*-*****ef')), re.I) is not None
+
+= Verify RandUUID with a range part
+* RandUUID template can contain a part with a range of values such a 01234567-89ab-*-01*-****c0:c9ef
+re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{8}c[0-9]ef', str(RandUUID('01234567-89ab-*-01*-****c0:c9ef')), re.I) is not None
+
+
+
++ Check DCE/RPC layer
+
+= DCE/RPC default values
+str(DceRpc()) == '04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000ffffffff000000000000'.decode('hex')
+
+= DCE/RPC payload length computation
+str(DceRpc() / '\x00\x01\x02\x03') == '04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000ffffffff00040000000000010203'.decode('hex')
+
+= DCE/RPC Guess payload class fallback with no possible payload
+p = DceRpc('04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000ffffffff00040000000000010203'.decode('hex'))
+p.payload.__class__ == conf.raw_layer
+
+= DCE/RPC Guess payload class to a registered heuristical payload
+* A payload to be valid must implement the method can_handle and be registered to DceRpcPayload
+class DummyPayload(Packet):
+  fields_desc = [StrField('load', '')]
+  @classmethod
+  def can_handle(cls, pkt, dce):
+    if pkt[0] == '\x01':
+      return True
+    else:
+      return False
+
+DceRpcPayload.register_possible_payload(DummyPayload)
+p = DceRpc('04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000ffffffff00040000000001020304'.decode('hex'))
+p.payload.__class__ == DummyPayload
+
+= DCE/RPC Guess payload class fallback with possible payload classes
+p = DceRpc('04000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000ffffffff00040000000000010203'.decode('hex'))
+p.payload.__class__ == conf.raw_layer
+
+= DCE/RPC little-endian build
+str(DceRpc(type='response', endianess='little', opnum=3) / '\x00\x01\x02\x03') == '04020000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000300ffffffff04000000000000010203'.decode('hex')
+
+= DCE/RPC little-endian dissection
+p = DceRpc('04020000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000300ffffffff04000000000000010203'.decode('hex'))
+p.type == 2 and p.opnum == 3 and p.frag_len == 4
+

--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -1,0 +1,725 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016 Gauthier Sebaux
+
+# scapy.contrib.description = ProfinetIO Remote Procedure Call (RPC)
+# scapy.contrib.status = loads
+
+"""
+PNIO RPC endpoints
+"""
+
+# External imports
+import struct
+
+
+# Scapy imports
+from scapy.all import Packet, bind_layers, ConditionalField, conf
+from scapy.fields import BitEnumField, BitField, ByteField,\
+        FieldLenField, FieldListField,\
+        IntEnumField, IntField,\
+        LenField,\
+        MACField,\
+        PadField, PacketField, PacketListField,\
+        ShortEnumField, ShortField, StrFixedLenField, StrLenField,\
+        XByteField, XIntField, XShortEnumField, XShortField
+
+
+# internal imports
+from scapy.contrib.pnio_rpc_consts import BLOCK_TYPES_ENUM, IOD_WRITE_REQ_INDEX,\
+    AR_TYPE, IOCR_TYPE, IOCR_BLOCK_REQ_IOCR_PROPERTIES, RPC_INTERFACE_UUID
+
+from scapy.contrib.dce_rpc import DceRpc, EndiannessField, DceRpcPayload,\
+        UUIDField, RandUUID
+
+
+##########################
+## Generic Block Packet ##
+##########################
+
+class BlockHeader(Packet):
+    """Abstract packet to centralize block headers fields"""
+    fields_desc = [
+        ShortEnumField("block_type", None, BLOCK_TYPES_ENUM),
+        ShortField("block_length", None),
+        ByteField("block_version_high", 1),
+        ByteField("block_version_low", 0),
+        ]
+    def __new__(cls, name, bases, dct):
+        raise NotImplementedError()
+
+class Block(Packet):
+    """A generic block packet for PNIO RPC"""
+    fields_desc = [
+        BlockHeader,
+        StrLenField("load", "", length_from=lambda pkt: pkt.block_length - 2),
+        ]
+    # default block_type
+    block_type = 0
+
+    def post_build(self, p, pay):
+        # update the block_length if needed
+        if self.block_length is None:
+            # block_length and block_type are not part of the length count
+            length = len(p) - 4
+            p = p[:2] + struct.pack("!H", length) + p[4:]
+
+        return Packet.post_build(self, p, pay)
+
+    def extract_padding(self, s):
+        # all fields after block_length are included in the length and must be
+        # substracted from the pdu length l
+        length = self.payload_length()
+        return s[:length], s[length:]
+
+    def payload_length(self):
+        """A function for each block, to determine the lenght of the payload"""
+        return 0        # default, no payload
+
+
+###############################################################################
+                          ############################
+                          ## Specific Block Packets ##
+                          ############################
+###############################################################################
+
+
+#######################
+## IODControlRe{q,s} ##
+#######################
+
+class IODControlReq(Block):
+    """IODControl request block"""
+    fields_desc = [
+        BlockHeader,
+        StrFixedLenField("padding", "", length=2),
+        UUIDField("ARUUID", None),
+        ShortField("SessionKey", 0),
+        XShortField("AlarmSequenceNumber", 0),
+        # ControlCommand
+        BitField("ControlCommand_reserved", 0, 9),
+        BitField("ControlCommand_PrmBegin", 0, 1),
+        BitField("ControlCommand_ReadyForRT_CLASS_3", 0, 1),
+        BitField("ControlCommand_ReadyForCompanion", 0, 1),
+        BitField("ControlCommand_Done", 0, 1),
+        BitField("ControlCommand_Release", 0, 1),
+        BitField("ControlCommand_ApplicationReady", 0, 1),
+        BitField("ControlCommand_PrmEnd", 0, 1),
+        XShortField("ControlBlockProperties", 0)
+        ]
+
+    def post_build(self, p, pay):
+        # Try to find the right block type
+        if self.block_type is None:
+            if self.ControlCommand_PrmBegin:
+                p = struct.pack("!H", 0x0118) + p[2:]
+            elif self.ControlCommand_ReadyForRT_CLASS_3:
+                p = struct.pack("!H", 0x0117) + p[2:]
+            elif self.ControlCommand_ReadyForCompanion:
+                p = struct.pack("!H", 0x0116) + p[2:]
+            elif self.ControlCommand_Release:
+                p = struct.pack("!H", 0x0114) + p[2:]
+            elif self.ControlCommand_ApplicationReady:
+                if self.AlarmSequenceNumber > 0:
+                    p = struct.pack("!H", 0x0113) + p[2:]
+                else:
+                    p = struct.pack("!H", 0x0112) + p[2:]
+            elif self.ControlCommand_PrmEnd:
+                if self.AlarmSequenceNumber > 0:
+                    p = struct.pack("!H", 0x0111) + p[2:]
+                else:
+                    p = struct.pack("!H", 0x0110) + p[2:]
+
+        return Block.post_build(self, p, pay)
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        res = IODControlRes()
+        for field in ["ARUUID", "SessionKey", "AlarmSequenceNumber"]:
+            res.setfieldval(field, self.getfieldval(field))
+
+        res.block_type = self.block_type + 0x8000
+        return res
+
+
+class IODControlRes(Block):
+    """IODControl response block"""
+    fields_desc = [
+        BlockHeader,
+        StrFixedLenField("padding", "", length=2),
+        UUIDField("ARUUID", None),
+        ShortField("SessionKey", 0),
+        XShortField("AlarmSequenceNumber", 0),
+        # ControlCommand
+        BitField("ControlCommand_reserved", 0, 9),
+        BitField("ControlCommand_PrmBegin", 0, 1),
+        BitField("ControlCommand_ReadyForRT_CLASS_3", 0, 1),
+        BitField("ControlCommand_ReadyForCompanion", 0, 1),
+        BitField("ControlCommand_Done", 1, 1),
+        BitField("ControlCommand_Release", 0, 1),
+        BitField("ControlCommand_ApplicationReady", 0, 1),
+        BitField("ControlCommand_PrmEnd", 0, 1),
+        XShortField("ControlBlockProperties", 0)
+        ]
+
+    # default block_type value
+    block_type = 0x8110
+    # The block_type can be among 0x8110 to 0x8118 except 0x8115
+    # The right type is however determine by the type of the request
+    # (same type as the request + 0x8000)
+
+
+#####################
+## IODWriteRe{q,s} ##
+#####################
+
+class IODWriteReq(Block):
+    """IODWrite request block"""
+    fields_desc = [
+        BlockHeader,
+        ShortField("seqNum", 0),
+        UUIDField("ARUUID", None),
+        XIntField("API", 0),
+        XShortField("slotNumber", 0),
+        XShortField("subslotNumber", 0),
+        StrFixedLenField("padding", "", length=2),
+        XShortEnumField("index", 0, IOD_WRITE_REQ_INDEX),
+        LenField("recordDataLength", None, fmt="I"),
+        StrFixedLenField("RWPadding", "", length=24),
+        ]
+    # default block_type value
+    block_type = 0x0008
+
+    def payload_length(self):
+        return self.recordDataLength
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        res = IODWriteRes()
+        for field in ["seqNum", "ARUUID", "API", "slotNumber", "subslotNumber",
+                      "index"]:
+            res.setfieldval(field, self.getfieldval(field))
+        return res
+
+
+class IODWriteRes(Block):
+    """IODWrite response block"""
+    fields_desc = [
+        BlockHeader,
+        ShortField("seqNum", 0),
+        UUIDField("ARUUID", None),
+        XIntField("API", 0),
+        XShortField("slotNumber", 0),
+        XShortField("subslotNumber", 0),
+        StrFixedLenField("padding", "", length=2),
+        XShortEnumField("index", 0, IOD_WRITE_REQ_INDEX),
+        LenField("recordDataLength", None, fmt="I"),
+        XShortField("additionalValue1", 0),
+        XShortField("additionalValue2", 0),
+        IntEnumField("status", 0, ["OK"]),
+        StrFixedLenField("RWPadding", "", length=16),
+        ]
+    # default block_type value
+    block_type = 0x8008
+
+
+F_PARAMETERS_BLOCK_ID = ["No_F_WD_Time2_No_F_iPar_CRC", "No_F_WD_Time2_F_iPar_CRC",
+                         "F_WD_Time2_No_F_iPar_CRC", "F_WD_Time2_F_iPar_CRC",
+                         "reserved_4", "reserved_5", "reserved_6", "reserved_7"]
+class FParametersBlock(Packet):
+    """F-Parameters configuration block"""
+    name = "F-Parameters Block"
+    fields_desc = [
+        # F_Prm_Flag1
+        BitField("F_Prm_Flag1_Reserved_7", 0, 1),
+        BitField("F_CRC_Seed", 0, 1),
+        BitEnumField("F_CRC_Length", 0, 2, ["CRC-24", "depreciated", "CRC-32", "reserved"]),
+        BitEnumField("F_SIL", 2, 2, ["SIL_1", "SIL_2", "SIL_3", "No_SIL"]),
+        BitField("F_Check_iPar", 0, 1),
+        BitField("F_Check_SeqNr", 0, 1),
+
+        # F_Prm_Flag2
+        BitEnumField("F_Par_Version", 1, 2, ["V1", "V2", "reserved_2", "reserved_3"]),
+        BitEnumField("F_Block_ID", 0, 3, F_PARAMETERS_BLOCK_ID),
+        BitField("F_Prm_Flag2_Reserved", 0, 2),
+        BitField("F_Passivation", 0, 1),
+
+        XShortField("F_Source_Add", 0),
+        XShortField("F_Dest_Add", 0),
+        ShortField("F_WD_Time", 0),
+        ConditionalField(cond=lambda p: p.getfieldval("F_Block_ID") & 0b110 == 0b010, fld=ShortField("F_WD_Time_2", 0)),
+        ConditionalField(cond=lambda p: p.getfieldval("F_Block_ID") & 0b101 == 0b001, fld=XIntField("F_iPar_CRC", 0)),
+        XShortField("F_Par_CRC", 0)
+        ]
+    overload_fields = {
+        IODWriteReq: {
+            "index": 0x100, # commonly used index for F-Parameters block
+            }
+        }
+
+bind_layers(IODWriteReq, FParametersBlock, index=0x0100)
+bind_layers(FParametersBlock, conf.padding_layer)
+
+#############################
+## IODWriteMultipleRe{q,s} ##
+#############################
+
+class PadFieldWithLen(PadField):
+    """PadField which handles the i2len function to include padding"""
+    def i2len(self, pkt, val):
+        """get the length of the field, including the padding length"""
+        fld_len = self._fld.i2len(pkt, val)
+        return fld_len + self.padlen(fld_len)
+
+class IODWriteMultipleReq(Block):
+    """IODWriteMultiple request"""
+    fields_desc = [
+        BlockHeader,
+        ShortField("seqNum", 0),
+        UUIDField("ARUUID", None),
+        XIntField("API", 0xffffffff),
+        XShortField("slotNumber", 0xffff),
+        XShortField("subslotNumber", 0xffff),
+        StrFixedLenField("padding", "", length=2),
+        XShortEnumField("index", 0, IOD_WRITE_REQ_INDEX),
+        FieldLenField("recordDataLength", None, fmt="I", length_of="blocks"),
+        StrFixedLenField("RWPadding", "", length=24),
+        FieldListField("blocks", [], PadFieldWithLen(PacketField("", None, IODWriteReq), 4), length_from=lambda pkt: pkt.recordDataLength)
+        ]
+    # default values
+    block_type = 0x0008
+    index = 0xe040
+    API = 0xffffffff
+    slotNumber = 0xffff
+    subslotNumber = 0xffff
+
+    def post_build(self, p, pay):
+        # patch the update of block_length, as requests field must not be
+        # included. block_length is always 60
+        if self.block_length is None:
+            p = p[:2] + struct.pack("!H", 60) + p[4:]
+
+        # Remove the final padding added in requests
+        fld, val = self.getfield_and_val("blocks")
+        if fld.i2count(self, val) > 0:
+            length = len(val[-1])
+            pad = fld.field.padlen(length)
+            if pad > 0:
+                p = p[:-pad]
+                # also reduce the recordDataLength accordingly
+                if self.recordDataLength is None:
+                    val = struct.unpack("!I", p[36:40])[0]
+                    val -= pad
+                    p = p[:36] + struct.pack("!I", val) + p[40:]
+
+        return Packet.post_build(self, p, pay)
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        res = IODWriteMultipleRes()
+        for field in ["seqNum", "ARUUID", "API", "slotNumber", "subslotNumber",
+                      "index"]:
+            res.setfieldval(field, self.getfieldval(field))
+
+        # append all block response
+        res_blocks = []
+        for block in self.getfieldval("blocks"):
+            res_blocks.append(block.get_response())
+        res.setfieldval("blocks", res_blocks)
+        return res
+
+
+class IODWriteMultipleRes(Block):
+    """IODWriteMultiple response"""
+    fields_desc = [
+        BlockHeader,
+        ShortField("seqNum", 0),
+        UUIDField("ARUUID", None),
+        XIntField("API", 0xffffffff),
+        XShortField("slotNumber", 0xffff),
+        XShortField("subslotNumber", 0xffff),
+        StrFixedLenField("padding", "", length=2),
+        XShortEnumField("index", 0, IOD_WRITE_REQ_INDEX),
+        FieldLenField("recordDataLength", None, fmt="I", length_of="blocks"),
+        XShortField("additionalValue1", 0),
+        XShortField("additionalValue2", 0),
+        IntEnumField("status", 0, ["OK"]),
+        StrFixedLenField("RWPadding", "", length=16),
+        FieldListField("blocks", [], PacketField("", None, IODWriteRes), length_from=lambda pkt: pkt.recordDataLength)
+        ]
+    # default values
+    block_type = 0x8008
+    index = 0xe040
+
+    def post_build(self, p, pay):
+        # patch the update of block_length, as requests field must not be
+        # included. block_length is always 60
+        if self.block_length is None:
+            p = p[:2] + struct.pack("!H", 60) + p[4:]
+
+        return Packet.post_build(self, p, pay)
+
+
+
+####################
+## ARBlockRe{q,s} ##
+####################
+
+class ARBlockReq(Block):
+    """Application relationship block request"""
+    fields_desc = [
+        BlockHeader,
+        XShortEnumField("ARType", 1, AR_TYPE),
+        UUIDField("ARUUID", None),
+        ShortField("SessionKey", 0),
+        MACField("CMInitiatorMacAdd", None),
+        UUIDField("CMInitiatorObjectUUID", None),
+        # ARProperties
+        BitField("ARProperties_PullModuleAlarmAllowed", 0, 1),
+        BitEnumField("ARProperties_StartupMode", 0, 1, ["Legacy", "Advanced"]),
+        BitField("ARProperties_reserved_3", 0, 6),
+        BitField("ARProperties_reserved_2", 0, 12),
+        BitField("ARProperties_AcknowledgeCompanionAR", 0, 1),
+        BitEnumField("ARProperties_CompanionAR", 0, 2, ["Single_AR", "First_AR", "Companion_AR", "reserved"]),
+        BitEnumField("ARProperties_DeviceAccess", 0, 1, ["ExpectedSubmodule", "Controlled_by_IO_device_app"]),
+        BitField("ARProperties_reserved_1", 0, 3),
+        BitEnumField("ARProperties_ParametrizationServer", 0, 1, ["External_PrmServer", "CM_Initator"]),
+        BitField("ARProperties_SupervisorTakeoverAllowed", 0, 1),
+        BitEnumField("ARProperties_State", 1, 3, {1: "Active"}),
+        ShortField("CMInitiatorActivityTimeoutFactor", 1000),
+        ShortField("CMInitiatorUDPRTPort", 0x8892),
+        FieldLenField("StationNameLength", None, fmt="H", length_of="CMInitiatorStationName"),
+        StrLenField("CMInitiatorStationName", "", length_from=lambda pkt: pkt.StationNameLength),
+        ]
+    # default block_type value
+    block_type = 0x0101
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        res = ARBlockRes()
+        for field in ["ARType", "ARUUID", "SessionKey"]:
+            res.setfieldval(field, self.getfieldval(field))
+        return res
+
+
+class ARBlockRes(Block):
+    """Application relationship block response"""
+    fields_desc = [
+        BlockHeader,
+        XShortEnumField("ARType", 1, AR_TYPE),
+        UUIDField("ARUUID", None),
+        ShortField("SessionKey", 0),
+        MACField("CMResponderMacAdd", None),
+        ShortField("CMResponderUDPRTPort", 0x8892),
+        ]
+    # default block_type value
+    block_type = 0x8101
+
+
+######################
+## IOCRBlockRe{q,s} ##
+######################
+
+class IOCRAPIObject(Packet):
+    """API item descriptor used in API description of IOCR blocks"""
+    name = "API item"
+    fields_desc = [
+        XShortField("SlotNumber", 0),
+        XShortField("SubslotNumber", 0),
+        ShortField("FrameOffset", 0),
+        ]
+    def extract_padding(self, s):
+        return None, s  # No extra payload
+
+class IOCRAPI(Packet):
+    """API description used in IOCR block"""
+    name = "API"
+    fields_desc = [
+        XIntField("API", 0),
+        FieldLenField("NumberOfIODataObjects", None, count_of="IODataObjects"),
+        PacketListField("IODataObjects", [], IOCRAPIObject, count_from=lambda p: p.NumberOfIODataObjects),
+        FieldLenField("NumberOfIOCS", None, count_of="IOCSs"),
+        PacketListField("IOCSs", [], IOCRAPIObject, count_from=lambda p: p.NumberOfIOCS),
+        ]
+    def extract_padding(self, s):
+        return None, s  # No extra payload
+
+class IOCRBlockReq(Block):
+    """IO Connection Relationship block request"""
+    fields_desc = [
+        BlockHeader,
+        XShortEnumField("IOCRType", 1, IOCR_TYPE),
+        XShortField("IOCRReference", 1),
+        XShortField("LT", 0x8892),
+        #IOCRProperties
+        BitField("IOCRProperties_reserved3", 0, 8),
+        BitField("IOCRProperties_reserved2", 0, 11),
+        BitField("IOCRProperties_reserved1", 0, 9),
+        BitEnumField("IOCRProperties_RTClass", 0, 4, IOCR_BLOCK_REQ_IOCR_PROPERTIES),
+        ShortField("DataLength", 40),
+        XShortField("FrameID", 0x8000),
+        ShortField("SendClockFactor", 32),
+        ShortField("ReductionRatio", 32),
+        ShortField("Phase", 1),
+        ShortField("Sequence", 0),
+        XIntField("FrameSendOffset", 0xffffffff),
+        ShortField("WatchdogFactor", 10),
+        ShortField("DataHoldFactor", 10),
+        #IOCRTagHeader
+        BitEnumField("IOCRTagHeader_IOUserPriority", 6, 3, {6: "IOCRPriority"}),
+        BitField("IOCRTagHeader_reserved", 0, 1),
+        BitField("IOCRTagHeader_IOCRVLANID", 0, 12),
+        MACField("IOCRMulticastMACAdd", None),
+        FieldLenField("NumberOfAPIs", None, fmt="H", count_of="APIs"),
+        PacketListField("APIs", [], IOCRAPI, count_from=lambda p: p.NumberOfAPIs)
+        ]
+    # default block_type value
+    block_type = 0x0102
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        res = IOCRBlockRes()
+        for field in ["IOCRType", "IOCRReference", "FrameID"]:
+            res.setfieldval(field, self.getfieldval(field))
+        return res
+
+
+class IOCRBlockRes(Block):
+    """IO Connection Relationship block response"""
+    fields_desc = [
+        BlockHeader,
+        XShortEnumField("IOCRType", 1, IOCR_TYPE),
+        XShortField("IOCRReference", 1),
+        XShortField("FrameID", 0x8000),
+        ]
+    # default block_type value
+    block_type = 0x8102
+
+###############################
+## ExpectedSubmoduleBlockReq ##
+###############################
+
+class ExpectedSubmoduleDataDescription(Packet):
+    """Description of the data of a submodule"""
+    name = "Data Description"
+    fields_desc = [
+        XShortEnumField("DataDescription", 0, {1: "Input", 2: "Output"}),
+        ShortField("SubmoduleDataLength", 0),
+        ByteField("LengthIOCS", 0),
+        ByteField("LengthIOPS", 0),
+        ]
+    def extract_padding(self, s):
+        return None, s  # No extra payload
+
+class ExpectedSubmodule(Packet):
+    """Description of a submodule in an API of an expected submodule"""
+    name = "Submodule"
+    fields_desc = [
+        XShortField("SubslotNumber", 0),
+        XIntField("SubmoduleIdentNumber", 0),
+        # Submodule Properties
+        XByteField("SubmoduleProperties_reserved_2", 0),
+        BitField("SubmoduleProperties_reserved_1", 0, 2),
+        BitField("SubmoduleProperties_DiscardIOXS", 0, 1),
+        BitField("SubmoduleProperties_ReduceOutputSubmoduleDataLength", 0, 1),
+        BitField("SubmoduleProperties_ReduceInputSubmoduleDataLength", 0, 1),
+        BitField("SubmoduleProperties_SharedInput", 0, 1),
+        BitEnumField("SubmoduleProperties_Type", 0, 2, ["NO_IO", "INPUT", "OUTPUT", "INPUT_OUTPUT"]),
+        PacketListField("DataDescription", [], ExpectedSubmoduleDataDescription, count_from=lambda p: 2 if p.SubmoduleProperties_Type == 3 else 1),
+        ]
+    def extract_padding(self, s):
+        return None, s  # No extra payload
+
+class ExpectedSubmoduleAPI(Packet):
+    """Description of an API in the expected submodules blocks"""
+    name = "API"
+    fields_desc = [
+        XIntField("API", 0),
+        XShortField("SlotNumber", 0),
+        XIntField("ModuleIdentNumber", 0),
+        XShortField("ModuleProperties", 0),
+        FieldLenField("NumberOfSubmodules", None, fmt="H", count_of="Submodules"),
+        PacketListField("Submodules", [], ExpectedSubmodule, count_from=lambda p: p.NumberOfSubmodules),
+        ]
+    def extract_padding(self, s):
+        return None, s  # No extra payload
+
+class ExpectedSubmoduleBlockReq(Block):
+    """Expected submodule block request"""
+    fields_desc = [
+        BlockHeader,
+        FieldLenField("NumberOfAPIs", None, fmt="H", count_of="APIs"),
+        PacketListField("APIs", [], ExpectedSubmoduleAPI, count_from=lambda p: p.NumberOfAPIs)
+        ]
+    # default block_type value
+    block_type = 0x0104
+
+    def get_response(self):
+        """Generate the response block of this request.
+        Carefull: it only sets the fields which can be set from the request
+        """
+        return None # no response associated (should be modulediffblock)
+
+###############################################################################
+
+
+
+###############################################################################
+
+
+#############################
+## PROFINET IO DCE/RPC PDU ##
+#############################
+
+PNIO_RPC_BLOCK_ASSOCIATION = {
+    # requests
+    "0101": ARBlockReq,
+    "0102": IOCRBlockReq,
+    "0104": ExpectedSubmoduleBlockReq,
+    "0110": IODControlReq,
+    "0111": IODControlReq,
+    "0112": IODControlReq,
+    "0113": IODControlReq,
+    "0114": IODControlReq,
+    "0116": IODControlReq,
+    "0117": IODControlReq,
+    "0118": IODControlReq,
+
+    # responses
+    "8101": ARBlockRes,
+    "8102": IOCRBlockRes,
+    "8110": IODControlRes,
+    "8111": IODControlRes,
+    "8112": IODControlRes,
+    "8113": IODControlRes,
+    "8114": IODControlRes,
+    "8116": IODControlRes,
+    "8117": IODControlRes,
+    "8118": IODControlRes,
+    }
+
+def _guess_block_class(_pkt, *args, **kargs):
+    cls = Block         # Default block type
+
+    # Special cases
+    if _pkt[:2] == "0008".decode("hex"):    # IODWriteReq
+        if _pkt[34:36] == "e040".decode("hex"): # IODWriteMultipleReq
+            cls = IODWriteMultipleReq
+        else:
+            cls = IODWriteReq
+
+    elif _pkt[:2] == "8008".decode("hex"):    # IODWriteRes
+        if _pkt[34:36] == "e040".decode("hex"): # IODWriteMultipleRes
+            cls = IODWriteMultipleRes
+        else:
+            cls = IODWriteRes
+
+    # Common cases
+    else:
+        btype = _pkt[:2].encode("hex")
+        if btype in PNIO_RPC_BLOCK_ASSOCIATION:
+            cls = PNIO_RPC_BLOCK_ASSOCIATION[btype]
+
+    return cls(_pkt, *args, **kargs)
+
+def dce_rpc_endianess(pkt):
+    """determine the symbol for the endianess of a the DCE/RPC"""
+    endianess = pkt.underlayer.endianess
+    if endianess == 0:  # big endian
+        return ">"
+    elif endianess == 1:  # little endian
+        return "<"
+    else:
+        return "!"
+
+class NDRData(Packet):
+    """Base NDRData to centralize some fields. It can't be instanciated"""
+    fields_desc = [
+        EndiannessField(FieldLenField("args_length", None, fmt="I", length_of="blocks"), endianess_from=dce_rpc_endianess),
+        EndiannessField(FieldLenField("max_count", None, fmt="I", length_of="blocks"), endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("offset", 0), endianess_from=dce_rpc_endianess),
+        EndiannessField(FieldLenField("actual_count", None, fmt="I", length_of="blocks"), endianess_from=dce_rpc_endianess),
+        PacketListField("blocks", [], _guess_block_class, length_from=lambda p: p.args_length)
+        ]
+    def __new__(cls, name, bases, dct):
+        raise NotImplementedError()
+
+class PNIOServiceReqPDU(Packet):
+    """PNIO PDU for RPC Request"""
+    fields_desc = [
+        EndiannessField(FieldLenField("args_max", None, fmt="I", length_of="blocks"), endianess_from=dce_rpc_endianess),
+        NDRData,
+        ]
+    overload_fields = {
+        DceRpc: {
+            # random object_uuid in the appropriate range
+            "object_uuid": RandUUID("dea00000-6c97-11d1-8271-******"),
+            # interface uuid to send to a device
+            "interface_uuid": RPC_INTERFACE_UUID["UUID_IO_DeviceInterface"],
+            # Request DCE/RPC type
+            "type": 0,
+            },
+        }
+
+    @classmethod
+    def can_handle(cls, pkt, rpc):
+        """heuristical guess_payload_class"""
+        # type = 0 => request
+        if rpc.getfieldval("type") == 0 and \
+                rpc.object_uuid.startswith("dea00000-6c97-11d1-8271-"):
+            return True
+        return False
+
+DceRpcPayload.register_possible_payload(PNIOServiceReqPDU)
+
+
+class PNIOServiceResPDU(Packet):
+    """PNIO PDU for RPC Response"""
+    fields_desc = [
+        EndiannessField(IntEnumField("status", 0, ["OK"]), endianess_from=dce_rpc_endianess),
+        NDRData,
+        ]
+    overload_fields = {
+        DceRpc: {
+            # random object_uuid in the appropriate range
+            "object_uuid": RandUUID("dea00000-6c97-11d1-8271-******"),
+            # interface uuid to send to a host
+            "interface_uuid": RPC_INTERFACE_UUID["UUID_IO_ControllerInterface"],
+            # Request DCE/RPC type
+            "type": 2,
+            },
+        }
+
+    @classmethod
+    def can_handle(cls, pkt, rpc):
+        """heuristical guess_payload_class"""
+        # type = 2 => response
+        if rpc.getfieldval("type") == 2 and \
+                rpc.object_uuid.startswith("dea00000-6c97-11d1-8271-"):
+            return True
+        return False
+
+DceRpcPayload.register_possible_payload(PNIOServiceResPDU)
+

--- a/scapy/contrib/pnio_rpc.uts
+++ b/scapy/contrib/pnio_rpc.uts
@@ -1,0 +1,666 @@
+% PNIO RPC layer test campaign
+
++ Syntax check
+= Import the PNIO RPC layer
+from scapy.contrib.dce_rpc import *
+from scapy.contrib.pnio_rpc import *
+
+
++ Check Block
+
+= Block default values
+str(Block()) == '000000020100'.decode('hex')
+
+= Block basic example
+str(Block(load='\x01\x02\x03')) == '000000050100010203'.decode('hex')
+
+= Block has no payload (only padding)
+p = Block('000000050100010203040506'.decode('hex'))
+p == Block(block_length=5, load='\x01\x02\x03') / conf.padding_layer('\x04\x05\x06')
+
+
+####################################################################
+####################################################################
+
++ Check IODControlReq
+
+= IODControlReq default values
+str(IODControlReq()) == '0000001c01000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODControlReq basic example (IODControlReq PrmEnd control)
+str(IODControlReq(ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=2, ControlCommand_PrmEnd=1)) == '0110001c010000000123456789abcdef0123456789abcdef0002000000010000'.decode('hex')
+
+= IODControlReq dissection
+p = IODControlReq('0118001c010000000123456789abcdef0123456789abcdef0005000000400000ef'.decode('hex'))
+p == IODControlReq(ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=5, ControlCommand_PrmBegin=1, block_type='IODBlockReq_connect_begin', block_length=28, padding='\0\0') / conf.padding_layer('\xef')
+
+= IODControlReq response
+p = p.get_response()
+p == IODControlRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=5, block_type='IODBlockRes_connect_begin')
+
+####################################################################
+
++ Check IODControlRes
+
+= IODControlRes default values
+str(IODControlRes()) == '8110001c01000000000000000000000000000000000000000000000000080000'.decode('hex')
+
+= IODControlRes basic example (IODControlRes PrmEnd control)
+str(IODControlRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=2, block_type='IODBlockRes_connect_end')) == '8110001c010000000123456789abcdef0123456789abcdef0002000000080000'.decode('hex')
+
+= IODControlRes dissection
+p = IODControlRes('8118001c010000000123456789abcdef0123456789abcdef0005000000080000ef'.decode('hex'))
+p == IODControlRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=5, block_type='IODBlockRes_connect_begin', block_length=28, padding='\0\0') / conf.padding_layer('\xef')
+
+
+####################################################################
+####################################################################
+
++ Check IODWriteReq
+
+= IODWriteReq default values
+str(IODWriteReq()) == '0008003c010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODWriteReq basic example
+str(IODWriteReq(
+  ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+  index=0x4321
+  ) / '\xab\xcd'
+  ) == '0008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000002000000000000000000000000000000000000000000000000abcd'.decode('hex')
+
+= IODWriteReq dissection
+p = IODWriteReq('0008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000002000000000000000000000000000000000000000000000000abcdef'.decode('hex'))
+p == IODWriteReq(ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+  index=0x4321, block_length=60, recordDataLength=2, padding='\0\0', RWPadding='\0'*24
+  ) / '\xab\xcd' / conf.padding_layer('\xef')
+
+= IODWriteReq response
+p = p.get_response()
+p == IODWriteRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+  index=0x4321)
+
+####################################################################
+
++ Check IODWriteRes
+
+= IODWriteRes default values
+str(IODWriteRes()) == '8008003c010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODWriteRes basic example
+str(IODWriteRes(
+  ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+  index=0x4321
+  )) == '8008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODWriteRes dissection
+p = IODWriteRes('8008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000000000000000000000000000000000000000000000000000000ef'.decode('hex'))
+p == IODWriteRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+  index=0x4321, recordDataLength=0, block_length=60, padding='\0\0', RWPadding='\0'*16
+  ) / conf.padding_layer('\xef')
+
+
+####################################################################
+####################################################################
+
++ Check IODWriteMultipleReq
+
+#########
+= IODWriteMultipleReq default values
+str(IODWriteMultipleReq()) == '0008003c0100000000000000000000000000000000000000ffffffffffffffff0000e04000000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+#########
+= IODWriteMultipleReq basic example
+str(IODWriteMultipleReq(ARUUID='01234567-89ab-cdef-0123-456789abcdef', blocks=[
+  IODWriteReq(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+    index=0x4321
+    ) / '\xab\xcd',
+  IODWriteReq(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=2, API=2, slotNumber=3, subslotNumber=4,
+    index=0x1234
+    ) / '\x01\x02',
+  ])
+  ) == '0008003c010000000123456789abcdef0123456789abcdefffffffffffffffff0000e04000000086000000000000000000000000000000000000000000000000'.decode('hex') + \
+       '0008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000002000000000000000000000000000000000000000000000000abcd'.decode('hex') + '\0\0' + \
+       '0008003c010000020123456789abcdef0123456789abcdef000000020003000400001234000000020000000000000000000000000000000000000000000000000102'.decode('hex')
+
+#########
+= IODWriteMultipleReq dissection
+p = IODWriteMultipleReq(
+  '0008003c010000000123456789abcdef0123456789abcdefffffffffffffffff0000e04000000086000000000000000000000000000000000000000000000000'.decode('hex') + \
+  '0008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000002000000000000000000000000000000000000000000000000abcd'.decode('hex') + '\0\0' + \
+  '0008003c010000020123456789abcdef0123456789abcdef000000020003000400001234000000020000000000000000000000000000000000000000000000000102'.decode('hex') + '\xef'
+  )
+p == IODWriteMultipleReq(ARUUID='01234567-89ab-cdef-0123-456789abcdef', recordDataLength=0x86,
+  padding='\0'*2, RWPadding='\0'*24, block_length=60, blocks=[
+    IODWriteReq(
+      ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+      index=0x4321, recordDataLength=2, padding='\0'*2, RWPadding='\0'*24, block_length=60
+      ) / '\xab\xcd',
+    IODWriteReq(
+      ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=2, API=2, slotNumber=3, subslotNumber=4,
+      index=0x1234, recordDataLength=2, padding='\0'*2, RWPadding='\0'*24, block_length=60
+      ) / '\x01\x02',
+    ]) / conf.padding_layer('\xef')
+
+#########
+= IODWriteMultipleReq response
+p = p.get_response()
+p == IODWriteMultipleRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', blocks=[
+  IODWriteRes(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+    index=0x4321
+    ),
+  IODWriteRes(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=2, API=2, slotNumber=3, subslotNumber=4,
+    index=0x1234
+    ),
+  ])
+
+
+####################################################################
+
++ Check IODWriteMultipleRes
+
+= IODWriteMultipleRes default values
+str(IODWriteMultipleRes()) == '8008003c0100000000000000000000000000000000000000ffffffffffffffff0000e04000000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODWriteMultipleRes basic example
+str(IODWriteMultipleRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', blocks=[
+  IODWriteRes(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+    index=0x4321
+    ),
+  IODWriteRes(
+    ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=2, API=2, slotNumber=3, subslotNumber=4,
+    index=0x1234
+    ),
+  ])
+  ) == '8008003c010000000123456789abcdef0123456789abcdefffffffffffffffff0000e04000000080000000000000000000000000000000000000000000000000'.decode('hex') + \
+       '8008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000000000000000000000000000000000000000000000000000000'.decode('hex') + \
+       '8008003c010000020123456789abcdef0123456789abcdef00000002000300040000123400000000000000000000000000000000000000000000000000000000'.decode('hex')
+
+= IODWriteMultipleRes dissection
+p = IODWriteMultipleRes(
+  '8008003c010000000123456789abcdef0123456789abcdefffffffffffffffff0000e04000000080000000000000000000000000000000000000000000000000'.decode('hex') + \
+  '8008003c010000010123456789abcdef0123456789abcdef00000001000200030000432100000000000000000000000000000000000000000000000000000000'.decode('hex') + \
+  '8008003c010000020123456789abcdef0123456789abcdef00000002000300040000123400000000000000000000000000000000000000000000000000000000'.decode('hex') + '\xef'
+  )
+p == IODWriteMultipleRes(ARUUID='01234567-89ab-cdef-0123-456789abcdef', recordDataLength=0x80,
+  padding='\0'*2, RWPadding='\0'*16, block_length=60, blocks=[
+    IODWriteRes(
+      ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=1, API=1, slotNumber=2, subslotNumber=3,
+      index=0x4321, recordDataLength=0, padding='\0'*2, RWPadding='\0'*16, block_length=60
+      ),
+    IODWriteRes(
+      ARUUID='01234567-89ab-cdef-0123-456789abcdef', seqNum=2, API=2, slotNumber=3, subslotNumber=4,
+      index=0x1234, recordDataLength=0, padding='\0'*2, RWPadding='\0'*16, block_length=60
+      ),
+    ]) / conf.padding_layer('\xef')
+
+
+####################################################################
+####################################################################
+
++ Check ARBlockReq
+
+= ARBlockReq default values
+str(ARBlockReq()) == '0101003601000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000103e888920000'.decode('hex')
+
+= ARBlockReq basic example
+str(ARBlockReq(
+  ARType='IOCARSingle', ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=1,
+  CMInitiatorObjectUUID='dea00000-6c97-11d1-8271-010203040506', ARProperties_ParametrizationServer='CM_Initator',
+  CMInitiatorStationName='plc1')
+  ) == '0101003a010000010123456789abcdef0123456789abcdef0001000000000000dea000006c9711d182710102030405060000001103e888920004'.decode('hex') + 'plc1'
+
+= ARBlockReq dissection
+p = ARBlockReq('0101003a010000010123456789abcdef0123456789abcdef0001010203040506dea000006c9711d182710102030405060000001103e888920004'.decode('hex') + 'plc1\xef')
+p == ARBlockReq(
+  ARType='IOCARSingle', ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=1,
+  CMInitiatorObjectUUID='dea00000-6c97-11d1-8271-010203040506', ARProperties_ParametrizationServer='CM_Initator',
+  CMInitiatorMacAdd='01:02:03:04:05:06', StationNameLength=4, CMInitiatorStationName='plc1', block_length=58
+  ) / conf.padding_layer('\xef')
+
+= ARBlockReq response
+p = p.get_response()
+p == ARBlockRes(ARType='IOCARSingle', ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=1)
+
+####################################################################
+
++ Check ARBlockRes
+
+= ARBlockRes default values
+str(ARBlockRes()) == '8101001e010000010000000000000000000000000000000000000000000000008892'.decode('hex')
+
+= ARBlockRes basic example
+str(
+  ARBlockRes(ARType='IOCARSingle', ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=1)
+  ) == '8101001e010000010123456789abcdef0123456789abcdef00010000000000008892'.decode('hex')
+
+= ARBlockRes dissection
+p = ARBlockRes('8101001e010000010123456789abcdef0123456789abcdef00010102030405068892ef'.decode('hex'))
+p == ARBlockRes(
+  ARType='IOCARSingle', ARUUID='01234567-89ab-cdef-0123-456789abcdef', SessionKey=1,
+  CMResponderMacAdd='01:02:03:04:05:06', block_length=30) / conf.padding_layer('\xef')
+
+
+####################################################################
+####################################################################
+
++ Check IOCRBlockReq
+
+= IOCRBlockReq default values
+str(IOCRBlockReq()) == '0102002a010000010001889200000000002880000020002000010000ffffffff000a000ac0000000000000000000'.decode('hex')
+
+= IOCRAPI default values
+str(IOCRAPI()) == '0000000000000000'.decode('hex')
+
+= IOCRAPIObject default values
+str(IOCRAPIObject()) == '000000000000'.decode('hex')
+
+= IOCRBlockReq basic example
+p = IOCRBlockReq(
+  IOCRType='OutputCR', IOCRReference=1, SendClockFactor=2,
+  ReductionRatio=32, DataLength=47, FrameID=0x8014,
+  APIs=[
+    IOCRAPI(
+      API=4,
+      IODataObjects=[
+        IOCRAPIObject(SlotNumber=2, SubslotNumber=1, FrameOffset=0),
+        IOCRAPIObject(SlotNumber=1, SubslotNumber=1, FrameOffset=9),
+        ]
+      ),
+    IOCRAPI(
+      API=0,
+      IODataObjects=[
+        IOCRAPIObject(SlotNumber=3, SubslotNumber=1, FrameOffset=15),
+        ],
+      IOCSs=[
+        IOCRAPIObject(SlotNumber=3, SubslotNumber=1, FrameOffset=4),
+        ],
+      ),
+    ]
+  )
+str(p) == \
+  '01020052010000020001889200000000002f80140002002000010000ffffffff000a000ac0000000000000000002'.decode('hex') + \
+  '0000000400020002000100000001000100090000'.decode('hex') + \
+  '00000000000100030001000f0001000300010004'.decode('hex')
+
+= IOCRBlockReq dissection
+p = IOCRBlockReq(
+  '01020052010000020001889200000000002f80140002002000010000ffffffff000a000ac0000102030405060002'.decode('hex') + \
+  '0000000400020002000100000001000100090000'.decode('hex') + \
+  '00000000000100030001000f0001000300010004'.decode('hex') + '\xef')
+p == IOCRBlockReq(
+  IOCRType='OutputCR', IOCRReference=1, SendClockFactor=2, IOCRMulticastMACAdd='01:02:03:04:05:06',
+  ReductionRatio=32, DataLength=47, FrameID=0x8014, block_length=82,
+  NumberOfAPIs=2, APIs=[
+    IOCRAPI(
+      API=4,
+      NumberOfIODataObjects=2, IODataObjects=[
+        IOCRAPIObject(SlotNumber=2, SubslotNumber=1, FrameOffset=0),
+        IOCRAPIObject(SlotNumber=1, SubslotNumber=1, FrameOffset=9),
+        ],
+      NumberOfIOCS=0
+      ),
+    IOCRAPI(
+      API=0,
+      NumberOfIODataObjects=1, IODataObjects=[
+        IOCRAPIObject(SlotNumber=3, SubslotNumber=1, FrameOffset=15),
+        ],
+      NumberOfIOCS=1, IOCSs=[
+        IOCRAPIObject(SlotNumber=3, SubslotNumber=1, FrameOffset=4),
+        ],
+      ),
+    ]
+  ) / conf.padding_layer('\xef')
+
+= IOCRBlockReq response
+p = p.get_response()
+p == IOCRBlockRes(IOCRType='OutputCR', IOCRReference=1, FrameID=0x8014)
+
+####################################################################
+
++ Check IOCRBlockRes
+
+= IOCRBlockRes default values
+str(IOCRBlockRes()) == '810200080100000100018000'.decode('hex')
+
+= IOCRBlockRes basic example
+str(
+  IOCRBlockRes(IOCRType='InputCR', IOCRReference=2, FrameID=0x8014)
+  ) == '810200080100000100028014'.decode('hex')
+
+= IOCRBlockRes dissection
+p = IOCRBlockRes('810200080100000100028014ef'.decode('hex'))
+p == IOCRBlockRes(IOCRType='InputCR', IOCRReference=2, FrameID=0x8014,
+  block_length=8) / conf.padding_layer('\xef')
+
+
+####################################################################
+####################################################################
+
++ Check ExpectedSubmoduleBlockReq
+
+= ExpectedSubmoduleBlockReq default values
+str(ExpectedSubmoduleBlockReq()) == '0104000401000000'.decode('hex')
+
+= ExpectedSubmoduleAPI default values
+str(ExpectedSubmoduleAPI()) == '0000000000000000000000000000'.decode('hex')
+
+= ExpectedSubmodule default values
+str(ExpectedSubmodule()) == '0000000000000000'.decode('hex')
+
+= ExpectedSubmoduleDataDescription default values
+str(ExpectedSubmoduleDataDescription()) == '000000000000'.decode('hex')
+
+= ExpectedSubmoduleBlockReq basic example
+p = ExpectedSubmoduleBlockReq(
+  APIs=[
+    ExpectedSubmoduleAPI(
+      API=4, SlotNumber=2, ModuleIdentNumber=0x08c4,
+      Submodules=[
+        ExpectedSubmodule(
+          SubslotNumber=1, SubmoduleIdentNumber=0x0123,
+          SubmoduleProperties_Type='INPUT_OUTPUT',
+          DataDescription=[
+            ExpectedSubmoduleDataDescription(
+              DataDescription='Output',
+              SubmoduleDataLength=5,
+              LengthIOPS=2, LengthIOCS=0
+              ),
+            ExpectedSubmoduleDataDescription(
+              DataDescription='Input',
+              SubmoduleDataLength=3,
+              LengthIOPS=1, LengthIOCS=2
+              )
+            ]
+          ),
+        ]
+      ),
+    ]
+  )
+str(p) == \
+  '0104002601000001'.decode('hex') + \
+    '000000040002000008c400000001'.decode('hex') + \
+      '0001000001230003'.decode('hex') + \
+        '000200050002'.decode('hex') + \
+        '000100030201'.decode('hex')
+
+= ExpectedSubmoduleBlockReq dissection
+p = ExpectedSubmoduleBlockReq(
+  '0104002601000001'.decode('hex') + \
+    '000000040002000008c400000001'.decode('hex') + \
+      '0001000001230003'.decode('hex') + \
+        '000200050002'.decode('hex') + \
+        '000100030201'.decode('hex') + '\xef'
+  )
+p == ExpectedSubmoduleBlockReq(block_length=38,
+  NumberOfAPIs=1, APIs=[
+    ExpectedSubmoduleAPI(
+      API=4, SlotNumber=2, ModuleIdentNumber=0x08c4,
+      NumberOfSubmodules=1 ,Submodules=[
+        ExpectedSubmodule(
+          SubslotNumber=1, SubmoduleIdentNumber=0x0123,
+          SubmoduleProperties_Type='INPUT_OUTPUT',
+          DataDescription=[
+            ExpectedSubmoduleDataDescription(
+              DataDescription='Output',
+              SubmoduleDataLength=5,
+              LengthIOPS=2, LengthIOCS=0
+              ),
+            ExpectedSubmoduleDataDescription(
+              DataDescription='Input',
+              SubmoduleDataLength=3,
+              LengthIOPS=1, LengthIOCS=2
+              )
+            ]
+          ),
+        ]
+      ),
+    ]
+  ) / conf.padding_layer('\xef')
+
+####################################################################
+####################################################################
+
++ Check PNIOServiceReqPDU
+
+= PNIOServiceReqPDU basic example
+* PNIOServiceReqPDU must always be placed above a DCE/RPC layer as it requires the endianess field
+p = DceRpc() / PNIOServiceReqPDU(blocks=[
+  Block(load='\x01\x02')
+  ])
+s = str(p)
+# Remove the random UUID part before comparaison
+s[:18] + s[24:] == \
+  '0400000000000000dea000006c9711d18271'.decode('hex') + 'dea000016c9711d1827100a02442df7d000000000000000000000000000000000000000000000001000000000000ffffffff001c00000000'.decode('hex') + \
+  '0000000800000008000000080000000000000008'.decode('hex') + \
+  '0000000401000102'.decode('hex')
+
+= PNIOServiceReqPDU dissection
+p = DceRpc(
+  '0400000000000000dea000006c9711d18271010203040506dea000016c9711d1827100a02442df7d000000000000000000000000000000000000000000000001000000000000ffffffff001c00000000'.decode('hex') + \
+  '0000000f000000080000000f0000000000000008'.decode('hex') + \
+  '0000000401000102ef'.decode('hex')
+  )
+p.payload == PNIOServiceReqPDU(args_length=8, args_max=15, max_count=15, actual_count=8,
+  blocks=[
+    Block(block_length=4, load='\x01\x02')
+    ]
+  ) / '\xef'
+
+
+####################################################################
+####################################################################
+
++ Check PNIOServiceResPDU
+
+= PNIOServiceResPDU basic example
+* PNIOServiceResPDU must always be placed above a DCE/RPC layer as it requires the endianess field
+p = DceRpc() / PNIOServiceResPDU(blocks=[
+  Block(load='\x01\x02')
+  ])
+s = str(p)
+# Remove the random UUID part before comparaison
+s[:18] + s[24:] == \
+  '0402000000000000dea000006c9711d18271'.decode('hex') + 'dea000026c9711d1827100a02442df7d000000000000000000000000000000000000000000000001000000000000ffffffff001c00000000'.decode('hex') + \
+  '0000000000000008000000080000000000000008'.decode('hex') + \
+  '0000000401000102'.decode('hex')
+
+= PNIOServiceResPDU dissection
+p = DceRpc(
+  '0402000000000000dea000006c9711d18271010203040506dea000026c9711d1827100a02442df7d000000000000000000000000000000000000000000000001000000000000ffffffff001c00000000'.decode('hex') + \
+  '00001234000000080000000f0000000000000008'.decode('hex') + \
+  '0000000401000102ef'.decode('hex')
+  )
+p.payload == PNIOServiceResPDU(status=0x1234, args_length=8, max_count=15, actual_count=8,
+  blocks=[
+    Block(block_length=4, load='\x01\x02')
+    ]
+  ) / '\xef'
+
+####################################################################
+##                      Some usual examples                       ##
+####################################################################
+
++ Check some basic examples
+
+#### Connect Request
+= A PNIO RPC Connect Request
+p = DceRpc(
+  endianess='little', opnum=0, sequence_num=0,
+  object_uuid='dea00000-6c97-11d1-8271-010203040506',
+  activity='01234567-89ab-cdef-0123-456789abcdef'
+  ) / PNIOServiceReqPDU(
+  blocks=[
+    # AR block
+    ARBlockReq(
+      ARType='IOCARSingle', ARUUID='fedcba98-7654-3210-fedc-ba9876543210', SessionKey=0,
+      CMInitiatorMacAdd='01:02:03:04:05:06', CMInitiatorStationName='plc-1',
+      CMInitiatorObjectUUID='dea00000-6c97-11d1-8271-010203040506', ARProperties_ParametrizationServer='CM_Initator'
+      ),
+    # IO CR input block
+    IOCRBlockReq(
+      IOCRType='InputCR', IOCRReference=1, SendClockFactor=2,
+      ReductionRatio=32, DataLength=40,
+      APIs=[
+        IOCRAPI(
+          API=0,
+          IODataObjects=[
+            IOCRAPIObject(SlotNumber=3, SubslotNumber=1,FrameOffset=15),
+            ],
+          IOCSs=[
+            IOCRAPIObject(SlotNumber=3, SubslotNumber=1,FrameOffset=4),
+            ],
+          ),
+        ]
+      ),
+    # IO CR output block
+    IOCRBlockReq(
+      IOCRType='OutputCR', IOCRReference=2, SendClockFactor=8, ReductionRatio=32,
+      DataLength=52, FrameID=0xffff,
+      APIs=[
+        IOCRAPI(
+          API=0,
+          IODataObjects=[
+            IOCRAPIObject(SlotNumber=3, SubslotNumber=1,FrameOffset=0),
+            IOCRAPIObject(SlotNumber=1, SubslotNumber=2,FrameOffset=9),
+            ],
+          ),
+        ]
+      ),
+    # List of expected submodules
+    ExpectedSubmoduleBlockReq(
+      APIs=[
+        ExpectedSubmoduleAPI(
+          API=0, SlotNumber=3, ModuleIdentNumber=0x08c4,
+          Submodules=[
+            ExpectedSubmodule(
+              SubslotNumber=1, SubmoduleIdentNumber=0x0124,
+              SubmoduleProperties_Type='INPUT_OUTPUT',
+              DataDescription=[
+                ExpectedSubmoduleDataDescription(
+                  DataDescription='Output',
+                  SubmoduleDataLength=3,
+                  LengthIOPS=1, LengthIOCS=1
+                  ),
+                ExpectedSubmoduleDataDescription(
+                  DataDescription='Input',
+                  SubmoduleDataLength=5,
+                  LengthIOPS=2, LengthIOCS=0
+                  )
+                ]
+              ),
+            ]
+          ),
+        ]
+      ),
+    ExpectedSubmoduleBlockReq(
+      APIs=[
+        ExpectedSubmoduleAPI(
+          API=0, SlotNumber=1, ModuleIdentNumber=0x08c3,
+          Submodules=[
+            ExpectedSubmodule(
+              SubslotNumber=2, SubmoduleIdentNumber=0x0424,
+              SubmoduleProperties_Type='OUTPUT',
+              DataDescription=[
+                ExpectedSubmoduleDataDescription(
+                  DataDescription='Output',
+                  SubmoduleDataLength=5,
+                  LengthIOPS=1, LengthIOCS=0
+                  )
+                ]
+              ),
+            ]
+          ),
+        ]
+      ),
+    ]
+  )
+str(p).encode('hex') == \
+  '04000000100000000000a0de976cd11182710102030405060100a0de976cd111827100a02442df7d67452301ab89efcd0123456789abcdef0000000001000000000000000000ffffffff250100000000' + \
+  '1101000011010000110100000000000011010000' + \
+    '0101003b01000001fedcba9876543210fedcba98765432100000010203040506dea000006c9711d182710102030405060000001103e888920005' + 'plc-1'.encode('hex') + \
+    '0102003e010000010001889200000000002880000002002000010000ffffffff000a000ac0000000000000000001' + \
+      '00000000000100030001000f0001000300010004' + \
+    '0102003e0100000200028892000000000034ffff0008002000010000ffffffff000a000ac0000000000000000001' + \
+      '0000000000020003000100000001000200090000' + \
+    '0104002601000001000000000003000008c400000001' + \
+      '0001000001240003' + \
+        '000200030101' + \
+        '000100050002' + \
+    '0104002001000001000000000001000008c300000001' + \
+      '0002000004240002' + \
+        '000200050001'
+
+
+#### Write Request
+= A PNIO RPC Write Request
+p = DceRpc(
+  endianess='little', opnum=2, sequence_num=1,
+  object_uuid='dea00000-6c97-11d1-8271-010203040506',
+  activity='01234567-89ab-cdef-0123-456789abcdef'
+  ) / PNIOServiceReqPDU(
+  blocks=[
+    IODWriteMultipleReq(
+      seqNum=0, ARUUID='fedcba98-7654-3210-fedc-ba9876543210', blocks=[
+        IODWriteReq(
+          seqNum=1, API=0, slotNumber=1, subslotNumber=1, index=0x123,
+          ARUUID='fedcba98-7654-3210-fedc-ba9876543210'
+          ) / '\x01\x02',
+        IODWriteReq(
+          seqNum=2, API=0, slotNumber=3, subslotNumber=1,
+          ARUUID='fedcba98-7654-3210-fedc-ba9876543210'
+          ) / FParametersBlock(
+            F_CRC_Seed=1, F_CRC_Length='CRC-24', F_Source_Add=0xc1, F_Dest_Add=0xc2,
+            F_WD_Time=500, F_Par_CRC=0x1234
+            ),
+        ]
+      )
+    ]
+  )
+str(p).encode('hex') == \
+  '04000000100000000000a0de976cd11182710102030405060100a0de976cd111827100a02442df7d67452301ab89efcd0123456789abcdef0000000001000000010000000200ffffffffe20000000000' + \
+  'ce000000ce000000ce00000000000000ce000000' + \
+    '0008003c01000000fedcba9876543210fedcba9876543210ffffffffffffffff0000e0400000008e' + '00' * 24 + \
+      '0008003c01000001fedcba9876543210fedcba987654321000000000000100010000012300000002' + '00' * 24 + \
+        '01020000' + \
+      '0008003c01000002fedcba9876543210fedcba98765432100000000000030001000001000000000a' + '00' * 24 + \
+        '484000c100c201f41234'
+
+
+#### PrmEnd control Request
+= A PNIO RPC PrmEnd Control Request
+p = DceRpc(
+  endianess='little', opnum=0, sequence_num=2,
+  object_uuid='dea00000-6c97-11d1-8271-010203040506',
+  activity='01234567-89ab-cdef-0123-456789abcdef'
+  ) / PNIOServiceReqPDU(
+  blocks=[
+    IODControlReq(ARUUID='fedcba98-7654-3210-fedc-ba9876543210', SessionKey=0, ControlCommand_PrmEnd=1)
+    ]
+  )
+str(p).encode('hex') == \
+  '04000000100000000000a0de976cd11182710102030405060100a0de976cd111827100a02442df7d67452301ab89efcd0123456789abcdef0000000001000000020000000000ffffffff340000000000' + \
+  '2000000020000000200000000000000020000000' + \
+    '0110001c01000000fedcba9876543210fedcba98765432100000000000010000'
+
+#### ApplicationReady control Request
+= A PNIO RPC PrmEnd Control Request
+p = DceRpc(
+  endianess='little', opnum=0, sequence_num=0,
+  object_uuid='dea00000-6c97-11d1-8271-060504030201',
+  activity='01020304-0506-0708-090a-0b0c0d0e0f00',
+  interface_uuid=RPC_INTERFACE_UUID['UUID_IO_ControllerInterface'],
+  ) / PNIOServiceReqPDU(
+  blocks=[
+    IODControlReq(ARUUID='fedcba98-7654-3210-fedc-ba9876543210', SessionKey=0, ControlCommand_ApplicationReady=1)
+    ]
+  )
+str(p).encode('hex') == \
+  '04000000100000000000a0de976cd11182710605040302010200a0de976cd111827100a02442df7d0403020106050807090a0b0c0d0e0f000000000001000000000000000000ffffffff340000000000' + \
+  '2000000020000000200000000000000020000000' + \
+    '0112001c01000000fedcba9876543210fedcba98765432100000000000020000'
+

--- a/scapy/contrib/pnio_rpc_consts.py
+++ b/scapy/contrib/pnio_rpc_consts.py
@@ -1,0 +1,283 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (C) 2016 Gauthier Sebaux
+
+"""
+PNIO RPC constants
+"""
+
+##################
+## Block Packet ##
+##################
+
+BLOCK_TYPES_ENUM = {
+    0x0000: "AlarmNotification_High",
+    0x0001: "AlarmNotification_Low",
+    0x0008: "IODWriteReqHeader",
+    0x0009: "IODReadReqHeader",
+    0x0010: "DiagnosisData",
+    0x0012: "ExpectedIdentificationData",
+    0x0013: "RealIdentificationData",
+    0x0014: "SubsituteValue",
+    0x0015: "RecordInputDataObjectElement",
+    0x0016: "RecordOutputDataObjectElement",
+    0x0018: "ARData",
+    0x0019: "LogBookData",
+    0x001a: "APIData",
+    0x001b: "SRLData",
+    0x0020: "I&M0",
+    0x0021: "I&M1",
+    0x0022: "I&M2",
+    0x0023: "I&M3",
+    0x0024: "I&M4",
+    0x0030: "I&M0FilterDataSubmodule",
+    0x0031: "I&M0FilterDataModule",
+    0x0032: "I&M0FilterDataDevice",
+    0x0101: "ARBlockReq",
+    0x0102: "IOCRBlockReq",
+    0x0103: "AlarmCRBlockReq",
+    0x0104: "ExpectedSubmoduleBlockReq",
+    0x0105: "PrmServerBlockReq",
+    0x0106: "MCRBlockReq",
+    0x0107: "ARRPCBlockReq",
+    0x0108: "ARVendorBlockReq",
+    0x0109: "IRInfoBlock",
+    0x010a: "SRInfoBlock",
+    0x010b: "ARFSUBlock",
+    0x0110: "IODBlockReq_connect_end",
+    0x0111: "IODBlockReq_plug",
+    0x0112: "IOXBlockReq_connect",
+    0x0113: "IOXBlockReq_plug",
+    0x0114: "ReleaseBlockReq",
+    0x0116: "IOXBlockReq_companion",
+    0x0117: "IOXBlockReq_rt_class_3",
+    0x0118: "IODBlockReq_connect_begin",
+    0x0119: "SubmoduleListBlock",
+    0x0200: "PDPortDataCheck",
+    0x0201: "PdevData",
+    0x0202: "PDPortDataAdjust",
+    0x0203: "PDSyncData",
+    0x0204: "IsochronousModeData",
+    0x0205: "PDIRData",
+    0x0206: "PDIRGlobalData",
+    0x0207: "PDIRFrameData",
+    0x0208: "PDIRBeginEndData",
+    0x0209: "AdjustDomainBoundary",
+    0x020a: "SubBlock_check_Peers",
+    0x020b: "SubBlock_check_LineDelay",
+    0x020c: "SubBlock_check_MAUType",
+    0x020e: "AdjustMAUType",
+    0x020f: "PDPortDataReal",
+    0x0210: "AdjustMulticastBoundary",
+    0x0211: "PDInterfaceMrpDataAdjust",
+    0x0212: "PDInterfaceMrpDataReal",
+    0x0213: "PDInterfaceMrpDataCheck",
+    0x0214: "PDPortMrpDataAdjust",
+    0x0215: "PDPortMrpDataReal",
+    0x0216: "MrpManagerParams",
+    0x0217: "MrpClientParams",
+    0x0219: "MrpRingStateData",
+    0x021b: "AdjustLinkState",
+    0x021c: "CheckLinkState",
+    0x021e: "CheckSyncDifference",
+    0x021f: "CheckMAUTypeDifference",
+    0x0220: "PDPortFODataReal",
+    0x0221: "FiberOpticManufacturerSpecific",
+    0x0222: "PDPortFODataAdjust",
+    0x0223: "PDPortFODataCheck",
+    0x0224: "AdjustPeerToPeerBoundary",
+    0x0225: "AdjustDCPBoundary",
+    0x0226: "AdjustPreambleLength",
+    0x0228: "FiberOpticDiagnosisInfo",
+    0x022a: "PDIRSubframeData",
+    0x022b: "SubframeBlock",
+    0x022d: "PDTimeData",
+    0x0230: "PDNCDataCheck",
+    0x0231: "MrpInstanceDataAdjustBlock",
+    0x0232: "MrpInstanceDataRealBlock",
+    0x0233: "MrpInstanceDataCheckBlock",
+    0x0240: "PDInterfaceDataReal",
+    0x0250: "PDInterfaceAdjust",
+    0x0251: "PDPortStatistic",
+    0x0400: "MultipleBlockHeader",
+    0x0401: "COContainerContent",
+    0x0500: "RecordDataReadQuery",
+    0x0600: "FSHelloBlock",
+    0x0601: "FSParameterBlock",
+    0x0608: "PDInterfaceFSUDataAdjust",
+    0x0609: "ARFSUDataAdjust",
+    0x0700: "AutoConfiguration",
+    0x0701: "AutoConfigurationCommunication",
+    0x0702: "AutoConfigurationConfiguration",
+    0x0703: "AutoConfigurationIsochronous",
+    0x0A00: "UploadBLOBQuery",
+    0x0A01: "UploadBLOB",
+    0x0A02: "NestedDiagnosisInfo",
+    0x0F00: "MaintenanceItem",
+    0x0F01: "UploadRecord",
+    0x0F02: "iParameterItem",
+    0x0F03: "RetrieveRecord",
+    0x0F04: "RetrieveAllRecord",
+    0x8001: "AlarmAckHigh",
+    0x8002: "AlarmAckLow",
+    0x8008: "IODWriteResHeader",
+    0x8009: "IODReadResHeader",
+    0x8101: "ARBlockRes",
+    0x8102: "IOCRBlockRes",
+    0x8103: "AlarmCRBlockRes",
+    0x8104: "ModuleDiffBlock",
+    0x8105: "PrmServerBlockRes",
+    0x8106: "ARServerBlockRes",
+    0x8107: "ARRPCBlockRes",
+    0x8108: "ARVendorBlockRes",
+    0x8110: "IODBlockRes_connect_end",
+    0x8111: "IODBlockRes_plug",
+    0x8112: "IOXBlockRes_connect",
+    0x8113: "IOXBlockRes_plug",
+    0x8114: "ReleaseBlockRes",
+    0x8116: "IOXBlockRes_companion",
+    0x8117: "IOXBlockRes_rt_class_3",
+    0x8118: "IODBlockRes_connect_begin",
+    }
+
+
+###############################################
+## IODWriteReq & IODWriteMultipleReq Packets ##
+###############################################
+
+IOD_WRITE_REQ_INDEX = {
+    0x8000: "ExpectedIdentificationData_subslot",
+    0x8001: "RealIdentificationData_subslot",
+    0x800a: "Diagnosis_channel_subslot",
+    0x800b: "Diagnosis_all_subslot",
+    0x800c: "Diagnosis_Maintenance_subslot",
+    0x8010: "Maintenance_required_in_channel_subslot",
+    0x8011: "Maintenance_demanded_in_channel_subslot",
+    0x8012: "Maintenance_required_in_all_channels_subslot",
+    0x8013: "Maintenance_demanded_in_all_channels_subslot",
+    0x801e: "SubstitueValue_subslot",
+    0x8020: "PDIRSubframeData_subslot",
+    0x8028: "RecordInputDataObjectElement_subslot",
+    0x8029: "RecordOutputDataObjectElement_subslot",
+    0x802a: "PDPortDataReal_subslot",
+    0x802b: "PDPortDataCheck_subslot",
+    0x802c: "PDIRData_subslot",
+    0x802d: "Expected_PDSyncData_subslot",
+    0x802f: "PDPortDataAdjust_subslot",
+    0x8030: "IsochronousModeData_subslot",
+    0x8031: "Expected_PDTimeData_subslot",
+    0x8050: "PDInterfaceMrpDataReal_subslot",
+    0x8051: "PDInterfaceMrpDataCheck_subslot",
+    0x8052: "PDInterfaceMrpDataAdjust_subslot",
+    0x8053: "PDPortMrpDataAdjust_subslot",
+    0x8054: "PDPortMrpDataReal_subslot",
+    0x8060: "PDPortFODataReal_subslot",
+    0x8061: "PDPortFODataCheck_subslot",
+    0x8062: "PDPortFODataAdjust_subslot",
+    0x8070: "PdNCDataCheck_subslot",
+    0x8071: "PDInterfaceAdjust_subslot",
+    0x8072: "PDPortStatistic_subslot",
+    0x8080: "PDInterfaceDataReal_subslot",
+    0x8090: "Expected_PDInterfaceFSUDataAdjust",
+    0x80a0: "Energy_saving_profile_record_0",
+    0x80b0: "CombinedObjectContainer",
+    0x80c0: "Sequence_events_profile_record_0",
+    0xaff0: "I&M0",
+    0xaff1: "I&M1",
+    0xaff2: "I&M2",
+    0xaff3: "I&M3",
+    0xaff4: "I&M4",
+    0xc000: "Expect edIdentificationData_slot",
+    0xc001: "RealId entificationData_slot",
+    0xc00a: "Diagno sis_channel_slot",
+    0xc00b: "Diagnosis_all_slot",
+    0xc00c: "Diagnosis_Maintenance_slot",
+    0xc010: "Maintenance_required_in_channel_slot",
+    0xc011: "Maintenance_demanded_in_channel_slot",
+    0xc012: "Maintenance_required_in_all_channels_slot",
+    0xc013: "Maintenance_demanded_in_all_channels_slot",
+    0xe000: "ExpectedIdentificationData_AR",
+    0xe001: "RealIdentificationData_AR",
+    0xe002: "ModuleDiffBlock_AR",
+    0xe00a: "Diagnosis_channel_AR",
+    0xe00b: "Diagnosis_all_AR",
+    0xe00c: "Diagnosis_Maintenance_AR",
+    0xe010: "Maintenance_required_in_channel_AR",
+    0xe011: "Maintenance_demanded_in_channel_AR",
+    0xe012: "Maintenance_required_in_all_channels_AR",
+    0xe013: "Maintenance_demanded_in_all_channels_AR",
+    0xe040: "WriteMultiple",
+    0xe050: "ARFSUDataAdjust_AR",
+    0xf000: "RealIdentificationData_API",
+    0xf00a: "Diagnosis_channel_API",
+    0xf00b: "Diagnosis_all_API",
+    0xf00c: "Diagnosis_Maintenance_API",
+    0xf010: "Maintenance_required_in_channel_API",
+    0xf011: "Maintenance_demanded_in_channel_API",
+    0xf012: "Maintenance_required_in_all_channels_API",
+    0xf013: "Maintenance_demanded_in_all_channels_API",
+    0xf020: "ARData_API",
+    0xf80c: "Diagnosis_Maintenance_device",
+    0xf820: "ARData",
+    0xf821: "APIData",
+    0xf830: "LogBookData",
+    0xf831: "PdevData",
+    0xf840: "I&M0FilterData",
+    0xf841: "PDRealData",
+    0xf842: "PDExpectedData",
+    0xf850: "AutoConfiguration",
+    0xf860: "GSD_upload",
+    0xf861: "Nested_Diagnosis_info",
+    0xfbff: "Trigger_index_CMSM",
+    }
+
+########################
+## ARBlockReq Packets ##
+########################
+
+AR_TYPE = {
+    0x0001: "IOCARSingle",
+    0x0006: "IOSAR",
+    0x0010: "IOCARSingle_RT_CLASS_3",
+    0x0020: "IOCARSR",
+    }
+
+
+##########################
+## IOCRBlockReq Packets ##
+##########################
+
+IOCR_TYPE = {
+    0x0001: "InputCR",
+    0x0002: "OutputCR",
+    0x0003: "MulticastProviderCR",
+    0x0004: "MulticastConsumerCR",
+    }
+
+IOCR_BLOCK_REQ_IOCR_PROPERTIES = {
+    0x1: "RT_CLASS_1",
+    0x2: "RT_CLASS_2",
+    0x3: "RT_CLASS_3",
+    0x4: "RT_CLASS_UDP",
+    }
+
+# list of all valid activiy uuid for the DceRpc layer with PROFINET RPC
+# endpoint
+RPC_INTERFACE_UUID = {
+    "UUID_IO_DeviceInterface": "dea00001-6c97-11d1-8271-00a02442df7d",
+    "UUID_IO_ControllerInterface": "dea00002-6c97-11d1-8271-00a02442df7d",
+    "UUID_IO_SupervisorInterface": "dea00003-6c97-11d1-8271-00a02442df7d",
+    "UUID_IO_ParameterServerInterface": "dea00004-6c97-11d1-8271-00a02442df7d",
+    }


### PR DESCRIPTION
This PR follows the PR #256 which defines the upper layer (DCE/RPC) of PROFINET RPC.

It adds the PROFINET DCE/RPC endpoint, known as context manager. It's a layer composed of blocks whose base class is capable of handling all kinds of block like Raw would do.

More specialized blocks are also defined to provide an easier way to build complex RPC requests or responses. Examples of different kinds of requests and responses are located at the end of the unit tests file.
