### PR TITLE
[SCTP] RFC 4895 & 5061

### DIFF
--- a/doc/scapy/advanced_usage.rst
+++ b/doc/scapy/advanced_usage.rst
@@ -1059,3 +1059,30 @@ However, one can set ``len`` to modify this behaviour. ``len`` controls the leng
     >>> str(PNIORealTime(cycleCounter=0x4242, data=[PNIORealTimeIOxS()], len=30))
     '\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00BB5\x00'
 
+
+SCTP
+====
+
+SCTP is a relatively young transport-layer protocol combining both TCP and UDP characteristics. The `RFC 3286 <https://tools.ietf.org/html/rfc3286>`_ introduces it and its description lays in the `RFC 4960 <https://tools.ietf.org/html/rfc4960>`_.
+
+It is not broadly used, its mainly present in core networks operated by telecommunication companies, to support VoIP for instance.
+
+
+Enabling dynamic addressing reconfiguration and chunk authentication capabilities
+---------------------------------------------------------------------------------
+
+If you are trying to discuss with SCTP servers, you may be interested in capabilities added in `RFC 4895 <https://tools.ietf.org/html/rfc4895>`_ which describe how to authenticated some SCTP chunks, and/or `RFC 5061 <https://tools.ietf.org/html/rfc5061>`_ to dynamically reconfigure the IP address of a SCTP association.
+
+These capabilities are not always enabled by default on Linux. Scapy does not need any modification on its end, but SCTP servers may need specific activation.
+
+To enable the RFC 4895 about authenticating chunks::
+
+    $ sudo echo 1 > /proc/sys/net/sctp/auth_enable
+
+To enable the RFC 5061 about dynamic address reconfiguration::
+
+    $ sudo echo 1 > /proc/sys/net/sctp/addip_enable
+
+You may also want to use the dynamic address reconfiguration without necessarily enabling the chunk authentication::
+
+    $ sudo echo 1 > /proc/sys/net/sctp/addip_noauth_enable

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -321,7 +321,7 @@ class SCTPChunkParamRandom(_SCTPChunkParam, Packet):
                                   adjust = lambda pkt,x:x+4),
                     PadField(StrLenField("random", os.urandom(32),
                                          length_from=lambda pkt: pkt.len-4),
-                             4, padwith="\x00"),]
+                             4, padwith=b"\x00"),]
 
 class SCTPChunkParamChunkList(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0x8003, sctpchunkparamtypes),
@@ -330,7 +330,7 @@ class SCTPChunkParamChunkList(_SCTPChunkParam, Packet):
                     PadField(FieldListField("chunk_list", None,
                                             ByteEnumField("chunk", None, sctpchunktypes),
                                             length_from=lambda pkt: pkt.len-4),
-                             4, padwith="\x00"),]
+                             4, padwith=b"\x00"),]
 
 class SCTPChunkParamRequestedHMACFunctions(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0x8004, sctpchunkparamtypes),
@@ -339,7 +339,7 @@ class SCTPChunkParamRequestedHMACFunctions(_SCTPChunkParam, Packet):
                     PadField(FieldListField("HMAC_functions_list", [ "SHA-1" ],
                                             ShortEnumField("HMAC_function", 1, hmactypes),
                                             length_from=lambda pkt: pkt.len-4),
-                             4, padwith="\x00"),]
+                             4, padwith=b"\x00"),]
 
 class SCTPChunkParamSupportedExtensions(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0x8008, sctpchunkparamtypes),
@@ -352,7 +352,7 @@ class SCTPChunkParamSupportedExtensions(_SCTPChunkParam, Packet):
                                             ByteEnumField("supported_extensions",
                                                           None, sctpchunktypes),
                                             length_from=lambda pkt: pkt.len-4),
-                             4, padwith="\x00"),]
+                             4, padwith=b"\x00"),]
 
 class SCTPChunkParamFwdTSN(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0xc000, sctpchunkparamtypes),
@@ -395,7 +395,7 @@ class SCTPChunkParamErrorIndication(_SCTPChunkParam, Packet):
                     XIntField("correlation_id", None),
                     PadField(StrLenField("error_causes", "",
                                          length_from=lambda pkt: pkt.len-4),
-                             4, padwith="\x00"),]
+                             4, padwith=b"\x00"),]
 
 class SCTPChunkParamSetPrimaryAddr(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0xc004, sctpchunkparamtypes),
@@ -557,7 +557,7 @@ class SCTPChunkCookieAck(_SCTPChunkGuessPayload, Packet):
                    ]
 
 class SCTPChunkShutdownComplete(_SCTPChunkGuessPayload, Packet):
-    fields_desc = [ ByteEnumField("type", 12, sctpchunktypes),
+    fields_desc = [ ByteEnumField("type", 14, sctpchunktypes),
                     BitField("reserved", None, 7),
                     BitField("TCB", 0, 1),
                     ShortField("len", 4),
@@ -571,7 +571,7 @@ class SCTPChunkAuthentication(_SCTPChunkGuessPayload, Packet):
                     ShortField("shared_key_id", None),
                     ShortField("HMAC_function", None),
                     PadField(StrLenField("HMAC", "", length_from=lambda pkt: pkt.len-8),
-                             4, padwith="\x00"),
+                             4, padwith=b"\x00"),
                    ]
 
 class SCTPChunkAddressConf(_SCTPChunkGuessPayload, Packet):

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -8,9 +8,9 @@
 SCTP (Stream Control Transmission Protocol).
 """
 
-import os
 import struct
 
+from scapy.volatile import RandBin
 from scapy.config import conf
 from scapy.packet import *
 from scapy.fields import *
@@ -319,7 +319,7 @@ class SCTPChunkParamRandom(_SCTPChunkParam, Packet):
     fields_desc = [ ShortEnumField("type", 0x8002, sctpchunkparamtypes),
                     FieldLenField("len", None, length_of="random",
                                   adjust = lambda pkt,x:x+4),
-                    PadField(StrLenField("random", os.urandom(32),
+                    PadField(StrLenField("random", RandBin(32),
                                          length_from=lambda pkt: pkt.len-4),
                              4, padwith=b"\x00"),]
 

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -8,6 +8,7 @@
 SCTP (Stream Control Transmission Protocol).
 """
 
+import os
 import struct
 
 from scapy.config import conf
@@ -114,6 +115,13 @@ def sctp_checksum(buf):
     return update_adler32(1, buf)
 """
 
+hmactypes = {
+    0 : "Reserved1",
+    1 : "SHA-1",
+    2 : "Reserved2",
+    3 : "SHA-256",
+    }
+
 sctpchunktypescls = {
     0 : "SCTPChunkData",
     1 : "SCTPChunkInit",
@@ -128,6 +136,9 @@ sctpchunktypescls = {
     10 : "SCTPChunkCookieEcho",
     11 : "SCTPChunkCookieAck",
     14 : "SCTPChunkShutdownComplete",
+    15 : "SCTPChunkAuthentication",
+    0x80 : "SCTPChunkAddressConfAck",
+    0xc1 : "SCTPChunkAddressConf",
     }
 
 sctpchunktypes = {
@@ -144,6 +155,9 @@ sctpchunktypes = {
     10 : "cookie-echo",
     11 : "cookie-ack",
     14 : "shutdown-complete",
+    15 : "authentication",
+    0x80 : "address-configuration-ack",
+    0xc1 : "address-configuration",
     }
 
 sctpchunkparamtypescls = {
@@ -155,9 +169,18 @@ sctpchunkparamtypescls = {
     9 : "SCTPChunkParamCookiePreservative",
     11 : "SCTPChunkParamHostname",
     12 : "SCTPChunkParamSupportedAddrTypes",
-    32768 : "SCTPChunkParamECNCapable",
-    49152 : "SCTPChunkParamFwdTSN",
-    49158 : "SCTPChunkParamAdaptationLayer",
+    0x8000 : "SCTPChunkParamECNCapable",
+    0x8002 : "SCTPChunkParamRandom",
+    0x8003 : "SCTPChunkParamChunkList",
+    0x8004 : "SCTPChunkParamRequestedHMACFunctions",
+    0x8008 : "SCTPChunkParamSupportedExtensions",
+    0xc000 : "SCTPChunkParamFwdTSN",
+    0xc001 : "SCTPChunkParamAddIPAddr",
+    0xc002 : "SCTPChunkParamDelIPAddr",
+    0xc003 : "SCTPChunkParamErrorIndication",
+    0xc004 : "SCTPChunkParamSetPrimaryAddr",
+    0xc005 : "SCTPChunkParamSuccessIndication",
+    0xc006 : "SCTPChunkParamAdaptationLayer",
     }
 
 sctpchunkparamtypes = {
@@ -169,9 +192,18 @@ sctpchunkparamtypes = {
     9 : "cookie-preservative",
     11 : "hostname",
     12 : "addrtypes",
-    32768 : "ecn-capable",
-    49152 : "fwd-tsn-supported",
-    49158 : "adaptation-layer",
+    0x8000 : "ecn-capable",
+    0x8002 : "random",
+    0x8003 : "chunk-list",
+    0x8004 : "requested-HMAC-functions",
+    0x8008 : "supported-extensions",
+    0xc000 : "fwd-tsn-supported",
+    0xc001 : "add-IP",
+    0xc002 : "del-IP",
+    0xc003 : "error-indication",
+    0xc004 : "set-primary-addr",
+    0xc005 : "success-indication",
+    0xc006 : "adaptation-layer",
     }
 
 ############## SCTP header
@@ -280,15 +312,113 @@ class SCTPChunkParamSupportedAddrTypes(_SCTPChunkParam, Packet):
                              4, padwith=b"\x00"), ]
 
 class SCTPChunkParamECNCapable(_SCTPChunkParam, Packet):
-    fields_desc = [ ShortEnumField("type", 32768, sctpchunkparamtypes),
+    fields_desc = [ ShortEnumField("type", 0x8000, sctpchunkparamtypes),
                     ShortField("len", 4), ]
+
+class SCTPChunkParamRandom(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0x8002, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="random",
+                                  adjust = lambda pkt,x:x+4),
+                    PadField(StrLenField("random", os.urandom(32),
+                                         length_from=lambda pkt: pkt.len-4),
+                             4, padwith="\x00"),]
+
+class SCTPChunkParamChunkList(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0x8003, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="chunk_list",
+                                  adjust = lambda pkt,x:x+4),
+                    PadField(FieldListField("chunk_list", None,
+                                            ByteEnumField("chunk", None, sctpchunktypes),
+                                            length_from=lambda pkt: pkt.len-4),
+                             4, padwith="\x00"),]
+
+class SCTPChunkParamRequestedHMACFunctions(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0x8004, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="HMAC_functions_list",
+                                  adjust = lambda pkt,x:x+4),
+                    PadField(FieldListField("HMAC_functions_list", [ "SHA-1" ],
+                                            ShortEnumField("HMAC_function", 1, hmactypes),
+                                            length_from=lambda pkt: pkt.len-4),
+                             4, padwith="\x00"),]
+
+class SCTPChunkParamSupportedExtensions(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0x8008, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="supported_extensions",
+                                adjust = lambda pkt,x:x+4),
+                    PadField(FieldListField("supported_extensions",
+                                            [ "authentication",
+                                              "address-configuration",
+                                              "address-configuration-ack" ],
+                                            ByteEnumField("supported_extensions",
+                                                          None, sctpchunktypes),
+                                            length_from=lambda pkt: pkt.len-4),
+                             4, padwith="\x00"),]
 
 class SCTPChunkParamFwdTSN(_SCTPChunkParam, Packet):
-    fields_desc = [ ShortEnumField("type", 49152, sctpchunkparamtypes),
+    fields_desc = [ ShortEnumField("type", 0xc000, sctpchunkparamtypes),
                     ShortField("len", 4), ]
 
+class SCTPChunkParamAddIPAddr(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0xc001, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+12),
+                    XIntField("correlation_id", None),
+                    ShortEnumField("addr_type", 5, sctpchunkparamtypes),
+                    FieldLenField("addr_len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+4),
+                    ConditionalField(
+                        IPField("addr", "127.0.0.1"),
+                        lambda p: p.addr_type == 5),
+                    ConditionalField(
+                        IP6Field("addr", "::1"),
+                        lambda p: p.addr_type == 6),]
+
+class SCTPChunkParamDelIPAddr(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0xc002, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+12),
+                    XIntField("correlation_id", None),
+                    ShortEnumField("addr_type", 5, sctpchunkparamtypes),
+                    FieldLenField("addr_len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+4),
+                    ConditionalField(
+                        IPField("addr", "127.0.0.1"),
+                        lambda p: p.addr_type == 5),
+                    ConditionalField(
+                        IP6Field("addr", "::1"),
+                        lambda p: p.addr_type == 6),]
+
+class SCTPChunkParamErrorIndication(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0xc003, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="error_causes",
+                                  adjust = lambda pkt,x:x+8),
+                    XIntField("correlation_id", None),
+                    PadField(StrLenField("error_causes", "",
+                                         length_from=lambda pkt: pkt.len-4),
+                             4, padwith="\x00"),]
+
+class SCTPChunkParamSetPrimaryAddr(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0xc004, sctpchunkparamtypes),
+                    FieldLenField("len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+12),
+                    XIntField("correlation_id", None),
+                    ShortEnumField("addr_type", 5, sctpchunkparamtypes),
+                    FieldLenField("addr_len", None, length_of="addr",
+                                  adjust = lambda pkt,x:x+4),
+                    ConditionalField(
+                        IPField("addr", "127.0.0.1"),
+                        lambda p: p.addr_type == 5),
+                    ConditionalField(
+                        IP6Field("addr", "::1"),
+                        lambda p: p.addr_type == 6),]
+
+class SCTPChunkParamSuccessIndication(_SCTPChunkParam, Packet):
+    fields_desc = [ ShortEnumField("type", 0xc005, sctpchunkparamtypes),
+                    ShortField("len", 8),
+                    XIntField("correlation_id", None), ]
+
 class SCTPChunkParamAdaptationLayer(_SCTPChunkParam, Packet):
-    fields_desc = [ ShortEnumField("type", 49158, sctpchunkparamtypes),
+    fields_desc = [ ShortEnumField("type", 0xc006, sctpchunkparamtypes),
                     ShortField("len", 8),
                     XIntField("indication", None), ]
 
@@ -433,6 +563,34 @@ class SCTPChunkShutdownComplete(_SCTPChunkGuessPayload, Packet):
                     ShortField("len", 4),
                     ]
 
+class SCTPChunkAuthentication(_SCTPChunkGuessPayload, Packet):
+    fields_desc = [ ByteEnumField("type", 15, sctpchunktypes),
+                    XByteField("flags", None),
+                    FieldLenField("len", None, length_of="HMAC",
+                                  adjust = lambda pkt,x:x+8),
+                    ShortField("shared_key_id", None),
+                    ShortField("HMAC_function", None),
+                    PadField(StrLenField("HMAC", "", length_from=lambda pkt: pkt.len-8),
+                             4, padwith="\x00"),
+                   ]
+
+class SCTPChunkAddressConf(_SCTPChunkGuessPayload, Packet):
+    fields_desc = [ ByteEnumField("type", 0xc1, sctpchunktypes),
+                    XByteField("flags", None),
+                    FieldLenField("len", None, length_of="params",
+                                  adjust=lambda pkt,x:x+8),
+                    IntField("seq", 0),
+                    ChunkParamField("params", None, length_from=lambda pkt:pkt.len-8),
+                   ]
+
+class SCTPChunkAddressConfAck(_SCTPChunkGuessPayload, Packet):
+    fields_desc = [ ByteEnumField("type",0x80, sctpchunktypes),
+                    XByteField("flags", None),
+                    FieldLenField("len", None, length_of="params",
+                                  adjust=lambda pkt,x:x+8),
+                    IntField("seq", 0),
+                    ChunkParamField("params", None, length_from=lambda pkt:pkt.len-8),
+                   ]
+
 bind_layers( IP,           SCTP,          proto=IPPROTO_SCTP)
 bind_layers( IPv6,           SCTP,          nh=IPPROTO_SCTP)
-

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7892,6 +7892,11 @@ assert(p.len == 8)
 assert(p.seq == 0)
 assert(p.params == [])
 
+= SCTPChunkParamRandom - Consecutive calls
+~ sctp
+param1, param2 = SCTPChunkParamRandom(), SCTPChunkParamRandom()
+assert(param1.random != param2.random)
+
 ############
 ############
 + DHCP

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7664,6 +7664,233 @@ SCTPChunkSACK in p and p[SCTP].chksum == 0x3b01d404 and p[SCTPChunkSACK].gap_ack
 = SCTP - answers
 (IP()/SCTP()).answers(IP()/SCTP()) == True
 
+= SCTP basic header - Dissection
+~ sctp
+blob = b"\x1A\x85\x26\x94\x00\x00\x00\x0D\x00\x00\x04\xD2"
+p = SCTP(blob)
+assert(p.dport == 9876)
+assert(p.sport == 6789)
+assert(p.tag == 13)
+assert(p.chksum == 1234)
+
+= basic SCTPChunkData - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x64\x61\x74\x61"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkData))
+assert(p.reserved == 0)
+assert(p.delay_sack == 0)
+assert(p.unordered == 0)
+assert(p.beginning == 0)
+assert(p.ending == 0)
+assert(p.tsn == 0)
+assert(p.stream_id == 0)
+assert(p.stream_seq == 0)
+assert(p.len == (len("data") + 16))
+assert(p.data == "data")
+
+= basic SCTPChunkInit - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkInit))
+assert(p.flags == 0)
+assert(p.len == 20)
+assert(p.init_tag == 0)
+assert(p.a_rwnd == 0)
+assert(p.n_out_streams == 0)
+assert(p.n_in_streams == 0)
+assert(p.init_tsn == 0)
+assert(p.params == [])
+
+= SCTPChunkInit multiple valid parameters - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x5C\x00\x00\x00\x65\x00\x00\x00\x66\x00\x67\x00\x68\x00\x00\x00\x69\x00\x0C\x00\x06\x00\x05\x00\x00\x80\x00\x00\x04\xC0\x00\x00\x04\x80\x08\x00\x07\x0F\xC1\x80\x00\x80\x03\x00\x04\x80\x02\x00\x24\x87\x77\x21\x29\x3F\xDA\x62\x0C\x06\x6F\x10\xA5\x39\x58\x60\x98\x4C\xD4\x59\xD8\x8A\x00\x85\xFB\x9E\x2E\x66\xBA\x3A\x23\x54\xEF\x80\x04\x00\x06\x00\x01\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkInit))
+assert(p.flags == 0)
+assert(p.len == 92)
+assert(p.init_tag == 101)
+assert(p.a_rwnd == 102)
+assert(p.n_out_streams == 103)
+assert(p.n_in_streams == 104)
+assert(p.init_tsn == 105)
+assert(len(p.params) == 7)
+params = {type(param): param for param in p.params}
+assert(set(params.keys()) == {SCTPChunkParamECNCapable, SCTPChunkParamFwdTSN,
+                              SCTPChunkParamSupportedExtensions, SCTPChunkParamChunkList,
+                              SCTPChunkParamRandom, SCTPChunkParamRequestedHMACFunctions,
+                              SCTPChunkParamSupportedAddrTypes})
+assert(params[SCTPChunkParamECNCapable] == SCTPChunkParamECNCapable())
+assert(params[SCTPChunkParamFwdTSN] == SCTPChunkParamFwdTSN())
+assert(params[SCTPChunkParamSupportedExtensions] == SCTPChunkParamSupportedExtensions(len=7))
+assert(params[SCTPChunkParamChunkList] == SCTPChunkParamChunkList(len=4))
+assert(params[SCTPChunkParamRandom].len == 4+32)
+assert(len(params[SCTPChunkParamRandom].random) == 32)
+assert(params[SCTPChunkParamRequestedHMACFunctions] == SCTPChunkParamRequestedHMACFunctions(len=6))
+assert(params[SCTPChunkParamSupportedAddrTypes] == SCTPChunkParamSupportedAddrTypes(len=6))
+
+= basic SCTPChunkInitAck - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkInitAck))
+assert(p.flags == 0)
+assert(p.len == 20)
+assert(p.init_tag == 0)
+assert(p.a_rwnd == 0)
+assert(p.n_out_streams == 0)
+assert(p.n_in_streams == 0)
+assert(p.init_tsn == 0)
+assert(p.params == [])
+
+= SCTPChunkInitAck with state cookie - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x4C\x00\x00\x00\x65\x00\x00\x00\x66\x00\x67\x00\x68\x00\x00\x00\x69\x80\x00\x00\x04\x00\x0B\x00\x0D\x6C\x6F\x63\x61\x6C\x68\x6F\x73\x74\x00\x00\x00\xC0\x00\x00\x04\x80\x08\x00\x07\x0F\xC1\x80\x00\x00\x07\x00\x14\x00\x10\x9E\xB2\x86\xCE\xE1\x7D\x0F\x6A\xAD\xFD\xB3\x5D\xBC\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkInitAck))
+assert(p.flags == 0)
+assert(p.len == 76)
+assert(p.init_tag == 101)
+assert(p.a_rwnd == 102)
+assert(p.n_out_streams == 103)
+assert(p.n_in_streams == 104)
+assert(p.init_tsn == 105)
+assert(len(p.params) == 5)
+params = {type(param): param for param in p.params}
+assert(set(params.keys()) == {SCTPChunkParamECNCapable, SCTPChunkParamHostname,
+                              SCTPChunkParamFwdTSN, SCTPChunkParamSupportedExtensions,
+                              SCTPChunkParamStateCookie})
+assert(params[SCTPChunkParamECNCapable] == SCTPChunkParamECNCapable())
+assert(params[SCTPChunkParamHostname] == SCTPChunkParamHostname(len=13, hostname="localhost"))
+assert(params[SCTPChunkParamFwdTSN] == SCTPChunkParamFwdTSN())
+assert(params[SCTPChunkParamSupportedExtensions] == SCTPChunkParamSupportedExtensions(len=7))
+assert(params[SCTPChunkParamStateCookie].len == 4+16)
+assert(len(params[SCTPChunkParamStateCookie].cookie) == 16)
+
+= basic SCTPChunkSACK - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkSACK))
+assert(p.flags == 0)
+assert(p.len == 16)
+assert(p.cumul_tsn_ack == 0)
+assert(p.a_rwnd == 0)
+assert(p.n_gap_ack == 0)
+assert(p.n_dup_tsn == 0)
+assert(p.gap_ack_list == [])
+assert(p.dup_tsn_list == [])
+
+= basic SCTPChunkHeartbeatReq - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkHeartbeatReq))
+assert(p.flags == 0)
+assert(p.len == 4)
+assert(p.params == [])
+
+= basic SCTPChunkHeartbeatAck - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkHeartbeatAck))
+assert(p.flags == 0)
+assert(p.len == 4)
+assert(p.params == [])
+
+= basic SCTPChunkAbort - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkAbort))
+assert(p.reserved == 0)
+assert(p.TCB == 0)
+assert(p.len == 4)
+assert(p.error_causes == "")
+
+= basic SCTPChunkShutDown - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x08\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkShutdown))
+assert(p.flags == 0)
+assert(p.len == 8)
+assert(p.cumul_tsn_ack == 0)
+
+= basic SCTPChunkShutDownAck - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkShutdownAck))
+assert(p.flags == 0)
+assert(p.len == 4)
+
+= basic SCTPChunkError - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x09\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkError))
+assert(p.flags == 0)
+assert(p.len == 4)
+assert(p.error_causes == "")
+
+= basic SCTPChunkCookieEcho - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0A\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkCookieEcho))
+assert(p.flags == 0)
+assert(p.len == 4)
+assert(p.cookie == "")
+
+= basic SCTPChunkCookieAck - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0B\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkCookieAck))
+assert(p.flags == 0)
+assert(p.len == 4)
+
+= basic SCTPChunkShutdownComplete - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0E\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkShutdownComplete))
+assert(p.reserved == 0)
+assert(p.TCB == 0)
+assert(p.len == 4)
+
+= basic SCTPChunkAuthentication - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x08\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkAuthentication))
+assert(p.flags == 0)
+assert(p.len == 8)
+assert(p.shared_key_id == 0)
+assert(p.HMAC_function == 0)
+
+= basic SCTPChunkAddressConf - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xc1\x00\x00\x08\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkAddressConf))
+assert(p.flags == 0)
+assert(p.len == 8)
+assert(p.seq == 0)
+assert(p.params == [])
+
+= basic SCTPChunkAddressConfAck - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x08\x00\x00\x00\x00"
+p = SCTP(blob).lastlayer()
+assert(isinstance(p, SCTPChunkAddressConfAck))
+assert(p.flags == 0)
+assert(p.len == 8)
+assert(p.seq == 0)
+assert(p.params == [])
 
 ############
 ############


### PR DESCRIPTION
Hi,

This PR adds both RFC 4895 (authenticated chunks) and 5061 (dynamic address reconfiguration, "ADD-IP") specifics SCTP chunks and params.

I'm sorry, my pep8 pass and my editor trailing whitespace autodeletion made the diff much bigger it really is. Would you want me to revert these unnecessary changes? [edit: well it seems the missing trailing whitespace breaks the tests. Reverting]

Tests on SCTP are still petty, will improve them when got some time.

=====
Linux kernel precision to fully enable these SCTP capabilities (from https://sourceforge.net/p/lksctp/mailman/message/20054557/):
"""
You need to enable ADD-IP on your server and your client buy doing:
$ echo 1 > /proc/sys/net/sctp/addip_enable

If you are running a new enough kernel that supports SCTP Authentication extensions, you need to enable that as well:
$ echo 1 > /proc/sys/net/sctp/auth_enable

If one of your systems does not support SCTP Authentication extensions (/proc/sys/net/sctp/auth_enable is not present), you need to turn on the backward compatibility mode on the system:
$ echo 1 > /proc/sys/net/sctp/addip_noauth_enable.
"""