### PR TITLE
Remove unused import

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -12,7 +12,6 @@ import socket,struct,array
 from ctypes import *
 from select import select
 
-from scapy.all import *
 from scapy.config import conf
 from scapy.packet import *
 from scapy.fields import *


### PR DESCRIPTION
In fact, https://github.com/secdev/scapy/issues/403 should simply have done this...
We won't bother with the specific imports....