### PR TITLE
Removing Python 2.6 from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
     include:
         # Run as a regular user
         - os: linux
-          python: 2.6
-
-        - os: linux
           python: 2.7
 
         - os: linux


### PR DESCRIPTION
As Python 2.6 is not supported anymore, travis tests can be removed.