### PR TITLE
make sure that conf.route[6] is initialized before using it

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -265,6 +265,9 @@ class SourceIPField(IPField):
         return IPField.i2m(self, pkt, x)
     def i2h(self, pkt, x):
         if x is None:
+            if conf.route is None:
+                # unused import, only to initialize conf.route
+                import scapy.route
             dst=getattr(pkt,self.dstname)
             if isinstance(dst,Gen):
                 r = map(conf.route.route, dst)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -392,6 +392,9 @@ class IP(Packet, IPTools):
         dst = self.dst
         if isinstance(dst,Gen):
             dst = iter(dst).next()
+        if conf.route is None:
+            # unused import, only to initialize conf.route
+            import scapy.route
         return conf.route.route(dst)
     def hashret(self):
         if ( (self.proto == socket.IPPROTO_ICMP)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -51,6 +51,9 @@ from scapy.layers.l2 import *
 from scapy.layers.inet import *
 from scapy.utils import inet_pton, inet_ntop, strxor
 from scapy.error import warning
+if conf.route6 is None:
+    # unused import, only to initialize conf.route6
+    import scapy.route6
 
 
 #############################################################################

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -19,6 +19,9 @@ from scapy.fields import *
 from scapy.sendrecv import *
 from scapy.arch import get_if_hwaddr
 from scapy.utils import inet_ntoa, inet_aton
+if conf.route is None:
+    # unused import, only to initialize conf.route
+    import scapy.route
 
 
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -20,6 +20,9 @@ from scapy.packet import NoPayload, Packet
 from scapy.error import warning, Scapy_Exception, log_runtime
 from scapy.volatile import RandInt, RandByte, RandChoice, RandNum, RandShort, RandString
 from scapy.sendrecv import sniff
+if conf.route is None:
+    # unused import, only to initialize conf.route
+    import scapy.route
 
 conf.p0f_base ="/etc/p0f/p0f.fp"
 conf.p0fa_base ="/etc/p0f/p0fa.fp"

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -20,6 +20,9 @@ from scapy import plist
 from scapy.error import log_runtime,log_interactive
 from scapy.base_classes import SetGen
 from scapy.supersocket import StreamSocket
+if conf.route is None:
+    # unused import, only to initialize conf.route
+    import scapy.route
 
 #################
 ## Debug class ##


### PR DESCRIPTION
To avoid circular import problems, conf.route and conf.route6 are
initialized in scapy.route and scapy.route6.

Make sure that these modules are imported before using conf.route[6].

This fixes issue #290.