### PR TITLE
Only read version from git when in scapy

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -38,6 +38,9 @@ def _version_from_git_describe():
         >>> _version_from_git_describe()
         '2.3.2.dev346'
     """
+    if not os.path.isdir(os.path.join(_SCAPY_PKG_DIR, '../.git')):
+        raise ValueError('not in scapy git repo')
+
     p = subprocess.Popen(['git', 'describe', '--always'], cwd=_SCAPY_PKG_DIR,
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
Scapy may be used as third party library by other projects, themselves managed under git. This leads to surprising results such as this:

```console
$ git describe
awesomeproject-v5.22-1-ga1316614c290
$ virtualenv env
...
$ . env/bin/activate
$ pip install scapy==2.3.3
...
$ cat env/lib/python2.7/site-packages/scapy/VERSION
2.3.3
$ which scapy
/home/.../env/bin/scapy
$ scapy
...
Welcome to Scapy (awesomeproject-v5.22.dev1)
>>>
```

Scapy's version is wrongly set to the current project's version.

When trying to determine scapy's version from git, make sure that the code is executed from the root of a git repo. If not, read the version from the `scapy/VERSION` file which has been generated when packaging scapy source archive.

This fixes commit: 4f71027fcdcb ("enhance version management")