### PR TITLE
Packet layers manipulations

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -203,9 +203,10 @@ class Packet(BasePacket):
         return clone
 
     def set_byte(self, index, val):
-        #TODO: chack that val is an hexa char value
+        if type(val) is not str:
+            raise TypeError("Val argument must be of char or str type")
         if (index < 0):
-            print "invalid index"
+            raise IndexError("Invalid negative index")
         payload = self.payload
         self.remove_payload()
         if index < len(self):
@@ -222,7 +223,7 @@ class Packet(BasePacket):
             if isinstance(self.payload,Packet):
                 self.payload.set_byte(index,val)
             else:
-                raise TypeError("modified payload must be a Packet instance")
+                raise TypeError("Modified payload must be a Packet instance")
         return self
 
     def lastlayer_index(self):
@@ -241,14 +242,21 @@ class Packet(BasePacket):
         return self
 
     def decode_lastlayer_as(self,cls):
-        #S'il n'y a qu'une seule layer dans le paquet, inutile de la retirer
+        #If there is only one layer in the packet no need to remove it
         if self.lastlayer() == self:
             s = str(self)
-            self = cls(s)
+            try:
+                self = cls(s)
+            except:
+                raise ValueError("Unable to decode last layer as specified class")
             return self
         s = str(self.lastlayer())
+        try:
+            newlayer = cls(s, _internal=1, _underlayer=self)
+        except:
+            raise ValueError("Unable to decode last layer as specified class")
         self.remove_lastlayer()
-        self.add_payload(cls(s, _internal=1, _underlayer=self))
+        self.add_payload(newlayer)
         pp = self
         while pp.underlayer is not None:
             pp = pp.underlayer

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -202,6 +202,59 @@ class Packet(BasePacket):
         clone.time = self.time
         return clone
 
+    def set_byte(self, index, val):
+        #TODO: chack that val is an hexa char value
+        if (index < 0):
+            print "invalid index"
+        payload = self.payload
+        self.remove_payload()
+        if index < len(self):
+            s = list(str(self)) #convert packet to list of chars
+            s[index] = val
+            s = "".join(s)
+            self.dissect(s)
+            self.add_payload(payload)
+        else:
+            index -= len(self)
+            if isinstance(self,NoPayload):
+                raise IndexError("User supplied index out of bounds")
+            self.add_payload(payload)
+            if isinstance(self.payload,Packet):
+                self.payload.set_byte(index,val)
+            else:
+                raise TypeError("modified payload must be a Packet instance")
+        return self
+
+    def lastlayer_index(self):
+        #Find the lastlayer index
+        nb=1
+        layer = self.getlayer(None,nb)
+        while layer is not None:
+            nb += 1
+            layer = self.getlayer(None,nb)
+        lastlayerindex = nb - 2
+        return lastlayerindex
+
+    def remove_lastlayer(self):
+        index = self.lastlayer_index()
+        del(self[index])
+        return self
+
+    def decode_lastlayer_as(self,cls):
+        #S'il n'y a qu'une seule layer dans le paquet, inutile de la retirer
+        if self.lastlayer() == self:
+            s = str(self)
+            self = cls(s)
+            return self
+        s = str(self.lastlayer())
+        self.remove_lastlayer()
+        self.add_payload(cls(s, _internal=1, _underlayer=self))
+        pp = self
+        while pp.underlayer is not None:
+            pp = pp.underlayer
+        self.payload.dissection_done(pp)
+        return self
+
     def getfieldval(self, attr):
         if attr in self.fields:
             return self.fields[attr]

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -210,29 +210,29 @@ class Packet(BasePacket):
         payload = self.payload
         self.remove_payload()
         if index < len(self):
-            s = list(str(self)) #convert packet to list of chars
+            s = list(str(self))  # convert packet to list of chars
             s[index] = val
             s = "".join(s)
             self.dissect(s)
             self.add_payload(payload)
         else:
             index -= len(self)
-            if isinstance(self,NoPayload):
+            if isinstance(self, NoPayload):
                 raise IndexError("User supplied index out of bounds")
             self.add_payload(payload)
-            if isinstance(self.payload,Packet):
-                self.payload.set_byte(index,val)
+            if isinstance(self.payload, Packet):
+                self.payload.set_byte(index, val)
             else:
                 raise TypeError("Modified payload must be a Packet instance")
         return self
 
     def lastlayer_index(self):
-        #Find the lastlayer index
-        nb=1
-        layer = self.getlayer(None,nb)
+        # Find the lastlayer index
+        nb = 1
+        layer = self.getlayer(None, nb)
         while layer is not None:
             nb += 1
-            layer = self.getlayer(None,nb)
+            layer = self.getlayer(None, nb)
         lastlayerindex = nb - 2
         return lastlayerindex
 
@@ -241,14 +241,15 @@ class Packet(BasePacket):
         del(self[index])
         return self
 
-    def decode_lastlayer_as(self,cls):
-        #If there is only one layer in the packet no need to remove it
+    def decode_lastlayer_as(self, cls):
+        # If there is only one layer in the packet no need to remove it
         if self.lastlayer() == self:
             s = str(self)
             try:
                 self = cls(s)
             except:
-                raise ValueError("Unable to decode last layer as specified class")
+                raise ValueError(\
+		            "Unable to decode last layer as specified class")
             return self
         s = str(self.lastlayer())
         try:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -536,6 +536,42 @@ p1 = IP(src=a1, dst=a2)/TCP(flags='A', seq=s1+9, ack=s2+10, sport=prt1, dport=pr
 assert not p2.answers(p1)
 assert not p1.answers(p2)
 
+= lastlayer manipulations
+~ lastlayer_index
+pkt = IP() / UDP()
+s = str(pkt)
+assert(pkt.lastlayer_index() == 1)
+
+~ decode_lastlayer_as
+length = len(pkt)
+pkt.decode_lastlayer_as(ISAKMP)
+len(pkt) == length
+
+~ remove_lastlayer
+(pkt / DNS()).remove_lastlayer() == pkt
+
+= set_byte function
+~ Normal usage
+pkt.set_byte(3,'\x03')
+s = str(pkt)
+s[3] == '\x03'
+
+~ Error handling
+try:
+    pkt.set_byte(-1,'\x00')
+except IndexError:
+    True
+
+try:
+    pkt.set_byte(70,'\x03')
+except IndexError:
+    True
+
+try:
+    pkt.set_byte(3, 4)
+except TypeError:
+    True
+
 
 ############
 ############


### PR DESCRIPTION
Proposition of adding new methods into the main Packet class:
* lastlayer_index
* remove_lastlayer
* decode_lastlayer_as
This proposition is based on the fact that the last layer of a packet is not easy to manipulate (in an automated way), when not dealing with a simple payload.

An other method I propose to add is:
* set_byte

This method purpose is to modify just one or several byte of a packet string without modifying its properties and decoding status as a Packet instance.

The use of these methods is mainly directed to scripts and bigger tools that may require these kind of manipulations.
I'm looking forward your opinion on these and the opportunity to merge them into the framework.
As for the implementation part, there may well be some adjustments to make.