### PR TITLE
[Routing/Windows] Improve routing system

### DIFF
--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -59,8 +59,6 @@ WINDOWS = platform.startswith("win32")
 BSD = DARWIN or FREEBSD or OPENBSD or NETBSD
 # See https://docs.python.org/3/library/platform.html#cross-platform
 IS_64BITS = maxsize > 2**32
-# Windows only
-LOOPBACK_INTERFACE = None
 
 if WINDOWS:
     try:
@@ -74,11 +72,8 @@ else:
     uname = os.uname()
     LOOPBACK_NAME = "lo" if LINUX else "lo0"
 
-def getLoopbackInterface():
-    if LOOPBACK_INTERFACE and WINDOWS:
-        return LOOPBACK_INTERFACE
-    else:
-        return LOOPBACK_NAME
+# Will be different on Windows
+LOOPBACK_INTERFACE = LOOPBACK_NAME
 
 def parent_function():
     return inspect.getouterframes(inspect.currentframe())

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -59,6 +59,8 @@ WINDOWS = platform.startswith("win32")
 BSD = DARWIN or FREEBSD or OPENBSD or NETBSD
 # See https://docs.python.org/3/library/platform.html#cross-platform
 IS_64BITS = maxsize > 2**32
+# Windows only
+LOOPBACK_INTERFACE = None
 
 if WINDOWS:
     try:
@@ -71,6 +73,12 @@ if WINDOWS:
 else:
     uname = os.uname()
     LOOPBACK_NAME = "lo" if LINUX else "lo0"
+
+def getLoopbackInterface():
+    if LOOPBACK_INTERFACE and WINDOWS:
+        return LOOPBACK_INTERFACE
+    else:
+        return LOOPBACK_NAME
 
 def parent_function():
     return inspect.getouterframes(inspect.currentframe())

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -18,7 +18,7 @@ from scapy.plist import SndRcvList
 from scapy.fields import *
 from scapy.sendrecv import srp, srp1, srpflood
 from scapy.arch import get_if_hwaddr
-from scapy.consts import LOOPBACK_NAME
+from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.error import warning
 if conf.route is None:
@@ -63,7 +63,7 @@ def getmacbyip(ip, chainCC=0):
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
         return "01:00:5e:%.2x:%.2x:%.2x" % (tmp[1]&0x7f,tmp[2],tmp[3])
     iff,a,gw = conf.route.route(ip)
-    if ( (iff == LOOPBACK_NAME) or (ip == conf.route.get_if_bcast(iff)) ):
+    if ( (iff == getLoopbackInterface()) or (ip == conf.route.get_if_bcast(iff)) ):
         return "ff:ff:ff:ff:ff:ff"
     if gw != "0.0.0.0":
         ip = gw

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -18,7 +18,7 @@ from scapy.plist import SndRcvList
 from scapy.fields import *
 from scapy.sendrecv import srp, srp1, srpflood
 from scapy.arch import get_if_hwaddr
-from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
+from scapy.consts import LOOPBACK_INTERFACE
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.error import warning
 if conf.route is None:
@@ -63,7 +63,7 @@ def getmacbyip(ip, chainCC=0):
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
         return "01:00:5e:%.2x:%.2x:%.2x" % (tmp[1]&0x7f,tmp[2],tmp[3])
     iff,a,gw = conf.route.route(ip)
-    if ( (iff == getLoopbackInterface()) or (ip == conf.route.get_if_bcast(iff)) ):
+    if ( (iff == LOOPBACK_INTERFACE) or (ip == conf.route.get_if_bcast(iff)) ):
         return "ff:ff:ff:ff:ff:ff"
     if gw != "0.0.0.0":
         ip = gw

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -8,7 +8,7 @@ Routing and handling of network interfaces.
 """
 
 import socket
-from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
+from scapy.consts import LOOPBACK_NAME, LOOPBACK_INTERFACE
 from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
@@ -152,13 +152,13 @@ class Route:
                 continue
             aa = atol(a)
             if aa == dst:
-                pathes.append((0xffffffffL,(getLoopbackInterface(),a,"0.0.0.0")))
+                pathes.append((0xffffffffL,(LOOPBACK_INTERFACE,a,"0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m,(i,a,gw)))
         if not pathes:
             if verbose:
                 warning("No route found (no default route?)")
-            return getLoopbackInterface(),"0.0.0.0","0.0.0.0"
+            return LOOPBACK_INTERFACE,"0.0.0.0","0.0.0.0"
         # Choose the more specific route (greatest netmask).
         # XXX: we don't care about metrics
         pathes.sort()

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -190,6 +190,6 @@ conf.route=Route()
 
 #XXX use "with"
 _betteriface = conf.route.route("0.0.0.0", verbose=0)[0]
-if ((_betteriface.name != LOOPBACK_NAME) if WINDOWS else (_betteriface != LOOPBACK_NAME)):
+if ((_betteriface if (isinstance(_betteriface, basestring) or _betteriface is None) else _betteriface.name) != LOOPBACK_NAME):
     conf.iface = _betteriface
 del(_betteriface)

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -9,7 +9,7 @@ Routing and handling of network interfaces.
 
 import socket
 from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
-from scapy.utils import atol, ltoa, itom
+from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.arch import WINDOWS
@@ -41,15 +41,8 @@ class Route:
                       (iface.name if not isinstance(iface, basestring) else iface),
                       addr))
 
-        # Sort correctly
-        rtlst.sort(key=lambda x: x[0])
-        # Append tag
-        rtlst = [("Network", "Netmask", "Gateway", "Iface", "Output IP")] + rtlst
-        
-        colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst))
-        fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
-        rt = "\n".join(map(lambda x: fmt % x, rtlst))
-        return rt
+        return pretty_routes(rtlst,
+                             [("Network", "Netmask", "Gateway", "Iface", "Output IP")])
 
     def make_route(self, host=None, net=None, gw=None, dev=None):
         from scapy.arch import get_if_addr

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -8,7 +8,7 @@ Routing and handling of network interfaces.
 """
 
 import socket
-from scapy.consts import LOOPBACK_NAME
+from scapy.consts import LOOPBACK_NAME, getLoopbackInterface
 from scapy.utils import atol, ltoa, itom
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
@@ -32,7 +32,7 @@ class Route:
         self.routes = read_routes()
 
     def __repr__(self):
-        rtlst = [("Network", "Netmask", "Gateway", "Iface", "Output IP")]
+        rtlst = []
         
         for net,msk,gw,iface,addr in self.routes:
 	    rtlst.append((ltoa(net),
@@ -40,6 +40,11 @@ class Route:
                       gw,
                       (iface.name if not isinstance(iface, basestring) else iface),
                       addr))
+
+        # Sort correctly
+        rtlst.sort(key=lambda x: x[0])
+        # Append tag
+        rtlst = [("Network", "Netmask", "Gateway", "Iface", "Output IP")] + rtlst
         
         colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst))
         fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
@@ -154,13 +159,13 @@ class Route:
                 continue
             aa = atol(a)
             if aa == dst:
-                pathes.append((0xffffffffL,(LOOPBACK_NAME,a,"0.0.0.0")))
+                pathes.append((0xffffffffL,(getLoopbackInterface(),a,"0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m,(i,a,gw)))
         if not pathes:
             if verbose:
                 warning("No route found (no default route?)")
-            return LOOPBACK_NAME,"0.0.0.0","0.0.0.0" #XXX linux specific!
+            return getLoopbackInterface(),"0.0.0.0","0.0.0.0"
         # Choose the more specific route (greatest netmask).
         # XXX: we don't care about metrics
         pathes.sort()
@@ -185,6 +190,6 @@ conf.route=Route()
 
 #XXX use "with"
 _betteriface = conf.route.route("0.0.0.0", verbose=0)[0]
-if _betteriface != LOOPBACK_NAME:
+if ((_betteriface.name != LOOPBACK_NAME) if WINDOWS else (_betteriface != LOOPBACK_NAME)):
     conf.iface = _betteriface
 del(_betteriface)

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -22,7 +22,7 @@ from scapy.utils6 import *
 from scapy.arch import *
 from scapy.pton_ntop import *
 from scapy.error import warning, log_loading
-from scapy.consts import getLoopbackInterface
+from scapy.consts import LOOPBACK_INTERFACE
 
 
 class Route6:
@@ -75,7 +75,7 @@ class Route6:
             # replace that unique address by the list of all addresses
             lifaddr = in6_getifaddr()
             devaddrs = filter(lambda x: x[2] == dev, lifaddr)
-            ifaddr = construct_source_candidate_set(prefix, plen, devaddrs, getLoopbackInterface())
+            ifaddr = construct_source_candidate_set(prefix, plen, devaddrs, LOOPBACK_INTERFACE)
 
         return (prefix, plen, gw, dev, ifaddr)
 
@@ -218,7 +218,7 @@ class Route6:
 
         if not pathes:
             warning("No route found for IPv6 destination %s (no default route?)" % dst)
-            return (getLoopbackInterface(), "::", "::")
+            return (LOOPBACK_INTERFACE, "::", "::")
 
         # Sort with longest prefix first
         pathes.sort(reverse=True)
@@ -235,7 +235,7 @@ class Route6:
 
         if res == []:
             warning("Found a route for IPv6 destination '%s', but no possible source address." % dst)
-            return (getLoopbackInterface(), "::", "::")
+            return (LOOPBACK_INTERFACE, "::", "::")
 
         # Symptom  : 2 routes with same weight (our weight is plen)
         # Solution :

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -50,19 +50,11 @@ class Route6:
         rtlst = []
 
         for net,msk,gw,iface,cset in self.routes:
-            rtlst.append(('%s/%i'% (net,msk), gw, (iface if isinstance(iface, basestring) else iface.name), ", ".join(cset)))
+            rtlst.append(('%s/%i'% (net,msk), gw, (iface if isinstance(iface, basestring) else iface.name), ", ".join(cset) if len(cset) > 0 else ""))
 
-        # Sort correctly
-        rtlst.sort(key=lambda x: x[0])
-        # Append tag
-        rtlst = [('Destination', 'Next Hop', "iface", "src candidates")] + rtlst
-        
-        colwidth = [max([len(y) for y in x]) for x in zip(*rtlst)]
-        fmt = "  ".join(["%%-%ds"%x for x in colwidth])
-        rt = "\n".join([fmt % x for x in rtlst])
-
-        return rt
-
+        return pretty_routes(rtlst,
+                             [('Destination', 'Next Hop', "Iface", "Src candidates")],
+                             sortBy = 1)
 
     # Unlike Scapy's Route.make_route() function, we do not have 'host' and 'net'
     # parameters. We only have a 'dst' parameter that accepts 'prefix' and

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -184,15 +184,10 @@ class UnitTest(TestClass):
         self.crc = None
         self.expand = 1
     def decode(self):
-        self.test = self.test.decode("utf8")
-        self.output = self.output.decode("utf8")
-        self.comments = self.comments.decode("utf8")
-        self.result = self.result.decode("utf8")
-    def encode(self):
-        self.test = self.test.encode("utf8")
-        self.output = self.output.encode("utf8")
-        self.comments = self.comments.encode("utf8")
-        self.result = self.result.encode("utf8")
+        self.test = self.test.decode("utf8", "ignore")
+        self.output = self.output.decode("utf8", "ignore")
+        self.comments = self.comments.decode("utf8", "ignore")
+        self.result = self.result.decode("utf8", "ignore")
     def __nonzero__(self):
         return self.res
 

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -21,7 +21,7 @@ from scapy.volatile import RandMAC
 from scapy.error import warning
 
 
-def construct_source_candidate_set(addr, plen, laddr, loname):
+def construct_source_candidate_set(addr, plen, laddr, loiface):
     """
     Given all addresses assigned to a specific interface ('laddr' parameter),
     this function returns the "candidate set" associated with 'addr/plen'.
@@ -57,7 +57,7 @@ def construct_source_candidate_set(addr, plen, laddr, loname):
         cset = filter(lambda x: x[1] == IPV6_ADDR_SITELOCAL, laddr)
     elif in6_ismaddr(addr):
         if in6_ismnladdr(addr):
-            cset = [('::1', 16, loname)]
+            cset = [('::1', 16, loiface)]
         elif in6_ismgladdr(addr):
             cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
         elif in6_ismlladdr(addr):

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -201,7 +201,7 @@ def test_show_interfaces(mock_stdout):
         if not l.strip():
             continue
         try:
-            int(l[0])
+            int(l[:2])
         except:
             sys.stderr.write(l)
             return False

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -8,10 +8,15 @@
 
 = Windows with fake IPv6 adapter
 
-import mock
+route_add_loopback()
 
-def check_mandatory_ipv6_routes_windows(routes6):
-    """Ensure that mandatory IPv6 routes are present. There is not always a loopback interface on windows !"""
+import mock
+from scapy.arch.windows import _read_routes6_post2008
+
+def check_mandatory_ipv6_routes(routes6):
+    """Ensure that mandatory IPv6 routes are present."""
+    if len(filter(lambda r: r[0] == "::" and r[-1] == ["::1"], routes6)) < 1:
+        return False
     if len(filter(lambda r: r[0] == "fe80::" and (r[1] == 64 or r[1] == 32), routes6)) < 1:
         return False
     if len(filter(lambda r: in6_islladdr(r[0]) and r[1] == 128, routes6)) < 1:
@@ -19,23 +24,24 @@ def check_mandatory_ipv6_routes_windows(routes6):
     return True
 
 def dev_from_index_custom(if_index):
-    if_list = [{'mac': 'D0-50-99-56-DD-F9', 'win_index': '13', 'guid': '{C56DFFB3-992C-4964-B000-3E7C0F76E8BA}', 'name': 'Killer E2200 Gigabit Ethernet Controller', 'description': 'Ethernet'}, {'mac': '00-FF-0E-C7-25-37', 'win_index': '3', 'guid': '{0EC72537-B662-4F5D-B34E-48BFAE799BBE}', 'name': 'TAP-Windows Adapter V9', 'description': 'Ethernet 2'}]
+    if_list = [{'mac': 'D0:50:99:56:DD:F9', 'win_index': '13', 'guid': '{C56DFFB3-992C-4964-B000-3E7C0F76E8BA}', 'name': 'Killer E2200 Gigabit Ethernet Controller', 'description': 'Ethernet'}, {'mac': '00:FF:0E:C7:25:37', 'win_index': '3', 'guid': '{0EC72537-B662-4F5D-B34E-48BFAE799BBE}', 'name': 'TAP-Windows Adapter V9', 'description': 'Ethernet 2'}]
     values = {}
     for i in if_list:
-            try:
-                interface = NetworkInterface(i)
-                values[interface.guid] = interface
-            except (KeyError, PcapNameNotFoundError):
-                pass
+        try:
+            interface = NetworkInterface(i)
+            values[interface.guid] = interface
+        except (KeyError, PcapNameNotFoundError):
+            pass
     for devname, iface in values.items():
         if iface.win_index == str(if_index):
             return iface
     raise ValueError("Unknown network interface index %r" % if_index)
 
+@mock.patch("scapy.utils6.construct_source_candidate_set")
 @mock.patch("scapy.arch.windows.winpcapy_get_if_list")
 @mock.patch("scapy.arch.windows.dev_from_index")
 @mock.patch("scapy.arch.windows.sp.Popen")
-def test_read_routes6_windows(mock_comm, mock_dev_from_index, mock_winpcapylist):
+def test_read_routes6_windows(mock_comm, mock_dev_from_index, mock_winpcapylist, mock_utils6cset):
     """Test read_routes6() on Windows"""
     # 'Get-NetRoute -AddressFamily IPV6 | select ifIndex, DestinationPrefix, NextHop'
     get_net_route_output = """
@@ -60,12 +66,15 @@ ifIndex DestinationPrefix                          NextHop
     mock_winpcapylist.return_value = [u'\\Device\\NPF_{0EC72537-B662-4F5D-B34E-48BFAE799BBE}', u'\\Device\\NPF_{C56DFFB3-992C-4964-B000-3E7C0F76E8BA}']
     # Mocked in6_getifaddr() output
     mock_dev_from_index.side_effect = dev_from_index_custom
+    # Random
+    mock_utils6cset.side_effect = lambda w,x,y,z: ["::1"] if w=="::" else ["fdbb:d995:ddd8:51fc::"]
     # Test the function
-    routes = read_routes6()
+    routes = _read_routes6_post2008()
     for r in routes:
         print r
+    print(len(routes))
     assert(len(routes) == 9)
-    assert(check_mandatory_ipv6_routes_windows(routes))
+    assert(check_mandatory_ipv6_routes(routes))
 
 
 test_read_routes6_windows()

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -11,6 +11,8 @@
 * Dump the current configuration
 conf
 
+IP().src
+
 = List layers
 ~ conf command
 ls()
@@ -91,6 +93,15 @@ else:
 = Test ifchange()
 conf.route6.ifchange(LOOPBACK_NAME, "::1/128")
 True
+
+= UTscapy route check
+* Check that UTscapy has correctly replaced the routes. Many tests won't work otherwise
+
+if WINDOWS:
+    route_add_loopback()
+
+IP().src
+assert _ == "127.0.0.1"
 
 ############
 ############


### PR DESCRIPTION
This PR improves routes by different ways:
- Add Windows 7 + no powershell routing detection ==> fix https://github.com/secdev/scapy/issues/562
- Fix localhost routes on windows
- Fix a bad dupplicated method in arch.windows.\_\_init\_\_
- Remove linux only routing usages
- Make routes pretty: I have very big interface names, so using `conf.route` makes something ugly. Should crop too long names.

Small tiny bug fixed: in UTscapy, ignore non utf8 characters while loading the output