### PR TITLE
[Windows]v ix misplaced quotes

### DIFF
--- a/test/run_tests.bat
+++ b/test/run_tests.bat
@@ -3,7 +3,7 @@ set MYDIR=%cd%\..
 set PYTHONPATH=%MYDIR%
 if [%1]==[] (
   SET date=%DATE%
-  python "%MYDIR%\scapy\tools\UTscapy.py -t regression.uts -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html"
+  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
-  python "%MYDIR%\scapy\tools\UTscapy.py %@"
+  python "%MYDIR%\scapy\tools\UTscapy.py" %@
 )


### PR DESCRIPTION
I had not tested it last time... 
When running  `python`, the first parameter is the file. So here all the arguments were passed as the file name...