### PR TITLE
Fix import errors in windows

### DIFF
--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -20,7 +20,9 @@ from scapy.config import conf,ConfClass
 from scapy.base_classes import Gen, SetGen
 import scapy.plist as plist
 from scapy.utils import PcapReader
-from scapy.data import MTU, ETH_P_ARP
+from scapy.arch.pcapdnet import PcapTimeoutElapsed
+from scapy.error import log_runtime
+from scapy.data import MTU, ETH_P_ARP,ETH_P_ALL
 
 WINDOWS = True
 


### PR DESCRIPTION
`log_runtime`, `ETH_P_ALL` and `PcapTimeoutElapsed` are used in this code but are not imported. This causes sniff and sndrcv functions to fail on windows.
It seems in #322 there was an attempted to take only the import fixes from #313 but it missed this 3 imports.