### PR TITLE
Remove ecdsa from appveyor install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - choco install -y winpcap wireshark
   - ps: wget http://www.winpcap.org/windump/install/bin/windump_3_9_5/WinDump.exe -UseBasicParsing -OutFile C:\Windows\System32\windump.exe
   # Install Python modules
-  - "%PYTHON%\\python -m pip install ecdsa cryptography coverage mock pyreadline keyboard"
+  - "%PYTHON%\\python -m pip install cryptography coverage mock pyreadline keyboard"
   - set PATH="%PYTHON%\\Scripts\\;%PATH%"
 
 test_script:


### PR DESCRIPTION
Should have been merged with #371. `ecdsa` is no longer used.