### PR TITLE
layers/inet6/routes: fix ndp resolution without default route

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -106,7 +106,7 @@ def getmacbyip6(ip6, chainCC=0):
         mac = in6_getnsmac(inet_pton(socket.AF_INET6, ip6))
         return mac
 
-    iff,a,nh = conf.route6.route(ip6, dev=conf.iface6)
+    iff,a,nh = conf.route6.route(ip6)
 
     if iff == LOOPBACK_NAME:
         return "ff:ff:ff:ff:ff:ff"


### PR DESCRIPTION
Sending a IPv6 packet without `Ether.dst` mac defined fails when there is not default IPv6 route defined with the following message:

```
WARNING: No route found for IPv6 destination fd00:200::1 (no default route?)
```

Because, when there is no default IPv6 route defined, `conf.iface6` is initialized to the loopback interface and the `conf.route6.route()` method is called with `dev=conf.iface6`.

According to the docstring of `conf.route6.route()`:

```
  if optional 'dev' parameter is provided a specific interface,
  filtering is performed to limit search to route associated to
  that interface.
```

This will result in the system never finding on which interface it should send a NDP packet.

Do not call `conf.route6.route()` with `dev=conf.iface6`.