### PR TITLE
Unify IPv4 and IPv6 NLRI code and allow '0/0' notation for IPv4 default

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -91,8 +91,8 @@ class BGPFieldIPv4(Field):
     IPv4 Field (CIDR)
     Using pton_ntop allows IPv4 and IPv6 to share code with marginal fixes
     """
-    alen = 4
-    af = socket.AF_INET
+    alen=4
+    af=socket.AF_INET
     def mask2iplen(self, mask):
         """Get the IP field mask length (in bytes)."""
         return (mask + 7) // 8
@@ -114,7 +114,7 @@ class BGPFieldIPv4(Field):
         #
         # Show IPv4 default prefix as "0/0"
         #
-        if self.af == socket.AF_INET and ip == "0.0.0.0":
+        if self.af == socket.AF_INET and ip = "0.0.0.0":
             ip = "0"
         return ip + "/" + str(mask)
 
@@ -149,8 +149,8 @@ class BGPFieldIPv4(Field):
 
 class BGPFieldIPv6(BGPFieldIPv4):
     """IPv6 Field (CIDR)"""
-    alen = 16
-    af = socket.AF_INET6
+    alen=16
+    af=socket.AF_INET6
 
 
 def has_extended_length(flags):

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -114,7 +114,7 @@ class BGPFieldIPv4(Field):
         #
         # Show IPv4 default prefix as "0/0"
         #
-        if self.af == socket.AF_INET and ip = "0.0.0.0":
+        if self.af == socket.AF_INET and ip == "0.0.0.0":
             ip = "0"
         return ip + "/" + str(mask)
 

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -182,7 +182,7 @@ class BGPNLRI_IPv6(Packet):
 
 class TLVListField(PacketListField):
     __slots__ = ["count_from", "length_from", "slen_from"]
-    def __init__(self, name, default, cls, length_from=None, slen_from=None):
+    def __init__(self, name, default, cls, count_from = None, length_from=None, slen_from=None):
         """
         @param count_from(pkt): get the number of packets in the list from the
                packet (optional)
@@ -192,7 +192,7 @@ class TLVListField(PacketListField):
                from the byte stream (mandatory)
         """
         PacketListField.__init__(self, name, default, cls)
-        self.count_from = length_from
+        self.count_from = count_from
         self.length_from = length_from
         self.slen_from = slen_from
 

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -91,8 +91,8 @@ class BGPFieldIPv4(Field):
     IPv4 Field (CIDR)
     Using pton_ntop allows IPv4 and IPv6 to share code with marginal fixes
     """
-    alen=4
-    af=socket.AF_INET
+    alen = 4
+    af = socket.AF_INET
     def mask2iplen(self, mask):
         """Get the IP field mask length (in bytes)."""
         return (mask + 7) // 8
@@ -114,7 +114,7 @@ class BGPFieldIPv4(Field):
         #
         # Show IPv4 default prefix as "0/0"
         #
-        if self.af == socket.AF_INET and ip = "0.0.0.0":
+        if self.af == socket.AF_INET and ip == "0.0.0.0":
             ip = "0"
         return ip + "/" + str(mask)
 
@@ -149,8 +149,8 @@ class BGPFieldIPv4(Field):
 
 class BGPFieldIPv6(BGPFieldIPv4):
     """IPv6 Field (CIDR)"""
-    alen=16
-    af=socket.AF_INET6
+    alen = 16
+    af = socket.AF_INET6
 
 
 def has_extended_length(flags):

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -103,7 +103,7 @@ class BGPFieldIPv4(Field):
         #
         # Allow IPv4 default prefix as "0/0"
         #
-        if self.af == socket.AF_INET && ip == "0":
+        if self.af == socket.AF_INET and ip == "0":
             ip = "0.0.0.0"
         return int(mask), ip
 
@@ -114,7 +114,7 @@ class BGPFieldIPv4(Field):
         #
         # Show IPv4 default prefix as "0/0"
         #
-        if self.af == socket.AF_INET && ip = "0.0.0.0":
+        if self.af == socket.AF_INET and ip = "0.0.0.0":
             ip = "0"
         return ip + "/" + str(mask)
 

--- a/scapy/contrib/bgp.uts
+++ b/scapy/contrib/bgp.uts
@@ -14,14 +14,14 @@ str(BGPNLRI_IPv4()) == b'\x00'
 str(BGPNLRI_IPv4(prefix = '255.255.255.255/32')) == b' \xff\xff\xff\xff'
 
 = BGPNLRI_IPv4 - Instantiation with specific values (2)
-str(BGPNLRI_IPv4(prefix = '0.0.0.0/0')) == b'\x00'
+str(BGPNLRI_IPv4(prefix = '0/0')) == b'\x00'
 
 = BGPNLRI_IPv4 - Instantiation with specific values (3)
 str(BGPNLRI_IPv4(prefix = '192.0.2.0/24')) == b'\x18\xc0\x00\x02'
 
 = BGPNLRI_IPv4 - Basic dissection
 nlri = BGPNLRI_IPv4(b'\x00')
-nlri.prefix == '0.0.0.0/0'
+nlri.prefix == '0/0'
 
 = BGPNLRI_IPv4 - Dissection with specific values
 nlri = BGPNLRI_IPv4(b'\x18\xc0\x00\x02')
@@ -665,5 +665,5 @@ assert(m.orf_data[0].entries[0].match == 1)
 assert(m.orf_data[0].entries[0].prefix.prefix == "1.1.0.0/21")
 assert(m.orf_data[0].entries[1].action == 0)
 assert(m.orf_data[0].entries[1].match == 0)
-assert(m.orf_data[0].entries[1].prefix.prefix == "0.0.0.0/0")
+assert(m.orf_data[0].entries[1].prefix.prefix == "0/0")
 

--- a/scapy/contrib/bgp.uts
+++ b/scapy/contrib/bgp.uts
@@ -667,3 +667,25 @@ assert(m.orf_data[0].entries[1].action == 0)
 assert(m.orf_data[0].entries[1].match == 0)
 assert(m.orf_data[0].entries[1].prefix.prefix == "0/0")
 
+########## BGPStream Class ###################################
++ BGPStream class tests
+
+= BGPStream: Two Keepalive packets back-to-back
+
+m = BGP()
+s = BGPStream(2*str(m))
+s.show()
+assert len(s.packet) == 2
+
+= BGPStream: Two Keepalive packets followed by a corrupted packet
+m = BGP()
+s = BGPStream(2*str(m)+b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff')
+s.show()
+assert len(s.packet) == 3
+
+= BGPStream KeepAlive - Notification (Admin Reset) - KeepAlive 
+m1 = BGP()
+m2 = BGP(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x15\x03\x06\x04')
+s = BGPStream(str(m1)+str(m2)+str(m1))
+s.show()
+assert len(s.packet) == 3


### PR DESCRIPTION
This patch simplifies the prefix treatment code.
IPv4 and IPv6 can be unified with pton_ntop methods.
In addition, allow the 'short version' of the IPv4 default '0/0'.
