### PR TITLE
[IPv6] Windows: fix IPv6 routing + Net6

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -23,6 +23,8 @@ if [ "$SCAPY_USE_PCAPDNET" = "yes" ]
 then
   UT_FLAGS+=" -K not_pcapdnet"
 fi
+# IPv6 is not available yet on travis
+UT_FLAGS+=" -K ipv6"
 
 # AES-CCM, ChaCha20Poly1305 and X25519 were added to Cryptography v2.0
 # but the minimal version mandated by scapy is v1.7
@@ -72,9 +74,11 @@ then
     $SCAPY_SUDO ./run_tests -q -F -t bpf.uts $UT_FLAGS || exit $?
   fi
   UT_FLAGS+=" -K manufdb -K linux"
-else
-  # IPv6 is not available yet on the linux machines (but is on OSX)
-  UT_FLAGS+=" -K ipv6"
+fi
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]
+then
+  UT_FLAGS+=" -K osx"
 fi
 
 # Run all normal and contrib tests

--- a/scapy/all.py
+++ b/scapy/all.py
@@ -36,6 +36,7 @@ from scapy.automaton import *
 from scapy.autorun import *
 
 from scapy.main import *
+from scapy.consts import *
 
 from scapy.layers.all import *
 

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -70,7 +70,7 @@ elif WINDOWS:
     from scapy.arch.windows import *
 
 if scapy.config.conf.iface is None:
-    scapy.config.conf.iface = LOOPBACK_NAME
+    scapy.config.conf.iface = scapy.consts.LOOPBACK_INTERFACE
 
 
 def get_if_addr6(iff):

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -333,7 +333,12 @@ if conf.use_winpcapy:
           else:
             return
       def send(self, x):
-          cls = conf.l2types[1]
+          ll = self.ins.datalink()
+          if ll in conf.l2types:
+              cls = conf.l2types[ll]
+          else:
+              cls = conf.default_l2
+              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
           sx = raw(cls()/x)
           if hasattr(x, "sent_time"):
               x.sent_time = time.time()

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -333,6 +333,7 @@ if conf.use_winpcapy:
           else:
             return
       def send(self, x):
+          # Makes send detects when it should add Loopback(), Dot11... instead of Ether()
           ll = self.ins.datalink()
           if ll in conf.l2types:
               cls = conf.l2types[ll]

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -18,6 +18,7 @@ from scapy.config import conf
 from scapy.utils import mac2str
 from scapy.supersocket import SuperSocket
 from scapy.error import Scapy_Exception, log_loading, warning
+from scapy.pton_ntop import inet_ntop
 import scapy.arch
 import scapy.consts
 
@@ -113,7 +114,7 @@ if conf.use_winpcapy:
       pcap_freealldevs(devs)
   if conf.use_winpcapy:
       get_if_list = winpcapy_get_if_list
-  def in6_getifaddr():
+  def in6_getifaddr_raw():
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
     ret = []
@@ -128,7 +129,7 @@ if conf.use_winpcapy:
           if a.contents.addr.contents.sa_family == socket.AF_INET6:
             ap = a.contents.addr
             val = cast(ap, POINTER(sockaddr_in6))
-            addr = socket.inet_ntop(socket.AF_INET6, str(val.contents.sin6_addr[:]))
+            addr = inet_ntop(socket.AF_INET6, "".join(chr(x) for x in val.contents.sin6_addr[:]))
             scope = scapy.utils6.in6_getscope(addr)
             ret.append((addr, scope, p.contents.name.decode('ascii')))
           a = a.contents.next

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -262,7 +262,8 @@ if conf.prog.tcpdump and conf.use_npcap and conf.prog.os_access:
         try:
             p_test_windump = sp.Popen([conf.prog.tcpdump, "-help"], stdout=sp.PIPE, stderr=sp.STDOUT)
             stdout, err = p_test_windump.communicate()
-            return b"npcap" in stdout.lower()
+            _output = stdout.lower()
+            return b"npcap" in _output and not b"winpcap" in _output
         except:
             return False
     windump_ok = test_windump_npcap()

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -461,6 +461,7 @@ class NetworkInterfaceDict(UserDict):
                 scapy.consts.LOOPBACK_INTERFACE = self.dev_from_name(
                     scapy.consts.LOOPBACK_NAME,
                 )
+            except:
                 pass
 
     def dev_from_name(self, name):

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -13,6 +13,7 @@ import subprocess as sp
 from glob import glob
 import tempfile
 
+import scapy
 from scapy.config import conf, ConfClass
 from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
 from scapy.utils import atol, itom, inet_aton, inet_ntoa, PcapReader
@@ -459,7 +460,6 @@ class NetworkInterfaceDict(UserDict):
                 scapy.consts.LOOPBACK_INTERFACE = self.dev_from_name(
                     scapy.consts.LOOPBACK_NAME,
                 )
-            except:
                 pass
 
     def dev_from_name(self, name):
@@ -814,7 +814,7 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
         if not conf.route.routes:
             return
     data = {}
-    data['name'] = LOOPBACK_NAME
+    data['name'] = scapy.consts.LOOPBACK_NAME
     data['description'] = "Loopback"
     data['win_index'] = -1
     data['guid'] = "{0XX00000-X000-0X0X-X00X-00XXXX000XXX}"
@@ -827,11 +827,11 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
     # Remove all LOOPBACK_NAME routes
     for route in list(conf.route.routes):
         iface = route[3]
-        if iface.name == LOOPBACK_NAME:
+        if iface.name == scapy.consts.LOOPBACK_NAME:
             conf.route.routes.remove(route)
     # Remove LOOPBACK_NAME interface
     for devname, iface in IFACES.items():
-        if iface.name == LOOPBACK_NAME:
+        if iface.name == scapy.consts.LOOPBACK_NAME:
             IFACES.pop(devname)
     # Inject interface
     IFACES[data['guid']] = adapter

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -81,7 +81,7 @@ class Net(Gen):
         self.parsed,self.netmask = self._parse_net(net)
 
     def __str__(self):
-        return self.repr
+        return next(self.__iter__())
                                                                                                
     def __iter__(self):
         for d in range(*self.parsed[3]):

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -51,7 +51,7 @@ class SetGen(Gen):
 class Net(Gen):
     """Generate a list of IPs from a network address or a name"""
     name = "ip"
-    ipaddress = re.compile(r"^(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)(/[0-3]?[0-9])?$")
+    ip_regex = re.compile(r"^(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)(/[0-3]?[0-9])?$")
 
     @staticmethod
     def _parse_digit(a,netmask):
@@ -70,7 +70,7 @@ class Net(Gen):
     @classmethod
     def _parse_net(cls, net):
         tmp=net.split('/')+["32"]
-        if not cls.ipaddress.match(net):
+        if not cls.ip_regex.match(net):
             tmp[0]=socket.gethostbyname(tmp[0])
         netmask = int(tmp[1])
         ret_list = [cls._parse_digit(x, y-netmask) for (x, y) in zip(tmp[0].split('.'), [8, 16, 24, 32])]

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -81,7 +81,10 @@ class Net(Gen):
         self.parsed,self.netmask = self._parse_net(net)
 
     def __str__(self):
-        return next(self.__iter__())
+        try:
+            return next(self.__iter__())
+        except StopIteration:
+            return None
                                                                                                
     def __iter__(self):
         for d in range(*self.parsed[3]):

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -68,12 +68,12 @@ if WINDOWS:
             LOOPBACK_NAME = "Microsoft Loopback Adapter"
     except ValueError:
         LOOPBACK_NAME = "Microsoft Loopback Adapter"
+    # Will be different on Windows
+    LOOPBACK_INTERFACE = None
 else:
     uname = os.uname()
     LOOPBACK_NAME = "lo" if LINUX else "lo0"
-
-# Will be different on Windows
-LOOPBACK_INTERFACE = LOOPBACK_NAME
+    LOOPBACK_INTERFACE = LOOPBACK_NAME
 
 def parent_function():
     return inspect.getouterframes(inspect.currentframe())

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -49,6 +49,7 @@ class IPTools(object):
         else:
             os.system("whois %s" % self.src)
     def _ttl(self):
+        """Returns ttl or hlim, depending on the IP version"""
         return self.hlim if isinstance(self, IPv6) else self.ttl
     def ottl(self):
         t = sorted([32,64,128,255]+[self._ttl()])

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -48,11 +48,13 @@ class IPTools(object):
             print(whois(self.src))
         else:
             os.system("whois %s" % self.src)
+    def _ttl(self):
+        return self.hlim if isinstance(self, IPv6) else self.ttl
     def ottl(self):
-        t = sorted([32,64,128,255]+[self.ttl])
-        return t[t.index(self.ttl)+1]
+        t = sorted([32,64,128,255]+[self._ttl()])
+        return t[t.index(self._ttl())+1]
     def hops(self):
-        return self.ottl() - self.ttl
+        return self.ottl() - self._ttl()
 
 
 _ip_options_names = { 0: "end_of_list",

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -153,13 +153,13 @@ def getmacbyip6(ip6, chainCC=0):
 class Net6(Gen): # syntax ex. fec0::/126
     """Generate a list of IPv6s from a network address or a name"""
     name = "ipv6"
-    ipaddress = re.compile(r"^([a-fA-F0-9:]+)(/[1]?[0-3]?[0-9])?$")
+    ip_regex = re.compile(r"^([a-fA-F0-9:]+)(/[1]?[0-3]?[0-9])?$")
 
     def __init__(self, net):
         self.repr = net
 
         tmp = net.split('/')+["128"]
-        if not self.ipaddress.match(net):
+        if not self.ip_regex.match(net):
             tmp[0]=socket.getaddrinfo(tmp[0], None, socket.AF_INET6)[0][-1][0]
 
         netmask = int(tmp[1])

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -199,7 +199,16 @@ class Net6(Gen): # syntax ex. fec0::/126
         return iter(rec(0, ['']))
 
     def __str__(self):
-        return next(self.__iter__())
+        try:
+            return next(self.__iter__())
+        except StopIteration:
+            return None
+
+    def __eq__(self, other):
+        return str(other) == str(self)
+
+    def __ne__(self, other):
+        return str(other) != str(self)
 
     def __repr__(self):
         return "Net6(%r)" % self.repr
@@ -408,7 +417,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
         return conf.route6.route(dst)
 
     def mysummary(self):
-        return "%s > %s (%i)" % (str(self.src), str(self.dst), self.nh)
+        return "%s > %s (%i)" % (self.src, self.dst, self.nh)
 
     def post_build(self, p, pay):
         p += pay
@@ -432,10 +441,8 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             return self.payload.hashret()
 
         nh = self.nh
-        _sd = str(self.dst)
-        _ss = str(self.src)
-        sd = str(_sd)
-        ss=str(_ss)
+        sd = self.dst
+        ss = self.src
         if self.nh == 43 and isinstance(self.payload, IPv6ExtHdrRouting):
             # With routing header, the destination is the last
             # address of the IPv6 list if segleft > 0
@@ -459,7 +466,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             try:
                 sd = self.addresses[0]
             except IndexError:
-                sd = str(_sd)
+                sd = self.dst
 
         if self.nh == 44 and isinstance(self.payload, IPv6ExtHdrFragment):
             nh = self.payload.nh
@@ -478,7 +485,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
 
         if conf.checkIPsrc and conf.checkIPaddr and not in6_ismaddr(sd):
             sd = inet_pton(socket.AF_INET6, sd)
-            ss = inet_pton(socket.AF_INET6, str(_ss))
+            ss = inet_pton(socket.AF_INET6, self.src)
             return strxor(sd, ss) + struct.pack("B", nh) + self.payload.hashret()
         else:
             return struct.pack("B", nh)+self.payload.hashret()
@@ -493,23 +500,19 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                 return self.answers(other.payload)
         if not isinstance(other, IPv6): # self is reply, other is request
             return False
-        _sd = str(self.dst)
-        _ss = str(self.src)
-        _od = str(other.dst)
-        _os = str(other.src)
         if conf.checkIPaddr:
-            ss = inet_pton(socket.AF_INET6, _ss)
-            sd = inet_pton(socket.AF_INET6, _sd)
-            os = inet_pton(socket.AF_INET6, _os)
-            od = inet_pton(socket.AF_INET6, _od)
+            ss = inet_pton(socket.AF_INET6, self.src)
+            sd = inet_pton(socket.AF_INET6, self.dst)
+            os = inet_pton(socket.AF_INET6, other.src)
+            od = inet_pton(socket.AF_INET6, other.dst)
             # request was sent to a multicast address (other.dst)
             # Check reply destination addr matches request source addr (i.e
             # sd == os) except when reply is multicasted too
             # XXX test mcast scope matching ?
-            if in6_ismaddr(_od):
-                if in6_ismaddr(_sd):
+            if in6_ismaddr(other.dst):
+                if in6_ismaddr(self.dst):
                     if ((od == sd) or
-                        (in6_isaddrllallnodes(_od) and in6_isaddrllallservers(_od))):
+                        (in6_isaddrllallnodes(self.dst) and in6_isaddrllallservers(other.dst))):
                          return self.payload.answers(other.payload)
                     return False
                 if (os == sd):
@@ -568,10 +571,10 @@ class IPerror6(IPv6):
     def answers(self, other):
         if not isinstance(other, IPv6):
             return False
-        sd = inet_pton(socket.AF_INET6, str(self.dst))
-        ss = inet_pton(socket.AF_INET6, str(self.src))
-        od = inet_pton(socket.AF_INET6, str(other.dst))
-        os = inet_pton(socket.AF_INET6, str(other.src))
+        sd = inet_pton(socket.AF_INET6, self.dst)
+        ss = inet_pton(socket.AF_INET6, self.src)
+        od = inet_pton(socket.AF_INET6, other.dst)
+        os = inet_pton(socket.AF_INET6, other.src)
 
         # Make sure that the ICMPv6 error is related to the packet scapy sent
         if isinstance(self.underlayer, _ICMPv6) and self.underlayer.type < 128:
@@ -3162,7 +3165,7 @@ class TracerouteResult6(TracerouteResult):
         for s,r in self.res:
             if IPv6 not in s:
                 continue
-            d = str(s[IPv6].dst)
+            d = s[IPv6].dst
             if d not in trace:
                 trace[d] = {}
 
@@ -3171,7 +3174,7 @@ class TracerouteResult6(TracerouteResult):
                      ICMPv6PacketTooBig in r or
                      ICMPv6ParamProblem in r)
 
-            trace[d][s[IPv6].hlim] = str(r[IPv6].src), t
+            trace[d][s[IPv6].hlim] = r[IPv6].src, t
 
         for k in six.itervalues(trace):
             try:
@@ -3258,13 +3261,13 @@ class _IPv6inIP(SuperSocket):
       return p
     elif isinstance(p, IP):
       # TODO: verify checksum
-      if str(p.src) == str(self.dst) and p.proto == socket.IPPROTO_IPV6:
+      if p.src == self.dst and p.proto == socket.IPPROTO_IPV6:
         if isinstance(p.payload, IPv6):
           return p.payload
     return p
 
   def send(self, x):
-    return self.worker.send(IP(dst=str(self.dst), src=str(self.src), proto=socket.IPPROTO_IPV6)/x)
+    return self.worker.send(IP(dst=self.dst, src=self.src, proto=socket.IPPROTO_IPV6)/x)
 
 
 #############################################################################
@@ -3295,15 +3298,15 @@ def _NDP_Attack_DAD_DoS(reply_callback, iface=None, mac_src_filter=None,
             return 0
 
         # Source must be the unspecified address
-        if str(req[IPv6].src) != "::":
+        if req[IPv6].src != "::":
             return 0
 
         # Check destination is the link-local solicited-node multicast
         # address associated with target address in received NS
-        tgt = socket.inet_pton(socket.AF_INET6, req[ICMPv6ND_NS].tgt)
+        tgt = inet_pton(socket.AF_INET6, req[ICMPv6ND_NS].tgt)
         if tgt_filter and tgt != tgt_filter:
             return 0
-        received_snma = socket.inet_pton(socket.AF_INET6, str(req[IPv6].dst))
+        received_snma = inet_pton(socket.AF_INET6, req[IPv6].dst)
         expected_snma = in6_getnsma(tgt)
         if received_snma != expected_snma:
             return 0
@@ -3370,7 +3373,7 @@ def NDP_Attack_DAD_DoS_via_NS(iface=None, mac_src_filter=None, tgt_filter=None,
 
         # Let's build a reply and send it
         mac = req[Ether].src
-        dst = str(req[IPv6].dst)
+        dst = req[IPv6].dst
         tgt = req[ICMPv6ND_NS].tgt
         rep = Ether(src=reply_mac)/IPv6(src="::", dst=dst)/ICMPv6ND_NS(tgt=tgt)
         sendp(rep, iface=iface, verbose=0)
@@ -3429,7 +3432,7 @@ def NDP_Attack_DAD_DoS_via_NA(iface=None, mac_src_filter=None, tgt_filter=None,
 
         # Let's build a reply and send it
         mac = req[Ether].src
-        dst = str(req[IPv6].dst)
+        dst = req[IPv6].dst
         tgt = req[ICMPv6ND_NS].tgt
         rep = Ether(src=reply_mac)/IPv6(src=tgt, dst=dst)
         rep /= ICMPv6ND_NA(tgt=tgt, S=0, R=0, O=1)
@@ -3516,14 +3519,14 @@ def NDP_Attack_NA_Spoofing(iface=None, mac_src_filter=None, tgt_filter=None,
             return 0
 
         # Source must NOT be the unspecified address
-        if str(req[IPv6].src) == "::":
+        if req[IPv6].src == "::":
             return 0
 
-        tgt = socket.inet_pton(socket.AF_INET6, req[ICMPv6ND_NS].tgt)
+        tgt = inet_pton(socket.AF_INET6, req[ICMPv6ND_NS].tgt)
         if tgt_filter and tgt != tgt_filter:
             return 0
 
-        dst = str(req[IPv6].dst)
+        dst = req[IPv6].dst
         if in6_isllsnmaddr(dst): # Address is Link Layer Solicited Node mcast.
 
             # If this is a real address resolution NS, then the destination
@@ -3549,7 +3552,7 @@ def NDP_Attack_NA_Spoofing(iface=None, mac_src_filter=None, tgt_filter=None,
         # send it back.
         mac = req[Ether].src
         pkt = req[IPv6]
-        src = str(pkt.src)
+        src = pkt.src
         tgt = req[ICMPv6ND_NS].tgt
         rep = Ether(src=reply_mac, dst=mac)/IPv6(src=tgt, dst=src)
         rep /= ICMPv6ND_NA(tgt=tgt, S=1, R=router, O=1) # target from the NS
@@ -3743,7 +3746,7 @@ def NDP_Attack_Kill_Default_Router(iface=None, mac_src_filter=None,
         if mac_src_filter and mac_src != mac_src_filter:
             return 0
 
-        ip_src = str(req[IPv6].src)
+        ip_src = req[IPv6].src
         if ip_src_filter and ip_src != ip_src_filter:
             return 0
 
@@ -3761,7 +3764,7 @@ def NDP_Attack_Kill_Default_Router(iface=None, mac_src_filter=None,
 
         # Let's build a reply and send it
 
-        src = str(req[IPv6].src)
+        src = req[IPv6].src
 
         # Prepare packets parameters
         ether_params = {}
@@ -3864,7 +3867,7 @@ def NDP_Attack_Fake_Router(ra, iface=None, mac_src_filter=None,
         if mac_src_filter and mac_src != mac_src_filter:
             return 0
 
-        ip_src = str(req[IPv6].src)
+        ip_src = req[IPv6].src
         if ip_src_filter and ip_src != ip_src_filter:
             return 0
 
@@ -3875,7 +3878,7 @@ def NDP_Attack_Fake_Router(ra, iface=None, mac_src_filter=None,
         Callback that sends an RA in reply to an RS
         """
 
-        src = str(req[IPv6].src)
+        src = req[IPv6].src
         sendp(ra, iface=iface, verbose=0)
         print("Fake RA sent in response to RS from %s" % src)
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -108,7 +108,7 @@ def getmacbyip6(ip6, chainCC=0):
      used to perform the resolution, if needed)
     """
     
-    if isinstance(ip6,Net6):
+    if isinstance(ip6, Net6):
         ip6 = iter(ip6).next()
 
     if in6_ismaddr(ip6): # Multicast
@@ -408,7 +408,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
         return conf.route6.route(dst)
 
     def mysummary(self):
-        return "%s > %s (%i)" % (str(self.src),str(self.dst), self.nh)
+        return "%s > %s (%i)" % (str(self.src), str(self.dst), self.nh)
 
     def post_build(self, p, pay):
         p += pay

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -107,6 +107,9 @@ def getmacbyip6(ip6, chainCC=0):
     (chainCC parameter value ends up being passed to sending function
      used to perform the resolution, if needed)
     """
+    
+    if isinstance(ip6,Net6):
+        ip6 = iter(ip6).next()
 
     if in6_ismaddr(ip6): # Multicast
         mac = in6_getnsmac(inet_pton(socket.AF_INET6, ip6))

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os, struct, time, socket
 
+import scapy
 from scapy.base_classes import Net
 from scapy.config import conf
 from scapy.data import *
@@ -21,7 +22,6 @@ from scapy.plist import SndRcvList
 from scapy.fields import *
 from scapy.sendrecv import srp, srp1, srpflood
 from scapy.arch import get_if_hwaddr
-from scapy.consts import LOOPBACK_INTERFACE
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.error import warning
 if conf.route is None:
@@ -66,7 +66,7 @@ def getmacbyip(ip, chainCC=0):
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
         return "01:00:5e:%.2x:%.2x:%.2x" % (tmp[1]&0x7f,tmp[2],tmp[3])
     iff,a,gw = conf.route.route(ip)
-    if ( (iff == LOOPBACK_INTERFACE) or (ip == conf.route.get_if_bcast(iff)) ):
+    if ( (iff == scapy.consts.LOOPBACK_INTERFACE) or (ip == conf.route.get_if_bcast(iff)) ):
         return "ff:ff:ff:ff:ff:ff"
     if gw != "0.0.0.0":
         ip = gw

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -79,6 +79,9 @@ _INET_PTON = {
 
 def inet_pton(af, addr):
     """Convert an IP address from text representation into binary form."""
+    # Will replace Net/Net6 objects
+    if not isinstance(addr, str):
+        addr = str(addr)
     # Use inet_pton if available
     addr = plain_str(addr)
     try:

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -8,7 +8,6 @@ Routing and handling of network interfaces.
 """
 
 from __future__ import absolute_import
-from scapy.consts import LOOPBACK_NAME, LOOPBACK_INTERFACE
 from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
@@ -153,13 +152,13 @@ class Route:
                 continue
             aa = atol(a)
             if aa == dst:
-                pathes.append((0xffffffff,(LOOPBACK_INTERFACE,a,"0.0.0.0")))
+                pathes.append((0xffffffff,(scapy.consts.LOOPBACK_INTERFACE,a,"0.0.0.0")))
             if (dst & m) == (d & m):
                 pathes.append((m,(i,a,gw)))
         if not pathes:
             if verbose:
                 warning("No route found (no default route?)")
-            return LOOPBACK_INTERFACE,"0.0.0.0","0.0.0.0"
+            return scapy.consts.LOOPBACK_INTERFACE,"0.0.0.0","0.0.0.0"
         # Choose the more specific route (greatest netmask).
         # XXX: we don't care about metrics
         pathes.sort(key=lambda x: x[0])
@@ -184,6 +183,6 @@ conf.route=Route()
 
 #XXX use "with"
 _betteriface = conf.route.route("0.0.0.0", verbose=0)[0]
-if ((_betteriface if (isinstance(_betteriface, six.string_types) or _betteriface is None) else _betteriface.name) != LOOPBACK_NAME):
+if ((_betteriface if (isinstance(_betteriface, six.string_types) or _betteriface is None) else _betteriface.name) != scapy.consts.LOOPBACK_NAME):
     conf.iface = _betteriface
 del(_betteriface)

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -12,6 +12,7 @@ from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.arch import WINDOWS
+import scapy.consts
 import scapy.modules.six as six
 
 ##############################

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -18,7 +18,7 @@ Routing and network interface handling for IPv6.
 
 from __future__ import absolute_import
 import socket
-import scapy
+import scapy.consts
 from scapy.config import conf
 from scapy.utils6 import *
 from scapy.arch import *

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -18,12 +18,12 @@ Routing and network interface handling for IPv6.
 
 from __future__ import absolute_import
 import socket
+import scapy
 from scapy.config import conf
 from scapy.utils6 import *
 from scapy.arch import *
 from scapy.pton_ntop import *
 from scapy.error import warning, log_loading
-from scapy.consts import LOOPBACK_INTERFACE
 import scapy.modules.six as six
 
 
@@ -220,7 +220,7 @@ class Route6:
 
         if not pathes:
             warning("No route found for IPv6 destination %s (no default route?)" % dst)
-            return (LOOPBACK_INTERFACE, "::", "::")
+            return (scapy.consts.LOOPBACK_INTERFACE, "::", "::")
 
         # Sort with longest prefix first
         pathes.sort(reverse=True)
@@ -237,7 +237,7 @@ class Route6:
 
         if res == []:
             warning("Found a route for IPv6 destination '%s', but no possible source address." % dst)
-            return (LOOPBACK_INTERFACE, "::", "::")
+            return (scapy.consts.LOOPBACK_INTERFACE, "::", "::")
 
         # Symptom  : 2 routes with same weight (our weight is plen)
         # Solution :

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -395,11 +395,7 @@ else:
     inet_aton = socket.inet_aton
 
 inet_ntoa = socket.inet_ntoa
-try:
-    inet_ntop = socket.inet_ntop
-    inet_pton = socket.inet_pton
-except AttributeError:
-    from scapy.pton_ntop import *
+from scapy.pton_ntop import *
 
 
 def atol(x):

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -59,3 +59,48 @@ def check_DNS_am_reply(packet):
 test_am(DNS_am,
         IP()/UDP()/DNS(qd=DNSQR(qname="www.secdev.org")),
         check_DNS_am_reply)
+
+= DHCPv6_am - Basic Instantiaion
+~ osx netaccess
+a = DHCPv6_am()
+a.usage()
+
+a.parse_options(dns="2001:500::1035", domain="localdomain, local", duid=None,
+	iface=conf.iface6, advpref=255, sntpservers=None, 
+        sipdomains=None, sipservers=None, 
+        nisdomain=None, nisservers=None, 
+        nispdomain=None, nispservers=None,
+        bcmcsdomains=None, bcmcsservers=None,
+	debug=1)
+
+= DHCPv6_am - SOLICIT
+~ osx netaccess
+req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=1)/DHCP6OptClientId(duid=DUID_LLT())
+assert a.is_request(req)
+res = a.make_reply(req)
+assert not a.is_request(res)
+assert res[DHCP6_Advertise]
+assert res[DHCP6OptPref].prefval == 255
+assert res[DHCP6OptReconfAccept]
+a.print_reply(req, res)
+
+= DHCPv6_am - INFO-REQUEST
+~ osx netaccess
+req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=11)/DHCP6OptClientId(duid=DUID_LLT())
+assert a.is_request(req)
+res = a.make_reply(req)
+assert not a.is_request(res)
+assert res[DHCP6_Reply]
+assert "local" in res[DHCP6OptDNSDomains].dnsdomains
+a.print_reply(req, res)
+
+= DHCPv6_am - REQUEST
+~ osx netaccess
+req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=3)/DHCP6OptClientId(duid=DUID_LLT())/DHCP6OptServerId(duid=a.duid)
+assert a.is_request(req)
+res = a.make_reply(req)
+assert not a.is_request(res)
+assert res[UDP].dport == 546
+assert res[DHCP6_Solicit]
+a.print_reply(req, res)
+

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -12,6 +12,8 @@
   },
   "format": "text",
   "kw_ko": [
-    "crypto_advanced"
+    "crypto_advanced",
+    "ipv6",
+    "osx"
   ]
 }

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -90,35 +90,6 @@ ifIndex DestinationPrefix                          NextHop
 
 test_read_routes6_windows()
 
-= Restore normal routes & Ifaces
-
-IFACES.reload()
-conf.route.resync()
-conf.route6.resync()
-
-# Loopback Adapter is not installed on Appveyor for an unknown reason...
-
-#= Test LOOPBACK_INTERFACE on IPv4
-#
-#scapy.consts.LOOPBACK_INTERFACE
-#
-#a = srp1(Loopback()/IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE)
-#assert a.src == "127.0.0.1"
-#assert a.haslayer(ICMP)
-#
-#a = sr1(IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE)
-#assert a.src == "127.0.0.1"
-#assert a.haslayer(ICMP)
-
-#= Test LOOPBACK_INTERFACE on IPv6
-#
-#b = srp1(Loopback()/IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE)
-#assert b.src == "::1"
-#assert b.haslayer(ICMPv6EchoReply)
-#
-#b = sr1(IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE)
-#assert b.src == "::1"
-#assert b.haslayer(ICMPv6EchoReply)
 
 ############
 ############

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -19,12 +19,6 @@ assert select_objects([TimeOutSelector()], 1) == []
 ############
 + Windows Networking tests
 
-= Restore normal routes
-
-IFACES.reload()
-conf.route.resync()
-conf.route6.resync()
-
 = Mocked read_routes6() calls
 
 import mock
@@ -96,17 +90,33 @@ ifIndex DestinationPrefix                          NextHop
 
 test_read_routes6_windows()
 
-= Test LOOPBACK_INTERFACE
+= Restore normal routes & Ifaces
 
-# Not available yet on appveyor/travis
+IFACES.reload()
+conf.route.resync()
+conf.route6.resync()
 
+# Loopback Adapter is not installed on Appveyor for an unknown reason...
+
+#= Test LOOPBACK_INTERFACE on IPv4
+#
 #scapy.consts.LOOPBACK_INTERFACE
 #
-#a = sr1(IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE, timeout=3)
+#a = srp1(Loopback()/IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE)
 #assert a.src == "127.0.0.1"
 #assert a.haslayer(ICMP)
 #
-#b = sr1(IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE, timeout=3)
+#a = sr1(IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE)
+#assert a.src == "127.0.0.1"
+#assert a.haslayer(ICMP)
+
+#= Test LOOPBACK_INTERFACE on IPv6
+#
+#b = srp1(Loopback()/IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE)
+#assert b.src == "::1"
+#assert b.haslayer(ICMPv6EchoReply)
+#
+#b = sr1(IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE)
 #assert b.src == "::1"
 #assert b.haslayer(ICMPv6EchoReply)
 

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -19,9 +19,13 @@ assert select_objects([TimeOutSelector()], 1) == []
 ############
 + Windows Networking tests
 
-= Mocked read_routes6() calls
+= Restore normal routes
 
-route_add_loopback()
+IFACES.reload()
+conf.route.resync()
+conf.route6.resync()
+
+= Mocked read_routes6() calls
 
 import mock
 from scapy.arch.windows import _read_routes6_post2008
@@ -92,15 +96,19 @@ ifIndex DestinationPrefix                          NextHop
 
 test_read_routes6_windows()
 
-= Test LOOPBACK_INTERFACE ping
+= Test LOOPBACK_INTERFACE
 
-a = sr1(IP()/ICMP(), iface=LOOPBACK_INTERFACE, timeout=3)
-assert a.src == "127.0.0.1"
-assert a.haslayer(ICMP)
+# Not available yet on appveyor/travis
 
-b = sr1(IPv6()/ICMPv6EchoRequest(), iface=LOOPBACK_INTERFACE, timeout=3)
-assert b.src == "::1"
-assert b.haslayer(ICMPv6EchoReply)
+#scapy.consts.LOOPBACK_INTERFACE
+#
+#a = sr1(IP()/ICMP(), iface=scapy.consts.LOOPBACK_INTERFACE, timeout=3)
+#assert a.src == "127.0.0.1"
+#assert a.haslayer(ICMP)
+#
+#b = sr1(IPv6()/ICMPv6EchoRequest(), iface=scapy.consts.LOOPBACK_INTERFACE, timeout=3)
+#assert b.src == "::1"
+#assert b.haslayer(ICMPv6EchoReply)
 
 ############
 ############

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -17,9 +17,9 @@ assert select_objects([TimeOutSelector()], 1) == []
 
 ############
 ############
-+ Mocked read_routes6() calls
++ Windows Networking tests
 
-= Windows with fake IPv6 adapter
+= Mocked read_routes6() calls
 
 route_add_loopback()
 
@@ -91,6 +91,16 @@ ifIndex DestinationPrefix                          NextHop
 
 
 test_read_routes6_windows()
+
+= Test LOOPBACK_INTERFACE ping
+
+a = sr1(IP()/ICMP(), iface=LOOPBACK_INTERFACE, timeout=3)
+assert a.src == "127.0.0.1"
+assert a.haslayer(ICMP)
+
+b = sr1(IPv6()/ICMPv6EchoRequest(), iface=LOOPBACK_INTERFACE, timeout=3)
+assert b.src == "::1"
+assert b.haslayer(ICMPv6EchoReply)
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -509,12 +509,16 @@ assert all(p.hashret() == p2.hashret() for p in px)
 assert not any(p.answers(p2) for p in px)
 assert all(p2.answers(p) for p in px)
 conf.checkIPinIP = conf_back
+
+a1, a2 = Net("www.google.com"), Net("www.secdev.org")
 prt1, prt2 = 12345, 54321
 s1, s2 = 2767216324, 3845532842
 p1 = IP(src=a1, dst=a2)/TCP(flags='SA', seq=s1, ack=s2, sport=prt1, dport=prt2)
 p2 = IP(src=a2, dst=a1)/TCP(flags='R', seq=s2, ack=0, sport=prt2, dport=prt1)
 assert p2.answers(p1)
 assert not p1.answers(p2)
+# Not available yet because of IPv6
+# a1, a2 = Net6("www.google.com"), Net6("www.secdev.org")
 p1 = IP(src=a1, dst=a2)/TCP(flags='S', seq=s1, ack=0, sport=prt1, dport=prt2)
 p2 = IP(src=a2, dst=a1)/TCP(flags='RA', seq=0, ack=s1+1, sport=prt2, dport=prt1)
 assert p2.answers(p1)
@@ -690,16 +694,16 @@ assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
 x is not None and ICMP in x and x[ICMP].type == 0
 
-#= Sending and receiving an ICMPv6EchoRequest
-#~ netaccess ipv6
-#old_debug_dissector = conf.debug_dissector
-#conf.debug_dissector = False
-#x = sr1(IPv6(dst="www.google.com")/ICMPv6EchoRequest(),timeout=3)
-#conf.debug_dissector = old_debug_dissector
-#x
-#assert x[IPv6].ottl() in [32, 64, 128, 255]
-#assert 0 <= x[IPv6].hops() <= 126
-#x is not None and ICMPv6EchoReply in x and x[ICMPv6EchoReply].type == 129
+= Sending and receiving an ICMPv6EchoRequest
+~ netaccess ipv6
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+x = sr1(IPv6(dst="www.google.com")/ICMPv6EchoRequest(),timeout=3)
+conf.debug_dissector = old_debug_dissector
+x
+assert x[IPv6].ottl() in [32, 64, 128, 255]
+assert 0 <= x[IPv6].hops() <= 126
+x is not None and ICMPv6EchoReply in x and x[ICMPv6EchoReply].type == 129
 
 = DNS request
 ~ netaccess IP UDP DNS
@@ -1808,13 +1812,13 @@ b=IPv6(src="2047::deca", dst="2048::cafe")/ICMPv6EchoReply(id=0x6666, seq=0x7777
 a=IPv6(src="2048::cafe", dst="2047::deca")/ICMPv6EchoRequest(id=0x6666, seq=0x7777, data="somedata")
 (a > b) == True
 
-#= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
-#~ netaccess ipv6
-#
-#a = IPv6(dst="www.google.com")/ICMPv6EchoRequest()
-#b = IPv6(src="www.google.com", dst=a.src)/ICMPv6EchoReply()
-#assert b.answers(a)
-#assert (a > b)
+= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
+~ netaccess ipv6
+
+a = IPv6(dst="www.google.com")/ICMPv6EchoRequest()
+b = IPv6(src="www.google.com", dst=a.src)/ICMPv6EchoReply()
+assert b.answers(a)
+assert (a > b)
 
 
 ########### ICMPv6MRD* Classes ######################################
@@ -3162,12 +3166,12 @@ ICMPv6MLQuery in p and p[IPv6].dst == "ff02::1"
 if WINDOWS:
     route_add_loopback()
 
-#= Ether IPv6 checking for dst
-#~ netaccess ipv6
-#
-#p = Ether()/IPv6(dst="www.google.com")/TCP()
-#assert p.dst != p[IPv6].dst
-#p.show()
+= Ether IPv6 checking for dst
+~ netaccess ipv6
+
+p = Ether()/IPv6(dst="www.google.com")/TCP()
+assert p.dst != p[IPv6].dst
+p.show()
 
 ############
 ############
@@ -4398,53 +4402,6 @@ str(DHCP6_RelayReply()) == b'\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
 a=DHCP6_RelayReply(b'\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 a.msgtype == 13 and a.hopcount == 0 and a.linkaddr == "::" and a.peeraddr == "::"
 
-############
-############
-+ Test DHCPv6_am
-
-= DHCPv6_am - Basic Instantiaion
-~ ipv6 netaccess
-a = DHCPv6_am()
-a.usage()
-
-a.parse_options(dns="2001:500::1035", domain="localdomain, local", duid=None,
-	iface=conf.iface6, advpref=255, sntpservers=None, 
-        sipdomains=None, sipservers=None, 
-        nisdomain=None, nisservers=None, 
-        nispdomain=None, nispservers=None,
-        bcmcsdomains=None, bcmcsservers=None,
-	debug=1)
-
-= DHCPv6_am - SOLICIT
-~ ipv6 netaccess
-req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=1)/DHCP6OptClientId(duid=DUID_LLT())
-assert a.is_request(req)
-res = a.make_reply(req)
-assert not a.is_request(res)
-assert res[DHCP6_Advertise]
-assert res[DHCP6OptPref].prefval == 255
-assert res[DHCP6OptReconfAccept]
-a.print_reply(req, res)
-
-= DHCPv6_am - INFO-REQUEST
-~ ipv6 netaccess
-req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=11)/DHCP6OptClientId(duid=DUID_LLT())
-assert a.is_request(req)
-res = a.make_reply(req)
-assert not a.is_request(res)
-assert res[DHCP6_Reply]
-assert "local" in res[DHCP6OptDNSDomains].dnsdomains
-a.print_reply(req, res)
-
-= DHCPv6_am - REQUEST
-~ ipv6 netaccess
-req = IPv6(dst="::1")/UDP()/DHCP6(msgtype=3)/DHCP6OptClientId(duid=DUID_LLT())/DHCP6OptServerId(duid=a.duid)
-assert a.is_request(req)
-res = a.make_reply(req)
-assert not a.is_request(res)
-assert res[UDP].dport == 546
-assert res[DHCP6_Solicit]
-a.print_reply(req, res)
 
 ############
 ############
@@ -7973,14 +7930,14 @@ len([ o for o in oid ]) == 3
 n1 = Net6("2001:db8::/127")
 len([ip for ip in n1]) == 2
 
-#= Net6 using web address
-#~ ipv6
-#
-#ip = IPv6(dst="www.google.com")
-#n1 = ip.dst
-#assert isinstance(n1, Net6)
-#assert n1.ip_regex.match(str(n1))
-#ip.show()
+= Net6 using web address
+~ netaccess ipv6
+
+ip = IPv6(dst="www.google.com")
+n1 = ip.dst
+assert isinstance(n1, Net6)
+assert n1.ip_regex.match(str(n1))
+ip.show()
 
 ############
 ############
@@ -8949,3 +8906,15 @@ p1[IP]
 p2[MPLS]
 p2[MPLS:1]
 p2[IP]
+
+
++ Restore normal routes & Ifaces
+
+= Windows
+
+if WINDOWS:
+    IFACES.reload()
+    conf.route.resync()
+    conf.route6.resync()
+
+True

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -690,10 +690,8 @@ assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
 x is not None and ICMP in x and x[ICMP].type == 0
 
-# Not available on travis/appveyor
-
 #= Sending and receiving an ICMPv6EchoRequest
-#~ netaccess IP ICMP
+#~ netaccess ipv6
 #old_debug_dissector = conf.debug_dissector
 #conf.debug_dissector = False
 #x = sr1(IPv6(dst="www.google.com")/ICMPv6EchoRequest(),timeout=3)
@@ -1810,10 +1808,8 @@ b=IPv6(src="2047::deca", dst="2048::cafe")/ICMPv6EchoReply(id=0x6666, seq=0x7777
 a=IPv6(src="2048::cafe", dst="2047::deca")/ICMPv6EchoRequest(id=0x6666, seq=0x7777, data="somedata")
 (a > b) == True
 
-# Not available on travis/appveyor
-
 #= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
-#~ netaccess
+#~ netaccess ipv6
 #
 #a = IPv6(dst="www.google.com")/ICMPv6EchoRequest()
 #b = IPv6(src="www.google.com", dst=a.src)/ICMPv6EchoReply()
@@ -3161,14 +3157,14 @@ ICMPv6MLQuery in p and p[IPv6].dst == "ff02::1"
 ############
 + Ether tests with IPv6
 
-= Ether IPv6 checking for dst
-~ netaccess
-
+= Logic
 # No more routing test after this line
 if WINDOWS:
     route_add_loopback()
 
-# Not available on travis/appveyor
+#= Ether IPv6 checking for dst
+#~ netaccess ipv6
+#
 #p = Ether()/IPv6(dst="www.google.com")/TCP()
 #assert p.dst != p[IPv6].dst
 #p.show()
@@ -7977,9 +7973,8 @@ len([ o for o in oid ]) == 3
 n1 = Net6("2001:db8::/127")
 len([ip for ip in n1]) == 2
 
-# Not available yet on travis/appveyor
-
 #= Net6 using web address
+#~ ipv6
 #
 #ip = IPv6(dst="www.google.com")
 #n1 = ip.dst

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -690,6 +690,19 @@ assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
 x is not None and ICMP in x and x[ICMP].type == 0
 
+# Not available on travis/appveyor
+
+#= Sending and receiving an ICMPv6EchoRequest
+#~ netaccess IP ICMP
+#old_debug_dissector = conf.debug_dissector
+#conf.debug_dissector = False
+#x = sr1(IPv6(dst="www.google.com")/ICMPv6EchoRequest(),timeout=3)
+#conf.debug_dissector = old_debug_dissector
+#x
+#assert x[IPv6].ottl() in [32, 64, 128, 255]
+#assert 0 <= x[IPv6].hops() <= 126
+#x is not None and ICMPv6EchoReply in x and x[ICMPv6EchoReply].type == 129
+
 = DNS request
 ~ netaccess IP UDP DNS
 * A possible cause of failure could be that the open DNS (resolver1.opendns.com)
@@ -1797,13 +1810,15 @@ b=IPv6(src="2047::deca", dst="2048::cafe")/ICMPv6EchoReply(id=0x6666, seq=0x7777
 a=IPv6(src="2048::cafe", dst="2047::deca")/ICMPv6EchoRequest(id=0x6666, seq=0x7777, data="somedata")
 (a > b) == True
 
-= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
-~ netaccess
+# Not available on travis/appveyor
 
-a = IPv6(dst="www.google.fr")/ICMPv6EchoRequest()
-b = IPv6(src="www.google.fr", dst=a.src)/ICMPv6EchoReply()
-assert b.answers(a)
-assert (a > b)
+#= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
+#~ netaccess
+#
+#a = IPv6(dst="www.google.com")/ICMPv6EchoRequest()
+#b = IPv6(src="www.google.com", dst=a.src)/ICMPv6EchoReply()
+#assert b.answers(a)
+#assert (a > b)
 
 
 ########### ICMPv6MRD* Classes ######################################
@@ -3153,9 +3168,10 @@ ICMPv6MLQuery in p and p[IPv6].dst == "ff02::1"
 if WINDOWS:
     route_add_loopback()
 
-p = Ether()/IPv6(dst="www.google.com")/TCP()
-assert p.dst != p[IPv6].dst
-p.show()
+# Not available on travis/appveyor
+#p = Ether()/IPv6(dst="www.google.com")/TCP()
+#assert p.dst != p[IPv6].dst
+#p.show()
 
 ############
 ############
@@ -7945,7 +7961,7 @@ len([ip for ip in n3]) == 5
 
 = Net using web address
 
-ip = IP(dst="www.google.fr")
+ip = IP(dst="www.google.com")
 n1 = ip.dst
 assert isinstance(n1, Net)
 assert n1.ip_regex.match(str(n1))
@@ -7961,13 +7977,15 @@ len([ o for o in oid ]) == 3
 n1 = Net6("2001:db8::/127")
 len([ip for ip in n1]) == 2
 
-= Net6 using web address
+# Not available yet on travis/appveyor
 
-ip = IPv6(dst="www.google.fr")
-n1 = ip.dst
-assert isinstance(n1, Net6)
-assert n1.ip_regex.match(str(n1))
-ip.show()
+#= Net6 using web address
+#
+#ip = IPv6(dst="www.google.com")
+#n1 = ip.dst
+#assert isinstance(n1, Net6)
+#assert n1.ip_regex.match(str(n1))
+#ip.show()
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -3136,6 +3136,21 @@ ICMPv6MLQuery in p and p[IPv6].dst == "ff02::1"
 
 ############
 ############
++ Ether tests with IPv6
+
+= Ether IPv6 checking for dst
+~ netaccess
+
+# No more routing test after this line
+if WINDOWS:
+    route_add_loopback()
+
+p = Ether()/IPv6(dst="www.google.com")/TCP()
+assert p.dst != p[IPv6].dst
+p.show()
+
+############
+############
 + TracerouteResult6
 
 = get_trace()
@@ -4437,8 +4452,6 @@ not a < b and a > b
 + Mobile Prefix Solicitation/Advertisement
 
 = ICMPv6MPSol - build (default values)
-if WINDOWS:
-    route_add_loopback()
 
 s = b'`\x00\x00\x00\x00\x08:@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x92\x00m\xbb\x00\x00\x00\x00'
 str(IPv6()/ICMPv6MPSol()) == s
@@ -7922,6 +7935,14 @@ len([ip for ip in n3]) == 5
 
 (n3 in n2) == True
 
+= Net using web address
+
+ip = IP(dst="www.google.fr")
+n1 = ip.dst
+assert isinstance(n1, Net)
+assert n1.ip_regex.match(str(n1))
+ip.show()
+
 = OID
 
 oid = OID("1.2.3.4.5.6-8")
@@ -7932,6 +7953,13 @@ len([ o for o in oid ]) == 3
 n1 = Net6("2001:db8::/127")
 len([ip for ip in n1]) == 2
 
+= Net6 using web address
+
+ip = IPv6(dst="www.google.fr")
+n1 = ip.dst
+assert isinstance(n1, Net6)
+assert n1.ip_regex.match(str(n1))
+ip.show()
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1797,6 +1797,14 @@ b=IPv6(src="2047::deca", dst="2048::cafe")/ICMPv6EchoReply(id=0x6666, seq=0x7777
 a=IPv6(src="2048::cafe", dst="2047::deca")/ICMPv6EchoRequest(id=0x6666, seq=0x7777, data="somedata")
 (a > b) == True
 
+= ICMPv6EchoRequest and ICMPv6EchoReply - live answers() use Net6
+~ netaccess
+
+a = IPv6(dst="www.google.fr")/ICMPv6EchoRequest()
+b = IPv6(src="www.google.fr", dst=a.src)/ICMPv6EchoReply()
+assert b.answers(a)
+assert (a > b)
+
 
 ########### ICMPv6MRD* Classes ######################################
 


### PR DESCRIPTION
This PR:
- fix https://github.com/secdev/scapy/issues/643 + bugs created when using Net6
- **fix the pcapdnet `in6_getifaddr` function: replace the windows one by the Pcap API**
- rename the `ipaddress` regex (the name was really confusing)
- filters globals ipv6 addresses out of the possible source candidates on Windows. ==> windows now correctly sends/recieves IPv6 packets
- fixes LOOPBACK_INTERFACE not beeing properly updated, causing IPv6 routes beeing outdated
- fixes `in6_getifaddr` function of `pcapdnet.py` ==> now use it when loading IPv6