### PR TITLE
OS X Travis tests fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - os: osx
           language: generic
           env:
+            - TRAVIS_SUDO=false
             - SCAPY_USE_PCAPDNET=yes
 
         # Run as root

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,3 +1,7 @@
+# Dump environment variables
+echo "TRAVIS_SUDO=" $TRAVIS_SUDO
+echo "TRAVIS_OS_NAME=" $TRAVIS_OS_NAME
+
 # Dump Scapy config
 python -c "from scapy.all import *; print conf"
 


### PR DESCRIPTION
It seems that Travis OS X tests as a regular user were broken as `TRAVIS_SUDO` became a real Travis environment variable.

`TRAVIS_SUDO` is always set to true on OS X. Hence all tests were replaced by `true ./run_tests [..]` and were all succeeding real fast =)