### PR TITLE
Create a secdev team in AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scapy #
 
 [![Travis Build Status](https://travis-ci.org/secdev/scapy.svg?branch=master)](https://travis-ci.org/secdev/scapy)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/secdev/scapy?svg=true)](https://ci.appveyor.com/project/p-l-/scapy)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/secdev/scapy?svg=true)](https://ci.appveyor.com/project/secdev/scapy)
 [![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy)
 
 Scapy is a powerful Python-based interactive packet manipulation


### PR DESCRIPTION
People in secdev/owners should be allowed to manage AppVeyor builds now.