### PR TITLE
[Pipetools/coverage] Make pipes work on windows + add tests

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -335,7 +335,7 @@ def select_objects(inputs, remain, customTypes=()):
         r = []
         def look_for_select():
             for fd in inputs:
-                if isinstance(fd, ObjectPipe) or isinstance(fd, Automaton._IO_fdwrapper) or (isinstance(fd, customTypes)):
+                if isinstance(fd, (ObjectPipe, Automaton._IO_fdwrapper) + customTypes):
                     if fd.checkRecv():
                         r.append(fd)
                 else:

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -324,12 +324,18 @@ class Automaton_metaclass(type):
         s += "}\n"
         return do_graph(s, **kargs)
         
-def select_objects(inputs, remain):
+def select_objects(inputs, remain, customTypes=()):
+    """
+    Select object that have checkRecv function.
+    inputs: objects to process
+    remain: timeout. If 0, return [].
+    customTypes: types of the objects that have the checkRecv function.
+    """
     if WINDOWS:
         r = []
         def look_for_select():
             for fd in inputs:
-                if isinstance(fd, ObjectPipe) or isinstance(fd, Automaton._IO_fdwrapper):
+                if isinstance(fd, ObjectPipe) or isinstance(fd, Automaton._IO_fdwrapper) or (isinstance(fd, customTypes)):
                     if fd.checkRecv():
                         r.append(fd)
                 else:

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -334,7 +334,7 @@ def select_objects(inputs, remain, customTypes=()):
     if WINDOWS:
         r = []
         def look_for_select():
-            for fd in inputs:
+            for fd in list(inputs):
                 if isinstance(fd, (ObjectPipe, Automaton._IO_fdwrapper) + customTypes):
                     if fd.checkRecv():
                         r.append(fd)

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -316,6 +316,8 @@ class Source(Pipe):
         self._send(msg)
     def fileno(self):
         return None
+    def checkRecv(self):
+        return False
     def exhausted(self):
         return self.is_exhausted
     def start(self):
@@ -418,14 +420,15 @@ class RawConsoleSink(Sink):
     def __init__(self, name=None, newlines=True):
         Sink.__init__(self, name=name)
         self.newlines = newlines
+        self._write_pipe = 1
     def push(self, msg):
         if self.newlines:
             msg += "\n"
-        os.write(1, str(msg))
+        os.write(self._write_pipe, str(msg))
     def high_push(self, msg):
         if self.newlines:
             msg += "\n"
-        os.write(1, str(msg))
+        os.write(self._write_pipe, str(msg))
 
 class CLIFeeder(AutoSource):
     """Send messages from python command line

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -128,7 +128,7 @@ class PipeEngine:
                             STOP_IF_EXHAUSTED = True
                         elif cmd == "A":
                             sources = self.active_sources-exhausted
-                            sources.add(self.__fdr)
+                            sources.add(self)
                         else:
                             warning("Unknown internal pipe engine command: %r. Ignoring." % cmd)
                     elif fd in sources:

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -609,26 +609,3 @@ class DownDrain(Drain):
         pass
     def high_push(self, msg):
         self._send(msg)
-        
-
-def _testmain():
-    s = PeriodicSource("hello", 1, name="src")
-    d1 = Drain(name="d1")
-    c = ConsoleSink(name="c")
-    tf = TransformDrain(lambda x:"Got %r" % x)
-    t = TermSink(name="t", keepterm=False)
-
-    s > d1 > c
-    d1 > tf > t
-
-    p = PipeEngine(s)
-
-    p.graph(type="png",target="> /tmp/pipe.png")
-
-    p.start()
-    time.sleep(5)
-    p.stop()
-
-
-if __name__ == "__main__":
-    _testmain()

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -436,7 +436,10 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
         format = "-T %s" % format
     w,r = os.popen2("%s %s %s %s" % (prog,options or "", format or "", target))
     w.write(graph)
-    w.close()
+    try:
+        w.close()
+    except IOError:
+        pass
     if start_viewer:
         # Workaround for file not found error: We wait until tempfile is written.
         waiting_start = time.time()

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -31,6 +31,45 @@ x = p.spawn_Pipe()
 assert len(p.active_pipes) == 3
 assert isinstance(x, Pipe)
 
+= Test exhausted source
+
+s = AutoSource()
+s._gen_data("hello")
+s.is_exhausted = True
+d1 = Drain(name="d1")
+c = ConsoleSink(name="c")
+s > d1 > c
+
+p = PipeEngine(s)
+p.start()
+time.sleep(1)
+p.wait_and_stop()
+
+= Test add_pipe on running instance
+
+test_val = None
+
+class TestSink(Sink):
+    def push(self, msg):
+        global test_val
+        test_val = msg
+
+p = PipeEngine()
+p.start()
+
+s = AutoSource()
+s._gen_data("hello")
+s.is_exhausted = True
+
+d1 = Drain(name="d1")
+c = TestSink(name="c")
+s > d1 > c
+
+p.add(s)
+time.sleep(1)
+p.wait_and_stop()
+assert test_val == "hello"
+
 = Test Operators
 
 s = AutoSource()
@@ -58,6 +97,28 @@ assert len(b.high_sinks) == 1
 assert len(b.high_sources) == 0
 a
 b
+
+a = AutoSource()
+b = AutoSource()
+a == b
+assert len(a.sinks) == 1
+assert len(a.sources) == 1
+assert len(b.sinks) == 1
+assert len(b.sources) == 1
+
+a = AutoSource()
+b = AutoSource()
+a//b
+assert len(a.high_sinks) == 1
+assert len(a.high_sources) == 1
+assert len(b.high_sinks) == 1
+assert len(b.high_sources) == 1
+
+a = AutoSource()
+b = AutoSource()
+a^b
+assert len(b.trigger_sources) == 1
+assert len(a.trigger_sinks) == 1
 
 = Test doc
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -19,3 +19,49 @@ p.graph(type="png",target="> /tmp/pipe.png")
 p.start()
 time.sleep(3)
 p.stop()
+
+= Test add_pipe
+
+s = AutoSource()
+p = PipeEngine(s)
+p.add(Pipe())
+assert len(p.active_pipes) == 2
+
+x = p.spawn_Pipe()
+assert len(p.active_pipes) == 3
+assert isinstance(x, Pipe)
+
+= Test Operators
+
+s = AutoSource()
+p = PipeEngine(s)
+assert p == p
+assert not p < p
+assert not p > p
+
+a = AutoSource()
+b = AutoSource()
+a >> b
+assert len(a.high_sinks) == 1
+assert len(a.high_sources) == 0
+assert len(b.high_sinks) == 0
+assert len(b.high_sources) == 1
+a
+b
+
+a = AutoSource()
+b = AutoSource()
+a << b
+assert len(a.high_sinks) == 0
+assert len(a.high_sources) == 1
+assert len(b.high_sinks) == 1
+assert len(b.high_sources) == 0
+a
+b
+
+= Test doc
+
+s = AutoSource()
+p = PipeEngine(s)
+p.list_pipes()
+p.list_pipes_detailed()

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -126,3 +126,94 @@ s = AutoSource()
 p = PipeEngine(s)
 p.list_pipes()
 p.list_pipes_detailed()
+
+= Test RawConsoleSink with CLIFeeder
+
+p = PipeEngine()
+p.start()
+
+s = CLIFeeder()
+s.send("hello")
+s.is_exhausted = True
+
+r, w = os.pipe()
+
+d1 = Drain(name="d1")
+c = RawConsoleSink(name="c")
+c._write_pipe = w
+s > d1 > c
+
+p.add(s)
+time.sleep(1)
+p.wait_and_stop()
+assert os.read(r, 20) == "hello\n"
+
+= Test QueueSink with CLIFeeder
+
+p = PipeEngine()
+p.start()
+
+s = CLIFeeder()
+s.send("hello")
+s.is_exhausted = True
+
+d1 = Drain(name="d1")
+c = QueueSink(name="c")
+s > d1 > c
+
+p.add(s)
+time.sleep(1)
+p.wait_and_stop()
+assert c.recv() == "hello"
+
+= Test UpDrain
+
+test_val = None
+
+class TestSink(Sink):
+    def high_push(self, msg):
+        global test_val
+        test_val = msg
+
+p = PipeEngine()
+p.start()
+
+s = CLIFeeder()
+s.send("hello")
+s.is_exhausted = True
+
+d1 = UpDrain(name="d1")
+c = TestSink(name="c")
+s > d1
+d1 >> c
+
+p.add(s)
+time.sleep(1)
+p.wait_and_stop()
+assert test_val == "hello"
+
+= Test DownDrain
+
+test_val = None
+
+class TestSink(Sink):
+    def push(self, msg):
+        global test_val
+        test_val = msg
+
+p = PipeEngine()
+p.start()
+
+s = CLIHighFeeder()
+s.send("hello")
+s.is_exhausted = True
+
+d1 = DownDrain(name="d1")
+c = TestSink(name="c")
+s >> d1
+d1 > c
+
+p.add(s)
+time.sleep(1)
+p.wait_and_stop()
+assert test_val == "hello"

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -1,0 +1,21 @@
+########################
+% Pipetool related tests
+########################
+
++ Basic tests
+
+= Test default test case
+
+s = PeriodicSource("hello", 1, name="src")
+d1 = Drain(name="d1")
+c = ConsoleSink(name="c")
+tf = TransformDrain(lambda x:"Got %r" % x)
+t = TermSink(name="t", keepterm=False)
+s > d1 > c
+d1 > tf > t
+
+p = PipeEngine(s)
+p.graph(type="png",target="> /tmp/pipe.png")
+p.start()
+time.sleep(3)
+p.stop()


### PR DESCRIPTION
This PR:
- re-use some of my work on `automaton.py` to replace `select.select` in `pipetools.py`
- add an implementation for Windows (there where some `xterm` calls ==> adapted the functions to work with powershell)

@phil777 You might want to have a look at this, as you did https://github.com/secdev/scapy/pull/620