### PR TITLE
[Windows] Fix loopback routes

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -16,7 +16,7 @@ from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader
 from scapy.base_classes import Gen, Net, SetGen
 from scapy.data import MTU, ETHER_BROADCAST, ETH_P_ARP
-from scapy.consts import LOOPBACK_NAME
+from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
 
 conf.use_pcap = False
 conf.use_dnet = False
@@ -337,6 +337,7 @@ def get_ip_from_name(ifname, v6=False):
                                     ['Description', 'IPAddress']):
         if descr == ifname.strip():
             return ipaddr.split(",", 1)[v6].strip('{}').strip()
+    return None
         
 class NetworkInterface(object):
     """A network interface of your local host"""
@@ -371,6 +372,9 @@ class NetworkInterface(object):
         try:
             if not self.ip:
                 self.ip=get_ip_from_name(data['name'])
+            if not self.ip:
+                # No IP detected
+                self.invalid = True
         except (KeyError, AttributeError, NameError) as e:
             print e
         if not self.ip and self.name == LOOPBACK_NAME:
@@ -413,6 +417,14 @@ class NetworkInterfaceDict(UserDict):
                                 "You probably won't be able to send packets. "
                                 "Deactivating unneeded interfaces and restarting Scapy might help."
                                 "Check your winpcap and powershell installation, and access rights.", True)
+        else:
+            # Loading state: remove invalid interfaces
+            self.remove_invalid_ifaces()
+            # Replace interface for getLoopbackInterface()
+            try:
+                scapy.consts.LOOPBACK_INTERFACE = self.dev_from_name(LOOPBACK_NAME)
+            except:
+                pass
 
     def dev_from_name(self, name):
         """Return the first pcap device name for a given Windows
@@ -435,7 +447,18 @@ class NetworkInterfaceDict(UserDict):
         for devname, iface in self.items():
             if iface.win_index == str(if_index):
                 return iface
+        if str(if_index) == "1":
+            # Local loopback
+            loopback = getLoopbackInterface()
+            if loopback != LOOPBACK_NAME:
+                return loopback
         raise ValueError("Unknown network interface index %r" % if_index)
+
+    def remove_invalid_ifaces(self):
+        """Remove all invalid interfaces"""
+        for devname, iface in self.items():
+            if iface.is_invalid():
+                self.data.pop(devname)
 
     def show(self, resolve_mac=True):
         """Print list of available network interfaces in human readable form"""
@@ -635,13 +658,10 @@ def read_routes6():
                 cset = ['::1']
             else:
                 devaddrs = filter(lambda x: x[2] == iface, lifaddr)
-                cset = scapy.utils6.construct_source_candidate_set(d, dp, devaddrs, LOOPBACK_NAME)
+                cset = scapy.utils6.construct_source_candidate_set(d, dp, devaddrs, getLoopbackInterface())
             # APPEND (DESTINATION, NETMASK, NEXT HOP, IFACE, CANDIDATS)
             routes.append((d, dp, nh, iface, cset))
     return routes
-
-
-
 
 if conf.interactive_shell != 'ipython' and conf.interactive:
     try:
@@ -680,12 +700,13 @@ def get_working_if():
         return min(read_routes(), key=lambda x: x[1])[3]
     except ValueError:
         # no route
-        return LOOPBACK_NAME
+        return getLoopbackInterface()
 
 conf.iface = get_working_if()
 
 def route_add_loopback(routes=None, ipv6=False, iflist=None):
     """Add a route to 127.0.0.1 and ::1 to simplify unit tests on Windows"""
+    warning("This will completly mess up the routes. Testing purpose only !")
     # Add only if some adpaters already exist
     if ipv6:
         if len(conf.route6.routes) == 0:
@@ -699,10 +720,22 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
     data['win_index'] = -1
     data['guid'] = "{0XX00000-X000-0X0X-X00X-00XXXX000XXX}"
     data['invalid'] = True
+    data['mac'] = '00:00:00:00:00:00'
     adapter = NetworkInterface(data)
     if iflist:
         iflist.append(unicode("\\Device\\NPF_" + adapter.guid))
         return
+    # Remove all LOOPBACK_NAME routes
+    for route in list(conf.route.routes):
+        iface = route[3]
+        if iface.name == LOOPBACK_NAME:
+            conf.route.routes.remove(route)
+    # Remove LOOPBACK_NAME interface
+    for devname, iface in IFACES.items():
+        if iface.name == LOOPBACK_NAME:
+            IFACES.pop(devname)
+    # Inject interface
+    IFACES[data['guid']] = adapter
     # Build the packed network addresses
     loop_net = struct.unpack("!I", socket.inet_aton("127.0.0.0"))[0]
     loop_mask = struct.unpack("!I", socket.inet_aton("255.0.0.0"))[0]

--- a/scapy/arch/windows/output.txt
+++ b/scapy/arch/windows/output.txt
@@ -1,0 +1,191 @@
+
+Préfixe de destination :      ::/0
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    8
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      ::1/128
+Préfixe source :              ::/0
+Index d'interface :           1
+Nom de passerelle/interface : Loopback Pseudo-Interface 1
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      2001::/32
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    8
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      2001:0:9d38:6abd:3857:1d60:3f57:fefb/128
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::/64
+Préfixe source :              ::/0
+Index d'interface :           11
+Nom de passerelle/interface : Connexion au réseau local
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::/64
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::/64
+Préfixe source :              ::/0
+Index d'interface :           19
+Nom de passerelle/interface : Npcap Loopback Adapter
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::5efe:169.254.173.204/128
+Préfixe source :              ::/0
+Index d'interface :           22
+Nom de passerelle/interface : isatap.{1A7C386A-D8B7-49C2-BDD9-1EC7391400CF}
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::5efe:192.168.1.4/128
+Préfixe source :              ::/0
+Index d'interface :           12
+Nom de passerelle/interface : isatap.{08059C5F-6C38-4455-9DB6-6C6D733170A2}
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::3857:1d60:3f57:fefb/128
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::58af:d9b1:f7a9:adcc/128
+Préfixe source :              ::/0
+Index d'interface :           19
+Nom de passerelle/interface : Npcap Loopback Adapter
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      fe80::7ce6:3e2d:9a3f:9ded/128
+Préfixe source :              ::/0
+Index d'interface :           11
+Nom de passerelle/interface : Connexion au réseau local
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      ff00::/8
+Préfixe source :              ::/0
+Index d'interface :           1
+Nom de passerelle/interface : Loopback Pseudo-Interface 1
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      ff00::/8
+Préfixe source :              ::/0
+Index d'interface :           13
+Nom de passerelle/interface : Teredo Tunneling Pseudo-Interface
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      ff00::/8
+Préfixe source :              ::/0
+Index d'interface :           11
+Nom de passerelle/interface : Connexion au réseau local
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini
+
+
+Préfixe de destination :      ff00::/8
+Préfixe source :              ::/0
+Index d'interface :           19
+Nom de passerelle/interface : Npcap Loopback Adapter
+Publication :                 Non
+Type :                        Manuel
+Métrique :                    256
+Longueur de préfixe de site   0
+Durée de vie valide           Infini
+Durée de vie préférée         Infini

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -59,6 +59,8 @@ WINDOWS = platform.startswith("win32")
 BSD = DARWIN or FREEBSD or OPENBSD or NETBSD
 # See https://docs.python.org/3/library/platform.html#cross-platform
 IS_64BITS = maxsize > 2**32
+# Windows only
+LOOPBACK_INTERFACE = None
 
 if WINDOWS:
     try:
@@ -71,6 +73,12 @@ if WINDOWS:
 else:
     uname = os.uname()
     LOOPBACK_NAME = "lo" if LINUX else "lo0"
+
+def getLoopbackInterface():
+    if LOOPBACK_INTERFACE and WINDOWS:
+        return LOOPBACK_INTERFACE
+    else:
+        return LOOPBACK_NAME
 
 def parent_function():
     return inspect.getouterframes(inspect.currentframe())

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -63,7 +63,7 @@ def getmacbyip(ip, chainCC=0):
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
         return "01:00:5e:%.2x:%.2x:%.2x" % (tmp[1]&0x7f,tmp[2],tmp[3])
     iff,a,gw = conf.route.route(ip)
-    if ( (iff == LOOPBACK_NAME) or (ip == conf.route.get_if_bcast(iff)) ):
+    if ( (iff == getLoopbackInterface()) or (ip == conf.route.get_if_bcast(iff)) ):
         return "ff:ff:ff:ff:ff:ff"
     if gw != "0.0.0.0":
         ip = gw

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -190,6 +190,6 @@ conf.route=Route()
 
 #XXX use "with"
 _betteriface = conf.route.route("0.0.0.0", verbose=0)[0]
-if ((_betteriface.name != LOOPBACK_NAME) if WINDOWS else (_betteriface != LOOPBACK_NAME)):
+if ((_betteriface if (isinstance(_betteriface, basestring) or _betteriface is None) else _betteriface.name) != LOOPBACK_NAME):
     conf.iface = _betteriface
 del(_betteriface)

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -21,7 +21,7 @@ from scapy.volatile import RandMAC
 from scapy.error import warning
 
 
-def construct_source_candidate_set(addr, plen, laddr, loname):
+def construct_source_candidate_set(addr, plen, laddr, loiface):
     """
     Given all addresses assigned to a specific interface ('laddr' parameter),
     this function returns the "candidate set" associated with 'addr/plen'.
@@ -57,7 +57,7 @@ def construct_source_candidate_set(addr, plen, laddr, loname):
         cset = filter(lambda x: x[1] == IPV6_ADDR_SITELOCAL, laddr)
     elif in6_ismaddr(addr):
         if in6_ismnladdr(addr):
-            cset = [('::1', 16, loname)]
+            cset = [('::1', 16, loiface)]
         elif in6_ismgladdr(addr):
             cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
         elif in6_ismlladdr(addr):

--- a/test/edns0.uts
+++ b/test/edns0.uts
@@ -50,7 +50,7 @@ str(tlv) == b'\x00\x05\x00\x04\x00\x11"3'
 #* NB: 85.17.219.217 and www.edns-ping.org seem down
 #old_debug_dissector = conf.debug_dissector
 #conf.debug_dissector = False
-#r = sr1(IP(dst="85.17.219.217")/UDP()/DNS(qd=[DNSQR(qtype="A", qname="www.edns-ping.org.")], ar=[DNSRROPT(z=0, rdata=[EDNS0TLV(optcode="PING", optdata=b"\x00\x11\x22\x33")])]), timeout=1)
+#r = sr1(IP(dst="85.17.219.217")/UDP()/DNS(qd=[DNSQR(qtype="A", qname="www.edns-ping.org.")], ar=[DNSRROPT(z=0, rdata=[EDNS0TLV(optcode="PING", optdata=b"\x00\x11\x22\x33")])]), timeout=3)
 #conf.debug_dissector = old_debug_dissector
 #len(r.ar) and r.ar.rdata[0].optcode == 4  # XXX: should be 5
 
@@ -64,6 +64,6 @@ str(tlv) == b'\x00\x02\x00\x00'
 ~ netaccess
 old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
-r = sr1(IP(dst="l.root-servers.net")/UDP()/DNS(qd=[DNSQR(qtype="SOA", qname=".")], ar=[DNSRROPT(z=0, rdata=[EDNS0TLV(optcode="NSID")])]), timeout=1)
+r = sr1(IP(dst="l.root-servers.net")/UDP()/DNS(qd=[DNSQR(qtype="SOA", qname=".")], ar=[DNSRROPT(z=0, rdata=[EDNS0TLV(optcode="NSID")])]), timeout=3)
 conf.debug_dissector = old_debug_dissector
 len(r.ar) and DNSRROPT in r.ar and len(r.ar[DNSRROPT].rdata) and len([x for x in r.ar[DNSRROPT].rdata if x.optcode == 3])

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -201,7 +201,7 @@ def test_show_interfaces(mock_stdout):
         if not l.strip():
             continue
         try:
-            int(l[0])
+            int(l[:2])
         except:
             sys.stderr.write(l)
             return False

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -11,6 +11,8 @@
 * Dump the current configuration
 conf
 
+IP().src
+
 = List layers
 ~ conf command
 ls()
@@ -91,6 +93,15 @@ else:
 = Test ifchange()
 conf.route6.ifchange(LOOPBACK_NAME, "::1/128")
 True
+
+= UTscapy route check
+* Check that UTscapy has correctly replaced the routes. Many tests won't work otherwise
+
+if WINDOWS:
+    route_add_loopback()
+
+IP().src
+assert _ == "127.0.0.1"
 
 ############
 ############


### PR DESCRIPTION
This PR:
- Adds a better loopback support for windows: now detects "127.0.0.1"
- Fixes VBS detection duplicated function
- Fixes several Linux only usages
- Now sort the output of `conf.route` and `conf.route6`
- Fixes buggy routes (without IP)

edit: i'm currently looking for an explanation of the tests failure.