### PR TITLE
[coverage] Speed up all tests x2

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -63,18 +63,8 @@ then
   fi
 fi
 
-for f in *.uts
-do
-  if [ "$f" = "bpf.uts" ] || [ "$f" = "mock_windows.uts" ] ; then
-    continue
-  fi
-  $SCAPY_SUDO ./run_tests -q -F -t $f $UT_FLAGS || exit $?
-done
-
-for f in ../scapy/contrib/*.uts
-do
-  $SCAPY_SUDO ./run_tests -f text -t $f $UT_FLAGS -P "load_contrib('$(basename ${f/.uts})')" || exit $?
-done
+# Run all normal and contrib tests
+$SCAPY_SUDO ./run_tests -c ./configs/travis.utsc -T "bpf.uts" -T "mock_windows.uts" $UT_FLAGS || exit $?
 
 # Run unit tests with openssl if we have root privileges
 if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z $SCAPY_USE_PCAPDNET ] && [ ! -z $SCAPY_SUDO ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,12 +27,9 @@ test_script:
   - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd || exit /b 42"
   - 'del test\regression.uts'
 
-  # Secondary unit tests
+  # Secondary and contrib unit tests
   - 'del test\bpf.uts' # Don't bother with BPF regression tests
-  - "for %%t in (test\\*.uts) do (%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t %%t -F -K combined_modes_ccm || exit /b 42)"
-  
-  # Contrib unit tests
-  - "for %%t in (scapy\\contrib\\*.uts) do (%PYTHON%\\python -m coverage run -a bin\\UTscapy -f text -t %%t -F -P \"load_contrib(\'%%~nt\')\"  || exit /b 42)"
+  - "%PYTHON%\\python -m coverage run -a bin\\UTscapy -c test\\configs\\windows.utsc || exit /b 42"
 
 after_test:
   # Install & run codecov

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -25,7 +25,7 @@ class DADict_Exception(Scapy_Exception):
 class DADict:
     def __init__(self, _name="DADict", **kargs):
         self._name=_name
-        self.__dict__.update(kargs)
+        self._update(kargs)
     def fixname(self,val):
         return fixname(val)
     def __contains__(self, val):
@@ -55,6 +55,10 @@ class DADict:
             if k not in self or self[k] != kargs[k]:
                 return False
         return True
+
+    def _update(self, *args, **kwargs):
+        for k, v in dict(*args, **kwargs).iteritems():
+            self[k] = v
     
     def _find(self, *args, **kargs):
          return self._recurs_find((), *args, **kargs)

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -25,7 +25,7 @@ class DADict_Exception(Scapy_Exception):
 class DADict:
     def __init__(self, _name="DADict", **kargs):
         self._name=_name
-        self._update(kargs)
+        self.update(kargs)
     def fixname(self,val):
         return fixname(val)
     def __contains__(self, val):
@@ -56,7 +56,7 @@ class DADict:
                 return False
         return True
 
-    def _update(self, *args, **kwargs):
+    def update(self, *args, **kwargs):
         for k, v in dict(*args, **kwargs).iteritems():
             self[k] = v
     

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -24,9 +24,6 @@ sox_base = "sox -t .ul %s - -t ossdsp /dev/dsp"
 if WINDOWS:
     if conf.prog.sox is None:
         raise OSError("Sox must be installed to play VoIP packets")
-    finally:
-        if p_test:
-            p_test.terminate()
     sox_base = "\"" + conf.prog.sox + "\" -t .ul %s - -t waveaudio"
 
 def _merge_sound_bytes(x,y,sample_size=2):

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -193,7 +193,7 @@ x.version == 3
 x.serial == 0xB45E7043E7090B71
 
 = Cert class : Checking signature algorithm
-x.sigAlg == 'sha1-with-rsa-signature' 
+x.sigAlg == 'sha1_with_rsa_signature' 
 
 = Cert class : Checking issuer extraction in basic format (/C=FR ...)
 x.issuer_str == '/C=FR/ST=Paris/L=Paris/O=Mushroom Corp./OU=Mushroom VPN Services/CN=IKEv2 X.509 Test certificate/emailAddress=ikev2-test@mushroom.corp'

--- a/test/configs/travis.utsc
+++ b/test/configs/travis.utsc
@@ -1,0 +1,11 @@
+{
+  "testfiles": [
+    "*.uts",
+    "../scapy/contrib/*.uts"
+  ],
+  "onlyfailed": true,
+  "preexec": {
+    "../scapy/contrib/*.uts": "load_contrib(\"%name%\")"
+  },
+  "format": "text"
+}

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -1,0 +1,14 @@
+{
+  "testfiles": [
+    "test\\*.uts",
+    "scapy\\contrib\\*.uts"
+  ],
+  "onlyfailed": true,
+  "preexec": {
+    "scapy\\contrib\\*.uts": "load_contrib(\"%name%\")"
+  },
+  "format": "text",
+  "kw_ko": [
+    "combined_modes_ccm"
+  ]
+}

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -1,0 +1,15 @@
+{
+  "testfiles": [
+    "*.uts",
+    "..\\scapy\\contrib\\*.uts"
+  ],
+  "onlyfailed": true,
+  "preexec": {
+    "..\\scapy\\contrib\\*.uts": "load_contrib(\"%name%\")"
+  },
+  "format": "html",
+  "kw_ko": [
+    "combined_modes_ccm",
+    "mock_read_routes6_bsd"
+  ]
+}

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1217,7 +1217,7 @@ in6_addrtomac("FE80::" + in6_mactoifaceid("FF:00:00:00:00:00", ulbit=0)) == 'ff:
 import socket
 
 res=True
-for _ in xrange(10):
+for a in xrange(10):
     s1,s2 = in6_getRandomizedIfaceId('20b:93ff:feeb:2d3')
     inet_pton(socket.AF_INET6, '::'+s1)
     tmp2 = inet_pton(socket.AF_INET6, '::'+s2)
@@ -7446,10 +7446,11 @@ def test_show():
         result_show += s
     mock_stdout = mock.Mock()
     mock_stdout.write = write
+    saved_stdout = sys.stdout
     sys.stdout = mock_stdout
     tr = TracerouteResult(tr_packets)
     tr.show()
-    sys.stdout = sys.__stdout__
+    sys.stdout = saved_stdout
     expected = "  192.168.0.1:tcp80  \n"
     expected += "1 192.168.0.1     11 \n"
     expected += "2 192.168.0.2     11 \n"
@@ -7498,10 +7499,11 @@ def test_IPID_count():
         result_IPID_count += s
     mock_stdout = mock.Mock()
     mock_stdout.write = write
+    saved_stdout = sys.stdout
     sys.stdout = mock_stdout
     random.seed(0x2807)
     IPID_count([(IP()/UDP(), IP(id=random.randint(0, 65535))/UDP()) for i in range(3)])
-    sys.stdout = sys.__stdout__
+    sys.stdout = saved_stdout
     lines = result_IPID_count.split("\n")
     print len(lines) == 5
     print lines[0] == "Probably 3 classes: [4613, 53881, 58437]"

--- a/test/run_tests.bat
+++ b/test/run_tests.bat
@@ -1,8 +1,9 @@
 @echo off
+title UTscapy - All tests
 set MYDIR=%cd%\..
 set PYTHONPATH=%MYDIR%
 if [%1]==[] (
-  python "%MYDIR%\scapy\tools\UTscapy.py" -t regression.uts -K mock_read_routes6_bsd -f html -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
+  python "%MYDIR%\scapy\tools\UTscapy.py" -c configs\\windows2.utsc -T bpf.uts -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
   python "%MYDIR%\scapy\tools\UTscapy.py" %@
 )

--- a/test/run_tls_test.bat
+++ b/test/run_tls_test.bat
@@ -1,5 +1,0 @@
-@echo off
-set MYDIR=%cd%\..
-set PYTHONPATH=%MYDIR%
-python "%MYDIR%\scapy\tools\UTscapy.py" -t tls/tests_tls_netaccess.uts -f html -o scapy_tls_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
-PAUSE

--- a/test/x509.uts
+++ b/test/x509.uts
@@ -65,7 +65,7 @@ tbs.serialNumber == ASN1_INTEGER(0xb45e7043e7090b71)
 
 = Cert class : Signature algorithm (as advertised by TBSCertificate)
 assert(type(tbs.signature) is X509_AlgorithmIdentifier)
-tbs.signature.algorithm == ASN1_OID("sha1-with-rsa-signature")
+tbs.signature.algorithm == ASN1_OID("sha1_with_rsa_signature")
 
 = Cert class : Issuer structure
 assert(type(tbs.issuer) is list)
@@ -121,7 +121,7 @@ ext[0].extnValue.keyIdentifier == ASN1_STRING('\xf3\xd8N\xde\x90\xf7\xe6]\xd2\xc
 
 = Cert class : Signature algorithm
 assert(type(x.signatureAlgorithm) is X509_AlgorithmIdentifier)
-x.signatureAlgorithm.algorithm == ASN1_OID("sha1-with-rsa-signature")
+x.signatureAlgorithm.algorithm == ASN1_OID("sha1_with_rsa_signature")
 
 = Cert class : Signature value
 x.signatureValue == ASN1_BIT_STRING("6\xce\xdd\x01\xbdz\x1f\x89[\xc71i_\xb5\x90\xac\xb5\x06\x9a\xc1\xe8\xf5Jlk\x01\xf0\xc1\xe0\xd5\x0c\xdb\x83l\x1b\xe5\x19#\xcf\x17\x03\x95\xcc\xe9\n%\x99\xfc\x8a\x9c\xda\xe8\x98\xc2\xc2\xd7\xee\x82h\\c\xabx\xc2\xfe\xa7R\xee'\xda\x94R\xd0V\x8e\xe2\x93\xfb^\xd3>\x8e\x96\x8d\x11\x90\x13`\xc9\xa8\x16=}\x8bG\x99\x07{\xd4oH;\xa8<\x8b\x1bHs&$\x0f|\x01\x9c\x1a\xb5\xbb\xc4\x86l\xcc \xd2MR\x81\xd5\xce\x13\xde\x1d\x99\xc8h\x18\x14\x06\r6]B\xe4\xfcIbt\xeeuE\xfd\xe0\x87\xc7Q\xfeH\x05A$\x13\xeb\xce\xef\xb3\\}M`\xf4\xd3=\x10\xd9\xbb6P]\xceo\x7f\x8dbA\x06\x12\x8eE\xf5\x17\x8fBm&c\xde\x02Oll\xe9jG\xa3N\xb4\x16\x8e\xdfV\x90\x05\x92\xd3\x16\xc7[\xe9\xbb\xec,\x11\xb4\x00\x86\x01\xaaWG\xc2Gd0(2\x1bN\xb3\xd6\xfe\x9fG&\xd2CaX\xd8t\x01q\xaf{;W\xbe\xf2", readable=True)
@@ -146,7 +146,7 @@ tbs.version == None
 
 = CRL class : Signature algorithm (as advertised by TBSCertList)
 assert(type(tbs.signature) is X509_AlgorithmIdentifier)
-tbs.signature.algorithm == ASN1_OID("sha1-with-rsa-signature")
+tbs.signature.algorithm == ASN1_OID("sha1_with_rsa_signature")
 
 = CRL class : Issuer structure
 assert(type(tbs.issuer) is list)
@@ -180,7 +180,7 @@ tbs.crlExtensions == None
 
 = CRL class : Signature algorithm
 assert(type(x.signatureAlgorithm) is X509_AlgorithmIdentifier)
-x.signatureAlgorithm.algorithm == ASN1_OID("sha1-with-rsa-signature")
+x.signatureAlgorithm.algorithm == ASN1_OID("sha1_with_rsa_signature")
 
 = CRL class : Signature value
 x.signatureValue == ASN1_BIT_STRING('"\xc9\xf6\xbb\x1d\xa1\xa5=$\xc7\xff\xb0"\x11\xb3p\x06[\xc5U\xdd3v\xa0\x98"\x08cDi\xcfOG%w\x99\x12\x84\xd2\x19\xae \x94\xca,T\x9ak\x81\xd2\x038\xa6Z\x95\x8d*\xe2a\xce\xdb\x19\xcdu\'Y&|V\xe1\xe4\x80q\x1aI\xb2\xaa\xcdI[\xda\x0f\xa8\xff\xce<\n\xfc\xc9\xad\xc6\xde\xc8@d\x0c&\t#\x90\xb7\x9c\xb9P\x03\x8fK\x18\x9f\xb0\xe0e\x0f`\x1c\x1ag\xe5\x85\xc4%\xf5\x0b\xc93\x82R\xe6', readable=True)
@@ -215,7 +215,7 @@ response = OCSP_Response(s)
 assert(response.responseStatus.val == 0)
 assert(isinstance(response.responseBytes, OCSP_ResponseBytes))
 responseBytes = response.responseBytes
-assert(responseBytes.responseType == ASN1_OID("basic-response"))
+assert(responseBytes.responseType == ASN1_OID("basic_response"))
 assert(responseBytes.signatureAlgorithm.algorithm == ASN1_OID("sha256WithRSAEncryption"))
 assert(responseBytes.signatureAlgorithm.parameters == ASN1_NULL(0))
 assert(responseBytes.signature.val_readable[:3] == "\x90\xef\xf9" and responseBytes.signature.val_readable[-3:] == "\x8bb\xfc")


### PR DESCRIPTION
This PR:
- brings a new feature: multi file support in UTscapy.
That allow us to use the same scapy instance to run multiple tests, and speed up the tests. (also added a new log level with more user-friendly texts)
- brings a new feature: JSON config files in UTscapy. Optional, it reduces the command line complexity and allow to use complex `PREEXEC` structures
- Fixes some bugs with the tests (`_` used with `xrange` made `_` a static value, removed `sys.__stdout__` usage)
- Fixes `fixname()` function not being called in DaDict

(PR won't work without the bug fixes)

Results:
- Travis CI:
from an [older build](https://travis-ci.org/gpotter2/scapy/builds/207658839), built in 9 min 19 sec, we're [now](https://travis-ci.org/gpotter2/scapy/builds/207800650) at 4 min 48 sec
- Appveyor: even better,
from [older](https://ci.appveyor.com/project/gpotter2/scapy/build/1.0.296) in 9 min 21 sec we're [now](https://ci.appveyor.com/project/gpotter2/scapy/build/1.0.298) at 3 min 56 sec.

So in average, that should speed up the tests (running part only), by 2.