### PR TITLE
[Bug] TLS: fix shell start with old cryptography

### DIFF
--- a/scapy/layers/tls/crypto/ffdh.py
+++ b/scapy/layers/tls/crypto/ffdh.py
@@ -9,8 +9,12 @@ XXX These groups (and the ones from RFC 7919) should be registered to
 the cryptography library. And this file should eventually be removed.
 """
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import dh
+from scapy.config import conf
+if conf.crypto_valid:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.asymmetric import dh
+else:
+    default_backend = dh = None
 
 from scapy.utils import long_converter
 
@@ -202,10 +206,11 @@ _ffdh_raw_params = { 'modp768' : modp768,
                      'modp8192': modp8192  }
 
 FFDH_GROUPS = {}
-for name, group in _ffdh_raw_params.iteritems():
-    pn = dh.DHParameterNumbers(group.m, group.g)
-    params = pn.parameters(default_backend())
-    FFDH_GROUPS[name] = [params, group.mLen]
+if dh and default_backend:
+    for name, group in _ffdh_raw_params.iteritems():
+        pn = dh.DHParameterNumbers(group.m, group.g)
+        params = pn.parameters(default_backend())
+        FFDH_GROUPS[name] = [params, group.mLen]
 
 
 #from scapy.layers.tls.crypto.pkcs1 import pkcs_os2ip, pkcs_i2osp


### PR DESCRIPTION
Hello!

Seen on Redhat-7 with distribution version of python-cryptography (1.3.1):

```
# scapy
INFO: Can't import matplotlib. Won't be able to plot.
INFO: Can't import PyX. Won't be able to use psdump() or pdfdump().
WARNING: No route found for IPv6 destination :: (no default route?)
INFO: Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption.
INFO: Can't import python-cryptography v1.7+. Disabled IPsec encryption/authentication.
INFO: Can't import python-cryptography v1.7+. Disabled PKI & TLS crypto-related features.
Traceback (most recent call last):
  File "/usr/local/bin/scapy", line 25, in <module>
    interact()
  File "/usr/lib/python2.7/site-packages/scapy/main.py", line 359, in interact
    init_session(None, mydict)
  File "/usr/lib/python2.7/site-packages/scapy/main.py", line 183, in init_session
    scapy_builtins = __import__("all",globals(),locals(),".").__dict__
  File "/usr/lib/python2.7/site-packages/scapy/all.py", line 43, in <module>
    from scapy.layers.tls.all import *
  File "/usr/lib/python2.7/site-packages/scapy/layers/tls/all.py", line 12, in <module>
    from scapy.layers.tls.automaton import *
  File "/usr/lib/python2.7/site-packages/scapy/layers/tls/automaton.py", line 35, in <module>
    from scapy.layers.tls.handshake import *
  File "/usr/lib/python2.7/site-packages/scapy/layers/tls/handshake.py", line 22, in <module>
    from scapy.layers.tls.keyexchange import (_tls_named_curves, _tls_hash_sig,
  File "/usr/lib/python2.7/site-packages/scapy/layers/tls/keyexchange.py", line 24, in <module>
    from scapy.layers.tls.crypto.ffdh import FFDH_GROUPS
  File "/usr/lib/python2.7/site-packages/scapy/layers/tls/crypto/ffdh.py", line 207, in <module>
    params = pn.parameters(default_backend())
AttributeError: 'DHParameterNumbers' object has no attribute 'parameters'
```

There are several ways to fix this issue. I chose to check conf.crypto_valid before importing cryptography in the faulty module, but I also thought of checking it entirely in the scapy.layers.tls.all module. What would you prefer?

If we check in specific modules, shouldn't we also check in the following modules that import stuff from cryptography:
- scapy/layers/tls/crypto/cipher_aead.py
- scapy/layers/tls/crypto/cipher_block.py
- scapy/layers/tls/crypto/cipher_stream.py
- scapy/layers/tls/keyexchange.py

These modules do not actually raise exceptions but checking for crypto_valid may be interesting...

What do you think?