### PR TITLE
setup.py: ensure __import__('scapy').VERSION uses the current directory

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -71,6 +71,18 @@ def _version():
                 tag = f.read()
             return tag
         except:
+            # last attempt, try to use the directory name, if it
+            # matches a Github archive structure
+            #
+            # NB: this might result in messages such as "Welcome to
+            # Scapy (master)", but that's still better than "Welcome
+            # to Scapy (unknown.version)" as this will tell us it
+            # comes from a Github archive
+            dirname = os.path.basename(os.path.dirname(os.path.abspath(
+                _SCAPY_PKG_DIR
+            )))
+            if dirname.startswith('scapy-'):
+                return dirname[6:]
             return 'unknown.version'
 
 VERSION = _version()

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from distutils import sysconfig
 from distutils.core import setup
 from distutils.command.sdist import sdist
 import os
+import sys
 
 
 EZIP_HEADER = """#! /bin/sh
@@ -44,6 +45,8 @@ SCRIPTS = ['bin/scapy', 'bin/UTscapy']
 # On Windows we also need additional batch files to run the above scripts
 if os.name == "nt":
     SCRIPTS += ['bin/scapy.bat', 'bin/UTscapy.bat']
+
+sys.path.append(os.path.dirname(sys.argv[0]) or '.')
 
 setup(
     name='scapy',


### PR DESCRIPTION
Unrelated to #321 (won't fix it). But I'm not sure whether this could be useful or not. @guedou @robin-jarry what do you think?