### PR TITLE
[Windows] Tiny fix to show error when interface does not exist

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -363,9 +363,11 @@ def pcapname(dev):
     try:
         return IFACES.dev_from_name(dev).pcap_name
     except ValueError:
-        # pcap.pcap() will choose a sensible default for sniffing if
-        # iface=None
-        return None
+        if conf.use_pcap:
+            # pcap.pcap() will choose a sensible default for sniffing if
+            # iface=None
+            return None
+        raise
 
 def dev_from_pcapname(pcap_name):
     """Return libdnet/Scapy device name for given pypcap device name"""


### PR DESCRIPTION
When the provided interface name is invalid, scapy won't show the error under windows.

This now raise the error correctly, in order to avoid issues like https://github.com/secdev/scapy/issues/436
