### PR TITLE
vxlan: fixed incorrect field layout specification

### DIFF
--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -12,7 +12,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IPv6
 from scapy.fields import FlagsField, XByteField, ThreeBytesField, \
-        ConditionalField, ShortField, ByteEnumField, X3BytesField
+    ConditionalField, ShortField, ByteEnumField, X3BytesField
 
 _GP_FLAGS = ["R", "R", "R", "A", "R", "R", "D", "R"]
 
@@ -24,15 +24,22 @@ class VXLAN(Packet):
         FlagsField("flags", 0x8, 8,
                    ['OAM', 'R', 'NextProtocol', 'Instance',
                     'V1', 'V2', 'R', 'G']),
-        ByteEnumField('NextProtocol', 0,
-                      {0: 'NotDefined',
-                       1: 'IPv4',
-                       2: 'IPv6',
-                       3: 'Ethernet',
-                       4: 'NSH'}),
+        ConditionalField(
+            ShortField("reserved0", 0),
+            lambda pkt: pkt.flags & 0x04,
+        ),
+        ConditionalField(
+            ByteEnumField('NextProtocol', 0,
+                          {0: 'NotDefined',
+                           1: 'IPv4',
+                           2: 'IPv6',
+                           3: 'Ethernet',
+                           4: 'NSH'}),
+            lambda pkt: pkt.flags & 0x04,
+        ),
         ConditionalField(
             ThreeBytesField("reserved1", 0x000000),
-            lambda pkt: not pkt.flags & 0x80,
+            lambda pkt: (not pkt.flags & 0x80) and (not pkt.flags & 0x04),
         ),
         ConditionalField(
             FlagsField("gpflags", 0x0, 8, _GP_FLAGS),
@@ -58,9 +65,11 @@ class VXLAN(Packet):
             return self.sprintf("VXLAN (vni=%VXLAN.vni%)")
 
 bind_layers(UDP, VXLAN, dport=4789)  # RFC standard port
-bind_layers(UDP, VXLAN, dport=6633)  # New IANA assigned port when used with NSH
+bind_layers(UDP, VXLAN, dport=6633)  # New IANA assigned port for use with NSH
 bind_layers(UDP, VXLAN, dport=8472)  # Linux implementation port
-bind_layers(VXLAN, Ether, {'flags': 0x8}, NextProtocol=0)
+bind_layers(VXLAN, Ether, {'flags': 0x8})
+bind_layers(VXLAN, Ether, {'flags': 0x88})
+bind_layers(VXLAN, Ether, {'flags': 0xC, 'NextProtocol': 0}, NextProtocol=0)
 bind_layers(VXLAN, IP, {'flags': 0xC, 'NextProtocol': 1}, NextProtocol=1)
 bind_layers(VXLAN, IPv6, {'flags': 0xC, 'NextProtocol': 2}, NextProtocol=2)
 bind_layers(VXLAN, Ether, {'flags': 0xC, 'NextProtocol': 3}, NextProtocol=3)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6123,10 +6123,10 @@ assert(p.data[0].ifname.startswith("lo"))
 + VXLAN layer
 
 = Build a VXLAN packet with VNI of 42
-str(UDP(sport=1024, dport=4789, len=None, chksum=None)/VXLAN(flags=0x08, vni=42)) == '\x04\x00\x12\xb5\x00\x11\x00\x00\x08\x00\x00\x00\x00\x00\x00\x2a\x00'
+str(UDP(sport=1024, dport=4789, len=None, chksum=None)/VXLAN(flags=0x08, vni=42)) == '\x04\x00\x12\xb5\x00\x10\x00\x00\x08\x00\x00\x00\x00\x00\x2a\x00'
 
 = Verify VXLAN Ethernet Binding
-str(VXLAN(vni=23)/Ether(dst="11:11:11:11:11:11", src="11:11:11:11:11:11", type=0x800)) == '\x0c\x03\x00\x00\x00\x00\x00\x17\x00\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x08\x00'
+str(VXLAN(vni=23)/Ether(dst="11:11:11:11:11:11", src="11:11:11:11:11:11", type=0x800)) == '\x0c\x00\x00\x03\x00\x00\x17\x00\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x08\x00'
 
 = Verify UDP dport overloading
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
@@ -6134,6 +6134,17 @@ p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
 p /= VXLAN(flags=0x8, vni=42) / Ether() / IP()
 p = Ether(str(p))
 assert(p[UDP].dport == 8472)
+assert(p[Ether:2].type == 0x800)
+
+= Build a VXLAN packet with next protocol field
+p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
+p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
+p /= VXLAN(flags=0xC, vni=42, NextProtocol=3) / Ether() / IP()
+p = Ether(str(p))
+assert(p[UDP].dport == 8472)
+assert(p[VXLAN].reserved0 == 0x0)
+assert(p[VXLAN].NextProtocol == 3)
+assert(p[Ether:2].type == 0x800)
 
 = Build a VXLAN packet with no group policy ID
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
@@ -6142,6 +6153,7 @@ p /= VXLAN(flags=0x8, vni=42) / Ether() / IP()
 p = Ether(str(p))
 assert(p[VXLAN].reserved1 == 0x0)
 assert(p[VXLAN].gpid is None)
+assert(p[Ether:2].type == 0x800)
 
 = Build a VXLAN packet with group policy ID = 42
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
@@ -6150,3 +6162,4 @@ p /= VXLAN(flags=0x88, gpid=42, vni=42) / Ether() / IP()
 p = Ether(str(p))
 assert(p[VXLAN].gpid == 42)
 assert(p[VXLAN].reserved1 is None)
+assert(p[Ether:2].type == 0x800)


### PR DESCRIPTION
The "NextProtocol" field was added as an unconditional field which made the
VXLAN packet header consume an additional 8-bts when used in a Legacy VXLAN
deployments (flags=0x08) or in GPID deployments (flags=0x88).  The resulting
regression caused incorrect parsing of subsequent headers.  For example, if an
Ethernet header followed the VXLAN header then it would not be interpreted as
an Ethernet header.  The actually interpretation would depend on what value was
stored in the Ether.dst field.

This change updates the field layout specification such that the NextProtocol
field is conditional on flags=0x04, and shortens the reserved field by 8-bits
if that condition is true.

fixes bug #281

Signed-off-by: Allain Legacy <allain.legacy@windriver.com>