### PR TITLE
Fix empty LLTDAttribute build & dissect

### DIFF
--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -298,6 +298,8 @@ class LLTDAttribute(Packet):
             cmd = kargs["type"]
             if isinstance(cmd, basestring):
                 cmd = cls.fields_desc[0].s2i[cmd]
+        else:
+            return cls
         return SPECIFIC_CLASSES.get(cmd, cls)
 
 SPECIFIC_CLASSES = {}
@@ -719,7 +721,7 @@ class LLTDAttributeMachineName(LLTDAttribute):
 class LLTDAttributeDeviceUUID(LLTDAttribute):
     name = "LLTD Attribute - Device UUID"
     fields_desc = [
-        FieldLenField("len", None, length_of="value", fmt="B"),
+        FieldLenField("len", None, length_of="uuid", fmt="B"),
         StrLenField("uuid", "\x00" * 16, length_from=lambda pkt: pkt.len),
     ]
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4801,6 +4801,12 @@ assert pkt.src == pkt.real_src
 assert pkt.tos == 0
 assert pkt.function == 0
 
+= Attribute build / dissection
+assert isinstance(LLTDAttribute(), LLTDAttribute)
+assert isinstance(LLTDAttribute(str(LLTDAttribute())), LLTDAttribute)
+assert all(isinstance(LLTDAttribute(type=i), LLTDAttribute) for i in xrange(256))
+assert all(isinstance(LLTDAttribute(str(LLTDAttribute(type=i))), LLTDAttribute) for i in xrange(256))
+
 = Large TLV
 m1, m2, seq = RandMAC()._fix(), RandMAC()._fix(), 123
 preqbase = Ether(src=m1, dst=m2) / LLTD() / \


### PR DESCRIPTION
  - LLTDAttribute() produces a Raw instance (or crashes, when
    conf.debug_dissector is set).
  - str(LLTDAttribute(type=18)) crashes.