### PR TITLE
Travis CI: fix install & tests

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,7 +1,11 @@
 # Install dependencies using pip
-if [ -z $TRAVIS_SUDO ] && [ "$TRAVIS_OS_NAME" = "osx" ]
-then 
-  PIP_INSTALL_FLAGS="--user"
+if [ -z "$TRAVIS_SUDO" -o "$TRAVIS_SUDO" = "false" ]
+then
+  TRAVIS_SUDO=""
+  if [ "$TRAVIS_OS_NAME" = "osx" ]
+  then
+    PIP_INSTALL_FLAGS="--user"
+  fi
 fi
 $TRAVIS_SUDO pip install $PIP_INSTALL_FLAGS ecdsa mock
 

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,10 +1,11 @@
 # Dump Scapy config
 python -c "from scapy.all import *; print conf"
 
-# Don't run tests that requires root privileges
-if [ -z $TRAVIS_SUDO ]
+# Don't run tests that require root privileges
+if [ -z "$TRAVIS_SUDO" -o "$TRAVIS_SUDO" = "false" ]
 then
   UT_FLAGS="-K netaccess "
+  TRAVIS_SUDO=""
 fi
 
 # Test AEAD modes in IPSec if available


### PR DESCRIPTION
For some reason, `TRAVIS_SUDO` gets set to `"false"`, instead of `""`, which was breaking "regular" (i.e., Linux, non-root) tests.