### PR TITLE
AppVeyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+environment:
+
+  # Python versions that will be tested
+  # Note: it defines variables that can be used later
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+# There is no build phase for Scapy
+build: off
+
+install:
+  # Installing WinPcap directly does not work,
+  # see http://help.appveyor.com/discussions/problems/2280-winpcap-installation-issue
+  - choco install -y nmap
+  - refreshenv
+
+  # Install Python modules
+  - "%PYTHON%\\python -m pip install ecdsa pycrypto"
+
+test_script:
+  # Set environment variables
+  - set PYTHONPATH=%APPVEYOR_BUILD_FOLDER%
+  - set PATH=%APPVEYOR_BUILD_FOLDER%;C:\Windows\System32\Npcap\;%PATH%
+  
+  # Main unit tests
+  - "%PYTHON%\\python bin\\UTscapy -f text -t test\\regression.uts -F -K automaton -K mock_read_routes6_bsd || exit /b 42"
+  - 'del test\regression.uts'
+
+  # Secondary unit tests
+  - 'del test\bpf.uts' # Don't bother with BPF regression tests
+  - "for %%t in (test\\*.uts) do (%PYTHON%\\python bin\\UTscapy -f text -t %%t -F -K combined_modes || exit /b 42)"
+  
+  # Contrib unit tests
+  - "for %%t in (scapy\\contrib\\*.uts) do (%PYTHON%\\python bin\\UTscapy -f text -t %%t -F -P \"load_contrib(\'%%~nt\')\"  || exit /b 42)"

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -85,7 +85,7 @@ if conf.use_winpcapy:
     try:
       p = devs
       while p:
-        if p.contents.name.endswith(iff):
+        if p.contents.name.endswith(iff.guid):
           a = p.contents.addresses
           while a:
             if a.contents.addr.contents.sa_family == socket.AF_INET:

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -87,9 +87,15 @@ def inet_ntop(af, addr):
                 hexstr = hex(value)[2:]
             except TypeError:
                 raise Exception("Illegal syntax for IP address")
-            parts.append(hexstr.lower())
-
-        # Note: the returned address is never compact
-        return ":".join(parts)
+            parts.append(hexstr.lstrip("0").lower())
+        result = ":".join(parts)
+        while ":::" in result:
+            result = result.replace(":::", "::")
+        # Leaving out leading and trailing zeros is only allowed with ::
+        if result.endswith(":") and not result.endswith("::"):
+            result = result + "0"
+        if result.startswith(":") and not result.startswith("::"):
+            result = "0" + result
+        return result
     else:
         raise Exception("Address family not supported yet")   

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -9,6 +9,7 @@ Unit testing infrastructure for Scapy
 
 import sys,getopt,imp
 import bz2, base64, os.path, time, traceback, zlib, sha
+from scapy.arch.consts import WINDOWS
 
 
 #### Import tool ####
@@ -293,6 +294,10 @@ def remove_empty_testsets(test_campaign):
 #### RUN CAMPAIGN #####
 
 def run_campaign(test_campaign, get_interactive_session, verb=2):
+    if WINDOWS:
+        # Add a route to 127.0.0.1
+        from scapy.arch.windows import route_add_loopback
+        route_add_loopback()
     passed=failed=0
     if test_campaign.preexec:
         test_campaign.preexec_output = get_interactive_session(test_campaign.preexec.strip())[0]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4562,6 +4562,7 @@ assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)
 + Mocked read_routes() calls
 
 = Truncated netstat -rn output on OS X
+~ mock_read_routes6_bsd
 
 import mock
 import StringIO
@@ -4618,6 +4619,7 @@ test_osx_netstat_truncated()
 + Mocked read_routes6() calls
 
 = Preliminary definitions
+~ mock_read_routes6_bsd
 
 import mock
 import StringIO
@@ -4647,6 +4649,7 @@ def check_mandatory_ipv6_routes(routes6):
 
 
 = Mac OS X 10.9.5
+~ mock_read_routes6_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -4687,6 +4690,7 @@ test_osx_10_9_5()
 
 
 = Mac OS X 10.9.5 with global IPv6 connectivity
+~ mock_read_routes6_bsd
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
 def test_osx_10_9_5_global(mock_os, mock_in6_getifaddr):
@@ -4734,6 +4738,7 @@ test_osx_10_9_5_global()
 
 
 = Mac OS X 10.10.4
+~ mock_read_routes6_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -4773,6 +4778,7 @@ test_osx_10_10_4()
 
 
 = FreeBSD 10.2
+~ mock_read_routes6_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -4811,6 +4817,7 @@ test_freebsd_10_2()
 
 
 = OpenBSD 5.5
+~ mock_read_routes6_bsd
 
 @mock.patch("scapy.arch.unix.OPENBSD")
 @mock.patch("scapy.arch.unix.in6_getifaddr")
@@ -4868,6 +4875,7 @@ test_openbsd_5_5()
 
 
 = NetBSD 7.0
+~ mock_read_routes6_bsd
 
 @mock.patch("scapy.arch.unix.NETBSD")
 @mock.patch("scapy.arch.unix.in6_getifaddr")


### PR DESCRIPTION
Here is an attempt to add Windows Continuous Integration to Scapy using AppVeyor. The patch is pretty _wide_ and does not only contain an `appveyor.yml` file. We might want to reject this PR and split it into smaller ones.

Some notes about this PR:
- [it works](https://ci.appveyor.com/project/guedou/scapy-appveyor) and does not break Travis
- the `get_if_raw_addr()` API on Windows was changed to accept `conf.iface` directly
- `route_add_loopback()` was added as a trick to be able to use 127.0.0.1 as the source address on Windows. Otherwise most of unit tests fails as the real IP address is selected
- code removed by PR#363 was partially added: there is no inet_ntop/inet_pton on Windows and they must be emulated
- automaton are broken on Windows. The corresponding tests were disabled

How does this look ?