### PR TITLE
Enhance and fix ls()

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1320,7 +1320,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                                                    else "")
                 print "%-10s : %-35s =" % (f.name, class_name),
                 if is_pkt:
-                    print "%-15r" % getattr(obj,f.name),
+                    print "%-15r" % (getattr(obj, f.name),),
                 print "(%r)" % (f.default,)
                 for attr in long_attrs:
                     print "%-15s%s" % ("", attr)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1309,10 +1309,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                             )
                 elif verbose and isinstance(cur_fld, FlagsField):
                     names = cur_fld.names
-                    if isinstance(names, basestring):
-                        long_attrs.append(", ".join(names))
-                    else:
-                        long_attrs.append(", ".join(name[0] for name in names))
+                    long_attrs.append(", ".join(names))
                 class_name = "%s (%s)" % (
                     cur_fld.__class__.__name__,
                     ", ".join(attrs)) if attrs else cur_fld.__class__.__name__

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1283,7 +1283,8 @@ def ls(obj=None, case_sensitive=False, verbose=False):
                 attrs = []
                 long_attrs = []
                 while isinstance(cur_fld, (Emph, ConditionalField)):
-                    attrs.append(cur_fld.__class__.__name__[:4])
+                    if isinstance(cur_fld, ConditionalField):
+                        attrs.append(cur_fld.__class__.__name__[:4])
                     cur_fld = cur_fld.fld
                 if verbose and isinstance(cur_fld, EnumField) \
                    and hasattr(cur_fld, "i2s"):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -771,6 +771,7 @@ all(x[1] == 15169 for x in ret)
 = Implicit logic
 ~ IP TCP
 a=IP(ttl=(5,10))/TCP(dport=[80,443])
+ls(a)
 [p for p in a]
 len(_) == 12
 


### PR DESCRIPTION
This PR:
  - Fixes short flags display (when `verbose=1`).
  - No longer displays "(Emph)" (for example in `ls(IP)` for `src` and `dst` fields).
  - Fixes tuple values display (for example `ls(IP(ttl=(1, 10)))`).
