### PR TITLE
[Windows] support Npcap

### DIFF
--- a/.appveyor/InstallWindump.ps1
+++ b/.appveyor/InstallWindump.ps1
@@ -1,4 +1,4 @@
-wget https://github.com/hsluoyz/WinDump/releases/download/v0.1/WinDump-for-Npcap-0.1.zip -UseBasicParsing -OutFile .\npcap.zip
+wget https://github.com/hsluoyz/WinDump/releases/download/v0.2/WinDump-for-Npcap-0.2.zip -UseBasicParsing -OutFile $PSScriptRoot"\npcap.zip"
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 function Unzip
 {
@@ -7,6 +7,6 @@ function Unzip
     [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
 }
 Unzip $PSScriptRoot"\npcap.zip" $PSScriptRoot"\npcap"
-Remove-Item ".\npcap.zip"
-Move-Item -Force ".\npcap\x64\WinDump.exe" "C:\Windows\System32\windump.exe"
-Remove-Item ".\npcap" -recurse
+Remove-Item $PSScriptRoot"\npcap.zip"
+Move-Item -Force $PSScriptRoot"\npcap\x64\WinDump.exe" "C:\Windows\System32\windump.exe"
+Remove-Item $PSScriptRoot"\npcap" -recurse

--- a/.appveyor/InstallWindump.ps1
+++ b/.appveyor/InstallWindump.ps1
@@ -1,4 +1,11 @@
-wget https://github.com/hsluoyz/WinDump/releases/download/v0.2/WinDump-for-Npcap-0.2.zip -UseBasicParsing -OutFile $PSScriptRoot"\npcap.zip"
+# Config
+$urlPath = "https://github.com/hsluoyz/WinDump/releases/download/v0.2/WinDump-for-Npcap-0.2.zip"
+$checksum = "9182934bb822511236b4112ddaa006c95c86c864ecc5c2e3c355228463e43bf2"
+
+############
+############
+# Download the file
+wget $urlPath -UseBasicParsing -OutFile $PSScriptRoot"\npcap.zip"
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 function Unzip
 {
@@ -8,5 +15,14 @@ function Unzip
 }
 Unzip $PSScriptRoot"\npcap.zip" $PSScriptRoot"\npcap"
 Remove-Item $PSScriptRoot"\npcap.zip"
+# Now let's check its checksum
+$_chksum = $(CertUtil -hashfile $PSScriptRoot"\npcap\x64\WinDump.exe" SHA256)[1] -replace " ",""
+if ($_chksum -ne $checksum){
+    echo "Checksums does NOT match !"
+    exit
+} else {
+    echo "Checksums matches !"
+}
+# Finally, move it and remove tmp files
 Move-Item -Force $PSScriptRoot"\npcap\x64\WinDump.exe" "C:\Windows\System32\windump.exe"
 Remove-Item $PSScriptRoot"\npcap" -recurse

--- a/.appveyor/InstallWindump.ps1
+++ b/.appveyor/InstallWindump.ps1
@@ -1,0 +1,12 @@
+wget https://github.com/hsluoyz/WinDump/releases/download/v0.1/WinDump-for-Npcap-0.1.zip -UseBasicParsing -OutFile .\npcap.zip
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+Unzip $PSScriptRoot"\npcap.zip" $PSScriptRoot"\npcap"
+Remove-Item ".\npcap.zip"
+Move-Item -Force ".\npcap\x64\WinDump.exe" "C:\Windows\System32\windump.exe"
+Remove-Item ".\npcap" -recurse

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - choco install -y npcap wireshark
   - ps: .\.appveyor\InstallWindump.ps1
   # Install Python modules
-  - "%PYTHON%\\python -m pip install cryptography coverage mock pyreadline keyboard"
+  - "%PYTHON%\\python -m pip install cryptography coverage mock pyreadline"
   - set PATH="%PYTHON%\\Scripts\\;%PATH%"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ environment:
 build: off
 
 install:
-  # Install the winpcap, windump and wireshark suites
-  - choco install -y winpcap wireshark
-  - ps: wget http://www.winpcap.org/windump/install/bin/windump_3_9_5/WinDump.exe -UseBasicParsing -OutFile C:\Windows\System32\windump.exe
+  # Install the npcap, windump and wireshark suites
+  - choco install -y npcap wireshark
+  - ps: .\.appveyor\InstallWindump.ps1
   # Install Python modules
   - "%PYTHON%\\python -m pip install cryptography coverage mock pyreadline keyboard"
   - set PATH="%PYTHON%\\Scripts\\;%PATH%"

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -361,7 +361,7 @@ Scapy is primarily being developed for Unix-like systems and works best on those
 You need the following software packages in order to install Scapy on Windows:
 
   * `Python <http://www.python.org>`_: `python-2.7.12.msi <https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python27`` and ``C:\Python27\Scripts`` respectively.
-  * `WinPcap <http://www.winpcap.org/>`_: `WinPcap_4_1_3.exe <https://www.winpcap.org/install/bin/WinPcap_4_1_3.exe>`_. You might want to choose "[x] Automatically start the WinPcap driver at boot time", so that non-privileged users can sniff, especially under Vista and Windows 7. If you want to use the ethernet vendor database to resolve MAC addresses or use the ``wireshark()`` command, download `Wireshark <http://www.wireshark.org/>`_ which already includes WinPcap. 
+  * `Npcap <https://nmap.org/npcap/>`_: `npcap-0.81.exe <https://nmap.org/npcap/dist/npcap-0.81.exe>`_. Default values are recommanded. Scapy will also work with Winpcap.
   * `pyreadline <https://pypi.python.org/pypi/pyreadline>`_: `pyreadline-2.1.win-amd64.exe <https://pypi.python.org/packages/8b/13/bed49b87af0b4f345b4e54897b5ab6a4b848e4dd300ec4195a0016b8650c/pyreadline-2.1.win-amd64.exe>`_ (64bits) or `pyreadline-2.1.win32.exe <https://pypi.python.org/packages/bc/ca/316035ec616c08979bbed47fb25b843415cf2d118a2f95f55173334300a6/pyreadline-2.1.win32.exe>`_ (32bits)  
   * `Scapy <http://www.secdev.org/projects/scapy/>`_: `latest development version <https://github.com/secdev/scapy/archive/master.zip>`_ from the `Git repository <https://github.com/secdev/scapy>`_. Unzip the archive, open a command prompt in that directory and run "python setup.py install". 
 
@@ -473,6 +473,21 @@ Known bugs
  * You may not be able to capture WLAN traffic on Windows. Reasons are explained on the Wireshark wiki and in the WinPcap FAQ. Try switching off promiscuous mode with ``conf.sniff_promisc=False``.
  * Packets sometimes cannot be sent to localhost (or local IP addresses on your own host).
  
+Winpcap/Npcap conflicts
+^^^^^^^^^^^^^^^^^^^^^^^
+
+As Winpcap is becoming old, it's recommanded to use Npcap instead. Npcap is part of the Nmap project.
+
+1. If you get the message 'Winpcap is installed over Npcap.' it means that you have installed both winpcap and npcap versions, which isn't recommanded.
+
+You may uninstall winpcap from your Program Files, then you will need to remove:
+ * C:/Windows/System32/wpcap.dll
+ * C:/Windows/System32/Packet.dll
+
+To use npcap instead.
+
+2. If you get the message 'The installed Windump version does not work with Npcap' it means that you have installed an old version of Windump.
+Download the correct one on https://github.com/hsluoyz/WinDump/releases
 
 Build the documentation offline
 ===============================

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -7,7 +7,7 @@
 Packet sending and receiving with libdnet and libpcap/WinPcap.
 """
 
-import time,struct,sys
+import time, struct, sys, platform
 import socket
 if not sys.platform.startswith("win"):
     from fcntl import ioctl
@@ -45,7 +45,7 @@ if conf.use_winpcapy:
       if "winpcap" in version.lower():
           if os.path.exists(os.environ["WINDIR"] + "\\System32\\Npcap\\wpcap.dll"):
               warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", True)
-          else:
+          elif platform.release() != "XP":
               warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", True)
       elif "npcap" in version.lower():
           conf.use_npcap = True

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -18,32 +18,44 @@ from scapy.utils import mac2str
 from scapy.supersocket import SuperSocket
 from scapy.error import Scapy_Exception, log_loading, warning
 import scapy.arch
+import scapy.consts
 
 if conf.use_winpcapy:
   #mostly code from https://github.com/phaethon/scapy translated to python2.X
   try:
-    from scapy.arch.winpcapy import *
-    def winpcapy_get_if_list():
-      err = create_string_buffer(PCAP_ERRBUF_SIZE)
-      devs = POINTER(pcap_if_t)()
-      ret = []
-      if pcap_findalldevs(byref(devs), err) < 0:
-        return ret
-      try:
-        p = devs
-        while p:
-          ret.append(p.contents.name.decode('ascii'))
-          p = p.contents.next
-        return ret
-      finally:
-        pcap_freealldevs(devs)
-
+      from scapy.arch.winpcapy import *
+      def winpcapy_get_if_list():
+          err = create_string_buffer(PCAP_ERRBUF_SIZE)
+          devs = POINTER(pcap_if_t)()
+          ret = []
+          if pcap_findalldevs(byref(devs), err) < 0:
+              return ret
+          try:
+              p = devs
+              while p:
+                  ret.append(p.contents.name.decode('ascii'))
+                  p = p.contents.next
+              return ret
+          except:
+              raise
+          finally:
+              pcap_freealldevs(devs)
+      # Detect Pcap version
+      version = pcap_lib_version()
+      if "winpcap" in version.lower():
+          if os.path.exists(os.environ["WINDIR"] + "\\System32\\Npcap\\wpcap.dll"):
+              warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", True)
+          else:
+              warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", True)
+      elif "npcap" in version.lower():
+          conf.use_npcap = True
+          LOOPBACK_NAME = scapy.consts.LOOPBACK_NAME = "Npcap Loopback Adapter"
   except OSError as e:
-    def winpcapy_get_if_list():
-        return []
-    conf.use_winpcapy = False
-    if conf.interactive:
-      log_loading.warning("wpcap.dll is not installed. You won't be able to send/recieve packets. Visit the scapy's doc to install it")
+      def winpcapy_get_if_list():
+          return []
+      conf.use_winpcapy = False
+      if conf.interactive:
+          log_loading.warning("wpcap.dll is not installed. You won't be able to send/recieve packets. Visit the scapy's doc to install it")
 
   # From BSD net/bpf.h
   #BIOCIMMEDIATE=0x80044270

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -6,7 +6,7 @@
 """
 Customizations needed to support Microsoft Windows.
 """
-import os, re, sys, socket, time, itertools, platform
+import os, re, sys, socket, time, itertools, platform, subprocess
 import subprocess as sp
 from glob import glob
 import tempfile
@@ -280,6 +280,20 @@ if conf.prog.powershell == "powershell":
     conf.prog.powershell = None
 if conf.prog.sox == "sox":
     conf.prog.sox = None
+
+if conf.prog.tcpdump != "windump" and conf.use_npcap:
+    def test_windump_npcap():
+        """Return wether windump version is correct or not"""
+        try:
+            p_test_windump = subprocess.Popen([conf.prog.tcpdump, "-help"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout, err = p_test_windump.communicate()
+            return "npcap" in stdout.lower()
+        except:
+            return False
+    windump_ok = test_windump_npcap()
+    if not windump_ok:
+        warning("The installed Windump version does not work with Npcap ! Refer to 'Winpcap/Npcap conflicts' in scapy's doc", True)
+    del windump_ok
 
 class PcapNameNotFoundError(Scapy_Exception):
     pass    

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -6,7 +6,7 @@
 """
 Customizations needed to support Microsoft Windows.
 """
-import os, re, sys, socket, time, itertools, platform, subprocess
+import os, re, sys, socket, time, itertools, platform
 import subprocess as sp
 from glob import glob
 import tempfile
@@ -233,6 +233,7 @@ def win_find_exe(filename, installsubdir=None, env="ProgramFiles"):
             break        
     return path
 
+
 def is_new_release(ignoreVBS=False):
     release = platform.release()
     if conf.prog.powershell is None and not ignoreVBS:
@@ -285,7 +286,7 @@ if conf.prog.tcpdump != "windump" and conf.use_npcap:
     def test_windump_npcap():
         """Return wether windump version is correct or not"""
         try:
-            p_test_windump = subprocess.Popen([conf.prog.tcpdump, "-help"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            p_test_windump = sp.Popen([conf.prog.tcpdump, "-help"], stdout=sp.PIPE, stderr=sp.STDOUT)
             stdout, err = p_test_windump.communicate()
             return "npcap" in stdout.lower()
         except:

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -391,6 +391,7 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     use_dnet = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
     use_bpf = False
     use_winpcapy = False
+    use_npcap = False
     ipv6_enabled = socket.has_ipv6
     ethertypes = ETHER_TYPES
     protocols = IP_PROTOS

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -32,13 +32,18 @@ class Route:
         self.routes = read_routes()
 
     def __repr__(self):
-        rt = "Network         Netmask         Gateway         Iface           Output IP\n"
+        rtlst = [("Network", "Netmask", "Gateway", "Iface", "Output IP")]
+        
         for net,msk,gw,iface,addr in self.routes:
-            rt += "%-15s %-15s %-15s %-15s %-15s\n" % (ltoa(net),
-                                              ltoa(msk),
-                                              gw,
-                                              (iface.name if not isinstance(iface, basestring) else iface),
-                                              addr)
+	    rtlst.append((ltoa(net),
+                      ltoa(msk),
+                      gw,
+                      (iface.name if not isinstance(iface, basestring) else iface),
+                      addr))
+        
+        colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst))
+        fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
+        rt = "\n".join(map(lambda x: fmt % x, rtlst))
         return rt
 
     def make_route(self, host=None, net=None, gw=None, dev=None):

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -362,7 +362,7 @@ def remove_empty_testsets(test_campaign):
 
 def run_campaign(test_campaign, get_interactive_session, verb=3):
     if WINDOWS:
-        # Add a route to 127.0.0.1
+        # Add a route to 127.0.0.1 and ::1
         from scapy.arch.windows import route_add_loopback
         route_add_loopback()
     passed=failed=0

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -82,21 +82,6 @@ import sys
 
 import mock
 import readline
-from threading import Thread, Event
-
-class sendTextAndTab(Thread):
-    """Send text directly as Input"""
-    def __init__(self, event, text):
-        Thread.__init__(self)
-        self.stopped = event
-        self.send_text = text
-    def run(self):
-        import keyboard
-        time.sleep(1)
-        while not self.stopped.wait(0.5):
-            keyboard.write(self.send_text)
-            keyboard.send("tab")
-            keyboard.send("enter")
 
 index = 0
 @mock.patch("pyreadline.console.console.Console.size")
@@ -114,12 +99,8 @@ def emulate_main_input(data, mock_readfunc, mock_pyr_size):
             r_data = data[index]
             if r_data.startswith("#AUTOCOMPLETE"):
                 send_text = re.match(r'#AUTOCOMPLETE{(.*)}', r_data).group(1)
-                stopFlag = Event()
-                thread = sendTextAndTab(stopFlag, send_text)
-                thread.start()
-                # This will block the program until the thread has pushed the stuff
-                r_data = readline.rl.readline()
-                stopFlag.set()
+                cmpl = readline.rl.get_completer()
+                r_data = cmpl(send_text, 0)
         index +=1
         print r_data
         return r_data


### PR DESCRIPTION
Winpcap hasn't been updated since 2013. This PR add support for Npcap and display a warning encouraging people to migrate to Npcap.

This also means that we have to use the updated windump version.

Npcap is a relevant program, part of the nmap project, which brings functions like loopback adapter and update the code for newer versions. The windump version is made by the author of Npcap.

Also has several fixes:
- Loopback Routing fixes (as Npcap supports loopback)
- Updated` route.py` \_\_repr\_\_ with the one located in `route6.py` (better spaces management)
- Fixed mock_windows.uts with a way easier tests