### PR TITLE
Fix sebek "command" field 

### DIFF
--- a/scapy/contrib/sebek.py
+++ b/scapy/contrib/sebek.py
@@ -38,14 +38,14 @@ class SebekV1(Packet):
     fields_desc = [ IntField("pid", 0),
                     IntField("uid", 0),
                     IntField("fd", 0),
-                    StrFixedLenField("command", "", 12),
+                    StrFixedLenField("cmd", "", 12),
                     FieldLenField("data_length", None, "data",fmt="I"),
                     StrLenField("data", "", length_from=lambda x:x.data_length) ]
     def mysummary(self):
         if isinstance(self.underlayer, SebekHead):
-            return self.underlayer.sprintf("Sebek v1 %SebekHead.type% (%SebekV1.command%)")
+            return self.underlayer.sprintf("Sebek v1 %SebekHead.type% (%SebekV1.cmd%)")
         else:
-            return self.sprintf("Sebek v1 (%SebekV1.command%)")
+            return self.sprintf("Sebek v1 (%SebekV1.cmd%)")
 
 class SebekV3(Packet):
     name = "Sebek v3"
@@ -54,21 +54,21 @@ class SebekV3(Packet):
                     IntField("uid", 0),
                     IntField("fd", 0),
                     IntField("inode", 0),
-                    StrFixedLenField("command", "", 12),
+                    StrFixedLenField("cmd", "", 12),
                     FieldLenField("data_length", None, "data",fmt="I"),
                     StrLenField("data", "", length_from=lambda x:x.data_length) ]
     def mysummary(self):
         if isinstance(self.underlayer, SebekHead):
-            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV3.command%)")
+            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV3.cmd%)")
         else:
-            return self.sprintf("Sebek v3 (%SebekV3.command%)")
+            return self.sprintf("Sebek v3 (%SebekV3.cmd%)")
 
 class SebekV2(SebekV3):
     def mysummary(self):
         if isinstance(self.underlayer, SebekHead):
-            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV2.command%)")
+            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV2.cmd%)")
         else:
-            return self.sprintf("Sebek v2 (%SebekV2.command%)")
+            return self.sprintf("Sebek v2 (%SebekV2.cmd%)")
 
 class SebekV3Sock(Packet):
     name = "Sebek v2 socket"
@@ -77,7 +77,7 @@ class SebekV3Sock(Packet):
                     IntField("uid", 0),
                     IntField("fd", 0),
                     IntField("inode", 0),
-                    StrFixedLenField("command", "", 12),
+                    StrFixedLenField("cmd", "", 12),
                     IntField("data_length", 15),
                     IPField("dip", "127.0.0.1"),
                     ShortField("dport", 0),
@@ -91,16 +91,16 @@ class SebekV3Sock(Packet):
                     ByteEnumField("proto", 0, IP_PROTOS) ]
     def mysummary(self):
         if isinstance(self.underlayer, SebekHead):
-            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV3Sock.command%)")
+            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV3Sock.cmd%)")
         else:
-            return self.sprintf("Sebek v3 socket (%SebekV3Sock.command%)")
+            return self.sprintf("Sebek v3 socket (%SebekV3Sock.cmd%)")
 
 class SebekV2Sock(SebekV3Sock):
     def mysummary(self):
         if isinstance(self.underlayer, SebekHead):
-            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV2Sock.command%)")
+            return self.underlayer.sprintf("Sebek v%SebekHead.version% %SebekHead.type% (%SebekV2Sock.cmd%)")
         else:
-            return self.sprintf("Sebek v2 socket (%SebekV2Sock.command%)")
+            return self.sprintf("Sebek v2 socket (%SebekV2Sock.cmd%)")
 
 bind_layers( UDP,           SebekHead,     sport=1101)
 bind_layers( UDP,           SebekHead,     dport=1101)


### PR DESCRIPTION
Fix sebek "command" field 

There is a field nameded "command".When I  print the field content (**print payload.command**) , I get the information:

` <bound method SebekV3Sock.command of <SebekV3Sock  parent_pid=2665 pid=4 uid=0 fd=0 inode=0 command='System' data_length=15 dip=0.0.0.0 dport=0 sip=192.168.200.2 sport=0 call=sendto proto=hopopt |>>`

But I want to get "**System**".

And Then.

I change the field name "command" to "cmd" in Class SebekV3Sock, **print payload.cmd and payload.command**. 
I get the information : 

**payload.cmd**
`System`

**payload.command**
`<bound method SebekV3Sock.command of <SebekV3Sock  parent_pid=2665 pid=4 uid=0 fd=0 inode=0 cmd='System' data_length=15 dip=0.0.0.0 dport=0 sip=192.168.200.2 sport=0 call=sendto proto=hopopt |>> `

So I change field name "command" to "cmd" in all Class to fix.
