### PR TITLE
[convergence] map() calls rewritten as list comprehensions

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -146,7 +146,7 @@ def attach_filter(s, bpf_filter, iface):
     nb = int(lines[0])
     bpf = ""
     for l in lines[1:]:
-        bpf += struct.pack("HBBI",*map(long,l.split()))
+        bpf += struct.pack("HBBI", *(int(e) for e in l.split()))
 
     # XXX. Argl! We need to give the kernel a pointer on the BPF,
     # python object header seems to be 20 bytes. 36 bytes for x86 64bits arch.

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -103,8 +103,7 @@ if conf.use_winpcapy:
             if a.contents.addr.contents.sa_family == socket.AF_INET:
               ap = a.contents.addr
               val = cast(ap, POINTER(sockaddr_in))
-              #ret = bytes(val.contents.sin_addr[:4])
-              ret = "".join([chr(x) for x in val.contents.sin_addr[:4]])
+              ret = "".join(chr(x) for x in val.contents.sin_addr[:4])
             a = a.contents.next
           break
         p = p.contents.next
@@ -151,8 +150,7 @@ if conf.use_winpcapy:
           if not c > 0:
               return
           ts = self.header.contents.ts.tv_sec
-          pkt = "".join([ chr(i) for i in self.pkt_data[:self.header.contents.len] ])
-          #pkt = bytes(self.pkt_data[:self.header.contents.len])
+          pkt = "".join(chr(i) for i in self.pkt_data[:self.header.contents.len])
           return ts, pkt
       def datalink(self):
           return pcap_datalink(self.pcap)

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -88,7 +88,7 @@ class AS_resolver_cymru(AS_resolver):
         for l in r.splitlines()[1:]:
             if "|" not in l:
                 continue
-            asn,ip,desc = map(str.strip, l.split("|"))
+            asn, ip, desc = [elt.strip() for elt in l.split('|')]
             if asn == "NA":
                 continue
             asn = "AS" + str(int(asn))

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -88,7 +88,7 @@ def BER_num_enc(l, size=1):
                 x[0] |= 0x80
             l >>= 7
             size -= 1
-        return "".join([chr(k) for k in x])
+        return "".join(chr(k) for k in x)
 def BER_num_dec(s, cls_id=0):
         if len(s) == 0:
             raise BER_Decoding_Error("BER_num_dec: got empty string", remaining=s)
@@ -282,7 +282,7 @@ class BERcodec_INTEGER(BERcodec_Object):
             i >>= 8
             if not i:
                 break
-        s = map(chr, s)
+        s = [chr(c) for c in s]
         s.append(BER_len_enc(len(s)))
         s.append(chr(cls.tag))
         s.reverse()
@@ -357,7 +357,7 @@ class BERcodec_OID(BERcodec_Object):
         if len(lst) >= 2:
             lst[1] += 40*lst[0]
             del(lst[0])
-        s = "".join([BER_num_enc(k) for k in lst])
+        s = "".join(BER_num_enc(k) for k in lst)
         return chr(cls.tag)+BER_len_enc(len(s))+s
     @classmethod
     def do_dec(cls, s, context=None, safe=False):
@@ -369,7 +369,7 @@ class BERcodec_OID(BERcodec_Object):
         if (len(lst) > 0):
             lst.insert(0,lst[0]/40)
             lst[1] %= 40
-        return cls.asn1_object(".".join([str(k) for k in lst])), t
+        return cls.asn1_object(".".join(str(k) for k in lst)), t
 
 class BERcodec_ENUMERATED(BERcodec_INTEGER):
     tag = ASN1_Class_UNIVERSAL.ENUMERATED
@@ -406,7 +406,7 @@ class BERcodec_SEQUENCE(BERcodec_Object):
     @classmethod
     def enc(cls, l):
         if type(l) is not str:
-            l = "".join(map(lambda x: x.enc(cls.codec), l))
+            l = "".join(x.enc(cls.codec) for x in l)
         return chr(cls.tag)+BER_len_enc(len(l))+l
     @classmethod
     def do_dec(cls, s, context=None, safe=False):

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -57,7 +57,7 @@ class Net(Gen):
         if a == "*":
             a = (0,256)
         elif a.find("-") >= 0:
-            x,y = map(int,a.split("-"))
+            x, y = [int(d) for d in a.split('-')]
             if x > y:
                 y = x
             a = (x &  (0xff<<netmask) , max(y, (x | (0xff>>(8-netmask))))+1)
@@ -71,7 +71,8 @@ class Net(Gen):
         if not cls.ipaddress.match(net):
             tmp[0]=socket.gethostbyname(tmp[0])
         netmask = int(tmp[1])
-        return map(lambda x,y: cls._parse_digit(x,y), tmp[0].split("."), map(lambda x,nm=netmask: x-nm, (8,16,24,32))),netmask
+        ret_list = [cls._parse_digit(x, y-netmask) for (x, y) in zip(tmp[0].split('.'), [8, 16, 24, 32])]
+        return ret_list, netmask
 
     def __init__(self, net):
         self.repr=net

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -50,7 +50,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s+reduce(str.__add__, map(str, val),"")
+        return s + ''.join(str(v) for v in val)
 
 _DTP_TLV_CLS = {
                     0x0001 : "DTPDomain",

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -431,7 +431,7 @@ class RepeatedTlvListField(PacketListField):
         return remain,lst
 
     def addfield(self, pkt, s, val):
-        return s + reduce(str.__add__, map(str, val), "")
+        return s + ''.join(str(v) for v in val)
 
 def _EIGRPGuessPayloadClass(p, **kargs):
     cls = conf.raw_layer

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -2409,7 +2409,7 @@ class HPackHdrTable(Sized):
         # type: () -> int
         """ __len__ returns the summed length of all dynamic entries
         """
-        return sum([len(x) for x in self._dynamic_table])
+        return sum(len(x) for x in self._dynamic_table)
 
     def gen_txt_repr(self, hdrs, register=True):
         # type: (Union[H2Frame, List[HPackHeaders]], Optional[bool]) -> str

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -31,7 +31,7 @@ class HashField(Field):
             except socket.error:
                 x = Net6(x)
         elif type(x) is list:
-            x = map(Net6, x)
+            x = [Net6(e) for e in x]
         return x
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, x)

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -152,7 +152,7 @@ class ManufDA(DADict):
             return ":".join([self[oui][0]]+ mac.split(":")[3:])
         return mac
     def __repr__(self):
-        return "\n".join(["<%s %s, %s>" % (i[0], i[1][0], i[1][1]) for i in self.__dict__.items()])
+        return "\n".join("<%s %s, %s>" % (i[0], i[1][0], i[1][1]) for i in self.__dict__.items())
         
         
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -489,7 +489,7 @@ class PacketListField(PacketField):
             lst.append(p)
         return remain+ret,lst
     def addfield(self, pkt, s, val):
-        return s+"".join(map(str, val))
+        return s + "".join(str(v) for v in val)
 
 
 class StrFixedLenField(StrField):
@@ -539,7 +539,7 @@ class NetBIOSNameField(StrFixedLenField):
             x = ""
         x += " "*(l)
         x = x[:l]
-        x = "".join(map(lambda x: chr(0x41+(ord(x)>>4))+chr(0x41+(ord(x)&0xf)), x))
+        x = "".join(chr(0x41 + ord(b)>>4) + chr(0x41 + ord(b)&0xf) for b in x)
         x = " "+x
         return x
     def m2i(self, pkt, x):
@@ -621,7 +621,7 @@ class FieldListField(Field):
         if type(x) is not list:
             return [self.field.any2i(pkt, x)]
         else:
-            return map(lambda e, pkt=pkt: self.field.any2i(pkt, e), x)
+            return [self.field.any2i(pkt, e) for e in x]
     def i2repr(self, pkt, x):
         res = []
         for v in x:
@@ -863,13 +863,13 @@ class _EnumField(Field):
 
     def any2i(self, pkt, x):
         if type(x) is list:
-            return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
+            return [self.any2i_one(pkt, z) for z in x]
         else:
             return self.any2i_one(pkt,x)
 
     def i2repr(self, pkt, x):
         if type(x) is list:
-            return map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x)
+            return [self.i2repr_one(pkt, z) for z in x]
         else:
             return self.i2repr_one(pkt,x)
 

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -319,7 +319,7 @@ class _IANAOptField(PacketListField):
     def i2len(self, pkt, z):
         if z is None or z == []:
             return 0
-        return sum(map(lambda x: len(str(x)) ,z))
+        return sum(len(str(x)) for x in z)
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
@@ -395,7 +395,7 @@ class _OptReqListField(StrLenField):
         return r
     
     def i2m(self, pkt, x):
-        return "".join(map(lambda y: struct.pack("!H", y), x))
+        return "".join(struct.pack('!H', y) for y in x)
 
 # A client may include an ORO in a solicit, Request, Renew, Rebind,
 # Confirm or Information-request
@@ -547,7 +547,7 @@ class _UserClassDataField(PacketListField):
     def i2len(self, pkt, z):
         if z is None or z == []:
             return 0
-        return sum(map(lambda x: len(str(x)) ,z))
+        return sum(len(str(x)) for x in z)
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
@@ -747,7 +747,7 @@ class DomainNameField(StrLenField):
     def i2m(self, pkt, x):
         if not x:
             return ""
-        tmp = "".join(map(lambda z: chr(len(z))+z, x.split('.')))
+        tmp = "".join(chr(len(z)) + z for z in x.split('.'))
         return tmp
 
 class DHCP6OptNISDomain(_DHCP6OptGuessPayload):             #RFC3898
@@ -1271,7 +1271,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                 return val
             elif type(val) is str:
                 l = val.split(',')
-                return map(lambda x: x.strip(), l)
+                return [x.strip() for x in l]
             else:
                 print "Bad '%s' parameter provided." % param_name
                 self.usage()
@@ -1337,7 +1337,7 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
 
             # Mac Address
             rawmac = get_if_raw_hwaddr(iface)[1]
-            mac = ":".join(map(lambda x: "%.02x" % ord(x), list(rawmac)))
+            mac = ":".join("%.02x" % ord(x) for x in rawmac)
 
             self.duid = DUID_LLT(timeval = timeval, lladdr = mac)
             
@@ -1447,12 +1447,10 @@ dhcp6d( dns="2001:500::1035", domain="localdomain, local", duid=None)
                 elif isinstance(it, DHCP6OptIA_TA):
                     l = it.iataopts
 
-                opsaddr = filter(lambda x: isinstance(x, DHCP6OptIAAddress),l)
-                a=map(lambda x: x.addr,  opsaddr)
-                addrs += a
+                addrs += [x.addr for x in l if isinstance(x, DHCP6OptIAAddress)]
                 it = it.payload
                     
-            addrs = map(lambda x: bo + x + n, addrs)
+            addrs = [bo + x + n for x in addrs]
             if debug:
                 msg = r + "[DEBUG]" + n + " Received " + g + "Decline" + n 
                 msg += " from " + bo + src + vendor + " for "

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -29,8 +29,8 @@ class DNSStrField(StrField):
         if x == ".":
           return b"\x00"
 
-        x = [k[:63] for k in x.split(".")] # Truncate chunks that cannot be encoded (more than 63 bytes..)
-        x = map(lambda y: chr(len(y))+y, x)
+        # Truncate chunks that cannot be encoded (more than 63 bytes..)
+        x = "".join(chr(len(y)) + y for y in (k[:63] for k in x.split(".")))
         x = "".join(x)
         if x[-1] != b"\x00":
             x += b"\x00"
@@ -201,7 +201,7 @@ class RDataField(StrLenField):
             if s:
                 s = inet_aton(s)
         elif pkt.type in [2, 3, 4, 5, 12]: # NS, MD, MF, CNAME, PTR
-            s = "".join(map(lambda x: chr(len(x))+x, s.split(".")))
+            s = "".join(chr(len(x)) + x for x in s.split('.'))
             if ord(s[-1]):
                 s += b"\x00"
         elif pkt.type == 16: # TXT
@@ -431,8 +431,7 @@ def RRlist2bitmap(lst):
     lst = list(set(lst))
     lst.sort()
 
-    lst = filter(lambda x: x <= 65535, lst)
-    lst = map(lambda x: abs(x), lst)
+    lst = [abs(x) for x in lst if x <= 65535]
 
     # number of window blocks
     max_window_blocks = int(math.ceil(lst[-1] / 256.))
@@ -465,11 +464,10 @@ def RRlist2bitmap(lst):
             v = 0
             # Remove out of range Resource Records
             tmp_rrlist = filter(lambda x: 256 * wb + 8 * tmp <= x < 256 * wb + 8 * tmp + 8, rrlist)
-            if not tmp_rrlist == []:
+            if tmp_rrlist:
                 # 1. rescale to fit into 8 bits
-                tmp_rrlist = map(lambda x: (x-256*wb)-(tmp*8), tmp_rrlist)
                 # 2. x gives the bit position ; compute the corresponding value
-                tmp_rrlist = map(lambda x: 2**(7-x) , tmp_rrlist)
+                tmp_rrlist = [2 ** (7 - (x - 256 * wb) + (tmp * 8)) for x in tmp_rrlist]
                 # 3. sum everything
                 v = reduce(lambda x,y: x+y, tmp_rrlist)
             bitmap += struct.pack("B", v)

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -509,7 +509,7 @@ class Dot11PacketList(PacketList):
 
         PacketList.__init__(self, res, name, stats)
     def toEthernet(self):
-        data = map(lambda x:x.getlayer(Dot11), filter(lambda x : x.haslayer(Dot11) and x.type == 2, self.res))
+        data = [x[Dot11] for x in self.res if Dot11 in x and x.type == 2]
         r2 = []
         for p in data:
             q = p.copy()

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1004,7 +1004,7 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
     """Tries to graph the timeskew between the timestamps and real time for a given ip"""
 
     # Filter TCP segments which source address is 'ip'
-    res = map(lambda x: self._elt2pkt(x), self.res)
+    res = [self._elt2pkt(x) for x in self.res]
     b = filter(lambda x:x.haslayer(IP) and x.getlayer(IP).src == ip and x.haslayer(TCP), res)
 
     # Build a list of tuples (creation_time, replied_timestamp)
@@ -1034,7 +1034,7 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
 
         return X, Y
 
-    data = map(_wrap_data, c)
+    data = [_wrap_data(e) for e in c]
 
     # Mimic the default gnuplot output
     if kargs == {}:
@@ -1642,10 +1642,10 @@ def IPID_count(lst, funcID=lambda x:x[1].id, funcpres=lambda x:x[1].summary()):
 lst:      a list of packets
 funcID:   a function that returns IP id values
 funcpres: a function used to summarize packets"""
-    idlst = map(funcID, lst)
+    idlst = [funcID(e) for e in lst]
     idlst.sort()
-    classes = [idlst[0]]+map(lambda x:x[1],filter(lambda (x,y): abs(x-y)>50, map(lambda x,y: (x,y),idlst[:-1], idlst[1:])))
-    lst = map(lambda x:(funcID(x), funcpres(x)), lst)
+    classes = [idlst[0]] + [x[1] for x in zip(idlst[:-1], idlst[1:]) if abs(x[0] - x[1]) > 50]
+    lst = [(funcID(x), funcpres(x)) for x in lst]
     lst.sort()
     print "Probably %i classes:" % len(classes), classes
     for id,pr in lst:

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -166,7 +166,7 @@ class Net6(Gen): # syntax ex. fec0::/126
         tuple = filter(lambda x: m8(x), xrange(8, 129))
 
         a = in6_and(self.net, self.mask)
-        tmp = map(lambda x:  x, struct.unpack('16B', a))
+        tmp = [x for x in struct.unpack("16B", a)]
 
         def parse_digit(a, netmask):
             netmask = min(8,max(netmask,0))
@@ -214,7 +214,7 @@ class IP6Field(Field):
             except socket.error:
                 x = Net6(x)
         elif type(x) is list:
-            x = map(Net6, x)
+            x = [Net6(a) for a in x]
         return x
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, x)
@@ -1915,8 +1915,8 @@ class DomainNameListField(StrLenField):
                 return z
             return z+b'\x00'
         # Build the encode names
-        tmp = map(lambda y: map((lambda z: chr(len(z))+z), y.split('.')), x)
-        ret_string  = "".join(map(lambda x: conditionalTrailingDot("".join(x)), tmp))
+        tmp = [[chr(len(z)) + z for z in y.split('.')] for y in x]
+        ret_string  = "".join(conditionalTrailingDot("".join(x)) for x in tmp)
 
         # In padded mode, add some \x00 bytes
         if self.padded and not len(ret_string) % self.padded_unit == 0:
@@ -2159,7 +2159,7 @@ def names2dnsrepr(x):
         termin = b"\x00"
         if n.count('.') == 0: # single-component gets one more
             termin += b'\x00'
-        n = "".join(map(lambda y: chr(len(y))+y, n.split("."))) + termin
+        n = "".join(chr(len(y)) + y for y in n.split('.')) + termin
         res.append(n)
     return "".join(res)
 
@@ -2389,7 +2389,7 @@ class NIReplyDataField(StrField):
                     return (0, x)
                 return x
 
-            return (qtype, map(addttl, x))
+            return (qtype, [addttl(d) for d in x])
 
         return (qtype, x)
 

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -124,7 +124,7 @@ class ISAKMPTransformSetField(StrLenField):
     def i2m(self, pkt, i):
         if i is None:
             return ""
-        i = map(self.type2num, i)
+        i = [self.type2num(e) for e in i]
         return "".join(i)
     def m2i(self, pkt, m):
         # I try to ensure that we don't read off the end of our packet based

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -59,7 +59,7 @@ def getmacbyip(ip, chainCC=0):
     if isinstance(ip,Net):
         ip = iter(ip).next()
     ip = inet_ntoa(inet_aton(ip))
-    tmp = map(ord, inet_aton(ip))
+    tmp = [ord(e) for e in inet_aton(ip)]
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
         return "01:00:5e:%.2x:%.2x:%.2x" % (tmp[1]&0x7f,tmp[2],tmp[3])
     iff,a,gw = conf.route.route(ip)

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -470,7 +470,7 @@ class GapAckField(Field):
     def i2m(self, pkt, x):
         if x is None:
             return b"\0\0\0\0"
-        sta, end = map(int, x.split(":"))
+        sta, end = [int(e) for e in x.split(':')]
         args = tuple([">HH", sta, end])
         return struct.pack(*args)
     def m2i(self, pkt, x):

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -706,11 +706,9 @@ class Cert(object):
             if (self.authorityKeyID is not None and
                 c.authorityKeyID is not None and
                 self.authorityKeyID == c.authorityKeyID):
-                return self.serial in map(lambda x: x[0],
-                                                    c.revoked_cert_serials)
+                return self.serial in (x[0] for x in c.revoked_cert_serials)
             elif self.issuer == c.issuer:
-                return self.serial in map(lambda x: x[0],
-                                                    c.revoked_cert_serials)
+                return self.serial in (x[0] for x in c.revoked_cert_serials)
         return False
 
     def export(self, filename, fmt="DER"):

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -220,7 +220,7 @@ def pkcs_emsa_pss_encode(M, emBits, h, mgf, sLen):
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\x00'
     if rem:
-        j = chr(reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem))))
+        j = sum(1 << x for x in range(8 - rem))
         andMask += j
         l += 1
     maskedDB = strand(maskedDB[:l], andMask) + maskedDB[l:]
@@ -262,7 +262,7 @@ def pkcs_emsa_pss_verify(M, EM, emBits, h, mgf, sLen):
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\xff'
     if rem:
-        val = reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem)))
+        val = sum(1 << x for x in range(8 - rem))
         j = chr(~val & 0xff)
         andMask += j
         l += 1
@@ -274,7 +274,7 @@ def pkcs_emsa_pss_verify(M, EM, emBits, h, mgf, sLen):
     rem = 8*emLen - emBits - 8*l # additionnal bits
     andMask = l*b'\x00'
     if rem:
-        j = chr(reduce(lambda x,y: x+y, map(lambda x: 1<<x, range(8-rem))))
+        j = chr(sum(1 << x for x in range(8 - rem)))
         andMask += j
         l += 1
     DB = strand(DB[:l], andMask) + DB[l:]

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -155,12 +155,12 @@ class _CipherSuitesField(StrLenField):
     def any2i(self, pkt, x):
         if type(x) is not list:
             x = [x]
-        return map(lambda z,pkt=pkt:self.any2i_one(pkt,z), x)
+        return [self.any2i_one(pkt, z) for z in x]
 
     def i2repr(self, pkt, x):
         if x is None:
             return "None"
-        l = map(lambda z,pkt=pkt:self.i2repr_one(pkt,z), x)
+        l = [self.i2repr_one(pkt, z) for x in x]
         if len(l) == 1:
             l = l[0]
         else:
@@ -170,7 +170,7 @@ class _CipherSuitesField(StrLenField):
     def i2m(self, pkt, val):
         if val is None:
             val = []
-        return "".join(map(lambda x: struct.pack(self.itemfmt, x), val))
+        return "".join(struct.pack(self.itemfmt, x) for x in val)
 
     def m2i(self, pkt, m):
         res = []
@@ -959,7 +959,7 @@ class _ASN1CertListField(StrLenField):
             return i
         if isinstance(i, Cert):
             i = [i]
-        return "".join(map(lambda x: i2m_one(x), i))
+        return "".join(i2m_one(x) for x in i)
 
     def any2i(self, pkt, x):
         return x
@@ -979,9 +979,9 @@ class TLSCertificate(_TLSHandshake):
     def post_dissection_tls_session_update(self, msg_str):
         connection_end = self.tls_session.connection_end
         if connection_end == "client":
-            self.tls_session.server_certs = map(lambda x: x[1], self.certs)
+            self.tls_session.server_certs = [x[1] for x in self.certs]
         else:
-            self.tls_session.client_certs = map(lambda x: x[1], self.certs)
+            self.tls_session.client_certs = [x[1] for x in self.certs]
         self.tls_session.handshake_messages.append(msg_str)
         self.tls_session.handshake_messages_parsed.append(self)
 

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -208,7 +208,7 @@ class connState(object):
         def indent(s):
             if s and s[-1] == '\n':
                 s = s[:-1]
-            s = '\n'.join(map(lambda x: '\t'+x, s.split('\n')) + [''])
+            s = '\n'.join('\t' + x for x in s.split('\n')) + '\n'
             return s
 
         res =  "Connection end : %s\n" % self.connection_end.upper()
@@ -566,8 +566,7 @@ class _tls_sessions(object):
                 if len(sid) > 12:
                     sid = sid[:11] + "..."
                 res.append((src, dst, sid))
-        colwidth = map(lambda x: max(map(lambda y: len(y), x)),
-                       apply(zip, res))
+        colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, res))
         fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
         return "\n".join(map(lambda x: fmt % x, res))
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -69,7 +69,7 @@ class p0fKnowledgeBase(KnowledgeBase):
                     if x.isdigit():
                         return int(x)
                     return x
-                li = map(a2i, l[1:4])
+                li = [a2i(e) for e in l[1:4]]
                 #if li[0] not in self.ttl_range:
                 #    self.ttl_range.append(li[0])
                 #    self.ttl_range.sort()
@@ -530,7 +530,9 @@ interface and may (are likely to) be different than those generated on
         # XXX are the packets also seen twice on non Linux systems ?
         count=14
         pl = sniff(iface=iface, filter='tcp and port ' + str(port), count = count, timeout=3)
-        map(addresult, map(packet2p0f, pl))
+        for pkt in pl:
+            for elt in packet2p0f(pkt):
+                addresult(elt)
         os.waitpid(pid,0)
     elif pid < 0:
         log_runtime.error("fork error")

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -751,7 +751,7 @@ def main(argv):
                     try:
                         NUM.append(int(v))
                     except ValueError:
-                        v1, v2 = map(int, v.split("-", 1))
+                        v1, v2 = [int(e) for e in v.split('-', 1)]
                         NUM.extend(xrange(v1, v2 + 1))
             elif opt == "-m":
                 MODULES.append(optarg)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -137,7 +137,7 @@ def chexdump(x, dump=False):
     :returns: a String only if dump=True
     """
     x = str(x)
-    s = str(", ".join(map(lambda x: "%#04x"%ord(x), x)))
+    s = str(", ".join("%#04x" % ord(x) for x in x))
     if dump:
         return s
     else:
@@ -147,14 +147,14 @@ def chexdump(x, dump=False):
 def hexstr(x, onlyasc=0, onlyhex=0):
     s = []
     if not onlyasc:
-        s.append(" ".join(map(lambda x:"%02x"%ord(x), x)))
+        s.append(" ".join("%02x" % ord(b) for b in x))
     if not onlyhex:
         s.append(sane(x)) 
     return "  ".join(s)
 
 def repr_hex(s):
     """ Convert provided bitstring to a simple string of hex digits """
-    return "".join(map(lambda x: "%02x" % ord(x),s))
+    return "".join("%02x" % ord(x) for x in s)
 
 @conf.commands.register
 def hexdiff(x,y):
@@ -339,7 +339,7 @@ def fletcher16_checkbytes(binbuf, offset):
 
 
 def mac2str(mac):
-    return "".join(map(lambda x: chr(int(x,16)), mac.split(":")))
+    return "".join(chr(int(x, 16)) for x in mac.split(':'))
 
 def str2mac(s):
     return ("%02x:"*6)[:-1] % tuple(map(ord, s)) 
@@ -348,15 +348,13 @@ def randstring(l):
     """
     Returns a random string of length l (l >= 0)
     """
-    tmp = map(lambda x: struct.pack("B", random.randrange(0, 256, 1)), [""]*l)
-    return "".join(tmp)
+    return b"".join(struct.pack('B', random.randint(0, 255)) for _ in xrange(l))
 
 def zerofree_randstring(l):
     """
     Returns a random string of length l (l >= 0) without zero in it.
     """
-    tmp = map(lambda x: struct.pack("B", random.randrange(1, 256, 1)), [""]*l)
-    return "".join(tmp)
+    return b"".join(struct.pack('B', random.randint(1, 255)) for _ in xrange(l))
 
 def strxor(s1, s2):
     """
@@ -1317,7 +1315,7 @@ def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None,
     vyf = {}
     l = 0
     for e in list:
-        xx,yy,zz = map(str, fxyz(e))
+        xx, yy, zz = [str(s) for s in fxyz(e)]
         l = max(len(yy),l)
         vx[xx] = max(vx.get(xx,0), len(xx), len(zz))
         vy[yy] = None
@@ -1348,7 +1346,7 @@ def __make_table(yfmtfunc, fmtfunc, endline, list, fxyz, sortx=None, sorty=None,
 
 
     if seplinefunc:
-        sepline = seplinefunc(l, map(lambda x:vx[x],vxk))
+        sepline = seplinefunc(l, [vx[x] for x in vxk])
         print sepline
 
     fmt = yfmtfunc(l)
@@ -1372,7 +1370,7 @@ def make_table(*args, **kargs):
     
 def make_lined_table(*args, **kargs):
     __make_table(lambda l:"%%-%is |" % l, lambda l:"%%-%is |" % l, "",
-                 seplinefunc=lambda a,x:"+".join(map(lambda y:"-"*(y+2), [a-1]+x+[-2])),
+                 seplinefunc=lambda a,x:"+".join('-'*(y+2) for y in [a-1]+x+[-2]),
                  *args, **kargs)
 
 def make_tex_table(*args, **kargs):

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -66,7 +66,7 @@ def construct_source_candidate_set(addr, plen, laddr, loiface):
             cset = filter(lambda x: x[1] == IPV6_ADDR_SITELOCAL, laddr)
     elif addr == '::' and plen == 0:
         cset = filter(lambda x: x[1] == IPV6_ADDR_GLOBAL, laddr)
-    cset = map(lambda x: x[0], cset)
+    cset = [x[0] for x in cset]
     cset.sort(cmp=cset_sort) # Sort with global addresses first
     return cset            
 
@@ -222,7 +222,7 @@ def in6_ifaceidtomac(ifaceid): # TODO: finish commenting function behavior
     first = struct.pack("B", ((first & 0xFD) | ulbit))
     oui = first + ifaceid[1:3]
     end = ifaceid[5:]
-    l = map(lambda x: "%.02x" % struct.unpack("B", x)[0], list(oui+end))
+    l = ["%.02x" % struct.unpack('B', x)[0] for x in list(oui + end)]
     return ":".join(l)
 
 def in6_addrtomac(addr):
@@ -523,10 +523,9 @@ def _in6_bitops(a1, a2, operator=0):
     fop = [ lambda x,y: x | y,
             lambda x,y: x & y,
             lambda x,y: x ^ y
-          ]  
+          ]
     ret = map(fop[operator%len(fop)], a1, a2)
-    t = ''.join(map(lambda x: struct.pack('I', x), ret))
-    return t
+    return ''.join(struct.pack('I', x) for x in ret)
 
 def in6_or(a1, a2):
     """
@@ -567,7 +566,7 @@ def in6_cidr2mask(m):
         t.append(max(0, 2**32  - 2**(32-min(32, m))))
         m -= 32
 
-    return ''.join(map(lambda x: struct.pack('!I', x), t))
+    return ''.join(struct.pack('!I', x) for x in t)
 
 def in6_getnsma(a): 
     """
@@ -588,7 +587,7 @@ def in6_getnsmac(a): # return multicast Ethernet address associated with multica
 
     a = struct.unpack('16B', a)[-4:]
     mac = '33:33:'
-    mac += ':'.join(map(lambda x: '%.2x' %x, a))
+    mac += ':'.join("%.2x" %x for x in a)
     return mac
 
 def in6_getha(prefix): 

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -341,7 +341,7 @@ class RandOID(RandString):
                 if i == "*":
                     oid.append(str(self.idnum))
                 elif i == "**":
-                    oid += map(str, [self.idnum for i in xrange(1+self.depth)])
+                    oid += [str(self.idnum) for i in xrange(1 + self.depth)]
                 elif type(i) is tuple:
                     oid.append(str(random.randrange(*i)))
                 else:
@@ -375,7 +375,7 @@ class RandRegExp(RandField):
                 s = s[:p-1]+rng+s[p+1:]
         res = m+s
         if invert:
-            res = "".join([chr(x) for x in xrange(256) if chr(x) not in res])
+            res = "".join(chr(x) for x in xrange(256) if chr(x) not in res)
         return res
 
     @staticmethod


### PR DESCRIPTION
This PR rewrites most of the `map()` calls into list comprehensions. Some calls are left when the resulting iterators is consumed right away.

I spent quite some time to write it, and I believe that it will be also difficult to review. The unit tests run fine locally but I will expect some to fail with Travis and AppVeyor.

On a side node, I wonder if I should also update CONTRIBUTING.md to make it clear that we won't accept patch with `map()` calls.