### PR TITLE
Add conf.checkIPinIP

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -301,6 +301,8 @@ checkIPID: if 0, doesn't check that IPID matches between IP sent and ICMP IP cit
            if 1, checks that they either are equal or byte swapped equals (bug in some IP stacks)
            if 2, strictly checks that they are equals
 checkIPsrc: if 1, checks IP src in IP and ICMP IP citation match (bug in some NAT stacks)
+checkIPinIP: if True, checks that IP-in-IP layers match. If False, do not
+             check IP layers that encapsulates another IP layer
 check_TCPerror_seqack: if 1, also check that TCP seq and ack match the ones in ICMP citation
 iff      : selects the default output interface for srp() and sendp(). default:"eth0")
 verb     : level of verbosity, from 0 (almost mute) to 3 (verbose)
@@ -334,6 +336,7 @@ contribs: a dict which can be used by contrib layers to store local configuratio
     checkIPID = 0
     checkIPsrc = 1
     checkIPaddr = 1
+    checkIPinIP = True
     check_TCPerror_seqack = 0
     verb = 2
     prompt = ">>> "

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -401,6 +401,8 @@ class IP(Packet, IPTools):
              and (isinstance(self.payload, ICMP))
              and (self.payload.type in [3,4,5,11,12]) ):
             return self.payload.payload.hashret()
+        elif not conf.checkIPinIP and self.proto == 4:  # IPIP
+            return self.payload.hashret()
         else:
             if self.dst == "224.0.0.251":  # mDNS
                 return struct.pack("B", self.proto) + self.payload.hashret()
@@ -411,6 +413,11 @@ class IP(Packet, IPTools):
     def answers(self, other):
         if not isinstance(other,IP):
             return 0
+        elif not conf.checkIPinIP:  # IPIP
+            if self.proto == 4:
+                return self.payload.answers(other)
+            if other.proto == 4:
+                return self.answers(other.payload)
         if conf.checkIPaddr:
             if other.dst == "224.0.0.251" and self.dst == "224.0.0.251":  # mDNS
                 return self.payload.answers(other.payload)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -401,7 +401,7 @@ class IP(Packet, IPTools):
              and (isinstance(self.payload, ICMP))
              and (self.payload.type in [3,4,5,11,12]) ):
             return self.payload.payload.hashret()
-        elif not conf.checkIPinIP and self.proto == 4:  # IPIP
+        elif not conf.checkIPinIP and self.proto in [4, 41]:  # IP, IPv6
             return self.payload.hashret()
         else:
             if self.dst == "224.0.0.251":  # mDNS
@@ -413,10 +413,10 @@ class IP(Packet, IPTools):
     def answers(self, other):
         if not isinstance(other,IP):
             return 0
-        elif not conf.checkIPinIP:  # IPIP
-            if self.proto == 4:
+        elif not conf.checkIPinIP:  # skip IP in IP and IPv6 in IP
+            if self.proto in [4, 41]:
                 return self.payload.answers(other)
-            if other.proto == 4:
+            if other.proto in [4, 41]:
                 return self.answers(other.payload)
         if conf.checkIPaddr:
             if other.dst == "224.0.0.251" and self.dst == "224.0.0.251":  # mDNS

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -401,23 +401,26 @@ class IP(Packet, IPTools):
              and (isinstance(self.payload, ICMP))
              and (self.payload.type in [3,4,5,11,12]) ):
             return self.payload.payload.hashret()
-        elif not conf.checkIPinIP and self.proto in [4, 41]:  # IP, IPv6
+        if not conf.checkIPinIP and self.proto in [4, 41]:  # IP, IPv6
             return self.payload.hashret()
-        else:
-            if self.dst == "224.0.0.251":  # mDNS
-                return struct.pack("B", self.proto) + self.payload.hashret()
-            if conf.checkIPsrc and conf.checkIPaddr:
-                return strxor(inet_aton(self.src),inet_aton(self.dst))+struct.pack("B",self.proto)+self.payload.hashret()
-            else:
-                return struct.pack("B", self.proto)+self.payload.hashret()
+        if self.dst == "224.0.0.251":  # mDNS
+            return struct.pack("B", self.proto) + self.payload.hashret()
+        if conf.checkIPsrc and conf.checkIPaddr:
+            return (strxor(inet_aton(self.src), inet_aton(self.dst))
+                    + struct.pack("B",self.proto) + self.payload.hashret())
+        return struct.pack("B", self.proto) + self.payload.hashret()
     def answers(self, other):
-        if not isinstance(other,IP):
-            return 0
-        elif not conf.checkIPinIP:  # skip IP in IP and IPv6 in IP
+        if not conf.checkIPinIP:  # skip IP in IP and IPv6 in IP
             if self.proto in [4, 41]:
                 return self.payload.answers(other)
-            if other.proto in [4, 41]:
+            if isinstance(other, IP) and other.proto in [4, 41]:
                 return self.answers(other.payload)
+            if conf.ipv6_enabled \
+               and isinstance(other, scapy.layers.inet6.IPv6) \
+               and other.nh in [4, 41]:
+                return self.answers(other.payload)                
+        if not isinstance(other,IP):
+            return 0
         if conf.checkIPaddr:
             if other.dst == "224.0.0.251" and self.dst == "224.0.0.251":  # mDNS
                 return self.payload.answers(other.payload)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -456,13 +456,15 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             return struct.pack("B", nh)+self.payload.hashret()
 
     def answers(self, other):
-        if not isinstance(other, IPv6): # self is reply, other is request
-            return False
         if not conf.checkIPinIP:  # skip IP in IP and IPv6 in IP
             if self.nh in [4, 41]:
                 return self.payload.answers(other)
-            if other.nh in [4, 41]:
+            if isinstance(other, IPv6) and other.nh in [4, 41]:
                 return self.answers(other.payload)
+            if isinstance(other, IP) and other.proto in [4, 41]:
+                return self.answers(other.payload)
+        if not isinstance(other, IPv6): # self is reply, other is request
+            return False
         if conf.checkIPaddr: 
             ss = inet_pton(socket.AF_INET6, self.src)
             sd = inet_pton(socket.AF_INET6, self.dst)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -156,6 +156,26 @@ t=Ether()/IP()/TCP()
 x==y, x==z, x==t, y==z, y==t, z==t, w==x
 _ == (False, False, False, False, False, False, True)
 
+= answers
+~ basic
+a1, a2 = "1.2.3.4", "5.6.7.8"
+p1 = IP(src=a1, dst=a2)/ICMP(type=8)
+p2 = IP(src=a2, dst=a1)/ICMP(type=0)
+assert p1.hashret() == p2.hashret()
+assert not p1.answers(p2)
+assert p2.answers(p1)
+conf_back = conf.checkIPinIP
+conf.checkIPinIP = True
+px = [IP()/p1, IPv6()/p1]
+assert not any(p.hashret() == p2.hashret() for p in px)
+assert not any(p.answers(p2) for p in px)
+assert not any(p2.answers(p) for p in px)
+conf.checkIPinIP = False
+assert all(p.hashret() == p2.hashret() for p in px)
+assert not any(p.answers(p2) for p in px)
+assert all(p2.answers(p) for p in px)
+conf.checkIPinIP = conf_back
+
 
 ############
 ############


### PR DESCRIPTION
This setting, when set to False, will exclude IP layers which encapsulate
another IP layer from the checks to tell if a packet is an answer to
another one.

Fixes #383