### PR TITLE
[General] Update licenses & Contrib flags

### DIFF
--- a/scapy/contrib/HomePlugAV.py
+++ b/scapy/contrib/HomePlugAV.py
@@ -1,3 +1,22 @@
+#! /usr/bin/env python
+
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# scapy.contrib.description = HomePlugAV Layer
+# scapy.contrib.status = loads
+
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import Ether

--- a/scapy/contrib/avs.py
+++ b/scapy/contrib/avs.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = AVS WLAN Monitor Header
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/avs.py
+++ b/scapy/contrib/avs.py
@@ -1,9 +1,21 @@
 #! /usr/bin/env python
 
-# http://trac.secdev.org/scapy/ticket/82
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = AVS WLAN Monitor Header
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1,7 +1,16 @@
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = BGP v0.1
 # scapy.contrib.status = loads

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -13,7 +13,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = CARP
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 import struct, hmac, hashlib
 

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -1,6 +1,19 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = CARP
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 import struct, hmac, hashlib
 

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -11,7 +11,8 @@
 ##                       Arnaud Ebalard  <arnaud.ebalard AT eads DOT net>  ##
 ##                       EADS/CRC security team                            ##
 ##                                                                         ##
-## This program is free software; you can redistribute it and/or modify it ##
+## This file is part of Scapy                                              ##
+## Scapy is free software: you can redistribute it and/or modify it        ##
 ## under the terms of the GNU General Public License version 2 as          ##
 ## published by the Free Software Foundation; version 2.                   ##
 ##                                                                         ##

--- a/scapy/contrib/chdlc.py
+++ b/scapy/contrib/chdlc.py
@@ -13,7 +13,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = Cisco HDLC and SLARP
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 # This layer is based on information from http://www.nethelp.no/net/cisco-hdlc.txt
 

--- a/scapy/contrib/chdlc.py
+++ b/scapy/contrib/chdlc.py
@@ -1,7 +1,19 @@
-# http://trac.secdev.org/scapy/ticket/88
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = Cisco HDLC and SLARP
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 # This layer is based on information from http://www.nethelp.no/net/cisco-hdlc.txt
 

--- a/scapy/contrib/coap.py
+++ b/scapy/contrib/coap.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 # This file is part of Scapy.
 # See http://www.secdev.org/projects/scapy for more information.
 #
@@ -15,6 +17,9 @@
 # along with Scapy.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright (C) 2016 Anmol Sarma <me@anmolsarma.in>
+
+# scapy.contrib.description = Constrained Application Protocol (CoAP)
+# scapy.contrib.status = loads
 
 """
 RFC 7252 - Constrained Application Protocol (CoAP) layer for Scapy

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python
 
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # scapy.contrib.description = DTP
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 """
     DTP Scapy Extension

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = DTP
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 """
     DTP Scapy Extension

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # scapy.contrib.description = EIGRP
 # scapy.contrib.status = loads
 
@@ -11,16 +25,6 @@
     :copyright: 2009 by Jochen Bartl
     :e-mail:    lobo@c3a.de / jochen.bartl@gmail.com
     :license:   GPL v2
-
-        This program is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This program is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :TODO
 

--- a/scapy/contrib/etherip.py
+++ b/scapy/contrib/etherip.py
@@ -1,5 +1,16 @@
-
-# http://trac.secdev.org/scapy/ticket/297
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = EtherIP
 # scapy.contrib.status = loads

--- a/scapy/contrib/gsm_um.py
+++ b/scapy/contrib/gsm_um.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python
 
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # scapy.contrib.description = PPI
-# scapy.contrib.status = loads
-
-"""
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
+# scapy.contrib.status = untested
 
     ####################################################################
     # This file holds the GSM UM interface implementation for Scapy    #

--- a/scapy/contrib/gsm_um.py
+++ b/scapy/contrib/gsm_um.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = PPI
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
     ####################################################################
     # This file holds the GSM UM interface implementation for Scapy    #

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -2,8 +2,20 @@
 
 # Copyright (C) 2017 Alessio Deiana <adeiana@gmail.com>
 # 2017 Alexis Sultan <alexis.sultan@sfr.com>
-##
-# This program is published under a GPLv2 license
+
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = GTPv2
 # scapy.contrib.status = loads

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -6,7 +6,8 @@
 ##                                                                         ##
 ## Copyright (C) 2016  Florian Maury <florian.maury@ssi.gouv.fr>           ##
 ##                                                                         ##
-## This program is free software; you can redistribute it and/or modify it ##
+## This file is part of Scapy                                              ##
+## Scapy is free software: you can redistribute it and/or modify it        ##
 ## under the terms of the GNU General Public License version 2 as          ##
 ## published by the Free Software Foundation.                              ##
 ##                                                                         ##

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = ICMP Extensions
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 import scapy
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -1,3 +1,22 @@
+#! /usr/bin/env python
+
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# scapy.contrib.description = ICMP Extensions
+# scapy.contrib.status = untested
+
 import scapy
 from scapy.packet import Packet, bind_layers
 from scapy.fields import *

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -1,7 +1,21 @@
 #! /usr/bin/env python
 
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # scapy.contrib.description = IGMP/IGMPv2
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 
 #  TODO: scapy 2 has function getmacbyip, maybe it can replace igmpize

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = IGMP/IGMPv2
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 
 #  TODO: scapy 2 has function getmacbyip, maybe it can replace igmpize

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -1,9 +1,21 @@
 #! /usr/bin/env python
 
-# http://trac.secdev.org/scapy/ticket/31
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = IGMPv3
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = IGMPv3
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python
 
-# http://trac.secdev.org/scapy/ticket/353
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = IKEv2
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 import logging
 import struct

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = IKEv2
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 import logging
 import struct

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -1,3 +1,17 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # scapy.contrib.description = ISIS
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -1,5 +1,5 @@
 # scapy.contrib.description = Label Distribution Protocol (LDP)
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 # http://git.savannah.gnu.org/cgit/ldpscapy.git/snapshot/ldpscapy-5285b81d6e628043df2a83301b292f24a95f0ba1.tar.gz
 

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -1,5 +1,5 @@
 # scapy.contrib.description = Label Distribution Protocol (LDP)
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 # http://git.savannah.gnu.org/cgit/ldpscapy.git/snapshot/ldpscapy-5285b81d6e628043df2a83301b292f24a95f0ba1.tar.gz
 

--- a/scapy/contrib/modbus.py
+++ b/scapy/contrib/modbus.py
@@ -14,6 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
+# scapy.contrib.description = ModBus Protocol
+# scapy.contrib.status = loads
+
 # Copyright (C) 2016 Arthur Gervais, Ken LE PRADO, Sébastien Mainand
 
 from scapy.packet import *

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -1,4 +1,16 @@
-# http://trac.secdev.org/scapy/ticket/31
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = MPLS
 # scapy.contrib.status = loads

--- a/scapy/contrib/nsh.py
+++ b/scapy/contrib/nsh.py
@@ -1,6 +1,20 @@
-#! /usr/bin/env python
-# scapy.contrib.description = nsh
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# scapy.contrib.description = NSH Protocol
 # scapy.contrib.status = loads
+
 from scapy.all import bind_layers
 from scapy.fields import BitField, ByteField, ByteEnumField
 from scapy.fields import ShortField, X3BytesField, XIntField

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -8,7 +8,7 @@
 ## Based on OpenFlow v1.0.1
 ## Specifications can be retrieved from https://www.opennetworking.org/
 
-# scapy.contrib.description = openflow v1.0
+# scapy.contrib.description = Openflow v1.0
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -8,7 +8,7 @@
 ## Based on OpenFlow v1.3.4
 ## Specifications can be retrieved from https://www.opennetworking.org/
 
-# scapy.contrib.description = openflow v1.3
+# scapy.contrib.description = Openflow v1.3
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # scapy.contrib.description = OSPF
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 # This file is part of Scapy
 # Scapy is free software: you can redistribute it and/or modify

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python
 
 # scapy.contrib.description = OSPF
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
+
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 """
 OSPF extension for Scapy <http://www.secdev.org/scapy>
@@ -11,16 +25,6 @@ routing protocol as defined in RFC 2328 and RFC 5340.
 
 Copyright (c) 2008 Dirk Loss  :  mail dirk-loss de
 Copyright (c) 2010 Jochen Bartl  :  jochen.bartl gmail com
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
 """
 
 

--- a/scapy/contrib/ppi.py
+++ b/scapy/contrib/ppi.py
@@ -1,7 +1,18 @@
-## This file is (hopefully) part of Scapy
-## See http://www.secdev.org/projects/scapy for more informations
-## <jellch@harris.com>
-## This program is published under a GPLv2 license
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# author: <jellch@harris.com>
 
 # scapy.contrib.description = PPI
 # scapy.contrib.status = loads

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -1,10 +1,21 @@
-## This file is (hopefully) part of Scapy
-## See http://www.secdev.org/projects/scapy for more informations
-## <jellch@harris.com>
-## This program is published under a GPLv2 license
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# author: <jellch@harris.com>
 
 # scapy.contrib.description = PPI CACE
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 """
 CACE PPI types 

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -15,7 +15,7 @@
 # author: <jellch@harris.com>
 
 # scapy.contrib.description = PPI CACE
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 """
 CACE PPI types 

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -1,7 +1,18 @@
-## This file is (hopefully) part of Scapy
-## See http://www.secdev.org/projects/scapy for more informations
-## <jellch@harris.com>
-## This program is published under a GPLv2 license
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
+# author: <jellch@harris.com>
 
 # scapy.contrib.description = PPI GEOLOCATION
 # scapy.contrib.status = loads

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = RIPng
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python
 
-# http://trac.secdev.org/scapy/ticket/301
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = RIPng
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = RSVP
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -1,9 +1,21 @@
 ## RSVP layer
 
-# http://trac.secdev.org/scapy/ticket/197
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = RSVP
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -19,7 +19,7 @@
 
 # Partial support of RFC3971
 # scapy.contrib.description = SEND (ICMPv6)
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 import socket
 

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -1,12 +1,25 @@
 #! /usr/bin/env python
 
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 ## Copyright (C) 2009 Adline Stephane <adline.stephane@gmail.com>
 ##
-## This program is published under a GPLv2 license
 
 # Partial support of RFC3971
-# scapy.contrib.description = SEND
-# scapy.contrib.status = loads
+# scapy.contrib.description = SEND (ICMPv6)
+# scapy.contrib.status = untested
 
 import socket
 

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # scapy.contrib.description = Skinny Call Control Protocol (SCCP)
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 
 #############################################################################

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # scapy.contrib.description = Skinny Call Control Protocol (SCCP)
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 
 #############################################################################
@@ -11,7 +11,8 @@
 ## Copyright (C) 2006    Nicolas Bareil      <nicolas.bareil@ eads.net>    ##
 ##                       EADS/CRC security team                            ##
 ##                                                                         ##
-## This program is free software; you can redistribute it and/or modify it ##
+## This file is part of Scapy                                              ##
+## Scapy is free software: you can redistribute it and/or modify           ##
 ## under the terms of the GNU General Public License version 2 as          ##
 ## published by the Free Software Foundation; version 2.                   ##
 ##                                                                         ##

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -18,7 +18,7 @@
 # Modeled after the scapy VXLAN contribution
 
 # scapy.contrib.description = SBPM
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 """
  Example SPB Frame Creation

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -1,22 +1,40 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # IEEE 802.1aq - Shorest Path Bridging Mac-in-mac (SPBM):
 # Ethernet based link state protocol that enables Layer 2 Unicast, Layer 2 Multicast, Layer 3 Unicast, and Layer 3 Multicast virtualized services
 # https://en.wikipedia.org/wiki/IEEE_802.1aq
 # Modeled after the scapy VXLAN contribution
-#
-#############################################################
-# Example SPB Frame Creation
-# 
-# Note the outer Dot1Q Ethertype marking (0x88e7)
-#############################################################
-# backboneEther     = Ether(dst='00:bb:00:00:90:00', src='00:bb:00:00:40:00', type=0x8100)
-# backboneDot1Q     = Dot1Q(vlan=4051,type=0x88e7)
-# backboneServiceID = SPBM(prio=1,isid=20011)
-# customerEther     = Ether(dst='00:1b:4f:5e:ca:00',src='00:00:00:00:00:01',type=0x8100)
-# customerDot1Q     = Dot1Q(prio=1,vlan=11,type=0x0800)
-# customerIP        = IP(src='10.100.11.10',dst='10.100.12.10',id=0x0629,len=106)
-# customerUDP       = UDP(sport=1024,dport=1025,chksum=0,len=86)
-#
-# spb_example = backboneEther/backboneDot1Q/backboneServiceID/customerEther/customerDot1Q/customerIP/customerUDP/"Payload"
+
+# scapy.contrib.description = SBPM
+# scapy.contrib.status = untested
+
+"""
+ Example SPB Frame Creation
+ 
+ Note the outer Dot1Q Ethertype marking (0x88e7)
+
+ backboneEther     = Ether(dst='00:bb:00:00:90:00', src='00:bb:00:00:40:00', type=0x8100)
+ backboneDot1Q     = Dot1Q(vlan=4051,type=0x88e7)
+ backboneServiceID = SPBM(prio=1,isid=20011)
+ customerEther     = Ether(dst='00:1b:4f:5e:ca:00',src='00:00:00:00:00:01',type=0x8100)
+ customerDot1Q     = Dot1Q(prio=1,vlan=11,type=0x0800)
+ customerIP        = IP(src='10.100.11.10',dst='10.100.12.10',id=0x0629,len=106)
+ customerUDP       = UDP(sport=1024,dport=1025,chksum=0,len=86)
+
+ spb_example = backboneEther/backboneDot1Q/backboneServiceID/customerEther/customerDot1Q/customerIP/customerUDP/"Payload"
+"""
 
 from scapy.packet import Packet, bind_layers
 from scapy.fields import *

--- a/scapy/contrib/ubberlogger.py
+++ b/scapy/contrib/ubberlogger.py
@@ -1,5 +1,18 @@
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+
 # Author: Sylvain SARMEJEANNE
-# http://trac.secdev.org/scapy/ticket/1
 
 # scapy.contrib.description = Ubberlogger dissectors
 # scapy.contrib.status = untested

--- a/scapy/contrib/ubberlogger.py
+++ b/scapy/contrib/ubberlogger.py
@@ -15,7 +15,7 @@
 # Author: Sylvain SARMEJEANNE
 
 # scapy.contrib.description = Ubberlogger dissectors
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/vqp.py
+++ b/scapy/contrib/vqp.py
@@ -1,8 +1,19 @@
-
-# http://trac.secdev.org/scapy/ticket/147
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = VLAN Query Protocol
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/vqp.py
+++ b/scapy/contrib/vqp.py
@@ -13,7 +13,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = VLAN Query Protocol
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/vtp.py
+++ b/scapy/contrib/vtp.py
@@ -13,7 +13,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = VLAN Trunking Protocol (VTP)
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 """
     VTP Scapy Extension

--- a/scapy/contrib/vtp.py
+++ b/scapy/contrib/vtp.py
@@ -1,7 +1,19 @@
-#!/usr/bin/env python
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = VLAN Trunking Protocol (VTP)
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 """
     VTP Scapy Extension

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -13,7 +13,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = WPA EAPOL dissector
-# scapy.contrib.status = untested
+# scapy.contrib.status = loads
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -1,8 +1,19 @@
-
-# http://trac.secdev.org/scapy/ticket/104
+# This file is part of Scapy
+# Scapy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+#
+# Scapy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = WPA EAPOL dissector
-# scapy.contrib.status = loads
+# scapy.contrib.status = untested
 
 from scapy.packet import *
 from scapy.fields import *

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -91,7 +91,7 @@ def list_contrib(name=None):
     elif "*" not in name and "?" not in name and not name.endswith(".py"):
         name += ".py"
     name = os.path.join(os.path.dirname(__file__), "contrib", name)
-    for f in glob.glob(name):
+    for f in sorted(glob.glob(name)):
         mod = os.path.basename(f)
         if mod.startswith("__"):
             continue


### PR DESCRIPTION
This PR:
- adds all missing licences at the top of `contrib/` files.
- Updates or adds `scapy.contrib.*` so all un-tested modules (the one that do not have a `.uts` file, are marked as so)