### PR TITLE
Remove support for Python 2.5 to clean the code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
     include:
         # Run as a regular user
         - os: linux
-          python: 2.6
-
-        - os: linux
           python: 2.7
 
         - os: linux

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -20,7 +20,8 @@ At the moment, there are two different versions of Scapy:
 * **Scapy v1.x**. It consists of only one file and works on Python 2.4, so it might be easier to install.
   Moreover, your OS may already have a specially prepared packages or ports for it. Last version is v1.2.2.
 * **Scapy v2.x**. The current development version adds several features (e.g. IPv6). It consists of several
-  files  packaged in the standard distutils way. Scapy v2 needs Python 2.5.
+  files  packaged in the standard distutils way. Scapy v2 <= 2.3.3 needs Python 2.5, Scapy v2 > 2.3.3 needs
+  Python 2.7.
 
 .. note::
 
@@ -198,7 +199,7 @@ Linux native
 
 Scapy can run natively on Linux, without libdnet and libpcap.
 
-* Install `Python 2.5 <http://www.python.org>`_.
+* Install `Python 2.7 <http://www.python.org>`_.
 * Install `tcpdump <http://www.tcpdump.org>`_ and make sure it is in the $PATH. (It's only used to compile BPF filters (``-ddd option``))
 * Make sure your kernel has Packet sockets selected (``CONFIG_PACKET``)
 * If your kernel is < 2.6, make sure that Socket filtering is selected ``CONFIG_FILTER``) 
@@ -354,7 +355,7 @@ Scapy is primarily being developed for Unix-like systems and works best on those
 
 You need the following software packages in order to install Scapy on Windows:
 
-  * `Python <http://www.python.org>`_: `python-2.5.4.msi <http://www.python.org/ftp/python/2.5.4/python-2.5.4.msi>`_. `python-2.6.3.msi <http://www.python.org/ftp/python/2.6.3/python-2.6.3.msi>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python25`` and ``C:\Python25\Scripts`` or ``C:\Python26`` and ``C:\Python26\Scripts`` respectively.
+  * `Python <http://www.python.org>`_: `python-2.7.12.msi <https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python27`` and ``C:\Python27\Scripts`` respectively.
   * `Scapy <http://www.secdev.org/projects/scapy/>`_: `latest development version <https://github.com/secdev/scapy/archive/master.zip>`_ from the `Git repository <https://github.com/secdev/scapy>`_. Unzip the archive, open a command prompt in that directory and run "python setup.py install". 
   * `pywin32 <http://python.net/crew/mhammond/win32/Downloads.html>`_: `pywin32-214.win32-py2.5.exe <http://surfnet.dl.sourceforge.net/sourceforge/pywin32/pywin32-214.win32-py2.5.exe>`_ `pywin32-214.win32-py2.6.exe <http://downloads.sourceforge.net/project/pywin32/pywin32/Build%20214/pywin32-214.win32-py2.6.exe>`_
   * `WinPcap <http://www.winpcap.org/>`_: `WinPcap_4_1_1.exe <http://www.winpcap.org/install/bin/WinPcap_4_1_1.exe>`_. You might want to choose "[x] Automatically start the WinPcap driver at boot time", so that non-privileged users can sniff, especially under Vista and Windows 7. If you want to use the ethernet vendor database to resolve MAC addresses or use the ``wireshark()`` command, download `Wireshark <http://www.wireshark.org/>`_ which already includes WinPcap. 

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -3,8 +3,6 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-from __future__ import with_statement
-
 """
 Scapy: create, send, sniff, dissect and manipulate network packets.
 

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -7,7 +7,6 @@
 Linux specific functions.
 """
 
-from __future__ import with_statement
 import sys,os,struct,socket,time
 from select import select
 from fcntl import ioctl

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -7,8 +7,6 @@
 Common customizations for all Unix-like operating systems other than Linux
 """
 
-from __future__ import with_statement
-
 import sys,os,struct,socket,time
 from fcntl import ioctl
 import socket

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -7,7 +7,6 @@
 Customizations needed to support Microsoft Windows.
 """
 
-from __future__ import with_statement
 import os,re,sys,socket,time, itertools
 import subprocess as sp
 from glob import glob
@@ -359,8 +358,7 @@ def read_routes_xp():
     routes = []
     partial_routes = []
     # map local IP addresses to interfaces
-    local_addresses = dict((iface.ip, iface)
-                           for iface in IFACES.itervalues())
+    local_addresses = {iface.ip: iface for iface in IFACES.itervalues()}
     iface_indexes = {}
     for line in exec_query(['Get-WmiObject', 'Win32_IP4RouteTable'],
                            ['Name', 'Mask', 'NextHop', 'InterfaceIndex']):

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -7,7 +7,6 @@
 Automata with states, transitions and actions.
 """
 
-from __future__ import with_statement
 import types,itertools,time,os,sys,socket,traceback
 from select import select
 from collections import deque

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -44,18 +44,7 @@ import struct
 try:
     from Crypto.Util.number import GCD as gcd
 except ImportError:
-    try:
-        from fractions import gcd
-    except ImportError:
-        def gcd(a, b):
-            """Fallback implementation when Crypto is missing, and fractions does
-            not exist (Python 2.5)
-
-            """
-            if b > a:
-                a, b = b, a
-            c = a % b
-            return b if c == 0 else gcd(c, b)
+    from fractions import gcd
 
 
 from scapy.data import IP_PROTOS

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -304,8 +304,8 @@ SPECIFIC_CLASSES = {}
 
 
 def _register_lltd_specific_class(*attr_types):
-    """This can be used as a class decorator, but since we want to
-    support Python 2.5, we have to replace
+    """This can be used as a class decorator; if we want to support Python
+    2.5, we have to replace
 
 @_register_lltd_specific_class(x[, y[, ...]])
 class LLTDAttributeSpecific(LLTDAttribute):
@@ -330,14 +330,13 @@ LLTDAttributeSpecific = _register_lltd_specific_class(x[, y[, ...]])(
     return _register
 
 
+@_register_lltd_specific_class(0)
 class LLTDAttributeEOP(LLTDAttribute):
     name = "LLTD Attribute - End Of Property"
     fields_desc = []
 
 
-LLTDAttributeEOP = _register_lltd_specific_class(0)(LLTDAttributeEOP)
-
-
+@_register_lltd_specific_class(1)
 class LLTDAttributeHostID(LLTDAttribute):
     name = "LLTD Attribute - Host ID"
     fields_desc = [
@@ -349,9 +348,7 @@ class LLTDAttributeHostID(LLTDAttribute):
         return "ID: %s" % self.mac, [LLTD, LLTDAttributeMachineName]
 
 
-LLTDAttributeHostID = _register_lltd_specific_class(1)(LLTDAttributeHostID)
-
-
+@_register_lltd_specific_class(2)
 class LLTDAttributeCharacteristics(LLTDAttribute):
     name = "LLTD Attribute - Characteristics"
     fields_desc = [
@@ -366,11 +363,7 @@ class LLTDAttributeCharacteristics(LLTDAttribute):
     ]
 
 
-LLTDAttributeCharacteristics = _register_lltd_specific_class(2)(
-    LLTDAttributeCharacteristics
-)
-
-
+@_register_lltd_specific_class(3)
 class LLTDAttributePhysicalMedium(LLTDAttribute):
     name = "LLTD Attribute - Physical Medium"
     fields_desc = [
@@ -656,11 +649,7 @@ class LLTDAttributePhysicalMedium(LLTDAttribute):
     ]
 
 
-LLTDAttributePhysicalMedium = _register_lltd_specific_class(3)(
-    LLTDAttributePhysicalMedium
-)
-
-
+@_register_lltd_specific_class(7)
 class LLTDAttributeIPv4Address(LLTDAttribute):
     name = "LLTD Attribute - IPv4 Address"
     fields_desc = [
@@ -669,11 +658,7 @@ class LLTDAttributeIPv4Address(LLTDAttribute):
     ]
 
 
-LLTDAttributeIPv4Address = _register_lltd_specific_class(7)(
-    LLTDAttributeIPv4Address
-)
-
-
+@_register_lltd_specific_class(8)
 class LLTDAttributeIPv6Address(LLTDAttribute):
     name = "LLTD Attribute - IPv6 Address"
     fields_desc = [
@@ -682,11 +667,7 @@ class LLTDAttributeIPv6Address(LLTDAttribute):
     ]
 
 
-LLTDAttributeIPv6Address = _register_lltd_specific_class(8)(
-    LLTDAttributeIPv6Address
-)
-
-
+@_register_lltd_specific_class(9)
 class LLTDAttribute80211MaxRate(LLTDAttribute):
     name = "LLTD Attribute - 802.11 Max Rate"
     fields_desc = [
@@ -695,11 +676,7 @@ class LLTDAttribute80211MaxRate(LLTDAttribute):
     ]
 
 
-LLTDAttribute80211MaxRate = _register_lltd_specific_class(9)(
-    LLTDAttribute80211MaxRate
-)
-
-
+@_register_lltd_specific_class(10)
 class LLTDAttributePerformanceCounterFrequency(LLTDAttribute):
     name = "LLTD Attribute - Performance Counter Frequency"
     fields_desc = [
@@ -708,11 +685,7 @@ class LLTDAttributePerformanceCounterFrequency(LLTDAttribute):
     ]
 
 
-LLTDAttributePerformanceCounterFrequency = _register_lltd_specific_class(10)(
-    LLTDAttributePerformanceCounterFrequency
-)
-
-
+@_register_lltd_specific_class(12)
 class LLTDAttributeLinkSpeed(LLTDAttribute):
     name = "LLTD Attribute - Link Speed"
     fields_desc = [
@@ -721,11 +694,7 @@ class LLTDAttributeLinkSpeed(LLTDAttribute):
     ]
 
 
-LLTDAttributeLinkSpeed = _register_lltd_specific_class(12)(
-    LLTDAttributeLinkSpeed
-)
-
-
+@_register_lltd_specific_class(14, 24, 26)
 class LLTDAttributeLargeTLV(LLTDAttribute):
     name = "LLTD Attribute - Large TLV"
     fields_desc = [
@@ -733,11 +702,7 @@ class LLTDAttributeLargeTLV(LLTDAttribute):
     ]
 
 
-LLTDAttributeLargeTLV = _register_lltd_specific_class(14, 24, 26)(
-    LLTDAttributeLargeTLV
-)
-
-
+@_register_lltd_specific_class(15)
 class LLTDAttributeMachineName(LLTDAttribute):
     name = "LLTD Attribute - Machine Name"
     fields_desc = [
@@ -750,11 +715,7 @@ class LLTDAttributeMachineName(LLTDAttribute):
                 [LLTD, LLTDAttributeHostID])
 
 
-LLTDAttributeMachineName = _register_lltd_specific_class(15)(
-    LLTDAttributeMachineName
-)
-
-
+@_register_lltd_specific_class(18)
 class LLTDAttributeDeviceUUID(LLTDAttribute):
     name = "LLTD Attribute - Device UUID"
     fields_desc = [
@@ -763,11 +724,7 @@ class LLTDAttributeDeviceUUID(LLTDAttribute):
     ]
 
 
-LLTDAttributeDeviceUUID = _register_lltd_specific_class(18)(
-    LLTDAttributeDeviceUUID
-)
-
-
+@_register_lltd_specific_class(20)
 class LLTDAttributeQOSCharacteristics(LLTDAttribute):
     name = "LLTD Attribute - QoS Characteristics"
     fields_desc = [
@@ -778,11 +735,7 @@ class LLTDAttributeQOSCharacteristics(LLTDAttribute):
     ]
 
 
-LLTDAttributeQOSCharacteristics = _register_lltd_specific_class(20)(
-    LLTDAttributeQOSCharacteristics
-)
-
-
+@_register_lltd_specific_class(21)
 class LLTDAttribute80211PhysicalMedium(LLTDAttribute):
     name = "LLTD Attribute - 802.11 Physical Medium"
     fields_desc = [
@@ -799,22 +752,13 @@ class LLTDAttribute80211PhysicalMedium(LLTDAttribute):
     ]
 
 
-LLTDAttribute80211PhysicalMedium = _register_lltd_specific_class(21)(
-    LLTDAttribute80211PhysicalMedium
-)
-
-
+@_register_lltd_specific_class(25)
 class LLTDAttributeSeesList(LLTDAttribute):
     name = "LLTD Attribute - Sees List Working Set"
     fields_desc = [
         ByteField("len", 2),
         ShortField("max_entries", 0),
     ]
-
-
-LLTDAttributeSeesList = _register_lltd_specific_class(25)(
-    LLTDAttributeSeesList
-)
 
 
 bind_layers(Ether, LLTD, type=0x88d9)
@@ -890,5 +834,5 @@ class LargeTlvBuilder(object):
         fetched, also as a string.
 
         """
-        return dict((key, "".join(chr(byte) for byte in data))
-                    for key, data in self.data.iteritems())
+        return {key: "".join(chr(byte) for byte in data)
+                for key, data in self.data.iteritems()}

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -7,7 +7,6 @@
 Main module for interactive startup.
 """
 
-from __future__ import generators
 import os,sys
 import glob
 import types

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -309,8 +309,8 @@ class Packet(BasePacket):
     def copy_fields_dict(self, fields):
         if fields is None:
             return None
-        return dict([fname, self.copy_field_value(fname, fval)]
-                    for fname, fval in fields.iteritems())
+        return {fname: self.copy_field_value(fname, fval)
+                for fname, fval in fields.iteritems()}
     def self_build(self, field_pos_list=None):
         if self.raw_packet_cache is not None:
             for fname, fval in self.raw_packet_cache_fields.iteritems():

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -5,8 +5,6 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-from __future__ import with_statement
-
 import os,thread,select
 import subprocess
 import itertools

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -47,7 +47,7 @@ class PacketList(BasePacketList):
     def _elt2show(self, elt):
         return self._elt2sum(elt)
     def __repr__(self):
-        stats = dict((x, 0) for x in self.stats)
+        stats = {x: 0 for x in self.stats}
         other = 0
         for r in self.res:
             f = 0

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -82,12 +82,12 @@ vzM985aHXOHAxQN2UQZbQkUv3D4Vc+lyvalAffv3Tyg4ks3a22kPXiyeCGweviNX
 0K8TKasyOhGsVamTUAZBXfQVw1zmdS4rHDnbHgtIjX3DcCt6UIr0BHTYjdV0JbPj
 r1APYgXihjQwM2M83AKIhwQQJv/F3JFOFCQNsEI0QA==""")
     def get_local_dict(cls):
-        return dict((x, y.name) for (x, y) in cls.__dict__.iteritems()
-                    if isinstance(y, File))
+        return {x: y.name for (x, y) in cls.__dict__.iteritems()
+                if isinstance(y, File)}
     get_local_dict = classmethod(get_local_dict)
     def get_URL_dict(cls):
-        return dict((x, y.URL) for (x, y) in cls.__dict__.iteritems()
-                    if isinstance(y, File))
+        return {x: y.URL for (x, y) in cls.__dict__.iteritems()
+                if isinstance(y, File)}
     get_URL_dict = classmethod(get_URL_dict)
 
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -7,7 +7,6 @@
 General utility functions.
 """
 
-from __future__ import with_statement
 import os,sys,socket,types
 import random,time
 import gzip,zlib,cPickle
@@ -422,20 +421,8 @@ def incremental_label(label="tag%05i", start=0):
         yield label % start
         start += 1
 
-
-# Python <= 2.5 do not provide bin() built-in function
-try:
-    bin(0)
-except NameError:
-    def _binrepr(val):
-        while val:
-            yield val & 1
-            val >>= 1
-
-    binrepr = lambda val: "".join(reversed([str(bit) for bit in
-                                            _binrepr(val)])) or "0"
-else:
-    binrepr = lambda val: bin(val)[2:]
+def binrepr(val):
+    return bin(val)[2:]
 
 def long_converter(s):
     return long(s.replace('\n', '').replace(' ', ''), 16)

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ setup(
         "Intended Audience :: Telecommunications Industry",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.5",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Topic :: Security",
         "Topic :: System :: Networking",


### PR DESCRIPTION
- update (part of) the documentation
  - some URLs for Windows need to be updated
- update classifiers in setup.py
- remove `from __future__ import with_statement`
- use `{k: v for ...}` instead of `dict((k, v) for ...)`
- remove hacks for `gcd()` and `binrepr()` implementations
- use class decorators
- remove Python 2.6 Travis-CI tests (which would fail, now)