### PR TITLE
Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - os: osx
           language: generic
           env:
-            - SCAPY_USE_PCAPDNET=true
+            - SCAPY_USE_PCAPDNET=yes
 
         # Run as root
         - os: linux
@@ -29,13 +29,13 @@ matrix:
           python: 2.7
           env:
             - TRAVIS_SUDO=sudo
-            - SCAPY_USE_PCAPDNET=true
+            - SCAPY_USE_PCAPDNET=yes
 
         - os: osx
           language: generic
           env:
             - TRAVIS_SUDO=sudo
-            - SCAPY_USE_PCAPDNET=true
+            - SCAPY_USE_PCAPDNET=yes
 
 install: bash .travis/install.sh
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,7 +10,7 @@ if [ ! -z $SCAPY_USE_PCAPDNET ]
 then
   if [ "$TRAVIS_OS_NAME" = "linux" ]
   then
-    $TRAVIS_SUDO apt-get install python-pcapy python-dumbnet
+    $TRAVIS_SUDO apt-get install python-libpcap python-dumbnet
   elif [ "$TRAVIS_OS_NAME" = "osx" ]
   then
     mkdir -p /Users/travis/Library/Python/2.7/lib/python/site-packages

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,18 +1,21 @@
+# Dump Scapy config
+python -c "from scapy.all import *; print conf"
+
 # Don't run tests that requires root privileges
 if [ -z $TRAVIS_SUDO ]
 then
   UT_FLAGS="-K netaccess"
 fi
 
-# Run unit tests
+# Run unit tests
 cd test/
 
 for f in *.uts
 do
-  $TRAVIS_SUDO ./run_tests -q -F -t $f $UT_FLAGS || exit $?
+  $TRAVIS_SUDO ./run_tests -f text -t $f $UT_FLAGS || exit $?
 done
 
 for f in ../scapy/contrib/*.uts
 do
-  $TRAVIS_SUDO ./run_tests -q -F -t $f $UT_FLAGS -P "load_contrib('$(basename ${f/.uts})')" || exit $?
+  $TRAVIS_SUDO ./run_tests -f text -t $f $UT_FLAGS -P "load_contrib('$(basename ${f/.uts})')" || exit $?
 done


### PR DESCRIPTION
Here are some Travis CI changes:
1. dump the conf `variable` before starting a test. That's useful to debug Travis CI runs;
2. use the pcap/dnet modules. On Linux, the typo (`true` instead of `yes`) prevented such tests to run as expected;
3. install the correct `pcap` Python module. As `pcapy` does not expose the file number, it is not the best candidate;
4. get the whole output: do not run UTScapy with the `-q` and `-F ` parameters.