### PR TITLE
Use special code path for OpenBSD in sndrcv.

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -11,7 +11,7 @@ import errno
 import cPickle,os,sys,time,subprocess
 import itertools
 from select import select
-from scapy.arch.consts import DARWIN, FREEBSD
+from scapy.arch.consts import DARWIN, FREEBSD, OPENBSD
 from scapy.data import *
 from scapy.config import conf
 from scapy.packet import Gen
@@ -132,7 +132,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                                 inp = bpf_select(inmask)
                                 if pks in inp:
                                     r = pks.recv()
-                            elif not isinstance(pks, StreamSocket) and (FREEBSD or DARWIN):
+                            elif not isinstance(pks, StreamSocket) and (FREEBSD or DARWIN or OPENBSD):
                                 inp, out, err = select(inmask,[],[], 0.05)
                                 if len(inp) == 0 or pks in inp:
                                     r = pks.nonblock_recv()


### PR DESCRIPTION
On OpenBSD use the non-blocking recv() after select() in sndrcv().
That was already done for FreeBSD and Darwin.  This fixes sniffing
on real hardware with libdnet backend.

I have found this on scapy 2.3.3 without bpf implemention.  But
when I enable dnet with SCAPY_USE_PCAPDNET=y this is still relevant.
