### PR TITLE
Smaller unit tests results

### DIFF
--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -90,3 +90,5 @@ class DADict:
         return list(self.iterkeys())
     def iterkeys(self):
         return (x for x in self.__dict__ if x and x[0] != "_")
+    def __len__(self):
+        return len(self.__dict__)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -687,7 +687,7 @@ send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 = __repr__
 
 if conf.manufdb:
-    conf.manufdb
+    len(conf.manufdb)
 else:
     True
 


### PR DESCRIPTION
Dumping `conf.manufdb` could result in a very large file (+2MB) while performing unit tests. The resulting HTML file takes ages to load on a browser.