### PR TITLE
[Windows] Add pcap service controller

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -461,6 +461,7 @@ class NetworkInterfaceDict(UserDict):
                     elif _confir in ["no", "n"]:
                         return False
                 return False
+            _error_msg = "No match between your pcap and windows network interfaces found. "
             if _detect[0] and not _detect[2] and ((hasattr(self, "restarted_adapter") and not self.restarted_adapter)
                                                  or not hasattr(self, "restarted_adapter")):
                 warning("Scapy has detected that your pcap service is not running !")
@@ -471,15 +472,11 @@ class NetworkInterfaceDict(UserDict):
                         log_loading.info("Pcap service started !")
                         self.load_from_powershell()
                         return
-                warning("Could not start the pcap service ! "
-                            "You probably won't be able to send packets. "
-                            "Deactivating unneeded interfaces and restarting Scapy might help. "
-                            "Check your winpcap and powershell installation, and access rights.")
-            else:
-                warning("No match between your pcap and windows network interfaces found. "
-                                    "You probably won't be able to send packets. "
-                                    "Deactivating unneeded interfaces and restarting Scapy might help. "
-                                    "Check your winpcap and powershell installation, and access rights.", True)
+                _error_msg = "Could not start the pcap service ! "
+            warning(_error_msg +
+                    "You probably won't be able to send packets. "
+                    "Deactivating unneeded interfaces and restarting Scapy might help. "
+                    "Check your winpcap and powershell installation, and access rights.", True)
         else:
             # Loading state: remove invalid interfaces
             self.remove_invalid_ifaces()

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -247,8 +247,9 @@ class WinProgPath(ConfClass):
     def __init__(self):
         # This is a dict containing the name of the .exe and a keyword
         # that must be in the path of the file
-        external_prog_list = {"AcroRd32" : "", "gsview32" : "", "dot" : "graph", "windump" : "", "tshark" : "",
-                          "tcpreplay" : "", "hexer" : "", "sox" : "", "wireshark" : ""}
+        external_prog_list = {"AcroRd32" : "", "gsview32" : "", "dot" : "graph",
+                              "windump" : "", "tshark" : "", "tcpreplay" : "",
+                              "hexer" : "", "sox" : "", "wireshark" : ""}
         _deep_lookup(external_prog_list)
         self._reload()
 

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -197,11 +197,7 @@ for i in ps_read_routes:
 
 assert _correct
 
-conf.prog.powershell = win_find_exe(
-            "powershell",
-            installsubdir="System32\\WindowsPowerShell\\v1.0",
-            env="SystemRoot"
-        )
+conf.prog._reload()
 
 = show_interfaces
 

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -197,6 +197,12 @@ for i in ps_read_routes:
 
 assert _correct
 
+conf.prog.powershell = win_find_exe(
+            "powershell",
+            installsubdir="System32\\WindowsPowerShell\\v1.0",
+            env="SystemRoot"
+        )
+
 = show_interfaces
 
 from scapy.arch import show_interfaces
@@ -223,3 +229,20 @@ assert test_show_interfaces()
 from scapy.config import conf
 
 assert dev_from_pcapname(conf.iface.pcap_name).guid == conf.iface.guid
+
+= test pcap_service_status
+
+status = pcap_service_status()
+status
+assert status[0] in ["npcap", "npf"]
+assert status[2] == True
+
+= test pcap_service_stop
+
+pcap_service_stop()
+assert pcap_service_status()[2] == False
+
+= test pcap_service_start
+
+pcap_service_start()
+assert pcap_service_status()[2] == True


### PR DESCRIPTION
Previously, if the Npcap/Winpcap service was not started, scapy would not be working.

This PR:
- adds a detector + a util to ask the user if he wants to start the service automatically.
- makes scapy not crash when both powershell and cscript are unavailable
- restore VBS GUID change (I disabled it a quite long time ago, but it was indeed useful)