### PR TITLE
[coverage] More tests for inet.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ test_script:
   - 'del test\regression.uts'
 
   # Secondary and contrib unit tests
-  - 'del test\bpf.uts' # Don't bother with BPF regression tests
+  - 'del test\bpf.uts test\linux.uts' # Don't bother with OS dependent regression tests
   - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -c test\\configs\\windows.utsc || exit /b 42"
   
   # TLS unit tests

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -61,7 +61,7 @@ then
   then
     $SCAPY_SUDO ./run_tests -q -F -t bpf.uts $UT_FLAGS || exit $?
   fi
-  UT_FLAGS+=" -K manufdb"
+  UT_FLAGS+=" -K manufdb -K linux"
 fi
 
 # Run all normal and contrib tests

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -1,0 +1,55 @@
+% Regression tests for Linux only
+
+# More informations at http://www.secdev.org/projects/UTscapy/
+
+
+############
+############
+
++ Linux only test
+
+= TCP client automaton
+~ automaton netaccess linux needs_root
+* This test retries on failure because it often fails
+
+import os
+import time
+import signal
+
+def handler(signum, stack_frame):
+    raise Exception("Timer expired !")
+
+tmp = signal.signal(signal.SIGALRM, handler)
+
+SECDEV_IP4 = "203.178.141.194"
+IPTABLE_RULE = "iptables -%c INPUT -s %s -p tcp --sport 80 -j DROP"
+
+# Drop packets from SECDEV_IP4
+assert(os.system(IPTABLE_RULE % ('A', SECDEV_IP4)) == 0)
+
+success = False
+for i in xrange(10):
+    tmp = signal.alarm(5)
+    try:
+        r, w = os.pipe()
+        t = TCP_client(SECDEV_IP4, 80, external_fd={ "tcp": (r,w) })
+        tmp = os.write(w, "HEAD / HTTP/1.0\r\n\r\n")
+        t.runbg()
+        time.sleep(0.5)
+        response = os.read(r, 4096)
+        tmp = signal.alarm(0)  # cancel the alarm
+        t.stop()
+        os.close(r)
+        os.close(w)
+        if response.startswith("HTTP/1.1 200 OK"):
+            success = True
+            break
+        else:
+            time.sleep(0.5)
+    except Exception as e:
+        print e
+
+# Remove the iptables rule
+assert(os.system(IPTABLE_RULE % ('D', SECDEV_IP4)) == 0)
+
+assert(success)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8147,6 +8147,18 @@ assert("192.168.0.254" not in [p[IP].src for p in new_pl])
 
 = IPv4 - reporting
 
+@mock.patch("scapy.layers.inet.sr")
+def test_report_ports(mock_sr):
+    def sr(*args, **kargs):
+        return [(IP()/TCP(dport=81, flags="S"), IP()/TCP(sport=81, flags="SA")),
+                (IP()/TCP(dport=82, flags="S"), IP()/ICMP(type=3, code=1)),
+                (IP()/TCP(dport=83, flags="S"), IP()/TCP(sport=83, flags="R"))], [IP()/TCP(dport=84, flags="S")]
+    mock_sr.side_effect = sr
+    report = "\\begin{tabular}{|r|l|l|}\n\hline\n81 & open & SA \\\\\n\hline\n?? & closed & ICMP type dest-unreach/host-unreachable from 127.0.0.1 \\\\\n83 & closed & TCP R \\\\\n\hline\n84 & ? & unanswered \\\\\n\hline\n\end{tabular}\n"
+    assert(report_ports("www.secdev.org", [81,82,83,84]) == report)
+
+test_report_ports()
+
 result_IPID_count = ""
 def test_IPID_count():
     def write(s):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8150,12 +8150,12 @@ assert("192.168.0.254" not in [p[IP].src for p in new_pl])
 @mock.patch("scapy.layers.inet.sr")
 def test_report_ports(mock_sr):
     def sr(*args, **kargs):
-        return [(IP()/TCP(dport=81, flags="S"), IP()/TCP(sport=81, flags="SA")),
-                (IP()/TCP(dport=82, flags="S"), IP()/ICMP(type=3, code=1)),
-                (IP()/TCP(dport=83, flags="S"), IP()/TCP(sport=83, flags="R"))], [IP()/TCP(dport=84, flags="S")]
+        return [(IP()/TCP(dport=65081, flags="S"), IP()/TCP(sport=65081, flags="SA")),
+                (IP()/TCP(dport=65082, flags="S"), IP()/ICMP(type=3, code=1)),
+                (IP()/TCP(dport=65083, flags="S"), IP()/TCP(sport=65083, flags="R"))], [IP()/TCP(dport=65084, flags="S")]
     mock_sr.side_effect = sr
-    report = "\\begin{tabular}{|r|l|l|}\n\hline\n81 & open & SA \\\\\n\hline\n?? & closed & ICMP type dest-unreach/host-unreachable from 127.0.0.1 \\\\\n83 & closed & TCP R \\\\\n\hline\n84 & ? & unanswered \\\\\n\hline\n\end{tabular}\n"
-    assert(report_ports("www.secdev.org", [81,82,83,84]) == report)
+    report = "\\begin{tabular}{|r|l|l|}\n\hline\n65081 & open & SA \\\\\n\hline\n?? & closed & ICMP type dest-unreach/host-unreachable from 127.0.0.1 \\\\\n65083 & closed & TCP R \\\\\n\hline\n65084 & ? & unanswered \\\\\n\hline\n\end{tabular}\n"
+    assert(report_ports("www.secdev.org", [65081,65082,65083,65084]) == report)
 
 test_report_ports()
 


### PR DESCRIPTION
This PR test the `report_ports()` function as well as the `TCP_client()`  automaton. A new `linux.uts` was to tests Linux specific parts of Scapy. Here, it is used to call iptables in order to test the TCP automaton.

