### PR TITLE
[TLS] Unify UTCTimeField (small)

### DIFF
--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -16,9 +16,6 @@ from scapy.fields import *
 from scapy.contrib.ppi import PPIGenericFldHdr,addPPIType
 from scapy.error import warning
 
-# On windows, epoch is 01/02/1970 at 00:00
-EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 0, 0, 0))-86400
-
 CURR_GEOTAG_VER = 2 #Major revision of specification
 
 PPI_GPS     = 30002
@@ -156,24 +153,6 @@ class NSCounter_Field(LEIntField):
         else:
             y=self.i2h(pkt,x)
         return "%1.9f"%(y)
-
-class UTCTimeField(IntField):
-    __slots__ = ["epoch", "delta", "strf"]
-    def __init__(self, name, default, epoch=None, strf="%a, %d %b %Y %H:%M:%S +0000"):
-        IntField.__init__(self, name, default)
-        if epoch is None:
-            mk_epoch = EPOCH
-        else:
-            mk_epoch = time.mktime(epoch)
-        self.epoch = mk_epoch
-        self.delta = mk_epoch - EPOCH
-        self.strf = strf
-    def i2repr(self, pkt, x):
-        if x is None:
-            x = 0
-        x = int(x) + self.delta
-        t = time.strftime(self.strf, time.gmtime(x))
-        return "%s (%d)" % (t, x)
 
 class LETimeField(UTCTimeField,LEIntField):
     __slots__ = ["epoch", "delta", "strf"]

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -7,7 +7,7 @@
 Global variables and functions for handling external data sets.
 """
 
-import os,sys,re
+import os, sys, re, time
 from scapy.dadict import DADict
 from scapy.error import log_loading
 
@@ -51,7 +51,8 @@ IPV6_ADDR_6TO4        = 0x0100   # Added to have more specific info (should be 0
 IPV6_ADDR_UNSPECIFIED = 0x10000
 
 
-
+# On windows, epoch is 01/02/1970 at 00:00
+EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 3, 1, 0))-86400
 
 MTU = 0xffff # a.k.a give me all you have
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1314,3 +1314,21 @@ class IPPrefixField(_IPPrefixFieldBase):
 class IP6PrefixField(_IPPrefixFieldBase):
     def __init__(self, name, default, wordbytes= 1, length_from= None):
         _IPPrefixFieldBase.__init__(self, name, default, wordbytes, 16, lambda a: inet_pton(socket.AF_INET6, a), lambda n: inet_ntop(socket.AF_INET6, n), length_from)
+
+class UTCTimeField(IntField):
+    __slots__ = ["epoch", "delta", "strf"]
+    def __init__(self, name, default, epoch=None, strf="%a, %d %b %Y %H:%M:%S +0000"):
+        IntField.__init__(self, name, default)
+        if epoch is None:
+            mk_epoch = EPOCH
+        else:
+            mk_epoch = time.mktime(epoch)
+        self.epoch = mk_epoch
+        self.delta = mk_epoch - EPOCH
+        self.strf = strf
+    def i2repr(self, pkt, x):
+        if x is None:
+            x = 0
+        x = int(x) + self.delta
+        t = time.strftime(self.strf, time.gmtime(x))
+        return "%s (%d)" % (t, x)

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -193,15 +193,10 @@ duidhwtypes = {  0: "NET/ROM pseudo", # Not referenced by IANA
                 32: "InfiniBand (TM)",
                 33: "TIA-102 Project 25 Common Air Interface (CAI)" }
 
-class UTCTimeField(IntField):
-    epoch = (2000, 1, 1, 0, 0, 0, 5, 1, 0) # required Epoch
-    def i2repr(self, pkt, x):
-        x = self.i2h(pkt, x)
-        from time import gmtime, strftime, mktime
-        delta = mktime(self.epoch) - mktime(gmtime(0))
-        x = x + delta
-        t = strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime(x))
-        return "%s (%d)" % (t, x)
+class _UTCTimeField(UTCTimeField):
+    def __init__(self, *args, **kargs):
+        UTCTimeField.__init__(self, *args, **kargs)
+        self.epoch = (2000, 1, 1, 0, 0, 0, 5, 1, 0) # required Epoch
 
 class _LLAddrField(MACField):
     pass
@@ -212,7 +207,7 @@ class DUID_LLT(Packet):  # sect 9.2 RFC 3315
     name = "DUID - Link-layer address plus time"
     fields_desc = [ ShortEnumField("type", 1, duidtypes),
                     XShortEnumField("hwtype", 1, duidhwtypes), 
-                    UTCTimeField("timeval", 0), # i.e. 01 Jan 2000
+                    _UTCTimeField("timeval", 0), # i.e. 01 Jan 2000
                     _LLAddrField("lladdr", ETHER_ANY) ]
 
 # In fact, IANA enterprise-numbers file available at 

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -102,22 +102,11 @@ class TLSHelloRequest(_TLSHandshake):
 ### ClientHello fields                                                      ###
 ###############################################################################
 
-class _GMTUnixTimeField(IntField):
+class _GMTUnixTimeField(UTCTimeField):
     """
-    Piggybacked from scapy6 UTCTimeField
     "The current time and date in standard UNIX 32-bit format (seconds since
      the midnight starting Jan 1, 1970, GMT, ignoring leap seconds)."
     """
-    epoch = (1970, 1, 1, 0, 0, 0, 3, 1, 0)
-
-    def i2repr(self, pkt, x):
-        x = self.i2h(pkt, x)
-        from time import gmtime, strftime, mktime
-        delta = mktime(gmtime(0)) - mktime(self.epoch)
-        x = x-delta
-        t = strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime(x))
-        return "%s (%d)" % (t, x)
-
     def i2h(self, pkt, x):
         if x is not None:
             return x


### PR DESCRIPTION
This PR:
- replaces the UTCTimeField occurences (one in `ppi_geotag`, one in `dhcp6`
and one in `tls/handshake`) by a single one
- fixes https://github.com/secdev/scapy/issues/626