### PR TITLE
Fixed the invalid copy_flag in some ip options

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -124,10 +124,9 @@ class IPOption_Security(IPOption):
                     StrFixedLenField("transmission_control_code","xxx",3),
                     ]
     
-class IPOption_LSRR(IPOption):
-    name = "IP Option Loose Source and Record Route"
-    copy_flag = 1
-    option = 3
+class IPOption_RR(IPOption):
+    name = "IP Option Record Route"
+    option = 7
     fields_desc = [ _IPOption_HDR,
                     FieldLenField("length", None, fmt="B",
                                   length_of="routers", adjust=lambda pkt,l:l+3),
@@ -138,16 +137,19 @@ class IPOption_LSRR(IPOption):
     def get_current_router(self):
         return self.routers[self.pointer/4-1]
 
-class IPOption_RR(IPOption_LSRR):
-    name = "IP Option Record Route"
-    option = 7
+class IPOption_LSRR(IPOption_RR):
+    name = "IP Option Loose Source and Record Route"
+    copy_flag = 1
+    option = 3
 
-class IPOption_SSRR(IPOption_LSRR):
+class IPOption_SSRR(IPOption_RR):
     name = "IP Option Strict Source and Record Route"
+    copy_flag = 1
     option = 9
 
 class IPOption_Stream_Id(IPOption):
     name = "IP Option Stream ID"
+    copy_flag = 1
     option = 8
     fields_desc = [ _IPOption_HDR,
                     ByteField("length", 4),
@@ -166,7 +168,6 @@ class IPOption_MTU_Reply(IPOption_MTU_Probe):
 
 class IPOption_Traceroute(IPOption):
     name = "IP Option Traceroute"
-    copy_flag = 1
     option = 18
     fields_desc = [ _IPOption_HDR,
                     ByteField("length", 12),

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4486,15 +4486,15 @@ assert bpkt.chksum == 0x7cc3 and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(options=[IPOption_RR()]) / TCP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bb and bpkt.payload.chksum == 0x4b2c
+assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=54, options=[IPOption_RR()]) / TCP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bb and bpkt.payload.chksum == 0x4b2c
+assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=54, ihl=6, options=[IPOption_RR()]) / TCP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bb and bpkt.payload.chksum == 0x4b2c
+assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP() / UDP()
 bpkt = IP(str(pkt))
@@ -4522,15 +4522,15 @@ assert bpkt.chksum == 0x7cc4 and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(options=[IPOption_RR()]) / UDP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bc and bpkt.payload.chksum == 0xbb17
+assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=42, options=[IPOption_RR()]) / UDP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bc and bpkt.payload.chksum == 0xbb17
+assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=42, ihl=6, options=[IPOption_RR()]) / UDP() / ("A" * 10)
 bpkt = IP(str(pkt))
-assert bpkt.chksum == 0xf0bc and bpkt.payload.chksum == 0xbb17
+assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 = Layer binding
 


### PR DESCRIPTION
Port of the patch by Yitai Schwartz from [https://bitbucket.org/secdev/scapy/pull-requests/62/](https://bitbucket.org/secdev/scapy/pull-requests/62/)