### PR TITLE
coap: dont reorder options having the same option number

### DIFF
--- a/scapy/contrib/coap.py
+++ b/scapy/contrib/coap.py
@@ -178,7 +178,7 @@ class _CoAPOptsField(StrField):
                 opt_lst.append((coap_options[1][o[0]], o[1]))
             else:
                 opt_lst.append(o)
-        opt_lst.sort()
+        opt_lst.sort(key=lambda o:o[0])
 
         opts = _CoAPOpt(delta=opt_lst[0][0], opt_val=opt_lst[0][1])
         high_opt = opt_lst[0][0]

--- a/scapy/contrib/coap.uts
+++ b/scapy/contrib/coap.uts
@@ -29,6 +29,12 @@ str(CoAP(options=[("Uri-Query", "query")])) == '\x40\x00\x00\x00\xd5\x02\x71\x75
 = Extended option length
 str(CoAP(options=[("Location-Path", 'x' * 280)])) == '\x40\x00\x00\x00\x8e\x0b\x00' + '\x78' * 280
 
+= Options should be ordered by option number
+str(CoAP(options=[("Uri-Query", "b"),("Uri-Path","a")])) == '\x40\x00\x00\x00\xb1\x61\x41\x62'
+
+= Options of the same type should not be reordered
+str(CoAP(options=[("Uri-Path", "b"),("Uri-Path","a")])) == '\x40\x00\x00\x00\xb1\x62\x01\x61'
+
 + Test layer binding
 = Destination port
 p = UDP()/CoAP()


### PR DESCRIPTION
per rfc7252 section 3.1, coap options are ordered by their Option Number. However, the order of options with the same number should not be changed.