### PR TITLE
[Tests] Fix AS_RESOLVER

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -481,7 +481,7 @@ success = False
 for i in xrange(5):
     try:
         ret = conf.AS_resolver.resolve("8.8.8.8", "8.8.4.4")
-    except socket.error:
+    except RuntimeError:
         time.sleep(2)
     else:
         success = True
@@ -489,7 +489,7 @@ for i in xrange(5):
 
 assert (len(ret) == 2)
 
-all(x[1] == 15169 for x in ret)
+all(x[1] == "AS15169" for x in ret)
 
 
 ############


### PR DESCRIPTION
That "test" was a way too buggy:
- `AS_resolver_cymru` is nealy never working, and used to return a different value than the others.
- `AS_resolver_multi` did not play (at all) his role of trying all providers until it got the infos, and would just have crashed badly...

So this PR:
- Fix AS_resolver_multi
- Moved AS_resolver_cymru as last ressort
- Fixed AS_resolver_cymru which was returning a number (second param) where as all the others returned `AS[number]`
- Fixed tests