### PR TITLE
Fix VRRPv3 checksum

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -292,6 +292,7 @@ ipv6nh = { 0:"Hop-by-Hop Option Header",
           58:"ICMPv6",
           59:"No Next Header",
           60:"Destination Option Header",
+         112:"VRRP",
          132:"SCTP",
          135:"Mobility Header"}
 
@@ -643,8 +644,9 @@ class PseudoIPv6(Packet): # IPv6 Pseudo-header for checksum computation
 
 def in6_chksum(nh, u, p):
     """
-    Performs IPv6 Upper Layer checksum computation. Provided parameters are:
+    As Specified in RFC 2460 - 8.1 Upper-Layer Checksums
 
+    Performs IPv6 Upper Layer checksum computation. Provided parameters are:
     - 'nh' : value of upper layer protocol
     - 'u'  : upper layer instance (TCP, UDP, ICMPv6*, ). Instance must be
              provided with all under layers (IPv6 and all extension headers,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7657,6 +7657,15 @@ s == b'E\x00\x00$\x00\x01\x00\x00@p|g\x7f\x00\x00\x01\x7f\x00\x00\x01!\x01d\x00\
 p = IP(s)
 VRRP in p and p[VRRP].chksum == 0x7afd
 
+= VRRP - chksums
+# VRRPv3
+p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRP(priority=254,vrid=2,version=3,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
+a = Ether(str(p))
+assert a[VRRP].chksum == 0xb256
+# VRRPv1
+p[VRRP].version = 1
+b = Ether(str(p))
+assert b[VRRP].chksum == 0xc6f4
 
 ############
 ############


### PR DESCRIPTION
This PR:
- fixes VRRPv3 checksum computation https://github.com/secdev/scapy/issues/720
- Creates `in4_chksum` function: used the same way than `in6_chksum` for Upper-Layer checksum computations
- Removes duplicate chksum code (in TCP and UDP)