### PR TITLE
Ask for python-cryptography v1.7+ in warnings and documentation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ test_script:
 
   # Secondary unit tests
   - 'del test\bpf.uts' # Don't bother with BPF regression tests
-  - "for %%t in (test\\*.uts) do (%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t %%t -F -K combined_modes || exit /b 42)"
+  - "for %%t in (test\\*.uts) do (%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t %%t -F -K combined_modes_ccm || exit /b 42)"
   
   # Contrib unit tests
   - "for %%t in (scapy\\contrib\\*.uts) do (%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t %%t -F -P \"load_contrib(\'%%~nt\')\"  || exit /b 42)"

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -166,11 +166,13 @@ Here are the topics involved and some examples that you can use to try if your i
      >>> enc=rdpcap("weplab-64bit-AA-managed.pcap")
      >>> enc.show()
      >>> enc[0]
-      >>> conf.wepkey="AA\x00\x00\x00"
-      >>> dec=Dot11PacketList(enc).toEthernet()
-      >>> dec.show()
-      >>> dec[0]
+     >>> conf.wepkey="AA\x00\x00\x00"
+     >>> dec=Dot11PacketList(enc).toEthernet()
+     >>> dec.show()
+     >>> dec[0]
  
+* PKI operations and TLS decryption. `cryptography <https://cryptography.io>` is also needed.
+
 * Fingerprinting. ``nmap_fp()`` needs `Nmap <http://nmap.org>`_. You need an `old version <http://nmap.org/dist-old/>`_ (before v4.23) that still supports first generation fingerprinting.
 
   .. code-block:: python 
@@ -187,8 +189,6 @@ Here are the topics involved and some examples that you can use to try if your i
  
 * VOIP. ``voip_play()`` needs `SoX <http://sox.sourceforge.net/>`_.
  
-* IPsec Crypto Support. ``SecurityAssociation()`` needs `Pycrypto 2.7a1 <https://github.com/dlitz/pycrypto>`_. Combined AEAD modes such as GCM and CCM are not available yet because of cryptography restrictions.
-
 Platform-specific instructions
 ==============================
 
@@ -207,7 +207,13 @@ Debian/Ubuntu
 
 Just use the standard packages::
 
-$ sudo apt-get install tcpdump graphviz imagemagick python-gnuplot python-crypto python-pyx 
+$ sudo apt-get install tcpdump graphviz imagemagick python-gnuplot python-cryptography python-pyx
+
+Scapy optionally uses python-cryptography v1.7 or later. It has not been packaged for ``apt`` in less recent OS versions (e.g. Debian Jessie). If you need the cryptography-related methods, you may install the library with:
+
+.. code-block:: text
+
+    # pip install cryptography
 
 Fedora
 ------
@@ -226,7 +232,7 @@ Some optional packages:
 
 .. code-block:: text
 
-    # yum install graphviz python-crypto sox PyX gnuplot numpy
+    # yum install graphviz python-cryptography sox PyX gnuplot numpy
     # cd /tmp
     # wget http://heanet.dl.sourceforge.net/sourceforge/gnuplot-py/gnuplot-py-1.8.tar.gz
     # tar xvfz gnuplot-py-1.8.tar.gz
@@ -288,11 +294,11 @@ Here's how to install Scapy on OpenBSD 5.9+
 Optional packages (OpenBSD only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-py-crypto
+py-cryptography
 
 .. code-block:: text
 
- # pkg_add py-crypto
+ # pkg_add py-cryptography
 
 gnuplot and its Python binding: 
 

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -280,6 +280,10 @@ class LogLevel(object):
         
 
 def isCryptographyValid():
+    """
+    Check if the cryptography library is present, and if it is recent enough
+    (v1.7 or later).
+    """
     try:
         import cryptography
     except ImportError:

--- a/scapy/layers/tls/__init__.py
+++ b/scapy/layers/tls/__init__.py
@@ -7,12 +7,12 @@
 Tools for handling TLS sessions and digital certificates.
 """
 
-try:
-    import cryptography
-except ImportError:
+from scapy.config import conf
+
+if not conf.crypto_valid:
     import logging
     log_loading = logging.getLogger("scapy.loading")
-    log_loading.info("Can't import python cryptography lib. Disabled certificate manipulation tools")
+    log_loading.info("Can't import python-cryptography v1.7+. Disabled PKCS #1 signing/verifying.")
 
 try:
     import ecdsa

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -29,9 +29,13 @@ Supports both RSA and ECDSA objects.
 import base64, os, time
 
 import ecdsa
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import hashes
+
+from scapy.config import conf, crypto_validator
+if conf.crypto_valid:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.asymmetric import rsa
+else:
+    default_backend = rsa = None
 
 from scapy.layers.tls.crypto.curves import import_curve
 from scapy.layers.tls.crypto.pkcs1 import pkcs_os2ip, pkcs_i2osp, mapHashFunc
@@ -199,7 +203,7 @@ class _PubKeyFactory(_PKIObjMaker):
                 obj.__class__ = PubKeyECDSA
                 obj.updateWith(spki)
             else:
-                raise Exception("Unsupported publicKey type")
+                raise
             marker = "PUBLIC KEY"
         except:
             try:
@@ -241,6 +245,7 @@ class PubKeyRSA(_PKIObj, PubKey, _EncryptAndVerifyRSA):
     Wrapper for RSA keys based on _EncryptAndVerifyRSA from crypto/pkcs1.py
     Use the 'key' attribute to access original object.
     """
+    @crypto_validator
     def updateWith(self, pubkey):
         self.modulus    = pubkey.modulus.val
         self.modulusLen = len(binrepr(pubkey.modulus.val))
@@ -391,6 +396,7 @@ class PrivKeyRSA(_PKIObj, PrivKey, _EncryptAndVerifyRSA, _DecryptAndSignRSA):
     Wrapper for RSA keys based on _DecryptAndSignRSA from crypto/pkcs1.py
     Use the 'key' attribute to access original object.
     """
+    @crypto_validator
     def updateWith(self, privkey):
         self.modulus     = privkey.modulus.val
         self.modulusLen  = len(binrepr(privkey.modulus.val))

--- a/test/ipsec.uts
+++ b/test/ipsec.uts
@@ -2491,7 +2491,6 @@ assert(d[TCP] == p[TCP])
 
 #######################################
 = IPv4 / ESP - Tunnel - AES-GCM - NULL
-~ combined_modes
 
 p = IP(src='1.1.1.1', dst='2.2.2.2')
 p /= TCP(sport=45012, dport=80)
@@ -2526,7 +2525,7 @@ assert(d == p)
 
 #######################################
 = IPv4 / ESP - Tunnel - AES-CCM - NULL
-~ combined_modes combined_modes_ccm
+~ combined_modes_ccm
 
 p = IP(src='1.1.1.1', dst='2.2.2.2')
 p /= TCP(sport=45012, dport=80)


### PR DESCRIPTION
I came across two undesired warnings from `ipsec.py`.

The first one was caused by the absence of `pycrypto`, which we don't use anymore.

The second one was caused by the location of `ModeWithAuthenticationTag` inside `cryptography`. It was moved from `interfaces` to `primitives.ciphers`, but this change does not seem to have been packaged in the latest stable Debian release.