### PR TITLE
Fix & improve source fields

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -268,15 +268,15 @@ class SourceIPField(IPField):
             if conf.route is None:
                 # unused import, only to initialize conf.route
                 import scapy.route
-            dst=getattr(pkt,self.dstname)
-            if isinstance(dst,Gen):
-                r = map(conf.route.route, dst)
-                r.sort()
-                if r[0] != r[-1]:
-                    warning("More than one possible route for %s"%repr(dst))
-                iff,x,gw = r[0]
+            dst = ("0.0.0.0" if self.dstname is None else
+                   getattr(pkt, self.dstname))
+            if isinstance(dst, (Gen, list)):
+                r = {conf.route.route(daddr) for daddr in dst}
+                if len(r) > 1:
+                    warning("More than one possible route for %r" % (dst,))
+                x = min(r)[1]
             else:
-                iff,x,gw = conf.route.route(dst)
+                x = conf.route.route(dst)[1]
         return IPField.i2h(self, pkt, x)
 
     

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -247,17 +247,17 @@ class SourceIP6Field(IP6Field):
         return IP6Field.i2m(self, pkt, x)
     def i2h(self, pkt, x):
         if x is None:
-            dst=getattr(pkt,self.dstname)
-            if isinstance(dst,Gen):
-                r = map(conf.route6.route, dst)
-                r.sort()
-                if r[0] == r[-1]:
-                    x=r[0][1]
-                else:
-                    warning("More than one possible route for %s"%repr(dst))
-                    return None
+            if conf.route6 is None:
+                # unused import, only to initialize conf.route6
+                import scapy.route6
+            dst = ("::" if self.dstname is None else getattr(pkt, self.dstname))
+            if isinstance(dst, (Gen, list)):
+                r = {conf.route6.route(daddr) for daddr in dst}
+                if len(r) > 1:
+                    warning("More than one possible route for %r" % (dst,))
+                x = min(r)[1]
             else:
-                iff,x,nh = conf.route6.route(dst)
+                x = conf.route6.route(dst)[1]
         return IP6Field.i2h(self, pkt, x)
 
 class DestIP6Field(IP6Field, DestField):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -186,10 +186,12 @@ class Packet(BasePacket):
             return self.get_field(attr),self.overloaded_fields[attr]
         if attr in self.default_fields:
             return self.get_field(attr),self.default_fields[attr]
-        return self.payload.getfield_and_val(attr)
-    
+
     def __getattr__(self, attr):
-        fld,v = self.getfield_and_val(attr)
+        try:
+            fld, v = self.getfield_and_val(attr)
+        except TypeError:
+            return self.payload.__getattr__(attr)
         if fld is not None:
             return fld.i2h(self, v)
         return v

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -246,6 +246,12 @@ assert( _ == ("ABCD","c0:01:be:ef:ba:be") )
 m.addfield(None, "FOO", "c0:01:be:ef:ba:be")
 assert( _ == "FOO\xc0\x01\xbe\xef\xba\xbe" )
 
+= SourceMACField, ARPSourceMACField
+conf.route.add(net="1.2.3.4/32", dev=conf.iface)
+p = Ether() / ARP(pdst="1.2.3.4")
+assert p.src == p.hwsrc == p[ARP].hwsrc == get_if_hwaddr(conf.iface)
+conf.route.delt(net="1.2.3.4/32")
+
 = IPField class
 ~ core field
 i = IPField("foo", None)


### PR DESCRIPTION
This PR brings a new feature to IP/IPv6 source fields (using `None` as destination means "use the interface that has the default route") and fixes a bug in all the source fields (`packet[layer].field` could return a different value than `packet.field`, an example has been added to the tests).