### PR TITLE
[Windows/coverage] Fix and Support automaton

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
   - set PATH="%APPVEYOR_BUILD_FOLDER%;C:\Program Files\Wireshark\;%PATH%"
   
   # Main unit tests
-  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -K mock_read_routes6_bsd || exit /b 42"
+  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
   - 'del test\regression.uts'
 
   # Secondary unit tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
   - set PATH="%APPVEYOR_BUILD_FOLDER%;C:\Program Files\Wireshark\;%PATH%"
   
   # Main unit tests
-  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
+  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -K mock_read_routes6_bsd || exit /b 42"
   - 'del test\regression.uts'
 
   # Secondary unit tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
   - set PATH="%APPVEYOR_BUILD_FOLDER%;C:\Program Files\Wireshark\;%PATH%"
   
   # Main unit tests
-  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K automaton -K mock_read_routes6_bsd || exit /b 42"
+  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
   - 'del test\regression.uts'
 
   # Secondary unit tests

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -390,7 +390,7 @@ class Automaton:
                 return self.rd.send(msg)
             return os.write(self.wr,msg)
         def recv(self, n=65535):
-            return self.read(n)   
+            return self.read(n)        
         def send(self, msg):
             return self.write(msg)
 
@@ -443,7 +443,7 @@ class Automaton:
     ## Services
     def debug(self, lvl, msg):
         if self.debug_level >= lvl:
-            log_interactive.debug(msg)
+            log_interactive.debug(msg)            
 
     def send(self, pkt):
         if self.state.state in self.interception_points:
@@ -518,6 +518,7 @@ class Automaton:
                     _instance_state(getattr(self, stname)))
         
         self.parse_args(*args, **kargs)
+
         self.start()
 
     def __iter__(self):

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -12,8 +12,8 @@ from select import select
 from collections import deque
 import threading
 from scapy.config import conf
-from scapy.utils import do_graph, get_temp_file
-from scapy.error import log_interactive, log_runtime
+from scapy.utils import do_graph
+from scapy.error import log_interactive
 from scapy.plist import PacketList
 from scapy.data import MTU
 from scapy.supersocket import SuperSocket
@@ -21,8 +21,8 @@ from scapy.consts import WINDOWS
 
 class ObjectPipe:
     def __init__(self):
-        self.queue = deque()
         self.rd,self.wr = os.pipe()
+        self.queue = deque()
     def fileno(self):
         return self.rd
     def checkRecv(self):
@@ -54,8 +54,8 @@ class _instance_state:
     def __getattr__(self, attr):
         return getattr(self.im_func, attr)
 
-    def __call__(self, *args, **kwargs):
-        return self.im_func(self.im_self, *args, **kwargs)
+    def __call__(self, *args, **kargs):
+        return self.im_func(self.im_self, *args, **kargs)
     def breaks(self):
         return self.im_self.add_breakpoints(self.im_func)
     def intercepts(self):
@@ -79,7 +79,7 @@ class ATMT:
     IOEVENT = "I/O event"
 
     class NewStateRequested(Exception):
-        def __init__(self, state_func, automaton, *args, **kwargs):
+        def __init__(self, state_func, automaton, *args, **kargs):
             self.func = state_func
             self.state = state_func.atmt_state
             self.initial = state_func.atmt_initial
@@ -88,14 +88,14 @@ class ATMT:
             Exception.__init__(self, "Request state [%s]" % self.state)
             self.automaton = automaton
             self.args = args
-            self.kwargs = kwargs
+            self.kargs = kargs
             self.action_parameters() # init action parameters
-        def action_parameters(self, *args, **kwargs):
+        def action_parameters(self, *args, **kargs):
             self.action_args = args
-            self.action_kwargs = kwargs
+            self.action_kargs = kargs
             return self
         def run(self):
-            return self.func(self.automaton, *self.args, **self.kwargs)
+            return self.func(self.automaton, *self.args, **self.kargs)
         def __repr__(self):
             return "NewStateRequested(%s)" % self.state
 
@@ -107,8 +107,8 @@ class ATMT:
             f.atmt_initial = initial
             f.atmt_final = final
             f.atmt_error = error
-            def state_wrapper(self, *args, **kwargs):
-                return ATMT.NewStateRequested(f, self, *args, **kwargs)
+            def state_wrapper(self, *args, **kargs):
+                return ATMT.NewStateRequested(f, self, *args, **kargs)
 
             state_wrapper.func_name = "%s_wrapper" % f.func_name
             state_wrapper.atmt_type = ATMT.STATE
@@ -182,13 +182,13 @@ class _ATMT_Command:
     REJECT = "REJECT"
 
 class _ATMT_supersocket(SuperSocket):
-    def __init__(self, name, ioevent, automaton, proto, args, kwargs):
+    def __init__(self, name, ioevent, automaton, proto, args, kargs):
         self.name = name
         self.ioevent = ioevent
         self.proto = proto
         self.spa,self.spb = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
-        kwargs["external_fd"] = {ioevent:self.spb}
-        self.atmt = automaton(*args, **kwargs)
+        kargs["external_fd"] = {ioevent:self.spb}
+        self.atmt = automaton(*args, **kargs)
         self.atmt.runbg()
     def fileno(self):
         return self.spa.fileno()
@@ -209,8 +209,8 @@ class _ATMT_to_supersocket:
         self.name = name
         self.ioevent = ioevent
         self.automaton = automaton
-    def __call__(self, proto, *args, **kwargs):
-        return _ATMT_supersocket(self.name, self.ioevent, self.automaton, proto, args, kwargs)
+    def __call__(self, proto, *args, **kargs):
+        return _ATMT_supersocket(self.name, self.ioevent, self.automaton, proto, args, kargs)
 
 class Automaton_metaclass(type):
     def __new__(cls, name, bases, dct):
@@ -283,7 +283,7 @@ class Automaton_metaclass(type):
 
         return cls
 
-    def graph(self, **kwargs):
+    def graph(self, **kargs):
         s = 'digraph "%s" {\n'  % self.__class__.__name__
         
         se = "" # Keep initial nodes at the begining for better rendering
@@ -323,7 +323,7 @@ class Automaton_metaclass(type):
                             l += "\\l>[%s]" % x.func_name
                         s += '\t"%s" -> "%s" [label="%s",color=blue];\n' % (k,n,l)
         s += "}\n"
-        return do_graph(s, **kwargs)
+        return do_graph(s, **kargs)
         
 def select_objects(inputs, remain):
     if WINDOWS:
@@ -349,9 +349,9 @@ class Automaton:
     __metaclass__ = Automaton_metaclass
 
     ## Methods to overload
-    def parse_args(self, debug=0, store=1, **kwargs):
+    def parse_args(self, debug=0, store=1, **kargs):
         self.debug_level=debug
-        self.socket_kwargs = kwargs
+        self.socket_kargs = kargs
         self.store_packets = store        
 
     def master_filter(self, pkt):
@@ -396,18 +396,18 @@ class Automaton:
 
     class _IO_mixer:
         def __init__(self,rd,wr):
-            self.reader = rd
-            self.writer = wr
+            self.rd = rd
+            self.wr = wr
         def fileno(self):
             if type(self.rd) is int:
                 return self.rd
-            return self.reader.fileno()
+            return self.rd.fileno()
         def recv(self, n=None):
-            return self.reader.recv(n)
+            return self.rd.recv(n)
         def read(self, n=None):
             return self.recv(n)
         def send(self, msg):
-            return self.writer.send(msg)
+            return self.wr.send(msg)
         def write(self, msg):
             return self.send(msg)
 
@@ -471,10 +471,10 @@ class Automaton:
 
 
     ## Internals
-    def __init__(self, *args, **kwargs):
-        external_fd = kwargs.pop("external_fd",{})
-        self.send_sock_class = kwargs.pop("ll", conf.L3socket)
-        self.recv_sock_class = kwargs.pop("recvsock", conf.L2listen)
+    def __init__(self, *args, **kargs):
+        external_fd = kargs.pop("external_fd",{})
+        self.send_sock_class = kargs.pop("ll", conf.L3socket)
+        self.recv_sock_class = kargs.pop("recvsock", conf.L2listen)
         self.started = threading.Lock()
         self.threadid = None
         self.breakpointed = None
@@ -483,7 +483,7 @@ class Automaton:
         self.intercepted_packet = None
         self.debug_level=0
         self.init_args=args
-        self.init_kwargs=kwargs
+        self.init_kargs=kargs
         self.io = type.__new__(type, "IOnamespace",(),{})
         self.oi = type.__new__(type, "IOnamespace",(),{})
         self.cmdin = ObjectPipe()
@@ -517,7 +517,7 @@ class Automaton:
             setattr(self, stname, 
                     _instance_state(getattr(self, stname)))
         
-        self.parse_args(*args, **kwargs)
+        self.parse_args(*args, **kargs)
         self.start()
 
     def __iter__(self):
@@ -526,10 +526,10 @@ class Automaton:
     def __del__(self):
         self.stop()
 
-    def _run_condition(self, cond, *args, **kwargs):
+    def _run_condition(self, cond, *args, **kargs):
         try:
             self.debug(5, "Trying %s [%s]" % (cond.atmt_type, cond.atmt_condname))
-            cond(self,*args, **kwargs)
+            cond(self,*args, **kargs)
         except ATMT.NewStateRequested, state_req:
             self.debug(2, "%s [%s] taken to state [%s]" % (cond.atmt_type, cond.atmt_condname, state_req.state))
             if cond.atmt_type == ATMT.RECV:
@@ -537,7 +537,7 @@ class Automaton:
                     self.packets.append(args[0])
             for action in self.actions[cond.atmt_condname]:
                 self.debug(2, "   + Running action [%s]" % action.func_name)
-                action(self, *state_req.action_args, **state_req.action_kwargs)
+                action(self, *state_req.action_args, **state_req.action_kargs)
             raise
         except Exception,e:
             self.debug(2, "%s [%s] raised exception [%s]" % (cond.atmt_type, cond.atmt_condname, e))
@@ -545,23 +545,23 @@ class Automaton:
         else:
             self.debug(2, "%s [%s] not taken" % (cond.atmt_type, cond.atmt_condname))
 
-    def _do_start(self, *args, **kwargs):
-        threading.Thread(target=self._do_control, args=(args), kwargs=kwargs).start()
+    def _do_start(self, *args, **kargs):
+        threading.Thread(target=self._do_control, args=(args), kwargs=kargs).start()
 
-    def _do_control(self, *args, **kwargs):
+    def _do_control(self, *args, **kargs):
         with self.started:
             self.threadid = threading.currentThread().ident
 
             # Update default parameters
             a = args+self.init_args[len(args):]
-            k = self.init_kwargs.copy()
-            k.update(kwargs)
+            k = self.init_kargs.copy()
+            k.update(kargs)
             self.parse_args(*a,**k)
     
             # Start the automaton
             self.state=self.initial_states[0](self)
             self.send_sock = self.send_sock_class()
-            self.listen_sock = self.recv_sock_class(**self.socket_kwargs)
+            self.listen_sock = self.recv_sock_class(**self.socket_kargs)
             self.packets = PacketList(name="session[%s]"%self.__class__.__name__)
 
             singlestep = True
@@ -709,9 +709,9 @@ class Automaton:
                 bp = bp.atmt_state
             self.breakpoints.discard(bp)
 
-    def start(self, *args, **kwargs):
+    def start(self, *args, **kargs):
         if not self.started.locked():
-            self._do_start(*args, **kwargs)
+            self._do_start(*args, **kargs)
         
     def run(self, resume=None, wait=True):
         if resume is None:
@@ -751,9 +751,9 @@ class Automaton:
                 for fd in r:
                     fd.recv()
                 
-    def restart(self, *args, **kwargs):
+    def restart(self, *args, **kargs):
         self.stop()
-        self.start(*args, **kwargs)
+        self.start(*args, **kargs)
 
     def accept_packet(self, pkt=None, wait=False):
         rsm = Message()

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -876,6 +876,7 @@ send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 + Automaton tests
 
 = Simple automaton
+~ automaton
 class ATMT1(Automaton):
     def parse_args(self, init, *args, **kargs):
         Automaton.parse_args(self, *args, **kargs)
@@ -906,6 +907,7 @@ class ATMT1(Automaton):
         self.result = s
     
 = Simple automaton Tests
+~ automaton
 
 a=ATMT1(init="a", ll=lambda: None, recvsock=lambda: None)
 a.run()
@@ -919,6 +921,7 @@ a.result
 assert( _ == 'babababababababababababababab' )
 
 = Simple automaton stuck test
+~ automaton
 
 try:    
     ATMT1(init="", ll=lambda: None, recvsock=lambda: None).run()
@@ -929,6 +932,7 @@ else:
 
 
 = Automaton state overloading
+~ automaton
 class ATMT2(ATMT1):
     @ATMT.state()
     def MAIN(self, s):
@@ -949,6 +953,7 @@ assert( _ == 'cccccbaccbabaccccbaccbabab')
 
 
 = Automaton condition overloading
+~ automaton
 class ATMT3(ATMT2):
     @ATMT.condition(ATMT1.MAIN)
     def trA(self, s):
@@ -970,6 +975,7 @@ assert( _ == 'cccccbdaccbdabdaccccbdaccbdabdab' )
 
 
 = Automaton action overloading
+~ automaton
 class ATMT4(ATMT3):
     @ATMT.action(ATMT1.go_to_END)
     def action_test(self, s):
@@ -988,6 +994,7 @@ assert( _ == 'ecccccbdaccbdabdaccccbdaccbdabdabe' )
 
 
 = Automaton priorities
+~ automaton
 class ATMT5(Automaton):
     @ATMT.state(initial=1)
     def BEGIN(self):
@@ -1022,6 +1029,7 @@ a.run()
 assert( _ == 'Jupiter' )
 
 = Automaton test same action for many conditions
+~ automaton
 class ATMT6(Automaton):
     @ATMT.state(initial=1)
     def BEGIN(self):
@@ -1061,6 +1069,7 @@ a.run()
 assert( _ == 'Mercury' )
 
 = Automaton test io event
+~ automaton
 
 class ATMT7(Automaton):
     @ATMT.state(initial=1)
@@ -1099,6 +1108,7 @@ a.run()
 assert( _ == "Saturn" )
 
 = Automaton test io event from external fd
+~ automaton
 import os
 
 class ATMT8(Automaton):
@@ -1148,6 +1158,7 @@ a.run()
 assert( _ == "Uranus" )
 
 = Automaton test interception_points, and restart
+~ automaton
 class ATMT9(Automaton):
     def my_send(self, x):
         self.io.loop.send(x)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1099,7 +1099,6 @@ a.run()
 assert( _ == "Saturn" )
 
 = Automaton test io event from external fd
-~ automaton
 import os
 
 class ATMT8(Automaton):
@@ -1122,28 +1121,29 @@ class ATMT8(Automaton):
         self.res += "s"
         return self.res
 
-r,w = os.pipe()
 if WINDOWS:
-    r_ = ObjectPipe()
+    r = w = ObjectPipe()
 else:
-    r_ = r
+    r,w = os.pipe()
 
-a=ATMT8(external_fd={"extfd":r_}, ll=lambda: None, recvsock=lambda: None)
+def writeOn(w, msg):
+    if WINDOWS:
+        w.write(msg)
+    else:
+        os.write(w, msg)
+
+a=ATMT8(external_fd={"extfd":r}, ll=lambda: None, recvsock=lambda: None)
 a.run(wait=False)
-if WINDOWS:
-    r_.write("ra")
-    r_.write("nu")
-else:
-    os.write(w,"ra")
-    os.write(w,"nu")
+writeOn(w,"ra")
+writeOn(w,"nu")
 
 a.run()
 assert( _ == "Uranus" )
 
 a.restart()
 a.run(wait=False)
-os.write(w,"ra")
-os.write(w,"nu")
+writeOn(w,"ra")
+writeOn(w,"nu")
 a.run()
 assert( _ == "Uranus" )
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -876,7 +876,6 @@ send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 + Automaton tests
 
 = Simple automaton
-~ automaton
 class ATMT1(Automaton):
     def parse_args(self, init, *args, **kargs):
         Automaton.parse_args(self, *args, **kargs)
@@ -907,7 +906,6 @@ class ATMT1(Automaton):
         self.result = s
     
 = Simple automaton Tests
-~ automaton
 
 a=ATMT1(init="a", ll=lambda: None, recvsock=lambda: None)
 a.run()
@@ -921,7 +919,6 @@ a.result
 assert( _ == 'babababababababababababababab' )
 
 = Simple automaton stuck test
-~ automaton
 
 try:    
     ATMT1(init="", ll=lambda: None, recvsock=lambda: None).run()
@@ -932,7 +929,6 @@ else:
 
 
 = Automaton state overloading
-~ automaton
 class ATMT2(ATMT1):
     @ATMT.state()
     def MAIN(self, s):
@@ -953,7 +949,6 @@ assert( _ == 'cccccbaccbabaccccbaccbabab')
 
 
 = Automaton condition overloading
-~ automaton
 class ATMT3(ATMT2):
     @ATMT.condition(ATMT1.MAIN)
     def trA(self, s):
@@ -975,7 +970,6 @@ assert( _ == 'cccccbdaccbdabdaccccbdaccbdabdab' )
 
 
 = Automaton action overloading
-~ automaton
 class ATMT4(ATMT3):
     @ATMT.action(ATMT1.go_to_END)
     def action_test(self, s):
@@ -994,7 +988,6 @@ assert( _ == 'ecccccbdaccbdabdaccccbdaccbdabdabe' )
 
 
 = Automaton priorities
-~ automaton
 class ATMT5(Automaton):
     @ATMT.state(initial=1)
     def BEGIN(self):
@@ -1029,7 +1022,6 @@ a.run()
 assert( _ == 'Jupiter' )
 
 = Automaton test same action for many conditions
-~ automaton
 class ATMT6(Automaton):
     @ATMT.state(initial=1)
     def BEGIN(self):
@@ -1069,7 +1061,6 @@ a.run()
 assert( _ == 'Mercury' )
 
 = Automaton test io event
-~ automaton
 
 class ATMT7(Automaton):
     @ATMT.state(initial=1)
@@ -1132,11 +1123,20 @@ class ATMT8(Automaton):
         return self.res
 
 r,w = os.pipe()
+if WINDOWS:
+    r_ = ObjectPipe()
+else:
+    r_ = r
 
-a=ATMT8(external_fd={"extfd":r}, ll=lambda: None, recvsock=lambda: None)
+a=ATMT8(external_fd={"extfd":r_}, ll=lambda: None, recvsock=lambda: None)
 a.run(wait=False)
-os.write(w,"ra")
-os.write(w,"nu")
+if WINDOWS:
+    r_.write("ra")
+    r_.write("nu")
+else:
+    os.write(w,"ra")
+    os.write(w,"nu")
+
 a.run()
 assert( _ == "Uranus" )
 
@@ -1148,7 +1148,6 @@ a.run()
 assert( _ == "Uranus" )
 
 = Automaton test interception_points, and restart
-~ automaton
 class ATMT9(Automaton):
     def my_send(self, x):
         self.io.loop.send(x)

--- a/test/run_tests.bat
+++ b/test/run_tests.bat
@@ -2,7 +2,7 @@
 set MYDIR=%cd%\..
 set PYTHONPATH=%MYDIR%
 if [%1]==[] (
-  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -K mock_read_routes6_bsd -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
+  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -K automaton -K mock_read_routes6_bsd -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
   python "%MYDIR%\scapy\tools\UTscapy.py" %@
 )

--- a/test/run_tests.bat
+++ b/test/run_tests.bat
@@ -2,7 +2,7 @@
 set MYDIR=%cd%\..
 set PYTHONPATH=%MYDIR%
 if [%1]==[] (
-  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -K automaton -K mock_read_routes6_bsd -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
+  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -K mock_read_routes6_bsd -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
   python "%MYDIR%\scapy\tools\UTscapy.py" %@
 )


### PR DESCRIPTION
Hey !

I've finally found a way to support Automaton on windows ! That fixes https://github.com/secdev/scapy/issues/451

Every thing except `external_fd` will work exactly as on linux 😄 
`external_fd` will require a `ObjectPipe` instance instead of a `os.pipe` because of the unavailability of `select.select`

Hope it looks good.

@guedou