### PR TITLE
Updated IE_EndUserAddress to support IPv6 field

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -328,7 +328,7 @@ class IE_ChargingId(IE_Base):
 
 class IE_EndUserAddress(IE_Base):
     # Supply protocol specific information of the external packet 
-    name = "End User Addresss"
+    name = "End User Address"
     fields_desc = [ ByteEnumField("ietype", 128, IEType),
                     #         data network accessed by the GGPRS subscribers.
                     #            - Request
@@ -342,8 +342,10 @@ class IE_EndUserAddress(IE_Base):
                     BitField("SPARE", 15, 4),
                     BitField("PDPTypeOrganization", 1, 4),
                     XByteField("PDPTypeNumber", None),
-                    ConditionalField(IPField("PDPAddress", RandIP()),
-                                     lambda pkt: pkt.length > 2)]
+                    ConditionalField(IPField("PDPAddress_IPv4", RandIP()),
+                                     lambda pkt: pkt.length == 6 or pkt.length == 22),
+                    ConditionalField(IP6Field("PDPAddress_IPv6", "::1"), lambda
+                                    pkt: pkt.length == 18 or pkt.length == 22)]
 
 
 class APNStrLenField(StrLenField):

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+
 ## Copyright (C) 2017 Alexis Sultan    <alexis.sultan@sfr.com>
 ##               2017 Alessio Deiana <adeiana@gmail.com>
 ##               2014 Guillaume Valadon <guillaume.valadon@ssi.gouv.fr>
@@ -28,57 +29,57 @@ RATType = {
     5: "HSPA"
 }
 
-GTPmessageType = {   1: "echo_request",
-                     2: "echo_response",
-                    16: "create_pdp_context_req",
-                    17: "create_pdp_context_res",
-                    18: "update_pdp_context_req",
-                    19: "update_pdp_context_resp",
-                    20: "delete_pdp_context_req",
-                    21: "delete_pdp_context_res",
-                    26: "error_indication",
-                    27: "pdu_notification_req",
-                   255: "gtp_u_header" }
+GTPmessageType = {1: "echo_request",
+                  2: "echo_response",
+                  16: "create_pdp_context_req",
+                  17: "create_pdp_context_res",
+                  18: "update_pdp_context_req",
+                  19: "update_pdp_context_resp",
+                  20: "delete_pdp_context_req",
+                  21: "delete_pdp_context_res",
+                  26: "error_indication",
+                  27: "pdu_notification_req",
+                  255: "gtp_u_header"}
 
-IEType = {   1: "Cause",
-             2: "IMSI",
-             3: "RAI",
-             4: "TLLI",
-             5: "P_TMSI",
-             8: "IE_ReorderingRequired",
-            14: "Recovery",
-            15: "SelectionMode",
-            16: "TEIDI",
-            17: "TEICP",
-            19: "TeardownInd",
-            20: "NSAPI",
-            26: "ChargingChrt",
-            27: "TraceReference",
-            28: "TraceType",
-           127: "ChargingId",
-           128: "EndUserAddress",
-           131: "AccessPointName",
-           132: "ProtocolConfigurationOptions",
-           133: "GSNAddress",
-           134: "MSInternationalNumber",
-           135: "QoS",
-           148: "CommonFlags",
-           149: "APNRestriction",
-           151: "RatType",
-           152: "UserLocationInformation",
-           153: "MSTimeZone",
-           154: "IMEI",
-           181: "MSInfoChangeReportingAction",
-           184: "BearerControlMode",
-           191: "EvolvedAllocationRetentionPriority",
-           255: "PrivateExtention"}
+IEType = {1: "Cause",
+          2: "IMSI",
+          3: "RAI",
+          4: "TLLI",
+          5: "P_TMSI",
+          8: "IE_ReorderingRequired",
+          14: "Recovery",
+          15: "SelectionMode",
+          16: "TEIDI",
+          17: "TEICP",
+          19: "TeardownInd",
+          20: "NSAPI",
+          26: "ChargingChrt",
+          27: "TraceReference",
+          28: "TraceType",
+          127: "ChargingId",
+          128: "EndUserAddress",
+          131: "AccessPointName",
+          132: "ProtocolConfigurationOptions",
+          133: "GSNAddress",
+          134: "MSInternationalNumber",
+          135: "QoS",
+          148: "CommonFlags",
+          149: "APNRestriction",
+          151: "RatType",
+          152: "UserLocationInformation",
+          153: "MSTimeZone",
+          154: "IMEI",
+          181: "MSInfoChangeReportingAction",
+          184: "BearerControlMode",
+          191: "EvolvedAllocationRetentionPriority",
+          255: "PrivateExtention"}
 
-CauseValues = {  0: "Request IMSI",
-                 1: "Request IMEI",
-                 2: "Request IMSI and IMEI",
-                 3: "No identity needed",
-                 4: "MS Refuses",
-                 5: "MS is not GPRS Responding",
+CauseValues = {0: "Request IMSI",
+               1: "Request IMEI",
+               2: "Request IMSI and IMEI",
+               3: "No identity needed",
+               4: "MS Refuses",
+               5: "MS is not GPRS Responding",
                128: "Request accepted",
                129: "New PDP type due to network preference",
                130: "New PDP type due to single address bearer only",
@@ -118,24 +119,23 @@ CauseValues = {  0: "Request IMSI",
                225: "Invalid Correlation : ID",
                226: "MBMS Bearer Context Superseded",
                227: "Bearer Control Mode violation",
-               228: "Collision with network initiated request" }
+               228: "Collision with network initiated request"}
 
-Selection_Mode = { 11111100: "MS or APN",
-                   11111101: "MS",
-                   11111110: "NET",
-                   11111111: "FutureUse" }
+Selection_Mode = {11111100: "MS or APN",
+                  11111101: "MS",
+                  11111110: "NET",
+                  11111111: "FutureUse"}
 
 TrueFalse_value = {254: "False",
                    255: "True"}
 
 
 class TBCDByteField(StrFixedLenField):
-
     def i2h(self, pkt, val):
         return val
 
     def i2repr(self, pkt, x):
-        return repr(self.i2h(pkt,x))
+        return repr(self.i2h(pkt, x))
 
     def m2i(self, pkt, val):
         ret = []
@@ -153,11 +153,11 @@ class TBCDByteField(StrFixedLenField):
         val = str(val)
         ret_string = ""
         for i in xrange(0, len(val), 2):
-            tmp = val[i:i+2]
+            tmp = val[i:i + 2]
             if len(tmp) == 2:
-              ret_string += chr(int(tmp[1] + tmp[0], 16))
+                ret_string += chr(int(tmp[1] + tmp[0], 16))
             else:
-              ret_string += chr(int("F" + tmp[0], 16))
+                ret_string += chr(int("F" + tmp[0], 16))
         return ret_string
 
 
@@ -167,21 +167,21 @@ TBCD_TO_ASCII = "0123456789*#abc"
 class GTPHeader(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Header"
-    fields_desc=[ BitField("version", 1, 3),
-                  BitField("PT", 1, 1),
-                  BitField("reserved", 0, 1),
-                  BitField("E", 0, 1),
-                  BitField("S", 1, 1),
-                  BitField("PN", 0, 1),
-                  ByteEnumField("gtp_type", None, GTPmessageType),
-                  ShortField("length", None),
-                  IntField("teid", 0) ]
+    fields_desc = [BitField("version", 1, 3),
+                   BitField("PT", 1, 1),
+                   BitField("reserved", 0, 1),
+                   BitField("E", 0, 1),
+                   BitField("S", 1, 1),
+                   BitField("PN", 0, 1),
+                   ByteEnumField("gtp_type", None, GTPmessageType),
+                   ShortField("length", None),
+                   IntField("teid", 0)]
 
     def post_build(self, p, pay):
         p += pay
         if self.length is None:
-            l = len(p)-8
-            p = p[:2] + struct.pack("!H", l)+ p[4:]
+            l = len(p) - 8
+            p = p[:2] + struct.pack("!H", l) + p[4:]
         return p
 
     def hashret(self):
@@ -191,7 +191,6 @@ class GTPHeader(Packet):
         return (isinstance(other, GTPHeader) and
                 self.version == other.version and
                 self.payload.answers(other.payload))
-    
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kwargs):
         if _pkt and len(_pkt) >= 1:
@@ -204,16 +203,15 @@ class GTPHeader(Packet):
 class GTPEchoRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Echo Request"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),]
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0), ]
 
     def hashret(self):
         return struct.pack("H", self.seq)
 
 
 class IE_Base(Packet):
-
     def extract_padding(self, pkt):
         return "", pkt
 
@@ -232,13 +230,13 @@ class IE_IMSI(IE_Base):
 
 class IE_Routing(IE_Base):
     name = "Routing Area Identity"
-    fields_desc = [ ByteEnumField("ietype", 3, IEType),
-                    TBCDByteField("MCC", "", 2),
-                    # MNC: if the third digit of MCC is 0xf,
-                    # then the length of MNC is 1 byte
-                    TBCDByteField("MNC", "", 1),
-                    ShortField("LAC", None),
-                    ByteField("RAC", None) ]
+    fields_desc = [ByteEnumField("ietype", 3, IEType),
+                   TBCDByteField("MCC", "", 2),
+                   # MNC: if the third digit of MCC is 0xf,
+                   # then the length of MNC is 1 byte
+                   TBCDByteField("MNC", "", 1),
+                   ShortField("LAC", None),
+                   ByteField("RAC", None)]
 
 
 class IE_ReorderingRequired(IE_Base):
@@ -249,74 +247,75 @@ class IE_ReorderingRequired(IE_Base):
 
 class IE_Recovery(IE_Base):
     name = "Recovery"
-    fields_desc = [ ByteEnumField("ietype", 14, IEType),
-                    ByteField("restart_counter", 24) ]
+    fields_desc = [ByteEnumField("ietype", 14, IEType),
+                   ByteField("restart_counter", 24)]
 
 
 class IE_SelectionMode(IE_Base):
     # Indicates the origin of the APN in the message
     name = "Selection Mode"
-    fields_desc = [ ByteEnumField("ietype", 15, IEType),
-                    BitEnumField("SelectionMode", "MS or APN", 
-                                 8, Selection_Mode) ]
+    fields_desc = [ByteEnumField("ietype", 15, IEType),
+                   BitEnumField("SelectionMode", "MS or APN",
+                                8, Selection_Mode)]
 
 
 class IE_TEIDI(IE_Base):
     name = "Tunnel Endpoint Identifier Data"
-    fields_desc = [ ByteEnumField("ietype", 16, IEType),
-                    XIntField("TEIDI", RandInt()) ]
+    fields_desc = [ByteEnumField("ietype", 16, IEType),
+                   XIntField("TEIDI", RandInt())]
 
 
 class IE_TEICP(IE_Base):
     name = "Tunnel Endpoint Identifier Control Plane"
-    fields_desc = [ ByteEnumField("ietype", 17, IEType),
-                    XIntField("TEICI", RandInt())]
+    fields_desc = [ByteEnumField("ietype", 17, IEType),
+                   XIntField("TEICI", RandInt())]
 
 
 class IE_Teardown(IE_Base):
     name = "Teardown Indicator"
-    fields_desc = [ ByteEnumField("ietype", 19, IEType),
-                    ByteEnumField("indicator", "True", TrueFalse_value) ]
+    fields_desc = [ByteEnumField("ietype", 19, IEType),
+                   ByteEnumField("indicator", "True", TrueFalse_value)]
 
 
 class IE_NSAPI(IE_Base):
     # Identifies a PDP context in a mobility management context specified by TEICP
     name = "NSAPI"
-    fields_desc = [ ByteEnumField("ietype", 20, IEType),
-                    XBitField("sparebits", 0x0000, 4),
-                    XBitField("NSAPI", RandNum(0, 15), 4) ]
+    fields_desc = [ByteEnumField("ietype", 20, IEType),
+                   XBitField("sparebits", 0x0000, 4),
+                   XBitField("NSAPI", RandNum(0, 15), 4)]
 
 
 class IE_ChargingCharacteristics(IE_Base):
     # Way of informing both the SGSN and GGSN of the rules for 
     name = "Charging Characteristics"
-    fields_desc = [ ByteEnumField("ietype", 26, IEType),
-                    # producing charging information based on operator configured triggers.
-                    #    0000 .... .... .... : spare
-                    #    .... 1... .... .... : normal charging
-                    #    .... .0.. .... .... : prepaid charging
-                    #    .... ..0. .... .... : flat rate charging
-                    #    .... ...0 .... .... : hot billing charging
-                    #    .... .... 0000 0000 : reserved
-                    XBitField("Ch_ChSpare", None, 4),
-                    XBitField("normal_charging", None, 1),
-                    XBitField("prepaid_charging", None, 1),
-                    XBitField("flat_rate_charging", None, 1),
-                    XBitField("hot_billing_charging", None, 1),
-                    XBitField("Ch_ChReserved", 0, 8) ]
+    fields_desc = [ByteEnumField("ietype", 26, IEType),
+                   # producing charging information based on operator configured triggers.
+                   #    0000 .... .... .... : spare
+                   #    .... 1... .... .... : normal charging
+                   #    .... .0.. .... .... : prepaid charging
+                   #    .... ..0. .... .... : flat rate charging
+                   #    .... ...0 .... .... : hot billing charging
+                   #    .... .... 0000 0000 : reserved
+                   XBitField("Ch_ChSpare", None, 4),
+                   XBitField("normal_charging", None, 1),
+                   XBitField("prepaid_charging", None, 1),
+                   XBitField("flat_rate_charging", None, 1),
+                   XBitField("hot_billing_charging", None, 1),
+                   XBitField("Ch_ChReserved", 0, 8)]
+
 
 class IE_TraceReference(IE_Base):
     # Identifies a record or a collection of records for a particular trace.
     name = "Trace Reference"
-    fields_desc = [ ByteEnumField("ietype", 27, IEType),
-                    XBitField("Trace_reference", None, 16) ]
+    fields_desc = [ByteEnumField("ietype", 27, IEType),
+                   XBitField("Trace_reference", None, 16)]
 
 
 class IE_TraceType(IE_Base):
     # Indicates the type of the trace
     name = "Trace Type"
-    fields_desc = [ ByteEnumField("ietype", 28, IEType),
-                    XBitField("Trace_type", None, 16) ]
+    fields_desc = [ByteEnumField("ietype", 28, IEType),
+                   XBitField("Trace_type", None, 16)]
 
 
 class IE_ChargingId(IE_Base):
@@ -328,24 +327,24 @@ class IE_ChargingId(IE_Base):
 class IE_EndUserAddress(IE_Base):
     # Supply protocol specific information of the external packet 
     name = "End User Address"
-    fields_desc = [ ByteEnumField("ietype", 128, IEType),
-                    #         data network accessed by the GGPRS subscribers.
-                    #            - Request
-                    #                1    Type (1byte)
-                    #                2-3    Length (2bytes) - value 2
-                    #                4    Spare + PDP Type Organization
-                    #                5    PDP Type Number    
-                    #            - Response
-                    #                6-n    PDP Address
-                    ShortField("length", 2),
-                    BitField("SPARE", 15, 4),
-                    BitField("PDPTypeOrganization", 1, 4),
-                    XByteField("PDPTypeNumber", None),
-                    ConditionalField(IPField('PDPAddress_IPv4', RandIP()),
-                                     lambda pkt: pkt.length == 6 or pkt.length == 22),
-                    ConditionalField(IP6Field('PDPAddress_IPv6', '::1'),
-                                     lambda pkt: pkt.length == 18 or pkt.length == 22)
-                    ]
+    fields_desc = [ByteEnumField("ietype", 128, IEType),
+                   #         data network accessed by the GGPRS subscribers.
+                   #            - Request
+                   #                1    Type (1byte)
+                   #                2-3    Length (2bytes) - value 2
+                   #                4    Spare + PDP Type Organization
+                   #                5    PDP Type Number
+                   #            - Response
+                   #                6-n    PDP Address
+                   ShortField("length", 2),
+                   BitField("SPARE", 15, 4),
+                   BitField("PDPTypeOrganization", 1, 4),
+                   XByteField("PDPTypeNumber", None),
+                   ConditionalField(IPField("PDPAddress_IPv4", RandIP()),
+                                    lambda pkt: pkt.length == 6 or pkt.length == 22),
+                   ConditionalField(IP6Field("PDPAddress_IPv6", "::1"),
+                                    lambda pkt: pkt.length == 18 or pkt.length == 22)]
+
 
 class APNStrLenField(StrLenField):
     # Inspired by DNSStrField
@@ -356,52 +355,54 @@ class APNStrLenField(StrLenField):
             tmp_len = struct.unpack("!B", tmp_s[0])[0] + 1
             if tmp_len > len(tmp_s):
                 warning("APN prematured end of character-string (size=%i, remaining bytes=%i)" % (tmp_len, len(tmp_s)))
-            ret_s +=  tmp_s[1:tmp_len] 
+            ret_s += tmp_s[1:tmp_len]
             tmp_s = tmp_s[tmp_len:]
-            if len(tmp_s) :
+            if len(tmp_s):
                 ret_s += "."
         s = ret_s
         return s
+
     def i2m(self, pkt, s):
-        s = "".join(map(lambda x: chr(len(x))+x, s.split(".")))
+        s = "".join(map(lambda x: chr(len(x)) + x, s.split(".")))
         return s
 
 
 class IE_AccessPointName(IE_Base):
     # Sent by SGSN or by GGSN as defined in 3GPP TS 23.060
     name = "Access Point Name"
-    fields_desc = [ ByteEnumField("ietype", 131, IEType),
-                    ShortField("length",  None),
-                    APNStrLenField("APN", "nternet", length_from=lambda x: x.length) ]
+    fields_desc = [ByteEnumField("ietype", 131, IEType),
+                   ShortField("length", None),
+                   APNStrLenField("APN", "nternet", length_from=lambda x: x.length)]
 
     def post_build(self, p, pay):
         if self.length is None:
-            l = len(p)-3
-            p = p[:2] + struct.pack("!B", l)+ p[3:]
+            l = len(p) - 3
+            p = p[:2] + struct.pack("!B", l) + p[3:]
         return p
 
 
 class IE_ProtocolConfigurationOptions(IE_Base):
     name = "Protocol Configuration Options"
-    fields_desc = [ ByteEnumField("ietype", 132, IEType),
-            ShortField("length", 4),
-            StrLenField("Protocol_Configuration", "", 
-                        length_from=lambda x: x.length) ]
+    fields_desc = [ByteEnumField("ietype", 132, IEType),
+                   ShortField("length", 4),
+                   StrLenField("Protocol_Configuration", "",
+                               length_from=lambda x: x.length)]
 
 
 class IE_GSNAddress(IE_Base):
     name = "GSN Address"
-    fields_desc = [ ByteEnumField("ietype", 133, IEType),
-                    ShortField("length", 4),
-                    IPField("address", RandIP()) ]
+    fields_desc = [ByteEnumField("ietype", 133, IEType),
+                   ShortField("length", 4),
+                   IPField("address", RandIP())]
 
 
 class IE_MSInternationalNumber(IE_Base):
     name = "MS International Number"
-    fields_desc = [ ByteEnumField("ietype", 134, IEType),
-                    ShortField("length", None),
-                    FlagsField("flags", 0x91, 8, ["Extension","","","International Number","","","","ISDN numbering"]),
-                    TBCDByteField("digits", "33607080910", length_from=lambda x: x.length-1) ]
+    fields_desc = [ByteEnumField("ietype", 134, IEType),
+                   ShortField("length", None),
+                   FlagsField("flags", 0x91, 8,
+                              ["Extension", "", "", "International Number", "", "", "", "ISDN numbering"]),
+                   TBCDByteField("digits", "33607080910", length_from=lambda x: x.length - 1)]
 
 
 class QoS_Profile(IE_Base):
@@ -545,15 +546,15 @@ class IE_RATType(IE_Base):
 
 class IE_UserLocationInformation(IE_Base):
     name = "User Location Information"
-    fields_desc = [ ByteEnumField("ietype", 152, IEType),
-                    ShortField("length", None),
-                    ByteField("type", 1),
-                    # Only type 1 is currently supported
-                    TBCDByteField("MCC", "", 2),
-                    # MNC: if the third digit of MCC is 0xf, then the length of MNC is 1 byte
-                    TBCDByteField("MNC", "", 1),
-                    ShortField("LAC", None),
-                    ShortField("SAC", None) ]
+    fields_desc = [ByteEnumField("ietype", 152, IEType),
+                   ShortField("length", None),
+                   ByteField("type", 1),
+                   # Only type 1 is currently supported
+                   TBCDByteField("MCC", "", 2),
+                   # MNC: if the third digit of MCC is 0xf, then the length of MNC is 1 byte
+                   TBCDByteField("MNC", "", 1),
+                   ShortField("LAC", None),
+                   ShortField("SAC", None)]
 
 
 class IE_MSTimeZone(IE_Base):
@@ -572,9 +573,9 @@ class IE_MSTimeZone(IE_Base):
 
 class IE_IMEI(IE_Base):
     name = "IMEI"
-    fields_desc = [ ByteEnumField("ietype", 154, IEType),
-                    ShortField("length", None),
-                    TBCDByteField("IMEI", "", length_from=lambda x: x.length) ]
+    fields_desc = [ByteEnumField("ietype", 154, IEType),
+                   ShortField("length", None),
+                   TBCDByteField("IMEI", "", length_from=lambda x: x.length)]
 
 
 class IE_MSInfoChangeReportingAction(IE_Base):
@@ -622,9 +623,9 @@ class IE_CharginGatewayAddress(IE_Base):
                    ShortField("length", 4),
                    ConditionalField(IPField("ipv4_address", "127.0.0.1"),
                                     lambda
-                                    pkt: pkt.length == 4),
+                                        pkt: pkt.length == 4),
                    ConditionalField(IP6Field("ipv6_address", "::1"), lambda
-                                    pkt: pkt.length == 16)]
+                       pkt: pkt.length == 16)]
 
 
 class IE_PrivateExtension(IE_Base):
@@ -638,11 +639,12 @@ class IE_PrivateExtension(IE_Base):
 
 class IE_NotImplementedTLV(Packet):
     name = "IE not implemented"
-    fields_desc = [ ByteEnumField("ietype", 0, IEType),
-                    ShortField("length",  None),
-                    StrLenField("data", "", length_from=lambda x: x.length) ]
+    fields_desc = [ByteEnumField("ietype", 0, IEType),
+                   ShortField("length", None),
+                   StrLenField("data", "", length_from=lambda x: x.length)]
+
     def extract_padding(self, pkt):
-        return "",pkt
+        return "", pkt
 
 
 ietypecls = {1: IE_Cause,
@@ -680,28 +682,29 @@ ietypecls = {1: IE_Cause,
 
 
 def IE_Dispatcher(s):
-  """Choose the correct Information Element class."""
+    """Choose the correct Information Element class."""
 
-  if len(s) < 1:
-    return Raw(s)
+    if len(s) < 1:
+        return Raw(s)
 
-  # Get the IE type
-  ietype = ord(s[0])
-  cls = ietypecls.get(ietype, Raw)
+    # Get the IE type
+    ietype = ord(s[0])
+    cls = ietypecls.get(ietype, Raw)
 
-  # if ietype greater than 128 are TLVs
-  if cls == Raw and ietype & 128 == 128:
-    cls = IE_NotImplementedTLV
+    # if ietype greater than 128 are TLVs
+    if cls == Raw and ietype & 128 == 128:
+        cls = IE_NotImplementedTLV
 
-  return cls(s)
+    return cls(s)
+
 
 class GTPEchoResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Echo Response"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),
-                    PacketListField("IE_list", [], IE_Dispatcher) ]
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [], IE_Dispatcher)]
 
     def hashret(self):
         return struct.pack("H", self.seq)
@@ -713,23 +716,25 @@ class GTPEchoResponse(Packet):
 class GTPCreatePDPContextRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Create PDP Context Request"
-    fields_desc = [ ShortField("seq", RandShort()),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),
-                    PacketListField("IE_list", [ IE_TEIDI(), IE_NSAPI(), IE_GSNAddress(),
-                                                 IE_GSNAddress(),
-                                                 IE_NotImplementedTLV(ietype=135, length=15,data=RandString(15)) ],
-                                    IE_Dispatcher) ]
+    fields_desc = [ShortField("seq", RandShort()),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [IE_TEIDI(), IE_NSAPI(), IE_GSNAddress(),
+                                               IE_GSNAddress(),
+                                               IE_NotImplementedTLV(ietype=135, length=15, data=RandString(15))],
+                                   IE_Dispatcher)]
+
     def hashret(self):
         return struct.pack("H", self.seq)
+
 
 class GTPCreatePDPContextResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Create PDP Context Response"
-    fields_desc = [ ShortField("seq", RandShort()),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),
-                    PacketListField("IE_list", [], IE_Dispatcher) ]
+    fields_desc = [ShortField("seq", RandShort()),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [], IE_Dispatcher)]
 
     def hashret(self):
         return struct.pack("H", self.seq)
@@ -764,7 +769,7 @@ class GTPUpdatePDPContextRequest(Packet):
                        IE_MSInfoChangeReportingAction(),
                        IE_EvolvedAllocationRetentionPriority(),
                        IE_PrivateExtension()],
-        IE_Dispatcher)]
+                                   IE_Dispatcher)]
 
     def hashret(self):
         return struct.pack("H", self.seq)
@@ -785,48 +790,43 @@ class GTPUpdatePDPContextResponse(Packet):
 class GTPErrorIndication(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Error Indication"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex",0),
-                    PacketListField("IE_list", [], IE_Dispatcher) ]
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [], IE_Dispatcher)]
+
 
 class GTPDeletePDPContextRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Delete PDP Context Request"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),
-                    PacketListField("IE_list", [], IE_Dispatcher) ]
-    def hashret(self):
-        return struct.pack("H", self.seq)
-
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [], IE_Dispatcher)]
 
 
 class GTPDeletePDPContextResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Delete PDP Context Response"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex",0),
-                    PacketListField("IE_list", [], IE_Dispatcher) ]
-    def hashret(self):
-        return struct.pack("H", self.seq)
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [], IE_Dispatcher)]
 
-    def answers(self, other):
-        return self.seq == other.seq
 
 class GTPPDUNotificationRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP PDU Notification Request"
-    fields_desc = [ XBitField("seq", 0, 16),
-                    ByteField("npdu", 0),
-                    ByteField("next_ex", 0),
-                    PacketListField("IE_list", [ IE_IMSI(),
-                        IE_TEICP(TEICI=RandInt()),
-                        IE_EndUserAddress(PDPTypeNumber=0x21),
-                        IE_AccessPointName(),
-                        IE_GSNAddress(address="127.0.0.1"),
-                        ], IE_Dispatcher) ]
+    fields_desc = [XBitField("seq", 0, 16),
+                   ByteField("npdu", 0),
+                   ByteField("next_ex", 0),
+                   PacketListField("IE_list", [IE_IMSI(),
+                                               IE_TEICP(TEICI=RandInt()),
+                                               IE_EndUserAddress(PDPTypeNumber=0x21),
+                                               IE_AccessPointName(),
+                                               IE_GSNAddress(address="127.0.0.1"),
+                                               ], IE_Dispatcher)]
+
 
 class GTP_U_Header(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
@@ -834,36 +834,38 @@ class GTP_U_Header(Packet):
     # GTP-U protocol is used to transmit T-PDUs between GSN pairs (or between an SGSN and an RNC in UMTS), 
     # encapsulated in G-PDUs. A G-PDU is a packet including a GTP-U header and a T-PDU. The Path Protocol 
     # defines the path and the GTP-U header defines the tunnel. Several tunnels may be multiplexed on a single path. 
-    fields_desc = [ BitField("version", 1,3),
-                    BitField("PT", 1, 1),
-                    BitField("Reserved", 0, 1),
-                    BitField("E", 0,1),
-                    BitField("S", 0, 1),
-                    BitField("PN", 0, 1),
-                    ByteEnumField("gtp_type", None, GTPmessageType),
-                    BitField("length", None, 16),
-                    XBitField("TEID", 0, 32),
-                    ConditionalField(XBitField("seq", 0, 16), lambda pkt:pkt.E==1 or pkt.S==1 or pkt.PN==1),
-                    ConditionalField(ByteField("npdu", 0), lambda pkt:pkt.E==1 or pkt.S==1 or pkt.PN==1),
-                    ConditionalField(ByteField("next_ex", 0), lambda pkt:pkt.E==1 or pkt.S==1 or pkt.PN==1),
-            ]
+    fields_desc = [BitField("version", 1, 3),
+                   BitField("PT", 1, 1),
+                   BitField("Reserved", 0, 1),
+                   BitField("E", 0, 1),
+                   BitField("S", 0, 1),
+                   BitField("PN", 0, 1),
+                   ByteEnumField("gtp_type", None, GTPmessageType),
+                   BitField("length", None, 16),
+                   XBitField("TEID", 0, 32),
+                   ConditionalField(XBitField("seq", 0, 16), lambda pkt: pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ConditionalField(ByteField("npdu", 0), lambda pkt: pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ConditionalField(ByteField("next_ex", 0), lambda pkt: pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ]
 
     def post_build(self, p, pay):
         p += pay
         if self.length is None:
-            l = len(p)-8
-            p = p[:2] + struct.pack("!H", l)+ p[4:]
+            l = len(p) - 8
+            p = p[:2] + struct.pack("!H", l) + p[4:]
         return p
+
 
 class GTPmorethan1500(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP More than 1500"
-    fields_desc = [ ByteEnumField("IE_Cause", "Cause", IEType),
-                    BitField("IE", 1, 12000),]
+    fields_desc = [ByteEnumField("IE_Cause", "Cause", IEType),
+                   BitField("IE", 1, 12000), ]
+
 
 # Bind GTP-C
-bind_layers(UDP, GTPHeader, dport = 2123)
-bind_layers(UDP, GTPHeader, sport = 2123)
+bind_layers(UDP, GTPHeader, dport=2123)
+bind_layers(UDP, GTPHeader, sport=2123)
 bind_layers(GTPHeader, GTPEchoRequest, gtp_type=1)
 bind_layers(GTPHeader, GTPEchoResponse, gtp_type=2)
 bind_layers(GTPHeader, GTPCreatePDPContextRequest, gtp_type=16)
@@ -875,10 +877,11 @@ bind_layers(GTPHeader, GTPDeletePDPContextResponse, gtp_type=21)
 bind_layers(GTPHeader, GTPPDUNotificationRequest, gtp_type=27)
 
 # Bind GTP-U
-bind_layers(UDP, GTP_U_Header, dport = 2152)
-bind_layers(UDP, GTP_U_Header, sport = 2152)
-bind_layers(GTP_U_Header, IP, gtp_type = 255)
+bind_layers(UDP, GTP_U_Header, dport=2152)
+bind_layers(UDP, GTP_U_Header, sport=2152)
+bind_layers(GTP_U_Header, IP, gtp_type=255)
 
 if __name__ == "__main__":
     from scapy.all import *
+
     interact(mydict=globals(), mybanner="GTPv1 add-on")

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -193,9 +193,8 @@ class GTPHeader(Packet):
                 self.version == other.version and
                 self.payload.answers(other.payload))
     
-    
     @classmethod
-    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+    def dispatch_hook(cls, _pkt=None, *args, **kwargs):
         if _pkt and len(_pkt) >= 1:
             if (struct.unpack("B", _pkt[0])[0] >> 5) & 0x7 == 2:
                 import gtp_v2
@@ -343,11 +342,11 @@ class IE_EndUserAddress(IE_Base):
                     BitField("SPARE", 15, 4),
                     BitField("PDPTypeOrganization", 1, 4),
                     XByteField("PDPTypeNumber", None),
-                    ConditionalField(IPField("PDPAddress_IPv4", RandIP()),
+                    ConditionalField(IPField('PDPAddress_IPv4', RandIP()),
                                      lambda pkt: pkt.length == 6 or pkt.length == 22),
-                    ConditionalField(IP6Field("PDPAddress_IPv6", "::1"), lambda
-                                    pkt: pkt.length == 18 or pkt.length == 22)]
-
+                    ConditionalField(IP6Field('PDPAddress_IPv6', RandIP6()),
+                                     lambda pkt: pkt.length == 18 or pkt.length == 22)
+                    ]
 
 class APNStrLenField(StrLenField):
     # Inspired by DNSStrField

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -193,6 +193,7 @@ class GTPHeader(Packet):
                 self.version == other.version and
                 self.payload.answers(other.payload))
 
+    
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 1:

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -192,7 +192,6 @@ class GTPHeader(Packet):
         return (isinstance(other, GTPHeader) and
                 self.version == other.version and
                 self.payload.answers(other.payload))
-
     
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -193,6 +193,7 @@ class GTPHeader(Packet):
                 self.version == other.version and
                 self.payload.answers(other.payload))
     
+    
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 1:

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -343,7 +343,7 @@ class IE_EndUserAddress(IE_Base):
                     XByteField("PDPTypeNumber", None),
                     ConditionalField(IPField('PDPAddress_IPv4', RandIP()),
                                      lambda pkt: pkt.length == 6 or pkt.length == 22),
-                    ConditionalField(IP6Field('PDPAddress_IPv6', RandIP6()),
+                    ConditionalField(IP6Field('PDPAddress_IPv6', '::1'),
                                      lambda pkt: pkt.length == 18 or pkt.length == 22)
                     ]
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -797,6 +797,10 @@ class GTPDeletePDPContextRequest(Packet):
                     ByteField("npdu", 0),
                     ByteField("next_ex", 0),
                     PacketListField("IE_list", [], IE_Dispatcher) ]
+    def hashret(self):
+        return struct.pack("H", self.seq)
+
+
 
 class GTPDeletePDPContextResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
@@ -805,6 +809,11 @@ class GTPDeletePDPContextResponse(Packet):
                     ByteField("npdu", 0),
                     ByteField("next_ex",0),
                     PacketListField("IE_list", [], IE_Dispatcher) ]
+    def hashret(self):
+        return struct.pack("H", self.seq)
+
+    def answers(self, other):
+        return self.seq == other.seq
 
 class GTPPDUNotificationRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-
 ## Copyright (C) 2017 Alexis Sultan    <alexis.sultan@sfr.com>
 ##               2017 Alessio Deiana <adeiana@gmail.com>
 ##               2014 Guillaume Valadon <guillaume.valadon@ssi.gouv.fr>

--- a/scapy/contrib/gtp.uts
+++ b/scapy/contrib/gtp.uts
@@ -146,17 +146,17 @@ ie.ietype == 127 and ie.Charging_id == 0xff1bc3f2
 h = "3333333333332222222222228100838408004588008500000000fd11840b0a2a00010a2a0002084b4a6c00717c8a32110061c1b9728f356a0000018008fe10af709e9011e3cb6a4b7fb60e1b28800006f1210a2a00038400218080210a0301000a03060ab0aa93802110030100108106ac14020a8306ac1402278500040a2a00018500040a2a000187000c0213621f7396486874f2ffff44ded108"
 gtp = Ether(h.decode('hex'))
 ie = gtp.IE_list[5]
-ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress == '10.42.0.3'
+ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress_IPv4 == '10.42.0.3'
 
 = IE_EndUserAddress(), basic instantiation
 ie = IE_EndUserAddress(
     length=22, PDPTypeOrganization=1, PDPTypeNumber=0x8d, PDPAddress_IPv4='10.42.0.3', PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
-ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.PDPAddress_IPv4 == '10.42.0.3' and ie.PDPAddress_IPv6 = '2001:db8:a0b:12f0::1'
+ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.PDPAddress_IPv4 == '10.42.0.3' and ie.PDPAddress_IPv6 == '2001:db8:a0b:12f0::1'
 
 = IE_EndUserAddress(), basic instantiation
 ie = IE_EndUserAddress(
     length=18, PDPTypeOrganization=1, PDPTypeNumber=0x57, PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
-ie.ietype == 128 and ie.length == 18 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x57 and ie.PDPAddress_IPv6 = '2001:db8:a0b:12f0::1'
+ie.ietype == 128 and ie.length == 18 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x57 and ie.PDPAddress_IPv6 == '2001:db8:a0b:12f0::1'
 
 = IE_AccessPointName(), dissect
 h = "333333333333222222222222810083840800458800bc00000000fc1184c90a2a00010a2a00024acf084b00a87bbb3210009867fe972185e800000202081132547600000332f42004d27b0ffc1093b20c3f11940eb2bf14051a0400800002f1218300070661616161616184001480802110010000108106000000008306000000008500040a2a00018500040a2a00018600079111111111111187000f0213921f7396d3fe74f2ffff004a0094000120970001019800080132f42004d204d299000240009a000811111111111100001b1212951c5bbe"

--- a/scapy/contrib/gtp.uts
+++ b/scapy/contrib/gtp.uts
@@ -150,8 +150,13 @@ ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTy
 
 = IE_EndUserAddress(), basic instantiation
 ie = IE_EndUserAddress(
-    length=6, PDPTypeOrganization=1, PDPTypeNumber=0x21, PDPAddress='10.42.0.3')
-ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress == '10.42.0.3'
+    length=22, PDPTypeOrganization=1, PDPTypeNumber=0x8d, PDPAddress_IPv4='10.42.0.3', PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
+ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.PDPAddress_IPv4 == '10.42.0.3' and ie.PDPAddress_IPv6 = '2001:db8:a0b:12f0::1'
+
+= IE_EndUserAddress(), basic instantiation
+ie = IE_EndUserAddress(
+    length=18, PDPTypeOrganization=1, PDPTypeNumber=0x57, PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
+ie.ietype == 128 and ie.length == 18 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x57 and ie.PDPAddress_IPv6 = '2001:db8:a0b:12f0::1'
 
 = IE_AccessPointName(), dissect
 h = "333333333333222222222222810083840800458800bc00000000fc1184c90a2a00010a2a00024acf084b00a87bbb3210009867fe972185e800000202081132547600000332f42004d27b0ffc1093b20c3f11940eb2bf14051a0400800002f1218300070661616161616184001480802110010000108106000000008306000000008500040a2a00018500040a2a00018600079111111111111187000f0213921f7396d3fe74f2ffff004a0094000120970001019800080132f42004d204d299000240009a000811111111111100001b1212951c5bbe"

--- a/scapy/contrib/gtp.uts
+++ b/scapy/contrib/gtp.uts
@@ -148,15 +148,20 @@ gtp = Ether(h.decode('hex'))
 ie = gtp.IE_list[5]
 ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress_IPv4 == '10.42.0.3'
 
-= IE_EndUserAddress(), basic instantiation
+= IE_EndUserAddress(), basic instantiation IPv4v6
 ie = IE_EndUserAddress(
     length=22, PDPTypeOrganization=1, PDPTypeNumber=0x8d, PDPAddress_IPv4='10.42.0.3', PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
 ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.PDPAddress_IPv4 == '10.42.0.3' and ie.PDPAddress_IPv6 == '2001:db8:a0b:12f0::1'
 
-= IE_EndUserAddress(), basic instantiation
+= IE_EndUserAddress(), basic instantiation IPv6
 ie = IE_EndUserAddress(
     length=18, PDPTypeOrganization=1, PDPTypeNumber=0x57, PDPAddress_IPv6 = '2001:db8:a0b:12f0::1')
 ie.ietype == 128 and ie.length == 18 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x57 and ie.PDPAddress_IPv6 == '2001:db8:a0b:12f0::1'
+
+= IE_EndUserAddress(), basic instantiation IPv4
+ie = IE_EndUserAddress(
+    length=6, PDPTypeOrganization=1, PDPTypeNumber=0x21, PDPAddress_IPv4 = '10.42.0.3')
+ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress_IPv4 == '10.42.0.3'
 
 = IE_AccessPointName(), dissect
 h = "333333333333222222222222810083840800458800bc00000000fc1184c90a2a00010a2a00024acf084b00a87bbb3210009867fe972185e800000202081132547600000332f42004d27b0ffc1093b20c3f11940eb2bf14051a0400800002f1218300070661616161616184001480802110010000108106000000008306000000008500040a2a00018500040a2a00018600079111111111111187000f0213921f7396d3fe74f2ffff004a0094000120970001019800080132f42004d204d299000240009a000811111111111100001b1212951c5bbe"


### PR DESCRIPTION
Added the ConditionalField PDPAddress_IPv6 and changed the IPField name from PDPAddress to PDPAddress_IPv4.
Their condition matches 3GPP TS 29.060 7.7.27 Topic, which states that if there is only IPv4, length must be 6, if there is only IPv6, length must be 18 and if there is IPv4v6, length must be 22.

Also added new tests for this modification under IE_EndUserAddress() basic instatiations.