### PR TITLE
Cache fields initialization

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10506,6 +10506,19 @@ pkt = Test(raw(Test(Values=[0, 0, 0, 0, 1, 1, 1, 1])))
 assert(pkt.BitCount == 8)
 assert(pkt.ByteCount == 1)
 
+= PacketListField
+
+class TestPacket(Packet):
+  name = 'TestPacket'
+  fields_desc = [ PacketListField('list', [], 0) ]
+
+a = TestPacket()
+a.list.append(1)
+assert(len(a.list) == 1)
+
+b = TestPacket()
+assert(len(b.list) == 0)
+
 ############
 ############
 + MPLS tests


### PR DESCRIPTION
This PR attempts to enhance Scapy performance by caching the initialization of packets fields. Currently, they are initialized at each packet instantiation.

The benchmarks look quite nice and indicate that we can gain between 15% and 35% execution time depending on the use case.

| Type | Before - 2.7|  Before - 3.6 | After - 2.7 | After - 3.6 |
| --- | --- | --- | --- | --- |
| Build | 15.77s | 12.02s | 11.28s | 9.87s |
| Dissect | 6.84s | 4.62s | 4.50s | 3.82s |
| Build & dissect | 23.58s | 17.52s | 16.04s | 14.69s |

Here is the script used to bench this PR:
```python
import time

from scapy.all import *
from scapy.modules.six.moves import range

N = 20000
raw_packet = b'E\x00\x00(\x00\x01\x00\x00@\x11|\xc2\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x14\x00Z\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00'

start = time.time()
for i in range(N):
    p = IP() / UDP() / DNS()
    assert raw(p) == raw_packet
print("Build - %.2fs" % (time.time() - start))

start = time.time()
for i in range(N):
    p = IP(raw_packet)
    assert DNS in p
print("Dissect - %.2fs" % (time.time() - start))

start = time.time()
for i in range(N):
    p = IP() / UDP() / DNS()
    s = raw(p)
    assert s == raw_packet
    p = IP(s)
    assert DNS in p
print("Build & dissect - %.2fs" % (time.time() - start))
```

fixes https://github.com/secdev/scapy/issues/619