### PR TITLE
Fix ls(): fix layer names and handle tuple default values (test added)

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1271,7 +1271,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                                     or pattern.search(layer.name or ''))),
                                 key=lambda x: x.__name__)
         for layer in all_layers:
-            print "%-10s : %s" % (layer.__name__, layer.name)
+            print "%-10s : %s" % (layer.__name__, layer._name)
 
     else:
         is_pkt = isinstance(obj, Packet)
@@ -1321,7 +1321,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                 print "%-10s : %-35s =" % (f.name, class_name),
                 if is_pkt:
                     print "%-15r" % getattr(obj,f.name),
-                print "(%r)" % f.default
+                print "(%r)" % (f.default,)
                 for attr in long_attrs:
                     print "%-15s%s" % ("", attr)
             if is_pkt and not isinstance(obj.payload, NoPayload):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2268,7 +2268,9 @@ ICMPv6NIQueryName(data="169.254.253.252").data == '169.254.253.252'
 + Test Node Information Query - ICMPv6NIQueryIPv6
 
 = ICMPv6NIQueryIPv6 - single label DNS name (internal)
-a=ICMPv6NIQueryIPv6(data="abricot").getfieldval("data")
+a = ICMPv6NIQueryIPv6(data="abricot")
+ls(a)
+a = a.getfieldval("data")
 type(a) is tuple and len(a) == 2 and a[0] == 1 and a[1] == '\x07abricot\x00\x00'
 
 = ICMPv6NIQueryIPv6 - single label DNS name


### PR DESCRIPTION
Current output of `ls()` is bogus, and `ls(ICMPv6NIQueryIPv6)` crashes.