### PR TITLE
[coverage] Tests for ManufDB + Multiple fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,15 +24,22 @@ test_script:
   - set PATH="%APPVEYOR_BUILD_FOLDER%;C:\Program Files\Wireshark\;%PATH%"
   
   # Main unit tests
-  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
+  - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
   - 'del test\regression.uts'
 
   # Secondary and contrib unit tests
   - 'del test\bpf.uts' # Don't bother with BPF regression tests
-  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -c test\\configs\\windows.utsc || exit /b 42"
+  - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -c test\\configs\\windows.utsc || exit /b 42"
+  
+  # Tls unit tests
+  # Note: due to a multiprocessing bug, we got to be in the UTscapy.py folder and call it directly
+  - 'cd scapy/tools'
+  - "%PYTHON%\\python -m coverage run --concurrency=multiprocessing UTscapy.py -f text -t ..\\..\\test\\tls\\tests_tls_netaccess.uts -F -P \"sys.path.append(os.path.abspath('../../test/tls'))\" -K open_ssl_client || exit /b 42"
+  - 'cd ../../'
 
 after_test:
   # Install & run codecov
   - "%PYTHON%\\python -m pip install codecov"
   - "SET PATH=%PYTHON%\\Scripts\\;%PATH%"
+  - "coverage combine ./ ./scapy/tools/"
   - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ test_script:
   - 'del test\bpf.uts' # Don't bother with BPF regression tests
   - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -c test\\configs\\windows.utsc || exit /b 42"
   
-  # Tls unit tests
+  # TLS unit tests
   # Note: due to a multiprocessing bug, we got to be in the UTscapy.py folder and call it directly
   - 'cd scapy/tools'
   - "%PYTHON%\\python -m coverage run --concurrency=multiprocessing UTscapy.py -f text -t ..\\..\\test\\tls\\tests_tls_netaccess.uts -F -P \"sys.path.append(os.path.abspath('../../test/tls'))\" -K open_ssl_client || exit /b 42"

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -6,11 +6,13 @@
 """
 Customizations needed to support Microsoft Windows.
 """
+
 import os,re,sys,socket,time, itertools
 import subprocess as sp
 from glob import glob
 import tempfile
 
+#import scapy.data
 from scapy.config import conf, ConfClass
 from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader
@@ -259,6 +261,9 @@ class WinProgPath(ConfClass):
         )
         self.cscript = win_find_exe("cscript", installsubdir="System32",
                                env="SystemRoot")
+        if self.wireshark != "wireshark":
+            manu_path = load_manuf(os.path.sep.join(self.wireshark.split(os.path.sep)[:-1])+os.path.sep+"manuf")
+            scapy.data.MANUFDB = conf.manufdb = MANUFDB = manu_path
 
 conf.prog = WinProgPath()
 if conf.prog.powershell == "powershell":

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -12,7 +12,6 @@ import subprocess as sp
 from glob import glob
 import tempfile
 
-#import scapy.data
 from scapy.config import conf, ConfClass
 from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -147,7 +147,8 @@ class ManufDA(DADict):
         if oui in self:
             return ":".join([self[oui][0]]+ mac.split(":")[3:])
         return mac
-        
+    def __repr__(self):
+        return "\n".join(["<%s %s, %s>" % (i[0], i[1][0], i[1][1]) for i in self.__dict__.items()])
         
         
 
@@ -165,12 +166,12 @@ def load_manuf(filename):
                     lng=shrt
                 else:
                     lng = l[i+2:]
-                manufdb[oui] = shrt,lng
+                manufdb[oui] = shrt, lng
             except Exception,e:
                 log_loading.warning("Couldn't parse one line from [%s] [%r] (%s)" % (filename, l, e))
     except IOError:
         #log_loading.warning("Couldn't open [%s] file" % filename)
-        pass
+        return ""
     return manufdb
     
 
@@ -179,6 +180,7 @@ if WINDOWS:
     ETHER_TYPES=load_ethertypes("ethertypes")
     IP_PROTOS=load_protocols(os.environ["SystemRoot"]+"\system32\drivers\etc\protocol")
     TCP_SERVICES,UDP_SERVICES=load_services(os.environ["SystemRoot"] + "\system32\drivers\etc\services")
+    # Default value, will be updated by arch.windows
     MANUFDB = load_manuf(os.environ["ProgramFiles"] + "\\wireshark\\manuf")
 else:
     IP_PROTOS=load_protocols("/etc/protocols")

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -170,7 +170,7 @@ def load_manuf(filename):
             except Exception,e:
                 log_loading.warning("Couldn't parse one line from [%s] [%r] (%s)" % (filename, l, e))
     except IOError:
-        #log_loading.warning("Couldn't open [%s] file" % filename)
+        log_loading.warning("Couldn't open [%s] file" % filename)
         return ""
     return manufdb
     

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -209,9 +209,27 @@ assert _correct
 
 = show_interfaces
 
-from scapy.arch import *
-show_interfaces()
+from scapy.arch import show_interfaces
+from StringIO import StringIO
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+def test_show_interfaces(mock_stdout):
+    show_interfaces()
+    lines = mock_stdout.getvalue().split("\n")[1:]
+    for l in lines:
+        if not l.strip():
+            continue
+        try:
+            int(l[0])
+        except:
+            sys.stderr.write(l)
+            return False
+    return True
+
+assert test_show_interfaces()
 
 = dev_from_pcapname
+
+from scapy.config import conf
 
 assert dev_from_pcapname(conf.iface.pcap_name).guid == conf.iface.guid

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -206,3 +206,12 @@ for i in ps_read_routes:
         break
 
 assert _correct
+
+= show_interfaces
+
+from scapy.arch import *
+show_interfaces()
+
+= dev_from_pcapname
+
+assert dev_from_pcapname(conf.iface.pcap_name).guid == conf.iface.guid

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -650,6 +650,17 @@ send_and_sniff(IP(dst="secdev.org")/ICMP())
 send_and_sniff(IP(dst="secdev.org")/ICMP(), flt="icmp")
 send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 
+############
+############
++ ManuFDB tests
+
+= __repr__
+
+conf.manufdb
+
+= check _resolve_MAC
+
+assert conf.manufdb._resolve_MAC("00:00:63") == "HP"
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -656,11 +656,17 @@ send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 
 = __repr__
 
-conf.manufdb
+if conf.manufdb:
+    conf.manufdb
+else:
+    True
 
 = check _resolve_MAC
 
-assert conf.manufdb._resolve_MAC("00:00:63") == "HP"
+if conf.manufdb:
+    assert conf.manufdb._resolve_MAC("00:00:63") == "HP"
+else:
+    True
 
 ############
 ############

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -9,6 +9,7 @@
 ### DISCLAIMER: Those tests are slow ###
 
 = Load server util functions
+~ open_ssl_client
 
 import sys, os, re, time, multiprocessing, subprocess
 
@@ -58,14 +59,17 @@ def test_tls_server(suite="", version=""):
     
 
 = Testing TLS server with TLS 1.0 and TLS_RSA_WITH_RC4_128_SHA
+~ open_ssl_client
 
 test_tls_server("RC4-SHA", "-tls1")
 
 = Testing TLS server with TLS 1.2 and TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+~ open_ssl_client
 
 test_tls_server("DHE-RSA-AES128-SHA256", "-tls1_2")
 
 = Testing TLS server with TLS 1.2 and TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+~ open_ssl_client
 
 test_tls_server("ECDHE-RSA-AES256-GCM-SHA384", "-tls1_2")
 


### PR DESCRIPTION
This PR brings several small fixes to improve coverage:
- Add the tests that do not require OpenSSL on appveyor
- Fixes path detection of ManufDB to use the detected Wireshark path.
- Added __repr__ function for manufdb
- Small windows arch tests