### PR TITLE
EAP - fix variable length field computation

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -539,11 +539,12 @@ class EAP_MD5(EAP):
         ByteEnumField("code", 1, eap_codes),
         ByteField("id", 0),
         FieldLenField("len", None, fmt="H", length_of="optional_name",
-                      adjust=lambda p, x: x + p.value_size + 6),
+                adjust=lambda p, x: (x + p.value_size + 6) if p.value_size is not None else 6),
         ByteEnumField("type", 4, eap_types),
-        FieldLenField("value_size", 0, fmt="B", length_of="value"),
+        FieldLenField("value_size", None, fmt="B", length_of="value"),
         XStrLenField("value", '', length_from=lambda p: p.value_size),
-        XStrLenField("optional_name", '', length_from=lambda p: p.len - p.value_size - 6)
+        XStrLenField("optional_name", '',
+                length_from=lambda p: (p.len - p.value_size - 6) if p.len is not None and p.value_size is not None else 0)
     ]
 
 
@@ -564,7 +565,8 @@ class EAP_TLS(EAP):
         BitField('S', 0, 1),
         BitField('reserved', 0, 5),
         ConditionalField(IntField('tls_message_len', 0), lambda pkt: pkt.L == 1),
-        XStrLenField('tls_data', '', length_from=lambda pkt: pkt.len - 10 if pkt.L == 1 else pkt.len - 6)
+        XStrLenField('tls_data', '',
+                length_from=lambda pkt: pkt.len - 10 if pkt.len is not None and pkt.L == 1 else pkt.len - 6 if pkt.len is not None else 0)
     ]
 
 
@@ -587,7 +589,8 @@ class EAP_FAST(EAP):
         BitField('reserved', 0, 2),
         BitField('version', 0, 3),
         ConditionalField(IntField('message_len', 0), lambda pkt: pkt.L == 1),
-        XStrLenField('data', '', length_from=lambda pkt: pkt.len - 10 if pkt.L == 1 else pkt.len - 6)
+        XStrLenField('data', '', 
+                length_from=lambda pkt: pkt.len - 10 if pkt.len is not None and pkt.L == 1 else pkt.len - 6 if pkt.len is not None else 0)
     ]
 
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -591,6 +591,26 @@ class EAP_FAST(EAP):
     ]
 
 
+class LEAP(EAP):
+    """
+    Cisco LEAP (Lightweight EAP)
+    https://freeradius.org/rfc/leap.txt
+    """
+
+    name = "Cisco LEAP"
+    fields_desc = [
+        ByteEnumField("code", 1, eap_codes),
+        ByteField("id", 0),
+        ShortField("len", None),
+        ByteEnumField("type", 17, eap_types),
+        ByteField('version', 1),
+        XByteField('unused', 0),
+        FieldLenField("count", None, "challenge_response", "B", adjust=lambda p, x: len(p.challenge_response)),
+        XStrLenField("challenge_response", "", length_from=lambda p: 0 or p.count),
+        StrLenField("username", "", length_from=lambda p: p.len - (8 + (0 or p.count)))
+    ]
+
+
 #############################################################################
 ##### IEEE 802.1X-2010 - MACsec Key Agreement (MKA) protocol
 #############################################################################

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -5838,23 +5838,60 @@ assert(eap[EAP_MD5].value_size == 16)
 assert(eap[EAP_MD5].value == b'\xfd\x1e\xffe\xf5\x80y\xa8\xe3\xc8\xf1\xbd\xc2\x85\xae\xcf')
 assert(eap[EAP_MD5].optional_name == '')
 
+= EAP - LEAP - Basic Instantiation
+str(LEAP()) == b'\x01\x00\x00\x08\x11\x01\x00\x00'
+
+= EAP - LEAP - Request - Dissection (10)
+s = b'\x01D\x00\x1c\x11\x01\x00\x088\xb6\xd7\xa1E<!\x15supplicant-1'
+eap = LEAP(s)
+assert(eap.code == 1)
+assert(eap.id == 68)
+assert(eap.len == 28)
+assert(eap.type == 17)
+assert(eap.haslayer(LEAP))
+assert(eap[LEAP].version == 1)
+assert(eap[LEAP].count == 8)
+assert(eap[LEAP].challenge_response == b'8\xb6\xd7\xa1E<!\x15')
+assert(eap[LEAP].username == "supplicant-1")
+
+= EAP - LEAP - Response - Dissection (11)
+s = b'\x02D\x00,\x11\x01\x00\x18\xb3\x82[\x82\x8a\xc8M*\xf3\xe7\xb3\xad,7\x8b\xbfG\x81\xda\xbf\xe6\xc1\x9b\x95supplicant-1'
+eap = LEAP(s)
+assert(eap.code == 2)
+assert(eap.id == 68)
+assert(eap.len == 44)
+assert(eap.type == 17)
+assert(eap.haslayer(LEAP))
+assert(eap[LEAP].version == 1)
+assert(eap[LEAP].count == 24)
+assert(eap[LEAP].challenge_response == b'\xb3\x82[\x82\x8a\xc8M*\xf3\xe7\xb3\xad,7\x8b\xbfG\x81\xda\xbf\xe6\xc1\x9b\x95')
+assert(eap[LEAP].username == "supplicant-1")
+
 = EAP - Layers (1)
 eap = EAP_MD5()
 assert(EAP_MD5 in eap)
 assert(not EAP_TLS in eap)
 assert(not EAP_FAST in eap)
+assert(not LEAP in eap)
 assert(EAP in eap)
 eap = EAP_TLS()
 assert(EAP_TLS in eap)
 assert(not EAP_MD5 in eap)
 assert(not EAP_FAST in eap)
+assert(not LEAP in eap)
 assert(EAP in eap)
 eap = EAP_FAST()
 assert(EAP_FAST in eap)
 assert(not EAP_MD5 in eap)
 assert(not EAP_TLS in eap)
+assert(not LEAP in eap)
 assert(EAP in eap)
-
+eap = LEAP()
+assert(not EAP_MD5 in eap)
+assert(not EAP_TLS in eap)
+assert(not EAP_FAST in eap)
+assert(LEAP in eap)
+assert(EAP in eap)
 
 = EAP - Layers (2)
 eap = EAP_MD5()
@@ -5863,6 +5900,9 @@ eap = EAP_TLS()
 assert(type(eap[EAP]) == EAP_TLS)
 eap = EAP_FAST()
 assert(type(eap[EAP]) == EAP_FAST)
+eap = LEAP()
+assert(type(eap[EAP]) == LEAP)
+
 
 
 ############


### PR DESCRIPTION
This PR fixes variable length field computation in EAP_MD5, EAP_TLS and EAP_FAST.

Example:
```
>>> EAP_FAST().show()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "scapy/packet.py", line 923, in show
    return self._show_or_dump(dump, indent, lvl, label_lvl)
  File "scapy/packet.py", line 906, in _show_or_dump
    reprval = f.i2repr(self,fvalue)
  File "scapy/fields.py", line 572, in i2repr
    return x[:self.length_from(pkt)].encode("hex")
  File "scapy/layers/l2.py", line 590, in <lambda>
    XStrLenField('data', '', length_from=lambda pkt: pkt.len - 10 if
pkt.L == 1 else pkt.len - 6)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

Additional tests were added in order to prevent computation attempts when field values were `None`.