### PR TITLE
Fixed a bug in the sendrecv method when using multi-threading

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -10,7 +10,7 @@ Functions to send and receive packets.
 import errno
 import cPickle,os,sys,time,subprocess
 import itertools
-from select import select
+from select import select,error
 from scapy.data import *
 from scapy import arch
 from scapy.config import conf
@@ -132,6 +132,8 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                                 inp = []
                                 try:
                                     inp, out, err = select(inmask,[],[], remaintime)
+                                except error as e:
+                                    continue
                                 except IOError, exc:
                                     if exc.errno != errno.EINTR:
                                         raise


### PR DESCRIPTION
Like other people on the Internet I used to have troubles with the sr1 method, when using multi-threading (and pyqt4 in my case).
To reproduce the bug, start a simple Qt application, then try to send and receive any packet using the sr1 method wherever you want and it will result in something like the following:

```
      File "TestCase.py", line 123, in sendSYNnRecACK
        synackpkt = sr1(pck, verbose=0, timeout=1, retry=-2)
      File "/usr/local/lib/python2.7/dist-packages/scapy/sendrecv.py", line 354, in sr1 
        a,b=sndrcv(s,x,*args,**kargs)
      File "/usr/local/lib/python2.7/dist-packages/scapy/sendrecv.py", line 135, in sndrcv
        inp, out, err = select(inmask,[],[], remaintime)
    select.error: (4, 'Appel syst\xc3\xa8me interrompu')
```

The last error meaning "System call interrupted".

As I am not a good developer it may be awful code (I let you judge of that) but it allowed me to solve my issue.
