### PR TITLE
Preserve .overloaded_fields in .clone_with()

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -656,6 +656,7 @@ Creates an EPS file describing a packet. If filename is not provided a temporary
         pkt.explicit = 1
         pkt.fields = kargs
         pkt.default_fields = self.copy_fields_dict(self.default_fields)
+        pkt.overloaded_fields = self.overloaded_fields.copy()
         pkt.time = self.time
         pkt.underlayer = self.underlayer
         pkt.post_transforms = self.post_transforms

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4781,6 +4781,12 @@ assert frags[-1].flags == 0
 assert all(len(p.payload) == 8 for p in frags[:-1])
 assert len(frags[-1].payload) == ((payloadlen % fragsize) or fragsize)
 
+= fragment() and overloaded_fields
+pkt1 = Ether() / IP() / UDP()
+pkt2 = fragment(pkt1)[0]
+pkt3 = pkt2.__class__(str(pkt2))
+assert pkt1[IP].proto == pkt2[IP].proto == pkt3[IP].proto
+
 = defragment()
 defrags = defragment(frags)
 * we should have one single packet


### PR DESCRIPTION
This fixes at least #415 (for which a new test has been added)