### PR TITLE
[bug] fix issue with python-pcapy interface next() function 

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -390,6 +390,8 @@ if conf.use_pcap:
                         return None
                     else:
                         h,p = c
+                        if h is None:
+                            return
                         s,us = h.getts()
                         return (s+0.000001*us), p
                 def fileno(self):


### PR DESCRIPTION
python-pcapy interface next() function did not properly catch an edge case in which the incoming packet did not exist or the packet capture stream has ended.

For a fix, I added an if statement on the packet header variable to check if the packet exists. If the packet doesn't exist, the function returns nothing, otherwise it errors out on h.getts() method since h is None which was the original issue.