### PR TITLE
[Windows/coverage] Support sndrcvflood on Windows + select.select

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -418,6 +418,7 @@ if conf.use_pcap:
                         s,us = h.getts()
                         return (s+0.000001*us), p
                 def fileno(self):
+                    # TODO: Add it once https://github.com/CoreSecurity/pcapy/pull/22
                     warning("fileno: pcapy API does not permit to get capure file descriptor. Bugs ahead! Press Enter to trigger packet reading")
                     return 0
                 def __getattr__(self, attr):

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -7,7 +7,7 @@
 Packet sending and receiving with libdnet and libpcap/WinPcap.
 """
 
-import time, struct, sys, platform
+import time, struct, sys, platform, ctypes, select
 import socket
 if not sys.platform.startswith("win"):
     from fcntl import ioctl
@@ -156,9 +156,21 @@ if conf.use_winpcapy:
           return pcap_datalink(self.pcap)
       def fileno(self):
           if sys.platform.startswith("win"):
-            log_loading.error("Cannot get selectable PCAP fd on Windows")
+            log_loading.error("Cannot get selectable PCAP fd on Windows. "
+                              "Use L2socket/L3socket select() function instead !")
             return 0
-          return pcap_get_selectable_fd(self.pcap) 
+          return pcap_get_selectable_fd(self.pcap)
+      def select(self, socket, timeout):
+          if timeout <= 0:
+              return []
+          if WINDOWS:
+            status = ctypes.windll.kernel32.WaitForSingleObject(pcap_getevent(self.pcap), int(timeout*1000))
+            if status == 0:
+                return socket
+            return []
+          else:
+            r,_,_ = select.select([socket],[],[],timeout)
+            return r
       def setfilter(self, f):
           filter_exp = create_string_buffer(f)
           if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -164,13 +164,15 @@ if conf.use_winpcapy:
           if timeout <= 0:
               return []
           if WINDOWS:
-            status = ctypes.windll.kernel32.WaitForSingleObject(pcap_getevent(self.pcap), int(timeout*1000))
-            if status == 0:
-                return socket
-            return []
+              # Following https://www.winpcap.org/pipermail/winpcap-users/2007-February/001722.html
+              # We get the HANDLE of the socket, then wait for it through the Windows API
+              status = ctypes.windll.kernel32.WaitForSingleObject(pcap_getevent(self.pcap), int(timeout*1000))
+              if status == 0:
+                  return [socket]
+              return []
           else:
-            r,_,_ = select.select([socket],[],[],timeout)
-            return r
+              r,_,_ = select.select([socket],[],[],timeout)
+              return r
       def setfilter(self, f):
           filter_exp = create_string_buffer(f)
           if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -30,6 +30,7 @@ import scapy.modules.six as six
 WINDOWS = True
 
 def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, multi=0):
+    # Function to send or recieve a packet through the pks socket
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
         
@@ -171,13 +172,14 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")
 
 def sndrcvflood(pks, pkt, prn=lambda s_r: s_r[1].summary(), chainCC=0, store=1, unique=0, timeout=None):
+    # Function to send or recieve a packet by flooding it through the pks socket
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
     tobesent = [p for p in pkt]
     received = plist.SndRcvList()
     seen = {}
-
-    hsent={}
+    hsent = {}
+    
     for i in tobesent:
         h = i.hashret()
         if h in hsent:
@@ -186,7 +188,7 @@ def sndrcvflood(pks, pkt, prn=lambda s_r: s_r[1].summary(), chainCC=0, store=1, 
             hsent[h] = [i]
 
     def send_in_loop(tobesent):
-        while 1:
+        while True:
             for p in tobesent:
                 yield p
 
@@ -196,13 +198,12 @@ def sndrcvflood(pks, pkt, prn=lambda s_r: s_r[1].summary(), chainCC=0, store=1, 
         stoptime = time.time()+timeout
 
     try:
-        while 1:
+        while True:
             if timeout is not None:
                 remain = stoptime-time.time()
                 if remain <= 0:
                     break
             pks.send(packets_to_send.next())
-                
             p = pks.recv(MTU)
             if p is None:
                 continue

--- a/scapy/arch/windows/compatibility.py
+++ b/scapy/arch/windows/compatibility.py
@@ -170,9 +170,64 @@ def sndrcv(pks, pkt, timeout = 2, inter = 0, verbose=None, chainCC=0, retry=0, m
         print("\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv+len(ans), len(ans), notans))
     return plist.SndRcvList(ans),plist.PacketList(remain,"Unanswered")
 
+def sndrcvflood(pks, pkt, prn=lambda s_r: s_r[1].summary(), chainCC=0, store=1, unique=0, timeout=None):
+    if not isinstance(pkt, Gen):
+        pkt = SetGen(pkt)
+    tobesent = [p for p in pkt]
+    received = plist.SndRcvList()
+    seen = {}
+
+    hsent={}
+    for i in tobesent:
+        h = i.hashret()
+        if h in hsent:
+            hsent[h].append(i)
+        else:
+            hsent[h] = [i]
+
+    def send_in_loop(tobesent):
+        while 1:
+            for p in tobesent:
+                yield p
+
+    packets_to_send = send_in_loop(tobesent)
+
+    if timeout is not None:
+        stoptime = time.time()+timeout
+
+    try:
+        while 1:
+            if timeout is not None:
+                remain = stoptime-time.time()
+                if remain <= 0:
+                    break
+            pks.send(packets_to_send.next())
+                
+            p = pks.recv(MTU)
+            if p is None:
+                continue
+            h = p.hashret()
+            if h in hsent:
+                hlst = hsent[h]
+                for i in hlst:
+                    if p.answers(i):
+                        res = prn((i,p))
+                        if unique:
+                            if res in seen:
+                                continue
+                            seen[res] = None
+                        if res is not None:
+                            print res
+                        if store:
+                            received.append((i,p))
+    except KeyboardInterrupt:
+        if chainCC:
+            raise
+    return received
 
 import scapy.sendrecv as sendrecv
 sendrecv.sndrcv = sndrcv
+sendrecv.sndrcvflood = sndrcvflood
 
 def sniff(count=0, store=1, offline=None, prn = None, stop_filter=None, lfilter=None, L2socket=None, timeout=None, *arg, **karg):
     """Sniff packets

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1670,7 +1670,7 @@ def fragleak(target,sport=123, dport=123, timeout=0.2, onlyasc=0):
             try:
                 if not intr:
                     s.send(pkt)
-                sin,sout,serr = select([s],[],[],timeout)
+                sin = s.select(timeout)
                 if not sin:
                     continue
                 ans=s.recv(1600)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -480,7 +480,7 @@ srloop(pkts, [prn], [inter], [count], ...) --> None"""
     return __sr_loop(srp, pkts, *args, **kargs)
 
 
-def sndrcvflood(pks, pkt, prn=lambda s_r:s_r[1].summary(), chainCC=0, store=1, unique=0):
+def sndrcvflood(pks, pkt, prn=lambda s_r:s_r[1].summary(), chainCC=0, store=1, unique=0, timeout=None):
     if not isinstance(pkt, Gen):
         pkt = SetGen(pkt)
     tobesent = [p for p in pkt]
@@ -504,8 +504,15 @@ def sndrcvflood(pks, pkt, prn=lambda s_r:s_r[1].summary(), chainCC=0, store=1, u
 
     ssock = rsock = pks.fileno()
 
+    if timeout is not None:
+        stoptime = time.time()+timeout
+
     try:
         while True:
+            if timeout is not None:
+                remain = stoptime-time.time()
+                if remain <= 0:
+                    break
             if conf.use_bpf:
                 from scapy.arch.bpf.supersocket import bpf_select
                 readyr = bpf_select([rsock])

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -416,7 +416,7 @@ iface:    work only on the given interface"""
     else:
         return None
 
-def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summary(), inter=1, timeout=None, count=None, verbose=None, store=1, *args, **kargs):
+def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summary(), inter=1, timeout=None, loop_timeout=None, count=None, verbose=None, store=1, *args, **kargs):
     n = 0
     r = 0
     ct = conf.color_theme
@@ -427,8 +427,14 @@ def __sr_loop(srfunc, pkts, prn=lambda x:x[1].summary(), prnfail=lambda x:x.summ
     unans=[]
     if timeout is None:
         timeout = min(2*inter, 5)
+    if loop_timeout is not None:
+        stoptime = time.time()+loop_timeout
     try:
         while True:
+            if loop_timeout is not None:
+                remain = stoptime-time.time()
+                if remain <= 0:
+                    break
             parity ^= 1
             col = [ct.even,ct.odd][parity]
             if count is not None:
@@ -476,7 +482,7 @@ srloop(pkts, [prn], [inter], [count], ...) --> None"""
 @conf.commands.register
 def srploop(pkts, *args, **kargs):
     """Send a packet at layer 2 in loop and print the answer each time
-srloop(pkts, [prn], [inter], [count], ...) --> None"""
+srploop(pkts, [prn], [inter], [count], ...) --> None"""
     return __sr_loop(srp, pkts, *args, **kargs)
 
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -698,6 +698,18 @@ assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
 x is not None and ICMP in x
 
+= Sending and receiving an ICMP using loop methods
+~ netaccess IP ICMP
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+a = srploop(Ether()/IP(dst="www.google.com")/ICMP(), timeout=1, loop_timeout=3)
+conf.debug_dissector = old_debug_dissector
+a
+x = a[0][0][0]
+assert x[IP].ottl() in [32, 64, 128, 255]
+assert 0 <= x[IP].hops() <= 126
+x is not None and ICMP in x
+
 = DNS request
 ~ netaccess IP UDP DNS
 * A possible cause of failure could be that the open DNS (resolver1.opendns.com)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -685,6 +685,19 @@ assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
 x is not None and ICMP in x and x[ICMP].type == 0
 
+= Sending and receiving an ICMP using flooding methods
+~ netaccess IP ICMP
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+a = srpflood(Ether()/IP(dst="www.google.com")/ICMP(), timeout=1)
+conf.debug_dissector = old_debug_dissector
+a
+assert len(a) > 5
+x = a[0][0]
+assert x[IP].ottl() in [32, 64, 128, 255]
+assert 0 <= x[IP].hops() <= 126
+x is not None and ICMP in x
+
 = DNS request
 ~ netaccess IP UDP DNS
 * A possible cause of failure could be that the open DNS (resolver1.opendns.com)


### PR DESCRIPTION
This PR:
- Adds a very basic `select.select` windows alternative for the L2-3Sockets.
- Fix `sndrcvflood` on Windows.
- Adds tests for `sndrcvflood`