### PR TITLE
UDP checksum computation fixed

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -557,7 +557,10 @@ class UDP(Packet):
                                      inet_aton(self.underlayer.dst),
                                      self.underlayer.proto,
                                      ln)
-                ck=checksum(psdhdr+p)
+                ck = checksum(psdhdr+p)
+                # According to RFC768 if the result checksum is 0, it should be set to 0xFFFF
+                if ck == 0:
+                    ck = 0xFFFF
                 p = p[:6]+struct.pack("!H", ck)+p[8:]
             elif isinstance(self.underlayer, scapy.layers.inet6.IPv6) or isinstance(self.underlayer, scapy.layers.inet6._IPv6ExtHdr):
                 ck = scapy.layers.inet6.in6_chksum(socket.IPPROTO_UDP, self.underlayer, p)


### PR DESCRIPTION
Here is a fix for Issue #350 

Before the patch:
```
>>> IP(str(IP()/UDP()/Raw("\xff\xff\x01\x6a")))[UDP].chksum
0
```

After the patch:
```
>>> IP(str(IP()/UDP()/Raw("\xff\xff\x01\x6a")))[UDP].chksum
65535
```
