### PR TITLE
fix version when installing from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scapy/__init__.py	export-subst

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -71,7 +71,17 @@ def _version():
                 tag = f.read()
             return tag
         except:
-            return 'unknown.version'
+            # Rely on git archive "export-subst" git attribute.
+            # See 'man gitattributes' for more details.
+            git_archive_id = '$Format:%h %d$'
+            sha1 = git_archive_id.strip().split()[0]
+            match = re.search(r'tag:(\S+)', git_archive_id)
+            if match:
+                return match.group(1)
+            elif sha1:
+                return sha1
+            else:
+                return 'unknown.version'
 
 VERSION = _version()
 


### PR DESCRIPTION
When installing from a git archive downloaded from github, the file `scapy/VERSION` is not present since it is generated when building a source archive with:

```
./setup.py sdist
```

To work around the problem, use the `export-subst` git attribute to make git archive write the current revison information in `scapy/__init__.py`.

> From: https://git-scm.com/docs/gitattributes
> 
> `export-subst`
> 
> If the attribute `export-subst` is set for a file then Git will expand several placeholders when adding this file to an archive. The expansion depends on the availability of a commit ID, i.e., if [git-archive[1]](https://git-scm.com/docs/git-archive) has been given a tree instead of a commit or a tag then no replacement will be done. The placeholders are the same as those for the option `--pretty=format:` of [git-log[1]](https://git-scm.com/docs/git-log), except that they need to be wrapped like this: `$Format:PLACEHOLDERS$` in the file. E.g. the string `$Format:%H$` will be replaced by the commit hash.

Fixes #321, see #326 for reference.