### PR TITLE
[Windows/Tiny fix] Removed outdated readfunc function

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -487,7 +487,6 @@ if conf.interactive_shell != 'ipython':
         except (ImportError, AttributeError):
             log_loading.info("Could not get readline console. Will not interpret ANSI color codes.") 
         else:
-            conf.readfunc = readline.rl.readline
             orig_stdout = sys.stdout
             sys.stdout = console
 

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -333,7 +333,6 @@ contribs: a dict which can be used by contrib layers to store local configuratio
     stealth = "not implemented"
     iface = None
     iface6 = None
-    readfunc = None
     layers = LayersList()
     commands = CommandsList()
     logLevel = LogLevel()

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -381,7 +381,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
 
     else:
         code.interact(banner = the_banner % (conf.version),
-                      local=session, readfunc=conf.readfunc)
+                      local=session)
 
     if conf.session:
         save_session(conf.session, session)


### PR DESCRIPTION
The `readfunc` function is useless: the python default one works better than the libreadline one, which is buggy and here is why:

Using the libreadline `readfunc`:
```
>>> def test():
...     print "hello"
>>>     print "world"
  File "<console>", line 1
    print "world"
    ^
IndentationError: unexpected indent
>>>
```

Using the default one:
```
>>> def test():
...     print "hello"
...     print "world"
...
>>>
```

As you can see the ident is not detected properly with libreadline, which makes the user unvailable to copy paste functions inside scapy...