### PR TITLE
[coverage] Add a codecov configuration file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  notify:
+    # Do not send notifications when CI fails
+    require_ci_to_pass: true
+
+comment:
+  # Define codevov comments behavior and content
+  behavior: default
+  layout: header, diff, tree
+  require_changes: false
+
+coverage:
+  # Define coverage range and precision
+  precision: 2
+  range: "70..100"
+  round: down
+  status:
+    # Only consider changes to the whole project
+    project: true
+    patch: false
+    changes: false
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      macro: false
+      method: false
+  javascript:
+    enable_partials: yes


### PR DESCRIPTION
This configuration file aims to specify codecov behaviour for our project. More specifically, it disables the `patch` feature that return false if the PR does not add enough coverage.