### PR TITLE
[Deprecated PR] Python 3- Step 2: Auto-code migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 scapy/__init__.py	export-subst
+* text=auto
+*.bat eol=crlf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,11 @@ parsed from a string (during a network capture or a PCAP file
 read). Adding inefficient code here will have a disastrous effect on
 Scapy's performances.
 
+### Python 2 and 3 compatibility
+
+The project aims to provide code that works both on Python 2 and Python 3. Therefore, some rules need to be apply to achieve compatibility:
+- byte-string must be defined as b"\x00\x01\x02"
+
 ### Code review
 
 Maintainers tend to be picky, and you might feel frustrated that your

--- a/doc/scapy/conf.py
+++ b/doc/scapy/conf.py
@@ -10,6 +10,7 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
+from __future__ import absolute_import
 import sys, os
 
 # If your extensions are in another directory, add it here. If the directory

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -10,6 +10,7 @@ Usable either from an interactive console or as a Python library.
 http://www.secdev.org/projects/scapy
 """
 
+from __future__ import absolute_import
 import os
 import re
 import subprocess

--- a/scapy/all.py
+++ b/scapy/all.py
@@ -7,6 +7,7 @@
 Aggregate top level objects from all Scapy modules.
 """
 
+from __future__ import absolute_import
 from scapy.base_classes import *
 from scapy.config import *
 from scapy.dadict import *

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -11,9 +11,12 @@ Answering machines.
 ## Answering machines ##
 ########################
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.sendrecv import send,sendp,sniff
 from scapy.config import conf
 from scapy.error import log_interactive
+import six
 
 class ReferenceAM(type):
     def __new__(cls, name, bases, dct):
@@ -23,8 +26,7 @@ class ReferenceAM(type):
         return o
 
 
-class AnsweringMachine(object):
-    __metaclass__ = ReferenceAM
+class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
     function_name = ""
     filter = None
     sniff_options = { "store":0 }
@@ -53,7 +55,7 @@ class AnsweringMachine(object):
         for d in [self.optam2, self.optam1]:
             if attr in d:
                 return d[attr]
-        raise AttributeError,attr
+        raise AttributeError(attr)
                 
     def __setattr__(self, attr, val):
         mode = self.__dict__.get("mode",0)
@@ -99,7 +101,7 @@ class AnsweringMachine(object):
         self.send_function(reply, **self.optsend)
 
     def print_reply(self, req, reply):
-        print "%s ==> %s" % (req.summary(),reply.summary())
+        print("%s ==> %s" % (req.summary(),reply.summary()))
 
     def reply(self, pkt):
         if not self.is_request(pkt):
@@ -123,7 +125,7 @@ class AnsweringMachine(object):
         try:
             self.sniff()
         except KeyboardInterrupt:
-            print "Interrupted by user"
+            print("Interrupted by user")
         
     def sniff(self):
         sniff(**self.optsniff)

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 from scapy.sendrecv import send,sendp,sniff
 from scapy.config import conf
 from scapy.error import log_interactive
-import six
+import scapy.modules.six as six
 
 class ReferenceAM(type):
     def __new__(cls, name, bases, dct):

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -11,8 +11,7 @@ Answering machines.
 ## Answering machines ##
 ########################
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 from scapy.sendrecv import send,sendp,sniff
 from scapy.config import conf
 from scapy.error import log_interactive

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -7,6 +7,7 @@
 Operating system specific functionality.
 """
 
+from __future__ import absolute_import
 import socket
 
 from scapy.consts import LINUX, OPENBSD, FREEBSD, NETBSD, DARWIN, \
@@ -16,6 +17,7 @@ from scapy.error import *
 import scapy.config
 from scapy.pton_ntop import inet_pton
 from scapy.data import *
+from six.moves import map
 
 def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -17,7 +17,7 @@ from scapy.error import *
 import scapy.config
 from scapy.pton_ntop import inet_pton
 from scapy.data import *
-from six.moves import map
+from scapy.modules.six.moves import map
 
 def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 

--- a/scapy/arch/bpf/consts.py
+++ b/scapy/arch/bpf/consts.py
@@ -5,6 +5,7 @@ Scapy *BSD native support - constants
 """
 
 
+from __future__ import absolute_import
 from scapy.data import MTU
 
 

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -4,6 +4,7 @@
 Scapy *BSD native support - core
 """
 
+from __future__ import absolute_import
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.data import ARPHDR_LOOPBACK, ARPHDR_ETHER
@@ -20,6 +21,7 @@ import struct
 from ctypes import cdll, cast, pointer, POINTER, Structure
 from ctypes import c_uint, c_uint32, c_int, c_ulong, c_char_p, c_ushort, c_ubyte
 from ctypes.util import find_library
+from six.moves import range
 
 
 # ctypes definitions
@@ -51,7 +53,7 @@ def get_if_raw_addr(ifname):
     # Get ifconfig output
     try:
         fd = os.popen("%s %s" % (conf.prog.ifconfig, ifname))
-    except OSError, msg:
+    except OSError as msg:
         warning("Failed to execute ifconfig: (%s)" % msg)
         return b"\0\0\0\0"
 
@@ -78,7 +80,7 @@ def get_if_raw_hwaddr(ifname):
     # Get ifconfig output
     try:
         fd = os.popen("%s %s" % (conf.prog.ifconfig, ifname))
-    except OSError, msg:
+    except OSError as msg:
         raise Scapy_Exception("Failed to execute ifconfig: (%s)" % msg)
 
     # Get MAC addresses
@@ -104,7 +106,7 @@ def get_dev_bpf():
         try:
             fd = os.open("/dev/bpf%i" % bpf, os.O_RDWR)
             return (fd, bpf)
-        except OSError, err:
+        except OSError as err:
             continue
 
     raise Scapy_Exception("No /dev/bpf handle is available !")
@@ -117,7 +119,7 @@ def attach_filter(fd, iface, bpf_filter_string):
     command = "%s -i %s -ddd -s 1600 '%s'" % (conf.prog.tcpdump, iface, bpf_filter_string)
     try:
         f = os.popen(command)
-    except OSError, msg:
+    except OSError as msg:
         raise Scapy_Exception("Failed to execute tcpdump: (%s)" % msg)
 
     # Convert the byte code to a BPF program structure
@@ -132,7 +134,7 @@ def attach_filter(fd, iface, bpf_filter_string):
 
     # Fill the BPF instruction structures with the byte code
     lines = lines[1:]
-    for i in xrange(len(lines)):
+    for i in range(len(lines)):
         values = [int(v) for v in lines[i].split()]
         bip[i].code = c_ushort(values[0])
         bip[i].jt = c_ubyte(values[1])
@@ -154,7 +156,7 @@ def get_if_list():
     # Get ifconfig output
     try:
         fd = os.popen("%s -a" % conf.prog.ifconfig)
-    except OSError, msg:
+    except OSError as msg:
         raise Scapy_Exception("Failed to execute ifconfig: (%s)" % msg)
 
     # Get interfaces
@@ -184,7 +186,7 @@ def get_working_ifaces():
         # Get interface flags
         try:
             result = get_if(ifname, SIOCGIFFLAGS)
-        except IOError, msg:
+        except IOError as msg:
             warning("ioctl(SIOCGIFFLAGS) failed on %s !" % ifname)
             continue
 
@@ -201,7 +203,7 @@ def get_working_ifaces():
             try:
                 fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x", ifname))
                 interfaces.append((ifname, int(ifname[-1])))
-            except IOError, err:
+            except IOError as err:
                 pass
 
             # Close the file descriptor

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -21,7 +21,7 @@ import struct
 from ctypes import cdll, cast, pointer, POINTER, Structure
 from ctypes import c_uint, c_uint32, c_int, c_ulong, c_char_p, c_ushort, c_ubyte
 from ctypes.util import find_library
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 # ctypes definitions

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -4,6 +4,7 @@
 Scapy *BSD native support - BPF sockets
 """
 
+from __future__ import absolute_import
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.supersocket import SuperSocket
@@ -56,14 +57,14 @@ class _L2bpfSocket(SuperSocket):
         # Set the BPF buffer length
         try:
             fcntl.ioctl(self.ins, BIOCSBLEN, struct.pack('I', BPF_BUFFER_LENGTH))
-        except IOError, err:
+        except IOError as err:
             msg = "BIOCSBLEN failed on /dev/bpf%i" % self.dev_bpf
             raise Scapy_Exception(msg)
 
         # Assign the network interface to the BPF handle
         try:
             fcntl.ioctl(self.ins, BIOCSETIF, struct.pack("16s16x", self.iface))
-        except IOError, err:
+        except IOError as err:
             msg = "BIOCSETIF failed on %s" % self.iface
             raise Scapy_Exception(msg)
         self.assigned_interface = self.iface
@@ -75,7 +76,7 @@ class _L2bpfSocket(SuperSocket):
         # Don't block on read
         try:
             fcntl.ioctl(self.ins, BIOCIMMEDIATE, struct.pack('I', 1))
-        except IOError, err:
+        except IOError as err:
             msg = "BIOCIMMEDIATE failed on /dev/bpf%i" % self.dev_bpf
             raise Scapy_Exception(msg)
 
@@ -83,7 +84,7 @@ class _L2bpfSocket(SuperSocket):
         # Otherwise, it is written by the kernel
         try:
             fcntl.ioctl(self.ins, BIOCSHDRCMPLT, struct.pack('i', 1))
-        except IOError, err:
+        except IOError as err:
             msg = "BIOCSHDRCMPLT failed on /dev/bpf%i" % self.dev_bpf
             raise Scapy_Exception(msg)
 
@@ -105,7 +106,7 @@ class _L2bpfSocket(SuperSocket):
 
         try:
             fcntl.ioctl(self.ins, BIOCPROMISC, struct.pack('i', value))
-        except IOError, err:
+        except IOError as err:
             msg = "Can't put your interface (%s) into promiscuous mode !" % self.iface
             raise Scapy_Exception(msg)
 
@@ -120,7 +121,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGDLT, struct.pack('I', 0))
             ret = struct.unpack('I', ret)[0]
-        except IOError, err:
+        except IOError as err:
             warning("BIOCGDLT failed: unable to guess type. Using Ethernet !")
             return Ether
 
@@ -143,7 +144,7 @@ class _L2bpfSocket(SuperSocket):
         if self.fd_flags is None:
             try:
                 self.fd_flags = fcntl.fcntl(self.ins, fcntl.F_GETFL)
-            except IOError, err:
+            except IOError as err:
                 warning("Can't get flags on this file descriptor !")
                 return
 
@@ -165,7 +166,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGSTATS, struct.pack("2I", 0, 0))
             return struct.unpack("2I", ret)
-        except IOError, err:
+        except IOError as err:
             warning("Unable to get stats from BPF !")
             return (None, None)
 
@@ -175,7 +176,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGBLEN, struct.pack("I", 0))
             return struct.unpack("I", ret)[0]
-        except IOError, err:
+        except IOError as err:
             warning("Unable to get the BPF buffer length")
             return
 
@@ -282,7 +283,7 @@ class L2bpfListenSocket(_L2bpfSocket):
             # Get data from BPF
             try:
                 bpf_buffer = os.read(self.ins, x)
-            except EnvironmentError, e:
+            except EnvironmentError as e:
                 if e.errno == errno.EAGAIN:
                     return
                 else:
@@ -333,7 +334,7 @@ class L3bpfSocket(L2bpfSocket):
         if self.assigned_interface != iff:
             try:
                 fcntl.ioctl(self.outs, BIOCSETIF, struct.pack("16s16x", iff))
-            except IOError, err:
+            except IOError as err:
                 msg = "BIOCSETIF failed on %s" % iff
                 raise Scapy_Exception(msg)
             self.assigned_interface = iff

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -7,6 +7,7 @@
 Functions common to different architectures
 """
 
+from __future__ import absolute_import
 import socket
 from fcntl import ioctl
 import struct

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -23,7 +23,6 @@ from scapy.supersocket import SuperSocket
 import scapy.arch
 from scapy.error import warning, Scapy_Exception, log_interactive, log_loading
 from scapy.arch.common import get_if
-from six.moves import map
 
 
 

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -7,6 +7,7 @@
 Linux specific functions.
 """
 
+from __future__ import absolute_import
 import sys,os,struct,socket,time
 from select import select
 from fcntl import ioctl
@@ -22,6 +23,7 @@ from scapy.supersocket import SuperSocket
 import scapy.arch
 from scapy.error import warning, Scapy_Exception, log_interactive, log_loading
 from scapy.arch.common import get_if
+from six.moves import map
 
 
 
@@ -137,7 +139,7 @@ def attach_filter(s, bpf_filter, iface):
             conf.iface if iface is None else iface,
             bpf_filter,
         ))
-    except OSError,msg:
+    except OSError as msg:
         log_interactive.warning("Failed to execute tcpdump: (%s)")
         return
     lines = f.readlines()
@@ -146,7 +148,7 @@ def attach_filter(s, bpf_filter, iface):
     nb = int(lines[0])
     bpf = ""
     for l in lines[1:]:
-        bpf += struct.pack("HBBI",*map(long,l.split()))
+        bpf += struct.pack("HBBI",*list(map(int,l.split())))
 
     # XXX. Argl! We need to give the kernel a pointer on the BPF,
     # python object header seems to be 20 bytes. 36 bytes for x86 64bits arch.
@@ -282,7 +284,7 @@ def in6_getifaddr():
     ret = []
     try:
         f = open("/proc/net/if_inet6","r")
-    except IOError, err:    
+    except IOError as err:    
         return ret
     l = f.readlines()
     for i in l:
@@ -296,7 +298,7 @@ def in6_getifaddr():
 def read_routes6():
     try:
         f = open("/proc/net/ipv6_route","r")
-    except IOError, err:
+    except IOError as err:
         return []
     # 1. destination network
     # 2. destination prefix length
@@ -334,7 +336,7 @@ def read_routes6():
                 continue
             cset = ['::1']
         else:
-            devaddrs = filter(lambda x: x[2] == dev, lifaddr)
+            devaddrs = [x for x in lifaddr if x[2] == dev]
             cset = scapy.utils6.construct_source_candidate_set(d, dp, devaddrs, LOOPBACK_NAME)
         
         if len(cset) != 0:
@@ -457,7 +459,7 @@ class L3PacketSocket(SuperSocket):
         x.sent_time = time.time()
         try:
             self.outs.sendto(sx, sdto)
-        except socket.error, msg:
+        except socket.error as msg:
             if msg[0] == 22 and len(sx) < conf.min_pkt_size:
                 self.outs.send(sx + b"\x00" * (conf.min_pkt_size - len(sx)))
             elif conf.auto_fragment and msg[0] == 90:
@@ -522,7 +524,7 @@ class L2Socket(SuperSocket):
     def send(self, x):
         try:
             return SuperSocket.send(self, x)
-        except socket.error, msg:
+        except socket.error as msg:
             if msg[0] == 22 and len(x) < conf.min_pkt_size:
                 padding = b"\x00" * (conf.min_pkt_size - len(x))
                 if isinstance(x, Packet):

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -148,7 +148,7 @@ def attach_filter(s, bpf_filter, iface):
     nb = int(lines[0])
     bpf = ""
     for l in lines[1:]:
-        bpf += struct.pack("HBBI",*list(map(int,l.split())))
+        bpf += struct.pack("HBBI",*map(int,l.split()))
 
     # XXX. Argl! We need to give the kernel a pointer on the BPF,
     # python object header seems to be 20 bytes. 36 bytes for x86 64bits arch.

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -7,6 +7,7 @@
 Packet sending and receiving with libdnet and libpcap/WinPcap.
 """
 
+from __future__ import absolute_import
 import time, struct, sys, platform
 import socket
 if not sys.platform.startswith("win"):
@@ -219,7 +220,7 @@ if conf.use_winpcapy:
 
           pkt = None
           while pkt is None:
-              pkt = self.ins.next()
+              pkt = next(self.ins)
               if pkt is not None:
                   ts,pkt = pkt
               if scapy.arch.WINDOWS and pkt is None:
@@ -286,7 +287,7 @@ if conf.use_winpcapy:
               cls = conf.default_l2
               warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
   
-          pkt = self.ins.next()
+          pkt = next(self.ins)
           if pkt is not None:
               ts,pkt = pkt
           if pkt is None:
@@ -337,10 +338,10 @@ if conf.use_winpcapy:
 if conf.use_pcap:
     try:
         import pcap
-    except ImportError,e:
+    except ImportError as e:
         try:
             import pcapy as pcap
-        except ImportError,e2:
+        except ImportError as e2:
             if conf.interactive:
                 log_loading.error("Unable to import pcap module: %s/%s" % (e,e2))
                 conf.use_pcap = False
@@ -365,7 +366,7 @@ if conf.use_pcap:
                 def __del__(self):
                     warning("__del__: don't know how to close the file descriptor. Bugs ahead ! Please report this bug.")
                 def next(self):
-                    c = self.pcap.next()
+                    c = next(self.pcap)
                     if c is None:
                         return
                     ts, pkt = c
@@ -379,7 +380,7 @@ if conf.use_pcap:
                 def setfilter(self, filter):
                     self.pcap.setfilter(filter, 0, 0)
                 def next(self):
-                    c = self.pcap.next()
+                    c = next(self.pcap)
                     if c is None:
                         return
                     l,pkt,ts = c 
@@ -396,7 +397,7 @@ if conf.use_pcap:
                     self.pcap = pcap.open_live(*args, **kargs)
                 def next(self):
                     try:
-                        c = self.pcap.next()
+                        c = next(self.pcap)
                     except pcap.PcapError:
                         return None
                     else:
@@ -454,7 +455,7 @@ if conf.use_pcap:
                     cls = conf.default_l2
                     warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
         
-                pkt = self.ins.next()
+                pkt = next(self.ins)
                 if scapy.arch.WINDOWS and pkt is None:
                         raise PcapTimeoutElapsed
                 if pkt is not None:
@@ -485,7 +486,7 @@ if conf.use_dnet:
         except ImportError:
             # Then, try to import dumbnet as dnet
             import dumbnet as dnet
-    except ImportError,e:
+    except ImportError as e:
         if conf.interactive:
             log_loading.error("Unable to import dnet module: %s" % e)
             conf.use_dnet = False
@@ -608,7 +609,7 @@ if conf.use_pcap and conf.use_dnet:
                 cls = conf.default_l2
                 warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
     
-            pkt = self.ins.next()
+            pkt = next(self.ins)
             if pkt is not None:
                 ts,pkt = pkt
             if pkt is None:
@@ -678,7 +679,7 @@ if conf.use_pcap and conf.use_dnet:
                 cls = conf.default_l2
                 warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
     
-            pkt = self.ins.next()
+            pkt = next(self.ins)
             if pkt is not None:
                 ts,pkt = pkt
             if pkt is None:

--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -8,6 +8,7 @@ Customization for the Solaris operation system.
 """
 
 # IPPROTO_GRE is missing on Solaris
+from __future__ import absolute_import
 import socket
 socket.IPPROTO_GRE = 47
 

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -7,6 +7,7 @@
 Common customizations for all Unix-like operating systems other than Linux
 """
 
+from __future__ import absolute_import
 import sys,os,struct,socket,time
 from fcntl import ioctl
 import socket
@@ -82,8 +83,8 @@ def read_routes():
         if flg.find("Lc") >= 0:
             continue
         if dest == "default":
-            dest = 0L
-            netmask = 0L
+            dest = 0
+            netmask = 0
         else:
             if SOLARIS:
                 netmask = scapy.utils.atol(mask)
@@ -148,7 +149,7 @@ def _in6_getifaddr(ifname):
     # Get the output of ifconfig
     try:
         f = os.popen("%s %s" % (conf.prog.ifconfig, ifname))
-    except OSError,msg:
+    except OSError as msg:
         log_interactive.warning("Failed to execute ifconfig.")
         return []
 
@@ -188,7 +189,7 @@ def in6_getifaddr():
     if OPENBSD:
         try:
             f = os.popen("%s" % conf.prog.ifconfig)
-        except OSError,msg:
+        except OSError as msg:
             log_interactive.warning("Failed to execute ifconfig.")
             return []
 
@@ -202,7 +203,7 @@ def in6_getifaddr():
     else: # FreeBSD, NetBSD or Darwin
         try:
             f = os.popen("%s -l" % conf.prog.ifconfig)
-        except OSError,msg:
+        except OSError as msg:
             log_interactive.warning("Failed to execute ifconfig.")
             return []
 
@@ -319,7 +320,7 @@ def read_routes6():
             next_hop = "::"
         else:
             # Get possible IPv6 source addresses
-            devaddrs = filter(lambda x: x[2] == dev, lifaddr)
+            devaddrs = [x for x in lifaddr if x[2] == dev]
             cset = construct_source_candidate_set(destination, destination_plen, devaddrs, LOOPBACK_NAME)
 
         if len(cset):

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -7,8 +7,7 @@
 Customizations needed to support Microsoft Windows.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import os, re, sys, socket, time, itertools, platform
 import subprocess as sp
 from glob import glob
@@ -329,7 +328,7 @@ def get_windows_if_list():
                             'GUID', 'MacAddress'])
     return [
         iface for iface in
-        (dict(list(zip(['name', 'win_index', 'description', 'guid', 'mac'], line)))
+        (dict(zip(['name', 'win_index', 'description', 'guid', 'mac'], line))
          for line in query)
         if is_interface_valid(iface)
     ]

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -6,6 +6,9 @@
 """
 Customizations needed to support Microsoft Windows.
 """
+
+from __future__ import absolute_import
+from __future__ import print_function
 import os, re, sys, socket, time, itertools, platform
 import subprocess as sp
 from glob import glob
@@ -16,6 +19,9 @@ from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader
 from scapy.base_classes import Gen, Net, SetGen
 from scapy.data import MTU, ETHER_BROADCAST, ETH_P_ARP
+import six
+from six.moves import range
+from six.moves import zip
 
 conf.use_pcap = False
 conf.use_dnet = False
@@ -86,7 +92,7 @@ def _vbs_exec_code(code, split_tag="@"):
     ps = sp.Popen([conf.prog.cscript, tmpfile.name],
                   stdout=sp.PIPE, stderr=open(os.devnull),
                   universal_newlines=True)
-    for _ in xrange(3):
+    for _ in range(3):
         # skip 3 first lines
         ps.stdout.readline()
     for line in ps.stdout:
@@ -100,8 +106,8 @@ def _vbs_get_iface_guid(devid):
         return
     try:
         devid = str(int(devid) + 1)
-        guid = _vbs_exec_code("""WScript.Echo CreateObject("WScript.Shell").RegRead("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards\\%s\\ServiceName")
-""" % devid).__iter__().next()
+        guid = next(_vbs_exec_code("""WScript.Echo CreateObject("WScript.Shell").RegRead("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards\\%s\\ServiceName")
+""" % devid).__iter__())
         if guid.startswith('{') and guid.endswith('}\n'):
             return guid[:-1]
     except StopIteration:
@@ -323,7 +329,7 @@ def get_windows_if_list():
                             'GUID', 'MacAddress'])
     return [
         iface for iface in
-        (dict(zip(['name', 'win_index', 'description', 'guid', 'mac'], line))
+        (dict(list(zip(['name', 'win_index', 'description', 'guid', 'mac'], line)))
          for line in query)
         if is_interface_valid(iface)
     ]
@@ -375,7 +381,7 @@ class NetworkInterface(object):
                 # No IP detected
                 self.invalid = True
         except (KeyError, AttributeError, NameError) as e:
-            print e
+            print(e)
         try:
             self.mac = data['mac']
         except KeyError:
@@ -427,14 +433,14 @@ class NetworkInterfaceDict(UserDict):
         """Return the first pcap device name for a given Windows
         device name.
         """
-        for iface in self.itervalues():
+        for iface in six.itervalues(self):
             if iface.name == name:
                 return iface
         raise ValueError("Unknown network interface %r" % name)
 
     def dev_from_pcapname(self, pcap_name):
         """Return Windows device name for given pcap device name."""
-        for iface in self.itervalues():
+        for iface in six.itervalues(self):
             if iface.pcap_name == pcap_name:
                 return iface
         raise ValueError("Unknown pypcap network interface %r" % pcap_name)
@@ -463,13 +469,13 @@ class NetworkInterfaceDict(UserDict):
 
     def show(self, resolve_mac=True):
         """Print list of available network interfaces in human readable form"""
-        print "%s  %s  %s  %s" % ("INDEX".ljust(5), "IFACE".ljust(35), "IP".ljust(15), "MAC")
+        print("%s  %s  %s  %s" % ("INDEX".ljust(5), "IFACE".ljust(35), "IP".ljust(15), "MAC"))
         for iface_name in sorted(self.data):
             dev = self.data[iface_name]
             mac = dev.mac
             if resolve_mac:
                 mac = conf.manufdb._resolve_MAC(mac)
-            print "%s  %s  %s  %s" % (str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac)
+            print("%s  %s  %s  %s" % (str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac))
             
 IFACES = NetworkInterfaceDict()
 IFACES.load_from_powershell()
@@ -520,7 +526,7 @@ def _read_routes_xp():
     routes = []
     partial_routes = []
     # map local IP addresses to interfaces
-    local_addresses = {iface.ip: iface for iface in IFACES.itervalues()}
+    local_addresses = {iface.ip: iface for iface in six.itervalues(IFACES)}
     iface_indexes = {}
     for line in exec_query(['Get-WmiObject', 'Win32_IP4RouteTable'],
                            ['Name', 'Mask', 'NextHop', 'InterfaceIndex']):
@@ -763,7 +769,7 @@ if conf.interactive_shell != 'ipython' and conf.interactive:
                 if line.strip() == "":
                     end = True
                 result = result + "\n" + line
-            return unicode(result)
+            return six.text_type(result)
         try:
             import readline
             console = readline.GetOutputFile()
@@ -807,7 +813,7 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
     data['mac'] = '00:00:00:00:00:00'
     adapter = NetworkInterface(data)
     if iflist:
-        iflist.append(unicode("\\Device\\NPF_" + adapter.guid))
+        iflist.append(six.text_type("\\Device\\NPF_" + adapter.guid))
         return
     # Remove all LOOPBACK_NAME routes
     for route in list(conf.route.routes):

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -19,9 +19,9 @@ from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader
 from scapy.base_classes import Gen, Net, SetGen
 from scapy.data import MTU, ETHER_BROADCAST, ETH_P_ARP
-import six
-from six.moves import range
-from six.moves import zip
+
+import scapy.modules.six as six
+from scapy.modules.six.moves import range, zip
 
 conf.use_pcap = False
 conf.use_dnet = False

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -25,8 +25,8 @@ from scapy.utils import PcapReader, tcpdump
 from scapy.arch.pcapdnet import PcapTimeoutElapsed
 from scapy.error import log_runtime
 from scapy.data import MTU, ETH_P_ARP,ETH_P_ALL
-import six
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import zip
 
 WINDOWS = True
 

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -7,6 +7,8 @@
 Instanciate part of the customizations needed to support Microsoft Windows.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import itertools
 import os
 import re
@@ -23,6 +25,8 @@ from scapy.utils import PcapReader, tcpdump
 from scapy.arch.pcapdnet import PcapTimeoutElapsed
 from scapy.error import log_runtime
 from scapy.data import MTU, ETH_P_ARP,ETH_P_ALL
+import six
+from six.moves import zip
 
 WINDOWS = True
 
@@ -69,13 +73,13 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
                     try:
                         i = 0
                         if verbose:
-                            print "Begin emission:"
+                            print("Begin emission:")
                         for p in tobesent:
                             pks.send(p)
                             i += 1
                             time.sleep(inter)
                         if verbose:
-                            print "Finished to send %i packets." % i
+                            print("Finished to send %i packets." % i)
                     except SystemExit:
                         pass
                     except KeyboardInterrupt:
@@ -141,7 +145,7 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
         finally:
             pass
 
-        remain = list(itertools.chain(*hsent.itervalues()))
+        remain = list(itertools.chain(*six.itervalues(hsent)))
         if multi:
             remain = [p for p in remain if not hasattr(p, '_answered')]
             
@@ -164,7 +168,7 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
                 del(s._answered)
     
     if verbose:
-        print "\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans)
+        print("\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans))
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")
 
 
@@ -227,7 +231,7 @@ stop_filter: python function applied to each packet to determine
             if prn:
                 r = prn(p)
                 if r is not None:
-                    print r
+                    print(r)
             if stop_filter and stop_filter(p):
                 break
             if 0 < count <= c:

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -7,8 +7,7 @@
 Instanciate part of the customizations needed to support Microsoft Windows.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import itertools
 import os
 import re

--- a/scapy/arch/windows/disable_sendrecv.py
+++ b/scapy/arch/windows/disable_sendrecv.py
@@ -7,6 +7,7 @@
 When wpcap.dll is not available, replace all sendrecv functions that won't work.
 """
 
+from __future__ import absolute_import
 from scapy.error import log_runtime
 import scapy.sendrecv as sendrecv
 import scapy.config as conf

--- a/scapy/arch/winpcapy.py
+++ b/scapy/arch/winpcapy.py
@@ -14,6 +14,7 @@
 ## See http://www.secdev.org/projects/scapy for more informations
 ## This program is published under a GPLv2 license
 
+from __future__ import absolute_import
 from ctypes import *
 from ctypes.util import find_library
 import sys, os

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -90,7 +90,7 @@ class AS_resolver_cymru(AS_resolver):
         for l in r.splitlines()[1:]:
             if "|" not in l:
                 continue
-            asn,ip,desc = list(map(str.strip, l.split("|")))
+            asn,ip,desc = map(str.strip, l.split("|"))
             if asn == "NA":
                 continue
             asn = "AS" + str(int(asn))

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -8,8 +8,10 @@ Resolve Autonomous Systems (AS).
 """
 
 
+from __future__ import absolute_import
 import socket, errno
 from scapy.config import conf
+from six.moves import map
 
 class AS_resolver:
     server = None
@@ -88,7 +90,7 @@ class AS_resolver_cymru(AS_resolver):
         for l in r.splitlines()[1:]:
             if "|" not in l:
                 continue
-            asn,ip,desc = map(str.strip, l.split("|"))
+            asn,ip,desc = list(map(str.strip, l.split("|")))
             if asn == "NA":
                 continue
             asn = "AS" + str(int(asn))

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -11,7 +11,7 @@ Resolve Autonomous Systems (AS).
 from __future__ import absolute_import
 import socket, errno
 from scapy.config import conf
-from six.moves import map
+from scapy.modules.six.moves import map
 
 class AS_resolver:
     server = None

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -16,9 +16,8 @@ from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
-import six
-from six.moves import range
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import range, zip
 
 class RandASN1Object(RandField):
     def __init__(self, objlist=None):

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -8,18 +8,23 @@
 ASN.1 (Abstract Syntax Notation One)
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import random
 from datetime import datetime
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
+import six
+from six.moves import range
+from six.moves import zip
 
 class RandASN1Object(RandField):
     def __init__(self, objlist=None):
         self.objlist = [
             x._asn1_obj
-            for x in ASN1_Class_UNIVERSAL.__rdict__.itervalues()
+            for x in six.itervalues(ASN1_Class_UNIVERSAL.__rdict__)
             if hasattr(x, "_asn1_obj")
         ] if objlist is None else objlist
         self.chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -32,11 +37,11 @@ class RandASN1Object(RandField):
             return o(z)
         elif issubclass(o, ASN1_STRING):
             z = int(random.expovariate(0.05)+1)
-            return o("".join(random.choice(self.chars) for _ in xrange(z)))
+            return o("".join(random.choice(self.chars) for _ in range(z)))
         elif issubclass(o, ASN1_SEQUENCE) and (n < 10):
             z = int(random.expovariate(0.08)+1)
             return o([self.__class__(objlist=self.objlist)._fix(n + 1)
-                      for _ in xrange(z)])
+                      for _ in range(z)])
         return ASN1_INTEGER(int(random.gauss(0,1000)))
 
 
@@ -72,8 +77,7 @@ class ASN1Codec(EnumElement):
 class ASN1_Codecs_metaclass(Enum_metaclass):
     element_class = ASN1Codec
 
-class ASN1_Codecs:
-    __metaclass__ = ASN1_Codecs_metaclass
+class ASN1_Codecs(six.with_metaclass(ASN1_Codecs_metaclass)):
     BER = 1
     DER = 2
     PER = 3
@@ -104,7 +108,7 @@ class ASN1Tag(EnumElement):
     def get_codec(self, codec):
         try:
             c = self._codec[codec]
-        except KeyError,msg:
+        except KeyError as msg:
             raise ASN1_Error("Codec %r not found for tag %r" % (codec, self))
         return c
 
@@ -112,12 +116,12 @@ class ASN1_Class_metaclass(Enum_metaclass):
     element_class = ASN1Tag
     def __new__(cls, name, bases, dct): # XXX factorise a bit with Enum_metaclass.__new__()
         for b in bases:
-            for k,v in b.__dict__.iteritems():
+            for k,v in six.iteritems(b.__dict__):
                 if k not in dct and isinstance(v,ASN1Tag):
                     dct[k] = v.clone()
 
         rdict = {}
-        for k,v in dct.iteritems():
+        for k,v in six.iteritems(dct):
             if type(v) is int:
                 v = ASN1Tag(k,v) 
                 dct[k] = v
@@ -133,8 +137,8 @@ class ASN1_Class_metaclass(Enum_metaclass):
         return cls
             
 
-class ASN1_Class:
-    __metaclass__ = ASN1_Class_metaclass
+class ASN1_Class(six.with_metaclass(ASN1_Class_metaclass)):
+    pass
 
 class ASN1_Class_UNIVERSAL(ASN1_Class):
     name = "UNIVERSAL"
@@ -185,8 +189,7 @@ class ASN1_Object_metaclass(type):
             warning("Error registering %r for %r" % (c.tag, c.codec))
         return c
 
-class ASN1_Object:
-    __metaclass__ = ASN1_Object_metaclass
+class ASN1_Object(six.with_metaclass(ASN1_Object_metaclass)):
     tag = ASN1_Class_UNIVERSAL.ANY
     def __init__(self, val):
         self.val = val
@@ -199,7 +202,7 @@ class ASN1_Object:
     def strshow(self, lvl=0):
         return ("  "*lvl)+repr(self)+"\n"
     def show(self, lvl=0):
-        print self.strshow(lvl)
+        print(self.strshow(lvl))
     def __eq__(self, other):
         return self.val == other
     def __cmp__(self, other):
@@ -279,7 +282,7 @@ class ASN1_BIT_STRING(ASN1_Object):
         elif name == "val":
             if isinstance(value, str):
                 if len([c for c in value if c not in ["0", "1"]]) > 0:
-                    print "Invalid operation: 'val' is not a valid bit string."
+                    print("Invalid operation: 'val' is not a valid bit string.")
                     return
                 else:
                     if len(value) % 8 == 0:
@@ -287,7 +290,7 @@ class ASN1_BIT_STRING(ASN1_Object):
                     else:
                         unused_bits = 8 - (len(value) % 8)
                     padded_value = value + ("0" * unused_bits)
-                    bytes_arr = zip(*[iter(padded_value)]*8)
+                    bytes_arr = list(zip(*[iter(padded_value)]*8))
                     val_readable = "".join(chr(int("".join(x),2)) for x in bytes_arr)
             else:
                 val_readable = "<invalid val>"
@@ -296,7 +299,7 @@ class ASN1_BIT_STRING(ASN1_Object):
             super(ASN1_Object, self).__setattr__(name, value)
             super(ASN1_Object, self).__setattr__("unused_bits", unused_bits)
         elif name == "unused_bits":
-            print "Invalid operation: unused_bits rewriting is not supported."
+            print("Invalid operation: unused_bits rewriting is not supported.")
         else:
             super(ASN1_Object, self).__setattr__(name, value)
     def __repr__(self):
@@ -364,7 +367,7 @@ class ASN1_UTC_TIME(ASN1_STRING):
             super(ASN1_UTC_TIME, self).__setattr__("pretty_time", pretty_time)
             super(ASN1_UTC_TIME, self).__setattr__(name, value)
         elif name == "pretty_time":
-            print "Invalid operation: pretty_time rewriting is not supported."
+            print("Invalid operation: pretty_time rewriting is not supported.")
         else:
             super(ASN1_UTC_TIME, self).__setattr__(name, value)
     def __repr__(self):
@@ -386,7 +389,7 @@ class ASN1_GENERALIZED_TIME(ASN1_STRING):
             super(ASN1_GENERALIZED_TIME, self).__setattr__("pretty_time", pretty_time)
             super(ASN1_GENERALIZED_TIME, self).__setattr__(name, value)
         elif name == "pretty_time":
-            print "Invalid operation: pretty_time rewriting is not supported."
+            print("Invalid operation: pretty_time rewriting is not supported.")
         else:
             super(ASN1_GENERALIZED_TIME, self).__setattr__(name, value)
     def __repr__(self):

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -408,7 +408,7 @@ class BERcodec_SEQUENCE(BERcodec_Object):
     @classmethod
     def enc(cls, l):
         if type(l) is not str:
-            l = "".join([x.enc(cls.codec) for x in l])
+            l = "".join(x.enc(cls.codec) for x in l)
         return chr(cls.tag)+BER_len_enc(len(l))+l
     @classmethod
     def do_dec(cls, s, context=None, safe=False):

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -9,9 +9,13 @@
 Basic Encoding Rules (BER) for ASN.1
 """
 
+from __future__ import absolute_import
 from scapy.error import warning
 from scapy.utils import binrepr,inet_aton,inet_ntoa
 from scapy.asn1.asn1 import ASN1_Decoding_Error,ASN1_Encoding_Error,ASN1_BadTag_Decoding_Error,ASN1_Codecs,ASN1_Class_UNIVERSAL,ASN1_Error,ASN1_DECODING_ERROR,ASN1_BADTAG
+from six.moves import map
+import six
+from six.moves import zip
 
 ##################
 ## BER encoding ##
@@ -62,7 +66,7 @@ def BER_len_enc(l, size=0):
         s = ""
         while l or size>0:
             s = chr(l&0xff)+s
-            l >>= 8L
+            l >>= 8
             size -= 1
         if len(s) > 127:
             raise BER_Exception("BER_len_enc: Length too long (%i) to be encoded [%r]" % (len(s),s))
@@ -74,9 +78,9 @@ def BER_len_dec(s):
         l &= 0x7f
         if len(s) <= l:
             raise BER_Decoding_Error("BER_len_dec: Got %i bytes while expecting %i" % (len(s)-1, l),remaining=s)
-        ll = 0L
+        ll = 0
         for c in s[1:l+1]:
-            ll <<= 8L
+            ll <<= 8
             ll |= ord(c)
         return ll,s[l+1:]
         
@@ -184,8 +188,7 @@ class BERcodec_metaclass(type):
         return c
 
 
-class BERcodec_Object:
-    __metaclass__ = BERcodec_metaclass
+class BERcodec_Object(six.with_metaclass(BERcodec_metaclass)):
     codec = ASN1_Codecs.BER
     tag = ASN1_Class_UNIVERSAL.ANY
 
@@ -241,12 +244,12 @@ class BERcodec_Object:
             return cls.do_dec(s, context, safe)
         try:
             return cls.do_dec(s, context, safe)
-        except BER_BadTag_Decoding_Error,e:
+        except BER_BadTag_Decoding_Error as e:
             o,remain = BERcodec_Object.dec(e.remaining, context, safe)
             return ASN1_BADTAG(o),remain
-        except BER_Decoding_Error, e:
+        except BER_Decoding_Error as e:
             return ASN1_DECODING_ERROR(s, exc=e),""
-        except ASN1_Error, e:
+        except ASN1_Error as e:
             return ASN1_DECODING_ERROR(s, exc=e),""
 
     @classmethod
@@ -282,7 +285,7 @@ class BERcodec_INTEGER(BERcodec_Object):
             i >>= 8
             if not i:
                 break
-        s = map(chr, s)
+        s = list(map(chr, s))
         s.append(BER_len_enc(len(s)))
         s.append(chr(cls.tag))
         s.reverse()
@@ -290,10 +293,10 @@ class BERcodec_INTEGER(BERcodec_Object):
     @classmethod
     def do_dec(cls, s, context=None, safe=False):
         l,s,t = cls.check_type_check_len(s)
-        x = 0L
+        x = 0
         if s:
             if ord(s[0])&0x80: # negative int
-                x = -1L
+                x = -1
             for c in s:
                 x <<= 8
                 x |= ord(c)
@@ -406,7 +409,7 @@ class BERcodec_SEQUENCE(BERcodec_Object):
     @classmethod
     def enc(cls, l):
         if type(l) is not str:
-            l = "".join(map(lambda x: x.enc(cls.codec), l))
+            l = "".join([x.enc(cls.codec) for x in l])
         return chr(cls.tag)+BER_len_enc(len(l))+l
     @classmethod
     def do_dec(cls, s, context=None, safe=False):
@@ -418,7 +421,7 @@ class BERcodec_SEQUENCE(BERcodec_Object):
         while s:
             try:
                 o,s = BERcodec_Object.dec(s, context, safe)
-            except BER_Decoding_Error, err:
+            except BER_Decoding_Error as err:
                 err.remaining += t
                 if err.decoded is not None:
                     obj.append(err.decoded)

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -13,9 +13,8 @@ from __future__ import absolute_import
 from scapy.error import warning
 from scapy.utils import binrepr,inet_aton,inet_ntoa
 from scapy.asn1.asn1 import ASN1_Decoding_Error,ASN1_Encoding_Error,ASN1_BadTag_Decoding_Error,ASN1_Codecs,ASN1_Class_UNIVERSAL,ASN1_Error,ASN1_DECODING_ERROR,ASN1_BADTAG
-from six.moves import map
-import six
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, zip
 
 ##################
 ## BER encoding ##

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -14,7 +14,7 @@ from glob import glob
 from scapy.dadict import DADict,fixname
 from scapy.config import conf
 from scapy.utils import do_graph
-import six
+import scapy.modules.six as six
 
 #################
 ## MIB parsing ##

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -8,11 +8,13 @@
 Management Information Base (MIB) parsing
 """
 
+from __future__ import absolute_import
 import re
 from glob import glob
 from scapy.dadict import DADict,fixname
 from scapy.config import conf
 from scapy.utils import do_graph
+import six
 
 #################
 ## MIB parsing ##
@@ -32,7 +34,7 @@ class MIBDict(DADict):
             x += "."
         max=0
         root="."
-        for k in self.iterkeys():
+        for k in six.iterkeys(self):
             if x.startswith(self[k]+"."):
                 if max < len(self[k]):
                     max = len(self[k])
@@ -53,8 +55,8 @@ class MIBDict(DADict):
     def _make_graph(self, other_keys=None, **kargs):
         if other_keys is None:
             other_keys = []
-        nodes = [(k, self[k]) for k in self.iterkeys()]
-        oids = [self[k] for k in self.iterkeys()]
+        nodes = [(k, self[k]) for k in six.iterkeys(self)]
+        oids = [self[k] for k in six.iterkeys(self)]
         for k in other_keys:
             if k not in oids:
                 nodes.append(self.oidname(k),k)
@@ -71,7 +73,7 @@ class MIBDict(DADict):
         s += "}\n"
         do_graph(s, **kargs)
     def __len__(self):
-        return len(self.keys())
+        return len(list(self.keys()))
 
 
 def mib_register(ident, value, the_mib, unresolved):
@@ -99,7 +101,7 @@ def mib_register(ident, value, the_mib, unresolved):
         return False
     else:
         the_mib[ident] = resval
-        keys = unresolved.keys()
+        keys = list(unresolved.keys())
         i = 0
         while i < len(keys):
             k = keys[i]
@@ -116,7 +118,7 @@ def mib_register(ident, value, the_mib, unresolved):
 def load_mib(filenames):
     the_mib = {'iso': ['1']}
     unresolved = {}
-    for k in conf.mib.iterkeys():
+    for k in six.iterkeys(conf.mib):
         mib_register(k, conf.mib[k].split("."), the_mib, unresolved)
 
     if type(filenames) is str:
@@ -138,9 +140,9 @@ def load_mib(filenames):
                 mib_register(ident, oid, the_mib, unresolved)
 
     newmib = MIBDict(_name="MIB")
-    for k,o in the_mib.iteritems():
+    for k,o in six.iteritems(the_mib):
         newmib[k]=".".join(o)
-    for k,o in unresolved.iteritems():
+    for k,o in six.iteritems(unresolved):
         newmib[k]=".".join(o)
 
     conf.mib=newmib

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -16,9 +16,8 @@ from scapy.volatile import *
 from scapy.base_classes import BasePacket
 from scapy.utils import binrepr
 from scapy import packet
-import six
-from six.moves import map
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range
 from functools import reduce
 
 class ASN1F_badsequence(Exception):

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -8,6 +8,7 @@
 Classes that implement ASN.1 data structures.
 """
 
+from __future__ import absolute_import
 from scapy.asn1.asn1 import *
 from scapy.asn1.ber import *
 from scapy.asn1.mib import *
@@ -15,6 +16,10 @@ from scapy.volatile import *
 from scapy.base_classes import BasePacket
 from scapy.utils import binrepr
 from scapy import packet
+import six
+from six.moves import map
+from six.moves import range
+from functools import reduce
 
 class ASN1F_badsequence(Exception):
     pass
@@ -129,7 +134,7 @@ class ASN1F_field(ASN1F_element):
             return x.copy()
         if type(x) is list:
             x = x[:]
-            for i in xrange(len(x)):
+            for i in range(len(x)):
                 if isinstance(x[i], BasePacket):
                     x[i] = x[i].copy()
         return x
@@ -171,10 +176,10 @@ class ASN1F_enum_INTEGER(ASN1F_INTEGER):
         i2s = self.i2s = {}
         s2i = self.s2i = {}
         if type(enum) is list:
-            keys = xrange(len(enum))
+            keys = range(len(enum))
         else:
-            keys = enum.keys()
-        if any(isinstance(x, basestring) for x in keys):
+            keys = list(enum.keys())
+        if any(isinstance(x, six.string_types) for x in keys):
             i2s, s2i = s2i, i2s
         for k in keys:
             i2s[k] = enum[k]
@@ -310,7 +315,7 @@ class ASN1F_SEQUENCE(ASN1F_field):
             for obj in self.seq:
                 try:
                     s = obj.dissect(pkt, s)
-                except ASN1F_badsequence,e:
+                except ASN1F_badsequence as e:
                     break
             if len(s) > 0:
                 raise BER_Decoding_Error("unexpected remainder", remaining=s)
@@ -439,7 +444,7 @@ class ASN1F_CHOICE(ASN1F_field):
         for p in args:
             if hasattr(p, "ASN1_root"):     # should be ASN1_Packet
                 if hasattr(p.ASN1_root, "choices"):
-                    for k,v in p.ASN1_root.choices.iteritems():
+                    for k,v in six.iteritems(p.ASN1_root.choices):
                         self.choices[k] = v         # ASN1F_CHOICE recursion
                 else:
                     self.choices[p.ASN1_root.network_tag] = p
@@ -489,7 +494,7 @@ class ASN1F_CHOICE(ASN1F_field):
         return BER_tagging_enc(s, explicit_tag=self.explicit_tag)
     def randval(self):
         randchoices = []
-        for p in self.choices.itervalues():
+        for p in six.itervalues(self.choices):
             if hasattr(p, "ASN1_root"):   # should be ASN1_Packet class
                 randchoices.append(packet.fuzz(p()))
             elif hasattr(p, "ASN1_tag"):

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -7,8 +7,10 @@
 Packet holding data in Abstract Syntax Notation (ASN.1).
 """
 
+from __future__ import absolute_import
 from scapy.base_classes import Packet_metaclass
 from scapy.packet import Packet
+import six
 
 class ASN1Packet_metaclass(Packet_metaclass):
     def __new__(cls, name, bases, dct):
@@ -16,8 +18,7 @@ class ASN1Packet_metaclass(Packet_metaclass):
             dct["fields_desc"] = dct["ASN1_root"].get_fields_list()
         return super(ASN1Packet_metaclass, cls).__new__(cls, name, bases, dct)
 
-class ASN1_Packet(Packet):
-    __metaclass__ = ASN1Packet_metaclass
+class ASN1_Packet(six.with_metaclass(ASN1Packet_metaclass, Packet)):
     ASN1_root = None
     ASN1_codec = None    
     def self_build(self):

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -10,7 +10,7 @@ Packet holding data in Abstract Syntax Notation (ASN.1).
 from __future__ import absolute_import
 from scapy.base_classes import Packet_metaclass
 from scapy.packet import Packet
-import six
+import scapy.modules.six as six
 
 class ASN1Packet_metaclass(Packet_metaclass):
     def __new__(cls, name, bases, dct):

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -19,7 +19,7 @@ from scapy.plist import PacketList
 from scapy.data import MTU
 from scapy.supersocket import SuperSocket
 from scapy.consts import WINDOWS
-import six
+import scapy.modules.six as six
 
 class ObjectPipe:
     def __init__(self):

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -7,6 +7,7 @@
 Automata with states, transitions and actions.
 """
 
+from __future__ import absolute_import
 import types,itertools,time,os,sys,socket,traceback
 from select import select
 from collections import deque
@@ -18,6 +19,7 @@ from scapy.plist import PacketList
 from scapy.data import MTU
 from scapy.supersocket import SuperSocket
 from scapy.consts import WINDOWS
+import six
 
 class ObjectPipe:
     def __init__(self):
@@ -43,26 +45,26 @@ class Message:
         self.__dict__.update(args)
     def __repr__(self):
         return "<Message %s>" % " ".join("%s=%r"%(k,v)
-                                         for (k,v) in self.__dict__.iteritems()
+                                         for (k,v) in six.iteritems(self.__dict__)
                                          if not k.startswith("_"))
 
 class _instance_state:
     def __init__(self, instance):
-        self.im_self = instance.im_self
-        self.im_func = instance.im_func
-        self.im_class = instance.im_class
+        self.__self__ = instance.__self__
+        self.__func__ = instance.__func__
+        self.__self__.__class__ = instance.__self__.__class__
     def __getattr__(self, attr):
-        return getattr(self.im_func, attr)
+        return getattr(self.__func__, attr)
     def __call__(self, *args, **kargs):
-        return self.im_func(self.im_self, *args, **kargs)
+        return self.__func__(self.__self__, *args, **kargs)
     def breaks(self):
-        return self.im_self.add_breakpoints(self.im_func)
+        return self.__self__.add_breakpoints(self.__func__)
     def intercepts(self):
-        return self.im_self.add_interception_points(self.im_func)
+        return self.__self__.add_interception_points(self.__func__)
     def unbreaks(self):
-        return self.im_self.remove_breakpoints(self.im_func)
+        return self.__self__.remove_breakpoints(self.__func__)
     def unintercepts(self):
-        return self.im_self.remove_interception_points(self.im_func)
+        return self.__self__.remove_interception_points(self.__func__)
         
 
 ##############
@@ -102,16 +104,16 @@ class ATMT:
     def state(initial=0,final=0,error=0):
         def deco(f,initial=initial, final=final):
             f.atmt_type = ATMT.STATE
-            f.atmt_state = f.func_name
+            f.atmt_state = f.__name__
             f.atmt_initial = initial
             f.atmt_final = final
             f.atmt_error = error
             def state_wrapper(self, *args, **kargs):
                 return ATMT.NewStateRequested(f, self, *args, **kargs)
 
-            state_wrapper.func_name = "%s_wrapper" % f.func_name
+            state_wrapper.__name__ = "%s_wrapper" % f.__name__
             state_wrapper.atmt_type = ATMT.STATE
-            state_wrapper.atmt_state = f.func_name
+            state_wrapper.atmt_state = f.__name__
             state_wrapper.atmt_initial = initial
             state_wrapper.atmt_final = final
             state_wrapper.atmt_error = error
@@ -132,7 +134,7 @@ class ATMT:
         def deco(f, state=state):
             f.atmt_type = ATMT.CONDITION
             f.atmt_state = state.atmt_state
-            f.atmt_condname = f.func_name
+            f.atmt_condname = f.__name__
             f.atmt_prio = prio
             return f
         return deco
@@ -141,7 +143,7 @@ class ATMT:
         def deco(f, state=state):
             f.atmt_type = ATMT.RECV
             f.atmt_state = state.atmt_state
-            f.atmt_condname = f.func_name
+            f.atmt_condname = f.__name__
             f.atmt_prio = prio
             return f
         return deco
@@ -150,7 +152,7 @@ class ATMT:
         def deco(f, state=state):
             f.atmt_type = ATMT.IOEVENT
             f.atmt_state = state.atmt_state
-            f.atmt_condname = f.func_name
+            f.atmt_condname = f.__name__
             f.atmt_ioname = name
             f.atmt_prio = prio
             f.atmt_as_supersocket = as_supersocket
@@ -162,7 +164,7 @@ class ATMT:
             f.atmt_type = ATMT.TIMEOUT
             f.atmt_state = state.atmt_state
             f.atmt_timeout = timeout
-            f.atmt_condname = f.func_name
+            f.atmt_condname = f.__name__
             return f
         return deco
 
@@ -230,11 +232,11 @@ class Automaton_metaclass(type):
         while classes:
             c = classes.pop(0) # order is important to avoid breaking method overloading
             classes += list(c.__bases__)
-            for k,v in c.__dict__.iteritems():
+            for k,v in six.iteritems(c.__dict__):
                 if k not in members:
                     members[k] = v
 
-        decorated = [v for v in members.itervalues()
+        decorated = [v for v in six.itervalues(members)
                      if type(v) is types.FunctionType and hasattr(v, "atmt_type")]
         
         for m in decorated:
@@ -267,14 +269,14 @@ class Automaton_metaclass(type):
                     cls.actions[c].append(m)
             
 
-        for v in cls.timeout.itervalues():
+        for v in six.itervalues(cls.timeout):
             v.sort(lambda (t1,f1),(t2,f2): cmp(t1,t2))
             v.append((None, None))
-        for v in itertools.chain(cls.conditions.itervalues(),
-                                 cls.recv_conditions.itervalues(),
-                                 cls.ioevents.itervalues()):
+        for v in itertools.chain(six.itervalues(cls.conditions),
+                                 six.itervalues(cls.recv_conditions),
+                                 six.itervalues(cls.ioevents)):
             v.sort(lambda c1,c2: cmp(c1.atmt_prio,c2.atmt_prio))
-        for condname,actlst in cls.actions.iteritems():
+        for condname,actlst in six.iteritems(cls.actions):
             actlst.sort(lambda c1,c2: cmp(c1.atmt_cond[condname], c2.atmt_cond[condname]))
 
         for ioev in cls.iosupersockets:
@@ -286,7 +288,7 @@ class Automaton_metaclass(type):
         s = 'digraph "%s" {\n'  % self.__class__.__name__
         
         se = "" # Keep initial nodes at the begining for better rendering
-        for st in self.states.itervalues():
+        for st in six.itervalues(self.states):
             if st.atmt_initial:
                 se = ('\t"%s" [ style=filled, fillcolor=blue, shape=box, root=true];\n' % st.atmt_state)+se
             elif st.atmt_final:
@@ -295,8 +297,8 @@ class Automaton_metaclass(type):
                 se += '\t"%s" [ style=filled, fillcolor=red, shape=octagon ];\n' % st.atmt_state
         s += se
 
-        for st in self.states.itervalues():
-            for n in st.atmt_origfunc.func_code.co_names+st.atmt_origfunc.func_code.co_consts:
+        for st in six.itervalues(self.states):
+            for n in st.atmt_origfunc.__code__.co_names+st.atmt_origfunc.__code__.co_consts:
                 if n in self.states:
                     s += '\t"%s" -> "%s" [ color=green ];\n' % (st.atmt_state,n)
             
@@ -305,21 +307,21 @@ class Automaton_metaclass(type):
                       [("red",k,v) for k,v in self.recv_conditions.items()]+
                       [("orange",k,v) for k,v in self.ioevents.items()]):
             for f in v:
-                for n in f.func_code.co_names+f.func_code.co_consts:
+                for n in f.__code__.co_names+f.__code__.co_consts:
                     if n in self.states:
                         l = f.atmt_condname
                         for x in self.actions[f.atmt_condname]:
-                            l += "\\l>[%s]" % x.func_name
+                            l += "\\l>[%s]" % x.__name__
                         s += '\t"%s" -> "%s" [label="%s", color=%s];\n' % (k,n,l,c)
-        for k,v in self.timeout.iteritems():
+        for k,v in six.iteritems(self.timeout):
             for t,f in v:
                 if f is None:
                     continue
-                for n in f.func_code.co_names+f.func_code.co_consts:
+                for n in f.__code__.co_names+f.__code__.co_consts:
                     if n in self.states:
                         l = "%s/%.1fs" % (f.atmt_condname,t)                        
                         for x in self.actions[f.atmt_condname]:
-                            l += "\\l>[%s]" % x.func_name
+                            l += "\\l>[%s]" % x.__name__
                         s += '\t"%s" -> "%s" [label="%s",color=blue];\n' % (k,n,l)
         s += "}\n"
         return do_graph(s, **kargs)
@@ -349,10 +351,7 @@ def select_objects(inputs, remain):
         r,_,_ = select(inputs,[],[],remain)
         return r
 
-class Automaton:
-    __metaclass__ = Automaton_metaclass
-
-    ## Methods to overload
+class Automaton(six.with_metaclass(Automaton_metaclass)):
     def parse_args(self, debug=0, store=1, **kargs):
         self.debug_level=debug
         self.socket_kargs = kargs
@@ -535,16 +534,16 @@ class Automaton:
         try:
             self.debug(5, "Trying %s [%s]" % (cond.atmt_type, cond.atmt_condname))
             cond(self,*args, **kargs)
-        except ATMT.NewStateRequested, state_req:
+        except ATMT.NewStateRequested as state_req:
             self.debug(2, "%s [%s] taken to state [%s]" % (cond.atmt_type, cond.atmt_condname, state_req.state))
             if cond.atmt_type == ATMT.RECV:
                 if self.store_packets:
                     self.packets.append(args[0])
             for action in self.actions[cond.atmt_condname]:
-                self.debug(2, "   + Running action [%s]" % action.func_name)
+                self.debug(2, "   + Running action [%s]" % action.__name__)
                 action(self, *state_req.action_args, **state_req.action_kargs)
             raise
-        except Exception,e:
+        except Exception as e:
             self.debug(2, "%s [%s] raised exception [%s]" % (cond.atmt_type, cond.atmt_condname, e))
             raise
         else:
@@ -589,7 +588,7 @@ class Automaton:
                     elif c.type == _ATMT_Command.STOP:
                         break
                     while True:
-                        state = iterator.next()
+                        state = next(iterator)
                         if isinstance(state, self.CommandMessage):
                             break
                         elif isinstance(state, self.Breakpoint):
@@ -600,10 +599,10 @@ class Automaton:
                             c = Message(type=_ATMT_Command.SINGLESTEP,state=state)
                             self.cmdout.send(c)
                             break
-            except StopIteration,e:
+            except StopIteration as e:
                 c = Message(type=_ATMT_Command.END, result=e.args[0])
                 self.cmdout.send(c)
-            except Exception,e:
+            except Exception as e:
                 exc_info = sys.exc_info()
                 self.debug(3, "Transfering exception from tid=%i:\n%s"% (self.threadid, traceback.format_exc(exc_info)))
                 m = Message(type=_ATMT_Command.EXCEPTION, exception=e, exc_info=exc_info)
@@ -647,7 +646,7 @@ class Automaton:
     
                 # Finally listen and pay attention to timeouts
                 expirations = iter(self.timeout[self.state.state])
-                next_timeout,timeout_func = expirations.next()
+                next_timeout,timeout_func = next(expirations)
                 t0 = time.time()
                 
                 fds = [self.cmdin]
@@ -660,7 +659,7 @@ class Automaton:
                     if next_timeout is not None:
                         if next_timeout <= t:
                             self._run_condition(timeout_func, *state_output)
-                            next_timeout,timeout_func = expirations.next()
+                            next_timeout,timeout_func = next(expirations)
                     if next_timeout is None:
                         remain = None
                     else:
@@ -688,7 +687,7 @@ class Automaton:
                                 if ioevt.atmt_ioname == fd.ioname:
                                     self._run_condition(ioevt, fd, *state_output)
     
-            except ATMT.NewStateRequested,state_req:
+            except ATMT.NewStateRequested as state_req:
                 self.debug(2, "switching from [%s] to [%s]" % (self.state.state,state_req.state))
                 self.state = state_req
                 yield state_req
@@ -741,7 +740,7 @@ class Automaton:
             elif c.type == _ATMT_Command.BREAKPOINT:
                 raise self.Breakpoint("breakpoint triggered on state [%s]"%c.state.state, state=c.state.state)
             elif c.type == _ATMT_Command.EXCEPTION:
-                raise c.exc_info[0],c.exc_info[1],c.exc_info[2]
+                six.reraise(c.exc_info[0], c.exc_info[1], c.exc_info[2])
 
     def runbg(self, resume=None, wait=False):
         self.run(resume, wait)

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -6,8 +6,10 @@
 """
 Run commands when the Scapy interpreter starts.
 """
+from __future__ import print_function
 
-import code,sys
+from __future__ import absolute_import
+import code, sys, importlib
 from scapy.config import conf
 from scapy.themes import *
 from scapy.error import Scapy_Exception
@@ -36,20 +38,23 @@ class ScapyAutorunInterpreter(code.InteractiveInterpreter):
         return code.InteractiveInterpreter.showtraceback(self, *args, **kargs)
 
 
-def autorun_commands(cmds,my_globals=None,verb=0):
+def autorun_commands(cmds, my_globals=None, ignore_globals=None, verb=0):
     sv = conf.verb
-    import __builtin__
+    import six.moves.builtins
     try:
         try:
             if my_globals is None:
-                my_globals = __import__("scapy.all").all.__dict__
+                my_globals = importlib.import_module(".all", "scapy").__dict__
+                if ignore_globals:
+                    for ig in ignore_globals:
+                        my_globals.pop(ig, None)
             conf.verb = verb
             interp = ScapyAutorunInterpreter(my_globals)
             cmd = ""
             cmds = cmds.splitlines()
             cmds.append("") # ensure we finish multi-line commands
             cmds.reverse()
-            __builtin__.__dict__["_"] = None
+            six.moves.builtins.__dict__["_"] = None
             while 1:
                 if cmd:
                     sys.stderr.write(sys.__dict__.get("ps2","... "))
@@ -57,7 +62,7 @@ def autorun_commands(cmds,my_globals=None,verb=0):
                     sys.stderr.write(str(sys.__dict__.get("ps1",ColorPrompt())))
                     
                 l = cmds.pop()
-                print l
+                print(l)
                 cmd += "\n"+l
                 if interp.runsource(cmd):
                     continue
@@ -87,7 +92,7 @@ def autorun_get_interactive_session(cmds, **kargs):
         try:
             sys.stdout = sys.stderr = sw
             res = autorun_commands(cmds, **kargs)
-        except StopAutorun,e:
+        except StopAutorun as e:
             e.code_run = sw.s
             raise
     finally:
@@ -119,7 +124,7 @@ def autorun_get_html_interactive_session(cmds, **kargs):
         try:
             conf.color_theme = HTMLTheme2()
             s,res = autorun_get_interactive_session(cmds, **kargs)
-        except StopAutorun,e:
+        except StopAutorun as e:
             e.code_run = to_html(e.code_run)
             raise
     finally:
@@ -134,11 +139,9 @@ def autorun_get_latex_interactive_session(cmds, **kargs):
         try:
             conf.color_theme = LatexTheme2()
             s,res = autorun_get_interactive_session(cmds, **kargs)
-        except StopAutorun,e:
+        except StopAutorun as e:
             e.code_run = to_latex(e.code_run)
             raise
     finally:
         conf.color_theme = ct
     return to_latex(s),res
-
-

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -6,9 +6,8 @@
 """
 Run commands when the Scapy interpreter starts.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
-from __future__ import absolute_import
 import code, sys, importlib
 from scapy.config import conf
 from scapy.themes import *

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -14,6 +14,7 @@ from scapy.config import conf
 from scapy.themes import *
 from scapy.error import Scapy_Exception
 from scapy.utils import tex_escape
+import scapy.modules.six as six
 
 
 #########################
@@ -40,7 +41,6 @@ class ScapyAutorunInterpreter(code.InteractiveInterpreter):
 
 def autorun_commands(cmds, my_globals=None, ignore_globals=None, verb=0):
     sv = conf.verb
-    import six.moves.builtins
     try:
         try:
             if my_globals is None:

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -11,8 +11,12 @@ Generators and packet meta classes.
 ## Generators ##
 ################
 
+from __future__ import absolute_import
 import re,random,socket
 import types
+from six.moves import map
+from six.moves import range
+from six.moves import zip
 
 class Gen(object):
     __slots__ = []
@@ -28,7 +32,7 @@ class SetGen(Gen):
              all(hasattr(i, "__int__") for i in values)):
             # We use values[1] + 1 as stop value for xrange to maintain
             # the behavior of using tuples as field `values`
-            self.values = [xrange(*((int(values[0]), int(values[1]) + 1)
+            self.values = [range(*((int(values[0]), int(values[1]) + 1)
                                     + tuple(int(v) for v in values[2:])))]
         else:
             self.values = [values]
@@ -57,12 +61,12 @@ class Net(Gen):
         if a == "*":
             a = (0,256)
         elif a.find("-") >= 0:
-            x,y = map(int,a.split("-"))
+            x,y = list(map(int,a.split("-")))
             if x > y:
                 y = x
-            a = (x &  (0xffL<<netmask) , max(y, (x | (0xffL>>(8-netmask))))+1)
+            a = (x &  (0xff<<netmask) , max(y, (x | (0xff>>(8-netmask))))+1)
         else:
-            a = (int(a) & (0xffL<<netmask),(int(a) | (0xffL>>(8-netmask)))+1)
+            a = (int(a) & (0xff<<netmask),(int(a) | (0xff>>(8-netmask)))+1)
         return a
 
     @classmethod
@@ -71,7 +75,7 @@ class Net(Gen):
         if not cls.ipaddress.match(net):
             tmp[0]=socket.gethostbyname(tmp[0])
         netmask = int(tmp[1])
-        return map(lambda x,y: cls._parse_digit(x,y), tmp[0].split("."), map(lambda x,nm=netmask: x-nm, (8,16,24,32))),netmask
+        return list(map(lambda x,y: cls._parse_digit(x,y), tmp[0].split("."), list(map(lambda x,nm=netmask: x-nm, (8,16,24,32))))),netmask
 
     def __init__(self, net):
         self.repr=net
@@ -81,10 +85,10 @@ class Net(Gen):
         return self.repr
                                                                                                
     def __iter__(self):
-        for d in xrange(*self.parsed[3]):
-            for c in xrange(*self.parsed[2]):
-                for b in xrange(*self.parsed[1]):
-                    for a in xrange(*self.parsed[0]):
+        for d in range(*self.parsed[3]):
+            for c in range(*self.parsed[2]):
+                for b in range(*self.parsed[1]):
+                    for a in range(*self.parsed[0]):
                         yield "%i.%i.%i.%i" % (a,b,c,d)
     def choice(self):
         ip = []

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -14,9 +14,7 @@ Generators and packet meta classes.
 from __future__ import absolute_import
 import re,random,socket
 import types
-from six.moves import map
-from six.moves import range
-from six.moves import zip
+from six.moves import map, range, zip
 
 class Gen(object):
     __slots__ = []

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -14,7 +14,8 @@ Generators and packet meta classes.
 from __future__ import absolute_import
 import re,random,socket
 import types
-from six.moves import map, range, zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range, zip
 
 class Gen(object):
     __slots__ = []
@@ -59,7 +60,7 @@ class Net(Gen):
         if a == "*":
             a = (0,256)
         elif a.find("-") >= 0:
-            x,y = list(map(int,a.split("-")))
+            x,y = map(int,a.split("-"))
             if x > y:
                 y = x
             a = (x &  (0xff<<netmask) , max(y, (x | (0xff>>(8-netmask))))+1)

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -16,7 +16,7 @@ from scapy.data import *
 from scapy import base_classes
 from scapy import themes
 from scapy.error import log_scapy
-import six
+import scapy.modules.six as six
 
 ############
 ## Config ##

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -7,8 +7,7 @@
 Implementation of the configuration object.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import os,time,socket,sys
 
 from scapy import VERSION

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -7,6 +7,8 @@
 Implementation of the configuration object.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os,time,socket,sys
 
 from scapy import VERSION
@@ -14,6 +16,7 @@ from scapy.data import *
 from scapy import base_classes
 from scapy import themes
 from scapy.error import log_scapy
+import six
 
 ############
 ## Config ##
@@ -127,14 +130,14 @@ class Num2Layer:
     
     def __repr__(self):
         lst = []
-        for num,layer in self.num2layer.iteritems():
+        for num,layer in six.iteritems(self.num2layer):
             if layer in self.layer2num and self.layer2num[layer] == num:
                 dir = "<->"
             else:
                 dir = " ->"
             lst.append((num,"%#6x %s %-20s (%s)" % (num, dir, layer.__name__,
                                                     layer._name)))
-        for layer,num in self.layer2num.iteritems():
+        for layer,num in six.iteritems(self.layer2num):
             if num not in self.num2layer or self.num2layer[num] != layer:
                 lst.append((num,"%#6x <-  %-20s (%s)" % (num, layer.__name__,
                                                          layer._name)))
@@ -166,7 +169,7 @@ class CommandsList(list):
         return cmd # return cmd so that method can be used as a decorator
 
 def lsc():
-    print repr(conf.commands)
+    print(repr(conf.commands))
 
 class CacheInstance(dict):
     def __init__(self, name="noname", timeout=None):
@@ -206,7 +209,7 @@ class CacheInstance(dict):
         t0=time.time()
         return (k for k in dict.iterkeys(self) if t0-self._timetable[k] < self.timeout)
     def __iter__(self):
-        return self.iterkeys()
+        return six.iterkeys(self)
     def itervalues(self):
         if self.timeout is None:
             return dict.itervalues(self)
@@ -230,15 +233,15 @@ class CacheInstance(dict):
     def __len__(self):
         if self.timeout is None:
             return dict.__len__(self)
-        return len(self.keys())
+        return len(list(self.keys()))
     def summary(self):
         return "%s: %i valid items. Timeout=%rs" % (self.name, len(self), self.timeout)
     def __repr__(self):
         s = []
         if self:
-            mk = max(len(k) for k in self.iterkeys())
+            mk = max(len(k) for k in six.iterkeys(self))
             fmt = "%%-%is %%s" % (mk+1)
-            for item in self.iteritems():
+            for item in six.iteritems(self):
                 s.append(fmt % item)
         return "\n".join(s)
             

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -3,6 +3,7 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
+from __future__ import absolute_import
 import os, inspect
 from sys import platform, maxsize
 import platform as platform_lib

--- a/scapy/contrib/HomePlugAV.py
+++ b/scapy/contrib/HomePlugAV.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import Ether
-from six.moves import range
+from scapy.modules.six.moves import range
 
 """
     Copyright (C) HomePlugAV Layer for Scapy by FlUxIuS (Sebastien Dudek)

--- a/scapy/contrib/HomePlugAV.py
+++ b/scapy/contrib/HomePlugAV.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import Ether
+from six.moves import range
 
 """
     Copyright (C) HomePlugAV Layer for Scapy by FlUxIuS (Sebastien Dudek)
@@ -430,7 +432,7 @@ ModuleIDList = {    0x00 : "MAC Soft-Loader Image",
 
 def chksum32(data):
     cksum = 0
-    for i in xrange(0, len(data), 4):
+    for i in range(0, len(data), 4):
         cksum = (cksum ^ struct.unpack('<I', data[i:i+4])[0]) & 0xffffffff   
     return (~cksum) & 0xffffffff
 

--- a/scapy/contrib/avs.py
+++ b/scapy/contrib/avs.py
@@ -5,6 +5,7 @@
 # scapy.contrib.description = AVS WLAN Monitor Header
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.dot11 import *

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -10,6 +10,7 @@
 BGP (Border Gateway Protocol).
 """
 
+from __future__ import absolute_import
 import struct
 import re
 import socket
@@ -27,6 +28,9 @@ from scapy.layers.inet import TCP
 from scapy.layers.inet6 import IP6Field
 from scapy.config import conf, ConfClass
 from scapy.error import log_runtime
+from six.moves import map
+import six
+from six.moves import range
 
 
 #
@@ -561,12 +565,10 @@ class _BGPCapability_metaclass(Packet_metaclass, _BGPCap_metaclass):
     pass
 
 
-class BGPCapability(Packet):
+class BGPCapability(six.with_metaclass(_BGPCapability_metaclass, Packet)):
     """
     Generic BGP capability.
     """
-
-    __metaclass__ = _BGPCapability_metaclass
 
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
@@ -2036,7 +2038,7 @@ class BGPPathAttr(Packet):
         # Set default flags value ?
         if self.type_flags is None:
             # Set the standard value, if it is exists in attributes_flags.
-            if attributes_flags.has_key(self.type_code):
+            if self.type_code in attributes_flags:
                 flags_value = attributes_flags.get(self.type_code)
 
             # Otherwise, set to optional, non-transitive.

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -28,9 +28,8 @@ from scapy.layers.inet import TCP
 from scapy.layers.inet6 import IP6Field
 from scapy.config import conf, ConfClass
 from scapy.error import log_runtime
-from six.moves import map
+from six.moves import map, range
 import six
-from six.moves import range
 
 
 #

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -28,8 +28,8 @@ from scapy.layers.inet import TCP
 from scapy.layers.inet6 import IP6Field
 from scapy.config import conf, ConfClass
 from scapy.error import log_runtime
-from six.moves import map, range
-import six
+from scapy.modules.six.moves import map, range
+import scapy.modules.six as six
 
 
 #

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -2,6 +2,7 @@
 # scapy.contrib.description = CARP
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import struct, hmac, hashlib
 
 from scapy.packet import *

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -22,9 +22,11 @@
 ##                                                                         ##
 #############################################################################
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet6 import *
+from six.moves import range
 
 
 #####################################################################
@@ -184,7 +186,7 @@ _cdp_capabilities = ["Router",
                      "Switch",
                      "Host",
                      "IGMPCapable",
-                     "Repeater"] + ["Bit%d" % x for x in xrange(25, 0, -1)]
+                     "Repeater"] + ["Bit%d" % x for x in range(25, 0, -1)]
 
 
 class CDPMsgCapabilities(CDPMsgGeneric):

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet6 import *
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 #####################################################################

--- a/scapy/contrib/chdlc.py
+++ b/scapy/contrib/chdlc.py
@@ -5,6 +5,7 @@
 
 # This layer is based on information from http://www.nethelp.no/net/cisco-hdlc.txt
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import *

--- a/scapy/contrib/coap.py
+++ b/scapy/contrib/coap.py
@@ -20,6 +20,7 @@
 RFC 7252 - Constrained Application Protocol (CoAP) layer for Scapy
 """
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.layers.inet import UDP
 from scapy.packet import *

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -22,7 +22,7 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import SNAP,Dot3,LLC
 from scapy.sendrecv import sendp
-from six.moves import map
+from scapy.modules.six.moves import map
 from functools import reduce
 
 class DtpGenericTlv(Packet):

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -16,10 +16,14 @@
         http://trac.secdev.org/scapy/ticket/18
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import SNAP,Dot3,LLC
 from scapy.sendrecv import sendp
+from six.moves import map
+from functools import reduce
 
 class DtpGenericTlv(Packet):
     name = "DTP Generic TLV"
@@ -50,7 +54,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s+reduce(str.__add__, map(str, val),"")
+        return s+reduce(str.__add__, list(map(str, val)),"")
 
 _DTP_TLV_CLS = {
                     0x0001 : "DTPDomain",
@@ -106,7 +110,7 @@ bind_layers(SNAP, DTP, code=0x2004, OUI=0xc)
 
 
 def negotiate_trunk(iface=conf.iface, mymac=str(RandMAC())):
-    print "Trying to negotiate a trunk on interface %s" % iface
+    print("Trying to negotiate a trunk on interface %s" % iface)
     p = Dot3(src=mymac, dst="01:00:0c:cc:cc:cc")/LLC()/SNAP()/DTP(tlvlist=[DTPDomain(),DTPStatus(),DTPType(),DTPNeighbor(neighbor=mymac)])
     sendp(p)
 

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -16,8 +16,7 @@
         http://trac.secdev.org/scapy/ticket/18
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import SNAP,Dot3,LLC
@@ -54,7 +53,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s+reduce(str.__add__, list(map(str, val)),"")
+        return s+reduce(str.__add__, map(str, val),"")
 
 _DTP_TLV_CLS = {
                     0x0001 : "DTPDomain",

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -44,7 +44,7 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import *
-from six.moves import map
+from scapy.modules.six.moves import map
 from functools import reduce
 
 class EigrpIPField(StrField, IPField):

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -39,10 +39,13 @@
     - IOS / EIGRP Version Representation FIX by Dirk Loss
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import *
+from six.moves import map
+from functools import reduce
 
 class EigrpIPField(StrField, IPField):
     """
@@ -431,7 +434,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s + reduce(str.__add__, map(str, val), "")
+        return s + reduce(str.__add__, list(map(str, val)), "")
 
 def _EIGRPGuessPayloadClass(p, **kargs):
     cls = conf.raw_layer

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -434,7 +434,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s + reduce(str.__add__, list(map(str, val)), "")
+        return s + reduce(str.__add__, map(str, val), "")
 
 def _EIGRPGuessPayloadClass(p, **kargs):
     cls = conf.raw_layer

--- a/scapy/contrib/etherip.py
+++ b/scapy/contrib/etherip.py
@@ -4,6 +4,7 @@
 # scapy.contrib.description = EtherIP
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.fields import BitField
 from scapy.packet import Packet, bind_layers
 from scapy.layers.inet import IP

--- a/scapy/contrib/gsm_um.py
+++ b/scapy/contrib/gsm_um.py
@@ -28,6 +28,8 @@
     # tested on: scapy-version: 2.2.0 (dev)                            #
     ####################################################################
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 from types import IntType
 from types import NoneType
@@ -68,8 +70,8 @@ def sendum(x, typeSock=0):
         s.send(x)
         s.close()
     except:
-        print "[Error]: There was a problem when trying to transmit data.\
-               Please make sure you started the socket server."
+        print("[Error]: There was a problem when trying to transmit data.\
+               Please make sure you started the socket server.")
 
 # Known Bugs/Problems:
 # If a message uses multiple times the same IE you cannot set the values
@@ -128,14 +130,14 @@ def adapt(min_length, max_length, fields, fields2, location=2):
 
 def examples(example=None):
     if example == None:
-        print """This command presents some example to introduce scapy
+        print("""This command presents some example to introduce scapy
 gsm-um to new users.
 The following parameters can be used:
     examples("imsiDetach")
     examples("call")
-    examples("dissect")"""
+    examples("dissect")""")
     elif example == "imsiDetach":
-        print """
+        print("""
 >>> a=imsiDetachIndication()
 ... a.typeOfId=1; a.odd=1; a.idDigit1=0xF; 
 ... a.idDigit2_1=2; a.idDigit2=7; a.idDigit3_1=0;
@@ -146,13 +148,13 @@ The following parameters can be used:
 >>> hexdump(a)
 0000   05 01 00 08 F0 27 07 72  00 01 27 75 14   .....'.r..'u.
 >>> sendum(a)
-"""
+""")
     elif example == "call":
-        print """
+        print("""
 If you use an USRP and the testcall function this sets up a phonecall:
 >>> sendum(setupMobileOriginated())
 >>> sendum(connectAcknowledge())
-"""
+""")
 
 
 # Section 10.2/3
@@ -2933,7 +2935,7 @@ class MobileIdHdr(Packet):
             p = p[:1] + struct.pack(">B", res[1]) + p[2:]
         if res[0] != 0:
             p = p[:-res[0]]
-        print repr(p)
+        print(repr(p))
         return p + pay
 
 
@@ -5952,7 +5954,7 @@ class BearerCapabilityHdr(Packet):
         if len(p) is 5:
             p = p[:-2]
         if self.lengthBC is None:
-            print "len von a %s" % (len(p),)
+            print("len von a %s" % (len(p),))
             p = p[:1] + struct.pack(">B", len(p)-3) + p[2:]
         return p + pay
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -19,7 +19,7 @@ from scapy.fields import *
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IP6Field
 from scapy.error import warning
-from six.moves import range
+from scapy.modules.six.moves import range
 
 # GTP Data types
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -364,7 +364,7 @@ class APNStrLenField(StrLenField):
         s = ret_s
         return s
     def i2m(self, pkt, s):
-        s = "".join([chr(len(x))+x for x in s.split(".")])
+        s = "".join(chr(len(x))+x for x in s.split("."))
         return s
 
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -10,6 +10,7 @@
 # scapy.contrib.description = GTP
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import time
 import logging
 
@@ -18,6 +19,7 @@ from scapy.fields import *
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IP6Field
 from scapy.error import warning
+from six.moves import range
 
 # GTP Data types
 
@@ -153,7 +155,7 @@ class TBCDByteField(StrFixedLenField):
     def i2m(self, pkt, val):
         val = str(val)
         ret_string = ""
-        for i in xrange(0, len(val), 2):
+        for i in range(0, len(val), 2):
             tmp = val[i:i+2]
             if len(tmp) == 2:
               ret_string += chr(int(tmp[1] + tmp[0], 16))
@@ -197,7 +199,7 @@ class GTPHeader(Packet):
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 1:
             if (struct.unpack("B", _pkt[0])[0] >> 5) & 0x7 == 2:
-                import gtp_v2
+                from . import gtp_v2
                 return gtp_v2.GTPHeader
         return GTPHeader
 
@@ -362,7 +364,7 @@ class APNStrLenField(StrLenField):
         s = ret_s
         return s
     def i2m(self, pkt, s):
-        s = "".join(map(lambda x: chr(len(x))+x, s.split(".")))
+        s = "".join([chr(len(x))+x for x in s.split(".")])
         return s
 
 

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -8,6 +8,7 @@
 # scapy.contrib.description = GTPv2
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import time
 import logging
 
@@ -16,7 +17,7 @@ from scapy.fields import *
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IP6Field
 
-import gtp
+from . import gtp
 
 RATType = {
     6: "EUTRAN",

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -31,8 +31,8 @@ import types
 import re
 import StringIO
 import struct
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -24,8 +24,7 @@ scapy.contrib.status=loads
 scapy.contrib.description=HTTP/2 (RFC 7540, RFC 7541)
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import abc
 import types
 import re

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -24,11 +24,15 @@ scapy.contrib.status=loads
 scapy.contrib.description=HTTP/2 (RFC 7540, RFC 7541)
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import abc
 import types
 import re
 import StringIO
 import struct
+import six
+from six.moves import range
 
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".
@@ -100,7 +104,7 @@ class HPackMagicBitField(fields.BitField):
         assert (
             isinstance(r, tuple)
             and len(r) == 2
-            and isinstance(r[1], (int, long))
+            and isinstance(r[1], six.integer_types)
         ), 'Second element of BitField.getfield return value expected to be an int or a long; API change detected'
         assert r[1] == self._magic, 'Invalid value parsed from s; error in class guessing detected!'
         return r
@@ -192,7 +196,7 @@ class AbstractUVarIntField(fields.Field):
         @return None
         @raise AssertionError
         """
-        assert(isinstance(default, types.NoneType) or (isinstance(default, (int, long)) and default >= 0))
+        assert(isinstance(default, type(None)) or (isinstance(default, six.integer_types) and default >= 0))
         assert(0 < size <= 8)
         super(AbstractUVarIntField, self).__init__(name, default)
         self.size = size
@@ -210,7 +214,7 @@ class AbstractUVarIntField(fields.Field):
         @return int|None: the converted value.
         @raise AssertionError
         """
-        assert(not isinstance(x, (int, long)) or x >= 0)
+        assert(not isinstance(x, six.integer_types) or x >= 0)
         return x
 
     def i2h(self, pkt, x):
@@ -334,16 +338,16 @@ class AbstractUVarIntField(fields.Field):
         @return int|None: the converted value.
         @raise AssertionError
         """
-        if isinstance(x, types.NoneType):
+        if isinstance(x, type(None)):
             return x
-        if isinstance(x, (int, long)):
+        if isinstance(x, six.integer_types):
             assert(x >= 0)
             ret = self.h2i(pkt, x)
-            assert(isinstance(ret, (int, long)) and ret >= 0)
+            assert(isinstance(ret, six.integer_types) and ret >= 0)
             return ret
         elif isinstance(x, str):
             ret = self.m2i(pkt, x)
-            assert (isinstance(ret, (int, long)) and ret >= 0)
+            assert (isinstance(ret, six.integer_types) and ret >= 0)
             return ret
         assert False, 'EINVAL: x: No idea what the parameter format is'
 
@@ -502,7 +506,7 @@ class UVarIntField(AbstractUVarIntField):
         @raise AssertionError
         """
         ret = super(UVarIntField, self).h2i(pkt, x)
-        assert(not isinstance(ret, types.NoneType) and ret >= 0)
+        assert(not isinstance(ret, type(None)) and ret >= 0)
         return ret
 
     def i2h(self, pkt, x):
@@ -515,7 +519,7 @@ class UVarIntField(AbstractUVarIntField):
         @raise AssertionError
         """
         ret = super(UVarIntField, self).i2h(pkt, x)
-        assert(not isinstance(ret, types.NoneType) and ret >= 0)
+        assert(not isinstance(ret, type(None)) and ret >= 0)
         return ret
 
     def any2i(self, pkt, x):
@@ -528,7 +532,7 @@ class UVarIntField(AbstractUVarIntField):
         @raise AssertionError
         """
         ret = super(UVarIntField, self).any2i(pkt, x)
-        assert(not isinstance(ret, types.NoneType) and ret >= 0)
+        assert(not isinstance(ret, type(None)) and ret >= 0)
         return ret
 
     def i2repr(self, pkt, x):
@@ -626,9 +630,7 @@ class FieldUVarLenField(AbstractUVarIntField):
 ################################################ HPACK String Fields ###################################################
 ########################################################################################################################
 
-class HPackStringsInterface(Sized):
-    __metaclass__ = abc.ABCMeta
-
+class HPackStringsInterface(six.with_metaclass(abc.ABCMeta, Sized)):
     @abc.abstractmethod
     def __str__(self): pass
 
@@ -1038,9 +1040,9 @@ class HPackZString(HPackStringsInterface):
         assert(i >= 0)
         assert(ibl >= 0)
 
-        if isinstance(cls.static_huffman_tree, types.NoneType):
+        if isinstance(cls.static_huffman_tree, type(None)):
             cls.huffman_compute_decode_tree()
-        assert(not isinstance(cls.static_huffman_tree, types.NoneType))
+        assert(not isinstance(cls.static_huffman_tree, type(None)))
 
         s = []
         j = 0
@@ -1057,7 +1059,7 @@ class HPackZString(HPackStringsInterface):
             if isinstance(elmt, HuffmanNode):
                 interrupted = True
                 cur = elmt
-                if isinstance(cur, types.NoneType):
+                if isinstance(cur, type(None)):
                     raise AssertionError()
             elif isinstance(elmt, EOS):
                 raise InvalidEncodingException('Huffman decoder met the full EOS symbol')
@@ -1145,7 +1147,7 @@ class HPackZString(HPackStringsInterface):
         i = 0
         for entry in cls.static_huffman_code:
             parent = cls.static_huffman_tree
-            for idx in xrange(entry[1] - 1, -1, -1):
+            for idx in range(entry[1] - 1, -1, -1):
                 b = (entry[0] >> idx) & 1
                 if isinstance(parent[b], str):
                     raise InvalidEncodingException('Huffman unique prefix violation :/')
@@ -2023,7 +2025,7 @@ class H2Frame(packet.Packet):
         @return (str, str): the padding and the payload data strings
         @raise AssertionError
         """
-        assert isinstance(self.len, (int, long)) and self.len >= 0, 'Invalid length: negative len?'
+        assert isinstance(self.len, six.integer_types) and self.len >= 0, 'Invalid length: negative len?'
         assert len(s) >= self.len, 'Invalid length: string too short for this length'
         return s[:self.len], s[self.len:]
 
@@ -2236,7 +2238,7 @@ class HPackHdrTable(Sized):
         @param int dynamic_table_cap_size: the maximum-maximum size of the dynamic entry table in bytes
         @raises AssertionError
         """
-        if isinstance(type(self)._static_entries_last_idx, types.NoneType):
+        if isinstance(type(self)._static_entries_last_idx, type(None)):
             type(self).init_static_table()
 
         assert dynamic_table_max_size <= dynamic_table_cap_size, \
@@ -2379,7 +2381,7 @@ class HPackHdrTable(Sized):
         for k in type(self)._static_entries.keys():
             if type(self)._static_entries[k].name() == name:
                 return k
-        for k in xrange(0, len(self._dynamic_table)):
+        for k in range(0, len(self._dynamic_table)):
             if self._dynamic_table[k].name() == name:
                 return type(self)._static_entries_last_idx + k + 1
         return None
@@ -2399,7 +2401,7 @@ class HPackHdrTable(Sized):
             elmt = type(self)._static_entries[k]
             if elmt.name() == name and elmt.value() == value:
                 return k
-        for k in xrange(0, len(self._dynamic_table)):
+        for k in range(0, len(self._dynamic_table)):
             elmt = self._dynamic_table[k]
             if elmt.name() == name and elmt.value() == value:
                 return type(self)._static_entries_last_idx + k + 1

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -6,7 +6,7 @@ from scapy.layers.inet import IP, ICMP
 from scapy.layers.inet6 import IP6Field
 from scapy.error import warning
 from scapy.contrib.mpls import MPLS
-import six
+import scapy.modules.six as six
 
 
 class ICMPExtensionObject(Packet):

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import scapy
 from scapy.packet import Packet, bind_layers
 from scapy.fields import *
@@ -5,6 +6,7 @@ from scapy.layers.inet import IP, ICMP
 from scapy.layers.inet6 import IP6Field
 from scapy.error import warning
 from scapy.contrib.mpls import MPLS
+import six
 
 
 class ICMPExtensionObject(Packet):
@@ -46,7 +48,7 @@ class ICMPExtensionHeader(Packet):
 
         for fval, cls in self.payload_guess:
             ok = 1
-            for k, v in fval.iteritems():
+            for k, v in six.iteritems(fval):
                 if not hasattr(ieo, k) or v != ieo.getfieldval(k):
                     ok = 0
                     break

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -7,6 +7,8 @@
 #  TODO: scapy 2 has function getmacbyip, maybe it can replace igmpize
 #          at least from the MAC layer
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *
@@ -148,7 +150,7 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
           ip.dst = self.gaddr                    # IP rule 3a
           retCode = True
         else:
-          print "Warning: Using invalid Group Address"
+          print("Warning: Using invalid Group Address")
           retCode = False
       elif ((self.type == 0x17) and isValidMCAddr(self.gaddr)):
           ip.dst = "224.0.0.2"                   # IP rule 2
@@ -157,10 +159,10 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
           ip.dst = self.gaddr                    # IP rule 3b
           retCode = True
       else:
-        print "Warning: Using invalid IGMP Type"
+        print("Warning: Using invalid IGMP Type")
         retCode = False
     else:
-      print "Warning: No IGMP Group Address set"
+      print("Warning: No IGMP Group Address set")
       retCode = False
     if retCode == True:
        ip.ttl=1                                  # IP Rule 4

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -7,8 +7,7 @@
 #  TODO: scapy 2 has function getmacbyip, maybe it can replace igmpize
 #          at least from the MAC layer
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -5,6 +5,8 @@
 # scapy.contrib.description = IGMPv3
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *
@@ -28,7 +30,7 @@ from scapy.contrib.igmp import isValidMCAddr
 #
 
 #import sys, socket, struct, time
-print "IGMPv3  is still under development - Nov 2010"
+print("IGMPv3  is still under development - Nov 2010")
 
 
 class IGMPv3gr(Packet):
@@ -59,8 +61,8 @@ class IGMPv3gr(Packet):
     """
     p += pay
     if self.auxdlen != 0:
-      print "NOTICE: A properly formatted and complaint V3 Group Record should have an Auxiliary Data length of zero (0)."
-      print "        Subsequent Group Records are lost!"
+      print("NOTICE: A properly formatted and complaint V3 Group Record should have an Auxiliary Data length of zero (0).")
+      print("        Subsequent Group Records are lost!")
     return p
 #--------------------------------------------------------------------------
   def mysummary(self):
@@ -246,7 +248,7 @@ class IGMPv3(Packet):
           ip.dst = self.gaddr                    # IP rule 3a
           retCode = True
         else:
-          print "Warning: Using invalid Group Address"
+          print("Warning: Using invalid Group Address")
           retCode = False
       elif ((self.type == 0x17) and isValidMCAddr(self.gaddr)):
           ip.dst = "224.0.0.2"                   # IP rule 2
@@ -255,10 +257,10 @@ class IGMPv3(Packet):
           ip.dst = self.gaddr                    # IP rule 3b
           retCode = True
       else:
-        print "Warning: Using invalid IGMP Type"
+        print("Warning: Using invalid IGMP Type")
         retCode = False
     else:
-      print "Warning: No IGMP Group Address set"
+      print("Warning: No IGMP Group Address set")
       retCode = False
     if retCode == True:
        ip.ttl=1                                  # IP Rule 4

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -5,6 +5,7 @@
 # scapy.contrib.description = IKEv2
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import logging
 import struct
 

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -46,6 +46,7 @@
 
 """
 
+from __future__ import absolute_import
 import struct
 import random
 
@@ -57,6 +58,8 @@ from scapy.layers.inet6 import IP6ListField, IP6Field
 from scapy.utils import fletcher16_checkbytes
 from scapy.volatile import RandString, RandByte
 import random
+from six.moves import map
+from six.moves import range
 
 
 EXT_VERSION = "v0.0.2"
@@ -139,7 +142,7 @@ class _ISIS_RandId(RandString):
 
         val = ()
 
-        for _ in xrange(self.bytecount):
+        for _ in range(self.bytecount):
             val += (RandByte(),)
 
         return self.format % val

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -58,8 +58,7 @@ from scapy.layers.inet6 import IP6ListField, IP6Field
 from scapy.utils import fletcher16_checkbytes
 from scapy.volatile import RandString, RandByte
 import random
-from six.moves import map
-from six.moves import range
+from scapy.modules.six.moves import map, range
 
 
 EXT_VERSION = "v0.0.2"

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -27,7 +27,7 @@ from scapy.ansmachine import *
 from scapy.layers.inet import UDP
 from scapy.layers.inet import TCP
 from scapy.base_classes import Net
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 # Guess payload

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -18,6 +18,7 @@
 
 # Copyright (C) 2010 Florian Duraffourg
 
+from __future__ import absolute_import
 import struct
 
 from scapy.packet import *
@@ -26,6 +27,7 @@ from scapy.ansmachine import *
 from scapy.layers.inet import UDP
 from scapy.layers.inet import TCP
 from scapy.base_classes import Net
+from six.moves import range
 
 
 # Guess payload
@@ -132,7 +134,7 @@ class AddressTLVField(StrField):
         nbr /= 4
         x=x[6:]
         list=[]
-        for i in xrange(0, nbr):
+        for i in range(0, nbr):
             add = x[4*i:4*i+4]
             list.append(inet_ntoa(add))
         return list

--- a/scapy/contrib/modbus.py
+++ b/scapy/contrib/modbus.py
@@ -16,6 +16,7 @@
 
 # Copyright (C) 2016 Arthur Gervais, Ken LE PRADO, Sébastien Mainand
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -3,6 +3,7 @@
 # scapy.contrib.description = MPLS
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import Packet, bind_layers, Padding
 from scapy.fields import BitField,ByteField
 from scapy.layers.inet import IP

--- a/scapy/contrib/nsh.py
+++ b/scapy/contrib/nsh.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 # scapy.contrib.description = nsh
 # scapy.contrib.status = loads
+from __future__ import absolute_import
 from scapy.all import bind_layers
 from scapy.fields import BitField, ByteField, ByteEnumField
 from scapy.fields import ShortField, X3BytesField, XIntField

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -16,7 +16,7 @@ import struct
 from scapy.fields import *
 from scapy.layers.l2 import *
 from scapy.layers.inet import *
-from six.moves import zip
+from scapy.modules.six.moves import zip
 
 ### If prereq_autocomplete is True then match prerequisites will be
 ### automatically handled. See OFPMatch class.

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -11,10 +11,12 @@
 # scapy.contrib.description = openflow v1.0
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import struct
 from scapy.fields import *
 from scapy.layers.l2 import *
 from scapy.layers.inet import *
+from six.moves import zip
 
 ### If prereq_autocomplete is True then match prerequisites will be
 ### automatically handled. See OFPMatch class.
@@ -658,7 +660,7 @@ class OFPTFeaturesRequest(_ofp_header):
                     IntField("xid", 0) ]
     overload_fields = {TCP: {"sport": 6653}}
 
-ofp_action_types_flags = ofp_action_types.values()[:-1]  # no ofpat_vendor flag
+ofp_action_types_flags = list(ofp_action_types.values())[:-1]  # no ofpat_vendor flag
 
 class OFPTFeaturesReply(_ofp_header):
     name = "OFPT_FEATURES_REPLY"

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -11,10 +11,12 @@
 # scapy.contrib.description = openflow v1.3
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import struct
 from scapy.fields import *
 from scapy.layers.l2 import *
 from scapy.layers.inet import *
+from six.moves import map
 
 ### If prereq_autocomplete is True then match prerequisites will be
 ### automatically handled. See OFPMatch class.
@@ -2628,7 +2630,7 @@ class OFPMPRequestGroupFeatures(_ofp_header):
                     XIntField("pad1", 0) ]
     overload_fields = {TCP: {"sport": 6653}}
 
-ofp_action_types_flags = ofp_action_types.values()[:-1]  # no ofpat_experimenter flag
+ofp_action_types_flags = list(ofp_action_types.values())[:-1]  # no ofpat_experimenter flag
 class OFPMPReplyGroupFeatures(_ofp_header):
     name = "OFPMP_REPLY_GROUP_FEATURES"
     fields_desc = [ ByteEnumField("version", 0x04, ofp_version),

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -16,7 +16,7 @@ import struct
 from scapy.fields import *
 from scapy.layers.l2 import *
 from scapy.layers.inet import *
-from six.moves import map
+from scapy.modules.six.moves import map
 
 ### If prereq_autocomplete is True then match prerequisites will be
 ### automatically handled. See OFPMatch class.

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 """
 
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import *

--- a/scapy/contrib/pnio.py
+++ b/scapy/contrib/pnio.py
@@ -22,8 +22,10 @@ A simple and non exhaustive Profinet IO layer for scapy
 """
 
 # Scapy imports
+from __future__ import absolute_import
 from scapy.all import Packet, bind_layers, Ether, UDP
 from scapy.fields import XShortEnumField
+from six.moves import range
 
 # Some constants
 PNIO_FRAME_IDS = {
@@ -42,13 +44,13 @@ PNIO_FRAME_IDS = {
     0xFF42:"PTCP-DelayFuResPDU",
     0xFF43:"PTCP-DelayResPDU",
     }
-for i in xrange(0x0100, 0x1000):
+for i in range(0x0100, 0x1000):
     PNIO_FRAME_IDS[i] = "RT_CLASS_3"
-for i in xrange(0x8000, 0xC000):
+for i in range(0x8000, 0xC000):
     PNIO_FRAME_IDS[i] = "RT_CLASS_1"
-for i in xrange(0xC000, 0xFC00):
+for i in range(0xC000, 0xFC00):
     PNIO_FRAME_IDS[i] = "RT_CLASS_UDP"
-for i in xrange(0xFF80, 0xFF90):
+for i in range(0xFF80, 0xFF90):
     PNIO_FRAME_IDS[i] = "FragmentationFrameID"
 
 #################

--- a/scapy/contrib/pnio.py
+++ b/scapy/contrib/pnio.py
@@ -25,7 +25,7 @@ A simple and non exhaustive Profinet IO layer for scapy
 from __future__ import absolute_import
 from scapy.all import Packet, bind_layers, Ether, UDP
 from scapy.fields import XShortEnumField
-from six.moves import range
+from scapy.modules.six.moves import range
 
 # Some constants
 PNIO_FRAME_IDS = {

--- a/scapy/contrib/pnio_rtc.py
+++ b/scapy/contrib/pnio_rtc.py
@@ -36,7 +36,7 @@ from scapy.fields import BitEnumField, BitField, ByteField,\
 
 # local imports
 from scapy.contrib.pnio import ProfinetIO
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 #####################################

--- a/scapy/contrib/pnio_rtc.py
+++ b/scapy/contrib/pnio_rtc.py
@@ -22,6 +22,7 @@ PROFINET IO layers for scapy which correspond to Real-Time Cyclic data
 """
 
 # external imports
+from __future__ import absolute_import
 import math
 import struct
 
@@ -35,6 +36,7 @@ from scapy.fields import BitEnumField, BitField, ByteField,\
 
 # local imports
 from scapy.contrib.pnio import ProfinetIO
+from six.moves import range
 
 
 #####################################

--- a/scapy/contrib/ppi.py
+++ b/scapy/contrib/ppi.py
@@ -10,6 +10,7 @@
 """
 PPI (Per-Packet Information).
 """
+from __future__ import absolute_import
 import logging,struct
 from scapy.config import conf
 from scapy.packet import *

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -9,6 +9,7 @@
 """
 CACE PPI types 
 """
+from __future__ import absolute_import
 import logging,struct
 from scapy.config import conf
 from scapy.packet import *

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -10,11 +10,14 @@
 """
 PPI-GEOLOCATION tags
 """
+from __future__ import absolute_import
 import struct, time
 from scapy.packet import *
 from scapy.fields import *
 from scapy.contrib.ppi import PPIGenericFldHdr,addPPIType
 from scapy.error import warning
+import six
+from six.moves import range
 
 # On windows, epoch is 01/02/1970 at 00:00
 EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 0, 0, 0))-86400
@@ -266,8 +269,8 @@ class HCSIAppField(StrFixedLenField):
         return StrFixedLenField.__init__(self, name, default, length=60)
 
 def _FlagsList(myfields):
-    flags = ["Reserved%02d" % i for i in xrange(32)]
-    for i, value in myfields.iteritems():
+    flags = ["Reserved%02d" % i for i in range(32)]
+    for i, value in six.iteritems(myfields):
         flags[i] = value
     return flags
 

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -16,8 +16,8 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.contrib.ppi import PPIGenericFldHdr,addPPIType
 from scapy.error import warning
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 
 # On windows, epoch is 01/02/1970 at 00:00
 EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 0, 0, 0))-86400

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -5,6 +5,7 @@
 # scapy.contrib.description = RIPng
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import UDP

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -5,6 +5,7 @@
 # scapy.contrib.description = RSVP
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP

--- a/scapy/contrib/sebek.py
+++ b/scapy/contrib/sebek.py
@@ -10,6 +10,7 @@ Sebek: kernel module for data collection on honeypots.
 # scapy.contrib.description = Sebek
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.layers.inet import UDP

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -14,7 +14,7 @@ import socket
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet6 import icmp6typescls, _ICMPv6NDGuessPayload, Net6
-from six.moves import map
+from scapy.modules.six.moves import map
 
 send_icmp6typescls = { 11: "ICMPv6NDOptCGA",
                        12: "ICMPv6NDOptRsaSig",

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -8,11 +8,13 @@
 # scapy.contrib.description = SEND
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 import socket
 
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet6 import icmp6typescls, _ICMPv6NDGuessPayload, Net6
+from six.moves import map
 
 send_icmp6typescls = { 11: "ICMPv6NDOptCGA",
                        12: "ICMPv6NDOptRsaSig",
@@ -31,7 +33,7 @@ class HashField(Field):
             except socket.error:
                 x = Net6(x)
         elif type(x) is list:
-            x = map(Net6, x)
+            x = list(map(Net6, x))
         return x
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, x)

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import TCP
-from six.moves import range
+from scapy.modules.six.moves import range
 
 #####################################################################
 # Helpers and constants

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -22,9 +22,11 @@
 ##                                                                         ##
 #############################################################################
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import TCP
+from six.moves import range
 
 #####################################################################
 # Helpers and constants
@@ -356,7 +358,7 @@ _skinny_message_callinfo_restrictions = ['CallerName'
                                          , 'OriginalCalledName'
                                          , 'OriginalCalledNumber'
                                          , 'LastRedirectName'
-                                         , 'LastRedirectNumber'] + ['Bit%d' % i for i in xrange(8,15)]
+                                         , 'LastRedirectNumber'] + ['Bit%d' % i for i in range(8,15)]
 class SkinnyMessageCallInfo(Packet):
     name='call information'
     fields_desc = [ StrFixedLenField("callername", "Jean Valjean", 40),

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -18,6 +18,7 @@
 #
 # spb_example = backboneEther/backboneDot1Q/backboneServiceID/customerEther/customerDot1Q/customerIP/customerUDP/"Payload"
 
+from __future__ import absolute_import
 from scapy.packet import Packet, bind_layers
 from scapy.fields import *
 from scapy.layers.l2 import Ether, Dot1Q

--- a/scapy/contrib/ubberlogger.py
+++ b/scapy/contrib/ubberlogger.py
@@ -4,6 +4,7 @@
 # scapy.contrib.description = Ubberlogger dissectors
 # scapy.contrib.status = untested
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 

--- a/scapy/contrib/vqp.py
+++ b/scapy/contrib/vqp.py
@@ -4,6 +4,7 @@
 # scapy.contrib.description = VLAN Query Protocol
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import UDP

--- a/scapy/contrib/vtp.py
+++ b/scapy/contrib/vtp.py
@@ -42,6 +42,7 @@
         http://www.cisco.com/en/US/tech/tk389/tk689/technologies_tech_note09186a0080094c52.shtml
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import *

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -4,6 +4,7 @@
 # scapy.contrib.description = WPA EAPOL dissector
 # scapy.contrib.status = loads
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import *

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -10,7 +10,7 @@ Direct Access dictionary.
 from __future__ import absolute_import
 from __future__ import print_function
 from scapy.error import Scapy_Exception
-import six
+import scapy.modules.six as six
 
 ###############################
 ## Direct Access dictionary  ##

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -38,13 +38,13 @@ class DADict:
     def __setitem__(self, attr, val):        
         return setattr(self, self.fixname(attr), val)
     def __iter__(self):
-        return iter([x_y1[1] for x_y1 in [x_y for x_y in list(self.__dict__.items()) if x_y[0] and x_y[0][0]!="_"]])
+        return (x_y1[1] for x_y1 in [x_y for x_y in list(self.__dict__.items()) if x_y[0] and x_y[0][0]!="_"])
     def _show(self):
         for k in self.__dict__.keys():
             if k and k[0] != "_":
                 print("%10s = %r" % (k,getattr(self,k)))
     def __repr__(self):
-        return "<%s/ %s>" % (self._name," ".join([x for x in list(self.__dict__.keys()) if x and x[0]!="_"]))
+        return "<%s/ %s>" % (self._name," ".join(x for x in list(self.__dict__.keys()) if x and x[0]!="_"))
 
     def _branch(self, br, uniq=0):
         if uniq and br._name in self:

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -7,7 +7,10 @@
 Direct Access dictionary.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.error import Scapy_Exception
+import six
 
 ###############################
 ## Direct Access dictionary  ##
@@ -35,13 +38,13 @@ class DADict:
     def __setitem__(self, attr, val):        
         return setattr(self, self.fixname(attr), val)
     def __iter__(self):
-        return iter(map(lambda (x,y):y,filter(lambda (x,y):x and x[0]!="_", self.__dict__.items())))
+        return iter([x_y1[1] for x_y1 in [x_y for x_y in list(self.__dict__.items()) if x_y[0] and x_y[0][0]!="_"]])
     def _show(self):
         for k in self.__dict__.keys():
             if k and k[0] != "_":
-                print "%10s = %r" % (k,getattr(self,k))
+                print("%10s = %r" % (k,getattr(self,k)))
     def __repr__(self):
-        return "<%s/ %s>" % (self._name," ".join(filter(lambda x:x and x[0]!="_",self.__dict__.keys())))
+        return "<%s/ %s>" % (self._name," ".join([x for x in list(self.__dict__.keys()) if x and x[0]!="_"]))
 
     def _branch(self, br, uniq=0):
         if uniq and br._name in self:
@@ -57,7 +60,7 @@ class DADict:
         return True
 
     def update(self, *args, **kwargs):
-        for k, v in dict(*args, **kwargs).iteritems():
+        for k, v in six.iteritems(dict(*args, **kwargs)):
             self[k] = v
     
     def _find(self, *args, **kargs):
@@ -87,7 +90,7 @@ class DADict:
                 r += p
         return r
     def keys(self):
-        return list(self.iterkeys())
+        return list(six.iterkeys(self))
     def iterkeys(self):
         return (x for x in self.__dict__ if x and x[0] != "_")
     def __len__(self):

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -7,6 +7,7 @@
 Global variables and functions for handling external data sets.
 """
 
+from __future__ import absolute_import
 import os,sys,re
 from scapy.dadict import DADict
 from scapy.error import log_loading
@@ -76,7 +77,7 @@ def load_protocols(filename):
                 if len(lt) < 2 or not lt[0]:
                     continue
                 dct[lt[0]] = int(lt[1])
-            except Exception,e:
+            except Exception as e:
                 log_loading.info("Couldn't parse file [%s]: line [%r] (%s)" % (filename,l,e))
     except IOError:
         log_loading.info("Can't open %s file" % filename)
@@ -99,10 +100,10 @@ def load_ethertypes(filename):
                 if len(lt) < 2 or not lt[0]:
                     continue
                 dct[lt[0]] = int(lt[1], 16)
-            except Exception,e:
+            except Exception as e:
                 log_loading.info("Couldn't parse file [%s]: line [%r] (%s)" % (filename,l,e))
         f.close()
-    except IOError,msg:
+    except IOError as msg:
         pass
     return dct
 
@@ -127,7 +128,7 @@ def load_services(filename):
                     tdct[lt[0]] = int(lt[1].split('/')[0])
                 elif lt[1].endswith("/udp"):
                     udct[lt[0]] = int(lt[1].split('/')[0])
-            except Exception,e:
+            except Exception as e:
                 log_loading.warning("Couldn't file [%s]: line [%r] (%s)" % (filename,l,e))
         f.close()
     except IOError:
@@ -170,7 +171,7 @@ def load_manuf(filename):
                 else:
                     lng = l[i+2:]
                 manufdb[oui] = shrt, lng
-            except Exception,e:
+            except Exception as e:
                 log_loading.warning("Couldn't parse one line from [%s] [%r] (%s)" % (filename, l, e))
     except IOError:
         log_loading.warning("Couldn't open [%s] file" % filename)

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -11,6 +11,7 @@ Logging subsystem and basic exception class.
 ##### Logging subsystem #####
 #############################
 
+from __future__ import absolute_import
 class Scapy_Exception(Exception):
     pass
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -7,6 +7,7 @@
 Fields: basic data structures that make up parts of packets.
 """
 
+from __future__ import absolute_import
 import struct,copy,socket,collections
 from scapy.config import conf
 from scapy.volatile import *
@@ -14,18 +15,20 @@ from scapy.data import *
 from scapy.utils import *
 from scapy.base_classes import BasePacket, Gen, Net, Field_metaclass
 from scapy.error import warning
+import six
+from six.moves import map
+from six.moves import range
 
 
 ############
 ## Fields ##
 ############
 
-class Field(object):
+class Field(six.with_metaclass(Field_metaclass, object)):
     """For more informations on how this work, please refer to
        http://www.secdev.org/projects/scapy/files/scapydoc.pdf
        chapter ``Adding a New Field''"""
     __slots__ = ["name", "fmt", "default", "sz", "owners"]
-    __metaclass__ = Field_metaclass
     islist = 0
     ismutable = False
     holds_packets = 0
@@ -80,7 +83,7 @@ class Field(object):
             return x.copy()
         if type(x) is list:
             x = x[:]
-            for i in xrange(len(x)):
+            for i in range(len(x)):
                 if isinstance(x[i], BasePacket):
                     x[i] = x[i].copy()
         return x
@@ -188,7 +191,7 @@ class DestField(Field):
         for addr, condition in self.bindings.get(pkt.payload.__class__, []):
             try:
                 if all(pkt.payload.getfieldval(field) == value
-                       for field, value in condition.iteritems()):
+                       for field, value in six.iteritems(condition)):
                     return addr
             except AttributeError:
                 pass
@@ -225,7 +228,7 @@ class IPField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "4s")
     def h2i(self, pkt, x):
-        if isinstance(x, basestring):
+        if isinstance(x, six.string_types):
             try:
                 inet_aton(x)
             except socket.error:
@@ -454,7 +457,7 @@ class PacketListField(PacketField):
         if x is None:
             return None
         else:
-            return [p if isinstance(p, basestring) else p.copy() for p in x]
+            return [p if isinstance(p, six.string_types) else p.copy() for p in x]
     def getfield(self, pkt, s):
         c = l = None
         if self.length_from is not None:
@@ -539,7 +542,7 @@ class NetBIOSNameField(StrFixedLenField):
             x = ""
         x += " "*(l)
         x = x[:l]
-        x = "".join(map(lambda x: chr(0x41+(ord(x)>>4))+chr(0x41+(ord(x)&0xf)), x))
+        x = "".join([chr(0x41+(ord(x)>>4))+chr(0x41+(ord(x)&0xf)) for x in x])
         x = " "+x
         return x
     def m2i(self, pkt, x):
@@ -621,7 +624,7 @@ class FieldListField(Field):
         if type(x) is not list:
             return [self.field.any2i(pkt, x)]
         else:
-            return map(lambda e, pkt=pkt: self.field.any2i(pkt, e), x)
+            return list(map(lambda e, pkt=pkt: self.field.any2i(pkt, e), x))
     def i2repr(self, pkt, x):
         res = []
         for v in x:
@@ -738,12 +741,12 @@ class BitField(Field):
         if self.rev:
             val = self.reverse(val)
         v <<= self.size
-        v |= val & ((1L<<self.size) - 1)
+        v |= val & ((1<<self.size) - 1)
         bitsdone += self.size
         while bitsdone >= 8:
             bitsdone -= 8
             s = s+struct.pack("!B", v >> bitsdone)
-            v &= (1L<<bitsdone)-1
+            v &= (1<<bitsdone)-1
         if bitsdone:
             return s,bitsdone,v
         else:
@@ -760,12 +763,12 @@ class BitField(Field):
         # split the substring byte by byte
         bytes = struct.unpack('!%dB' % nb_bytes , w)
 
-        b = 0L
-        for c in xrange(nb_bytes):
-            b |= long(bytes[c]) << (nb_bytes-c-1)*8
+        b = 0
+        for c in range(nb_bytes):
+            b |= int(bytes[c]) << (nb_bytes-c-1)*8
 
         # get rid of high order bits
-        b &= (1L << (nb_bytes*8-bn)) - 1
+        b &= (1 << (nb_bytes*8-bn)) - 1
 
         # remove low order bits
         b = b >> (nb_bytes*8 - self.size - bn)
@@ -795,7 +798,7 @@ class BitFieldLenField(BitField):
         self.count_of = count_of
         self.adjust = adjust
     def i2m(self, pkt, x):
-        return FieldLenField.i2m.im_func(self, pkt, x)
+        return FieldLenField.i2m.__func__(self, pkt, x)
 
 
 class XBitField(BitField):
@@ -831,9 +834,9 @@ class _EnumField(Field):
             self.i2s_cb = None
             self.s2i_cb = None
             if type(enum) is list:
-                keys = range(len(enum))
+                keys = list(range(len(enum)))
             else:
-                keys = enum.keys()
+                keys = list(enum.keys())
             if any(type(x) is str for x in keys):
                 i2s, s2i = s2i, i2s
             for k in keys:
@@ -863,13 +866,13 @@ class _EnumField(Field):
 
     def any2i(self, pkt, x):
         if type(x) is list:
-            return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
+            return list(map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x))
         else:
             return self.any2i_one(pkt,x)
 
     def i2repr(self, pkt, x):
         if type(x) is list:
-            return map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x)
+            return list(map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x))
         else:
             return self.i2repr_one(pkt,x)
 
@@ -880,7 +883,7 @@ class CharEnumField(EnumField):
     def __init__(self, name, default, enum, fmt = "1s"):
         EnumField.__init__(self, name, default, enum, fmt)
         if self.i2s is not None:
-            k = self.i2s.keys()
+            k = list(self.i2s.keys())
             if k and len(k[0]) != 1:
                 self.i2s,self.s2i = self.s2i,self.i2s
     def any2i_one(self, pkt, x):
@@ -952,7 +955,7 @@ class _MultiEnumField(_EnumField):
         self.s2i_all = {}
         for m in enum:
             self.s2i_multi[m] = s2i = {}
-            for k,v in enum[m].iteritems():
+            for k,v in six.iteritems(enum[m]):
                 s2i[v] = k
                 self.s2i_all[v] = k
         Field.__init__(self, name, default, fmt)
@@ -1018,7 +1021,7 @@ class LEFieldLenField(FieldLenField):
 class FlagValue(object):
     __slots__ = ["value", "names", "multi"]
     def _fixvalue(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             value = value.split('+') if self.multi else list(value)
         if isinstance(value, list):
             y = 0
@@ -1071,7 +1074,7 @@ class FlagValue(object):
         except ValueError:
             return super(FlagValue, self).__getattr__(attr)
     def __setattr__(self, attr, value):
-        if attr == "value" and not isinstance(value, (int, long)):
+        if attr == "value" and not isinstance(value, six.integer_types):
             raise ValueError(value)
         if attr in self.__slots__:
             return super(FlagValue, self).__setattr__(attr, value)
@@ -1143,15 +1146,15 @@ class MultiFlagsField(BitField):
         super(MultiFlagsField, self).__init__(name, default, size)
 
     def any2i(self, pkt, x):
-        assert isinstance(x, (int, long, set)), 'set expected'
+        assert isinstance(x, (int, int, set)), 'set expected'
 
         if pkt is not None:
-            if isinstance(x, (int, long)):
+            if isinstance(x, six.integer_types):
                 x = self.m2i(pkt, x)
             else:
                 v = self.depends_on(pkt)
                 if v is not None:
-                    assert self.names.has_key(v), 'invalid dependency'
+                    assert v in self.names, 'invalid dependency'
                     these_names = self.names[v]
                     s = set()
                     for i in x:
@@ -1204,14 +1207,14 @@ class MultiFlagsField(BitField):
 
     def i2repr(self, pkt, x):
         v = self.depends_on(pkt)
-        if self.names.has_key(v):
+        if v in self.names:
             these_names = self.names[v]
         else:
             these_names = {}
 
         r = set()
         for flag_set in x:
-            for i in these_names.itervalues():
+            for i in six.itervalues(these_names):
                 if i.short == flag_set:
                     r.add("{} ({})".format(i.long, i.short))
                     break
@@ -1235,7 +1238,7 @@ class FixedPointField(BitField):
 
     def i2h(self, pkt, val):
         int_part = val >> self.frac_bits
-        frac_part = val & (1L << self.frac_bits) - 1
+        frac_part = val & (1 << self.frac_bits) - 1
         frac_part /= 2.0**self.frac_bits
         return int_part+frac_part
     def i2repr(self, pkt, val):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -541,7 +541,7 @@ class NetBIOSNameField(StrFixedLenField):
             x = ""
         x += " "*(l)
         x = x[:l]
-        x = "".join([chr(0x41+(ord(x)>>4))+chr(0x41+(ord(x)&0xf)) for x in x])
+        x = "".join(chr(0x41+(ord(x)>>4))+chr(0x41+(ord(x)&0xf)) for x in x)
         x = " "+x
         return x
     def m2i(self, pkt, x):
@@ -833,9 +833,9 @@ class _EnumField(Field):
             self.i2s_cb = None
             self.s2i_cb = None
             if type(enum) is list:
-                keys = list(range(len(enum)))
+                keys = range(len(enum))
             else:
-                keys = list(enum.keys())
+                keys = enum.keys()
             if any(type(x) is str for x in keys):
                 i2s, s2i = s2i, i2s
             for k in keys:
@@ -1145,7 +1145,7 @@ class MultiFlagsField(BitField):
         super(MultiFlagsField, self).__init__(name, default, size)
 
     def any2i(self, pkt, x):
-        assert isinstance(x, (int, int, set)), 'set expected'
+        assert isinstance(x, six.integer_types + (set,)), 'set expected'
 
         if pkt is not None:
             if isinstance(x, six.integer_types):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -15,9 +15,8 @@ from scapy.data import *
 from scapy.utils import *
 from scapy.base_classes import BasePacket, Gen, Net, Field_metaclass
 from scapy.error import warning
-import six
-from six.moves import map
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range
 
 
 ############

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from scapy.config import conf
 from scapy.error import log_loading
 import logging
-import six
+import scapy.modules.six as six
 log = logging.getLogger("scapy.loading")
 
 __all__ = []

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -7,9 +7,11 @@
 All layers. Configurable with conf.load_layers.
 """
 
+from __future__ import absolute_import
 from scapy.config import conf
 from scapy.error import log_loading
 import logging
+import six
 log = logging.getLogger("scapy.loading")
 
 __all__ = []
@@ -23,7 +25,7 @@ def _import_star(m):
             globals()[name] = mod.__dict__[name]
     else:
         # import all the non-private symbols
-        for name, sym in mod.__dict__.iteritems():
+        for name, sym in six.iteritems(mod.__dict__):
             if name[0] != '_':
                 __all__.append(name)
                 globals()[name] = sym
@@ -33,6 +35,6 @@ for _l in conf.load_layers:
     try:
         if _l != "tls":
             _import_star(_l)
-    except Exception,e:
+    except Exception as e:
         log.warning("can't import layer %s: %s" % (_l,e))
 

--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -8,6 +8,7 @@
 Bluetooth layers, sockets and send/receive functions.
 """
 
+from __future__ import absolute_import
 import socket,struct,array
 from ctypes import *
 from select import select
@@ -783,7 +784,7 @@ class BluetoothHCISocket(SuperSocket):
         s = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI)
         s.setsockopt(socket.SOL_HCI, socket.HCI_DATA_DIR,1)
         s.setsockopt(socket.SOL_HCI, socket.HCI_TIME_STAMP,1)
-        s.setsockopt(socket.SOL_HCI, socket.HCI_FILTER, struct.pack("IIIh2x", 0xffffffffL,0xffffffffL,0xffffffffL,0)) #type mask, event mask, event mask, opcode
+        s.setsockopt(socket.SOL_HCI, socket.HCI_FILTER, struct.pack("IIIh2x", 0xffffffff,0xffffffff,0xffffffff,0)) #type mask, event mask, event mask, opcode
         s.bind((iface,))
         self.ins = self.outs = s
 #        s.connect((peer,0))

--- a/scapy/layers/clns.py
+++ b/scapy/layers/clns.py
@@ -21,6 +21,7 @@
         This module provides a registration function and a generic PDU
         for OSI Connectionless-mode Network Services (such as IS-IS).
 """
+from __future__ import absolute_import
 import struct
 
 from scapy.config import conf

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -7,8 +7,7 @@
 DHCP (Dynamic Host Configuration Protocol) and BOOTP
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 from collections import Iterable
 import struct
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -24,8 +24,8 @@ from scapy.volatile import RandField
 from scapy.arch import get_if_raw_hwaddr
 from scapy.sendrecv import *
 from scapy.error import warning
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 
 dhcpmagic=b"c\x82Sc"
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -7,6 +7,8 @@
 DHCP (Dynamic Host Configuration Protocol) and BOOTP
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from collections import Iterable
 import struct
 
@@ -22,6 +24,8 @@ from scapy.volatile import RandField
 from scapy.arch import get_if_raw_hwaddr
 from scapy.sendrecv import *
 from scapy.error import warning
+import six
+from six.moves import range
 
 dhcpmagic=b"c\x82Sc"
 
@@ -144,7 +148,7 @@ DHCPOptions = {
 
 DHCPRevOptions = {}
 
-for k,v in DHCPOptions.iteritems():
+for k,v in six.iteritems(DHCPOptions):
     if type(v) is str:
         n = v
         v = None
@@ -166,12 +170,12 @@ class RandDHCPOptions(RandField):
         if rndstr is None:
             rndstr = RandBin(RandNum(0,255))
         self.rndstr=rndstr
-        self._opts = DHCPOptions.values()
+        self._opts = list(DHCPOptions.values())
         self._opts.remove("pad")
         self._opts.remove("end")
     def _fix(self):
         op = []
-        for k in xrange(self.size):
+        for k in range(self.size):
             o = random.choice(self._opts)
             if type(o) is str:
                 op.append((o,self.rndstr*1))
@@ -186,7 +190,7 @@ class DHCPOptionsField(StrField):
         s = []
         for v in x:
             if type(v) is tuple and len(v) >= 2:
-                if  DHCPRevOptions.has_key(v[0]) and isinstance(DHCPRevOptions[v[0]][1],Field):
+                if  v[0] in DHCPRevOptions and isinstance(DHCPRevOptions[v[0]][1],Field):
                     f = DHCPRevOptions[v[0]][1]
                     vv = ",".join(f.i2repr(pkt,val) for val in v[1:])
                 else:
@@ -214,7 +218,7 @@ class DHCPOptionsField(StrField):
             if len(x) < 2 or len(x) < ord(x[1])+2:
                 opt.append(x)
                 break
-            elif DHCPOptions.has_key(o):
+            elif o in DHCPOptions:
                 f = DHCPOptions[o]
 
                 if isinstance(f, str):
@@ -252,7 +256,7 @@ class DHCPOptionsField(StrField):
 
                 if isinstance(name, int):
                     onum, oval = name, "".join(lval)
-                elif DHCPRevOptions.has_key(name):
+                elif name in DHCPRevOptions:
                     onum, f = DHCPRevOptions[name]
                     if  f is not None:
                         lval = [f.addfield(pkt,"",f.any2i(pkt,val)) for val in lval]
@@ -265,7 +269,7 @@ class DHCPOptionsField(StrField):
                 s += chr(len(oval))
                 s += oval
 
-            elif (type(o) is str and DHCPRevOptions.has_key(o) and 
+            elif (type(o) is str and o in DHCPRevOptions and 
                   DHCPRevOptions[o][1] == None):
                 s += chr(DHCPRevOptions[o][0])
             elif type(o) is int:
@@ -311,7 +315,7 @@ class BOOTP_am(AnsweringMachine):
         self.network = ltoa(atol(netw)&msk)
         self.broadcast = ltoa( atol(self.network) | (0xffffffff&~msk) )
         self.gw = gw
-        if isinstance(pool, basestring):
+        if isinstance(pool, six.string_types):
             pool = Net(pool)
         if isinstance(pool, Iterable):
             pool = [k for k in pool if k not in [gw, self.network, self.broadcast]]
@@ -332,12 +336,12 @@ class BOOTP_am(AnsweringMachine):
         return 1
 
     def print_reply(self, req, reply):
-        print "Reply %s to %s" % (reply.getlayer(IP).dst,reply.dst)
+        print("Reply %s to %s" % (reply.getlayer(IP).dst,reply.dst))
 
     def make_reply(self, req):        
         mac = req.src
         if type(self.pool) is list:
-            if not self.leases.has_key(mac):
+            if mac not in self.leases:
                 self.leases[mac] = self.pool.pop()
             ip = self.leases[mac]
         else:

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -326,7 +326,7 @@ class _IANAOptField(PacketListField):
     def i2len(self, pkt, z):
         if z is None or z == []:
             return 0
-        return sum([len(str(x)) for x in z])
+        return sum(len(str(x)) for x in z)
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
@@ -402,7 +402,7 @@ class _OptReqListField(StrLenField):
         return r
     
     def i2m(self, pkt, x):
-        return "".join([struct.pack("!H", y) for y in x])
+        return "".join(struct.pack("!H", y) for y in x)
 
 # A client may include an ORO in a solicit, Request, Renew, Rebind,
 # Confirm or Information-request
@@ -554,7 +554,7 @@ class _UserClassDataField(PacketListField):
     def i2len(self, pkt, z):
         if z is None or z == []:
             return 0
-        return sum([len(str(x)) for x in z])
+        return sum(len(str(x)) for x in z)
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
@@ -754,7 +754,7 @@ class DomainNameField(StrLenField):
     def i2m(self, pkt, x):
         if not x:
             return ""
-        tmp = "".join([chr(len(z))+z for z in x.split('.')])
+        tmp = "".join(chr(len(z))+z for z in x.split('.'))
         return tmp
 
 class DHCP6OptNISDomain(_DHCP6OptGuessPayload):             #RFC3898
@@ -1344,7 +1344,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
             # Mac Address
             rawmac = get_if_raw_hwaddr(iface)[1]
-            mac = ":".join(["%.02x" % ord(x) for x in list(rawmac)])
+            mac = ":".join("%.02x" % ord(x) for x in list(rawmac))
 
             self.duid = DUID_LLT(timeval = timeval, lladdr = mac)
             

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -7,6 +7,7 @@
 DNS: Domain Name System.
 """
 
+from __future__ import absolute_import
 import socket,struct
 
 from scapy.config import conf
@@ -17,6 +18,9 @@ from scapy.sendrecv import sr1
 from scapy.layers.inet import IP, DestIPField, UDP, TCP
 from scapy.layers.inet6 import DestIP6Field
 from scapy.error import warning
+import six
+from six.moves import range
+from functools import reduce
 
 class DNSStrField(StrField):
 
@@ -30,7 +34,7 @@ class DNSStrField(StrField):
           return b"\x00"
 
         x = [k[:63] for k in x.split(".")] # Truncate chunks that cannot be encoded (more than 63 bytes..)
-        x = map(lambda y: chr(len(y))+y, x)
+        x = [chr(len(y))+y for y in x]
         x = "".join(x)
         if x[-1] != b"\x00":
             x += b"\x00"
@@ -201,7 +205,7 @@ class RDataField(StrLenField):
             if s:
                 s = inet_aton(s)
         elif pkt.type in [2, 3, 4, 5, 12]: # NS, MD, MF, CNAME, PTR
-            s = "".join(map(lambda x: chr(len(x))+x, s.split(".")))
+            s = "".join([chr(len(x))+x for x in s.split(".")])
             if ord(s[-1]):
                 s += b"\x00"
         elif pkt.type == 16: # TXT
@@ -404,9 +408,9 @@ def bitmap2RRlist(bitmap):
         tmp_bitmap = bitmap[2:2+bitmap_len]
 
         # Let's compare each bit of tmp_bitmap and compute the real RR value
-        for b in xrange(len(tmp_bitmap)):
+        for b in range(len(tmp_bitmap)):
             v = 128
-            for i in xrange(8):
+            for i in range(8):
                 if ord(tmp_bitmap[b]) & v:
                     # each of the RR is encoded as a bit
                     RRlist += [ offset + b*8 + i ]
@@ -431,8 +435,8 @@ def RRlist2bitmap(lst):
     lst = list(set(lst))
     lst.sort()
 
-    lst = filter(lambda x: x <= 65535, lst)
-    lst = map(lambda x: abs(x), lst)
+    lst = [x for x in lst if x <= 65535]
+    lst = [abs(x) for x in lst]
 
     # number of window blocks
     max_window_blocks = int(math.ceil(lst[-1] / 256.))
@@ -440,10 +444,10 @@ def RRlist2bitmap(lst):
     if min_window_blocks == max_window_blocks:
         max_window_blocks += 1
 
-    for wb in xrange(min_window_blocks, max_window_blocks+1):
+    for wb in range(min_window_blocks, max_window_blocks+1):
         # First, filter out RR not encoded in the current window block
         # i.e. keep everything between 256*wb <= 256*(wb+1)
-        rrlist = filter(lambda x: 256 * wb <= x < 256 * (wb + 1), lst)
+        rrlist = [x for x in lst if 256 * wb <= x < 256 * (wb + 1)]
         rrlist.sort()
         if rrlist == []:
             continue
@@ -461,15 +465,15 @@ def RRlist2bitmap(lst):
         bitmap += struct.pack("B", bytes)
 
         # Generate the bitmap
-        for tmp in xrange(bytes):
+        for tmp in range(bytes):
             v = 0
             # Remove out of range Resource Records
-            tmp_rrlist = filter(lambda x: 256 * wb + 8 * tmp <= x < 256 * wb + 8 * tmp + 8, rrlist)
+            tmp_rrlist = [x for x in rrlist if 256 * wb + 8 * tmp <= x < 256 * wb + 8 * tmp + 8]
             if not tmp_rrlist == []:
                 # 1. rescale to fit into 8 bits
-                tmp_rrlist = map(lambda x: (x-256*wb)-(tmp*8), tmp_rrlist)
+                tmp_rrlist = [(x-256*wb)-(tmp*8) for x in tmp_rrlist]
                 # 2. x gives the bit position ; compute the corresponding value
-                tmp_rrlist = map(lambda x: 2**(7-x) , tmp_rrlist)
+                tmp_rrlist = [2**(7-x) for x in tmp_rrlist]
                 # 3. sum everything
                 v = reduce(lambda x,y: x+y, tmp_rrlist)
             bitmap += struct.pack("B", v)
@@ -631,7 +635,7 @@ DNSRR_DISPATCHER = {
     32769: DNSRRDLV,     # RFC 4431
 }
 
-DNSSEC_CLASSES = tuple(DNSRR_DISPATCHER.itervalues())
+DNSSEC_CLASSES = tuple(six.itervalues(DNSRR_DISPATCHER))
 
 def isdnssecRR(obj):
     return isinstance(obj, DNSSEC_CLASSES)

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -33,8 +33,8 @@ class DNSStrField(StrField):
         if x == ".":
           return b"\x00"
 
-        x = [k[:63] for k in x.split(".")] # Truncate chunks that cannot be encoded (more than 63 bytes..)
-        x = [chr(len(y))+y for y in x]
+        x = (k[:63] for k in x.split(".")) # Truncate chunks that cannot be encoded (more than 63 bytes..)
+        x = (chr(len(y))+y for y in x)
         x = "".join(x)
         if x[-1] != b"\x00":
             x += b"\x00"
@@ -205,7 +205,7 @@ class RDataField(StrLenField):
             if s:
                 s = inet_aton(s)
         elif pkt.type in [2, 3, 4, 5, 12]: # NS, MD, MF, CNAME, PTR
-            s = "".join([chr(len(x))+x for x in s.split(".")])
+            s = "".join(chr(len(x))+x for x in s.split("."))
             if ord(s[-1]):
                 s += b"\x00"
         elif pkt.type == 16: # TXT
@@ -435,8 +435,7 @@ def RRlist2bitmap(lst):
     lst = list(set(lst))
     lst.sort()
 
-    lst = [x for x in lst if x <= 65535]
-    lst = [abs(x) for x in lst]
+    lst = [abs(x) for x in lst if x <= 65535]
 
     # number of window blocks
     max_window_blocks = int(math.ceil(lst[-1] / 256.))
@@ -469,9 +468,9 @@ def RRlist2bitmap(lst):
             v = 0
             # Remove out of range Resource Records
             tmp_rrlist = [x for x in rrlist if 256 * wb + 8 * tmp <= x < 256 * wb + 8 * tmp + 8]
-            if not tmp_rrlist == []:
+            if tmp_rrlist:
                 # 1. rescale to fit into 8 bits
-                tmp_rrlist = [(x-256*wb)-(tmp*8) for x in tmp_rrlist]
+                tmp_rrlist = ((x-256*wb)-(tmp*8) for x in tmp_rrlist)
                 # 2. x gives the bit position ; compute the corresponding value
                 tmp_rrlist = [2**(7-x) for x in tmp_rrlist]
                 # 3. sum everything

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -18,8 +18,8 @@ from scapy.sendrecv import sr1
 from scapy.layers.inet import IP, DestIPField, UDP, TCP
 from scapy.layers.inet6 import DestIP6Field
 from scapy.error import warning
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 from functools import reduce
 
 class DNSStrField(StrField):

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -7,8 +7,7 @@
 Wireless LAN according to IEEE 802.11.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import re,struct
 from zlib import crc32
 
@@ -511,7 +510,7 @@ class Dot11PacketList(PacketList):
 
         PacketList.__init__(self, res, name, stats)
     def toEthernet(self):
-        data = [x.getlayer(Dot11) for x in [x for x in self.res if x.haslayer(Dot11) and x.type == 2]]
+        data = [x.getlayer(Dot11) for x in self.res if x.haslayer(Dot11) and x.type == 2]
         r2 = []
         for p in data:
             q = p.copy()

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -7,6 +7,8 @@
 Wireless LAN according to IEEE 802.11.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import re,struct
 from zlib import crc32
 
@@ -432,7 +434,7 @@ iwconfig wlan0 mode managed
         return [p,q]
     
     def print_reply(self):
-        print self.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%")
+        print(self.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%"))
 
     def send_reply(self, reply):
         sendp(reply, iface=self.ifto, **self.optsend)
@@ -490,7 +492,7 @@ iwconfig wlan0 mode managed
         q.getlayer(TCP).seq+=len(replace)
         
         sendp([p,q], iface=ifto, verbose=0)
-        print p.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%")
+        print(p.sprintf("Sent %IP.src%:%IP.sport% > %IP.dst%:%TCP.dport%"))
 
     sniff(iface=iffrom,prn=do_airpwn)
 
@@ -509,7 +511,7 @@ class Dot11PacketList(PacketList):
 
         PacketList.__init__(self, res, name, stats)
     def toEthernet(self):
-        data = map(lambda x:x.getlayer(Dot11), filter(lambda x : x.haslayer(Dot11) and x.type == 2, self.res))
+        data = [x.getlayer(Dot11) for x in [x for x in self.res if x.haslayer(Dot11) and x.type == 2]]
         r2 = []
         for p in data:
             q = p.copy()

--- a/scapy/layers/gprs.py
+++ b/scapy/layers/gprs.py
@@ -7,6 +7,7 @@
 GPRS (General Packet Radio Service) for mobile data communication.
 """
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.layers.inet import IP

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -32,6 +32,7 @@
 HSRP (Hot Standby Router Protocol): proprietary redundancy protocol for Cisco routers.
 """
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.layers.inet import DestIPField, UDP

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -7,6 +7,8 @@
 IPv4 (Internet Protocol v4).
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os,time,struct,re,socket,new
 from select import select
 from collections import defaultdict
@@ -29,6 +31,10 @@ from scapy.utils import whois
 import scapy.as_resolvers
 
 from scapy.arch import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
+import six
+from six.moves import map
+from six.moves import range
+from six.moves import zip
 
 ####################
 ## IP Tools class ##
@@ -40,7 +46,7 @@ class IPTools(object):
     def whois(self):
         """whois the source and print the output"""
         if WINDOWS:
-            print whois(self.src)
+            print(whois(self.src))
         else:
             os.system("whois %s" % self.src)
     def ottl(self):
@@ -269,7 +275,7 @@ class TCPOptionsField(StrField):
                 warning("Malformed TCP option (announced length is %i)" % olen)
                 olen = 2
             oval = x[2:olen]
-            if TCPOptions[0].has_key(onum):
+            if onum in TCPOptions[0]:
                 oname, ofmt = TCPOptions[0][onum]
                 if onum == 5: #SAck
                     ofmt += "%iI" % (len(oval)/4)
@@ -293,7 +299,7 @@ class TCPOptionsField(StrField):
                 elif oname == "EOL":
                     opt += b"\x00"
                     continue
-                elif TCPOptions[1].has_key(oname):
+                elif oname in TCPOptions[1]:
                     onum = TCPOptions[1][oname]
                     ofmt = TCPOptions[0][onum][1]
                     if onum == 5: #SAck
@@ -393,7 +399,7 @@ class IP(Packet, IPTools):
     def route(self):
         dst = self.dst
         if isinstance(dst,Gen):
-            dst = iter(dst).next()
+            dst = next(iter(dst))
         if conf.route is None:
             # unused import, only to initialize conf.route
             import scapy.route
@@ -458,7 +464,7 @@ class IP(Packet, IPTools):
         for p in fl:
             s = str(p[fnb].payload)
             nb = (len(s)+fragsize-1)/fragsize
-            for i in xrange(nb):            
+            for i in range(nb):            
                 q = p.copy()
                 del(q[fnb].payload)
                 del(q[fnb].chksum)
@@ -831,7 +837,7 @@ def fragment(pkt, fragsize=1480):
     for p in pkt:
         s = str(p[IP].payload)
         nb = (len(s)+fragsize-1)/fragsize
-        for i in xrange(nb):            
+        for i in range(nb):            
             q = p.copy()
             del(q[IP].payload)
             del(q[IP].chksum)
@@ -882,7 +888,7 @@ def defrag(plist):
         frags[uniq].append(p)
     defrag = []
     missfrag = []
-    for lst in frags.itervalues():
+    for lst in six.itervalues(frags):
         lst.sort(key=lambda x: x.frag)
         p = lst[0]
         lastp = lst[-1]
@@ -943,7 +949,7 @@ def defragment(plist):
 
     defrag = []
     missfrag = []
-    for lst in frags.itervalues():
+    for lst in six.itervalues(frags):
         lst.sort(key=lambda x: x.frag)
         p = lst[0]
         lastp = lst[-1]
@@ -1004,8 +1010,8 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
     """Tries to graph the timeskew between the timestamps and real time for a given ip"""
 
     # Filter TCP segments which source address is 'ip'
-    res = map(lambda x: self._elt2pkt(x), self.res)
-    b = filter(lambda x:x.haslayer(IP) and x.getlayer(IP).src == ip and x.haslayer(TCP), res)
+    res = [self._elt2pkt(x) for x in self.res]
+    b = [x for x in res if x.haslayer(IP) and x.getlayer(IP).src == ip and x.haslayer(TCP)]
 
     # Build a list of tuples (creation_time, replied_timestamp)
     c = []
@@ -1034,7 +1040,7 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
 
         return X, Y
 
-    data = map(_wrap_data, c)
+    data = list(map(_wrap_data, c))
 
     # Mimic the default gnuplot output
     if kargs == {}:
@@ -1063,9 +1069,9 @@ class TracerouteResult(SndRcvList):
         self.nloc = None
 
     def show(self):
-        return self.make_table(lambda (s,r): (s.sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
-                                              s.ttl,
-                                              r.sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
+        return self.make_table(lambda s_r: (s_r[0].sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
+                                              s_r[0].ttl,
+                                              s_r[1].sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
 
 
     def get_trace(self):
@@ -1077,9 +1083,9 @@ class TracerouteResult(SndRcvList):
             if d not in trace:
                 trace[d] = {}
             trace[d][s[IP].ttl] = r[IP].src, ICMP not in r
-        for k in trace.itervalues():
+        for k in six.itervalues(trace):
             try:
-                m = min(x for x, y in k.itervalues() if y)
+                m = min(x for x, y in six.itervalues(k) if y)
             except ValueError:
                 continue
             for l in k.keys():  # use .keys(): k is modified in the loop
@@ -1122,7 +1128,7 @@ class TracerouteResult(SndRcvList):
         for i in trace:
             tr = trace[i]
             tr3d[i] = []
-            for t in xrange(1, max(tr) + 1):
+            for t in range(1, max(tr) + 1):
                 if t not in rings:
                     rings[t] = []
                 if t in tr:
@@ -1135,7 +1141,7 @@ class TracerouteResult(SndRcvList):
         for t in rings:
             r = rings[t]
             l = len(r)
-            for i in xrange(l):
+            for i in range(l):
                 if r[i][1] == -1:
                     col = (0.75,0.75,0.75)
                 elif r[i][1]:
@@ -1146,13 +1152,13 @@ class TracerouteResult(SndRcvList):
                 s = IPsphere(pos=((l-1)*visual.cos(2*i*visual.pi/l),(l-1)*visual.sin(2*i*visual.pi/l),2*t),
                              ip = r[i][0],
                              color = col)
-                for trlst in tr3d.itervalues():
+                for trlst in six.itervalues(tr3d):
                     if t <= len(trlst):
                         if trlst[t-1] == i:
                             trlst[t-1] = s
         forecol = colgen(0.625, 0.4375, 0.25, 0.125)
-        for trlst in tr3d.itervalues():
-            col = forecol.next()
+        for trlst in six.itervalues(tr3d):
+            col = next(forecol)
             start = (0,0,0)
             for ip in trlst:
                 visual.cylinder(pos=start,axis=ip.pos-start,color=col,radius=0.2)
@@ -1235,7 +1241,7 @@ class TracerouteResult(SndRcvList):
                 trace_id = (s.src,s.dst,s.proto,0)
             trace = rt.get(trace_id,{})
             if not r.haslayer(ICMP) or r.type != 11:
-                if ports_done.has_key(trace_id):
+                if trace_id in ports_done:
                     continue
                 ports_done[trace_id] = None
             trace[s.ttl] = r.src
@@ -1246,7 +1252,7 @@ class TracerouteResult(SndRcvList):
         for trace_id in rt:
             trace = rt[trace_id]
             loctrace = []
-            for i in xrange(max(trace)):
+            for i in range(max(trace)):
                 ip = trace.get(i,None)
                 if ip is None:
                     continue
@@ -1265,7 +1271,7 @@ class TracerouteResult(SndRcvList):
         bmap = Basemap()
 
         # Split latitudes and longitudes per traceroute measurement
-        locations = [zip(*tr) for tr in trt.itervalues()]
+        locations = [list(zip(*tr)) for tr in six.itervalues(trt)]
 
         # Plot the traceroute measurement as lines in the map
         lines = [bmap.plot(*bmap(lons, lats)) for lons, lats in locations]
@@ -1332,10 +1338,10 @@ class TracerouteResult(SndRcvList):
         for rtk in rt:
             trace = rt[rtk]
             max_trace = max(trace)
-            for n in xrange(min(trace), max_trace):
-                if not trace.has_key(n):
-                    trace[n] = unknown_label.next()
-            if not ports_done.has_key(rtk):
+            for n in range(min(trace), max_trace):
+                if n not in trace:
+                    trace[n] = next(unknown_label)
+            if rtk not in ports_done:
                 if rtk[2] == 1: #ICMP
                     bh = "%s %i/icmp" % (rtk[1],rtk[3])
                 elif rtk[2] == 6: #TCP
@@ -1383,7 +1389,7 @@ class TracerouteResult(SndRcvList):
         s += "\n#ASN clustering\n"
         for asn in ASNs:
             s += '\tsubgraph cluster_%s {\n' % asn
-            col = backcolorlist.next()
+            col = next(backcolorlist)
             s += '\t\tcolor="#%s%s%s";' % col
             s += '\t\tnode [fillcolor="#%s%s%s",style=filled];' % col
             s += '\t\tfontsize = 10;'
@@ -1421,11 +1427,11 @@ class TracerouteResult(SndRcvList):
     
     
         for rtk in rt:
-            s += "#---[%s\n" % `rtk`
-            s += '\t\tedge [color="#%s%s%s"];\n' % forecolorlist.next()
+            s += "#---[%s\n" % repr(rtk)
+            s += '\t\tedge [color="#%s%s%s"];\n' % next(forecolorlist)
             trace = rt[rtk]
             maxtrace = max(trace)
-            for n in xrange(min(trace), maxtrace):
+            for n in range(min(trace), maxtrace):
                 s += '\t%s ->\n' % trace[n]
             s += '\t%s;\n' % trace[maxtrace]
     
@@ -1487,7 +1493,7 @@ traceroute(target, [maxttl=30,] [dport=80,] [sport=80,] [verbose=conf.verb]) -> 
 class TCP_client(Automaton):
     
     def parse_args(self, ip, port, *args, **kargs):
-        self.dst = iter(Net(ip)).next()
+        self.dst = next(iter(Net(ip)))
         self.dport = port
         self.sport = random.randrange(0,2**16)
         self.l4 = IP(dst=ip)/TCP(sport=self.sport, dport=self.dport, flags=0,
@@ -1642,14 +1648,14 @@ def IPID_count(lst, funcID=lambda x:x[1].id, funcpres=lambda x:x[1].summary()):
 lst:      a list of packets
 funcID:   a function that returns IP id values
 funcpres: a function used to summarize packets"""
-    idlst = map(funcID, lst)
+    idlst = list(map(funcID, lst))
     idlst.sort()
-    classes = [idlst[0]]+map(lambda x:x[1],filter(lambda (x,y): abs(x-y)>50, map(lambda x,y: (x,y),idlst[:-1], idlst[1:])))
-    lst = map(lambda x:(funcID(x), funcpres(x)), lst)
+    classes = [idlst[0]]+[x[1] for x in [x_y for x_y in map(lambda x,y: (x,y),idlst[:-1], idlst[1:]) if abs(x_y[0]-x_y[1])>50]]
+    lst = [(funcID(x), funcpres(x)) for x in lst]
     lst.sort()
-    print "Probably %i classes:" % len(classes), classes
+    print("Probably %i classes:" % len(classes), classes)
     for id,pr in lst:
-        print "%5i" % id, pr
+        print("%5i" % id, pr)
     
     
 @conf.commands.register
@@ -1679,7 +1685,7 @@ def fragleak(target,sport=123, dport=123, timeout=0.2, onlyasc=0):
                 if ans.payload.payload.dst != target:
                     continue
                 if ans.src  != target:
-                    print "leak from", ans.src,
+                    print("leak from", ans.src, end=' ')
 
 
 #                print repr(ans)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -32,9 +32,7 @@ import scapy.as_resolvers
 
 from scapy.arch import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 import six
-from six.moves import map
-from six.moves import range
-from six.moves import zip
+from six.moves import map, range, zip
 
 ####################
 ## IP Tools class ##
@@ -1070,8 +1068,8 @@ class TracerouteResult(SndRcvList):
 
     def show(self):
         return self.make_table(lambda s_r: (s_r[0].sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
-                                              s_r[0].ttl,
-                                              s_r[1].sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
+                                            s_r[0].ttl,
+                                            s_r[1].sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
 
 
     def get_trace(self):

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -7,8 +7,7 @@
 IPv4 (Internet Protocol v4).
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import os,time,struct,re,socket,new
 from select import select
 from collections import defaultdict
@@ -1009,7 +1008,7 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
 
     # Filter TCP segments which source address is 'ip'
     res = [self._elt2pkt(x) for x in self.res]
-    b = [x for x in res if x.haslayer(IP) and x.getlayer(IP).src == ip and x.haslayer(TCP)]
+    b = (x for x in res if x.haslayer(IP) and x.getlayer(IP).src == ip and x.haslayer(TCP))
 
     # Build a list of tuples (creation_time, replied_timestamp)
     c = []

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -31,8 +31,8 @@ from scapy.utils import whois
 import scapy.as_resolvers
 
 from scapy.arch import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
-import six
-from six.moves import map, range, zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range, zip
 
 ####################
 ## IP Tools class ##

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -24,9 +24,14 @@ IPv6 (Internet Protocol v6).
 """
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import random
 import socket
 import sys
+import six
+from six.moves import map
+from six.moves import range
 if not socket.has_ipv6:
     raise socket.error("can't use AF_INET6, IPv6 is disabled")
 if not hasattr(socket, "IPPROTO_IPV6"):
@@ -109,7 +114,7 @@ def getmacbyip6(ip6, chainCC=0):
 
     iff,a,nh = conf.route6.route(ip6)
 
-    if isinstance(iff, basestring):
+    if isinstance(iff, six.string_types):
         if iff == LOOPBACK_NAME:
             return "ff:ff:ff:ff:ff:ff"
     else:
@@ -163,16 +168,16 @@ class Net6(Gen): # syntax ex. fec0::/126
         def m8(i):
             if i % 8 == 0:
                 return i
-        tuple = filter(lambda x: m8(x), xrange(8, 129))
+        tuple = [x for x in range(8, 129) if m8(x)]
 
         a = in6_and(self.net, self.mask)
-        tmp = map(lambda x:  x, struct.unpack('16B', a))
+        tmp = [x for x in struct.unpack('16B', a)]
 
         def parse_digit(a, netmask):
             netmask = min(8,max(netmask,0))
-            a = (int(a) & (0xffL<<netmask),(int(a) | (0xffL>>(8-netmask)))+1)
+            a = (int(a) & (0xff<<netmask),(int(a) | (0xff>>(8-netmask)))+1)
             return a
-        self.parsed = map(lambda x,y: parse_digit(x,y), tmp, map(lambda x,nm=self.plen: x-nm, tuple))
+        self.parsed = list(map(lambda x,y: parse_digit(x,y), tmp, list(map(lambda x,nm=self.plen: x-nm, tuple))))
 
         def rec(n, l):
             if n and  n % 2 == 0:
@@ -183,7 +188,7 @@ class Net6(Gen): # syntax ex. fec0::/126
                 return l
             else:
                 ll = []
-                for i in xrange(*self.parsed[n]):
+                for i in range(*self.parsed[n]):
                     for y in l:
                         ll += [y+sep+'%.2x'%i]
                 return rec(n+1, ll)
@@ -214,7 +219,7 @@ class IP6Field(Field):
             except socket.error:
                 x = Net6(x)
         elif type(x) is list:
-            x = map(Net6, x)
+            x = list(map(Net6, x))
         return x
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, x)
@@ -392,7 +397,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
     def route(self):
         dst = self.dst
         if isinstance(dst,Gen):
-            dst = iter(dst).next()
+            dst = next(iter(dst))
         return conf.route6.route(dst)
 
     def mysummary(self):
@@ -851,7 +856,7 @@ class _HopByHopOptionsField(PacketListField):
                 c -= 1
             o = ord(x[0]) # Option type
             cls = self.cls
-            if _hbhoptcls.has_key(o):
+            if o in _hbhoptcls:
                 cls = _hbhoptcls[o]
             try:
                 op = cls(x)
@@ -1084,14 +1089,14 @@ def defragment6(pktlist):
     Crap is dropped. What lacks is completed by 'X' characters.
     """
 
-    l = filter(lambda x: IPv6ExtHdrFragment in x, pktlist) # remove non fragments
+    l = [x for x in pktlist if IPv6ExtHdrFragment in x] # remove non fragments
     if not l:
         return []
 
     id = l[0][IPv6ExtHdrFragment].id
 
     llen = len(l)
-    l = filter(lambda x: x[IPv6ExtHdrFragment].id == id, l)
+    l = [x for x in l if x[IPv6ExtHdrFragment].id == id]
     if len(l) != llen:
         warning("defragment6: some fragmented packets have been removed from list")
     llen = len(l)
@@ -1671,8 +1676,8 @@ class ICMPv6NDOptPrefixInfo(_ICMPv6NDGuessPayload, Packet):
                     BitField("A",1,1),
                     BitField("R",0,1),
                     BitField("res1",0,5),
-                    XIntField("validlifetime",0xffffffffL),
-                    XIntField("preferredlifetime",0xffffffffL),
+                    XIntField("validlifetime",0xffffffff),
+                    XIntField("preferredlifetime",0xffffffff),
                     XIntField("res2",0x00000000),
                     IP6Field("prefix","::") ]
     def mysummary(self):
@@ -1915,8 +1920,8 @@ class DomainNameListField(StrLenField):
                 return z
             return z+b'\x00'
         # Build the encode names
-        tmp = map(lambda y: map((lambda z: chr(len(z))+z), y.split('.')), x)
-        ret_string  = "".join(map(lambda x: conditionalTrailingDot("".join(x)), tmp))
+        tmp = [list(map((lambda z: chr(len(z))+z), y.split('.'))) for y in x]
+        ret_string  = "".join([conditionalTrailingDot("".join(x)) for x in tmp])
 
         # In padded mode, add some \x00 bytes
         if self.padded and not len(ret_string) % self.padded_unit == 0:
@@ -2159,7 +2164,7 @@ def names2dnsrepr(x):
         termin = b"\x00"
         if n.count('.') == 0: # single-component gets one more
             termin += b'\x00'
-        n = "".join(map(lambda y: chr(len(y))+y, n.split("."))) + termin
+        n = "".join([chr(len(y))+y for y in n.split(".")]) + termin
         res.append(n)
     return "".join(res)
 
@@ -2389,7 +2394,7 @@ class NIReplyDataField(StrField):
                     return (0, x)
                 return x
 
-            return (qtype, map(addttl, x))
+            return (qtype, list(map(addttl, x)))
 
         return (qtype, x)
 
@@ -2402,9 +2407,9 @@ class NIReplyDataField(StrField):
             ttl,dnsstr = tmp
             return s+ struct.pack("!I", ttl) + dnsstr
         elif t == 3:
-            return s + "".join(map(lambda (x,y): struct.pack("!I", x)+inet_pton(socket.AF_INET6, y), tmp))
+            return s + "".join([struct.pack("!I", x_y1[0])+inet_pton(socket.AF_INET6, x_y1[1]) for x_y1 in tmp])
         elif t == 4:
-            return s + "".join(map(lambda (x,y): struct.pack("!I", x)+inet_pton(socket.AF_INET, y), tmp))
+            return s + "".join([struct.pack("!I", x_y2[0])+inet_pton(socket.AF_INET, x_y2[1]) for x_y2 in tmp])
         else:
             return s + tmp
 
@@ -2457,7 +2462,7 @@ class NIReplyDataField(StrField):
                 l = dnsrepr2names(l)
                 return "ttl:%d %s" % (ttl, ", ".join(l))
             elif t == 3 or t == 4:
-                return "[ %s ]" % (", ".join(map(lambda (x,y): "(%d, %s)" % (x, y), val)))
+                return "[ %s ]" % (", ".join(["(%d, %s)" % (x_y[0], x_y[1]) for x_y in val]))
             return repr(val)
         return repr(x) # XXX should not happen
 
@@ -2877,7 +2882,7 @@ class _MobilityOptionsField(PacketListField):
         while x:
             o = ord(x[0]) # Option type
             cls = self.cls
-            if moboptcls.has_key(o):
+            if o in moboptcls:
                 cls = moboptcls[o]
             try:
                 op = cls(x)
@@ -3125,9 +3130,9 @@ class  AS_resolver6(AS_resolver_riswhois):
 class TracerouteResult6(TracerouteResult):
     __slots__ = []
     def show(self):
-        return self.make_table(lambda (s,r): (s.sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"), # TODO: ICMPv6 !
-                                              s.hlim,
-                                              r.sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}"+
+        return self.make_table(lambda s_r: (s_r[0].sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"), # TODO: ICMPv6 !
+                                              s_r[0].hlim,
+                                              s_r[1].sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}"+
                                                         "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}"+
                                                         "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}"+
                                                         "{ICMPv6EchoReply:%ir,type%}")))
@@ -3149,9 +3154,9 @@ class TracerouteResult6(TracerouteResult):
 
             trace[d][s[IPv6].hlim] = r[IPv6].src, t
 
-        for k in trace.itervalues():
+        for k in six.itervalues(trace):
             try:
-                m = min(x for x, y in k.itervalues() if y)
+                m = min(x for x, y in six.itervalues(k) if y)
             except ValueError:
                 continue
             for l in k.keys():  # use .keys(): k is modified in the loop
@@ -3351,7 +3356,7 @@ def NDP_Attack_DAD_DoS_via_NS(iface=None, mac_src_filter=None, tgt_filter=None,
         rep = Ether(src=reply_mac)/IPv6(src="::", dst=dst)/ICMPv6ND_NS(tgt=tgt)
         sendp(rep, iface=iface, verbose=0)
 
-        print "Reply NS for target address %s (received from %s)" % (tgt, mac)
+        print("Reply NS for target address %s (received from %s)" % (tgt, mac))
 
     _NDP_Attack_DAD_DoS(ns_reply_callback, iface, mac_src_filter,
                         tgt_filter, reply_mac)
@@ -3412,7 +3417,7 @@ def NDP_Attack_DAD_DoS_via_NA(iface=None, mac_src_filter=None, tgt_filter=None,
         rep /= ICMPv6NDOptDstLLAddr(lladdr=reply_mac)
         sendp(rep, iface=iface, verbose=0)
 
-        print "Reply NA for target address %s (received from %s)" % (tgt, mac)
+        print("Reply NA for target address %s (received from %s)" % (tgt, mac))
 
     _NDP_Attack_DAD_DoS(na_reply_callback, iface, mac_src_filter,
                         tgt_filter, reply_mac)
@@ -3511,7 +3516,7 @@ def NDP_Attack_NA_Spoofing(iface=None, mac_src_filter=None, tgt_filter=None,
             received_snma = socket.inet_pton(socket.AF_INET6, dst)
             expected_snma = in6_getnsma(tgt)
             if received_snma != expected_snma:
-                print "solicited node multicast @ does not match target @!"
+                print("solicited node multicast @ does not match target @!")
                 return 0
 
         return 1
@@ -3537,7 +3542,7 @@ def NDP_Attack_NA_Spoofing(iface=None, mac_src_filter=None, tgt_filter=None,
 
         sendp(rep, iface=iface, verbose=0)
 
-        print "Reply NA for target address %s (received from %s)" % (tgt, mac)
+        print("Reply NA for target address %s (received from %s)" % (tgt, mac))
 
     if not iface:
         iface = conf.iface
@@ -3768,7 +3773,7 @@ def NDP_Attack_Kill_Default_Router(iface=None, mac_src_filter=None,
 
         sendp(rep, iface=iface, verbose=0)
 
-        print "Fake RA sent with source address %s" % src
+        print("Fake RA sent with source address %s" % src)
 
 
     if not iface:
@@ -3853,7 +3858,7 @@ def NDP_Attack_Fake_Router(ra, iface=None, mac_src_filter=None,
 
         src = req[IPv6].src
         sendp(ra, iface=iface, verbose=0)
-        print "Fake RA sent in response to RS from %s" % src
+        print("Fake RA sent in response to RS from %s" % src)
 
     if not iface:
         iface = conf.iface

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -24,8 +24,7 @@ IPv6 (Internet Protocol v6).
 """
 
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import random
 import socket
 import sys
@@ -1920,7 +1919,7 @@ class DomainNameListField(StrLenField):
             return z+b'\x00'
         # Build the encode names
         tmp = [list(map((lambda z: chr(len(z))+z), y.split('.'))) for y in x]
-        ret_string  = "".join([conditionalTrailingDot("".join(x)) for x in tmp])
+        ret_string  = "".join(conditionalTrailingDot("".join(x)) for x in tmp)
 
         # In padded mode, add some \x00 bytes
         if self.padded and not len(ret_string) % self.padded_unit == 0:
@@ -2163,7 +2162,7 @@ def names2dnsrepr(x):
         termin = b"\x00"
         if n.count('.') == 0: # single-component gets one more
             termin += b'\x00'
-        n = "".join([chr(len(y))+y for y in n.split(".")]) + termin
+        n = "".join(chr(len(y))+y for y in n.split(".")) + termin
         res.append(n)
     return "".join(res)
 
@@ -2406,9 +2405,9 @@ class NIReplyDataField(StrField):
             ttl,dnsstr = tmp
             return s+ struct.pack("!I", ttl) + dnsstr
         elif t == 3:
-            return s + "".join([struct.pack("!I", x_y1[0])+inet_pton(socket.AF_INET6, x_y1[1]) for x_y1 in tmp])
+            return s + "".join(struct.pack("!I", x_y1[0])+inet_pton(socket.AF_INET6, x_y1[1]) for x_y1 in tmp)
         elif t == 4:
-            return s + "".join([struct.pack("!I", x_y2[0])+inet_pton(socket.AF_INET, x_y2[1]) for x_y2 in tmp])
+            return s + "".join(struct.pack("!I", x_y2[0])+inet_pton(socket.AF_INET, x_y2[1]) for x_y2 in tmp)
         else:
             return s + tmp
 
@@ -2461,7 +2460,7 @@ class NIReplyDataField(StrField):
                 l = dnsrepr2names(l)
                 return "ttl:%d %s" % (ttl, ", ".join(l))
             elif t == 3 or t == 4:
-                return "[ %s ]" % (", ".join(["(%d, %s)" % (x_y[0], x_y[1]) for x_y in val]))
+                return "[ %s ]" % (", ".join("(%d, %s)" % (x_y[0], x_y[1]) for x_y in val))
             return repr(val)
         return repr(x) # XXX should not happen
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3131,11 +3131,11 @@ class TracerouteResult6(TracerouteResult):
     __slots__ = []
     def show(self):
         return self.make_table(lambda s_r: (s_r[0].sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"), # TODO: ICMPv6 !
-                                              s_r[0].hlim,
-                                              s_r[1].sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}"+
-                                                        "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}"+
-                                                        "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}"+
-                                                        "{ICMPv6EchoReply:%ir,type%}")))
+                                            s_r[0].hlim,
+                                            s_r[1].sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}"+
+                                                           "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}"+
+                                                           "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}"+
+                                                           "{ICMPv6EchoReply:%ir,type%}")))
 
     def get_trace(self):
         trace = {}

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -29,9 +29,8 @@ from __future__ import print_function
 import random
 import socket
 import sys
-import six
-from six.moves import map
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range
 if not socket.has_ipv6:
     raise socket.error("can't use AF_INET6, IPv6 is disabled")
 if not hasattr(socket, "IPPROTO_IPV6"):

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -52,8 +52,8 @@ from scapy.fields import ByteEnumField, ByteField, IntField, PacketField, \
     ShortField, StrField, XIntField, XStrField, XStrLenField
 from scapy.packet import Packet, bind_layers, Raw
 from scapy.layers.inet import IP, UDP
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 from scapy.layers.inet6 import IPv6, IPv6ExtHdrHopByHop, IPv6ExtHdrDestOpt, \
     IPv6ExtHdrRouting
 

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -39,6 +39,7 @@ Example of use:
 True
 """
 
+from __future__ import absolute_import
 from fractions import gcd
 import os
 import socket
@@ -51,6 +52,8 @@ from scapy.fields import ByteEnumField, ByteField, IntField, PacketField, \
     ShortField, StrField, XIntField, XStrField, XStrLenField
 from scapy.packet import Packet, bind_layers, Raw
 from scapy.layers.inet import IP, UDP
+import six
+from six.moves import range
 from scapy.layers.inet6 import IPv6, IPv6ExtHdrHopByHop, IPv6ExtHdrDestOpt, \
     IPv6ExtHdrRouting
 
@@ -312,7 +315,7 @@ class CryptAlgo(object):
         # Still according to the RFC, the default value for padding *MUST* be an
         # array of bytes starting from 1 to padlen
         # TODO: Handle padding function according to the encryption algo
-        esp.padding = ''.join(chr(b) for b in xrange(1, esp.padlen + 1))
+        esp.padding = ''.join(chr(b) for b in range(1, esp.padlen + 1))
 
         # If the following test fails, it means that this algo does not comply
         # with the RFC
@@ -771,7 +774,7 @@ class SecurityAssociation(object):
 
         if proto not in (ESP, AH, ESP.name, AH.name):
             raise ValueError("proto must be either ESP or AH")
-        if isinstance(proto, basestring):
+        if isinstance(proto, six.string_types):
             self.proto = eval(proto)
         else:
             self.proto = proto
@@ -782,7 +785,7 @@ class SecurityAssociation(object):
         if crypt_algo:
             if crypt_algo not in CRYPT_ALGOS:
                 raise TypeError('unsupported encryption algo %r, try %r' %
-                                (crypt_algo, CRYPT_ALGOS.keys()))
+                                (crypt_algo, list(CRYPT_ALGOS.keys())))
             self.crypt_algo = CRYPT_ALGOS[crypt_algo]
 
             if crypt_key:
@@ -800,7 +803,7 @@ class SecurityAssociation(object):
         if auth_algo:
             if auth_algo not in AUTH_ALGOS:
                 raise TypeError('unsupported integrity algo %r, try %r' %
-                                (auth_algo, AUTH_ALGOS.keys()))
+                                (auth_algo, list(AUTH_ALGOS.keys())))
             self.auth_algo = AUTH_ALGOS[auth_algo]
             self.auth_key = auth_key
         else:

--- a/scapy/layers/ir.py
+++ b/scapy/layers/ir.py
@@ -7,6 +7,7 @@
 IrDA infrared data communication.
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import CookedLinux
@@ -26,7 +27,7 @@ class IrLAPCommand(Packet):
     fields_desc = [ XByteField("Control", 0),
                     XByteField("Format identifier", 0),
                     XIntField("Source address", 0),
-                    XIntField("Destination address", 0xffffffffL),
+                    XIntField("Destination address", 0xffffffff),
                     XByteField("Discovery flags", 0x1),
                     ByteEnumField("Slot number", 255, {"final":255}),
                     XByteField("Version", 0)]

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -16,7 +16,7 @@ from scapy.ansmachine import *
 from scapy.layers.inet import IP,UDP
 from scapy.sendrecv import sr
 from scapy.error import warning
-from six.moves import map
+from scapy.modules.six.moves import map
 from functools import reduce
 
 

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -128,7 +128,7 @@ class ISAKMPTransformSetField(StrLenField):
     def i2m(self, pkt, i):
         if i is None:
             return ""
-        i = list(map(self.type2num, i))
+        i = map(self.type2num, i)
         return "".join(i)
     def m2i(self, pkt, m):
         # I try to ensure that we don't read off the end of our packet based

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -7,6 +7,7 @@
 ISAKMP (Internet Security Association and Key Management Protocol).
 """
 
+from __future__ import absolute_import
 import struct
 from scapy.config import conf
 from scapy.packet import *
@@ -15,6 +16,8 @@ from scapy.ansmachine import *
 from scapy.layers.inet import IP,UDP
 from scapy.sendrecv import sr
 from scapy.error import warning
+from six.moves import map
+from functools import reduce
 
 
 # see http://www.iana.org/assignments/ipsec-registry for details
@@ -101,7 +104,8 @@ del(val)
 
 class ISAKMPTransformSetField(StrLenField):
     islist=1
-    def type2num(self, (typ,val)):
+    def type2num(self, xxx_todo_changeme):
+        (typ,val) = xxx_todo_changeme
         type_val,enc_dict,tlv = ISAKMPTransformTypes.get(typ, (typ,{},0))
         val = enc_dict.get(val, val)
         s = ""
@@ -124,7 +128,7 @@ class ISAKMPTransformSetField(StrLenField):
     def i2m(self, pkt, i):
         if i is None:
             return ""
-        i = map(self.type2num, i)
+        i = list(map(self.type2num, i))
         return "".join(i)
     def m2i(self, pkt, m):
         # I try to ensure that we don't read off the end of our packet based
@@ -144,7 +148,7 @@ class ISAKMPTransformSetField(StrLenField):
                 if value_len+4 > len(m):
                     warning("Bad length for ISAKMP tranform type=%#6x" % trans_type)
                 value = m[4:4+value_len]
-                value = reduce(lambda x,y: (x<<8L)|y, struct.unpack("!%s" % ("B"*len(value),), value),0)
+                value = reduce(lambda x,y: (x<<8)|y, struct.unpack("!%s" % ("B"*len(value),), value),0)
             else:
                 trans_type &= 0x7fff
                 value_len=0

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -23,7 +23,7 @@ from scapy.arch import get_if_hwaddr
 from scapy.consts import LOOPBACK_INTERFACE
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.error import warning
-from six.moves import map
+from scapy.modules.six.moves import map
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route

--- a/scapy/layers/l2tp.py
+++ b/scapy/layers/l2tp.py
@@ -9,6 +9,7 @@ L2TP (Layer 2 Tunneling Protocol) for VPNs.
 [RFC 2661]
 """
 
+from __future__ import absolute_import
 import struct
 
 from scapy.packet import *

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.layers.inet import UDP

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -23,7 +23,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import IPField
 from scapy.layers.inet6 import IP6Field
 from scapy.data import ETHER_ANY
-import six
+import scapy.modules.six as six
 
 # Protocol layers
 ##################

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -9,6 +9,7 @@ https://msdn.microsoft.com/en-us/library/cc233983.aspx
 
 """
 
+from __future__ import absolute_import
 import struct
 from array import array
 
@@ -22,6 +23,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import IPField
 from scapy.layers.inet6 import IP6Field
 from scapy.data import ETHER_ANY
+import six
 
 # Protocol layers
 ##################
@@ -296,7 +298,7 @@ class LLTDAttribute(Packet):
             cmd = struct.unpack("B", _pkt[0])[0]
         elif "type" in kargs:
             cmd = kargs["type"]
-            if isinstance(cmd, basestring):
+            if isinstance(cmd, six.string_types):
                 cmd = cls.fields_desc[0].s2i[cmd]
         else:
             return cls
@@ -837,4 +839,4 @@ class LargeTlvBuilder(object):
 
         """
         return {key: "".join(chr(byte) for byte in data)
-                for key, data in self.data.iteritems()}
+                for key, data in six.iteritems(self.data)}

--- a/scapy/layers/mgcp.py
+++ b/scapy/layers/mgcp.py
@@ -9,6 +9,7 @@ MGCP (Media Gateway Control Protocol)
 [RFC 2805]
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import UDP

--- a/scapy/layers/mobileip.py
+++ b/scapy/layers/mobileip.py
@@ -7,6 +7,7 @@
 Mobile IP.
 """
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.layers.inet import IP,UDP

--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -90,7 +90,7 @@ class NBNSRequest(Packet):
                    IntField("TTL", 0),
                    ShortField("RDLENGTH", 6),
                    BitEnumField("G",0,1,{0:"Unique name",1:"Group name"}),
-                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",0o1:"P node",0o2:"M node",0o3:"H node"}),
+                   BitEnumField("OWNER_NODE_TYPE",0,2,{0:"B node",1:"P node",2:"M node",3:"H node"}),
                    BitEnumField("UNUSED",0,13,{0:"Unused"}),
                    IPField("NB_ADDRESS", "127.0.0.1")]
 
@@ -132,7 +132,7 @@ class NBNSQueryResponseNegative(Packet):
                    IntField("TTL",0),
                    ShortField("RDLENGTH",6),
                    BitEnumField("G",0,1,{0:"Unique name",1:"Group name"}),
-                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",0o1:"P node",0o2:"M node",0o3:"H node"}),
+                   BitEnumField("OWNER_NODE_TYPE",0,2,{0:"B node",1:"P node",2:"M node",3:"H node"}),
                    BitEnumField("UNUSED",0,13,{0:"Unused"}),
                    IPField("NB_ADDRESS", "127.0.0.1")]
     

--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -9,6 +9,7 @@ NetBIOS over TCP/IP
 [RFC 1001/1002]
 """
 
+from __future__ import absolute_import
 import struct
 from scapy.packet import *
 from scapy.fields import *
@@ -89,7 +90,7 @@ class NBNSRequest(Packet):
                    IntField("TTL", 0),
                    ShortField("RDLENGTH", 6),
                    BitEnumField("G",0,1,{0:"Unique name",1:"Group name"}),
-                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",01:"P node",02:"M node",03:"H node"}),
+                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",0o1:"P node",0o2:"M node",0o3:"H node"}),
                    BitEnumField("UNUSED",0,13,{0:"Unused"}),
                    IPField("NB_ADDRESS", "127.0.0.1")]
 
@@ -131,7 +132,7 @@ class NBNSQueryResponseNegative(Packet):
                    IntField("TTL",0),
                    ShortField("RDLENGTH",6),
                    BitEnumField("G",0,1,{0:"Unique name",1:"Group name"}),
-                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",01:"P node",02:"M node",03:"H node"}),
+                   BitEnumField("OWNER_NODE_TYPE",00,2,{00:"B node",0o1:"P node",0o2:"M node",0o3:"H node"}),
                    BitEnumField("UNUSED",0,13,{0:"Unused"}),
                    IPField("NB_ADDRESS", "127.0.0.1")]
     

--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -9,6 +9,7 @@ Cisco NetFlow protocol v1 and v5
 """
 
 
+from __future__ import absolute_import
 from scapy.fields import *
 from scapy.packet import *
 from scapy.data import IP_PROTOS

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -8,6 +8,7 @@ NTP (Network Time Protocol).
 References : RFC 5905, RC 1305, ntpd source code
 """
 
+from __future__ import absolute_import
 import struct
 import time
 import datetime
@@ -22,6 +23,8 @@ from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet import UDP
 from scapy.utils import lhex
 from scapy.config import conf
+import six
+from six.moves import range
 
 
 
@@ -79,7 +82,7 @@ class TimeStampField(FixedPointField):
         return time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(val - _NTP_BASETIME))
 
     def any2i(self, pkt, val):
-        if isinstance(val, basestring):
+        if isinstance(val, six.string_types):
             val = int(time.mktime(time.strptime(val))) + _NTP_BASETIME
         elif isinstance(val, datetime.datetime):
             val = int(val.strftime("%s")) + _NTP_BASETIME

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -23,8 +23,8 @@ from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet import UDP
 from scapy.utils import lhex
 from scapy.config import conf
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import range
 
 
 

--- a/scapy/layers/pflog.py
+++ b/scapy/layers/pflog.py
@@ -7,6 +7,7 @@
 PFLog: OpenBSD PF packet filter logging.
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -9,6 +9,7 @@ PPP (Point to Point Protocol)
 [RFC 1661]
 """
 
+from __future__ import absolute_import
 import struct
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import Ether, CookedLinux, GRE_PPTP

--- a/scapy/layers/pptp.py
+++ b/scapy/layers/pptp.py
@@ -9,6 +9,7 @@ PPTP (Point to Point Tunneling Protocol)
 [RFC 2637]
 """
 
+from __future__ import absolute_import
 from scapy.packet import Packet, bind_layers
 from scapy.layers.inet import TCP
 from scapy.fields import ByteEnumField, FieldLenField, FlagsField, IntField, IntEnumField,\

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -8,6 +8,7 @@
 RADIUS (Remote Authentication Dial In User Service)
 """
 
+from __future__ import absolute_import
 import struct
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/layers/rip.py
+++ b/scapy/layers/rip.py
@@ -7,6 +7,7 @@
 RIP (Routing Information Protocol).
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import UDP

--- a/scapy/layers/rtp.py
+++ b/scapy/layers/rtp.py
@@ -7,6 +7,7 @@
 RTP (Real-time Transport Protocol).
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -18,7 +18,7 @@ from scapy.fields import *
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet6 import IPv6
-from six.moves import map
+from scapy.modules.six.moves import map
 
 IPPROTO_SCTP=132
 

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -472,7 +472,7 @@ class GapAckField(Field):
     def i2m(self, pkt, x):
         if x is None:
             return b"\0\0\0\0"
-        sta, end = list(map(int, x.split(":")))
+        sta, end = map(int, x.split(":"))
         args = tuple([">HH", sta, end])
         return struct.pack(*args)
     def m2i(self, pkt, x):

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -8,6 +8,7 @@
 SCTP (Stream Control Transmission Protocol).
 """
 
+from __future__ import absolute_import
 import struct
 
 from scapy.volatile import RandBin
@@ -17,6 +18,7 @@ from scapy.fields import *
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet6 import IPv6
+from six.moves import map
 
 IPPROTO_SCTP=132
 
@@ -470,7 +472,7 @@ class GapAckField(Field):
     def i2m(self, pkt, x):
         if x is None:
             return b"\0\0\0\0"
-        sta, end = map(int, x.split(":"))
+        sta, end = list(map(int, x.split(":")))
         args = tuple([">HH", sta, end])
         return struct.pack(*args)
     def m2i(self, pkt, x):

--- a/scapy/layers/skinny.py
+++ b/scapy/layers/skinny.py
@@ -7,6 +7,7 @@
 Cisco Skinny protocol.
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import TCP

--- a/scapy/layers/smb.py
+++ b/scapy/layers/smb.py
@@ -7,6 +7,7 @@
 SMB (Server Message Block), also known as CIFS.
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.netbios import NBTSession
@@ -168,7 +169,7 @@ class SMBNegociate_Protocol_Response_Advanced_Security(Packet):
                    BitField("CompBulk",0,2),
                    BitField("Reserved3",0,5),
 # There have been 127490112000000000 tenths of micro-seconds between 1st january 1601 and 1st january 2005. 127490112000000000=0x1C4EF94D6228000, so ServerTimeHigh=0xD6228000 and ServerTimeLow=0x1C4EF94.
-                   LEIntField("ServerTimeHigh",0xD6228000L),
+                   LEIntField("ServerTimeHigh",0xD6228000),
                    LEIntField("ServerTimeLow",0x1C4EF94),
                    LEShortField("ServerTimeZone",0x3c),
                    ByteField("EncryptionKeyLength",0),
@@ -209,7 +210,7 @@ class SMBNegociate_Protocol_Response_No_Security(Packet):
                    FlagsField("CompBulk",0,2,"CB"),
                    BitField("Reserved3",0,5),
                    # There have been 127490112000000000 tenths of micro-seconds between 1st january 1601 and 1st january 2005. 127490112000000000=0x1C4EF94D6228000, so ServerTimeHigh=0xD6228000 and ServerTimeLow=0x1C4EF94.
-                   LEIntField("ServerTimeHigh",0xD6228000L),
+                   LEIntField("ServerTimeHigh",0xD6228000),
                    LEIntField("ServerTimeLow",0x1C4EF94),
                    LEShortField("ServerTimeZone",0x3c),
                    ByteField("EncryptionKeyLength",8),
@@ -250,7 +251,7 @@ class SMBNegociate_Protocol_Response_No_Security_No_Key(Packet):
                    FlagsField("CompBulk",0,2,"CB"),
                    BitField("Reserved3",0,5),
                    # There have been 127490112000000000 tenths of micro-seconds between 1st january 1601 and 1st january 2005. 127490112000000000=0x1C4EF94D6228000, so ServerTimeHigh=0xD6228000 and ServerTimeLow=0x1C4EF94.
-                   LEIntField("ServerTimeHigh",0xD6228000L),
+                   LEIntField("ServerTimeHigh",0xD6228000),
                    LEIntField("ServerTimeLow",0x1C4EF94),
                    LEShortField("ServerTimeZone",0x3c),
                    ByteField("EncryptionKeyLength",0),

--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -7,6 +7,8 @@
 SNMP (Simple Network Management Protocol).
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 from scapy.packet import *
 from scapy.asn1packet import *
 from scapy.asn1fields import *
@@ -247,12 +249,12 @@ def snmpwalk(dst, oid="1", community="public"):
         while 1:
             r = sr1(IP(dst=dst)/UDP(sport=RandShort())/SNMP(community=community, PDU=SNMPnext(varbindlist=[SNMPvarbind(oid=oid)])),timeout=2, chainCC=1, verbose=0, retry=2)
             if ICMP in r:
-                print repr(r)
+                print(repr(r))
                 break
             if r is None:
-                print "No answers"
+                print("No answers")
                 break
-            print "%-40s: %r" % (r[SNMPvarbind].oid.val,r[SNMPvarbind].value)
+            print("%-40s: %r" % (r[SNMPvarbind].oid.val,r[SNMPvarbind].value))
             oid = r[SNMPvarbind].oid
             
     except KeyboardInterrupt:

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -7,11 +7,13 @@
 TFTP (Trivial File Transfer Protocol).
 """
 
+from __future__ import absolute_import
 import os,random
 from scapy.packet import *
 from scapy.fields import *
 from scapy.automaton import *
 from scapy.layers.inet import UDP, IP
+from six.moves import range
 
 
 
@@ -228,7 +230,7 @@ class TFTP_write(Automaton):
     @ATMT.state(initial=1)
     def BEGIN(self):
         self.data = [self.origdata[i*self.blocksize:(i+1)*self.blocksize]
-                     for i in xrange( len(self.origdata)/self.blocksize+1)]
+                     for i in range( len(self.origdata)/self.blocksize+1)]
         self.my_tid = self.sport or RandShort()._fix()
         bind_bottom_up(UDP, TFTP, dport=self.my_tid)
         self.server_tid = None

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -13,7 +13,7 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.automaton import *
 from scapy.layers.inet import UDP, IP
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 

--- a/scapy/layers/tls/__init__.py
+++ b/scapy/layers/tls/__init__.py
@@ -109,6 +109,7 @@ TODO list (may it be carved away by good souls):
         - Enhance PSK and session ticket support.
 """
 
+from __future__ import absolute_import
 from scapy.config import conf
 
 if not conf.crypto_valid:

--- a/scapy/layers/tls/all.py
+++ b/scapy/layers/tls/all.py
@@ -7,6 +7,7 @@
 Aggregate top level objects from all TLS modules.
 """
 
+from __future__ import absolute_import
 from scapy.layers.tls.cert import *
 
 from scapy.layers.tls.automaton import *

--- a/scapy/layers/tls/automaton.py
+++ b/scapy/layers/tls/automaton.py
@@ -24,6 +24,8 @@ t = TLSClientAutomaton(dport=50000, client_hello=ch)
 t.run()
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import socket
 import struct
 
@@ -248,7 +250,7 @@ class TLSClientAutomaton(Automaton):
 
     @ATMT.state(final=True)
     def MISSING_SH(self):
-        print "Missing TLS Server Hello message"
+        print("Missing TLS Server Hello message")
 
     @ATMT.condition(HANDLE_SH, prio=1)
     def should_HANDLE_CERT(self):
@@ -270,7 +272,7 @@ class TLSClientAutomaton(Automaton):
 
     @ATMT.state(final=True)
     def MISSING_CERT(self):
-        print "Missing TLS Certificate message"
+        print("Missing TLS Certificate message")
 
     @ATMT.state()
     def HANDLE_CERT_REQ(self):
@@ -549,16 +551,16 @@ class TLSClientAutomaton(Automaton):
         txt = self.data or "GET /\r\n\r\n"  # GET HTTP/1.1\r\n\r\n"
         p = TLS(type=23, tls_session=self.cur_session, msg=[Raw(load=txt)])
         self.socket.send(str(p))
-        print "Sent to server: \n%r" % txt
+        print("Sent to server: \n%r" % txt)
 
         self.get_next_msg(1, 0)
         if self.msg_list:
             p = self.msg_list[0]
             self.msg_list = self.msg_list[1:]
             if isinstance(p, Raw):
-                print "Received from server: \n%s" % p.load
+                print("Received from server: \n%s" % p.load)
             else:
-                print "Received from server: \n%s" % p
+                print("Received from server: \n%s" % p)
 
     @ATMT.state()
     def TESTED_CONNECTION(self):
@@ -581,7 +583,7 @@ class TLSClientAutomaton(Automaton):
         try:
             self.socket.send(str(self.cur_pkt))
         except:
-            print "Could not send termination Alert (maybe the server stopped)"
+            print("Could not send termination Alert (maybe the server stopped)")
         self.cur_pkt = None
 
     @ATMT.state()
@@ -731,8 +733,8 @@ class TLSServerAutomaton(Automaton):
             s.bind((self.local_ip, self.local_port))
             s.listen(1)
         except:
-            print "Unable to bind on address %s and port %d" % (self.local_ip,
-                                                                self.local_port)
+            print("Unable to bind on address %s and port %d" % (self.local_ip,
+                                                                self.local_port))
             return
         self.socket, addr = s.accept()
         if not isinstance(addr, tuple):
@@ -789,7 +791,7 @@ class TLSServerAutomaton(Automaton):
         """
         If there is no available cipher suite, close the session with an Alert.
         """
-        print "No usable cipher suite, closing connection"
+        print("No usable cipher suite, closing connection")
         self.cur_pkt = TLS(type=21, msg=[], tls_session=self.cur_session)
         p = TLSAlert(level=1, descr=0)
         self.cur_pkt.msg.append(p)
@@ -802,7 +804,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state(final=True)
     def MISSING_CH(self):
-        print "Missing TLS Client Hello message"
+        print("Missing TLS Client Hello message")
 
     @ATMT.condition(HANDLE_CH, prio=2)
     def should_REPLY_TO_CH(self):
@@ -837,8 +839,8 @@ class TLSServerAutomaton(Automaton):
         self.cur_session.tls_version = self.cur_pkt.version
         #XXX there should be some checks on this version from the ClientHello
         v = self.cur_session.tls_version
-        print "\nVersion: " + _tls_version[v]
-        print "Cipher suite: " + _tls_cipher_suites[c]
+        print("\nVersion: " + _tls_version[v])
+        print("Cipher suite: " + _tls_cipher_suites[c])
 
         self.cur_pkt = TLS(tls_session=self.cur_session, msg=[])
 
@@ -889,7 +891,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_ALERT_INSTEAD_OF_CKE(self):
-        print "Received Alert message instead of CKE"
+        print("Received Alert message instead of CKE")
 
     @ATMT.condition(SENT_SH, prio=3)
     def should_HANDLE_MISSING_CKE(self):
@@ -897,7 +899,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_MISSING_CKE(self):
-        print "Missing CKE in client's reply"
+        print("Missing CKE in client's reply")
 
 
     @ATMT.condition(HANDLE_CKE, prio=1)
@@ -927,7 +929,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_ALERT_INSTEAD_OF_CCS(self):
-        print "Received Alert message instead of CCS"
+        print("Received Alert message instead of CCS")
 
     @ATMT.condition(HANDLE_CKE, prio=3)
     def should_HANDLE_MISSING_CCS(self):
@@ -935,7 +937,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_MISSING_CCS(self):
-        print "Missing CCS in client's reply"
+        print("Missing CCS in client's reply")
 
     @ATMT.condition(HANDLE_CCS, prio=1)
     def should_HANDLE_Finished(self):
@@ -963,7 +965,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_ALERT_INSTEAD_OF_FINISHED(self):
-        print "Received Alert message instead of Finished"
+        print("Received Alert message instead of Finished")
 
     @ATMT.condition(HANDLE_CCS, prio=3)
     def should_HANDLE_MISSING_FINISHED(self):
@@ -971,7 +973,7 @@ class TLSServerAutomaton(Automaton):
 
     @ATMT.state()
     def HANDLE_MISSING_FINISHED(self):
-        print "Missing Finished in client's reply"
+        print("Missing Finished in client's reply")
 
     @ATMT.condition(HANDLE_FINISHED, prio=1)
     def should_SEND_CCS(self):
@@ -1002,7 +1004,7 @@ class TLSServerAutomaton(Automaton):
         self.get_next_msg()
         if self.msg_list:
             return
-        print "Client left. Closing connection..."
+        print("Client left. Closing connection...")
         raise self.FINAL()
 
     @ATMT.condition(FINISHED_SENT, prio=1)
@@ -1017,8 +1019,8 @@ class TLSServerAutomaton(Automaton):
     def HANDLE_ALERT_FROM_FINISHED_SENT(self):
         self.cur_pkt = self.msg_list[0]
         self.msg_list = self.msg_list[1:]
-        print "Received Alert Message after sending Finished"
-        print "Closing connection"
+        print("Received Alert Message after sending Finished")
+        print("Closing connection")
         #XXX no support for new connections, for now
         raise self.FINAL()
 
@@ -1048,7 +1050,7 @@ class TLSServerAutomaton(Automaton):
         self.msg_list = self.msg_list[1:]
 
         recv_data = self.cur_pkt.data
-        print "Received %s" % repr(recv_data)
+        print("Received %s" % repr(recv_data))
 
         if recv_data.startswith("GET / HTTP/1."):
             header  = "HTTP/1.1 200 OK\r\n"

--- a/scapy/layers/tls/automaton.py
+++ b/scapy/layers/tls/automaton.py
@@ -24,8 +24,7 @@ t = TLSClientAutomaton(dport=50000, client_hello=ch)
 t.run()
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import socket
 import struct
 

--- a/scapy/layers/tls/basefields.py
+++ b/scapy/layers/tls/basefields.py
@@ -8,6 +8,7 @@ TLS base fields, used for record parsing/building. As several operations depend
 upon the TLS version or ciphersuite, the packet has to provide a TLS context.
 """
 
+from __future__ import absolute_import
 from scapy.fields import *
 
 

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -24,8 +24,7 @@ For instance, here is what you could do in order to modify the serial of
 No need for obnoxious openssl tweaking anymore. :)
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import base64
 import os
 import time

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -24,11 +24,16 @@ For instance, here is what you could do in order to modify the serial of
 No need for obnoxious openssl tweaking anymore. :)
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import base64
 import os
 import time
 
 from scapy.config import conf, crypto_validator
+from six.moves import map
+import six
+from six.moves import range
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
@@ -229,12 +234,11 @@ class _PubKeyFactory(_PKIObjMaker):
         return obj
 
 
-class PubKey(object):
+class PubKey(six.with_metaclass(_PubKeyFactory, object)):
     """
     Parent class for both PubKeyRSA and PubKeyECDSA.
     Provides a common verifyCert() method.
     """
-    __metaclass__ = _PubKeyFactory
 
     def verifyCert(self, cert):
         """ Verifies either a Cert or an X509_Cert. """
@@ -396,12 +400,11 @@ class _PrivKeyFactory(_PKIObjMaker):
         return obj
 
 
-class PrivKey(object):
+class PrivKey(six.with_metaclass(_PrivKeyFactory, object)):
     """
     Parent class for both PrivKeyRSA and PrivKeyECDSA.
     Provides common signTBSCert() and resignCert() methods.
     """
-    __metaclass__ = _PrivKeyFactory
 
     def signTBSCert(self, tbsCert, h=None):
         """
@@ -554,12 +557,11 @@ class _CertMaker(_PKIObjMaker):
         return obj
 
 
-class Cert(object):
+class Cert(six.with_metaclass(_CertMaker, object)):
     """
     Wrapper for the X509_Cert from layers/x509.py.
     Use the 'x509Cert' attribute to access original object.
     """
-    __metaclass__ = _CertMaker
 
     def import_from_asn1pkt(self, cert):
         error_msg = "Unable to import certificate"
@@ -706,11 +708,9 @@ class Cert(object):
             if (self.authorityKeyID is not None and
                 c.authorityKeyID is not None and
                 self.authorityKeyID == c.authorityKeyID):
-                return self.serial in map(lambda x: x[0],
-                                                    c.revoked_cert_serials)
+                return self.serial in [x[0] for x in c.revoked_cert_serials]
             elif self.issuer == c.issuer:
-                return self.serial in map(lambda x: x[0],
-                                                    c.revoked_cert_serials)
+                return self.serial in [x[0] for x in c.revoked_cert_serials]
         return False
 
     def export(self, filename, fmt="DER"):
@@ -725,10 +725,10 @@ class Cert(object):
         f.close()
 
     def show(self):
-        print "Serial: %s" % self.serial
-        print "Issuer: " + self.issuer_str
-        print "Subject: " + self.subject_str
-        print "Validity: %s to %s" % (self.notBefore_str, self.notAfter_str)
+        print("Serial: %s" % self.serial)
+        print("Issuer: " + self.issuer_str)
+        print("Subject: " + self.subject_str)
+        print("Validity: %s to %s" % (self.notBefore_str, self.notAfter_str))
 
     def __repr__(self):
         return "[X.509 Cert. Subject:%s, Issuer:%s]" % (self.subject_str, self.issuer_str)
@@ -754,12 +754,11 @@ class _CRLMaker(_PKIObjMaker):
         return obj
 
 
-class CRL(object):
+class CRL(six.with_metaclass(_CRLMaker, object)):
     """
     Wrapper for the X509_CRL from layers/x509.py.
     Use the 'x509CRL' attribute to access original object.
     """
-    __metaclass__ = _CRLMaker
 
     def import_from_asn1pkt(self, crl):
         error_msg = "Unable to import CRL"
@@ -837,11 +836,11 @@ class CRL(object):
         return False
 
     def show(self):
-        print "Version: %d" % self.version
-        print "sigAlg: " + self.sigAlg
-        print "Issuer: " + self.issuer_str
-        print "lastUpdate: %s" % self.lastUpdate_str
-        print "nextUpdate: %s" % self.nextUpdate_str
+        print("Version: %d" % self.version)
+        print("sigAlg: " + self.sigAlg)
+        print("Issuer: " + self.issuer_str)
+        print("lastUpdate: %s" % self.lastUpdate_str)
+        print("nextUpdate: %s" % self.nextUpdate_str)
 
 
 ######################

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -31,9 +31,8 @@ import os
 import time
 
 from scapy.config import conf, crypto_validator
-from six.moves import map
-import six
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization

--- a/scapy/layers/tls/crypto/all.py
+++ b/scapy/layers/tls/crypto/all.py
@@ -9,6 +9,7 @@ Aggregate some TLS crypto objects.
 
 # XXX This line should be removed once standard FFDH groups have been
 # registered in the cryptography library.
+from __future__ import absolute_import
 from scapy.layers.tls.crypto.ffdh import *
 
 from scapy.layers.tls.crypto.suites import *

--- a/scapy/layers/tls/crypto/cipher_aead.py
+++ b/scapy/layers/tls/crypto/cipher_aead.py
@@ -23,7 +23,7 @@ from cryptography.exceptions import InvalidTag
 
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 from scapy.layers.tls.crypto.ciphers import CipherError
-import six
+import scapy.modules.six as six
 
 
 tls_aead_cipher_algs = {}

--- a/scapy/layers/tls/crypto/cipher_aead.py
+++ b/scapy/layers/tls/crypto/cipher_aead.py
@@ -14,6 +14,7 @@ For now the cryptography library only supports GCM mode.
 Their interface might (and should) be changed in the future.
 """
 
+from __future__ import absolute_import
 import struct
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -22,6 +23,7 @@ from cryptography.exceptions import InvalidTag
 
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 from scapy.layers.tls.crypto.ciphers import CipherError
+import six
 
 
 tls_aead_cipher_algs = {}
@@ -48,8 +50,7 @@ class AEADTagError(Exception):
     """
     pass
 
-class _AEADCipher(object):
-    __metaclass__ = _AEADCipherMetaclass
+class _AEADCipher(six.with_metaclass(_AEADCipherMetaclass, object)):
     type = "aead"
 
     def __init__(self, key=None, salt=None, nonce_explicit=None):
@@ -115,8 +116,8 @@ class _AEADCipher(object):
 
         Note that the cipher's authentication tag must be None when encrypting.
         """
-        if False in self.ready.itervalues():
-            raise CipherError, (P, A)
+        if False in six.itervalues(self.ready):
+            raise CipherError(P, A)
         self._cipher.mode._tag = None
         encryptor = self._cipher.encryptor()
         encryptor.authenticate_additional_data(A)
@@ -147,8 +148,8 @@ class _AEADCipher(object):
                                       C[self.nonce_explicit_len:-self.tag_len],
                                       C[-self.tag_len:])
 
-        if False in self.ready.itervalues():
-            raise CipherError, (nonce_explicit_str, C, mac)
+        if False in six.itervalues(self.ready):
+            raise CipherError(nonce_explicit_str, C, mac)
 
         self.nonce_explicit = pkcs_os2ip(nonce_explicit_str)
         self._cipher.mode._tag = mac
@@ -162,7 +163,7 @@ class _AEADCipher(object):
         try:
             decryptor.finalize()
         except InvalidTag:
-            raise AEADTagError, (nonce_explicit_str, P, mac)
+            raise AEADTagError(nonce_explicit_str, P, mac)
         return nonce_explicit_str, P, mac
 
 

--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -7,11 +7,13 @@
 Block ciphers.
 """
 
+from __future__ import absolute_import
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 
 from scapy.utils import strxor
 from scapy.layers.tls.crypto.ciphers import CipherError
+import six
 
 
 tls_block_cipher_algs = {}
@@ -31,8 +33,7 @@ class _BlockCipherMetaclass(type):
         return the_class
 
 
-class _BlockCipher(object):
-    __metaclass__ = _BlockCipherMetaclass
+class _BlockCipher(six.with_metaclass(_BlockCipherMetaclass, object)):
     type = "block"
 
     def __init__(self, key=None, iv=None):
@@ -73,8 +74,8 @@ class _BlockCipher(object):
         Encrypt the data. Also, update the cipher iv. This is needed for SSLv3
         and TLS 1.0. For TLS 1.1/1.2, it is overwritten in TLS.post_build().
         """
-        if False in self.ready.itervalues():
-            raise CipherError, data
+        if False in six.itervalues(self.ready):
+            raise CipherError(data)
         encryptor = self._cipher.encryptor()
         tmp = encryptor.update(data) + encryptor.finalize()
         self.iv = tmp[-self.block_size:]
@@ -86,8 +87,8 @@ class _BlockCipher(object):
         and TLS 1.0. For TLS 1.1/1.2, it is overwritten in TLS.pre_dissect().
         If we lack the key, we raise a CipherError which contains the input.
         """
-        if False in self.ready.itervalues():
-            raise CipherError, data
+        if False in six.itervalues(self.ready):
+            raise CipherError(data)
         decryptor = self._cipher.decryptor()
         tmp = decryptor.update(data) + decryptor.finalize()
         self.iv = data[-self.block_size:]

--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.backends import default_backend
 
 from scapy.utils import strxor
 from scapy.layers.tls.crypto.ciphers import CipherError
-import six
+import scapy.modules.six as six
 
 
 tls_block_cipher_algs = {}

--- a/scapy/layers/tls/crypto/cipher_stream.py
+++ b/scapy/layers/tls/crypto/cipher_stream.py
@@ -7,10 +7,12 @@
 Stream ciphers.
 """
 
+from __future__ import absolute_import
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
 
 from scapy.layers.tls.crypto.ciphers import CipherError
+import six
 
 
 tls_stream_cipher_algs = {}
@@ -30,8 +32,7 @@ class _StreamCipherMetaclass(type):
         return the_class
 
 
-class _StreamCipher(object):
-    __metaclass__ = _StreamCipherMetaclass
+class _StreamCipher(six.with_metaclass(_StreamCipherMetaclass, object)):
     type = "stream"
 
     def __init__(self, key=None):
@@ -65,13 +66,13 @@ class _StreamCipher(object):
         super(_StreamCipher, self).__setattr__(name, val)
 
     def encrypt(self, data):
-        if False in self.ready.itervalues():
-            raise CipherError, data
+        if False in six.itervalues(self.ready):
+            raise CipherError(data)
         return self.encryptor.update(data)
 
     def decrypt(self, data):
-        if False in self.ready.itervalues():
-            raise CipherError, data
+        if False in six.itervalues(self.ready):
+            raise CipherError(data)
         return self.decryptor.update(data)
 
 

--- a/scapy/layers/tls/crypto/cipher_stream.py
+++ b/scapy/layers/tls/crypto/cipher_stream.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
 
 from scapy.layers.tls.crypto.ciphers import CipherError
-import six
+import scapy.modules.six as six
 
 
 tls_stream_cipher_algs = {}

--- a/scapy/layers/tls/crypto/ciphers.py
+++ b/scapy/layers/tls/crypto/ciphers.py
@@ -8,6 +8,7 @@
 TLS ciphers.
 """
 
+from __future__ import absolute_import
 class CipherError(Exception):
     """
     Raised when .decrypt() or .auth_decrypt() fails.

--- a/scapy/layers/tls/crypto/compression.py
+++ b/scapy/layers/tls/crypto/compression.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import zlib
 
 from scapy.error import warning
-import six
+import scapy.modules.six as six
 
 
 _tls_compression_algs = {}

--- a/scapy/layers/tls/crypto/compression.py
+++ b/scapy/layers/tls/crypto/compression.py
@@ -7,9 +7,11 @@
 TLS compression.
 """
 
+from __future__ import absolute_import
 import zlib
 
 from scapy.error import warning
+import six
 
 
 _tls_compression_algs = {}
@@ -30,8 +32,8 @@ class _GenericCompMetaclass(type):
         return the_class
 
 
-class _GenericComp(object):
-    __metaclass__ = _GenericCompMetaclass
+class _GenericComp(six.with_metaclass(_GenericCompMetaclass, object)):
+    pass
 
 
 class Comp_NULL(_GenericComp):

--- a/scapy/layers/tls/crypto/ffdh.py
+++ b/scapy/layers/tls/crypto/ffdh.py
@@ -9,6 +9,7 @@ XXX These groups (and the ones from RFC 7919) should be registered to
 the cryptography library. And this file should eventually be removed.
 """
 
+from __future__ import absolute_import
 from scapy.config import conf
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
@@ -17,6 +18,7 @@ else:
     default_backend = dh = None
 
 from scapy.utils import long_converter
+import six
 
 
 class modp768: # From RFC 4306
@@ -207,7 +209,7 @@ _ffdh_raw_params = { 'modp768' : modp768,
 
 FFDH_GROUPS = {}
 if dh and default_backend:
-    for name, group in _ffdh_raw_params.iteritems():
+    for name, group in six.iteritems(_ffdh_raw_params):
         pn = dh.DHParameterNumbers(group.m, group.g)
         params = pn.parameters(default_backend())
         FFDH_GROUPS[name] = [params, group.mLen]

--- a/scapy/layers/tls/crypto/ffdh.py
+++ b/scapy/layers/tls/crypto/ffdh.py
@@ -18,7 +18,7 @@ else:
     default_backend = dh = None
 
 from scapy.utils import long_converter
-import six
+import scapy.modules.six as six
 
 
 class modp768: # From RFC 4306

--- a/scapy/layers/tls/crypto/h_mac.py
+++ b/scapy/layers/tls/crypto/h_mac.py
@@ -7,9 +7,11 @@
 HMAC classes.
 """
 
+from __future__ import absolute_import
 import hmac
 
 from scapy.layers.tls.crypto.hash import tls_hash_algs
+import six
 
 
 SSLv3_PAD1_MD5  = b"\x36"*48
@@ -48,9 +50,7 @@ class HMACError(Exception):
     """
     pass
 
-class _GenericHMAC(object):
-    __metaclass__ = _GenericHMACMetaclass
-
+class _GenericHMAC(six.with_metaclass(_GenericHMACMetaclass, object)):
     def __init__(self, key=None):
         self.key = key
 

--- a/scapy/layers/tls/crypto/h_mac.py
+++ b/scapy/layers/tls/crypto/h_mac.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import hmac
 
 from scapy.layers.tls.crypto.hash import tls_hash_algs
-import six
+import scapy.modules.six as six
 
 
 SSLv3_PAD1_MD5  = b"\x36"*48

--- a/scapy/layers/tls/crypto/hash.py
+++ b/scapy/layers/tls/crypto/hash.py
@@ -7,7 +7,9 @@
 Hash classes.
 """
 
+from __future__ import absolute_import
 from hashlib import md5, sha1, sha224, sha256, sha384, sha512
+import six
 
 
 tls_hash_algs = {}
@@ -27,9 +29,7 @@ class _GenericHashMetaclass(type):
         return the_class
 
 
-class _GenericHash(object):
-    __metaclass__ = _GenericHashMetaclass
-
+class _GenericHash(six.with_metaclass(_GenericHashMetaclass, object)):
     def digest(self, tbd):
         return self.hash_cls(tbd).digest()
 

--- a/scapy/layers/tls/crypto/hash.py
+++ b/scapy/layers/tls/crypto/hash.py
@@ -9,7 +9,7 @@ Hash classes.
 
 from __future__ import absolute_import
 from hashlib import md5, sha1, sha224, sha256, sha384, sha512
-import six
+import scapy.modules.six as six
 
 
 tls_hash_algs = {}

--- a/scapy/layers/tls/crypto/kx_algs.py
+++ b/scapy/layers/tls/crypto/kx_algs.py
@@ -16,7 +16,7 @@ from scapy.layers.tls.keyexchange import (ServerDHParams,
                                           ClientECDiffieHellmanPublic,
                                           _tls_server_ecdh_cls_guess,
                                           EncryptedPreMasterSecret)
-import six
+import scapy.modules.six as six
 
 
 tls_kx_algs = {}

--- a/scapy/layers/tls/crypto/kx_algs.py
+++ b/scapy/layers/tls/crypto/kx_algs.py
@@ -9,12 +9,14 @@ Key Exchange algorithms as listed in appendix C of RFC 4346.
 XXX Incomplete support for static DH, DSS, PSK, SRP, KRB and anonymous kx.
 """
 
+from __future__ import absolute_import
 from scapy.layers.tls.keyexchange import (ServerDHParams,
                                           ServerRSAParams,
                                           ClientDiffieHellmanPublic,
                                           ClientECDiffieHellmanPublic,
                                           _tls_server_ecdh_cls_guess,
                                           EncryptedPreMasterSecret)
+import six
 
 
 tls_kx_algs = {}
@@ -38,8 +40,8 @@ class _GenericKXMetaclass(type):
         return the_class
 
 
-class _GenericKX:
-    __metaclass__ = _GenericKXMetaclass
+class _GenericKX(six.with_metaclass(_GenericKXMetaclass)):
+    pass
 
 
 class KX_NULL(_GenericKX):

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -16,7 +16,7 @@ import os, popen2, tempfile
 import math, random, struct
 
 from scapy.config import conf, crypto_validator
-from six.moves import range
+from scapy.modules.six.moves import range
 from functools import reduce
 if conf.crypto_valid:
     from cryptography.exceptions import InvalidSignature

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -350,9 +350,11 @@ class _EncryptAndVerifyRSA(object):
         """
 
         n = self._modulus
+        # FIXME: long will not be supported anymore on Python 3 but
+        # removing it makes Python 2 crash
         if isinstance(m, int):
-            m = int(m)
-        if (not isinstance(m, int)) or m > n-1:
+            m = long(m)
+        if (not isinstance(m, long)) or m > n-1:
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
 
@@ -589,9 +591,11 @@ class _DecryptAndSignRSA(object):
         """
 
         n = self._modulus
+        # FIXME: long will not be supported anymore on Python 3 but
+        # removing it makes Python 2 crash
         if isinstance(c, int):
-            c = int(c)
-        if (not isinstance(c, int)) or c > n-1:
+            c = long(c)
+        if (not isinstance(c, long)) or c > n-1:
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
 

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -11,10 +11,13 @@ support our "tls" hash used with TLS 1.0. Once it is added to (or from) the
 library, most of the present module should be removed.
 """
 
+from __future__ import absolute_import
 import os, popen2, tempfile
 import math, random, struct
 
 from scapy.config import conf, crypto_validator
+from six.moves import range
+from functools import reduce
 if conf.crypto_valid:
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
@@ -163,7 +166,7 @@ def pkcs_mgf1(mgfSeed, maskLen, h):
     """
 
     # steps are those of Appendix B.2.1
-    if not _hashFuncParams.has_key(h):
+    if h not in _hashFuncParams:
         warning("pkcs_mgf1: invalid hash (%s) provided" % h)
         return None
     hLen = _hashFuncParams[h][0]
@@ -196,7 +199,7 @@ def pkcs_emsa_pss_encode(M, emBits, h, mgf, sLen):
        sLen  : intended length in octets of the salt
 
     Output:
-       encoded message, an octet string of length emLen = ceil(emBits/8)
+       encoded message, an octet string of length emLen = ceil(emBits//8)
 
     On error, None is returned.
     """
@@ -216,11 +219,11 @@ def pkcs_emsa_pss_encode(M, emBits, h, mgf, sLen):
     DB = PS + b'\x01' + salt                                  # 8)
     dbMask = mgf(H, emLen - hLen - 1)                        # 9)
     maskedDB = strxor(DB, dbMask)                            # 10)
-    l = (8*emLen - emBits)/8                                 # 11)
+    l = (8*emLen - emBits)//8                                 # 11)
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\x00'
     if rem:
-        j = chr(reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem))))
+        j = chr(reduce(lambda x,y: x+y, [1<<x for x in range(8-rem)]))
         andMask += j
         l += 1
     maskedDB = strand(maskedDB[:l], andMask) + maskedDB[l:]
@@ -258,11 +261,11 @@ def pkcs_emsa_pss_verify(M, EM, emBits, h, mgf, sLen):
     l = emLen - hLen - 1                                     # 5)
     maskedDB = EM[:l]
     H = EM[l:l+hLen]
-    l = (8*emLen - emBits)/8                                 # 6)
+    l = (8*emLen - emBits)//8                                 # 6)
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\xff'
     if rem:
-        val = reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem)))
+        val = reduce(lambda x,y: x+y, [1<<x for x in range(8-rem)])
         j = chr(~val & 0xff)
         andMask += j
         l += 1
@@ -270,11 +273,11 @@ def pkcs_emsa_pss_verify(M, EM, emBits, h, mgf, sLen):
         return False
     dbMask = mgf(H, emLen - hLen - 1)                        # 7)
     DB = strxor(maskedDB, dbMask)                            # 8)
-    l = (8*emLen - emBits)/8                                 # 9)
+    l = (8*emLen - emBits)//8                                 # 9)
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\x00'
     if rem:
-        j = chr(reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem))))
+        j = chr(reduce(lambda x,y: x+y, [1<<x for x in range(8-rem)]))
         andMask += j
         l += 1
     DB = strand(DB[:l], andMask) + DB[l:]
@@ -348,8 +351,8 @@ class _EncryptAndVerifyRSA(object):
 
         n = self._modulus
         if isinstance(m, int):
-            m = long(m)
-        if (not isinstance(m, long)) or m > n-1:
+            m = int(m)
+        if (not isinstance(m, int)) or m > n-1:
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
 
@@ -415,7 +418,7 @@ class _EncryptAndVerifyRSA(object):
         # Set default parameters if not provided
         if h is None: # By default, sha1
             h = "sha1"
-        if not _hashFuncParams.has_key(h):
+        if h not in _hashFuncParams:
             warning("Key._rsassa_pss_verify(): unknown hash function "
                     "provided (%s)" % h)
             return False
@@ -427,7 +430,7 @@ class _EncryptAndVerifyRSA(object):
 
         # 1) Length checking
         modBits = self._modulusLen
-        k = modBits / 8
+        k = modBits // 8
         if len(S) != k:
             return False
 
@@ -460,7 +463,7 @@ class _EncryptAndVerifyRSA(object):
         """
 
         # 1) Length checking
-        k = self._modulusLen / 8
+        k = self._modulusLen // 8
         if len(S) != k:
             warning("invalid signature (len(S) != k)")
             return False
@@ -587,8 +590,8 @@ class _DecryptAndSignRSA(object):
 
         n = self._modulus
         if isinstance(c, int):
-            c = long(c)
-        if (not isinstance(c, long)) or c > n-1:
+            c = int(c)
+        if (not isinstance(c, int)) or c > n-1:
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
 
@@ -657,7 +660,7 @@ class _DecryptAndSignRSA(object):
         # Set default parameters if not provided
         if h is None: # By default, sha1
             h = "sha1"
-        if not _hashFuncParams.has_key(h):
+        if h not in _hashFuncParams:
             warning("Key._rsassa_pss_sign(): unknown hash function "
                     "provided (%s)" % h)
             return None
@@ -669,7 +672,7 @@ class _DecryptAndSignRSA(object):
 
         # 1) EMSA-PSS encoding
         modBits = self._modulusLen
-        k = modBits / 8
+        k = modBits // 8
         EM = pkcs_emsa_pss_encode(M, modBits - 1, h, mgf, sLen)
         if EM is None:
             warning("Key._rsassa_pss_sign(): unable to encode")
@@ -698,7 +701,7 @@ class _DecryptAndSignRSA(object):
         """
 
         # 1) EMSA-PKCS1-v1_5 encoding
-        k = self._modulusLen / 8
+        k = self._modulusLen // 8
         EM = pkcs_emsa_pkcs1_v1_5_encode(M, k, h)
         if EM is None:
             warning("Key._rsassa_pkcs1_v1_5_sign(): unable to encode")
@@ -745,6 +748,7 @@ class _DecryptAndSignRSA(object):
                   default value (the byte length of the hash value for provided
                   algorithm) by providing another one with that parameter.
         """
+
         if t is None: # RSASP1
             M = pkcs_os2ip(M)
             n = self._modulus
@@ -754,7 +758,7 @@ class _DecryptAndSignRSA(object):
             s = self._rsasp1(M)
             if s is None:
                 return None
-            return pkcs_i2osp(s, self._modulusLen/8)
+            return pkcs_i2osp(s, self._modulusLen//8)
         elif t == "pkcs": # RSASSA-PKCS1-v1_5-SIGN
             if h is None:
                 h = "sha1"

--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -7,11 +7,13 @@
 TLS Pseudorandom Function.
 """
 
+from __future__ import absolute_import
 from scapy.error import warning
 from scapy.utils import strxor
 
 from scapy.layers.tls.crypto.hash import tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import tls_hmac_algs
+from six.moves import range
 
 
 ### Data expansion functions

--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -13,7 +13,7 @@ from scapy.utils import strxor
 
 from scapy.layers.tls.crypto.hash import tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import tls_hmac_algs
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 ### Data expansion functions

--- a/scapy/layers/tls/crypto/suites.py
+++ b/scapy/layers/tls/crypto/suites.py
@@ -15,7 +15,7 @@ from scapy.layers.tls.crypto.kx_algs import tls_kx_algs
 from scapy.layers.tls.crypto.hash import tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import tls_hmac_algs
 from scapy.layers.tls.crypto.ciphers import tls_cipher_algs
-import six
+import scapy.modules.six as six
 
 
 def get_algs_from_ciphersuite_name(ciphersuite_name):

--- a/scapy/layers/tls/crypto/suites.py
+++ b/scapy/layers/tls/crypto/suites.py
@@ -10,10 +10,12 @@ A comprehensive list of specified cipher suites can be consulted at:
 https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
 """
 
+from __future__ import absolute_import
 from scapy.layers.tls.crypto.kx_algs import tls_kx_algs
 from scapy.layers.tls.crypto.hash import tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import tls_hmac_algs
 from scapy.layers.tls.crypto.ciphers import tls_cipher_algs
+import six
 
 
 def get_algs_from_ciphersuite_name(ciphersuite_name):
@@ -108,9 +110,7 @@ class _GenericCipherSuiteMetaclass(type):
         return the_class
 
 
-class _GenericCipherSuite(object):
-    __metaclass__ = _GenericCipherSuiteMetaclass
-
+class _GenericCipherSuite(six.with_metaclass(_GenericCipherSuiteMetaclass, object)):
     def __init__(self, tls_version=0x0303):
         """
         Most of the attributes are fixed and have already been set by the
@@ -960,7 +960,7 @@ def get_usable_ciphersuites(l, kx):
     """
     res = []
     for c in l:
-        if _tls_cipher_suites_cls.has_key(c):
+        if c in _tls_cipher_suites_cls:
             ciph = _tls_cipher_suites_cls[c]
             if ciph.usable:
                 #XXX select among RSA and ECDSA cipher suites

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -38,7 +38,7 @@ from scapy.layers.tls.crypto.suites import (_tls_cipher_suites,
                                             _GenericCipherSuite,
                                             _GenericCipherSuiteMetaclass,
                                             TLS_DHE_RSA_WITH_AES_128_CBC_SHA)
-from six.moves import map
+from scapy.modules.six.moves import map
 
 
 ###############################################################################

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -10,6 +10,8 @@ This module covers the handshake TLS subprotocol, except for the key exchange
 mechanisms which are addressed with keyexchange.py.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import math
 
 from scapy.error import warning
@@ -36,6 +38,7 @@ from scapy.layers.tls.crypto.suites import (_tls_cipher_suites,
                                             _GenericCipherSuite,
                                             _GenericCipherSuiteMetaclass,
                                             TLS_DHE_RSA_WITH_AES_128_CBC_SHA)
+from six.moves import map
 
 
 ###############################################################################
@@ -146,7 +149,7 @@ class _CipherSuitesField(StrLenField):
         self.itemsize = struct.calcsize(itemfmt)
         i2s = self.i2s = {}
         s2i = self.s2i = {}
-        keys = dico.keys()
+        keys = list(dico.keys())
         for k in keys:
             i2s[k] = dico[k]
             s2i[dico[k]] = k
@@ -166,12 +169,12 @@ class _CipherSuitesField(StrLenField):
     def any2i(self, pkt, x):
         if type(x) is not list:
             x = [x]
-        return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
+        return list(map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x))
 
     def i2repr(self, pkt, x):
         if x is None:
             return "None"
-        l = map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x)
+        l = list(map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x))
         if len(l) == 1:
             l = l[0]
         else:
@@ -181,7 +184,7 @@ class _CipherSuitesField(StrLenField):
     def i2m(self, pkt, val):
         if val is None:
             val = []
-        return "".join(map(lambda x: struct.pack(self.itemfmt, x), val))
+        return "".join([struct.pack(self.itemfmt, x) for x in val])
 
     def m2i(self, pkt, m):
         res = []
@@ -292,7 +295,7 @@ class TLS_Ext_PrettyPacketList(TLS_Ext_Unknown):
                                 label_lvl=label_lvl, first_call=False)
 
         if first_call and not dump:
-            print s
+            print(s)
         else:
             return s
 
@@ -390,7 +393,7 @@ class _TAListField(PacketListField):
     def m2i(self, pkt, m):
         idtype = ord(m[0])
         cls = self.cls
-        if _tls_trusted_authority_cls.has_key(idtype):
+        if idtype in _tls_trusted_authority_cls:
             cls = _tls_trusted_authority_cls[idtype]
         return cls(m)
 
@@ -437,7 +440,7 @@ class _StatusReqField(PacketListField):
     def m2i(self, pkt, m):
         idtype = pkt.stype
         cls = self.cls
-        if _cert_status_req_cls.has_key(idtype):
+        if idtype in _cert_status_req_cls:
             cls = _cert_status_req_cls[idtype]
         return cls(m)
 
@@ -870,7 +873,7 @@ class TLSServerHello(TLSClientHello):
 
         if self.cipher:
             cs_val = self.cipher
-            if not _tls_cipher_suites_cls.has_key(cs_val):
+            if cs_val not in _tls_cipher_suites_cls:
                 warning("Unknown cipher suite %d from ServerHello" % cs_val)
                 # we do not try to set a default nor stop the execution
             else:
@@ -878,7 +881,7 @@ class TLSServerHello(TLSClientHello):
 
         if self.comp:
             comp_val = self.comp[0]
-            if not _tls_compression_algs_cls.has_key(comp_val):
+            if comp_val not in _tls_compression_algs_cls:
                 err = "Unknown compression alg %d from ServerHello" % comp_val
                 warning(err)
                 comp_val = 0
@@ -970,7 +973,7 @@ class _ASN1CertListField(StrLenField):
             return i
         if isinstance(i, Cert):
             i = [i]
-        return "".join(map(lambda x: i2m_one(x), i))
+        return "".join([i2m_one(x) for x in i])
 
     def any2i(self, pkt, x):
         return x
@@ -990,9 +993,9 @@ class TLSCertificate(_TLSHandshake):
     def post_dissection_tls_session_update(self, msg_str):
         connection_end = self.tls_session.connection_end
         if connection_end == "client":
-            self.tls_session.server_certs = map(lambda x: x[1], self.certs)
+            self.tls_session.server_certs = [x[1] for x in self.certs]
         else:
-            self.tls_session.client_certs = map(lambda x: x[1], self.certs)
+            self.tls_session.client_certs = [x[1] for x in self.certs]
         self.tls_session.handshake_messages.append(msg_str)
         self.tls_session.handshake_messages_parsed.append(self)
 
@@ -1076,13 +1079,13 @@ class TLSServerKeyExchange(_TLSHandshake):
         """
         s = self.tls_session
         if s.prcs and s.prcs.key_exchange.anonymous:
-            print "USELESS SERVER KEY EXCHANGE"
+            print("USELESS SERVER KEY EXCHANGE")
         if (s.client_random and s.server_random and
             s.server_certs and len(s.server_certs) > 0):
             m = s.client_random + s.server_random + str(self.params)
             sig_test = self.sig._verify_sig(m, s.server_certs[0])
             if not sig_test:
-                print "INVALID SERVER KEY EXCHANGE SIGNATURE"
+                print("INVALID SERVER KEY EXCHANGE SIGNATURE")
 
 
 ###############################################################################
@@ -1127,7 +1130,7 @@ class _CertAuthoritiesField(StrLenField):
         return res
 
     def i2m(self, pkt, i):
-        return "".join(map(lambda (x,y): struct.pack("!H", x) + y, i))
+        return "".join([struct.pack("!H", x_y[0]) + x_y[1] for x_y in i])
 
     def addfield(self, pkt, s, val):
         return s + self.i2m(pkt, val)
@@ -1199,7 +1202,7 @@ class TLSCertificateVerify(_TLSHandshake):
         if s.client_certs and len(s.client_certs) > 0:
             sig_test = self.sig._verify_sig(m, s.client_certs[0])
             if not sig_test:
-                print "INVALID CERTIFICATE VERIFY SIGNATURE"
+                print("INVALID CERTIFICATE VERIFY SIGNATURE")
 
 
 ###############################################################################
@@ -1296,7 +1299,7 @@ class TLSFinished(_TLSHandshake):
             verify_data = s.rcs.prf.compute_verify_data(con_end, "read",
                                                         handshake_msg, ms)
             if self.vdata != verify_data:
-                print "INVALID TLS FINISHED RECEIVED"
+                print("INVALID TLS FINISHED RECEIVED")
 
 
 ## Additional handshake messages
@@ -1374,7 +1377,7 @@ class _StatusField(PacketField):
     def m2i(self, pkt, m):
         idtype = pkt.status_type
         cls = self.cls
-        if _cert_status_cls.has_key(idtype):
+        if idtype in _cert_status_cls:
             cls = _cert_status_cls[idtype]
         return cls(m)
 

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -23,7 +23,7 @@ from scapy.layers.tls.session import _GenericTLSSessionInheritance
 from scapy.layers.tls.basefields import _tls_version, _TLSClientVersionField
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 from scapy.layers.tls.crypto.ffdh import FFDH_GROUPS
-import six
+import scapy.modules.six as six
 
 
 ###############################################################################

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -7,6 +7,7 @@
 TLS key exchange logic.
 """
 
+from __future__ import absolute_import
 import math
 
 from cryptography.hazmat.backends import default_backend
@@ -22,6 +23,7 @@ from scapy.layers.tls.session import _GenericTLSSessionInheritance
 from scapy.layers.tls.basefields import _tls_version, _TLSClientVersionField
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 from scapy.layers.tls.crypto.ffdh import FFDH_GROUPS
+import six
 
 
 ###############################################################################
@@ -519,7 +521,7 @@ class ServerECDHNamedCurveParams(_GenericTLSSessionInheritance):
             s.server_kx_privkey = ec.generate_private_key(curve,
                                                           default_backend())
             curve_id = 0
-            for cid, name in _tls_named_curves.iteritems():
+            for cid, name in six.iteritems(_tls_named_curves):
                 if name == curve.name:
                     curve_id = cid
                     break

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -12,6 +12,8 @@ ApplicationData submessages. For the Handshake type, see tls_handshake.py.
 See the TLS class documentation for more information.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import struct
 
 from scapy.config import conf
@@ -250,7 +252,7 @@ class TLS(_GenericTLSSessionInheritance):
             self.decipherable = False
             return e.args
         except AEADTagError as e:
-            print "INTEGRITY CHECK FAILED"
+            print("INTEGRITY CHECK FAILED")
             return e.args
 
     def _tls_decrypt(self, s):
@@ -368,7 +370,7 @@ class TLS(_GenericTLSSessionInheritance):
             hdr = hdr[:3] + struct.pack('!H', len(cfrag))
             is_mac_ok = self._tls_hmac_verify(hdr, cfrag, mac)
             if not is_mac_ok:
-                print "INTEGRITY CHECK FAILED"
+                print("INTEGRITY CHECK FAILED")
 
         elif cipher_type == 'stream':
             # Decrypt
@@ -386,7 +388,7 @@ class TLS(_GenericTLSSessionInheritance):
             hdr = hdr[:3] + struct.pack('!H', len(cfrag))
             is_mac_ok = self._tls_hmac_verify(hdr, cfrag, mac)
             if not is_mac_ok:
-                print "INTEGRITY CHECK FAILED"
+                print("INTEGRITY CHECK FAILED")
 
         elif cipher_type == 'aead':
             # Authenticated encryption

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -12,8 +12,7 @@ ApplicationData submessages. For the Handshake type, see tls_handshake.py.
 See the TLS class documentation for more information.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import struct
 
 from scapy.config import conf

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -19,7 +19,7 @@ from scapy.packet import Packet
 from scapy.utils import repr_hex
 from scapy.layers.tls.crypto.compression import Comp_NULL
 from scapy.layers.tls.crypto.prf import PRF
-from six.moves import zip
+from scapy.modules.six.moves import zip
 
 # Note the following import may happen inside connState.__init__()
 # in order to avoid to avoid cyclical dependancies.

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -7,8 +7,7 @@
 TLS session handler.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import random
 import socket
 import struct
@@ -211,7 +210,7 @@ class connState(object):
         def indent(s):
             if s and s[-1] == '\n':
                 s = s[:-1]
-            s = '\n'.join(['\t'+x for x in s.split('\n')] + [''])
+            s = '\n'.join('\t'+x for x in s.split('\n'))
             return s
 
         res =  "Connection end : %s\n" % self.connection_end.upper()

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -7,6 +7,7 @@
 TLS helpers, provided as out-of-context methods.
 """
 
+from __future__ import absolute_import
 from scapy.error import warning
 from scapy.fields import (ByteEnumField, ShortEnumField,
                           FieldLenField, StrLenField)

--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -8,6 +8,7 @@
 VRRP (Virtual Router Redundancy Protocol).
 """
 
+from __future__ import absolute_import
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -7,6 +7,7 @@
 # VXLAN Group Policy Option:
 # http://tools.ietf.org/html/draft-smith-vxlan-group-policy-00
 
+from __future__ import absolute_import
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP, UDP

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -8,6 +8,7 @@
 X.509 certificates.
 """
 
+from __future__ import absolute_import
 from scapy.asn1.asn1 import *
 from scapy.asn1.ber import *
 from scapy.asn1packet import *
@@ -648,7 +649,7 @@ class ASN1F_EXT_SEQUENCE(ASN1F_SEQUENCE):
             if not self.flexible_tag and len(s) > 0:
                 err_msg = "extension sequence length issue"
                 raise BER_Decoding_Error(err_msg, remaining=s)
-        except ASN1F_badsequence,e:
+        except ASN1F_badsequence as e:
             raise Exception("could not parse extensions")
         return remain
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -14,12 +14,10 @@ import glob
 import types
 import gzip
 import importlib
-import six.moves.cPickle
-import six.moves.builtins
+import scapy
+import scapy.modules.six as six
 
 from scapy.error import *
-import six
-    
 
 def _probe_config_file(cf):
     cf_path = os.path.join(os.path.expanduser("~"), cf)
@@ -287,7 +285,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
             def global_matches(self, text):
                 matches = []
                 n = len(text)
-                for lst in [dir(__builtin__), session]:
+                for lst in [dir(six.moves.builtins), session]:
                     for word in lst:
                         if word[:n] == text and word != "__builtins__":
                             matches.append(word)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -7,14 +7,18 @@
 Main module for interactive startup.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os,sys
 import glob
 import types
 import gzip
-import cPickle
-import __builtin__
+import importlib
+import six.moves.cPickle
+import six.moves.builtins
 
 from scapy.error import *
+import six
     
 
 def _probe_config_file(cf):
@@ -29,21 +33,25 @@ def _probe_config_file(cf):
 def _read_config_file(cf):
     log_loading.debug("Loading config file [%s]" % cf)
     try:
-        execfile(cf)
-    except IOError,e:
+        exec(compile(open(cf).read(), cf, 'exec'))
+    except IOError as e:
         log_loading.warning("Cannot read config file [%s] [%s]" % (cf,e))
-    except Exception,e:
+    except Exception as e:
         log_loading.exception("Error during evaluation of config file [%s]" % cf)
         
+ignored = list(six.moves.builtins.__dict__.keys())
+def _validate_local(x):
+    global ignored
+    return x[0] != "_" and not x in ignored
 
 DEFAULT_PRESTART_FILE = _probe_config_file(".scapy_prestart.py")
 DEFAULT_STARTUP_FILE = _probe_config_file(".scapy_startup.py")
 session = None
 
 def _usage():
-    print """Usage: scapy.py [-s sessionfile] [-c new_startup_file] [-p new_prestart_file] [-C] [-P]
+    print("""Usage: scapy.py [-s sessionfile] [-c new_startup_file] [-p new_prestart_file] [-C] [-P]
     -C: do not read startup file
-    -P: do not read pre-startup file"""
+    -P: do not read pre-startup file""")
     sys.exit(0)
 
 
@@ -58,17 +66,17 @@ from scapy.themes import DefaultTheme
 
 def _load(module):
     try:
-        mod = __import__(module,globals(),locals(),".")
+        mod = importlib.import_module(module)
         if '__all__' in mod.__dict__:
             # import listed symbols
             for name in mod.__dict__['__all__']:
-                __builtin__.__dict__[name] = mod.__dict__[name]
+                six.moves.builtins.__dict__[name] = mod.__dict__[name]
         else:
             # only import non-private symbols
-            for name, sym in mod.__dict__.iteritems():
+            for name, sym in six.iteritems(mod.__dict__):
                 if name[0] != '_':
-                    __builtin__.__dict__[name] = sym
-    except Exception,e:
+                    six.moves.builtins.__dict__[name] = sym
+    except Exception as e:
         log_interactive.error(e)
 
 def load_module(name):
@@ -106,7 +114,7 @@ def list_contrib(name=None):
                 key = l[p:q].strip()
                 value = l[q+1:].strip()
                 desc[key] = value
-        print "%(name)-20s: %(description)-40s status=%(status)s" % desc
+        print("%(name)-20s: %(description)-40s status=%(status)s" % desc)
 
                         
 
@@ -126,15 +134,15 @@ def save_session(fname=None, session=None, pickleProto=-1):
             conf.session = fname = utils.get_temp_file(keep=True)
             log_interactive.info("Use [%s] as session file" % fname)
     if session is None:
-        session = __builtin__.__dict__["scapy_session"]
+        session = six.moves.builtins.__dict__["scapy_session"]
 
     to_be_saved = session.copy()
         
-    if to_be_saved.has_key("__builtins__"):
+    if "__builtins__" in to_be_saved:
         del(to_be_saved["__builtins__"])
 
     for k in to_be_saved.keys():
-        if type(to_be_saved[k]) in [types.TypeType, types.ClassType, types.ModuleType]:
+        if type(to_be_saved[k]) in [type, type, types.ModuleType]:
              log_interactive.error("[%s] (%s) can't be saved." % (k, type(to_be_saved[k])))
              del(to_be_saved[k])
 
@@ -145,7 +153,7 @@ def save_session(fname=None, session=None, pickleProto=-1):
          pass
     
     f=gzip.open(fname,"wb")
-    cPickle.dump(to_be_saved, f, pickleProto)
+    six.moves.cPickle.dump(to_be_saved, f, pickleProto)
     f.close()
     del f
 
@@ -153,15 +161,15 @@ def load_session(fname=None):
     if fname is None:
         fname = conf.session
     try:
-        s = cPickle.load(gzip.open(fname,"rb"))
+        s = six.moves.cPickle.load(gzip.open(fname,"rb"))
     except IOError:
         try:
-            s = cPickle.load(open(fname,"rb"))
+            s = six.moves.cPickle.load(open(fname,"rb"))
         except IOError:
             # Raise "No such file exception"
             raise
 
-    scapy_session = __builtin__.__dict__["scapy_session"]
+    scapy_session = six.moves.builtins.__dict__["scapy_session"]
     scapy_session.clear()
     scapy_session.update(s)
     log_loading.info("Loaded session [%s]" % conf.session)
@@ -170,26 +178,26 @@ def update_session(fname=None):
     if fname is None:
         fname = conf.session
     try:
-        s = cPickle.load(gzip.open(fname,"rb"))
+        s = six.moves.cPickle.load(gzip.open(fname,"rb"))
     except IOError:
-        s = cPickle.load(open(fname,"rb"))
-    scapy_session = __builtin__.__dict__["scapy_session"]
+        s = six.moves.cPickle.load(open(fname,"rb"))
+    scapy_session = six.moves.builtins.__dict__["scapy_session"]
     scapy_session.update(s)
 
 def init_session(session_name, mydict=None):
     global session
     global globkeys
     
-    scapy_builtins = __import__("all",globals(),locals(),".").__dict__
-    for name, sym in scapy_builtins.iteritems():
-        if name [0] != '_':
-            __builtin__.__dict__[name] = sym
-    globkeys = scapy_builtins.keys()
+    scapy_builtins = importlib.import_module(".all", "scapy").__dict__
+    for name, sym in six.iteritems(scapy_builtins):
+        if _validate_local(name):
+            six.moves.builtins.__dict__[name] = sym
+    globkeys = list(scapy_builtins.keys())
     globkeys.append("scapy_session")
     scapy_builtins=None # XXX replace with "with" statement
     if mydict is not None:
-        __builtin__.__dict__.update(mydict)
-        globkeys += mydict.keys()
+        six.moves.builtins.__dict__.update(mydict)
+        globkeys += list(mydict.keys())
     
     if session_name:
         try:
@@ -199,9 +207,9 @@ def init_session(session_name, mydict=None):
         else:
             try:
                 try:
-                    session = cPickle.load(gzip.open(session_name,"rb"))
+                    session = six.moves.cPickle.load(gzip.open(session_name,"rb"))
                 except IOError:
-                    session = cPickle.load(open(session_name,"rb"))
+                    session = six.moves.cPickle.load(open(session_name,"rb"))
                 log_loading.info("Using session [%s]" % session_name)
             except EOFError:
                 log_loading.error("Error opening session [%s]" % session_name)
@@ -218,7 +226,7 @@ def init_session(session_name, mydict=None):
     else:
         session={"conf": conf}
 
-    __builtin__.__dict__["scapy_session"] = session
+    six.moves.builtins.__dict__["scapy_session"] = session
 
 ################
 ##### Main #####
@@ -236,7 +244,7 @@ def scapy_write_history_file(readline):
     if conf.histfile:
         try:
             readline.write_history_file(conf.histfile)
-        except IOError,e:
+        except IOError as e:
             try:
                 warning("Could not write history to [%s]\n\t (%s)" % (conf.histfile,e))
                 tmp = utils.get_temp_file(keep=True)
@@ -300,7 +308,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
                         return []
                 from scapy.packet import Packet, Packet_metaclass
                 if isinstance(object, Packet) or isinstance(object, Packet_metaclass):
-                    words = filter(lambda x: x[0]!="_",dir(object))
+                    words = [x for x in dir(object) if x[0]!="_"]
                     words += [x.name for x in object.fields_desc]
                 else:
                     words = dir(object)
@@ -345,7 +353,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
             raise getopt.GetoptError("Too many parameters : [%s]" % " ".join(opts[1]))
 
 
-    except getopt.GetoptError, msg:
+    except getopt.GetoptError as msg:
         log_loading.error(msg)
         sys.exit(1)
 
@@ -373,7 +381,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
         try:
             import IPython
             IPYTHON=True
-        except ImportError, e:
+        except ImportError as e:
             log_loading.warning("IPython not available. Using standard Python shell instead.")
             IPYTHON=False
         
@@ -385,7 +393,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
           args = ['']  # IPython command line args (will be seen as sys.argv)
           ipshell = IPython.Shell.IPShellEmbed(args, banner = banner)
           ipshell(local_ns=session)
-        except AttributeError, e:
+        except AttributeError as e:
           pass
 
         # In the IPython cookbook, see 'Updating-code-for-use-with-IPython-0.11-and-later'
@@ -401,7 +409,7 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
 
     for k in globkeys:
         try:
-            del(__builtin__.__dict__[k])
+            del(six.moves.builtins.__dict__[k])
         except:
             pass
 

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -16,7 +16,7 @@ from scapy.arch import WINDOWS
 from scapy.error import warning
 from scapy.layers.inet import IP, TCP, UDP, ICMP, UDPerror, IPerror
 from scapy.sendrecv import sr
-import six
+import scapy.modules.six as six
 
 
 if WINDOWS:

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -59,7 +59,7 @@ class NmapKnowledgeBase(KnowledgeBase):
                     warning("error reading nmap os fp base file")
                     continue
                 test = l[:op]
-                s = [x.split("=") for x in l[op+1:cl].split("%")]
+                s = (x.split("=") for x in l[op+1:cl].split("%"))
                 si = {}
                 for n,v in s:
                     si[n] = v
@@ -90,7 +90,7 @@ def nmap_tcppacket_sig(pkt):
         r["W"] = "%X" % pkt.window
         r["ACK"] = pkt.ack==2 and "S++" or pkt.ack==1 and "S" or "O"
         r["Flags"] = TCPflags2str(pkt.payload.flags)
-        r["Ops"] = "".join([x[0][0] for x in pkt.payload.options])
+        r["Ops"] = "".join(x[0][0] for x in pkt.payload.options)
     else:
         r["Resp"] = "N"
     return r
@@ -143,7 +143,7 @@ def nmap_sig(target, oport=80, cport=81, ucport=1):
               IP(str(IP(dst=target)/UDP(sport=5008,dport=ucport)/(300*"i"))) ]
 
     ans, unans = sr(tests, timeout=2)
-    ans += [(x,None) for x in unans]
+    ans.extend((x,None) for x in unans)
 
     for S,T in ans:
         if S.sport == 5008:

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -7,6 +7,7 @@
 Clone of Nmap's first generation OS fingerprinting.
 """
 
+from __future__ import absolute_import
 import os
 
 from scapy.data import KnowledgeBase
@@ -15,6 +16,7 @@ from scapy.arch import WINDOWS
 from scapy.error import warning
 from scapy.layers.inet import IP, TCP, UDP, ICMP, UDPerror, IPerror
 from scapy.sendrecv import sr
+import six
 
 
 if WINDOWS:
@@ -57,7 +59,7 @@ class NmapKnowledgeBase(KnowledgeBase):
                     warning("error reading nmap os fp base file")
                     continue
                 test = l[:op]
-                s = map(lambda x: x.split("="), l[op+1:cl].split("%"))
+                s = [x.split("=") for x in l[op+1:cl].split("%")]
                 si = {}
                 for n,v in s:
                     si[n] = v
@@ -88,7 +90,7 @@ def nmap_tcppacket_sig(pkt):
         r["W"] = "%X" % pkt.window
         r["ACK"] = pkt.ack==2 and "S++" or pkt.ack==1 and "S" or "O"
         r["Flags"] = TCPflags2str(pkt.payload.flags)
-        r["Ops"] = "".join(map(lambda x: x[0][0],pkt.payload.options))
+        r["Ops"] = "".join([x[0][0] for x in pkt.payload.options])
     else:
         r["Resp"] = "N"
     return r
@@ -114,7 +116,7 @@ def nmap_udppacket_sig(S,T):
 
 def nmap_match_one_sig(seen, ref):
     c = 0
-    for k, v in seen.iteritems():
+    for k, v in six.iteritems(seen):
         if k in ref:
             if v in ref[k].split("|"):
                 c += 1
@@ -141,7 +143,7 @@ def nmap_sig(target, oport=80, cport=81, ucport=1):
               IP(str(IP(dst=target)/UDP(sport=5008,dport=ucport)/(300*"i"))) ]
 
     ans, unans = sr(tests, timeout=2)
-    ans += map(lambda x: (x,None), unans)
+    ans += [(x,None) for x in unans]
 
     for S,T in ans:
         if S.sport == 5008:
@@ -170,7 +172,7 @@ def nmap_search(sigs):
     guess = 0,[]
     for os,fp in nmap_kdb.get_base():
         c = 0.0
-        for t, v in sigs.itervalues():
+        for t, v in six.itervalues(sigs):
             if t in fp:
                 c += nmap_match_one_sig(v, fp[t])
         c /= len(sigs)

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -22,8 +22,7 @@ from scapy.packet import NoPayload, Packet
 from scapy.error import warning, Scapy_Exception, log_runtime
 from scapy.volatile import RandInt, RandByte, RandChoice, RandNum, RandShort, RandString
 from scapy.sendrecv import sniff
-from six.moves import map
-from six.moves import range
+from scapy.modules.six.moves import map, range
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -7,8 +7,7 @@
 Clone of p0f passive OS fingerprinting
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import time
 import struct
 import os

--- a/scapy/modules/queso.py
+++ b/scapy/modules/queso.py
@@ -7,6 +7,7 @@
 Clone of queso OS fingerprinting
 """
 
+from __future__ import absolute_import
 from scapy.data import KnowledgeBase
 from scapy.config import conf
 from scapy.layers.inet import IP,TCP
@@ -56,7 +57,7 @@ class QuesoKnowledgeBase(KnowledgeBase):
                 res = l[2:].split()
                 res[-1] = quesoTCPflags(res[-1])
                 res = " ".join(res)
-                if not p.has_key(res):
+                if res not in p:
                     p[res] = {}
                 p = p[res]
             if p is not None:
@@ -100,7 +101,7 @@ def queso_search(sig):
         while sig:
             s = sig.pop()
             p = p[s]
-            if p.has_key(""):
+            if "" in p:
                 ret.append(p[""])
     except KeyError:
         pass

--- a/scapy/modules/six.py
+++ b/scapy/modules/six.py
@@ -1,0 +1,891 @@
+# Copyright (c) 2010-2017 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+## This file is part of Scapy
+## See http://www.secdev.org/projects/scapy for more informations
+## Copyright (C) Philippe Biondi <phil@secdev.org>
+## This program is published under a GPLv2 license
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.10.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import scapy.modules.six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getstatusoutput", "commands", "subprocess"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in scapy.modules.six.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in scapy.modules.six.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in scapy.modules.six.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in scapy.modules.six.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in scapy.modules.six.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a scapy.modules.six.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to scapy.modules.six."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from scapy.modules.six."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(meta):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -18,7 +18,7 @@ from scapy.layers.inet import IP,UDP
 from scapy.layers.rtp import RTP
 from scapy.consts import WINDOWS
 from scapy.config import conf
-from six.moves import range
+from scapy.modules.six.moves import range
 
 
 sox_base = "sox -t .ul %s - -t ossdsp /dev/dsp"

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -7,6 +7,7 @@
 VoIP (Voice over IP) related functions
 """
 
+from __future__ import absolute_import
 import os
 ###################
 ##  Listen VoIP  ##
@@ -17,6 +18,7 @@ from scapy.layers.inet import IP,UDP
 from scapy.layers.rtp import RTP
 from scapy.consts import WINDOWS
 from scapy.config import conf
+from six.moves import range
 
 
 sox_base = "sox -t .ul %s - -t ossdsp /dev/dsp"
@@ -38,7 +40,7 @@ def _merge_sound_bytes(x,y,sample_size=2):
     elif len(x) < len(y):
         min_ = x
     r_ = len(min_)
-    for i in xrange(r_/ss):
+    for i in range(r_/ss):
         m += x[ss*i:ss*(i+1)]+y[ss*i:ss*(i+1)]
     return x[r_:], y[r_:], m
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -22,9 +22,8 @@ from scapy.volatile import VolatileValue
 from scapy.utils import import_hexcap,tex_escape,colgen,get_temp_file
 from scapy.error import Scapy_Exception, log_runtime
 from scapy.consts import PYX
-import six
-from six.moves import filter
-from six.moves import map
+import scapy.modules.six as six
+from scapy.modules.six.moves import filter, map
 
 try:
     import pyx

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -7,8 +7,7 @@
 Packet class. Binding mechanism. fuzz() method.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import re
 import time,itertools
 import copy

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -5,14 +5,14 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-from __future__ import absolute_import
-from __future__ import print_function
-import os, six.moves._thread, select
+from __future__ import absolute_import, print_function
+
+import os, select
 import subprocess
 import itertools
 import collections
 import time
-import six.moves.queue
+import scapy.modules.six as six
 import scapy.utils
 
 from scapy.error import log_interactive, warning

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -5,12 +5,14 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-import os, thread, select
+from __future__ import absolute_import
+from __future__ import print_function
+import os, six.moves._thread, select
 import subprocess
 import itertools
 import collections
 import time
-import Queue
+import six.moves.queue
 import scapy.utils
 
 from scapy.error import log_interactive, warning
@@ -24,14 +26,14 @@ class PipeEngine:
             doc = pc.__doc__ or ""
             if doc:
                 doc = doc.splitlines()[0]
-            print "%20s: %s" % (pn, doc)
+            print("%20s: %s" % (pn, doc))
     @classmethod
     def list_pipes_detailed(cls):
         for pn,pc in sorted(cls.pipes.items()):
             if pc.__doc__:
-                print "###### %s\n %s" % (pn ,pc.__doc__)
+                print("###### %s\n %s" % (pn ,pc.__doc__))
             else:
-                print "###### %s" % pn
+                print("###### %s" % pn)
     
     def __init__(self, *pipes):
         self.active_pipes = set()
@@ -39,8 +41,8 @@ class PipeEngine:
         self.active_drains = set()
         self.active_sinks = set()
         self._add_pipes(*pipes)
-        self.thread_lock = thread.allocate_lock()
-        self.command_lock = thread.allocate_lock()
+        self.thread_lock = six.moves._thread.allocate_lock()
+        self.command_lock = six.moves._thread.allocate_lock()
         self.__fdr,self.__fdw = os.pipe()
         self.threadid = None
     def __getattr__(self, attr):
@@ -112,7 +114,7 @@ class PipeEngine:
                     elif fd in sources:
                         try:
                             fd.deliver()
-                        except Exception,e:
+                        except Exception as e:
                             log_interactive.exception("piping from %s failed: %s" % (fd.name, e))
                         else:
                             if fd.exhausted():
@@ -130,7 +132,7 @@ class PipeEngine:
 
     def start(self):
         if self.thread_lock.acquire(0):
-            self.threadid = thread.start_new_thread(self.run,())
+            self.threadid = six.moves._thread.start_new_thread(self.run,())
         else:
             warning("Pipe engine already running")
     def wait_and_stop(self):
@@ -146,7 +148,7 @@ class PipeEngine:
                 else:
                     warning("Pipe engine thread not running")
         except KeyboardInterrupt:
-            print "Interrupted by user."
+            print("Interrupted by user.")
 
     def add(self, *pipes):
         pipes = self._add_pipes(*pipes)
@@ -363,7 +365,7 @@ class ThreadGenSource(AutoSource):
         pass
     def start(self):
         self.RUN = True
-        thread.start_new_thread(self.generate,())
+        six.moves._thread.start_new_thread(self.generate,())
     def stop(self):
         self.RUN = False
 
@@ -378,9 +380,9 @@ class ConsoleSink(Sink):
      +-------+
 """
     def push(self, msg):
-        print ">%r" % msg
+        print(">%r" % msg)
     def high_push(self, msg):
-        print ">>%r" % msg
+        print(">>%r" % msg)
 
 class RawConsoleSink(Sink):
     """Print messages on low and high entries
@@ -510,7 +512,7 @@ class QueueSink(Sink):
 """
     def __init__(self, name=None):
         Sink.__init__(self, name=name)
-        self.q = Queue.Queue()
+        self.q = six.moves.queue.Queue()
     def push(self, msg):
         self.q.put(msg)
     def high_push(self, msg):
@@ -519,7 +521,7 @@ class QueueSink(Sink):
         while True:
             try:
                 return self.q.get(True, timeout=0.1)
-            except Queue.Empty:
+            except six.moves.queue.Empty:
                 pass
 
 
@@ -581,7 +583,7 @@ def _testmain():
     p.graph(type="png",target="> /tmp/pipe.png")
 
     p.start()
-    print p.threadid
+    print(p.threadid)
     time.sleep(5)
     p.stop()
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -8,6 +8,8 @@ PacketList: holds several packets and allows to do operations on them.
 """
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os,subprocess
 from collections import defaultdict
 
@@ -16,6 +18,11 @@ from scapy.base_classes import BasePacket,BasePacketList
 from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table,get_temp_file
 
 from scapy.consts import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
+import six
+from six.moves import filter
+from six.moves import range
+from six.moves import zip
+from functools import reduce
 
 
 #############
@@ -75,7 +82,7 @@ class PacketList(BasePacketList):
         return getattr(self.res, attr)
     def __getitem__(self, item):
         if isinstance(item,type) and issubclass(item,BasePacket):
-            return self.__class__(filter(lambda x: item in self._elt2pkt(x),self.res),
+            return self.__class__([x for x in self.res if item in self._elt2pkt(x)],
                                   name="%s from %s"%(item.__name__,self.listname))
         if type(item) is slice:
             return self.__class__(self.res.__getitem__(item),
@@ -96,9 +103,9 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                 if not lfilter(r):
                     continue
             if prn is None:
-                print self._elt2sum(r)
+                print(self._elt2sum(r))
             else:
-                print prn(r)
+                print(prn(r))
     def nsummary(self, prn=None, lfilter=None):
         """prints a summary of each packet with the packet's number
 prn:     function to apply to each packet instead of lambda x:x.summary()
@@ -107,11 +114,11 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             if lfilter is not None:
                 if not lfilter(res):
                     continue
-            print conf.color_theme.id(i,fmt="%04i"),
+            print(conf.color_theme.id(i,fmt="%04i"), end=' ')
             if prn is None:
-                print self._elt2sum(res)
+                print(self._elt2sum(res))
             else:
-                print prn(res)
+                print(prn(res))
     def display(self): # Deprecated. Use show()
         """deprecated. is show()"""
         self.show()
@@ -121,7 +128,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
     
     def filter(self, func):
         """Returns a packet list filtered by a truth function"""
-        return self.__class__(filter(func,self.res),
+        return self.__class__(list(filter(func,self.res)),
                               name="filtered %s"%self.listname)
     def make_table(self, *args, **kargs):
         """Prints a table using a function that returns for each packet its head column value, head row value and displayed value
@@ -151,7 +158,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         if kargs == {}:
             kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
         if plot_xy:
-            lines = plt.plot(*zip(*l), **kargs)
+            lines = plt.plot(*list(zip(*l)), **kargs)
         else:
             lines = plt.plot(l, **kargs)
 
@@ -171,10 +178,10 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         # Get the list of packets
         if lfilter is None:
             l = [f(self.res[i], self.res[i+1])
-                    for i in xrange(len(self.res) - delay)]
+                    for i in range(len(self.res) - delay)]
         else:
             l = [f(self.res[i], self.res[i+1])
-                    for i in xrange(len(self.res) - delay)
+                    for i in range(len(self.res) - delay)
                         if lfilter(self.res[i])]
 
         # Mimic the default gnuplot output
@@ -211,11 +218,11 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
 
         if plot_xy:
-            lines = [plt.plot(*zip(*pl), **dict(kargs, label=k))
-                     for k, pl in d.iteritems()]
+            lines = [plt.plot(*list(zip(*pl)), **dict(kargs, label=k))
+                     for k, pl in six.iteritems(d)]
         else:
             lines = [plt.plot(pl, **dict(kargs, label=k))
-                     for k, pl in d.iteritems()]
+                     for k, pl in six.iteritems(d)]
         plt.legend(loc="center right", bbox_to_anchor=(1.5, 0.5))
 
         # Call show() if matplotlib is not inlined
@@ -236,9 +243,9 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             p = self._elt2pkt(res)
             if lfilter is not None and not lfilter(p):
                 continue
-            print "%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
+            print("%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
                                 p.sprintf("%.time%"),
-                                self._elt2sum(res))
+                                self._elt2sum(res)))
             if p.haslayer(conf.raw_layer):
                 hexdump(p.getlayer(conf.raw_layer).load)
 
@@ -249,9 +256,9 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             p = self._elt2pkt(res)
             if lfilter is not None and not lfilter(p):
                 continue
-            print "%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
+            print("%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
                                 p.sprintf("%.time%"),
-                                self._elt2sum(res))
+                                self._elt2sum(res)))
             hexdump(p)
 
     def padding(self, lfilter=None):
@@ -260,9 +267,9 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             p = self._elt2pkt(res)
             if p.haslayer(conf.padding_layer):
                 if lfilter is None or lfilter(p):
-                    print "%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
+                    print("%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
                                         p.sprintf("%.time%"),
-                                        self._elt2sum(res))
+                                        self._elt2sum(res)))
                     hexdump(p.getlayer(conf.padding_layer).load)
 
     def nzpadding(self, lfilter=None):
@@ -274,9 +281,9 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                 if pad == pad[0]*len(pad):
                     continue
                 if lfilter is None or lfilter(p):
-                    print "%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
+                    print("%s %s %s" % (conf.color_theme.id(i,fmt="%04i"),
                                         p.sprintf("%.time%"),
-                                        self._elt2sum(res))
+                                        self._elt2sum(res)))
                     hexdump(p.getlayer(conf.padding_layer).load)
         
 
@@ -314,7 +321,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             else:
                 conv[c] = conv.get(c, 0) + 1
         gr = 'digraph "conv" {\n'
-        for (s, d), l in conv.iteritems():
+        for (s, d), l in six.iteritems(conv):
             gr += '\t "%s" -> "%s" [label="%s"]\n' % (
                 s, d, ', '.join(str(x) for x in l) if isinstance(l, set) else l
             )
@@ -370,33 +377,33 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                 M = 1
             return m, M
 
-        mins, maxs = minmax(x for x, _ in sl.itervalues())
-        mine, maxe = minmax(x for x, _ in el.itervalues())
-        mind, maxd = minmax(dl.itervalues())
+        mins, maxs = minmax(x for x, _ in six.itervalues(sl))
+        mine, maxe = minmax(x for x, _ in six.itervalues(el))
+        mind, maxd = minmax(six.itervalues(dl))
     
         gr = 'digraph "afterglow" {\n\tedge [len=2.5];\n'
 
         gr += "# src nodes\n"
         for s in sl:
             n,l = sl[s]; n = 1+float(n-mins)/(maxs-mins)
-            gr += '"src.%s" [label = "%s", shape=box, fillcolor="#FF0000", style=filled, fixedsize=1, height=%.2f,width=%.2f];\n' % (`s`,`s`,n,n)
+            gr += '"src.%s" [label = "%s", shape=box, fillcolor="#FF0000", style=filled, fixedsize=1, height=%.2f,width=%.2f];\n' % (repr(s),repr(s),n,n)
         gr += "# event nodes\n"
         for e in el:
             n,l = el[e]; n = n = 1+float(n-mine)/(maxe-mine)
-            gr += '"evt.%s" [label = "%s", shape=circle, fillcolor="#00FFFF", style=filled, fixedsize=1, height=%.2f, width=%.2f];\n' % (`e`,`e`,n,n)
+            gr += '"evt.%s" [label = "%s", shape=circle, fillcolor="#00FFFF", style=filled, fixedsize=1, height=%.2f, width=%.2f];\n' % (repr(e),repr(e),n,n)
         for d in dl:
             n = dl[d]; n = n = 1+float(n-mind)/(maxd-mind)
-            gr += '"dst.%s" [label = "%s", shape=triangle, fillcolor="#0000ff", style=filled, fixedsize=1, height=%.2f, width=%.2f];\n' % (`d`,`d`,n,n)
+            gr += '"dst.%s" [label = "%s", shape=triangle, fillcolor="#0000ff", style=filled, fixedsize=1, height=%.2f, width=%.2f];\n' % (repr(d),repr(d),n,n)
 
         gr += "###\n"
         for s in sl:
             n,l = sl[s]
             for e in l:
-                gr += ' "src.%s" -> "evt.%s";\n' % (`s`,`e`) 
+                gr += ' "src.%s" -> "evt.%s";\n' % (repr(s),repr(e)) 
         for e in el:
             n,l = el[e]
             for d in l:
-                gr += ' "evt.%s" -> "dst.%s";\n' % (`e`,`d`) 
+                gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d)) 
             
         gr += "}"
         return do_graph(gr, **kargs)
@@ -430,7 +437,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             subprocess.Popen([conf.prog.psreader, filename+".ps"])
         else:
             d.writePSfile(filename)
-        print
+        print()
         
     def pdfdump(self, filename = None, **kargs):
         """Creates a PDF file with a psdump of every packet
@@ -443,7 +450,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             subprocess.Popen([conf.prog.pdfreader, filename+".pdf"])
         else:
             d.writePDFfile(filename)
-        print
+        print()
 
     def sr(self,multi=0):
         """sr([multi=1]) -> (SndRcvList, PacketList)
@@ -469,7 +476,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                     break
             i += 1
         if multi:
-            remain = filter(lambda x:not hasattr(x,"_answered"), remain)
+            remain = [x for x in remain if not hasattr(x,"_answered")]
         return SndRcvList(sr),PacketList(remain)
 
     def sessions(self, session_extractor=None):

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -18,10 +18,8 @@ from scapy.base_classes import BasePacket,BasePacketList
 from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table,get_temp_file
 
 from scapy.consts import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
-import six
-from six.moves import filter
-from six.moves import range
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import filter, range, zip
 from functools import reduce
 
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -8,8 +8,7 @@ PacketList: holds several packets and allows to do operations on them.
 """
 
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import os,subprocess
 from collections import defaultdict
 
@@ -156,7 +155,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         if kargs == {}:
             kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
         if plot_xy:
-            lines = plt.plot(*list(zip(*l)), **kargs)
+            lines = plt.plot(*zip(*l), **kargs)
         else:
             lines = plt.plot(l, **kargs)
 
@@ -216,7 +215,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
 
         if plot_xy:
-            lines = [plt.plot(*list(zip(*pl)), **dict(kargs, label=k))
+            lines = [plt.plot(*zip(*pl), **dict(kargs, label=k))
                      for k, pl in six.iteritems(d)]
         else:
             lines = [plt.plot(pl, **dict(kargs, label=k))

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -10,8 +10,10 @@ These functions are missing when python is compiled
 without IPv6 support, on Windows for instance.
 """
 
+from __future__ import absolute_import
 import socket
 import re
+from six.moves import range
 
 _IP6_ZEROS = re.compile('(?::|^)(0(?::0)+)(?::|$)')
 _INET6_PTON_EXC = socket.error("illegal IP address string passed to inet_pton")
@@ -95,7 +97,7 @@ used when socket.inet_pton is not available.
 
     # Decode to hex representation
     address = ":".join(addr[idx:idx + 2].encode('hex').lstrip('0') or '0'
-                       for idx in xrange(0, 16, 2))
+                       for idx in range(0, 16, 2))
 
     try:
         # Get the longest set of zero blocks. We need to take a look

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -13,7 +13,7 @@ without IPv6 support, on Windows for instance.
 from __future__ import absolute_import
 import socket
 import re
-from six.moves import range
+from scapy.modules.six.moves import range
 
 _IP6_ZEROS = re.compile('(?::|^)(0(?::0)+)(?::|$)')
 _INET6_PTON_EXC = socket.error("illegal IP address string passed to inet_pton")

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -14,7 +14,7 @@ from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.arch import WINDOWS
-import six
+import scapy.modules.six as six
 
 ##############################
 ## Routing/Interfaces stuff ##

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -7,12 +7,14 @@
 Routing and handling of network interfaces.
 """
 
+from __future__ import absolute_import
 import socket
 from scapy.consts import LOOPBACK_NAME, LOOPBACK_INTERFACE
 from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.arch import WINDOWS
+import six
 
 ##############################
 ## Routing/Interfaces stuff ##
@@ -38,7 +40,7 @@ class Route:
 	    rtlst.append((ltoa(net),
                       ltoa(msk),
                       gw,
-                      (iface.name if not isinstance(iface, basestring) else iface),
+                      (iface.name if not isinstance(iface, six.string_types) else iface),
                       addr))
 
         return pretty_routes(rtlst,
@@ -152,7 +154,7 @@ class Route:
                 continue
             aa = atol(a)
             if aa == dst:
-                pathes.append((0xffffffffL,(LOOPBACK_INTERFACE,a,"0.0.0.0")))
+                pathes.append((0xffffffff,(LOOPBACK_INTERFACE,a,"0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m,(i,a,gw)))
         if not pathes:
@@ -175,7 +177,7 @@ class Route:
                     continue
             elif iff != iface:
                 continue
-            bcast = atol(addr)|(~msk&0xffffffffL); # FIXME: check error in atol()
+            bcast = atol(addr)|(~msk&0xffffffff); # FIXME: check error in atol()
             return ltoa(bcast)
         warning("No broadcast address found for iface %s\n" % iff);
 

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -227,7 +227,7 @@ class Route6:
         pathes.sort(reverse=True)
 
         best_plen = pathes[0][0]
-        pathes = [x for x in pathes if x[0] == best_plen]
+        pathes = (x for x in pathes if x[0] == best_plen)
 
         res = []
         for p in pathes: # Here we select best source address for every route

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -24,8 +24,8 @@ from scapy.arch import *
 from scapy.pton_ntop import *
 from scapy.error import warning, log_loading
 from scapy.consts import LOOPBACK_INTERFACE
-import six
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import zip
 
 
 class Route6:

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -16,6 +16,7 @@ Routing and network interface handling for IPv6.
 #############################################################################
 #############################################################################
 
+from __future__ import absolute_import
 import socket
 from scapy.config import conf
 from scapy.utils6 import *
@@ -23,6 +24,8 @@ from scapy.arch import *
 from scapy.pton_ntop import *
 from scapy.error import warning, log_loading
 from scapy.consts import LOOPBACK_INTERFACE
+import six
+from six.moves import zip
 
 
 class Route6:
@@ -74,7 +77,7 @@ class Route6:
             # TODO: do better than that
             # replace that unique address by the list of all addresses
             lifaddr = in6_getifaddr()
-            devaddrs = filter(lambda x: x[2] == dev, lifaddr)
+            devaddrs = [x for x in lifaddr if x[2] == dev]
             ifaddr = construct_source_candidate_set(prefix, plen, devaddrs, LOOPBACK_INTERFACE)
 
         return (prefix, plen, gw, dev, ifaddr)
@@ -100,7 +103,7 @@ class Route6:
         dst, plen = tmp.split('/')[:2]
         dst = in6_ptop(dst)
         plen = int(plen)
-        l = filter(lambda x: in6_ptop(x[0]) == dst and x[1] == plen, self.routes)
+        l = [x for x in self.routes if in6_ptop(x[0]) == dst and x[1] == plen]
         if gw:
             gw = in6_ptop(gw)
             l = [x for x in self.routes if in6_ptop(x[2]) == gw]
@@ -198,7 +201,7 @@ class Route6:
         # Deal with dev-specific request for cache search
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, basestring) else dev.pcap_name)
+            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)
         if k in self.cache:
             return self.cache[k]
 
@@ -224,7 +227,7 @@ class Route6:
         pathes.sort(reverse=True)
 
         best_plen = pathes[0][0]
-        pathes = filter(lambda x: x[0] == best_plen, pathes)
+        pathes = [x for x in pathes if x[0] == best_plen]
 
         res = []
         for p in pathes: # Here we select best source address for every route
@@ -252,10 +255,10 @@ class Route6:
             if in6_isgladdr(dst) and in6_isaddr6to4(dst):
                 # TODO : see if taking the longest match between dst and
                 #        every source addresses would provide better results
-                tmp = filter(lambda x: in6_isaddr6to4(x[1][1]), res)
+                tmp = [x for x in res if in6_isaddr6to4(x[1][1])]
             elif in6_ismaddr(dst) or in6_islladdr(dst):
                 # TODO : I'm sure we are not covering all addresses. Check that
-                tmp = filter(lambda x: x[1][0] == conf.iface6, res)
+                tmp = [x for x in res if x[1][0] == conf.iface6]
 
             if tmp:
                 res = tmp
@@ -263,7 +266,7 @@ class Route6:
         # Fill the cache (including dev-specific request)
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, basestring) else dev.pcap_name)
+            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)
         self.cache[k] = res[0][1]
 
         return res[0][1]

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -3,8 +3,7 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import socket
 from scapy.pipetool import Source,Drain,Sink
 from scapy.config import conf

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -3,6 +3,8 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
+from __future__ import absolute_import
+from __future__ import print_function
 import socket
 from scapy.pipetool import Source,Drain,Sink
 from scapy.config import conf
@@ -43,17 +45,17 @@ class RdpcapSource(Source):
         self.fname = fname
         self.f = PcapReader(self.fname)
     def start(self):
-        print "start"
+        print("start")
         self.f = PcapReader(self.fname)
         self.is_exhausted = False
     def stop(self):
-        print "stop"
+        print("stop")
         self.f.close()
     def fileno(self):
         return self.f.fileno()
     def deliver(self):    
         p = self.f.recv()
-        print "deliver %r" % p
+        print("deliver %r" % p)
         if p is None:
             self.is_exhausted = True
         else:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -7,8 +7,10 @@
 Functions to send and receive packets.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import errno
-import cPickle,os,sys,time,subprocess
+import six.moves.cPickle,os,sys,time,subprocess
 import itertools
 from select import select, error as select_error
 
@@ -21,6 +23,9 @@ from scapy import plist
 from scapy.error import log_runtime, log_interactive, warning
 from scapy.base_classes import SetGen
 from scapy.supersocket import StreamSocket
+import six
+from six.moves import map
+from six.moves import zip
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route
@@ -91,13 +96,13 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                     try:
                         i = 0
                         if verbose:
-                            print "Begin emission:"
+                            print("Begin emission:")
                         for p in tobesent:
                             pks.send(p)
                             i += 1
                             time.sleep(inter)
                         if verbose:
-                            print "Finished to send %i packets." % i
+                            print("Finished to send %i packets." % i)
                     except SystemExit:
                         pass
                     except KeyboardInterrupt:
@@ -109,7 +114,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                     try:
                         os.setpgrp() # Chance process group to avoid ctrl-C
                         sent_times = [p.sent_time for p in all_stimuli if p.sent_time]
-                        cPickle.dump( (conf.netcache,sent_times), wrpipe )
+                        six.moves.cPickle.dump( (conf.netcache,sent_times), wrpipe )
                         wrpipe.close()
                     except:
                         pass
@@ -186,7 +191,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                             raise
                 finally:
                     try:
-                        nc,sent_times = cPickle.load(rdpipe)
+                        nc,sent_times = six.moves.cPickle.load(rdpipe)
                     except EOFError:
                         warning("Child died unexpectedly. Packets may have not been sent %i"%os.getpid())
                     else:
@@ -198,7 +203,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
             if pid == 0:
                 os._exit(0)
 
-        remain = list(itertools.chain(*hsent.itervalues()))
+        remain = list(itertools.chain(*six.itervalues(hsent)))
         if multi:
             remain = [p for p in remain if not hasattr(p, '_answered')]
 
@@ -221,7 +226,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                 del(s._answered)
     
     if verbose:
-        print "\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans)
+        print("\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans))
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")
 
 
@@ -264,7 +269,7 @@ def __gen_send(s, x, inter=0, loop=0, count=None, verbose=None, realtime=None, r
         pass
     s.close()
     if verbose:
-        print "\nSent %i packets." % n
+        print("\nSent %i packets." % n)
     if return_packets:
         return sent_packets
         
@@ -318,7 +323,7 @@ def sendpfast(x, pps=None, mbps=None, realtime=None, loop=0, file_cache=False, i
         subprocess.check_call(argv)
     except KeyboardInterrupt:
         log_interactive.info("Interrupted by user")
-    except Exception,e:
+    except Exception as e:
         log_interactive.error("while trying to exec [%s]: %s" % (argv[0],e))
     finally:
         os.unlink(f)
@@ -338,7 +343,7 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface"""
-    if not kargs.has_key("timeout"):
+    if "timeout" not in kargs:
         kargs["timeout"] = -1
     s = conf.L3socket(promisc=promisc, filter=filter, iface=iface, nofilter=nofilter)
     a,b=sndrcv(s,x,*args,**kargs)
@@ -356,7 +361,7 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface"""
-    if not kargs.has_key("timeout"):
+    if "timeout" not in kargs:
         kargs["timeout"] = -1
     s=conf.L3socket(promisc=promisc, filter=filter, nofilter=nofilter, iface=iface)
     a,b=sndrcv(s,x,*args,**kargs)
@@ -377,7 +382,7 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface"""
-    if not kargs.has_key("timeout"):
+    if "timeout" not in kargs:
         kargs["timeout"] = -1
     if iface is None and iface_hint is not None:
         iface = conf.route.route(iface_hint)[0]
@@ -397,7 +402,7 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface"""
-    if not kargs.has_key("timeout"):
+    if "timeout" not in kargs:
         kargs["timeout"] = -1
     a,b=srp(*args,**kargs)
     if len(a) > 0:
@@ -425,24 +430,24 @@ def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summ
                     break
                 count -= 1
             start = time.time()
-            print "\rsend...\r",
+            print("\rsend...\r", end=' ')
             res = srfunc(pkts, timeout=timeout, verbose=0, chainCC=1, *args, **kargs)
             n += len(res[0])+len(res[1])
             r += len(res[0])
             if verbose > 1 and prn and len(res[0]) > 0:
                 msg = "RECV %i:" % len(res[0])
-                print  "\r"+ct.success(msg),
+                print("\r"+ct.success(msg), end=' ')
                 for p in res[0]:
-                    print col(prn(p))
-                    print " "*len(msg),
+                    print(col(prn(p)))
+                    print(" "*len(msg), end=' ')
             if verbose > 1 and prnfail and len(res[1]) > 0:
                 msg = "fail %i:" % len(res[1])
-                print "\r"+ct.fail(msg),
+                print("\r"+ct.fail(msg), end=' ')
                 for p in res[1]:
-                    print col(prnfail(p))
-                    print " "*len(msg),
+                    print(col(prnfail(p)))
+                    print(" "*len(msg), end=' ')
             if verbose > 1 and not (prn or prnfail):
-                print "recv:%i  fail:%i" % tuple(map(len, res[:2]))
+                print("recv:%i  fail:%i" % tuple(map(len, res[:2])))
             if store:
                 ans += res[0]
                 unans += res[1]
@@ -453,7 +458,7 @@ def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summ
         pass
  
     if verbose and n>0:
-        print ct.normal("\nSent %i packets, received %i packets. %3.1f%% hits." % (n,r,100.0*r/n))
+        print(ct.normal("\nSent %i packets, received %i packets. %3.1f%% hits." % (n,r,100.0*r/n)))
     return plist.SndRcvList(ans),plist.PacketList(unans)
 
 @conf.commands.register
@@ -469,7 +474,7 @@ srloop(pkts, [prn], [inter], [count], ...) --> None"""
     return __sr_loop(srp, pkts, *args, **kargs)
 
 
-def sndrcvflood(pks, pkt, prn=lambda (s,r):r.summary(), chainCC=0, store=1, unique=0):
+def sndrcvflood(pks, pkt, prn=lambda s_r:s_r[1].summary(), chainCC=0, store=1, unique=0):
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
     tobesent = [p for p in pkt]
@@ -503,7 +508,7 @@ def sndrcvflood(pks, pkt, prn=lambda (s,r):r.summary(), chainCC=0, store=1, uniq
                 readyr, readys, _ = select([rsock], [ssock], [])
 
             if ssock in readys:
-                pks.send(packets_to_send.next())
+                pks.send(next(packets_to_send))
                 
             if rsock in readyr:
                 p = pks.recv(MTU)
@@ -520,7 +525,7 @@ def sndrcvflood(pks, pkt, prn=lambda (s,r):r.summary(), chainCC=0, store=1, uniq
                                     continue
                                 seen[res] = None
                             if res is not None:
-                                print res
+                                print(res)
                             if store:
                                 received.append((i,p))
     except KeyboardInterrupt:
@@ -643,7 +648,7 @@ interfaces)
                     if prn:
                         r = prn(p)
                         if r is not None:
-                            print r
+                            print(r)
                     if stop_filter and stop_filter(p):
                         stop_event = True
                         break
@@ -718,7 +723,7 @@ stop_filter: python function applied to each packet to determine
                     if prn:
                         r = prn(p)
                         if r is not None:
-                            print r
+                            print(r)
                     if stop_filter and stop_filter(p):
                         stop_event = True
                         break

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -7,8 +7,7 @@
 Functions to send and receive packets.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import errno
 import os, sys, time, subprocess
 import itertools
@@ -202,9 +201,11 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
             if pid == 0:
                 os._exit(0)
 
-        remain = list(itertools.chain(*six.itervalues(hsent)))
+        remain = itertools.chain(*six.itervalues(hsent))
         if multi:
             remain = [p for p in remain if not hasattr(p, '_answered')]
+        else:
+            remain = [p for p in remain]
 
         if autostop and len(remain) > 0 and len(remain) != len(tobesent):
             retry = autostop

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -10,7 +10,7 @@ Functions to send and receive packets.
 from __future__ import absolute_import
 from __future__ import print_function
 import errno
-import six.moves.cPickle,os,sys,time,subprocess
+import os, sys, time, subprocess
 import itertools
 from select import select, error as select_error
 
@@ -23,9 +23,8 @@ from scapy import plist
 from scapy.error import log_runtime, log_interactive, warning
 from scapy.base_classes import SetGen
 from scapy.supersocket import StreamSocket
-import six
-from six.moves import map
-from six.moves import zip
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, zip
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -7,6 +7,7 @@
 SuperSocket.
 """
 
+from __future__ import absolute_import
 import socket,time
 
 from scapy.config import conf
@@ -14,6 +15,7 @@ from scapy.data import *
 from scapy.error import warning, log_runtime
 import scapy.packet
 from scapy.utils import PcapReader, tcpdump
+import six
 
 class _SuperSocket_metaclass(type):
     def __repr__(self):
@@ -23,8 +25,7 @@ class _SuperSocket_metaclass(type):
             return "<%s>" % self.__name__
 
 
-class SuperSocket:
-    __metaclass__ = _SuperSocket_metaclass
+class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
     desc = None
     closed=0
     def __init__(self, family=socket.AF_INET,type=socket.SOCK_STREAM, proto=0):
@@ -106,7 +107,7 @@ class L3RawSocket(SuperSocket):
             sx = str(x)
             x.sent_time = time.time()
             self.outs.sendto(sx,(x.dst,0))
-        except socket.error,msg:
+        except socket.error as msg:
             log_runtime.error(msg)
 
 class SimpleSocket(SuperSocket):

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -15,7 +15,7 @@ from scapy.data import *
 from scapy.error import warning, log_runtime
 import scapy.packet
 from scapy.utils import PcapReader, tcpdump
-import six
+import scapy.modules.six as six
 
 class _SuperSocket_metaclass(type):
     def __repr__(self):

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -11,6 +11,7 @@ Color themes for the interactive console.
 ## Color themes ##
 ##################
 
+from __future__ import absolute_import
 class Color:
     normal = b"\033[0m"
     black = b"\033[30m"

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -7,8 +7,7 @@
 Unit testing infrastructure for Scapy
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import sys, getopt, imp, glob
 import bz2, base64, os.path, time, traceback, zlib, sha
 from scapy.consts import WINDOWS
@@ -20,6 +19,9 @@ from scapy.modules.six.moves import map, range
 
 class Bunch:
     __init__ = lambda self, **kw: setattr(self, '__dict__', kw)
+
+def exec_info():
+    return sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2]
 
 #### Import tool ####
 
@@ -376,7 +378,7 @@ def run_campaign(test_campaign, get_interactive_session, verb=3, ignore_globals=
                     the_res= True
             except Exception as msg:
                 t.output+="UTscapy: Error during result interpretation:\n"
-                t.output+="".join(traceback.format_exception(sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2],))
+                t.output+="".join(traceback.format_exception(*exec_info()))
             if the_res:
                 t.res = True
                 res = "passed"
@@ -755,7 +757,7 @@ def main(argv):
                     try:
                         NUM.append(int(v))
                     except ValueError:
-                        v1, v2 = list(map(int, v.split("-", 1)))
+                        v1, v2 = map(int, v.split("-", 1))
                         NUM.extend(range(v1, v2 + 1))
             elif opt == "-m":
                 MODULES.append(optarg)

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -12,9 +12,8 @@ from __future__ import print_function
 import sys, getopt, imp, glob
 import bz2, base64, os.path, time, traceback, zlib, sha
 from scapy.consts import WINDOWS
-import six
-from six.moves import map
-from six.moves import range
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range
 
 
 ### Util class ###
@@ -676,7 +675,6 @@ def resolve_testfiles(TESTFILES):
     return TESTFILES
 
 def main(argv):
-    import six.moves.builtins
     ignore_globals = list(six.moves.builtins.__dict__.keys())
 
     # Parse arguments

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -7,9 +7,14 @@
 Unit testing infrastructure for Scapy
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys, getopt, imp, glob
 import bz2, base64, os.path, time, traceback, zlib, sha
 from scapy.consts import WINDOWS
+import six
+from six.moves import map
+from six.moves import range
 
 
 ### Util class ###
@@ -88,11 +93,11 @@ vzM985aHXOHAxQN2UQZbQkUv3D4Vc+lyvalAffv3Tyg4ks3a22kPXiyeCGweviNX
 0K8TKasyOhGsVamTUAZBXfQVw1zmdS4rHDnbHgtIjX3DcCt6UIr0BHTYjdV0JbPj
 r1APYgXihjQwM2M83AKIhwQQJv/F3JFOFCQNsEI0QA==""")
     def get_local_dict(cls):
-        return {x: y.name for (x, y) in cls.__dict__.iteritems()
+        return {x: y.name for (x, y) in six.iteritems(cls.__dict__)
                 if isinstance(y, File)}
     get_local_dict = classmethod(get_local_dict)
     def get_URL_dict(cls):
-        return {x: y.URL for (x, y) in cls.__dict__.iteritems()
+        return {x: y.URL for (x, y) in six.iteritems(cls.__dict__)
                 if isinstance(y, File)}
     get_URL_dict = classmethod(get_URL_dict)
 
@@ -118,7 +123,7 @@ class TestClass:
     def __getitem__(self, item):
         return getattr(self, item)
     def add_keywords(self, kws):
-        if isinstance(kws, basestring):
+        if isinstance(kws, six.string_types):
             kws = [kws]
         for kwd in kws:
             if kwd.startswith('-'):
@@ -220,7 +225,7 @@ def parse_config_file(config_path, verb=3):
     with open(config_path) as config_file:
         data = json.load(config_file, encoding="utf8")
         if verb > 2:
-            print >>sys.stderr, "### Loaded config file", config_path
+            print("### Loaded config file", config_path, file=sys.stderr)
     def get_if_exist(key, default):
         return data[key] if key in data else default
     return Bunch(testfiles=get_if_exist("testfiles", []), onlyfailed=get_if_exist("onlyfailed", False),
@@ -265,40 +270,40 @@ def parse_campaign_file(campaign_file):
         else:
             if test is None:
                 if l.strip():
-                    print >>sys.stderr, "Unknown content [%s]" % l.strip()
+                    print("Unknown content [%s]" % l.strip(), file=sys.stderr)
             else:
                 test.test += l
     return test_campaign
 
 def dump_campaign(test_campaign):
-    print "#"*(len(test_campaign.title)+6)
-    print "## %(title)s ##" % test_campaign
-    print "#"*(len(test_campaign.title)+6)
+    print("#"*(len(test_campaign.title)+6))
+    print("## %(title)s ##" % test_campaign)
+    print("#"*(len(test_campaign.title)+6))
     if test_campaign.sha and test_campaign.crc:
-        print "CRC=[%(crc)s] SHA=[%(sha)s]" % test_campaign
-    print "from file %(filename)s" % test_campaign
-    print
+        print("CRC=[%(crc)s] SHA=[%(sha)s]" % test_campaign)
+    print("from file %(filename)s" % test_campaign)
+    print()
     for ts in test_campaign:
         if ts.crc:
-            print "+--[%s]%s(%s)--" % (ts.name,"-"*max(2,80-len(ts.name)-18),ts.crc)
+            print("+--[%s]%s(%s)--" % (ts.name,"-"*max(2,80-len(ts.name)-18),ts.crc))
         else:
-            print "+--[%s]%s" % (ts.name,"-"*max(2,80-len(ts.name)-6))
+            print("+--[%s]%s" % (ts.name,"-"*max(2,80-len(ts.name)-6)))
         if ts.keywords:
-            print "  kw=%s" % ",".join(ts.keywords)
+            print("  kw=%s" % ",".join(ts.keywords))
         for t in ts:
-            print "%(num)03i %(name)s" % t
+            print("%(num)03i %(name)s" % t)
             c = k = ""
             if t.keywords:
                 k = "kw=%s" % ",".join(t.keywords)
             if t.crc:
                 c = "[%(crc)s] " % t
             if c or k:
-                print "    %s%s" % (c,k) 
+                print("    %s%s" % (c,k)) 
 
 #### COMPUTE CAMPAIGN DIGESTS ####
 
 def crc32(x):
-    return "%08X" % (0xffffffffL & zlib.crc32(x))
+    return "%08X" % (0xffffffff & zlib.crc32(x))
 
 def sha1(x):
     return sha.sha(x).hexdigest().upper()
@@ -355,24 +360,24 @@ def remove_empty_testsets(test_campaign):
 
 #### RUN CAMPAIGN #####
 
-def run_campaign(test_campaign, get_interactive_session, verb=3):
+def run_campaign(test_campaign, get_interactive_session, verb=3, ignore_globals=None):
     if WINDOWS:
         # Add a route to 127.0.0.1 and ::1
         from scapy.arch.windows import route_add_loopback
         route_add_loopback()
     passed=failed=0
     if test_campaign.preexec:
-        test_campaign.preexec_output = get_interactive_session(test_campaign.preexec.strip())[0]
+        test_campaign.preexec_output = get_interactive_session(test_campaign.preexec.strip(), ignore_globals=ignore_globals)[0]
     for testset in test_campaign:
         for t in testset:
-            t.output,res = get_interactive_session(t.test.strip())
+            t.output,res = get_interactive_session(t.test.strip(), ignore_globals=ignore_globals)
             the_res = False
             try:
                 if res is None or res:
                     the_res= True
-            except Exception,msg:
+            except Exception as msg:
                 t.output+="UTscapy: Error during result interpretation:\n"
-                t.output+="".join(traceback.format_exception(sys.exc_type, sys.exc_value, sys.exc_traceback,))
+                t.output+="".join(traceback.format_exception(sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2],))
             if the_res:
                 t.res = True
                 res = "passed"
@@ -384,12 +389,12 @@ def run_campaign(test_campaign, get_interactive_session, verb=3):
             t.result = res
             t.decode()
             if verb > 1:
-                print >>sys.stderr,"%(result)6s %(crc)s %(name)s" % t
+                print("%(result)6s %(crc)s %(name)s" % t, file=sys.stderr)
     test_campaign.passed = passed
     test_campaign.failed = failed
     if verb:
-        print >>sys.stderr,"Campaign CRC=%(crc)s  SHA=%(sha)s" % test_campaign
-        print >>sys.stderr,"PASSED=%i FAILED=%i" % (passed, failed)
+        print("Campaign CRC=%(crc)s  SHA=%(sha)s" % test_campaign, file=sys.stderr)
+        print("PASSED=%i FAILED=%i" % (passed, failed), file=sys.stderr)
     return failed
 
 
@@ -580,7 +585,7 @@ def campaign_to_LATEX(test_campaign):
 #### USAGE ####
                       
 def usage():
-    print >>sys.stderr,"""Usage: UTscapy [-m module] [-f {text|ansi|HTML|LaTeX}] [-o output_file] 
+    print("""Usage: UTscapy [-m module] [-f {text|ansi|HTML|LaTeX}] [-o output_file] 
                [-t testfile] [-T testfile] [-k keywords [-k ...]] [-K keywords [-K ...]]
                [-l] [-d|-D] [-F] [-q[q]] [-P preexecute_python_code]
                [-s /path/to/scapy] [-c configfile]
@@ -600,7 +605,7 @@ def usage():
 -k <kw1>,<kw2>,...\t: include only tests with one of those keywords (can be used many times)
 -K <kw1>,<kw2>,...\t: remove tests with one of those keywords (can be used many times)
 -P <preexecute_python_code>
-"""
+""", file=sys.stderr)
     raise SystemExit
 
 
@@ -671,7 +676,8 @@ def resolve_testfiles(TESTFILES):
     return TESTFILES
 
 def main(argv):
-    import __builtin__
+    import six.moves.builtins
+    ignore_globals = list(six.moves.builtins.__dict__.keys())
 
     # Parse arguments
     
@@ -713,7 +719,7 @@ def main(argv):
             elif opt == "-f":
                 try:
                     FORMAT = Format.from_string(optarg)
-                except KeyError,msg:
+                except KeyError as msg:
                     raise getopt.GetoptError("Unknown output format %s" % msg)
             elif opt == "-t":
                 TESTFILES.append(optarg)
@@ -738,7 +744,7 @@ def main(argv):
                 KW_KO = [data.kw_ko]
                 try:
                     FORMAT = Format.from_string(data.format)
-                except KeyError,msg:
+                except KeyError as msg:
                     raise getopt.GetoptError("Unknown output format %s" % msg)
                 TESTFILES = resolve_testfiles(TESTFILES)
             elif opt == "-o":
@@ -751,8 +757,8 @@ def main(argv):
                     try:
                         NUM.append(int(v))
                     except ValueError:
-                        v1, v2 = map(int, v.split("-", 1))
-                        NUM.extend(xrange(v1, v2 + 1))
+                        v1, v2 = list(map(int, v.split("-", 1)))
+                        NUM.extend(range(v1, v2 + 1))
             elif opt == "-m":
                 MODULES.append(optarg)
             elif opt == "-k":
@@ -761,21 +767,21 @@ def main(argv):
                 KW_KO.append(optarg.split(","))
 
         if VERB > 2:
-            print >>sys.stderr, "### Booting scapy..."
+            print("### Booting scapy...", file=sys.stderr)
         try:
             from scapy import all as scapy
-        except ImportError,e:
+        except ImportError as e:
             raise getopt.GetoptError("cannot import [%s]: %s" % (SCAPY,e))
 
         for m in MODULES:
             try:
                 mod = import_module(m)
-                __builtin__.__dict__.update(mod.__dict__)
-            except ImportError,e:
+                six.moves.builtins.__dict__.update(mod.__dict__)
+            except ImportError as e:
                 raise getopt.GetoptError("cannot import [%s]: %s" % (m,e))
                 
-    except getopt.GetoptError,msg:
-        print >>sys.stderr,"ERROR:",msg
+    except getopt.GetoptError as msg:
+        print("ERROR:",msg, file=sys.stderr)
         raise SystemExit
 
     autorun_func = {
@@ -787,7 +793,7 @@ def main(argv):
         }
 
     if VERB > 2:
-        print >>sys.stderr,"### Starting tests..."
+        print("### Starting tests...", file=sys.stderr)
 
     glob_output = ""
     glob_result = 0
@@ -810,7 +816,7 @@ def main(argv):
     # Execute all files
     for TESTFILE in TESTFILES:
         if VERB > 2:
-            print >>sys.stderr,"### Loading:", TESTFILE
+            print("### Loading:", TESTFILE, file=sys.stderr)
         PREEXEC = PREEXEC_DICT[TESTFILE] if TESTFILE in PREEXEC_DICT else GLOB_PREEXEC
         output, result, campaign = execute_campaign(open(TESTFILE), OUTPUTFILE,
                                           PREEXEC, NUM, KW_OK, KW_KO,
@@ -826,7 +832,7 @@ def main(argv):
             break
 
     if VERB > 2:
-            print >>sys.stderr,"### Writing output..."
+            print("### Writing output...", file=sys.stderr)
     # Concenate outputs
     if FORMAT == Format.HTML:
         glob_output = pack_html_campaigns(runned_campaigns, glob_output, LOCAL, glob_title)

--- a/scapy/tools/check_asdis.py
+++ b/scapy/tools/check_asdis.py
@@ -1,13 +1,15 @@
 #! /usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import getopt
 
 def usage():
-    print >>sys.stderr,"""Usage: check_asdis -i <pcap_file> [-o <wrong_packets.pcap>]
+    print("""Usage: check_asdis -i <pcap_file> [-o <wrong_packets.pcap>]
     -v   increase verbosity
     -d   hexdiff packets that differ
     -z   compress output pcap
-    -a   open pcap file in append mode"""
+    -a   open pcap file in append mode""", file=sys.stderr)
 
 def main(argv):
     PCAP_IN = None
@@ -39,8 +41,8 @@ def main(argv):
         if PCAP_IN is None:
             raise getopt.GetoptError("Missing pcap file (-i)")
     
-    except getopt.GetoptError,e:
-        print >>sys.stderr,"ERROR: %s" % e
+    except getopt.GetoptError as e:
+        print("ERROR: %s" % e, file=sys.stderr)
         raise SystemExit
     
     
@@ -58,7 +60,7 @@ def main(argv):
 
     LLcls = conf.l2types.get(pcap.linktype)
     if LLcls is None:
-        print >>sys.stderr," Unknown link type [%i]. Can't test anything!" % pcap.linktype
+        print(" Unknown link type [%i]. Can't test anything!" % pcap.linktype, file=sys.stderr)
         raise SystemExit
     
     
@@ -72,27 +74,27 @@ def main(argv):
             p2 = str(p2d)
         except KeyboardInterrupt:
             raise
-        except Exception,e:
-            print "Dissection error on packet %i" % i
+        except Exception as e:
+            print("Dissection error on packet %i" % i)
             failed += 1
         else:
             if p1 == p2:
                 if VERBOSE >= 2:
-                    print "Packet %i ok" % i
+                    print("Packet %i ok" % i)
                 continue
             else:
-                print "Packet %i differs" % i
+                print("Packet %i differs" % i)
                 differ += 1
                 if VERBOSE >= 1:
-                    print repr(p2d)
+                    print(repr(p2d))
                 if DIFF:
                     hexdiff(p1,p2)
         if pcap_out is not None:
             pcap_out.write(p1)
     i+=1
     correct = i-differ-failed
-    print "%i total packets. %i ok, %i differed, %i failed. %.2f%% correct." % (i, correct, differ,
-                                                                                failed, i and 100.0*(correct)/i)
+    print("%i total packets. %i ok, %i differed, %i failed. %.2f%% correct." % (i, correct, differ,
+                                                                                failed, i and 100.0*(correct)/i))
     
         
 if __name__ == "__main__":
@@ -100,4 +102,4 @@ if __name__ == "__main__":
     try:
         main(sys.argv[1:])
     except KeyboardInterrupt:
-        print >>sys.stderr,"Interrupted by user."
+        print("Interrupted by user.", file=sys.stderr)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -153,7 +153,7 @@ def chexdump(x, dump=False):
 def hexstr(x, onlyasc=0, onlyhex=0):
     s = []
     if not onlyasc:
-        s.append(" ".join(["%02x"%ord(x) for x in x]))
+        s.append(" ".join(["%02x"%ord(y) for y in x]))
     if not onlyhex:
         s.append(sane(x)) 
     return "  ".join(s)
@@ -504,7 +504,7 @@ def binrepr(val):
     return bin(val)[2:]
 
 def long_converter(s):
-    return int(s.replace('\n', '').replace(' ', ''), 16)
+    return long(s.replace('\n', '').replace(' ', ''), 16)
 
 #########################
 #### Enum management ####

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -7,14 +7,20 @@
 General utility functions.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os, sys, socket, types
 import random, time
-import gzip, zlib, cPickle
+import gzip, zlib, six.moves.cPickle
 import re, struct, array
 import subprocess
 import tempfile
 
 import warnings
+import six
+from six.moves import map
+from six.moves import range
+from six.moves import input
 warnings.filterwarnings("ignore","tempnam",RuntimeWarning, __name__)
 
 from scapy.config import conf
@@ -54,7 +60,7 @@ def sane(x):
     return r
 
 def lhex(x):
-    if type(x) in (int,long):
+    if type(x) in six.integer_types:
         return hex(x)
     elif type(x) is tuple:
         return "(%s)" % ", ".join(map(lhex, x))
@@ -77,7 +83,7 @@ def hexdump(x, dump=False):
     i = 0
     while i < l:
         s += "%04x  " % i
-        for j in xrange(16):
+        for j in range(16):
             if i+j < l:
                 s += "%02X" % ord(x[i+j])
             else:
@@ -94,7 +100,7 @@ def hexdump(x, dump=False):
     if dump:
         return s
     else:
-        print s
+        print(s)
 
 
 @conf.commands.register
@@ -113,7 +119,7 @@ def linehexdump(x, onlyasc=0, onlyhex=0, dump=False):
     x = str(x)
     l = len(x)
     if not onlyasc:
-        for i in xrange(l):
+        for i in range(l):
             s += "%02X" % ord(x[i])
         if not onlyhex:  # separate asc & hex if both are displayed
             s += " "
@@ -122,7 +128,7 @@ def linehexdump(x, onlyasc=0, onlyhex=0, dump=False):
     if dump:
         return s
     else:
-        print s
+        print(s)
 
 @conf.commands.register
 def chexdump(x, dump=False):
@@ -137,24 +143,24 @@ def chexdump(x, dump=False):
     :returns: a String only if dump=True
     """
     x = str(x)
-    s = str(", ".join(map(lambda x: "%#04x"%ord(x), x)))
+    s = str(", ".join(["%#04x"%ord(x) for x in x]))
     if dump:
         return s
     else:
-        print s
+        print(s)
 
 @conf.commands.register
 def hexstr(x, onlyasc=0, onlyhex=0):
     s = []
     if not onlyasc:
-        s.append(" ".join(map(lambda x:"%02x"%ord(x), x)))
+        s.append(" ".join(["%02x"%ord(x) for x in x]))
     if not onlyhex:
         s.append(sane(x)) 
     return "  ".join(s)
 
 def repr_hex(s):
     """ Convert provided bitstring to a simple string of hex digits """
-    return "".join(map(lambda x: "%02x" % ord(x),s))
+    return "".join(["%02x" % ord(x) for x in s])
 
 @conf.commands.register
 def hexdiff(x,y):
@@ -164,13 +170,13 @@ def hexdiff(x,y):
     SUBST=1
     INSERT=1
     d = {(-1, -1): (0, (-1, -1))}
-    for j in xrange(len(y)):
+    for j in range(len(y)):
         d[-1,j] = d[-1,j-1][0]+INSERT, (-1,j-1)
-    for i in xrange(len(x)):
+    for i in range(len(x)):
         d[i,-1] = d[i-1,-1][0]+INSERT, (i-1,-1)
 
-    for j in xrange(len(y)):
-        for i in xrange(len(x)):
+    for j in range(len(y)):
+        for i in range(len(x)):
             d[i,j] = min( ( d[i-1,j-1][0]+SUBST*(x[i] != y[j]), (i-1,j-1) ),
                           ( d[i-1,j][0]+INSERT, (i-1,j) ),
                           ( d[i,j-1][0]+INSERT, (i,j-1) ) )
@@ -214,45 +220,45 @@ def hexdiff(x,y):
             while not linex[j]:
                 j += 1
                 xd -= 1
-            print colorize[doy-dox]("%04x" % xd),
+            print(colorize[doy-dox]("%04x" % xd), end=' ')
             x += xx
             line=linex
         else:
-            print "    ",
+            print("    ", end=' ')
         if doy:
             yd = y
             j = 0
             while not liney[j]:
                 j += 1
                 yd -= 1
-            print colorize[doy-dox]("%04x" % yd),
+            print(colorize[doy-dox]("%04x" % yd), end=' ')
             y += yy
             line=liney
         else:
-            print "    ",
+            print("    ", end=' ')
             
-        print " ",
+        print(" ", end=' ')
         
         cl = ""
-        for j in xrange(16):
+        for j in range(16):
             if i+j < l:
                 if line[j]:
                     col = colorize[(linex[j]!=liney[j])*(doy-dox)]
-                    print col("%02X" % ord(line[j])),
+                    print(col("%02X" % ord(line[j])), end=' ')
                     if linex[j]==liney[j]:
                         cl += sane_color(line[j])
                     else:
                         cl += col(sane(line[j]))
                 else:
-                    print "  ",
+                    print("  ", end=' ')
                     cl += " "
             else:
-                print "  ",
+                print("  ", end=' ')
             if j == 7:
-                print "",
+                print("", end=' ')
 
 
-        print " ",cl
+        print(" ",cl)
 
         if doy or not yy:
             doy=0
@@ -339,7 +345,7 @@ def fletcher16_checkbytes(binbuf, offset):
 
 
 def mac2str(mac):
-    return "".join(map(lambda x: chr(int(x,16)), mac.split(":")))
+    return "".join([chr(int(x,16)) for x in mac.split(":")])
 
 def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
@@ -348,14 +354,14 @@ def randstring(l):
     """
     Returns a random string of length l (l >= 0)
     """
-    tmp = map(lambda x: struct.pack("B", random.randrange(0, 256, 1)), [""]*l)
+    tmp = [struct.pack("B", random.randrange(0, 256, 1)) for x in [""]*l]
     return "".join(tmp)
 
 def zerofree_randstring(l):
     """
     Returns a random string of length l (l >= 0) without zero in it.
     """
-    tmp = map(lambda x: struct.pack("B", random.randrange(1, 256, 1)), [""]*l)
+    tmp = [struct.pack("B", random.randrange(1, 256, 1)) for x in [""]*l]
     return "".join(tmp)
 
 def strxor(s1, s2):
@@ -403,7 +409,7 @@ def ltoa(x):
     return inet_ntoa(struct.pack("!I", x&0xffffffff))
 
 def itom(x):
-    return (0xffffffff00000000L>>x)&0xffffffffL
+    return (0xffffffff00000000>>x)&0xffffffff
 
 def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,options=None):
     """do_graph(graph, prog=conf.prog.dot, format="svg",
@@ -483,9 +489,9 @@ def colgen(*lstcol,**kargs):
         lstcol *= 2
     trans = kargs.get("trans", lambda x,y,z: (x,y,z))
     while 1:
-        for i in xrange(len(lstcol)):
-            for j in xrange(len(lstcol)):
-                for k in xrange(len(lstcol)):
+        for i in range(len(lstcol)):
+            for j in range(len(lstcol)):
+                for k in range(len(lstcol)):
                     if i != j or j != k or k != i:
                         yield trans(lstcol[(i+j)%len(lstcol)],lstcol[(j+k)%len(lstcol)],lstcol[(k+i)%len(lstcol)])
 
@@ -498,7 +504,7 @@ def binrepr(val):
     return bin(val)[2:]
 
 def long_converter(s):
-    return long(s.replace('\n', '').replace(' ', ''), 16)
+    return int(s.replace('\n', '').replace(' ', ''), 16)
 
 #########################
 #### Enum management ####
@@ -523,7 +529,7 @@ class Enum_metaclass(type):
     element_class = EnumElement
     def __new__(cls, name, bases, dct):
         rdict={}
-        for k,v in dct.iteritems():
+        for k,v in six.iteritems(dct):
             if type(v) is int:
                 v = cls.element_class(k,v)
                 dct[k] = v
@@ -547,24 +553,24 @@ class Enum_metaclass(type):
 
 
 def export_object(obj):
-    print gzip.zlib.compress(cPickle.dumps(obj,2),9).encode("base64")
+    print(gzip.zlib.compress(six.moves.cPickle.dumps(obj,2),9).encode("base64"))
 
 def import_object(obj=None):
     if obj is None:
         obj = sys.stdin.read()
-    return cPickle.loads(gzip.zlib.decompress(obj.strip().decode("base64")))
+    return six.moves.cPickle.loads(gzip.zlib.decompress(obj.strip().decode("base64")))
 
 
 def save_object(fname, obj):
     """Pickle a Python object"""
 
     fd = gzip.open(fname, "wb")
-    cPickle.dump(obj, fd)
+    six.moves.cPickle.dump(obj, fd)
     fd.close()
 
 def load_object(fname):
     """unpickle a Python object"""
-    return cPickle.load(gzip.open(fname,"rb"))
+    return six.moves.cPickle.load(gzip.open(fname,"rb"))
 
 @conf.commands.register
 def corrupt_bytes(s, p=0.01, n=None):
@@ -573,7 +579,7 @@ def corrupt_bytes(s, p=0.01, n=None):
     l = len(s)
     if n is None:
         n = max(1,int(l*p))
-    for i in random.sample(xrange(l), n):
+    for i in random.sample(range(l), n):
         s[i] = (s[i]+random.randint(1,255))%256
     return s.tostring()
 
@@ -584,7 +590,7 @@ def corrupt_bits(s, p=0.01, n=None):
     l = len(s)*8
     if n is None:
         n = max(1,int(l*p))
-    for i in random.sample(xrange(l), n):
+    for i in random.sample(range(l), n):
         s[i/8] ^= 1 << (i%8)
     return s.tostring()
 
@@ -664,7 +670,7 @@ class PcapReader_metaclass(type):
     @staticmethod
     def open(filename):
         """Open (if necessary) filename, and read the magic."""
-        if isinstance(filename, basestring):
+        if isinstance(filename, six.string_types):
             try:
                 fdesc = gzip.open(filename,"rb")
                 magic = fdesc.read(4)
@@ -680,9 +686,8 @@ class PcapReader_metaclass(type):
         return filename, fdesc, magic
 
 
-class RawPcapReader:
+class RawPcapReader(six.with_metaclass(PcapReader_metaclass)):
     """A stateful pcap reader. Each packet is returned as a string"""
-    __metaclass__ = PcapReader_metaclass
     def __init__(self, filename, fdesc, magic):
         self.filename = filename
         self.f = fdesc
@@ -984,7 +989,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
         if sync:
             bufsz = 0
 
-        if isinstance(filename, basestring):
+        if isinstance(filename, six.string_types):
             self.filename = filename
             self.f = [open,gzip.open][gz](filename,append and "ab" or "wb", gz and 9 or bufsz)
         else:
@@ -1008,7 +1013,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             if g.read(16):
                 return
             
-        self.f.write(struct.pack(self.endian+"IHHIIII", 0xa1b23c4dL if self.nano else 0xa1b2c3d4L,
+        self.f.write(struct.pack(self.endian+"IHHIIII", 0xa1b23c4d if self.nano else 0xa1b2c3d4,
                                  2, 4, 0, 0, MTU, self.linktype))
         self.f.flush()
     
@@ -1026,7 +1031,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             pkt = pkt.__iter__()
             if not self.header_present:
                 try:
-                    p = pkt.next()
+                    p = next(pkt)
                 except StopIteration:
                     self._write_header("")
                     return
@@ -1104,7 +1109,7 @@ def import_hexcap():
     p = ""
     try:
         while 1:
-            l = raw_input().strip()
+            l = input().strip()
             try:
                 p += re_extract_hexcap.match(l).groups()[2]
             except:
@@ -1178,7 +1183,7 @@ u'64'
     """
     if prog is None:
         prog = [conf.prog.tcpdump]
-    elif isinstance(prog, basestring):
+    elif isinstance(prog, six.string_types):
         prog = [prog]
     if pktlist is None:
         proc = subprocess.Popen(
@@ -1186,7 +1191,7 @@ u'64'
             stdout=subprocess.PIPE if dump or getfd else None,
             stderr=open(os.devnull),
         )
-    elif isinstance(pktlist, basestring):
+    elif isinstance(pktlist, six.string_types):
         proc = subprocess.Popen(
             prog + ["-r", pktlist] + (args if args is not None else []),
             stdout=subprocess.PIPE if dump or getfd else None,
@@ -1323,8 +1328,8 @@ def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None,
         vy[yy] = None
         vz[(xx,yy)] = zz
 
-    vxk = vx.keys()
-    vyk = vy.keys()
+    vxk = sorted(vx.keys())
+    vyk = sorted(vy.keys())
     if sortx:
         vxk.sort(sortx)
     else:
@@ -1348,31 +1353,31 @@ def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None,
 
 
     if seplinefunc:
-        sepline = seplinefunc(l, map(lambda x:vx[x],vxk))
-        print sepline
+        sepline = seplinefunc(l, [vx[x] for x in vxk])
+        print(sepline)
 
     fmt = yfmtfunc(l)
-    print fmt % "",
+    print(fmt % "", end=' ')
     for x in vxk:
         vxf[x] = fmtfunc(vx[x])
-        print vxf[x] % x,
-    print endline
+        print(vxf[x] % x, end=' ')
+    print(endline)
     if seplinefunc:
-        print sepline
+        print(sepline)
     for y in vyk:
-        print fmt % y,
+        print(fmt % y, end=' ')
         for x in vxk:
-            print vxf[x] % vz.get((x,y), "-"),
-        print endline
+            print(vxf[x] % vz.get((x,y), "-"), end=' ')
+        print(endline)
     if seplinefunc:
-        print sepline
+        print(sepline)
 
 def make_table(*args, **kargs):
     __make_table(lambda l:"%%-%is" % l, lambda l:"%%-%is" % l, "", *args, **kargs)
     
 def make_lined_table(*args, **kargs):
     __make_table(lambda l:"%%-%is |" % l, lambda l:"%%-%is |" % l, "",
-                 seplinefunc=lambda a,x:"+".join(map(lambda y:"-"*(y+2), [a-1]+x+[-2])),
+                 seplinefunc=lambda a,x:"+".join(["-"*(y+2) for y in [a-1]+x+[-2]]),
                  *args, **kargs)
 
 def make_tex_table(*args, **kargs):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -7,8 +7,7 @@
 General utility functions.
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import os, sys, socket, types
 import random, time
 import gzip, zlib
@@ -17,10 +16,8 @@ import subprocess
 import tempfile
 
 import warnings
-import six
-from six.moves import map
-from six.moves import range
-from six.moves import input
+import scapy.modules.six as six
+from scapy.modules.six.moves import map, range, input
 warnings.filterwarnings("ignore","tempnam",RuntimeWarning, __name__)
 
 from scapy.config import conf
@@ -345,7 +342,7 @@ def fletcher16_checkbytes(binbuf, offset):
 
 
 def mac2str(mac):
-    return "".join([chr(int(x,16)) for x in mac.split(":")])
+    return "".join(chr(int(x,16)) for x in mac.split(":"))
 
 def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
@@ -354,15 +351,13 @@ def randstring(l):
     """
     Returns a random string of length l (l >= 0)
     """
-    tmp = [struct.pack("B", random.randrange(0, 256, 1)) for x in [""]*l]
-    return "".join(tmp)
+    return "".join(struct.pack("B", random.randrange(0, 256, 1)) for x in [""]*l)
 
 def zerofree_randstring(l):
     """
     Returns a random string of length l (l >= 0) without zero in it.
     """
-    tmp = [struct.pack("B", random.randrange(1, 256, 1)) for x in [""]*l]
-    return "".join(tmp)
+    return "".join(struct.pack("B", random.randrange(1, 256, 1)) for x in [""]*l)
 
 def strxor(s1, s2):
     """
@@ -1287,7 +1282,7 @@ def pretty_routes(rtlst, header, sortBy=0):
     # Append tag
     rtlst = header + rtlst
     # Detect column's width
-    colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst))
+    colwidth = list(map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst)))
     # Make text fit in box (if exist)
     # TODO: find a better and more precise way of doing this. That's currently working but very complicated
     width = get_terminal_width()
@@ -1377,7 +1372,7 @@ def make_table(*args, **kargs):
     
 def make_lined_table(*args, **kargs):
     __make_table(lambda l:"%%-%is |" % l, lambda l:"%%-%is |" % l, "",
-                 seplinefunc=lambda a,x:"+".join(["-"*(y+2) for y in [a-1]+x+[-2]]),
+                 seplinefunc=lambda a,x:"+".join("-"*(y+2) for y in [a-1]+x+[-2]),
                  *args, **kargs)
 
 def make_tex_table(*args, **kargs):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os, sys, socket, types
 import random, time
-import gzip, zlib, six.moves.cPickle
+import gzip, zlib
 import re, struct, array
 import subprocess
 import tempfile

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -53,22 +53,22 @@ def construct_source_candidate_set(addr, plen, laddr, loiface):
 
     cset = []
     if in6_isgladdr(addr) or in6_isuladdr(addr):
-        cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
+        cset = (x for x in laddr if x[1] == IPV6_ADDR_GLOBAL)
     elif in6_islladdr(addr):
-        cset = [x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL]
+        cset = (x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL)
     elif in6_issladdr(addr):
-        cset = [x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL]
+        cset = (x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL)
     elif in6_ismaddr(addr):
         if in6_ismnladdr(addr):
             cset = [('::1', 16, loiface)]
         elif in6_ismgladdr(addr):
-            cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
+            cset = (x for x in laddr if x[1] == IPV6_ADDR_GLOBAL)
         elif in6_ismlladdr(addr):
-            cset = [x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL]
+            cset = (x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL)
         elif in6_ismsladdr(addr):
-            cset = [x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL]
+            cset = (x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL)
     elif addr == '::' and plen == 0:
-        cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
+        cset = (x for x in laddr if x[1] == IPV6_ADDR_GLOBAL)
     cset = [x[0] for x in cset]
     cset.sort(cmp=cset_sort) # Sort with global addresses first
     return cset            
@@ -225,8 +225,7 @@ def in6_ifaceidtomac(ifaceid): # TODO: finish commenting function behavior
     first = struct.pack("B", ((first & 0xFD) | ulbit))
     oui = first + ifaceid[1:3]
     end = ifaceid[5:]
-    l = ["%.02x" % struct.unpack("B", x)[0] for x in list(oui+end)]
-    return ":".join(l)
+    return ":".join("%.02x" % struct.unpack("B", x)[0] for x in list(oui+end))
 
 def in6_addrtomac(addr):
     """
@@ -527,9 +526,8 @@ def _in6_bitops(a1, a2, operator=0):
             lambda x,y: x & y,
             lambda x,y: x ^ y
           ]  
-    ret = list(map(fop[operator%len(fop)], a1, a2))
-    t = ''.join([struct.pack('I', x) for x in ret])
-    return t
+    ret = map(fop[operator%len(fop)], a1, a2)
+    return ''.join(struct.pack('I', x) for x in ret)
 
 def in6_or(a1, a2):
     """
@@ -566,11 +564,11 @@ def in6_cidr2mask(m):
         raise Scapy_Exception("value provided to in6_cidr2mask outside [0, 128] domain (%d)" % m)
 
     t = []
-    for i in range(0, 4):
+    for i in range(4):
         t.append(max(0, 2**32  - 2**(32-min(32, m))))
         m -= 32
 
-    return ''.join([struct.pack('!I', x) for x in t])
+    return ''.join(struct.pack('!I', x) for x in t)
 
 def in6_getnsma(a): 
     """
@@ -591,7 +589,7 @@ def in6_getnsmac(a): # return multicast Ethernet address associated with multica
 
     a = struct.unpack('16B', a)[-4:]
     mac = '33:33:'
-    mac += ':'.join(['%.2x' %x for x in a])
+    mac += ':'.join('%.2x' %x for x in a)
     return mac
 
 def in6_getha(prefix): 

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -9,6 +9,7 @@
 """
 Utility functions for IPv6.
 """
+from __future__ import absolute_import
 import random
 import socket
 import struct
@@ -19,6 +20,9 @@ from scapy.utils import *
 from scapy.pton_ntop import *
 from scapy.volatile import RandMAC
 from scapy.error import warning
+from six.moves import map
+from six.moves import range
+from functools import reduce
 
 
 def construct_source_candidate_set(addr, plen, laddr, loiface):
@@ -50,23 +54,23 @@ def construct_source_candidate_set(addr, plen, laddr, loiface):
 
     cset = []
     if in6_isgladdr(addr) or in6_isuladdr(addr):
-        cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
+        cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
     elif in6_islladdr(addr):
-        cset = filter(lambda x: x[1] == IPV6_ADDR_LINKLOCAL, laddr)
+        cset = [x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL]
     elif in6_issladdr(addr):
-        cset = filter(lambda x: x[1] == IPV6_ADDR_SITELOCAL, laddr)
+        cset = [x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL]
     elif in6_ismaddr(addr):
         if in6_ismnladdr(addr):
             cset = [('::1', 16, loiface)]
         elif in6_ismgladdr(addr):
-            cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
+            cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
         elif in6_ismlladdr(addr):
-            cset = filter(lambda x: x[1] == IPV6_ADDR_LINKLOCAL, laddr)
+            cset = [x for x in laddr if x[1] == IPV6_ADDR_LINKLOCAL]
         elif in6_ismsladdr(addr):
-            cset = filter(lambda x: x[1] == IPV6_ADDR_SITELOCAL, laddr)
+            cset = [x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL]
     elif addr == '::' and plen == 0:
-        cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
-    cset = map(lambda x: x[0], cset)
+        cset = [x for x in laddr if x[1] == IPV6_ADDR_GLOBAL]
+    cset = [x[0] for x in cset]
     cset.sort(cmp=cset_sort) # Sort with global addresses first
     return cset            
 
@@ -222,7 +226,7 @@ def in6_ifaceidtomac(ifaceid): # TODO: finish commenting function behavior
     first = struct.pack("B", ((first & 0xFD) | ulbit))
     oui = first + ifaceid[1:3]
     end = ifaceid[5:]
-    l = map(lambda x: "%.02x" % struct.unpack("B", x)[0], list(oui+end))
+    l = ["%.02x" % struct.unpack("B", x)[0] for x in list(oui+end)]
     return ":".join(l)
 
 def in6_addrtomac(addr):
@@ -389,8 +393,8 @@ def in6_getRandomizedIfaceId(ifaceid, previous=None):
 
     s = ""
     if previous is None:
-        d = "".join(chr(x) for x in xrange(256))
-        for _ in xrange(8):
+        d = "".join(chr(x) for x in range(256))
+        for _ in range(8):
             s += random.choice(d)
         previous = s
     s = inet_pton(socket.AF_INET6, "::"+ifaceid)[8:] + previous
@@ -417,14 +421,14 @@ def in6_ctop(addr):
     Returns None on error.
     """
     if len(addr) != 20 or not reduce(lambda x,y: x and y, 
-                                     map(lambda x: x in _rfc1924map, addr)):
+                                     [x in _rfc1924map for x in addr]):
         return None
     i = 0
     for c in addr:
         j = _rfc1924map.index(c)
         i = 85*i + j
     res = []
-    for j in xrange(4):
+    for j in range(4):
         res.append(struct.pack("!I", i%2**32))
         i = i/(2**32)
     res.reverse()
@@ -442,7 +446,7 @@ def in6_ptoc(addr):
         return None
     res = 0
     m = [2**96, 2**64, 2**32, 1]
-    for i in xrange(4):
+    for i in range(4):
         res += d[i]*m[i]
     rem = res
     res = []
@@ -524,8 +528,8 @@ def _in6_bitops(a1, a2, operator=0):
             lambda x,y: x & y,
             lambda x,y: x ^ y
           ]  
-    ret = map(fop[operator%len(fop)], a1, a2)
-    t = ''.join(map(lambda x: struct.pack('I', x), ret))
+    ret = list(map(fop[operator%len(fop)], a1, a2))
+    t = ''.join([struct.pack('I', x) for x in ret])
     return t
 
 def in6_or(a1, a2):
@@ -563,11 +567,11 @@ def in6_cidr2mask(m):
         raise Scapy_Exception("value provided to in6_cidr2mask outside [0, 128] domain (%d)" % m)
 
     t = []
-    for i in xrange(0, 4):
+    for i in range(0, 4):
         t.append(max(0, 2**32  - 2**(32-min(32, m))))
         m -= 32
 
-    return ''.join(map(lambda x: struct.pack('!I', x), t))
+    return ''.join([struct.pack('!I', x) for x in t])
 
 def in6_getnsma(a): 
     """
@@ -588,7 +592,7 @@ def in6_getnsmac(a): # return multicast Ethernet address associated with multica
 
     a = struct.unpack('16B', a)[-4:]
     mac = '33:33:'
-    mac += ':'.join(map(lambda x: '%.2x' %x, a))
+    mac += ':'.join(['%.2x' %x for x in a])
     return mac
 
 def in6_getha(prefix): 
@@ -754,7 +758,7 @@ def in6_get_common_plen(a, b):
     Return common prefix length of IPv6 addresses a and b.
     """
     def matching_bits(byte1, byte2):
-        for i in xrange(8):
+        for i in range(8):
             cur_mask = 0x80 >> i
             if (byte1 & cur_mask) != (byte2 & cur_mask):
                 return i
@@ -762,7 +766,7 @@ def in6_get_common_plen(a, b):
         
     tmpA = inet_pton(socket.AF_INET6, a)
     tmpB = inet_pton(socket.AF_INET6, b)
-    for i in xrange(16):
+    for i in range(16):
         mbits = matching_bits(ord(tmpA[i]), ord(tmpB[i]))
         if mbits != 8:
             return 8*i + mbits

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -20,8 +20,7 @@ from scapy.utils import *
 from scapy.pton_ntop import *
 from scapy.volatile import RandMAC
 from scapy.error import warning
-from six.moves import map
-from six.moves import range
+from scapy.modules.six.moves import map, range
 from functools import reduce
 
 

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -343,7 +343,7 @@ class RandOID(RandString):
                 if i == "*":
                     oid.append(str(self.idnum))
                 elif i == "**":
-                    oid += list(map(str, [self.idnum for i in range(1+self.depth)]))
+                    oid.extend(map(str, [self.idnum for i in range(1+self.depth)]))
                 elif type(i) is tuple:
                     oid.append(str(random.randrange(*i)))
                 else:
@@ -377,7 +377,7 @@ class RandRegExp(RandField):
                 s = s[:p-1]+rng+s[p+1:]
         res = m+s
         if invert:
-            res = "".join([chr(x) for x in range(256) if chr(x) not in res])
+            res = "".join(chr(x) for x in range(256) if chr(x) not in res)
         return res
 
     @staticmethod
@@ -517,7 +517,7 @@ class RandSingNum(RandSingularity):
             end = -end
             sign = -1
         end_n = int(math.log(end)/math.log(2))+1
-        return set([sign*2**i for i in range(end_n)])            
+        return set(sign*2**i for i in range(end_n))            
         
     def __init__(self, mn, mx):
         sing = set([0, mn, mx, int((mn+mx)/2)])

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -11,8 +11,7 @@ from __future__ import absolute_import
 import random,time,math
 from scapy.base_classes import Net
 from scapy.utils import corrupt_bits,corrupt_bytes
-from six.moves import map
-from six.moves import range
+from scapy.modules.six.moves import map, range
 
 ####################
 ## Random numbers ##

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -7,9 +7,12 @@
 Fields that hold random numbers.
 """
 
+from __future__ import absolute_import
 import random,time,math
 from scapy.base_classes import Net
 from scapy.utils import corrupt_bits,corrupt_bytes
+from six.moves import map
+from six.moves import range
 
 ####################
 ## Random numbers ##
@@ -48,12 +51,12 @@ class RandomEnumeration:
             if self.turns == 0 or (self.i == 0 and self.renewkeys):
                 self.cnt_key = self.rnd.randint(0,2**self.n-1)
                 self.sbox = [self.rnd.randint(0, self.fsmask)
-                             for _ in xrange(self.sbox_size)]
+                             for _ in range(self.sbox_size)]
             self.turns += 1
             while self.i < 2**self.n:
                 ct = self.i^self.cnt_key
                 self.i += 1
-                for _ in xrange(self.rounds): # Unbalanced Feistel Network
+                for _ in range(self.rounds): # Unbalanced Feistel Network
                     lsb = ct & self.fsmask
                     ct >>= self.fs
                     lsb ^= self.sbox[ct%self.sbox_size]
@@ -129,71 +132,71 @@ class RandEnum(RandNum):
     def __init__(self, min, max, seed=None):
         self.seq = RandomEnumeration(min,max,seed)
     def _fix(self):
-        return self.seq.next()
+        return next(self.seq)
 
 class RandByte(RandNum):
     def __init__(self):
-        RandNum.__init__(self, 0, 2L**8-1)
+        RandNum.__init__(self, 0, 2**8-1)
 
 class RandSByte(RandNum):
     def __init__(self):
-        RandNum.__init__(self, -2L**7, 2L**7-1)
+        RandNum.__init__(self, -2**7, 2**7-1)
 
 class RandShort(RandNum):
     def __init__(self):
-        RandNum.__init__(self, 0, 2L**16-1)
+        RandNum.__init__(self, 0, 2**16-1)
 
 class RandSShort(RandNum):
     def __init__(self):
-        RandNum.__init__(self, -2L**15, 2L**15-1)
+        RandNum.__init__(self, -2**15, 2**15-1)
 
 class RandInt(RandNum):
     def __init__(self):
-        RandNum.__init__(self, 0, 2L**32-1)
+        RandNum.__init__(self, 0, 2**32-1)
 
 class RandSInt(RandNum):
     def __init__(self):
-        RandNum.__init__(self, -2L**31, 2L**31-1)
+        RandNum.__init__(self, -2**31, 2**31-1)
 
 class RandLong(RandNum):
     def __init__(self):
-        RandNum.__init__(self, 0, 2L**64-1)
+        RandNum.__init__(self, 0, 2**64-1)
 
 class RandSLong(RandNum):
     def __init__(self):
-        RandNum.__init__(self, -2L**63, 2L**63-1)
+        RandNum.__init__(self, -2**63, 2**63-1)
 
 class RandEnumByte(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, 0, 2L**8-1)
+        RandEnum.__init__(self, 0, 2**8-1)
 
 class RandEnumSByte(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, -2L**7, 2L**7-1)
+        RandEnum.__init__(self, -2**7, 2**7-1)
 
 class RandEnumShort(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, 0, 2L**16-1)
+        RandEnum.__init__(self, 0, 2**16-1)
 
 class RandEnumSShort(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, -2L**15, 2L**15-1)
+        RandEnum.__init__(self, -2**15, 2**15-1)
 
 class RandEnumInt(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, 0, 2L**32-1)
+        RandEnum.__init__(self, 0, 2**32-1)
 
 class RandEnumSInt(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, -2L**31, 2L**31-1)
+        RandEnum.__init__(self, -2**31, 2**31-1)
 
 class RandEnumLong(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, 0, 2L**64-1)
+        RandEnum.__init__(self, 0, 2**64-1)
 
 class RandEnumSLong(RandEnum):
     def __init__(self):
-        RandEnum.__init__(self, -2L**63, 2L**63-1)
+        RandEnum.__init__(self, -2**63, 2**63-1)
 
 class RandEnumKeys(RandEnum):
     """Picks a random value from dict keys list. """
@@ -202,7 +205,7 @@ class RandEnumKeys(RandEnum):
         self.seq = RandomEnumeration(0, len(self.enum) - 1, seed)
 
     def _fix(self):
-        return self.enum[self.seq.next()]
+        return self.enum[next(self.seq)]
 
 class RandChoice(RandField):
     def __init__(self, *args):
@@ -220,18 +223,18 @@ class RandString(RandField):
         self.chars = chars
     def _fix(self):
         s = ""
-        for _ in xrange(self.size):
+        for _ in range(self.size):
             s += random.choice(self.chars)
         return s
 
 class RandBin(RandString):
     def __init__(self, size=None):
-        RandString.__init__(self, size, "".join(map(chr, xrange(256))))
+        RandString.__init__(self, size, "".join(map(chr, range(256))))
 
 
 class RandTermString(RandString):
     def __init__(self, size, term):
-        RandString.__init__(self, size, "".join(map(chr, xrange(1,256))))
+        RandString.__init__(self, size, "".join(map(chr, range(1,256))))
         self.term = term
     def _fix(self):
         return RandString._fix(self)+self.term
@@ -252,7 +255,7 @@ class RandMAC(RandString):
         template += ":*:*:*:*:*"
         template = template.split(":")
         self.mac = ()
-        for i in xrange(6):
+        for i in range(6):
             if template[i] == "*":
                 v = RandByte()
             elif "-" in template[i]:
@@ -300,7 +303,7 @@ class RandIP6(RandString):
                     remain += 1
                 if nbm or self.variable:
                     remain = random.randint(0,remain)
-                for j in xrange(remain):
+                for j in range(remain):
                     ip.append("%04x" % random.randint(0,65535))
             elif isinstance(n, RandNum):
                 ip.append("%04x" % n)
@@ -321,7 +324,7 @@ class RandOID(RandString):
         self.ori_fmt = fmt
         if fmt is not None:
             fmt = fmt.split(".")
-            for i in xrange(len(fmt)):
+            for i in range(len(fmt)):
                 if "-" in fmt[i]:
                     fmt[i] = tuple(map(int, fmt[i].split("-")))
         self.fmt = fmt
@@ -334,14 +337,14 @@ class RandOID(RandString):
             return "<%s [%s]>" % (self.__class__.__name__, self.ori_fmt)
     def _fix(self):
         if self.fmt is None:
-            return ".".join(map(str, [self.idnum for i in xrange(1+self.depth)]))
+            return ".".join(map(str, [self.idnum for i in range(1+self.depth)]))
         else:
             oid = []
             for i in self.fmt:
                 if i == "*":
                     oid.append(str(self.idnum))
                 elif i == "**":
-                    oid += map(str, [self.idnum for i in xrange(1+self.depth)])
+                    oid += list(map(str, [self.idnum for i in range(1+self.depth)]))
                 elif type(i) is tuple:
                     oid.append(str(random.randrange(*i)))
                 else:
@@ -371,11 +374,11 @@ class RandRegExp(RandField):
             else:
                 c1 = s[p-1]
                 c2 = s[p+1]
-                rng = "".join(map(chr, xrange(ord(c1), ord(c2)+1)))
+                rng = "".join(map(chr, range(ord(c1), ord(c2)+1)))
                 s = s[:p-1]+rng+s[p+1:]
         res = m+s
         if invert:
-            res = "".join([chr(x) for x in xrange(256) if chr(x) not in res])
+            res = "".join([chr(x) for x in range(256) if chr(x) not in res])
         return res
 
     @staticmethod
@@ -492,7 +495,7 @@ class RandRegExp(RandField):
                 if random.randint(0,1):
                     current.pop()
             elif c == '.':
-                current.append(RandChoice(*[chr(x) for x in xrange(256)]))
+                current.append(RandChoice(*[chr(x) for x in range(256)]))
             elif c == '$' or c == '^':
                 pass
             else:
@@ -515,7 +518,7 @@ class RandSingNum(RandSingularity):
             end = -end
             sign = -1
         end_n = int(math.log(end)/math.log(2))+1
-        return set([sign*2**i for i in xrange(end_n)])            
+        return set([sign*2**i for i in range(end_n)])            
         
     def __init__(self, mn, mx):
         sing = set([0, mn, mx, int((mn+mx)/2)])
@@ -533,35 +536,35 @@ class RandSingNum(RandSingularity):
 
 class RandSingByte(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, 0, 2L**8-1)
+        RandSingNum.__init__(self, 0, 2**8-1)
 
 class RandSingSByte(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, -2L**7, 2L**7-1)
+        RandSingNum.__init__(self, -2**7, 2**7-1)
 
 class RandSingShort(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, 0, 2L**16-1)
+        RandSingNum.__init__(self, 0, 2**16-1)
 
 class RandSingSShort(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, -2L**15, 2L**15-1)
+        RandSingNum.__init__(self, -2**15, 2**15-1)
 
 class RandSingInt(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, 0, 2L**32-1)
+        RandSingNum.__init__(self, 0, 2**32-1)
 
 class RandSingSInt(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, -2L**31, 2L**31-1)
+        RandSingNum.__init__(self, -2**31, 2**31-1)
 
 class RandSingLong(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, 0, 2L**64-1)
+        RandSingNum.__init__(self, 0, 2**64-1)
 
 class RandSingSLong(RandSingNum):
     def __init__(self):
-        RandSingNum.__init__(self, -2L**63, 2L**63-1)
+        RandSingNum.__init__(self, -2**63, 2**63-1)
 
 class RandSingString(RandSingularity):
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ Distutils setup file for Scapy.
 """
 
 
+from __future__ import absolute_import
 from distutils import archive_util
 from distutils import sysconfig
 from distutils.core import setup
@@ -33,7 +34,7 @@ def make_ezipfile(base_name, base_dir, verbose=0, dry_run=0, **kwargs):
     os.system("zip -A '%s'" % fname)
     of.close()
     os.unlink(ofname)
-    os.chmod(fname, 0755)
+    os.chmod(fname, 0o755)
     return fname
 
 

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -15,11 +15,11 @@ from scapy.arch.windows import _read_routes6_post2008
 
 def check_mandatory_ipv6_routes(routes6):
     """Ensure that mandatory IPv6 routes are present."""
-    if len(filter(lambda r: r[0] == "::" and r[-1] == ["::1"], routes6)) < 1:
+    if not any(r[0] == "::" and r[-1] == ["::1"] for r in routes6):
         return False
-    if len(filter(lambda r: r[0] == "fe80::" and (r[1] == 64 or r[1] == 32), routes6)) < 1:
+    if not any(r[0] == "fe80::" and (r[1] == 64 or r[1] == 32) for r in routes6):
         return False
-    if len(list(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128, routes6))) < 1:
+    if not any(in6_islladdr(r[0]) and r[1] == 128 for r in routes6):
         return False
     return True
 
@@ -74,7 +74,7 @@ ifIndex DestinationPrefix                          NextHop
         print r
     print(len(routes))
     assert(len(routes) == 9)
-    assert(check_mandatory_ipv6_routes(routes))
+    assert(check_mandatory_ipv6_routes(routes) == True)
 
 
 test_read_routes6_windows()

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -19,7 +19,7 @@ def check_mandatory_ipv6_routes(routes6):
         return False
     if len(filter(lambda r: r[0] == "fe80::" and (r[1] == 64 or r[1] == 32), routes6)) < 1:
         return False
-    if len(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128, routes6)) < 1:
+    if len(list(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128, routes6))) < 1:
         return False
     return True
 
@@ -115,6 +115,7 @@ def emulate_main_input(data, mock_readfunc, mock_pyr_size):
         return r_data
     mock_readfunc.side_effect = readlineScapy
     sys.argv = ['']
+    sys.last_value = None
     def console_exit(code):
         raise SystemExit(code)
     exit_code = -1

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -101,10 +101,10 @@ else:
 = Test read_routes6() - check mandatory routes
 
 if len(routes6):
-    assert(len(filter(lambda r: r[0] == "::1" and r[-1] == ["::1"], routes6)) >= 1)
+    assert(len(list(filter(lambda r: r[0] == "::1" and r[-1] == ["::1"], routes6))) >= 1)
     if iflist >= 2:
-        assert(len(filter(lambda r: r[0] == "fe80::" and r[1] == 64, routes6)) >= 1)
-        len(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128 and r[-1] == ["::1"], routes6)) >= 1
+        assert(len(list(filter(lambda r: r[0] == "fe80::" and r[1] == 64, routes6))) >= 1)
+        len(list(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128 and r[-1] == ["::1"], routes6))) >= 1
 else:
     True
 
@@ -799,7 +799,7 @@ old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
 ans,unans=sr(IP(dst="www.google.com/30")/TCP(dport=[80,443]),timeout=2)
 conf.debug_dissector = old_debug_dissector
-ans.make_table(lambda (s,r): (s.dst, s.dport, r.sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))
+ans.make_table(lambda s_r: (s_r[0].dst, s_r[0].dport, s_r[1].sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))
 
 = Traceroute function
 ~ netaccess
@@ -841,6 +841,11 @@ arping(_+"/24")
 ~ netaccess
 import time
 import os
+try:
+    from Queue import Queue as queue
+except:
+    from queue import Queue as queue
+
 def _send_or_sniff(pkt, timeout, flt, pid, fork, t_other=None):
     assert pid != -1
     if pid == 0:
@@ -875,7 +880,7 @@ def send_and_sniff(pkt, timeout=2, flt=None):
         def run_function(pkt, timeout, flt, pid, thread, results):
             _send_or_sniff(pkt, timeout, flt, pid, False, t_other=thread)
             results.put(True)
-        results = Queue.Queue()
+        results = queue()
         t_parent = Thread(target=run_function, args=(pkt, timeout, flt, 0, None, results))
         t_child = Thread(target=run_function, args=(pkt, timeout, flt, 1, t_parent, results))
         t_parent.start()
@@ -5579,12 +5584,12 @@ def valid_output_read_routes6(routes):
 
 def check_mandatory_ipv6_routes(routes6):
     """Ensure that mandatory IPv6 routes are present"""
-    if len(filter(lambda r: r[0] == "::1" and r[-1] == ["::1"], routes6)) < 1:
+    if len(list(filter(lambda r: r[0] == "::1" and r[-1] == ["::1"], routes6))) < 1:
         return False
-    if len(filter(lambda r: r[0] == "fe80::" and r[1] == 64, routes6)) < 1:
+    if len(list(filter(lambda r: r[0] == "fe80::" and r[1] == 64, routes6))) < 1:
         return False
-    if len(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128 and \
-            r[-1] == ["::1"], routes6)) < 1:
+    if len(list(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128 and \
+            r[-1] == ["::1"], routes6))) < 1:
         return False
     return True
 
@@ -7923,7 +7928,7 @@ assert TCP(flags="SA").flags | TCP(flags="S").flags == TCP(flags="SA").flags
 ~ IP TCP
 
 plist = PacketList(list(IP()/TCP(flags=(0, 2**9 - 1))))
-assert [p[TCP].flags for p in plist] == range(512)
+assert [p[TCP].flags for p in plist] == [x for x in range(512)]
 
 plist = PacketList(list(IP()/TCP(flags=["S", "SA", "A"])))
 assert [p[TCP].flags for p in plist] == [2, 18, 16]
@@ -8239,7 +8244,7 @@ s == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
 = Dot11 - dissection
 p = Dot11(s)
 Dot11 in p and p.addr3 == "00:00:00:00:00:00"
-p.mysummary() == '802.11 Management 0L 00:00:00:00:00:00 > 00:00:00:00:00:00'
+p.mysummary() == '802.11 Management 0 00:00:00:00:00:00 > 00:00:00:00:00:00'
 
 = Dot11QoS - build
 s = str(Dot11(type=2, subtype=8)/Dot11QoS())

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -10,6 +10,7 @@ For instance, "sudo ./client_simple.py c014" will try to connect to any TLS
 server at 127.0.0.1:4433, with suite TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA.
 """
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/test/tls/example_server.py
+++ b/test/tls/example_server.py
@@ -11,6 +11,7 @@ any TLS client connection. If provided, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
 will be preferred to any other suite the client might propose.
 """
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/test/tls/travis_test_client.py
+++ b/test/tls/travis_test_client.py
@@ -30,7 +30,7 @@ def run_tls_test_client(send_data=None, cipher_suite_code=None, version=None):
     t = TLSClientAutomaton(client_hello=ch, data=send_data)
     t.run()
 
-from .travis_test_server import run_tls_test_server
+from travis_test_server import run_tls_test_server
 
 def test_tls_client(suite, version, q):
     msg = "TestC_" + suite + "_data"

--- a/test/tls/travis_test_client.py
+++ b/test/tls/travis_test_client.py
@@ -12,6 +12,7 @@ Optional cipher_cuite_code and version may be provided as hexadecimal strings
 Reception of the exact send_data on the server is to be checked externally.
 """
 
+from __future__ import absolute_import
 import sys, os, time
 import multiprocessing
 
@@ -29,7 +30,7 @@ def run_tls_test_client(send_data=None, cipher_suite_code=None, version=None):
     t = TLSClientAutomaton(client_hello=ch, data=send_data)
     t.run()
 
-from travis_test_server import run_tls_test_server
+from .travis_test_server import run_tls_test_server
 
 def test_tls_client(suite, version, q):
     msg = "TestC_" + suite + "_data"

--- a/test/tls/travis_test_server.py
+++ b/test/tls/travis_test_server.py
@@ -12,6 +12,7 @@ expected_data, then we leave with exit code 0. Else we leave with exit code 1.
 If no expected_data was provided and the handshake was ok, we exit with 0.
 """
 
+from __future__ import absolute_import
 import os
 import sys
 from contextlib import contextmanager


### PR DESCRIPTION
**EDIT: That PR was splitted in smaller ones. This will stay open for legacy until all have been merged**

Next part of supporting Python 3. This increases the compatibility between python 2 and 3, by using common methods + six.py module. It does not provide a suitable python 3 compatibility yet.

The PR:
- used [Python-modernize](https://pypi.python.org/pypi/modernize) as a base to update scapy's code
- manually fixed some conflicts/bugs
- Included `six.py` in modules
- fix some small bugs (windows)