### PR TITLE
Fix VRRPv3 checksum

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -292,6 +292,7 @@ ipv6nh = { 0:"Hop-by-Hop Option Header",
           58:"ICMPv6",
           59:"No Next Header",
           60:"Destination Option Header",
+         112:"VRRP",
          132:"SCTP",
          135:"Mobility Header"}
 
@@ -643,8 +644,9 @@ class PseudoIPv6(Packet): # IPv6 Pseudo-header for checksum computation
 
 def in6_chksum(nh, u, p):
     """
-    Performs IPv6 Upper Layer checksum computation. Provided parameters are:
+    As Specified in RFC 2460 - 8.1 Upper-Layer Checksums
 
+    Performs IPv6 Upper Layer checksum computation. Provided parameters are:
     - 'nh' : value of upper layer protocol
     - 'u'  : upper layer instance (TCP, UDP, ICMPv6*, ). Instance must be
              provided with all under layers (IPv6 and all extension headers,

--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -10,15 +10,17 @@ VRRP (Virtual Router Redundancy Protocol).
 
 from scapy.packet import *
 from scapy.fields import *
-from scapy.layers.inet import IP
+from scapy.layers.inet import *
+from scapy.layers.inet6 import *
+from scapy.error import warning
 
 IPPROTO_VRRP=112
 
 # RFC 3768 - Virtual Router Redundancy Protocol (VRRP)
 class VRRP(Packet):
     fields_desc = [
-        BitField("version" , 2, 4),
-        BitField("type" , 1, 4),
+        BitField("version", 2, 4),
+        BitField("type", 1, 4),
         ByteField("vrid", 1),
         ByteField("priority", 100),
         FieldLenField("ipcount", None, count_of="addrlist", fmt="B"),
@@ -36,4 +38,51 @@ class VRRP(Packet):
             p = p[:6]+chr(ck>>8)+chr(ck&0xff)+p[8:]
         return p
 
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 9:
+            ver_n_type = ord(_pkt[0])
+            if ver_n_type >= 48 and ver_n_type <= 57: # Version == 3
+                return VRRPv3
+        return VRRP
+
+
+# RFC 5798 -  Virtual Router Redundancy Protocol (VRRP) Version 3
+class VRRPv3(Packet):
+    fields_desc = [
+        BitField("version", 3, 4),
+        BitField("type", 1, 4),
+        ByteField("vrid", 1),
+        ByteField("priority", 100),
+        FieldLenField("ipcount", None, count_of="addrlist", fmt="B"),
+        BitField("res", 0, 4),
+        BitField("adv", 100, 12),
+        XShortField("chksum", None),
+        # FIXME: addrlist should also allow IPv6 addresses :/
+        FieldListField("addrlist", [], IPField("", "0.0.0.0"),
+                       count_from = lambda pkt: pkt.ipcount)]
+
+    def post_build(self, p, pay):
+        if self.chksum is None:
+            if isinstance(self.underlayer, IP):
+                ck = in4_chksum(112, self.underlayer, p)
+            elif isinstance(self.underlayer, IPv6):
+                ck = in6_chksum(112, self.underlayer, p)
+            else:
+                warning("No IP(v6) layer to compute checksum on VRRP. Leaving null")
+                ck = 0
+            p = p[:6]+chr(ck>>8)+chr(ck&0xff)+p[8:]
+        return p
+
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 16:
+            ver_n_type = ord(_pkt[0])
+            if ver_n_type < 48 or ver_n_type > 57: # Version != 3
+                return VRRP
+        return VRRPv3
+
+# IPv6 is supported only on VRRPv3
 bind_layers( IP,            VRRP,          proto=IPPROTO_VRRP)
+bind_layers( IP,            VRRPv3,        proto=IPPROTO_VRRP)
+bind_layers( IPv6,          VRRPv3,        nh=IPPROTO_VRRP)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7657,6 +7657,15 @@ s == b'E\x00\x00$\x00\x01\x00\x00@p|g\x7f\x00\x00\x01\x7f\x00\x00\x01!\x01d\x00\
 p = IP(s)
 VRRP in p and p[VRRP].chksum == 0x7afd
 
+= VRRP - chksums
+# VRRPv3
+p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRPv3(priority=254,vrid=2,version=3,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
+a = Ether(str(p))
+assert a[VRRPv3].chksum == 0xb25e
+# VRRPv1
+p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRP(priority=254,vrid=2,version=1,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
+b = Ether(str(p))
+assert b[VRRP].chksum == 0xc6f4
 
 ############
 ############


### PR DESCRIPTION
This PR:

- adds VRRPv3 layer with fixed checksum computation #720
- Creates in4_chksum function: used the same way than in6_chksum for Upper-Layer checksum computations
- Removes duplicate chksum code (in TCP and UDP)