### PR TITLE
Improve TCP.answers()

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -525,7 +525,12 @@ class TCP(Packet):
             if not ((self.sport == other.dport) and
                     (self.dport == other.sport)):
                 return 0
-        if (abs(other.seq-self.ack) > 2+len(other.payload)):
+        if abs(other.ack - self.seq) > 2:
+            return 0
+        # Do not check ack value for RST packets when ack is 0
+        if self.flags.R and not self.ack:
+            return 1
+        if abs(other.seq - self.ack) > 2 + len(other.payload):
             return 0
         return 1
     def mysummary(self):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -304,6 +304,33 @@ assert all(p.hashret() == p2.hashret() for p in px)
 assert not any(p.answers(p2) for p in px)
 assert all(p2.answers(p) for p in px)
 conf.checkIPinIP = conf_back
+prt1, prt2 = 12345, 54321
+s1, s2 = 2767216324, 3845532842
+p1 = IP(src=a1, dst=a2)/TCP(flags='SA', seq=s1, ack=s2, sport=prt1, dport=prt2)
+p2 = IP(src=a2, dst=a1)/TCP(flags='R', seq=s2, ack=0, sport=prt2, dport=prt1)
+assert p2.answers(p1)
+assert not p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='S', seq=s1, ack=0, sport=prt1, dport=prt2)
+p2 = IP(src=a2, dst=a1)/TCP(flags='RA', seq=0, ack=s1+1, sport=prt2, dport=prt1)
+assert p2.answers(p1)
+assert not p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='S', seq=s1, ack=0, sport=prt1, dport=prt2)
+p2 = IP(src=a2, dst=a1)/TCP(flags='SA', seq=s2, ack=s1+1, sport=prt2, dport=prt1)
+assert p2.answers(p1)
+assert not p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='A', seq=s1, ack=s2+1, sport=prt1, dport=prt2)
+assert not p2.answers(p1)
+assert p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='S', seq=s1, ack=0, sport=prt1, dport=prt2)
+p2 = IP(src=a2, dst=a1)/TCP(flags='SA', seq=s2, ack=s1+10, sport=prt2, dport=prt1)
+assert not p2.answers(p1)
+assert not p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='A', seq=s1, ack=s2+1, sport=prt1, dport=prt2)
+assert not p2.answers(p1)
+assert not p1.answers(p2)
+p1 = IP(src=a1, dst=a2)/TCP(flags='A', seq=s1+9, ack=s2+10, sport=prt1, dport=prt2)
+assert not p2.answers(p1)
+assert not p1.answers(p2)
 
 
 ############


### PR DESCRIPTION
Without this code, when an out of connection TCP packet receives a
TCP answer with flag RST and the ack set to 0, it is not seen as an
answer.

This comes without online regression tests because I have been unable to
find a reliable machine without firewall on the Internet.

Simple test, if 192.168.0.1 has no firewall:

```
>>> sr(IP(dst="192.168.0.1")/TCP(sport=80, dport=12345, flags='SA'),
...    timeout=2)
```

This test will not terminate without this patch.

This PR also adds more tests on flags and seq/ack values.

New tests have been added to check `TCP.answers()`.