### PR TITLE
[Windows/Networking] Support no wpcap.dll

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -40,7 +40,9 @@ if conf.use_winpcapy:
 
   except OSError as e:
     if conf.interactive:
-      log_loading.error("Unable to import libpcap library: %s" % e)
+      log_loading.warning("wpcap.dll is not installed. You won't be able to send/recieve packets. Visit the scapy's doc to install it")
+      def winpcapy_get_if_list():
+          return []
       conf.use_winpcapy = False
     else:
       raise
@@ -99,7 +101,8 @@ if conf.use_winpcapy:
       return ret
     finally:
       pcap_freealldevs(devs)
-  get_if_list = winpcapy_get_if_list
+  if(conf.use_winpcapy):
+      get_if_list = winpcapy_get_if_list
   def in6_getifaddr():
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
@@ -320,10 +323,7 @@ if conf.use_winpcapy:
   conf.L2socket=L2pcapSocket
   conf.L3socket=L3pcapSocket
     
-if conf.use_pcap:    
-
-
-
+if conf.use_pcap:
     try:
         import pcap
     except ImportError,e:

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -39,13 +39,11 @@ if conf.use_winpcapy:
         pcap_freealldevs(devs)
 
   except OSError as e:
+    def winpcapy_get_if_list():
+        return []
+    conf.use_winpcapy = False
     if conf.interactive:
       log_loading.warning("wpcap.dll is not installed. You won't be able to send/recieve packets. Visit the scapy's doc to install it")
-      def winpcapy_get_if_list():
-          return []
-      conf.use_winpcapy = False
-    else:
-      raise
 
   # From BSD net/bpf.h
   #BIOCIMMEDIATE=0x80044270
@@ -101,7 +99,7 @@ if conf.use_winpcapy:
       return ret
     finally:
       pcap_freealldevs(devs)
-  if(conf.use_winpcapy):
+  if conf.use_winpcapy:
       get_if_list = winpcapy_get_if_list
   def in6_getifaddr():
     err = create_string_buffer(PCAP_ERRBUF_SIZE)

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -248,3 +248,7 @@ L2socket: use the provided L2socket
 
 import scapy.sendrecv
 scapy.sendrecv.sniff = sniff
+
+# If wpcap.dll is not available
+if (not conf.use_winpcapy) and (not conf.use_pcap) and (not conf.use_dnet):
+    from scapy.arch.windows.disable_sendrecv import *

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -250,5 +250,5 @@ import scapy.sendrecv
 scapy.sendrecv.sniff = sniff
 
 # If wpcap.dll is not available
-if (not conf.use_winpcapy) and (not conf.use_pcap) and (not conf.use_dnet):
+if not (conf.use_winpcapy or conf.use_pcap or conf.use_dnet):
     from scapy.arch.windows.disable_sendrecv import *

--- a/scapy/arch/windows/disable_sendrecv.py
+++ b/scapy/arch/windows/disable_sendrecv.py
@@ -1,0 +1,51 @@
+## This file is part of Scapy
+## See http://www.secdev.org/projects/scapy for more informations
+## Copyright (C) Philippe Biondi <phil@secdev.org>
+## This program is published under a GPLv2 license
+
+"""
+When wpcap.dll is not available, replace all sendrecv functions that won't work.
+"""
+
+from scapy.error import log_runtime
+import scapy.sendrecv as sendrecv
+import scapy.config as conf
+from scapy.supersocket import SuperSocket
+
+def not_available(*args, **kwargs):
+    log_runtime.warning("Function not available")
+    return None
+
+class not_available_socket(SuperSocket):
+    desc = "wpcap.dll missing"
+    def __init__(self, type=None, promisc=None, filter=None, iface=None, nofilter=0):
+        log_runtime.warning("Function not available")
+        return
+    def send(self, x):
+        return
+    def recv(self,x=None):
+        return
+    def nonblock_recv(self):
+        return
+    def close(self):
+        return
+    
+
+sendrecv.send = not_available
+sendrecv.sendp = not_available
+sendrecv.sendpfast = not_available
+sendrecv.sr = not_available
+sendrecv.sr1 = not_available
+sendrecv.srflood = not_available
+sendrecv.srloop = not_available
+sendrecv.srp = not_available
+sendrecv.srp1 = not_available
+sendrecv.srpflood = not_available
+sendrecv.srploop = not_available
+sendrecv.sniff = not_available
+sendrecv.sndrcv = not_available
+sendrecv.sndrcvflood = not_available
+sendrecv.tshark = not_available
+
+conf.L3socket=not_available_socket
+conf.L2socket=not_available_socket


### PR DESCRIPTION
As said in https://github.com/secdev/scapy/pull/398
This part only:
- Avoid Scapy from crashing when wpcap.dll is missing
- Disable the main functions