### PR TITLE
[Bugs/Format] Fix ICMPv6EchoRequest + Net6

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -49,7 +49,7 @@ class SetGen(Gen):
 class Net(Gen):
     """Generate a list of IPs from a network address or a name"""
     name = "ip"
-    ipaddress = re.compile(r"^(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)(/[0-3]?[0-9])?$")
+    _ip_regex = re.compile(r"^(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)(/[0-3]?[0-9])?$")
 
     @staticmethod
     def _parse_digit(a,netmask):
@@ -68,7 +68,7 @@ class Net(Gen):
     @classmethod
     def _parse_net(cls, net):
         tmp=net.split('/')+["32"]
-        if not cls.ipaddress.match(net):
+        if not cls._ip_regex.match(net):
             tmp[0]=socket.gethostbyname(tmp[0])
         netmask = int(tmp[1])
         return map(lambda x,y: cls._parse_digit(x,y), tmp[0].split("."), map(lambda x,nm=netmask: x-nm, (8,16,24,32))),netmask

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -102,6 +102,9 @@ def getmacbyip6(ip6, chainCC=0):
     (chainCC parameter value ends up being passed to sending function
      used to perform the resolution, if needed)
     """
+    
+    if isinstance(ip6,Net6):
+        ip6 = iter(ip6).next()
 
     if in6_ismaddr(ip6): # Multicast
         mac = in6_getnsmac(inet_pton(socket.AF_INET6, ip6))
@@ -145,13 +148,13 @@ def getmacbyip6(ip6, chainCC=0):
 class Net6(Gen): # syntax ex. fec0::/126
     """Generate a list of IPv6s from a network address or a name"""
     name = "ipv6"
-    ipaddress = re.compile(r"^([a-fA-F0-9:]+)(/[1]?[0-3]?[0-9])?$")
+    _ip6_regex = re.compile(r"^([a-fA-F0-9:]+)(/[1]?[0-3]?[0-9])?$")
 
     def __init__(self, net):
         self.repr = net
 
         tmp = net.split('/')+["128"]
-        if not self.ipaddress.match(net):
+        if not self._ip6_regex.match(net):
             tmp[0]=socket.getaddrinfo(tmp[0], None, socket.AF_INET6)[0][-1][0]
 
         netmask = int(tmp[1])
@@ -189,6 +192,9 @@ class Net6(Gen): # syntax ex. fec0::/126
                 return rec(n+1, ll)
 
         return iter(rec(0, ['']))
+
+    def __str__(self):
+        return self.repr
 
     def __repr__(self):
         return "Net6(%r)" % self.repr

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -415,6 +415,8 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                 return self.payload.payload.hashret()
             elif (self.payload.type in [133,134,135,136,144,145]):
                 return struct.pack("B", self.nh)+self.payload.hashret()
+            elif (self.payload.type in [128, 129]):
+                return self.payload.hashret()
 
         if not conf.checkIPinIP and self.nh in [4, 41]:  # IP, IPv6
             return self.payload.hashret()

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1785,6 +1785,19 @@ b=IPv6(src="2047::deca", dst="2048::cafe")/ICMPv6EchoReply(id=0x6666, seq=0x7777
 a=IPv6(src="2048::cafe", dst="2047::deca")/ICMPv6EchoRequest(id=0x6666, seq=0x7777, data="somedata")
 (a > b) == True
 
+########### ICMPv6EchoReply/Request Live tests #########
+
+# Disabled because Travis does not support IPv6 yet
+
+#= ICMPv6EchoRequest and ICMPv6EchoReply - Live test
+#~ netaccess
+#
+#r = sr1(IPv6(dst="ff02::1")/ICMPv6EchoRequest(), timeout=3)
+#assert r
+#assert len(r) != 0
+#l = IPv6().src
+#assert r[0].src != l
+
 
 ########### ICMPv6MRD* Classes ######################################
 


### PR DESCRIPTION
This PR:
- Fixes https://github.com/secdev/scapy/issues/546
- Fixes https://github.com/secdev/scapy/issues/643

The `ICMPv6EchoRequest` and `ICMPv6EchoReply` hashret should not be generated using the overlapping `IPv6` packet, to allow any src address.