### PR TITLE
[Installation] Check old ECDSA

### DIFF
--- a/scapy/layers/tls/crypto/curves.py
+++ b/scapy/layers/tls/crypto/curves.py
@@ -12,6 +12,7 @@ Implicit elliptic curves.
 # Note that this module will overwrite curves from python-ecdsa.
 
 import math
+import ecdsa
 from ecdsa.ellipticcurve import CurveFp, Point
 from ecdsa.curves import Curve
 from ecdsa.numbertheory import square_root_mod_prime
@@ -19,6 +20,17 @@ from ecdsa.numbertheory import square_root_mod_prime
 from scapy.utils import long_converter, binrepr
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 
+##############################################################
+# Version check
+##############################################################
+
+# Check if ECDSA is not too old (minimum is 0.13)
+
+try:
+    if float(ecdsa.__version__) < 0.13:
+        raise RuntimeError("Python-ECDSA is too old, please download the latest version with pip")
+except ValueError:
+    pass
 
 ##############################################################
 # Some helpers


### PR DESCRIPTION
The ubuntu ecdsa package is too old to work with scapy, so if you have installed ecdsa with:
`sudo apt-get install python-ecdsa`
Then there will be:
`WARNING: can't import layer tls: __init__() takes exactly 5 arguments (6 given)`

I don't find this explicit enough, so I've added a tiny test to check if the function is useable...