### PR TITLE
Fix issue #408 : complex ASN1 fields randval()

### DIFF
--- a/test/x509.uts
+++ b/test/x509.uts
@@ -190,3 +190,17 @@ s = str(X509_CRL())
 str(X509_CRL(s)) == s
 
 
+############ Randval tests ###############################################
+
+= Randval tests : ASN1F_SEQUENCE_OF
+random.seed(42)
+r = ASN1F_SEQUENCE_OF("test", [], ASN1P_INTEGER).randval().number
+assert(isinstance(r, RandNum))
+int(r) == -16393048219351680611L
+
+= Randval tests : ASN1F_PACKET
+random.seed(0xcafecafe)
+r = ASN1F_PACKET("otherName", None, X509_OtherName).randval()
+assert(isinstance(r, X509_OtherName))
+str(r.type_id) == '171.184.10.271'
+


### PR DESCRIPTION
This fixes issue #408, fixes a similar issue with `ASN1F_CHOICE`, and provides a randval() method for `ASN1F_PACKET`.