### PR TITLE
[Python 2 to 3] Main core fixes + regression.uts

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -19,7 +19,7 @@ from scapy.pton_ntop import inet_pton
 from scapy.data import *
 
 def str2mac(s):
-    return ("%02x:"*6)[:-1] % tuple(ord(x) for x in s)
+    return ("%02x:"*6)[:-1] % tuple(orb(x) for x in s)
 
 if not WINDOWS:
     if not scapy.config.conf.use_pcap and not scapy.config.conf.use_dnet:

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -10,6 +10,8 @@ Functions common to different architectures
 import socket
 from fcntl import ioctl
 import struct
+from ctypes import POINTER, Structure
+from ctypes import c_uint, c_uint32, c_ushort, c_ubyte
 
 def get_if(iff, cmd):
     """Ease SIOCGIF* ioctl calls"""
@@ -18,3 +20,37 @@ def get_if(iff, cmd):
     ifreq = ioctl(sck, cmd, struct.pack("16s16x", iff.encode("utf8")))
     sck.close()
     return ifreq
+
+class bpf_insn(Structure):
+    """"The BPF instruction data structure"""
+    _fields_ = [("code", c_ushort),
+                ("jt", c_ubyte),
+                ("jf", c_ubyte),
+                ("k", c_uint32)]
+
+
+class bpf_program(Structure):
+    """"Structure for BIOCSETF"""
+    _fields_ = [("bf_len", c_uint),
+                ("bf_insns", POINTER(bpf_insn))]
+
+def get_bpf_pointer(tcpdump_lines):
+    """Create a BPF Pointer for TCPDump filter"""
+    # Allocate BPF instructions
+    size = int(tcpdump_lines[0])
+    bpf_insn_a = bpf_insn * size
+    bip = bpf_insn_a()
+
+    # Fill the BPF instruction structures with the byte code
+    tcpdump_lines = tcpdump_lines[1:]
+    i = 0
+    for line in tcpdump_lines:
+        values = [int(v) for v in line.split()]
+        bip[i].code = c_ushort(values[0])
+        bip[i].jt = c_ubyte(values[1])
+        bip[i].jf = c_ubyte(values[2])
+        bip[i].k = c_uint(values[3])
+        i += 1
+
+    # Create the BPF program
+    return bpf_program(size, bip)

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -8,7 +8,7 @@ Linux specific functions.
 """
 
 from __future__ import absolute_import
-import sys,os,struct,socket,time
+import sys, os, struct, socket, time
 from select import select
 from fcntl import ioctl
 import array, ctypes
@@ -23,7 +23,7 @@ from scapy.data import *
 from scapy.supersocket import SuperSocket
 import scapy.arch
 from scapy.error import warning, Scapy_Exception, log_interactive, log_loading
-from scapy.arch.common import get_if
+from scapy.arch.common import get_if, get_bpf_pointer
 from scapy.modules.six.moves import range
 
 
@@ -152,18 +152,9 @@ def attach_filter(s, bpf_filter, iface):
             "Failed to attach filter: tcpdump returned %d", ret
         )
         return
-    nb = int(lines[0])
-    bpf = b""
-    for l in lines[1:]:
-        bpf += struct.pack("HBBI", *(int(e) for e in l.split()))
-
-    # XXX. Argl! We need to give the kernel a pointer on the BPF
-    bpf_buf = ctypes.create_string_buffer(bpf)
-    class BpfPointer(ctypes.Structure):
-        _fields_ = [ ("bf_len", ctypes.c_int),
-                     ("bf_insn", ctypes.POINTER(type(bpf_buf))) ]
-    bpfh = BpfPointer(nb, ctypes.pointer(bpf_buf))
-    s.setsockopt(SOL_SOCKET, SO_ATTACH_FILTER, bpfh)
+    
+    bp = get_bpf_pointer(lines)
+    s.setsockopt(SOL_SOCKET, SO_ATTACH_FILTER, bp)
 
 def set_promisc(s,iff,val=1):
     mreq = struct.pack("IHH8s", get_if_index(iff), PACKET_MR_PROMISC, 0, b"")

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -153,7 +153,7 @@ def attach_filter(s, bpf_filter, iface):
         )
         return
     nb = int(lines[0])
-    bpf = ""
+    bpf = b""
     for l in lines[1:]:
         bpf += struct.pack("HBBI", *(int(e) for e in l.split()))
 

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -129,7 +129,7 @@ if conf.use_winpcapy:
           if a.contents.addr.contents.sa_family == socket.AF_INET6:
             ap = a.contents.addr
             val = cast(ap, POINTER(sockaddr_in6))
-            addr = inet_ntop(socket.AF_INET6, "".join(chr(x) for x in val.contents.sin6_addr[:]))
+            addr = inet_ntop(socket.AF_INET6, b"".join(chb(x) for x in val.contents.sin6_addr[:]))
             scope = scapy.utils6.in6_getscope(addr)
             ret.append((addr, scope, p.contents.name.decode('ascii')))
           a = a.contents.next

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -105,7 +105,7 @@ if conf.use_winpcapy:
             if a.contents.addr.contents.sa_family == socket.AF_INET:
               ap = a.contents.addr
               val = cast(ap, POINTER(sockaddr_in))
-              ret = b"".join(chr(x) for x in val.contents.sin_addr[:4])
+              ret = b"".join(chb(x) for x in val.contents.sin_addr[:4])
             a = a.contents.next
           break
         p = p.contents.next

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -1,6 +1,7 @@
 ## This file is part of Scapy
 ## See http://www.secdev.org/projects/scapy for more informations
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
+## Copyright (C) Gabriel Potter <gabriel@potter.fr>
 ## This program is published under a GPLv2 license
 
 """

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -802,7 +802,7 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
         if iface.name == scapy.consts.LOOPBACK_NAME:
             conf.route.routes.remove(route)
     # Remove LOOPBACK_NAME interface
-    for devname, iface in IFACES.items():
+    for devname, iface in list(IFACES.items()):
         if iface.name == scapy.consts.LOOPBACK_NAME:
             IFACES.pop(devname)
     # Inject interface

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -16,6 +16,7 @@ from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
+from scapy.compat import plain_str
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
 
@@ -333,7 +334,7 @@ class ASN1_NULL(ASN1_Object):
 class ASN1_OID(ASN1_Object):
     tag = ASN1_Class_UNIVERSAL.OID
     def __init__(self, val):
-        val = conf.mib._oid(val)
+        val = conf.mib._oid(plain_str(val))
         ASN1_Object.__init__(self, val)
         self.oidname = conf.mib._oidname(val)
     def __repr__(self):

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -337,7 +337,7 @@ class BERcodec_STRING(BERcodec_Object):
     tag = ASN1_Class_UNIVERSAL.STRING
     @classmethod
     def enc(cls,s):
-        return chb(hash(cls.tag))+BER_len_enc(len(s))+s
+        return chb(hash(cls.tag))+BER_len_enc(len(s))+raw(s) # Be sure we are encoding bytes
     @classmethod
     def do_dec(cls, s, context=None, safe=False):
         l,s,t = cls.check_type_check_len(s)

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -71,7 +71,7 @@ def BER_len_enc(l, size=0):
             raise BER_Exception("BER_len_enc: Length too long (%i) to be encoded [%r]" % (len(s),s))
         return chb(len(s)|0x80)+s
 def BER_len_dec(s):
-        l = ord(s[0])
+        l = orb(s[0])
         if not l & 0x80:
             return l,s[1:]
         l &= 0x7f
@@ -80,7 +80,7 @@ def BER_len_dec(s):
         ll = 0
         for c in s[1:l+1]:
             ll <<= 8
-            ll |= ord(c)
+            ll |= orb(c)
         return ll,s[l+1:]
         
 def BER_num_enc(l, size=1):
@@ -97,7 +97,7 @@ def BER_num_dec(s, cls_id=0):
             raise BER_Decoding_Error("BER_num_dec: got empty string", remaining=s)
         x = cls_id
         for i, c in enumerate(s):
-            c = ord(c)
+            c = orb(c)
             x <<= 7
             x |= c&0x7f
             if not c&0x80:
@@ -123,7 +123,7 @@ def BER_id_dec(s):
     # encoded in scapy's tag in order to reuse it for packet building.
     # Note that tags thus may have to be hard-coded with their extended
     # information, e.g. a SEQUENCE from asn1.py has a direct tag 0x20|16.
-        x = ord(s[0])
+        x = orb(s[0])
         if x & 0x1f != 0x1f:
             # low-tag-number
             return x,s[1:]
@@ -137,7 +137,7 @@ def BER_id_enc(n):
         else:
             # high-tag-number
             s = BER_num_enc(n)
-            tag = ord(s[0])             # first byte, as an int
+            tag = orb(s[0])             # first byte, as an int
             tag &= 0x07                 # reset every bit from 8 to 4
             tag <<= 5                   # move back the info bits on top
             tag |= 0x1f                 # pad with 1s every bit from 5 to 1
@@ -294,11 +294,11 @@ class BERcodec_INTEGER(BERcodec_Object):
         l,s,t = cls.check_type_check_len(s)
         x = 0
         if s:
-            if ord(s[0])&0x80: # negative int
+            if orb(s[0])&0x80: # negative int
                 x = -1
             for c in s:
                 x <<= 8
-                x |= ord(c)
+                x |= orb(c)
         return cls.asn1_object(x),t
     
 class BERcodec_BOOLEAN(BERcodec_INTEGER):
@@ -311,10 +311,10 @@ class BERcodec_BIT_STRING(BERcodec_Object):
         # /!\ the unused_bits information is lost after this decoding
         l,s,t = cls.check_type_check_len(s)
         if len(s) > 0:
-            unused_bits = ord(s[0])
+            unused_bits = orb(s[0])
             if safe and unused_bits > 7:
                 raise BER_Decoding_Error("BERcodec_BIT_STRING: too many unused_bits advertised", remaining=s)
-            s = "".join(binrepr(ord(x)).zfill(8) for x in s[1:])
+            s = "".join(binrepr(orb(x)).zfill(8) for x in s[1:])
             if unused_bits > 0:
                 s = s[:-unused_bits]
             return cls.tag.asn1_object(s),t
@@ -323,12 +323,13 @@ class BERcodec_BIT_STRING(BERcodec_Object):
     @classmethod
     def enc(cls,s):
         # /!\ this is DER encoding (bit strings are only zero-bit padded)
+        s = raw(s)
         if len(s) % 8 == 0:
             unused_bits = 0
         else:
             unused_bits = 8 - len(s)%8
             s += b"0"*unused_bits
-        s = b"".join(chb(int(b"".join(x),2)) for x in zip(*[iter(s)]*8))
+        s = b"".join(chb(int(b"".join(chb(y) for y in x),2)) for x in zip(*[iter(s)]*8))
         s = chb(unused_bits) + s
         return chb(hash(cls.tag))+BER_len_enc(len(s))+s
 

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -102,7 +102,7 @@ def mib_register(ident, value, the_mib, unresolved):
         return False
     else:
         the_mib[ident] = resval
-        keys = unresolved.keys()
+        keys = list(unresolved.keys())
         i = 0
         while i < len(keys):
             k = keys[i]

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -644,11 +644,11 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
             ioin,ioout = extfd                
             if ioin is None:
                 ioin = ObjectPipe()
-            elif not isinstance(ioin, types.InstanceType):
+            elif not isinstance(ioin, SelectableObject):
                 ioin = self._IO_fdwrapper(ioin,None)
             if ioout is None:
                 ioout = ioin if WINDOWS else ObjectPipe()
-            elif not isinstance(ioout, types.InstanceType):
+            elif not isinstance(ioout, SelectableObject):
                 ioout = self._IO_fdwrapper(None,ioout)
 
             self.ioin[n] = ioin

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -746,7 +746,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                 self.cmdout.send(c)
             except Exception as e:
                 exc_info = sys.exc_info()
-                self.debug(3, "Transfering exception from tid=%i:\n%s"% (self.threadid, traceback.format_exc(exc_info)))
+                self.debug(3, "Transfering exception from tid=%i:\n%s"% (self.threadid, traceback.format_exception(*exc_info)))
                 m = Message(type=_ATMT_Command.EXCEPTION, exception=e, exc_info=exc_info)
                 self.cmdout.send(m)        
             self.debug(3, "Stopping control thread (tid=%i)"%self.threadid)

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -1,6 +1,7 @@
 ## This file is part of Scapy
 ## See http://www.secdev.org/projects/scapy for more informations
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
+## Copyright (C) Gabriel Potter <gabriel@potter.fr>
 ## This program is published under a GPLv2 license
 
 """

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -106,7 +106,7 @@ else:
         else:
             if hasattr(x, "__int__") and not isinstance(x, int):
                 return bytes(chr(int(x)), encoding="utf8")
-            return bytes(chr(x), encoding="utf8")
+            return bytes([x])
 
 def bytes_codec(x, codec, force_str=False):
     """Hexify a str or a bytes object"""

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -109,7 +109,7 @@ else:
             return bytes([x])
 
 def bytes_codec(x, codec, force_str=False):
-    """Hexify a str or a bytes object"""
+    """Encode a str or a bytes object with a codec"""
     if six.PY2:
         return str(x).encode(codec)
     else:
@@ -119,7 +119,7 @@ def bytes_codec(x, codec, force_str=False):
         return hex_
 
 def codec_bytes(x, codec):
-    """De-hexify a str or a byte object"""
+    """Decode a str or a byte object with a codec"""
     if six.PY2:
         return str(x).decode(codec)
     else:

--- a/scapy/contrib/gtp.uts
+++ b/scapy/contrib/gtp.uts
@@ -17,13 +17,12 @@ a = GTPHeader(str(GTP_U_Header()/GTPErrorIndication()))
 assert isinstance(a, GTP_U_Header)
 
 = GTPCreatePDPContextRequest(), basic instanciation
-gtp = IP()/UDP(dport=2123)/GTPHeader(teid=2807)/GTPCreatePDPContextRequest()
+gtp = IP(src="127.0.0.1")/UDP(dport=2123)/GTPHeader(teid=2807)/GTPCreatePDPContextRequest()
 gtp.dport == 2123 and gtp.teid == 2807 and len(gtp.IE_list) == 5
 
 = GTPCreatePDPContextRequest(), basic dissection
 random.seed(0x2807)
-str(gtp)
-assert _ == b"E\x00\x00K\x00\x01\x00\x00@\x11|\x9f\x7f\x00\x00\x01\x7f\x00\x00\x01\x08K\x08K\x007\xa6\xa70\x10\x00'\x00\x00\n\xf7\x10\xd6\xd2\xf6\xd8\x14\x0f\x85\x00\x04\x98\xfaz\xab\x85\x00\x04\x02`0A\x87\x00\x0fu8h9lxKbPaePK9o"
+assert raw(gtp) == b"E\x00\x00K\x00\x01\x00\x00@\x11|\x9f\x7f\x00\x00\x01\x7f\x00\x00\x01\x08K\x08K\x007\x1c\xdb0\x10\x00'\x00\x00\n\xf7\x10A\xb77-\x14\x0f\x85\x00\x04\xd6!-b\x85\x00\x04\xbf\xf8\xc9Z\x87\x00\x0faWdWRWX0qEAXLPE"
 
 = GTPV1UpdatePDPContextRequest(), dissect
 h = "3333333333332222222222228100a38408004588006800000000fd1134820a2a00010a2a00024aa5084b005408bb32120044ed99aea9386f0000100000530514058500040a2a00018500040a2a000187000c0213921f739680fe74f2ffff94000130970001019800080112f41004d204d29900024000b6000101"

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -224,7 +224,7 @@ def load_manuf(filename):
                     lng=shrt
                 else:
                     lng = l[i+2:]
-                manufdb[oui] = shrt, lng
+                manufdb[oui] = plain_str(shrt), plain_str(lng)
             except Exception:
                 log_loading.warning("Couldn't parse one line from [%s] [%r]",
                                     filename, l, exc_info=True)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -64,6 +64,8 @@ class Field(six.with_metaclass(Field_metaclass, object)):
         """Convert internal value to machine value"""
         if x is None:
             x = 0
+        elif isinstance(x, str):
+            return raw(x)
         return x
     def any2i(self, pkt, x):
         """Try to understand the most input values possible and make an internal value from them"""
@@ -575,8 +577,8 @@ class StrFixedLenField(StrField):
         if length is not None:
             self.length_from = lambda pkt,length=length: length
     def i2repr(self, pkt, v):
-        if isinstance(v, str):
-            v = v.rstrip("\0")
+        if isinstance(v, bytes):
+            v = v.rstrip(b"\0")
         return repr(v)
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
@@ -614,12 +616,12 @@ class NetBIOSNameField(StrFixedLenField):
             x = b""
         x += b" "*(l)
         x = x[:l]
-        x = b"".join(chb(0x41 + ord(b)>>4) + chb(0x41 + ord(b)&0xf) for b in x)
+        x = b"".join(chb(0x41 + orb(b)>>4) + chb(0x41 + orb(b)&0xf) for b in x)
         x = b" "+x
         return x
     def m2i(self, pkt, x):
-        x = x.strip(b"\x00").strip(" ")
-        return b"".join(map(lambda x,y: chb((((ord(x)-1)&0xf)<<4)+((ord(y)-1)&0xf)), x[::2],x[1::2]))
+        x = x.strip(b"\x00").strip(b" ")
+        return b"".join(map(lambda x,y: chb((((orb(x)-1)&0xf)<<4)+((orb(y)-1)&0xf)), x[::2],x[1::2]))
 
 class StrLenField(StrField):
     __slots__ = ["length_from"]

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -385,7 +385,7 @@ class StrField(Field):
         if x is None:
             x = b""
         elif not isinstance(x, bytes):
-            x = bytes(x)
+            x = raw(x)
         return x
     def addfield(self, pkt, s, val):
         return s + self.i2m(pkt, val)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -694,7 +694,7 @@ class FieldListField(Field):
             return len(val)
         return 1
     def i2len(self, pkt, val):
-        return sum( self.field.i2len(pkt,v) for v in val )
+        return int(sum(self.field.i2len(pkt,v) for v in val))
 
     def i2m(self, pkt, val):
         if val is None:

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -183,8 +183,6 @@ class RandDHCPOptions(RandField):
             else:
                 op.append((o.name, o.randval()._fix()))
         return op
-    def __bytes__(self):
-        return raw(self._fix())
 
 
 class DHCPOptionsField(StrField):
@@ -218,7 +216,7 @@ class DHCPOptionsField(StrField):
                 opt.append("pad")
                 x = x[1:]
                 continue
-            if len(x) < 2 or len(x) < ord(x[1])+2:
+            if len(x) < 2 or len(x) < orb(x[1])+2:
                 opt.append(x)
                 break
             elif o in DHCPOptions:
@@ -244,7 +242,7 @@ class DHCPOptionsField(StrField):
                     opt.append(otuple)
                     x = x[olen+2:]
             else:
-                olen = ord(x[1])
+                olen = orb(x[1])
                 opt.append((o, x[2:olen+2]))
                 x = x[olen+2:]
         return opt
@@ -274,7 +272,7 @@ class DHCPOptionsField(StrField):
 
             elif (isinstance(o, str) and o in DHCPRevOptions and 
                   DHCPRevOptions[o][1] == None):
-                s += raw(DHCPRevOptions[o][0])
+                s += chb(DHCPRevOptions[o][0])
             elif isinstance(o, int):
                 s += chb(o)+b"\0"
             elif isinstance(o, (str, bytes)):

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -184,7 +184,7 @@ class RandDHCPOptions(RandField):
                 op.append((o.name, o.randval()._fix()))
         return op
     def __bytes__(self):
-        return raw(self.__str__())
+        return raw(self._fix())
 
 
 class DHCPOptionsField(StrField):
@@ -209,7 +209,7 @@ class DHCPOptionsField(StrField):
     def m2i(self, pkt, x):
         opt = []
         while x:
-            o = ord(x[0])
+            o = orb(x[0])
             if o == 255:
                 opt.append("end")
                 x = x[1:]
@@ -225,11 +225,11 @@ class DHCPOptionsField(StrField):
                 f = DHCPOptions[o]
 
                 if isinstance(f, str):
-                    olen = ord(x[1])
+                    olen = orb(x[1])
                     opt.append( (f,x[2:olen+2]) )
                     x = x[olen+2:]
                 else:
-                    olen = ord(x[1])
+                    olen = orb(x[1])
                     lval = [f.name]
                     try:
                         left = x[2:olen+2]

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -19,7 +19,7 @@ from scapy.ansmachine import AnsweringMachine
 from scapy.arch import get_if_raw_hwaddr, in6_getifaddr
 from scapy.config import conf
 from scapy.data import EPOCH, ETHER_ANY
-from scapy.compat import raw, chb
+from scapy.compat import *
 from scapy.error import warning
 from scapy.fields import BitField, ByteEnumField, ByteField, FieldLenField, \
     FlagsField, IntEnumField, IntField, MACField, PacketField, \
@@ -545,7 +545,7 @@ class _UserClassDataField(PacketListField):
     def i2len(self, pkt, z):
         if z is None or z == []:
             return 0
-        return sum(len(str(x)) for x in z)
+        return sum(len(raw(x)) for x in z)
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -736,16 +736,16 @@ class DomainNameField(StrLenField):
     def m2i(self, pkt, x):
         cur = []
         while x:
-            l = ord(x[0])
+            l = orb(x[0])
             cur.append(x[1:1+l])
             x = x[l+1:]
-        ret_str = ".".join(cur)
-        return ret_str
+        ret_str = b".".join(cur)
+        return plain_str(ret_str)
 
     def i2m(self, pkt, x):
         if not x:
             return b""
-        return b"".join(chb(len(z)) + z for z in x.split('.'))
+        return b"".join(chb(len(z)) + z.encode("utf8") for z in x.split('.'))
 
 class DHCP6OptNISDomain(_DHCP6OptGuessPayload):             #RFC3898
     name = "DHCP6 Option - NIS Domain Name"
@@ -1188,7 +1188,7 @@ dhcp6_cls_by_type = {  1: "DHCP6_Solicit",
 def _dhcp6_dispatcher(x, *args, **kargs):
     cls = conf.raw_layer
     if len(x) >= 2:
-        cls = get_cls(dhcp6_cls_by_type.get(ord(x[0]), "Raw"), conf.raw_layer)
+        cls = get_cls(dhcp6_cls_by_type.get(orb(x[0]), "Raw"), conf.raw_layer)
     return cls(x, *args, **kargs)
 
 bind_bottom_up(UDP, _dhcp6_dispatcher, { "dport": 547 } )

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -42,11 +42,11 @@ class DNSStrField(StrField):
     def getfield(self, pkt, s):
         n = b""
 
-        if ord(s[0]) == 0:
+        if orb(s[0]) == 0:
           return s[1:], "."
 
         while True:
-            l = ord(s[0])
+            l = orb(s[0])
             s = s[1:]
             if not l:
                 break
@@ -89,7 +89,7 @@ def DNSgetstr(s,p):
         if p >= len(s):
             warning("DNS RR prematured end (ofs=%i, len=%i)"%(p,len(s)))
             break
-        l = ord(s[p])
+        l = orb(s[p])
         p += 1
         if l & 0xc0:
             if not q:
@@ -97,7 +97,7 @@ def DNSgetstr(s,p):
             if p >= len(s):
                 warning("DNS incomplete jump token at (ofs=%i)" % p)
                 break
-            p = ((l & 0x3f) << 8) + ord(s[p]) - 12
+            p = ((l & 0x3f) << 8) + orb(s[p]) - 12
             if p in jpath:
                 warning("DNS decompression loop detected")
                 break
@@ -205,7 +205,7 @@ class RDataField(StrLenField):
                 s = inet_aton(s)
         elif pkt.type in [2, 3, 4, 5, 12]: # NS, MD, MF, CNAME, PTR
             s = b"".join(chr(len(x)) + x for x in s.split('.'))
-            if ord(s[-1]):
+            if orb(s[-1]):
                 s += b"\x00"
         elif pkt.type == 16: # TXT
             if s:

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -34,8 +34,8 @@ class DNSStrField(StrField):
           return b"\x00"
 
         # Truncate chunks that cannot be encoded (more than 63 bytes..)
-        x = b"".join(chr(len(y)) + y for y in (k[:63] for k in x.split(".")))
-        if ord(x[-1]) != 0:
+        x = b"".join(chb(len(y)) + y for y in (k[:63] for k in x.split(".")))
+        if orb(x[-1]) != 0:
             x += b"\x00"
         return x
 

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -81,7 +81,7 @@ class EAPOL(Packet):
         return s[:l], s[l:]
 
     def hashret(self):
-        return chr(self.type) + self.payload.hashret()
+        return chb(self.type) + self.payload.hashret()
 
     def answers(self, other):
         if isinstance(other, EAPOL):
@@ -284,7 +284,7 @@ class EAP(Packet):
     def post_build(self, p, pay):
         if self.len is None:
             l = len(p) + len(pay)
-            p = p[:2] + chr((l >> 8) & 0xff) + chr(l & 0xff) + p[4:]
+            p = p[:2] + chb((l >> 8) & 0xff) + chb(l & 0xff) + p[4:]
         return p + pay
 
 
@@ -466,7 +466,7 @@ class MKAParamSet(Packet):
 
         cls = conf.raw_layer
         if _pkt is not None:
-            ptype = struct.unpack("!B", _pkt[0])[0]
+            ptype = orb(_pkt[0])
             return globals().get(_param_set_cls.get(ptype), conf.raw_layer)
 
         return cls

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -19,7 +19,7 @@ PacketListField, ConditionalField, PadField
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import SourceMACField, Ether, CookedLinux, GRE, SNAP
 from scapy.config import conf
-from scapy.compat import orb
+from scapy.compat import orb, chb
 
 #
 # EAPOL

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -19,7 +19,7 @@ PacketListField, ConditionalField, PadField
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import SourceMACField, Ether, CookedLinux, GRE, SNAP
 from scapy.config import conf
-
+from scapy.compat import orb
 
 #
 # EAPOL
@@ -231,9 +231,9 @@ class EAP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            c = ord(_pkt[0])
+            c = orb(_pkt[0])
             if c in [1, 2] and len(_pkt) >= 5:
-                t = ord(_pkt[4])
+                t = orb(_pkt[4])
                 return cls.registered_methods.get(t, cls)
         return cls
 

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -399,8 +399,8 @@ class IP(Packet, IPTools):
 
     def route(self):
         dst = self.dst
-        if isinstance(dst,Gen):
-            dst = iter(dst).next()
+        if isinstance(dst, Gen):
+            dst = next(iter(dst))
         if conf.route is None:
             # unused import, only to initialize conf.route
             import scapy.route
@@ -1159,7 +1159,7 @@ class TracerouteResult(SndRcvList):
                             trlst[t-1] = s
         forecol = colgen(0.625, 0.4375, 0.25, 0.125)
         for trlst in six.itervalues(tr3d):
-            col = forecol.next()
+            col = next(forecol)
             start = (0,0,0)
             for ip in trlst:
                 visual.cylinder(pos=start,axis=ip.pos-start,color=col,radius=0.2)
@@ -1341,7 +1341,7 @@ class TracerouteResult(SndRcvList):
             max_trace = max(trace)
             for n in range(min(trace), max_trace):
                 if n not in trace:
-                    trace[n] = unknown_label.next()
+                    trace[n] = next(unknown_label)
             if rtk not in ports_done:
                 if rtk[2] == 1: #ICMP
                     bh = "%s %i/icmp" % (rtk[1],rtk[3])
@@ -1390,7 +1390,7 @@ class TracerouteResult(SndRcvList):
         s += "\n#ASN clustering\n"
         for asn in ASNs:
             s += '\tsubgraph cluster_%s {\n' % asn
-            col = backcolorlist.next()
+            col = next(backcolorlist)
             s += '\t\tcolor="#%s%s%s";' % col
             s += '\t\tnode [fillcolor="#%s%s%s",style=filled];' % col
             s += '\t\tfontsize = 10;'
@@ -1429,7 +1429,7 @@ class TracerouteResult(SndRcvList):
     
         for rtk in rt:
             s += "#---[%s\n" % repr(rtk)
-            s += '\t\tedge [color="#%s%s%s"];\n' % forecolorlist.next()
+            s += '\t\tedge [color="#%s%s%s"];\n' % next(forecolorlist)
             trace = rt[rtk]
             maxtrace = max(trace)
             for n in range(min(trace), maxtrace):
@@ -1494,7 +1494,7 @@ traceroute(target, [maxttl=30,] [dport=80,] [sport=80,] [verbose=conf.verb]) -> 
 class TCP_client(Automaton):
     
     def parse_args(self, ip, port, *args, **kargs):
-        self.dst = iter(Net(ip)).next()
+        self.dst = str(Net(ip))
         self.dport = port
         self.sport = random.randrange(0,2**16)
         self.l4 = IP(dst=ip)/TCP(sport=self.sport, dport=self.dport, flags=0,

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -109,7 +109,7 @@ class IPOption(Packet):
     @classmethod
     def dispatch_hook(cls, pkt=None, *args, **kargs):
         if pkt:
-            opt = ord(pkt[0])&0x1f
+            opt = orb(pkt[0])&0x1f
             if opt in cls.registered_ip_options:
                 return cls.registered_ip_options[opt]
         return cls
@@ -262,7 +262,7 @@ class TCPOptionsField(StrField):
     def m2i(self, pkt, x):
         opt = []
         while x:
-            onum = ord(x[0])
+            onum = orb(x[0])
             if onum == 0:
                 opt.append(("EOL",None))
                 x=x[1:]
@@ -271,7 +271,7 @@ class TCPOptionsField(StrField):
                 opt.append(("NOP",None))
                 x=x[1:]
                 continue
-            olen = ord(x[1])
+            olen = orb(x[1])
             if olen < 2:
                 warning("Malformed TCP option (announced length is %i)" % olen)
                 olen = 2
@@ -525,7 +525,7 @@ class TCP(Packet):
         dataofs = self.dataofs
         if dataofs is None:
             dataofs = 5+((len(self.get_field("options").i2m(self,self.options))+3)//4)
-            p = p[:12]+chb((dataofs << 4) | ord(p[12])&0x0f)+p[13:]
+            p = p[:12]+chb((dataofs << 4) | orb(p[12])&0x0f)+p[13:]
         if self.chksum is None:
             if isinstance(self.underlayer, IP):
                 ck = in4_chksum(socket.IPPROTO_TCP, self.underlayer, p)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -390,7 +390,7 @@ class _IPv6GuessPayload:
             t = ord(p[0])
             if len(p) > 2 and (t == 139 or t == 140): # Node Info Query
                 return _niquery_guesser(p)
-            if len(p) >= icmp6typesminhdrlen.get(t, sys.maxint): # Other ICMPv6 messages
+            if len(p) >= icmp6typesminhdrlen.get(t, float("inf")): # Other ICMPv6 messages
                 return get_cls(icmp6typescls.get(t,"Raw"), "Raw")
             return Raw
         elif self.nh == 135 and len(p) > 3: # Mobile IPv6

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -2993,7 +2993,7 @@ class MIP6MH_CoTI(MIP6MH_HoTI):
     name = "IPv6 Mobility Header - Care-of Test Init"
     mhtype = 2
     def hashret(self):
-        return self.cookie
+        return raw(self.cookie)
 
 class MIP6MH_HoT(_MobilityHeader):
     name = "IPv6 Mobility Header - Home Test"
@@ -3010,7 +3010,7 @@ class MIP6MH_HoT(_MobilityHeader):
                                           length_from = lambda pkt: 8*(pkt.len-2)) ]
     overload_fields = { IPv6: { "nh": 135 } }
     def hashret(self):
-        return self.cookie
+        return raw(self.cookie)
     def answers(self, other):
         if (isinstance(other, MIP6MH_HoTI) and
             self.cookie == other.cookie):
@@ -3021,7 +3021,7 @@ class MIP6MH_CoT(MIP6MH_HoT):
     name = "IPv6 Mobility Header - Care-of Test"
     mhtype = 4
     def hashret(self):
-        return self.cookie
+        return raw(self.cookie)
 
     def answers(self):
         if (isinstance(other, MIP6MH_CoTI) and
@@ -3139,7 +3139,7 @@ class  AS_resolver6(AS_resolver_riswhois):
 
         _, asn, desc = AS_resolver_riswhois._resolve_one(self, addr)
 
-        if asn.startswith(b"AS"):
+        if asn.startswith("AS"):
             try:
                 asn = int(asn[2:])
             except ValueError:

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -2175,18 +2175,15 @@ def names2dnsrepr(x):
     if isinstance(x, str):
         if x and x[-1] == '\x00': # stupid heuristic
             return x.encode("utf8")
-        x = [x.encode("utf8")]
-    elif type(x) is bytes:
-        if x and x[-1] == 0:
-            return x
+        x = [x]
 
     res = []
     for n in x:
-        termin = b"\x00"
-        if n.count(b'.') == 0: # single-component gets one more
-            termin += b'\x00'
-        n = b"".join(chb(len(y)) + y for y in n.split(b'.')) + termin
-        res.append(n)
+        termin = "\x00"
+        if n.count('.') == 0: # single-component gets one more
+            termin += '\x00'
+        n = "".join(chr(len(y)) + y for y in n.split('.')) + termin
+        res.append(n.encode("utf8"))
     return b"".join(res)
 
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -59,7 +59,7 @@ conf.netcache.new_cache("arp_cache", 120) # cache entries expire after 120s
 @conf.commands.register
 def getmacbyip(ip, chainCC=0):
     """Return MAC address corresponding to a given IP address"""
-    if isinstance(ip,Net):
+    if isinstance(ip, Net):
         ip = iter(ip).next()
     ip = inet_ntoa(inet_aton(ip))
     tmp = [orb(e) for e in inet_aton(ip)]

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -51,7 +51,7 @@ class LLMNRResponse(LLMNRQuery):
 def _llmnr_dispatcher(x, *args, **kargs):
     cls = conf.raw_layer
     if len(x) >= 2:
-        if (ord(x[2]) & 0x80): # Response
+        if (orb(x[2]) & 0x80): # Response
             cls = LLMNRResponse
         else:                  # Query
             cls = LLMNRQuery

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -10,7 +10,6 @@ https://msdn.microsoft.com/en-us/library/cc233983.aspx
 """
 
 from __future__ import absolute_import
-import struct
 from array import array
 
 from scapy.fields import BitField, FlagsField, ByteField, ByteEnumField, \
@@ -215,7 +214,7 @@ class LLTDQueryResp(Packet):
         if self.descs_count is None:
             # descs_count should be a FieldLenField but has an
             # unsupported format (14 bits)
-            flags = ord(pkt[0]) & 0xc0
+            flags = orb(pkt[0]) & 0xc0
             count = len(self.descs_list)
             pkt = chb(flags + (count >> 8)) + chb(count % 256) + pkt[2:]
         return pkt + pay
@@ -257,7 +256,7 @@ class LLTDQueryLargeTlvResp(Packet):
         if self.len is None:
             # len should be a FieldLenField but has an unsupported
             # format (14 bits)
-            flags = ord(pkt[0]) & 0xc0
+            flags = orb(pkt[0]) & 0xc0
             length = len(self.value)
             pkt = chb(flags + (length >> 8)) + chb(length % 256) + pkt[2:]
         return pkt + pay
@@ -297,7 +296,7 @@ class LLTDAttribute(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         if _pkt:
-            cmd = struct.unpack("B", _pkt[0])[0]
+            cmd = orb(_pkt[0])
         elif "type" in kargs:
             cmd = kargs["type"]
             if isinstance(cmd, six.string_types):

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -199,7 +199,7 @@ def _ntp_dispatcher(payload):
     else:
         length = len(payload)
         if length >= _NTP_PACKET_MIN_SIZE:
-            first_byte = struct.unpack("!B", raw(payload[0]))[0]
+            first_byte = orb(payload[0])
 
             # Extract NTP mode
             mode_mask = 0x07
@@ -307,7 +307,7 @@ class NTPAuthenticator(Packet):
     ]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPExtension(Packet):
@@ -660,7 +660,7 @@ class NTPStatusPacket(Packet):
     fields_desc = [ShortField("status", 0)]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPSystemStatusPacket(Packet):
@@ -678,7 +678,7 @@ class NTPSystemStatusPacket(Packet):
     ]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPPeerStatusPacket(Packet):
@@ -699,7 +699,7 @@ class NTPPeerStatusPacket(Packet):
     ]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPClockStatusPacket(Packet):
@@ -714,7 +714,7 @@ class NTPClockStatusPacket(Packet):
     ]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPErrorStatusPacket(Packet):
@@ -729,7 +729,7 @@ class NTPErrorStatusPacket(Packet):
     ]
 
     def extract_padding(self, s):
-        return "", s
+        return b"", s
 
 
 class NTPControlStatusField(PacketField):

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -256,7 +256,7 @@ class PPP_IPCP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = ord(_pkt[0])
+            o = orb(_pkt[0])
             return cls.registered_options.get(o, cls)
         return cls
 

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -208,7 +208,7 @@ class PPP(Packet):
     fields_desc = [ ShortEnumField("proto", 0x0021, _PPP_proto) ]
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
-        if _pkt and ord(_pkt[0]) == 0xff:
+        if _pkt and orb(_pkt[0]) == 0xff:
             cls = HDLC
         return cls
 
@@ -324,7 +324,7 @@ class PPP_ECP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = ord(_pkt[0])
+            o = orb(_pkt[0])
             return cls.registered_options.get(o, cls)
         return cls
 
@@ -376,7 +376,7 @@ class PPP_LCP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt = None, *args, **kargs):
         if _pkt:
-            o = ord(_pkt[0])
+            o = orb(_pkt[0])
             if o in [1, 2, 3, 4]:
                 return PPP_LCP_Configure
             elif o in [5,6]:
@@ -423,7 +423,7 @@ class PPP_LCP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = ord(_pkt[0])
+            o = orb(_pkt[0])
             return cls.registered_options.get(o, cls)
         return cls
 
@@ -578,7 +578,7 @@ class PPP_PAP(Packet):
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         code = None
         if _pkt:
-            code = ord(_pkt[0])
+            code = orb(_pkt[0])
         elif "code" in kargs:
             code = kargs["code"]
             if isinstance(code, basestring):
@@ -651,7 +651,7 @@ class PPP_CHAP(Packet):
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         code = None
         if _pkt:
-            code = ord(_pkt[0])
+            code = orb(_pkt[0])
         elif "code" in kargs:
             code = kargs["code"]
             if isinstance(code, basestring):

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -264,7 +264,7 @@ class RadiusAttribute(Packet):
         """
 
         if _pkt:
-            attr_type = ord(_pkt[0])
+            attr_type = orb(_pkt[0])
             return cls.registered_attributes.get(attr_type, cls)
         return cls
 
@@ -1092,7 +1092,7 @@ class _RADIUSAttrPacketListField(PacketListField):
             remain, ret = s[:length], s[length:]
 
         while remain:
-            attr_len = struct.unpack("!B", remain[1])[0]
+            attr_len = orb(remain[1])
             current = remain[:attr_len]
             remain = remain[attr_len:]
             packet = self.m2i(pkt, current)

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -10,6 +10,7 @@ RADIUS (Remote Authentication Dial In User Service)
 
 import struct
 import logging
+from scapy.compat import *
 from scapy.packet import Packet, bind_layers
 from scapy.fields import ByteField, ByteEnumField, IntField, StrLenField,\
     XStrLenField, XStrFixedLenField, FieldLenField, PacketField,\
@@ -1185,9 +1186,9 @@ class Radius(Packet):
         packed_hdr = struct.pack("!B", self.code)
         packed_hdr += struct.pack("!B", self.id)
         packed_hdr += struct.pack("!H", self.len)
-        packed_attrs = ''
-        for index in range(0, len(self.attributes)):
-            packed_attrs = packed_attrs + str(self.attributes[index])
+        packed_attrs = b''
+        for attr in self.attributes:
+            packed_attrs = packed_attrs + raw(attr)
         packed_data = packed_hdr + packed_request_auth + packed_attrs +\
             shared_secret
 

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -93,7 +93,7 @@ crc32c_table = [
 def crc32c(buf):
     crc = 0xffffffff
     for c in buf:
-        crc = (crc>>8) ^ crc32c_table[(crc^(ord(c))) & 0xFF]
+        crc = (crc>>8) ^ crc32c_table[(crc^(orb(c))) & 0xFF]
     crc = (~crc) & 0xffffffff
     # reverse endianness
     return struct.unpack(">I",struct.pack("<I", crc))[0]
@@ -107,8 +107,8 @@ def update_adler32(adler, buf):
     print s1,s2
 
     for c in buf:
-        print ord(c)
-        s1 = (s1 + ord(c)) % BASE
+        print orb(c)
+        s1 = (s1 + orb(c)) % BASE
         s2 = (s2 + s1) % BASE
         print s1,s2
     return (s2 << 16) + s1
@@ -216,7 +216,7 @@ class _SCTPChunkGuessPayload:
         if len(p) < 4:
             return conf.padding_layer
         else:
-            t = ord(p[0])
+            t = orb(p[0])
             return globals().get(sctpchunktypescls.get(t, "Raw"), conf.raw_layer)
 
 
@@ -248,7 +248,7 @@ class ChunkParamField(PacketListField):
     def m2i(self, p, m):
         cls = conf.raw_layer
         if len(m) >= 4:
-            t = ord(m[0]) * 256 + ord(m[1])
+            t = orb(m[0]) * 256 + orb(m[1])
             cls = globals().get(sctpchunkparamtypescls.get(t, "Raw"), conf.raw_layer)
         return cls(m)
 

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -513,6 +513,7 @@ class PrivKeyECDSA(PrivKey):
 
     @crypto_validator
     def import_from_asn1pkt(self, privkey):
+        print(privkey)
         self.key = serialization.load_der_private_key(raw(privkey), None,
                                                   backend=default_backend())
         self.pubkey = self.key.public_key()

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -971,7 +971,7 @@ class _tls_sessions(object):
                 if len(sid) > 12:
                     sid = sid[:11] + "..."
                 res.append((src, dst, sid))
-        colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, res))
+        colwidth = [max([len(y) for y in x]) for x in zip(*res)]
         fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
         return "\n".join(map(lambda x: fmt % x, res))
 

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -971,7 +971,7 @@ class _tls_sessions(object):
                 if len(sid) > 12:
                     sid = sid[:11] + "..."
                 res.append((src, dst, sid))
-        colwidth = [max([len(y) for y in x]) for x in zip(*res)]
+        colwidth = (max([len(y) for y in x]) for x in zip(*res))
         fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
         return "\n".join(map(lambda x: fmt % x, res))
 

--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -42,7 +42,7 @@ class VRRP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 9:
-            ver_n_type = ord(_pkt[0])
+            ver_n_type = orb(_pkt[0])
             if ver_n_type >= 48 and ver_n_type <= 57: # Version == 3
                 return VRRPv3
         return VRRP
@@ -72,13 +72,13 @@ class VRRPv3(Packet):
             else:
                 warning("No IP(v6) layer to compute checksum on VRRP. Leaving null")
                 ck = 0
-            p = p[:6]+chr(ck>>8)+chr(ck&0xff)+p[8:]
+            p = p[:6]+chb(ck>>8)+chb(ck&0xff)+p[8:]
         return p
 
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 16:
-            ver_n_type = ord(_pkt[0])
+            ver_n_type = orb(_pkt[0])
             if ver_n_type < 48 or ver_n_type > 57: # Version != 3
                 return VRRP
         return VRRPv3

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -703,9 +703,9 @@ class ASN1F_X509_SubjectPublicKeyInfo(ASN1F_SEQUENCE):
     def m2i(self, pkt, x):
         c,s = ASN1F_SEQUENCE.m2i(self, pkt, x)
         keytype = pkt.fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in keytype.lower():
+        if "rsa" in keytype.lower():
             return ASN1F_X509_SubjectPublicKeyInfoRSA().m2i(pkt, x)
-        elif keytype == b"ecPublicKey":
+        elif keytype == "ecPublicKey":
             return ASN1F_X509_SubjectPublicKeyInfoECDSA().m2i(pkt, x)
         else:
             raise Exception("could not parse subjectPublicKeyInfo")
@@ -717,10 +717,10 @@ class ASN1F_X509_SubjectPublicKeyInfo(ASN1F_SEQUENCE):
             ktype = pkt.fields['signatureAlgorithm'].algorithm.oidname
         else:
             ktype = pkt.default_fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in ktype.lower():
+        if "rsa" in ktype.lower():
             pkt.default_fields["subjectPublicKey"] = RSAPublicKey()
             return ASN1F_X509_SubjectPublicKeyInfoRSA().build(pkt)
-        elif ktype == b"ecPublicKey":
+        elif ktype == "ecPublicKey":
             pkt.default_fields["subjectPublicKey"] = ECDSAPublicKey()
             return ASN1F_X509_SubjectPublicKeyInfoECDSA().build(pkt)
         else:
@@ -924,9 +924,9 @@ class ASN1F_X509_Cert(ASN1F_SEQUENCE):
     def m2i(self, pkt, x):
         c,s = ASN1F_SEQUENCE.m2i(self, pkt, x)
         sigtype = pkt.fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return c,s
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             return ASN1F_X509_CertECDSA().m2i(pkt, x)
         else:
             raise Exception("could not parse certificate")
@@ -938,9 +938,9 @@ class ASN1F_X509_Cert(ASN1F_SEQUENCE):
             sigtype = pkt.fields['signatureAlgorithm'].algorithm.oidname
         else:
             sigtype = pkt.default_fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return ASN1F_SEQUENCE.build(self, pkt)
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             pkt.default_fields["signatureValue"] = ECDSASignature()
             return ASN1F_X509_CertECDSA().build(pkt)
         else:
@@ -1032,9 +1032,9 @@ class ASN1F_X509_CRL(ASN1F_SEQUENCE):
     def m2i(self, pkt, x):
         c,s = ASN1F_SEQUENCE.m2i(self, pkt, x)
         sigtype = pkt.fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return c,s
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             return ASN1F_X509_CRLECDSA().m2i(pkt, x)
         else:
             raise Exception("could not parse certificate")
@@ -1046,9 +1046,9 @@ class ASN1F_X509_CRL(ASN1F_SEQUENCE):
             sigtype = pkt.fields['signatureAlgorithm'].algorithm.oidname
         else:
             sigtype = pkt.default_fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return ASN1F_SEQUENCE.build(self, pkt)
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             pkt.default_fields["signatureValue"] = ECDSASignature()
             return ASN1F_X509_CRLECDSA().build(pkt)
         else:
@@ -1181,9 +1181,9 @@ class ASN1F_OCSP_BasicResponse(ASN1F_SEQUENCE):
     def m2i(self, pkt, x):
         c,s = ASN1F_SEQUENCE.m2i(self, pkt, x)
         sigtype = pkt.fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return c,s
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             return ASN1F_OCSP_BasicResponseECDSA().m2i(pkt, x)
         else:
             raise Exception("could not parse OCSP basic response")
@@ -1195,9 +1195,9 @@ class ASN1F_OCSP_BasicResponse(ASN1F_SEQUENCE):
             sigtype = pkt.fields['signatureAlgorithm'].algorithm.oidname
         else:
             sigtype = pkt.default_fields["signatureAlgorithm"].algorithm.oidname
-        if b"rsa" in sigtype.lower():
+        if "rsa" in sigtype.lower():
             return ASN1F_SEQUENCE.build(self, pkt)
-        elif b"ecdsa" in sigtype.lower():
+        elif "ecdsa" in sigtype.lower():
             pkt.default_fields["signatureValue"] = ECDSASignature()
             return ASN1F_OCSP_BasicResponseECDSA().build(pkt)
         else:

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -681,7 +681,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             if f.islist or f.holds_packets or f.ismutable:
                 self.raw_packet_cache_fields[f.name] = f.do_copy(fval)
             self.fields[f.name] = fval
-        assert(_raw.endswith(s))
+        assert(_raw.endswith(raw(s)))
         self.raw_packet_cache = _raw[:-len(s)] if s else _raw
         self.explicit = 1
         return s

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -753,7 +753,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
 
     def hide_defaults(self):
         """Removes fields' values that are the same as default values."""
-        for k, v in self.fields.items():  # use .items(): self.fields is modified in the loop
+        for k in list(self.fields.keys()):  # use .items(): self.fields is modified in the loop
+            v = self.fields[k]
             if k in self.default_fields:
                 if self.default_fields[k] == v:
                     del self.fields[k]

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -223,7 +223,7 @@ class Route6:
             return (scapy.consts.LOOPBACK_INTERFACE, "::", "::")
 
         # Sort with longest prefix first
-        pathes.sort(reverse=True)
+        pathes.sort(reverse=True, key=lambda x: x[0])
 
         best_plen = pathes[0][0]
         pathes = [x for x in pathes if x[0] == best_plen]

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -43,7 +43,7 @@ def import_module(name):
 class File:
     def __init__(self, name, URL, local):
         self.name = name
-        self.local = local
+        self.local = local.encode("utf8")
         self.URL = URL
     def get_local(self):
         return bz2.decompress(base64.decodestring(self.local))

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -33,7 +33,8 @@ from scapy.base_classes import BasePacketList
 ###########
 
 def get_temp_file(keep=False, autoext=""):
-    f = os.tempnam("","scapy")
+    with tempfile.NamedTemporaryFile(prefix="scapy") as _f:
+        f = _f.name
     if not keep:
         conf.temp_files.append(f+autoext)
     return f + autoext
@@ -55,7 +56,7 @@ def sane(x):
         if (j < 32) or (j >= 127):
             r=r+"."
         else:
-            r=r+i
+            r=r+chb(i)
     return r
 
 def lhex(x):
@@ -485,7 +486,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
     start_viewer=False
     if target is None:
         if WINDOWS:
-            tempfile = os.tempnam("", "scapy") + "." + format
+            tempfile = get_temp_file() + "." + format
             target = "> %s" % tempfile
             start_viewer = True
         else:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -42,21 +42,21 @@ def get_temp_file(keep=False, autoext=""):
 def sane_color(x):
     r=""
     for i in x:
-        j = ord(i)
+        j = orb(i)
         if (j < 32) or (j >= 127):
             r=r+conf.color_theme.not_printable(".")
         else:
-            r=r+i
+            r=r+chr(j)
     return r
 
 def sane(x):
     r=""
     for i in x:
-        j = ord(i)
+        j = orb(i)
         if (j < 32) or (j >= 127):
             r=r+"."
         else:
-            r=r+i
+            r=r+chr(j)
     return r
 
 def lhex(x):
@@ -950,7 +950,7 @@ class RawPcapNgReader(RawPcapReader):
             # 4.2. - Interface Description Block
             # http://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi?url=https://raw.githubusercontent.com/pcapng/pcapng/master/draft-tuexen-opsawg-pcapng.xml&modeAsFormat=html/ascii&type=ascii#rfc.section.4.2
             if code == 9 and length == 1 and len(options) >= 5:
-                tsresol = ord(options[4])
+                tsresol = orb(options[4])
                 tsresol = (2 if tsresol & 128 else 10) ** (tsresol & 127)
             if code == 0:
                 if length != 0:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1096,7 +1096,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             pkt = pkt.__iter__()
             if not self.header_present:
                 try:
-                    p = pkt.next()
+                    p = next(pkt)
                 except StopIteration:
                     self._write_header(b"")
                     return

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -615,12 +615,12 @@ class Enum_metaclass(type):
 
 
 def export_object(obj):
-    print(gzip.zlib.compress(six.moves.cPickle.dumps(obj,2),9).encode("base64"))
+    print(bytes_codec(gzip.zlib.compress(six.moves.cPickle.dumps(obj,2),9), "base64"))
 
 def import_object(obj=None):
     if obj is None:
         obj = sys.stdin.read()
-    return six.moves.cPickle.loads(gzip.zlib.decompress(obj.strip().decode("base64")))
+    return six.moves.cPickle.loads(gzip.zlib.decompress(base64_bytes(obj.strip())))
 
 
 def save_object(fname, obj):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -459,7 +459,9 @@ class ContextManagerCaptureOutput(object):
     def __exit__(self, *exc):
         sys.stdout = self.bck_stdout
         return False
-    def get_output(self):
+    def get_output(self, eval_bytes=False):
+        if self.result_export_object.startswith("b'") and eval_bytes:
+            return plain_str(eval(self.result_export_object))
         return self.result_export_object
 
 def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,options=None):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -46,7 +46,7 @@ def sane_color(x):
         if (j < 32) or (j >= 127):
             r=r+conf.color_theme.not_printable(".")
         else:
-            r=r+chb(i)
+            r=r+i
     return r
 
 def sane(x):
@@ -56,7 +56,7 @@ def sane(x):
         if (j < 32) or (j >= 127):
             r=r+"."
         else:
-            r=r+chb(i)
+            r=r+i
     return r
 
 def lhex(x):
@@ -89,7 +89,7 @@ def hexdump(x, dump=False):
         s += "%04x  " % i
         for j in range(16):
             if i+j < l:
-                s += "%02X" % ord(x[i+j])
+                s += "%02X" % orb(x[i+j])
             else:
                 s += "  "
             if j%16 == 7:
@@ -124,7 +124,7 @@ def linehexdump(x, onlyasc=0, onlyhex=0, dump=False):
     l = len(x)
     if not onlyasc:
         for i in range(l):
-            s += "%02X" % ord(x[i])
+            s += "%02X" % orb(x[i])
         if not onlyhex:  # separate asc & hex if both are displayed
             s += " "
     if not onlyhex:
@@ -147,7 +147,7 @@ def chexdump(x, dump=False):
     :returns: a String only if dump=True
     """
     x = raw(x)
-    s = ", ".join("%#04x" % ord(x) for x in x)
+    s = ", ".join("%#04x" % orb(x) for x in x)
     if dump:
         return s
     else:
@@ -157,14 +157,14 @@ def chexdump(x, dump=False):
 def hexstr(x, onlyasc=0, onlyhex=0):
     s = []
     if not onlyasc:
-        s.append(" ".join("%02x" % ord(b) for b in x))
+        s.append(" ".join("%02x" % orb(b) for b in x))
     if not onlyhex:
         s.append(sane(x)) 
     return "  ".join(s)
 
 def repr_hex(s):
     """ Convert provided bitstring to a simple string of hex digits """
-    return "".join("%02x" % ord(x) for x in s)
+    return "".join("%02x" % orb(x) for x in s)
 
 @conf.commands.register
 def hexdiff(x,y):
@@ -248,7 +248,7 @@ def hexdiff(x,y):
             if i+j < l:
                 if line[j]:
                     col = colorize[(linex[j]!=liney[j])*(doy-dox)]
-                    print(col("%02X" % ord(line[j])), end=' ')
+                    print(col("%02X" % orb(line[j])), end=' ')
                     if linex[j]==liney[j]:
                         cl += sane_color(line[j])
                     else:
@@ -299,7 +299,7 @@ def _fletcher16(charbuf):
     # This is based on the GPLed C implementation in Zebra <http://www.zebra.org/>
     c0 = c1 = 0
     for char in charbuf:
-        c0 += ord(char)
+        c0 += orb(char)
         c1 += c0
 
     c0 %= 255
@@ -1380,7 +1380,7 @@ def pretty_routes(rtlst, header, sortBy=0):
                 return _r
             rtlst = [tuple([_crop(rtlst[j][i], colwidth[i]) for i in range(0, len(rtlst[j]))]) for j in range(0, len(rtlst))]
             # Recalculate column's width
-            colwidth = [max([len(y) for y in x]) for x in apply(zip, rtlst)]
+            colwidth = [max([len(y) for y in x]) for x in zip(*rtlst)]
     fmt = _space.join(["%%-%ds"%x for x in colwidth])
     rt = "\n".join([fmt % x for x in rtlst])
     return rt

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -456,7 +456,7 @@ def in6_ptoc(addr):
         res.append(_rfc1924map[rem%85])
         rem = rem//85
     res.reverse()
-    return b"".join(res)
+    return "".join(res)
 
     
 def in6_isaddr6to4(x):

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -228,7 +228,7 @@ def in6_ifaceidtomac(ifaceid): # TODO: finish commenting function behavior
     first = struct.pack("B", ((first & 0xFD) | ulbit))
     oui = first + ifaceid[1:3]
     end = ifaceid[5:]
-    l = ["%.02x" % struct.unpack('B', raw(x))[0] for x in list(oui + end)]
+    l = ["%.02x" % orb(x) for x in list(oui + end)]
     return ":".join(l)
 
 def in6_addrtomac(addr):
@@ -766,7 +766,7 @@ def in6_get_common_plen(a, b):
     tmpA = inet_pton(socket.AF_INET6, a)
     tmpB = inet_pton(socket.AF_INET6, b)
     for i in range(16):
-        mbits = matching_bits(ord(tmpA[i]), ord(tmpB[i]))
+        mbits = matching_bits(orb(tmpA[i]), orb(tmpB[i]))
         if mbits != 8:
             return 8*i + mbits
     return 128

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -167,11 +167,11 @@ def in6_getAddrType(addr):
     addrType = 0
     # _Assignable_ Global Unicast Address space
     # is defined in RFC 3513 as those in 2000::/3
-    if ((struct.unpack("B", raw(naddr[0]))[0] & 0xE0) == 0x20):
+    if ((orb(naddr[0]) & 0xE0) == 0x20):
         addrType = (IPV6_ADDR_UNICAST | IPV6_ADDR_GLOBAL)
         if naddr[:2] == b' \x02': # Mark 6to4 @
             addrType |= IPV6_ADDR_6TO4
-    elif ord(naddr[0]) == 0xff: # multicast
+    elif orb(naddr[0]) == 0xff: # multicast
         addrScope = paddr[3]
         if addrScope == '2':
             addrType = (IPV6_ADDR_LINKLOCAL | IPV6_ADDR_MULTICAST)
@@ -179,7 +179,7 @@ def in6_getAddrType(addr):
             addrType = (IPV6_ADDR_GLOBAL | IPV6_ADDR_MULTICAST)
         else:
             addrType = (IPV6_ADDR_GLOBAL | IPV6_ADDR_MULTICAST)
-    elif ((ord(naddr[0]) == 0xfe) and ((int(paddr[2], 16) & 0xC) == 0x8)):
+    elif ((orb(naddr[0]) == 0xfe) and ((int(paddr[2], 16) & 0xC) == 0x8)):
         addrType = (IPV6_ADDR_UNICAST | IPV6_ADDR_LINKLOCAL)
     elif paddr == "::1":
         addrType = IPV6_ADDR_LOOPBACK
@@ -384,10 +384,8 @@ def in6_getRandomizedIfaceId(ifaceid, previous=None):
     a "printable" format as depicted below.
     
     ex: 
-
     >>> in6_getRandomizedIfaceId('20b:93ff:feeb:2d3')
     ('4c61:76ff:f46a:a5f3', 'd006:d540:db11:b092')
-
     >>> in6_getRandomizedIfaceId('20b:93ff:feeb:2d3',
                                  previous='d006:d540:db11:b092')
     ('fe97:46fe:9871:bd38', 'eeed:d79c:2e3f:62e')
@@ -397,13 +395,13 @@ def in6_getRandomizedIfaceId(ifaceid, previous=None):
     if previous is None:
         d = b"".join(chb(x) for x in range(256))
         for _ in range(8):
-            s += random.choice(d)
+            s += chb(random.choice(d))
         previous = s
     s = inet_pton(socket.AF_INET6, "::"+ifaceid)[8:] + previous
     import hashlib
     s = hashlib.md5(s).digest()
     s1,s2 = s[:8],s[8:]
-    s1 = raw(ord(s1[0]) | 0x04) + s1[1:]  
+    s1 = chb(orb(s1[0]) | 0x04) + s1[1:]
     s1 = inet_ntop(socket.AF_INET6, b"\xff"*8 + s1)[20:]
     s2 = inet_ntop(socket.AF_INET6, b"\xff"*8 + s2)[20:]    
     return (s1, s2)

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -89,6 +89,7 @@ class VolatileValue:
         return raw(self._fix())
     def __len__(self):
         return len(self._fix())
+
     def _fix(self):
         return None
 
@@ -110,25 +111,31 @@ class RandNum(RandField):
         return int(self._fix())
     def __index__(self):
         return int(self)
+    def __add__(self, other):
+        return self._fix() + other
+    def __sub__(self, other):
+        return self._fix() - other
+    def __mul__(self, other):
+        return self._fix() * other
+    def __floordiv__(self, other):
+        return self._fix() / other
+    __div__ = __floordiv__
 
-    def __str__(self):
-        return str(self._fix())
-
-class RandNumGamma(RandField):
+class RandNumGamma(RandNum):
     def __init__(self, alpha, beta):
         self.alpha = alpha
         self.beta = beta
     def _fix(self):
         return int(round(random.gammavariate(self.alpha, self.beta)))
 
-class RandNumGauss(RandField):
+class RandNumGauss(RandNum):
     def __init__(self, mu, sigma):
         self.mu = mu
         self.sigma = sigma
     def _fix(self):
         return int(round(random.gauss(self.mu, self.sigma)))
 
-class RandNumExpo(RandField):
+class RandNumExpo(RandNum):
     def __init__(self, lambd, base=0):
         self.lambd = lambd
         self.base = base
@@ -234,6 +241,8 @@ class RandString(RandField):
         for _ in range(self.size):
             s += random.choice(self.chars)
         return s
+    def __mul__(self, n):
+        return self._fix()*n
 
 class RandBin(RandString):
     def __init__(self, size=None):

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -80,13 +80,15 @@ class VolatileValue:
             return False
         return x == y
     def __getattr__(self, attr):
-        if attr == "__setstate__":
+        if attr in ["__setstate__", "__getstate__"]:
             raise AttributeError(attr)
         return getattr(self._fix(),attr)
     def __str__(self):
         return str(self._fix())
     def __bytes__(self):
         return raw(self._fix())
+    def __len__(self):
+        return len(self._fix())
     def _fix(self):
         return None
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -263,6 +263,7 @@ os.unlink("t2.pcap")
 
 = Test InjectSink and Inject3Sink
 ~ needs_root
+import mock
 
 import mock
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -263,7 +263,6 @@ os.unlink("t2.pcap")
 
 = Test InjectSink and Inject3Sink
 ~ needs_root
-import mock
 
 import mock
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -27,7 +27,7 @@ def test_list_contrib():
         list_contrib()
         result_list_contrib = cmco.get_output()
     assert("http2               : HTTP/2 (RFC 7540, RFC 7541)              status=loads" in result_list_contrib)
-    assert(result_list_contrib.split('\n') > 40)
+    assert(len(result_list_contrib.split('\n')) > 40)
 
 test_list_contrib()
 
@@ -94,7 +94,7 @@ else:
 
 if len(routes6):
     assert(len([r for r in routes6 if r[0] == "::1" and r[-1] == ["::1"]]) >= 1)
-    if iflist >= 2:
+    if len(iflist) >= 2:
         assert(len([r for r in routes6 if r[0] == "fe80::" and r[1] == 64]) >= 1)
         len([r for r in routes6 if in6_islladdr(r[0]) and r[1] == 128 and r[-1] == ["::1"]]) >= 1
 else:
@@ -262,8 +262,8 @@ Ether(dst="ff:ff:ff:ff:ff:ff", src="ff:ff:ff:ff:ff:ff", type=0x9000)
 assert _.mysummary() == 'ff:ff:ff:ff:ff:ff > ff:ff:ff:ff:ff:ff (0x9000)'
 
 = Test fletcher16_* functions
-assert(fletcher16_checksum("\x28\x07") == 22319)
-assert(fletcher16_checkbytes("ABCDEF", 2) == "\x89\x67")
+assert(fletcher16_checksum(b"\x28\x07") == 22319)
+assert(fletcher16_checkbytes(b"ABCDEF", 2) == "\x89\x67")
 
 = Test zerofree_randstring function
 random.seed(0x2807)
@@ -275,7 +275,7 @@ def test_export_import_object():
     with ContextManagerCaptureOutput() as cmco:
         export_object(2807)
         result_export_object = cmco.get_output()
-    assert(result_export_object.endswith("eNprYPL9zqUHAAdrAf8=\n\n"))
+    assert(result_export_object.endswith(b"eNprYPL9zqUHAAdrAf8=\n\n"))
     assert(import_object(result_export_object) == 2807)
 
 test_export_import_object()
@@ -285,11 +285,11 @@ tex_escape("$#_") == "\\$\\#\\_"
 
 = Test colgen function
 f = colgen(range(3))
-assert(len([f.next() for i in range(2)]) == 2)
+assert(len([next(f) for i in range(2)]) == 2)
 
 = Test incremental_label function
 f = incremental_label()
-assert([f.next() for i in range(2)] == ["tag00000", "tag00001"])
+assert([next(f) for i in range(2)] == ["tag00000", "tag00001"])
 
 = Test corrupt_* functions
 import random
@@ -309,7 +309,7 @@ assert(load_object(fname) == 2807)
 = Test whois function
 if not WINDOWS:
     result = whois("193.0.6.139")
-    assert("inetnum" in result and "Amsterdam" in result)
+    assert(b"inetnum" in result and b"Amsterdam" in result)
 
 = Test manuf DB methods
 ~ manufdb
@@ -351,7 +351,7 @@ assert a.next() == (3, 2, 3)
 
 saved_conf_verb = conf.verb
 fd, fname = tempfile.mkstemp()
-os.write(fd, "conf.verb = 42\n")
+os.write(fd, b"conf.verb = 42\n")
 os.close(fd)
 from scapy.main import _read_config_file
 _read_config_file(fname, globals(), locals())
@@ -671,9 +671,9 @@ x=SNMP(b'0y\x02\x01\x00\x04\x06public\xa2l\x02\x01)\x02\x01\x00\x02\x01\x000a0!\
 x.show()
 assert(x.community==b"public" and x.version == 0)
 assert(x.PDU.id == 41 and len(x.PDU.varbindlist) == 3)
-assert(x.PDU.varbindlist[0].oid == "1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
+assert(x.PDU.varbindlist[0].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
 assert(x.PDU.varbindlist[0].value == "172.31.19.2")
-assert(x.PDU.varbindlist[2].oid == "1.3.6.1.4.1.253.8.64.4.2.1.5.10.14130400")
+assert(x.PDU.varbindlist[2].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.5.10.14130400")
 assert(x.PDU.varbindlist[2].value == 1)
 
 
@@ -891,7 +891,7 @@ def _send_or_sniff(pkt, timeout, flt, pid, fork, t_other=None):
             os.waitpid(pid, 0)
         else:
             t_other.join()
-    assert raw(pkt) in (str(p[pkt.__class__]) for p in pkts if pkt.__class__ in p)
+    assert raw(pkt) in (raw(p[pkt.__class__]) for p in pkts if pkt.__class__ in p)
 
 def send_and_sniff(pkt, timeout=2, flt=None):
     """Send a packet, sniff, and check the packet has been seen"""

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -275,8 +275,8 @@ import mock
 def test_export_import_object():
     with ContextManagerCaptureOutput() as cmco:
         export_object(2807)
-        result_export_object = cmco.get_output()
-    assert(result_export_object.endswith(b"eNprYPL9zqUHAAdrAf8=\n\n"))
+        result_export_object = cmco.get_output(eval_bytes=True)
+    assert(result_export_object.startswith("eNprYPL9zqUHAAdrAf8=\n"))
     assert(import_object(result_export_object) == 2807)
 
 test_export_import_object()
@@ -5368,7 +5368,7 @@ assert value == 'abcdefg'
 = fragment()
 payloadlen, fragsize = 100, 8
 assert fragsize % 8 == 0
-fragcount = (payloadlen / fragsize) + bool(payloadlen % fragsize)
+fragcount = (payloadlen // fragsize) + bool(payloadlen % fragsize)
 * create the packet
 pkt = IP() / ("X" * payloadlen)
 * create the fragments
@@ -5399,7 +5399,7 @@ assert ffrags[-1].flags == 0
 * fragment offset should be well computed
 plen = 0
 for p in ffrags:
-    assert p.frag == plen / 8
+    assert p.frag == plen // 8
     plen += len(p.payload)
 
 assert plen == payloadlen
@@ -5447,7 +5447,7 @@ assert plist_def[0][DNSRR].rrname == 'nyc.gov.'
 = Packet().fragment()
 payloadlen, fragsize = 100, 8
 assert fragsize % 8 == 0
-fragcount = (payloadlen / fragsize) + bool(payloadlen % fragsize)
+fragcount = (payloadlen // fragsize) + bool(payloadlen % fragsize)
 * create the packet
 pkt = IP() / ("X" * payloadlen)
 * create the fragments
@@ -8171,7 +8171,7 @@ assert(rek == 'b')
 = RandSingNum
 ~ not_pypy
 random.seed(0x2807)
-rs = RandSingNum(-28, 07)
+rs = RandSingNum(-28, 7)
 assert(rs == 3)
 assert(rs == -27)
 
@@ -8577,7 +8577,7 @@ BOOTP().hashret() == b"\x00\x00\x00\x00"
 
 import random
 random.seed(0x2807)
-raw(RandDHCPOptions()) == "[('WWW_server', '90.219.239.175')]"
+str(RandDHCPOptions()) == "[('WWW_server', '90.219.239.175')]"
 
 value = ("hostname", "scapy")
 dof = DHCPOptionsField("options", value)
@@ -8586,14 +8586,14 @@ dof.i2m("", value) == b'\x0cscapy'
 
 unknown_value_end = b"\xfe" + b"\xff"*257
 udof = DHCPOptionsField("options", unknown_value_end)
-udof.m2i("", unknown_value_end) == [(254, '\xff'*255), 'end']
+udof.m2i("", unknown_value_end) == [(254, b'\xff'*255), 'end']
 
 unknown_value_pad = b"\xfe" + b"\xff"*256 + b"\x00"
 udof = DHCPOptionsField("options", unknown_value_pad)
-udof.m2i("", unknown_value_pad) == [(254, '\xff'*255), 'pad']
+udof.m2i("", unknown_value_pad) == [(254, b'\xff'*255), 'pad']
 
 = DHCP - build
-s = raw(IP()/UDP()/BOOTP(chaddr="00:01:02:03:04:05")/DHCP(options=[("message-type","discover"),"end"]))
+s = raw(IP(src="127.0.0.1")/UDP()/BOOTP(chaddr="00:01:02:03:04:05")/DHCP(options=[("message-type","discover"),"end"]))
 s == b'E\x00\x01\x10\x00\x01\x00\x00@\x11{\xda\x7f\x00\x00\x01\x7f\x00\x00\x01\x00C\x00D\x00\xfcf\xea\x01\x01\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0000:01:02:03:04:0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00c\x82Sc5\x01\x01\xff'
 
 = DHCP - dissection

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -179,12 +179,13 @@ os.remove("scapySession1.dat")
 ~ appveyor_only
 
 tmpfile = get_temp_file(autoext=".ut")
+tmpfile
 if WINDOWS:
     assert("scapy" in tmpfile and tmpfile.lower().startswith('c:\\users\\appveyor\\appdata\\local\\temp'))
 else:
     import platform
-    IS_PYPY = platform.python_implementation().lower() == "pypy"
-    assert("scapy" in tmpfile and (IS_PYPY == True or "/tmp/" in tmpfile))
+    BYPASS_TMP = platform.python_implementation().lower() == "pypy" or DARWIN
+    assert("scapy" in tmpfile and (BYPASS_TMP == True or "/tmp/" in tmpfile))
 
 assert(conf.temp_files[0].endswith(".ut"))
 scapy_delete_temp_files()
@@ -338,14 +339,14 @@ assert(ret == ("\\textcolor{blue}{{\\tt\\char62}{\\tt\\char62}{\\tt\\char62} }IP
 assert tex_escape("{scapy}\\^$~#_&%|><") == "{\\tt\\char123}scapy{\\tt\\char125}{\\tt\\char92}\\^{}\\${\\tt\\char126}\\#\\_\\&\\%{\\tt\\char124}{\\tt\\char62}{\\tt\\char60}"
 
 a = colgen(1, 2, 3)
-assert a.next() == (1, 2, 2)
-assert a.next() == (1, 3, 3)
-assert a.next() == (2, 2, 1)
-assert a.next() == (2, 3, 2)
-assert a.next() == (2, 1, 3)
-assert a.next() == (3, 3, 1)
-assert a.next() == (3, 1, 2)
-assert a.next() == (3, 2, 3)
+assert next(a) == (1, 2, 2)
+assert next(a) == (1, 3, 3)
+assert next(a) == (2, 2, 1)
+assert next(a) == (2, 3, 2)
+assert next(a) == (2, 1, 3)
+assert next(a) == (3, 3, 1)
+assert next(a) == (3, 1, 2)
+assert next(a) == (3, 2, 3)
 
 = Test config file functions
 
@@ -568,7 +569,7 @@ assert( _.len == 23 and len(_) == 29 )
 ~ PadField padding
 
 class TestPad(Packet):
-    fields_desc = [ PadField(StrNullField("st", ""),4), StrField("id", "")]
+    fields_desc = [ PadField(StrNullField("st", b""),4), StrField("id", b"")]
 
 TestPad() == TestPad(raw(TestPad()))
 
@@ -1352,7 +1353,7 @@ assert(_ == b'\x80!\x01\x00\x00\x1f\x81\x06\x01\x02\x03\x04\x83\x06\x05\x06\x07\
 PPP(_)
 q=_
 assert( q[PPP_IPCP_Option].type == 123 )
-assert( q[PPP_IPCP_Option].data == 'ABCDEFG' )
+assert( q[PPP_IPCP_Option].data == b"ABCDEFG" )
 assert( q[PPP_IPCP_Option_NBNS2].data == '9.10.11.12' )
 
 
@@ -1373,7 +1374,7 @@ assert(_ == b'\x80S\x01\x00\x00\x13\x00\x06XYZ\x00\x01\tABCDEFG')
 PPP(_)
 q=_
 assert( raw(p) == raw(q) )
-assert( q[PPP_ECP_Option].data == "ABCDEFG" )
+assert( q[PPP_ECP_Option].data == b"ABCDEFG" )
 
 
 # Scapy6 Regression Test Campaign 
@@ -1876,7 +1877,7 @@ raw(HBHOptUnknown(optlen=9, optdata="B"*10)) == b'\x01\tBBBBBBBBBB'
 
 = HBHOptUnknown - Dissection with specific values 
 a=HBHOptUnknown(b'\x01\tBBBBBBBBBB')
-a.otype == 0x01 and a.optlen == 9 and a.optdata == b"B"*9 and isinstance(a.payload, Raw) and a.payload.load == "B"
+a.otype == 0x01 and a.optlen == 9 and a.optdata == b"B"*9 and isinstance(a.payload, Raw) and a.payload.load == b"B"
 
 
 ############
@@ -2213,12 +2214,12 @@ a=ICMPv6NDOptRedirectedHdr(b'\x04\x00\x00\x00')
 assert(a.type == 4)
 assert(a.len == 0)
 assert(a.res == b"\x00\x00")
-assert(a.pkt == "")
+assert(a.pkt == b"")
 
 = ICMPv6NDOptRedirectedHdr - Disssection with specific values
 ~ ICMPv6NDOptRedirectedHdr
 a=ICMPv6NDOptRedirectedHdr(b'\x04\xff\x11\x11\x00\x00\x00\x00somerawingthatisnotanipv6pac')
-a.type == 4 and a.len == 255 and a.res == b'\x11\x11\x00\x00\x00\x00' and isinstance(a.pkt, Raw) and a.pkt.load == "somerawingthatisnotanipv6pac"
+a.type == 4 and a.len == 255 and a.res == b'\x11\x11\x00\x00\x00\x00' and isinstance(a.pkt, Raw) and a.pkt.load == b"somerawingthatisnotanipv6pac"
 
 = ICMPv6NDOptRedirectedHdr - Dissection with cut IPv6 Header
 ~ ICMPv6NDOptRedirectedHdr
@@ -2330,13 +2331,13 @@ a.type == 9 and a.len == 1 and a.res == b'\x00\x00\x00\x00\x00\x00' and not a.ad
 
 = ICMPv6NDOptSrcAddrList - Dissection with specific values (auto len)
 a=ICMPv6NDOptSrcAddrList(b'\t\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11')
-a.type == 9 and a.len == 5 and a.res == 'BBBBBB' and len(a.addrlist) == 2 and a.addrlist[0] == "ffff::ffff" and a.addrlist[1] == "1111::1111"
+a.type == 9 and a.len == 5 and a.res == b'BBBBBB' and len(a.addrlist) == 2 and a.addrlist[0] == "ffff::ffff" and a.addrlist[1] == "1111::1111"
 
 = ICMPv6NDOptSrcAddrList - Dissection with specific values 
 conf.debug_dissector = False
 a=ICMPv6NDOptSrcAddrList(b'\t\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11')
 conf.debug_dissector = True
-a.type == 9 and a.len == 3 and a.res == 'BBBBBB' and len(a.addrlist) == 1 and a.addrlist[0] == "ffff::ffff" and isinstance(a.payload, Raw) and a.payload.load == b'\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+a.type == 9 and a.len == 3 and a.res == b'BBBBBB' and len(a.addrlist) == 1 and a.addrlist[0] == "ffff::ffff" and isinstance(a.payload, Raw) and a.payload.load == b'\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 
 ############
@@ -2358,13 +2359,13 @@ a.type == 10 and a.len == 1 and a.res == b'\x00\x00\x00\x00\x00\x00' and not a.a
 
 = ICMPv6NDOptTgtAddrList - Dissection with specific values (auto len)
 a=ICMPv6NDOptTgtAddrList(b'\n\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11')
-a.type == 10 and a.len == 5 and a.res == 'BBBBBB' and len(a.addrlist) == 2 and a.addrlist[0] == "ffff::ffff" and a.addrlist[1] == "1111::1111"
+a.type == 10 and a.len == 5 and a.res == b'BBBBBB' and len(a.addrlist) == 2 and a.addrlist[0] == "ffff::ffff" and a.addrlist[1] == "1111::1111"
 
 = ICMPv6NDOptTgtAddrList - Instantiation with specific values 
 conf.debug_dissector = False
 a=ICMPv6NDOptTgtAddrList(b'\n\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11')
 conf.debug_dissector = True
-a.type == 10 and a.len == 3 and a.res == 'BBBBBB' and len(a.addrlist) == 1 and a.addrlist[0] == "ffff::ffff" and isinstance(a.payload, Raw) and a.payload.load == b'\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+a.type == 10 and a.len == 3 and a.res == b'BBBBBB' and len(a.addrlist) == 1 and a.addrlist[0] == "ffff::ffff" and isinstance(a.payload, Raw) and a.payload.load == b'\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 
 ############
@@ -2552,7 +2553,7 @@ raw(ICMPv6NIQueryNOOP(nonce=b"\x00"*8)) == b'\x8b\x01\x00\x00\x00\x00\x00\x00\x0
 
 = ICMPv6NIQueryNOOP - Basic Dissection
 a = ICMPv6NIQueryNOOP(b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == ""
+a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == b""
 
 
 ############
@@ -3050,7 +3051,7 @@ len(l) == 33 and len(raw(l[-1])) == 644
 
 = defragment6 - test against a long TCP packet fragmented with a 1280 MTU
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280) 
-raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 'A'*40000)
+raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + b'A'*40000)
 
 
 = defragment6 - test against a large TCP packet fragmented with a 1280 bytes MTU and missing fragments
@@ -3059,7 +3060,7 @@ del(l[2])
 del(l[4])
 del(l[12])
 del(l[18])
-raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 2444*'A' + 1232*'X' + 2464*'A' + 1232*'X' + 9856*'A' + 1232*'X' + 7392*'A' + 1232*'X' + 12916*'A')
+raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 2444*b'A' + 1232*b'X' + 2464*b'A' + 1232*b'X' + 9856*b'A' + 1232*b'X' + 7392*b'A' + 1232*b'X' + 12916*b'A')
 
 
 = defragment6 - test against a TCP packet fragmented with a 800 bytes MTU and missing fragments
@@ -3289,7 +3290,7 @@ a.type == 2 and a.enterprisenum == 311
 
 = DUID_EN dissection with specific values 
 a=DUID_EN(b'\x00\x02\x11\x11\x11\x11iamarawing')
-a.type == 2 and a.enterprisenum == 0x11111111 and a.id =="iamarawing"
+a.type == 2 and a.enterprisenum == 0x11111111 and a.id == b"iamarawing"
 
 
 ############
@@ -3366,7 +3367,7 @@ a.optcode == 1 and a.optlen == 0
 
 = DHCP6OptClientId dissection with specific duid value
 a=DHCP6OptClientId(b'\x00\x01\x00\x04somerawing')
-a.optcode == 1 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == 'some' and isinstance(a.payload, DHCP6OptUnknown)
+a.optcode == 1 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == b'some' and isinstance(a.payload, DHCP6OptUnknown)
 
 = DHCP6OptClientId dissection with specific DUID_LL as duid value
 a=DHCP6OptClientId(b'\x00\x01\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00')
@@ -3412,7 +3413,7 @@ a.optcode == 2 and a.optlen == 0
 
 = DHCP6OptServerId dissection with specific duid value
 a=DHCP6OptServerId(b'\x00\x02\x00\x04somerawing')
-a.optcode == 2 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == 'some' and isinstance(a.payload, DHCP6OptUnknown)
+a.optcode == 2 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == b'some' and isinstance(a.payload, DHCP6OptUnknown)
 
 = DHCP6OptServerId dissection with specific DUID_LL as duid value
 a=DHCP6OptServerId(b'\x00\x02\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00')
@@ -3446,7 +3447,7 @@ raw(DHCP6OptIAAddress(addr="2222:3333::5555", preflft=0x66666666, validlft=0x777
 
 = DHCP6OptIAAddress - Dissection with specific values 
 a = DHCP6OptIAAddress(b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomerawing')
-a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts == "somerawing"
+a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts == b"somerawing"
 
 
 ############
@@ -3629,14 +3630,14 @@ raw(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something")])) == b'\
 
 = DHCP6OptUserClass - Dissection with one user class data rawucture
 a = DHCP6OptUserClass(b'\x00\x0f\x00\x0b\x00\tsomething')
-a.optcode == 15 and a.optlen == 11 and len(a.userclassdata) == 1 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == 'something'
+a.optcode == 15 and a.optlen == 11 and len(a.userclassdata) == 1 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == b'something'
 
 = DHCP6OptUserClass - Instantiation with two user class data rawuctures
 raw(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something"), USER_CLASS_DATA(data="somethingelse")])) == b'\x00\x0f\x00\x1a\x00\tsomething\x00\rsomethingelse'
 
 = DHCP6OptUserClass - Dissection with two user class data rawuctures
 a = DHCP6OptUserClass(b'\x00\x0f\x00\x1a\x00\tsomething\x00\rsomethingelse')
-a.optcode == 15 and a.optlen == 26 and len(a.userclassdata) == 2 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and isinstance(a.userclassdata[1], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == 'something' and a.userclassdata[1].len == 13 and a.userclassdata[1].data == 'somethingelse'
+a.optcode == 15 and a.optlen == 26 and len(a.userclassdata) == 2 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and isinstance(a.userclassdata[1], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == b'something' and a.userclassdata[1].len == 13 and a.userclassdata[1].data == b'somethingelse'
 
 
 ############
@@ -3655,14 +3656,14 @@ raw(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something")])) == b'\x00
 
 = DHCP6OptVendorClass - Dissection with one vendor class data rawucture
 a = DHCP6OptVendorClass(b'\x00\x10\x00\x0f\x00\x00\x00\x00\x00\tsomething')
-a.optcode == 16 and a.optlen == 15 and a.enterprisenum == 0 and len(a.vcdata) == 1 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == 'something'
+a.optcode == 16 and a.optlen == 15 and a.enterprisenum == 0 and len(a.vcdata) == 1 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == b'something'
 
 = DHCP6OptVendorClass - Instantiation with two vendor class data rawuctures
 raw(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something"), VENDOR_CLASS_DATA(data="somethingelse")])) == b'\x00\x10\x00\x1e\x00\x00\x00\x00\x00\tsomething\x00\rsomethingelse'
 
 = DHCP6OptVendorClass - Dissection with two vendor class data rawuctures
 a = DHCP6OptVendorClass(b'\x00\x10\x00\x1e\x00\x00\x00\x00\x00\tsomething\x00\rsomethingelse')
-a.optcode == 16 and a.optlen == 30 and a.enterprisenum == 0 and len(a.vcdata) == 2 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and isinstance(a.vcdata[1], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == 'something' and a.vcdata[1].len == 13 and a.vcdata[1].data == 'somethingelse'
+a.optcode == 16 and a.optlen == 30 and a.enterprisenum == 0 and len(a.vcdata) == 2 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and isinstance(a.vcdata[1], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == b'something' and a.vcdata[1].len == 13 and a.vcdata[1].data == b'somethingelse'
 
 
 ############
@@ -4071,7 +4072,7 @@ raw(DHCP6OptRemoteID()) == b'\x00%\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptRemoteID - Basic Dissection
 a = DHCP6OptRemoteID(b'\x00%\x00\x04\x00\x00\x00\x00')
-a.optcode == 37 and a.optlen == 4 and a.enterprisenum == 0 and a.remoteid == b""
+a.optcode == 37 and a.optlen == 4 and a.enterprisenum == 0 and a.remoteid == ""
 
 = DHCP6OptRemoteID - Instantiation with specific values 
 raw(DHCP6OptRemoteID(enterprisenum=0xeeeeeeee, remoteid="someid")) == b'\x00%\x00\n\xee\xee\xee\xeesomeid'
@@ -4090,7 +4091,7 @@ raw(DHCP6OptSubscriberID()) == b'\x00&\x00\x00'
 
 = DHCP6OptSubscriberID - Basic Dissection
 a = DHCP6OptSubscriberID(b'\x00&\x00\x00')
-a.optcode == 38 and a.optlen == 0 and a.subscriberid == b""
+a.optcode == 38 and a.optlen == 0 and a.subscriberid == ""
 
 = DHCP6OptSubscriberID - Instantiation with specific values
 raw(DHCP6OptSubscriberID(subscriberid="someid")) == b'\x00&\x00\x06someid'
@@ -4392,7 +4393,7 @@ a.msgtype == 12 and DHCP6OptRelayMsg in a and isinstance(a.message, DHCP6)
 + Test DHCP6 Messages - DHCP6OptRelayMsg
 
 = DHCP6OptRelayMsg - Basic Instantiation
-str(DHCP6OptRelayMsg(optcode=37)) == b'\x00%\x00\x04\x00\x00\x00\x00'
+raw(DHCP6OptRelayMsg(optcode=37)) == b'\x00%\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptRelayMsg - Basic Dissection
 a=DHCP6OptRelayMsg(b'\x00\r\x00\x00')
@@ -4629,7 +4630,7 @@ raw(MIP6OptMNID(subtype=42, id="someid")) == b'\x08\x07*someid'
 
 = MIP6OptMNID - dissection with specific values
 p = MIP6OptMNID(b'\x08\x07*someid')
-p.otype == 8 and p.olen == 7 and p.subtype == 42 and p.id == "someid"
+p.otype == 8 and p.olen == 7 and p.subtype == 42 and p.id == b"someid"
 
 
 
@@ -4642,14 +4643,14 @@ raw(MIP6OptMsgAuth()) == b'\x09\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
 
 = MIP6OptMsgAuth - basic dissection
 p = MIP6OptMsgAuth(b'\x09\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA')
-p.otype == 9 and p.olen == 17 and p.subtype == 1 and p.mspi == 0 and p.authdata == "A"*12
+p.otype == 9 and p.olen == 17 and p.subtype == 1 and p.mspi == 0 and p.authdata == b"A"*12
 
 = MIP6OptMsgAuth - build with specific values
 raw(MIP6OptMsgAuth(authdata="B"*16, mspi=0xeeeeeeee, subtype=0xff)) == b'\t\x15\xff\xee\xee\xee\xeeBBBBBBBBBBBBBBBB'
 
 = MIP6OptMsgAuth - dissection with specific values
 p = MIP6OptMsgAuth(b'\t\x15\xff\xee\xee\xee\xeeBBBBBBBBBBBBBBBB')
-p.otype == 9 and p.olen == 21 and p.subtype == 255 and p.mspi == 0xeeeeeeee and p.authdata == "B"*16
+p.otype == 9 and p.olen == 21 and p.subtype == 255 and p.mspi == 0xeeeeeeee and p.authdata == b"B"*16
 
 
 ############
@@ -4669,7 +4670,7 @@ s == b'\n*\x87V|\x00\x00\x00\x00\x00'
 
 = MIP6OptReplayProtection - dissection with specific values
 p = MIP6OptReplayProtection(s)
-p.otype == 10 and p.olen == 42 and p.timestamp == 9752118382559232000L
+p.otype == 10 and p.olen == 42 and p.timestamp == 9752118382559232000
 p.fields_desc[-1].i2repr("", p.timestamp) == 'Mon, 13 Dec 1971 23:50:39 +0000 (9752118382559232000)'
 
 
@@ -5167,7 +5168,7 @@ assert all(any(proto in pkt for pkt in pktpcap) for proto in [ICMP, UDP, TCP])
 = Check wrpcap()
 import os, tempfile
 fdesc, filename = tempfile.mkstemp()
-fdesc = os.fdopen(fdesc, "w")
+fdesc = os.fdopen(fdesc, "wb")
 wrpcap(fdesc, pktpcap)
 fdesc.close()
 
@@ -5195,7 +5196,7 @@ os.unlink(filename)
 
 = Check wrpcap(nano=True)
 fdesc, filename = tempfile.mkstemp()
-fdesc = os.fdopen(fdesc, "w")
+fdesc = os.fdopen(fdesc, "wb")
 pktpcapnano[0].time += 0.000000001
 wrpcap(fdesc, pktpcapnano, nano=True)
 fdesc.close()
@@ -5218,7 +5219,7 @@ assert isinstance(pkt, IP)
 pkt = pkt.payload
 assert isinstance(pkt, ICMP)
 pkt = pkt.payload
-assert isinstance(pkt, Raw) and pkt.load == 'abcdefghijklmnopqrstuvwabcdefghi'
+assert isinstance(pkt, Raw) and pkt.load == b'abcdefghijklmnopqrstuvwabcdefghi'
 pkt = pkt.payload
 assert isinstance(pkt, Padding) and pkt.load == b'\xeay$\xf6'
 pkt = pkt.payload
@@ -5236,7 +5237,7 @@ assert isinstance(pkt, IP)
 pkt = pkt.payload
 assert isinstance(pkt, ICMP)
 pkt = pkt.payload
-assert isinstance(pkt, Raw) and pkt.load == 'abcdefghijklmnopqrstuvwabcdefghi'
+assert isinstance(pkt, Raw) and pkt.load == b'abcdefghijklmnopqrstuvwabcdefghi'
 pkt = pkt.payload
 assert isinstance(pkt, Padding) and pkt.load == b'\xeay$\xf6'
 pkt = pkt.payload
@@ -5246,16 +5247,16 @@ assert isinstance(pkt, NoPayload)
 ~ tcpdump
 * No very specific tests because we do not want to depend on tcpdump output
 pcapfile = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00e\x00\x00\x00\xcf\xc5\xacVo*\n\x00(\x00\x00\x00(\x00\x00\x00E\x00\x00(\x00\x01\x00\x00@\x06|\xcd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91|\x00\x00\xcf\xc5\xacV_-\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r\xcf\xc5\xacV\xf90\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x01|\xde\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\xf7\xff\x00\x00\x00\x00')
-data = tcpdump(pcapfile, dump=True, args=['-n']).split('\n')
+data = tcpdump(pcapfile, dump=True, args=['-n']).split(b'\n')
 print(data)
-assert 'IP 127.0.0.1.20 > 127.0.0.1.80:' in data[0]
-assert 'IP 127.0.0.1.53 > 127.0.0.1.53:' in data[1]
-assert 'IP 127.0.0.1 > 127.0.0.1:' in data[2]
+assert b'IP 127.0.0.1.20 > 127.0.0.1.80:' in data[0]
+assert b'IP 127.0.0.1.53 > 127.0.0.1.53:' in data[1]
+assert b'IP 127.0.0.1 > 127.0.0.1:' in data[2]
 
 = Check tcpdump() command with tshark
 ~ tshark
 pcapfile = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00e\x00\x00\x00\xcf\xc5\xacVo*\n\x00(\x00\x00\x00(\x00\x00\x00E\x00\x00(\x00\x01\x00\x00@\x06|\xcd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91|\x00\x00\xcf\xc5\xacV_-\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r\xcf\xc5\xacV\xf90\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x01|\xde\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\xf7\xff\x00\x00\x00\x00')
-values = [tuple(int(val) for val in line[:-1].split('\t')) for line in tcpdump(pcapfile, prog=conf.prog.tshark, getfd=True, args=['-T', 'fields', '-e', 'ip.ttl', '-e', 'ip.proto'])]
+values = [tuple(int(val) for val in line[:-1].split(b'\t')) for line in tcpdump(pcapfile, prog=conf.prog.tshark, getfd=True, args=['-T', 'fields', '-e', 'ip.ttl', '-e', 'ip.proto'])]
 assert values == [(64, 6), (64, 17), (64, 1)]
 
 = Check Raw IP pcap files
@@ -5506,7 +5507,7 @@ raw(TCP(options=[('SAckOK', '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x0
 
 = TCP options: SAckOK - basic dissection
 sackok = TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x04\x02\x00\x00")
-sackok[TCP].options[0][0] == "SAckOK" and sackok[TCP].options[0][1] == ''
+sackok[TCP].options[0][0] == "SAckOK" and sackok[TCP].options[0][1] == b''
 
 = TCP options: EOL - basic build
 raw(TCP(options=[(0, '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x00\x02\x00\x00"
@@ -6178,7 +6179,7 @@ assert(eap.id == 1)
 assert(eap.len == 14)
 assert(eap.type == 1)
 assert(hasattr(eap, 'identity'))
-assert(eap.identity == 'anonymous')
+assert(eap.identity == b'anonymous')
 
 = EAP - Dissection (3)
 s = b'\x01\x01\x00\x06\r '
@@ -6275,7 +6276,7 @@ assert(eap.type == 4)
 assert(eap.haslayer(EAP_MD5))
 assert(eap[EAP_MD5].value_size == 16)
 assert(eap[EAP_MD5].value == b'\x86\xf9\x89\x94\x81\x01\xb3 nHh\x1b\x8d\xe7^\xdb')
-assert(eap[EAP_MD5].optional_name == '')
+assert(eap[EAP_MD5].optional_name == b'')
 
 = EAP - EAP_MD5 - Response - Dissection (9)
 s = b'\x02\x02\x00\x16\x04\x10\xfd\x1e\xffe\xf5\x80y\xa8\xe3\xc8\xf1\xbd\xc2\x85\xae\xcf\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -6287,7 +6288,7 @@ assert(eap.type == 4)
 assert(eap.haslayer(EAP_MD5))
 assert(eap[EAP_MD5].value_size == 16)
 assert(eap[EAP_MD5].value == b'\xfd\x1e\xffe\xf5\x80y\xa8\xe3\xc8\xf1\xbd\xc2\x85\xae\xcf')
-assert(eap[EAP_MD5].optional_name == '')
+assert(eap[EAP_MD5].optional_name == b'')
 
 = EAP - LEAP - Basic Instantiation
 raw(LEAP()) == b'\x01\x00\x00\x08\x11\x01\x00\x00'
@@ -6303,7 +6304,7 @@ assert(eap.haslayer(LEAP))
 assert(eap[LEAP].version == 1)
 assert(eap[LEAP].count == 8)
 assert(eap[LEAP].challenge_response == b'8\xb6\xd7\xa1E<!\x15')
-assert(eap[LEAP].username == "supplicant-1")
+assert(eap[LEAP].username == b"supplicant-1")
 
 = EAP - LEAP - Response - Dissection (11)
 s = b'\x02D\x00,\x11\x01\x00\x18\xb3\x82[\x82\x8a\xc8M*\xf3\xe7\xb3\xad,7\x8b\xbfG\x81\xda\xbf\xe6\xc1\x9b\x95supplicant-1'
@@ -6316,7 +6317,7 @@ assert(eap.haslayer(LEAP))
 assert(eap[LEAP].version == 1)
 assert(eap[LEAP].count == 24)
 assert(eap[LEAP].challenge_response == b'\xb3\x82[\x82\x8a\xc8M*\xf3\xe7\xb3\xad,7\x8b\xbfG\x81\xda\xbf\xe6\xc1\x9b\x95')
-assert(eap[LEAP].username == "supplicant-1")
+assert(eap[LEAP].username == b"supplicant-1")
 
 = EAP - Layers (1)
 eap = EAP_MD5()
@@ -6409,7 +6410,7 @@ s = b"!\x0b\x06\xea\x00\x00\x00\x00\x00\x00\xf2\xc1\x7f\x7f\x01\x00\xdb9\xe8\xa2
 p = NTP(s)
 assert(isinstance(p, NTPHeader))
 assert(p[NTPAuthenticator].key_id == 1)
-assert(bytes_hex(p[NTPAuthenticator].dgst) == 'ad79f3a1e5fcd032d26a1e27c3c1b60e')
+assert(bytes_hex(p[NTPAuthenticator].dgst) == b'ad79f3a1e5fcd032d26a1e27c3c1b60e')
 
 
 = NTPHeader - KoD
@@ -6420,7 +6421,7 @@ assert(p.leap == 3)
 assert(p.version == 4)
 assert(p.mode == 4)
 assert(p.stratum == 0)
-assert(p.ref_id == 'INIT')
+assert(p.ref_id == b'INIT')
 
 
 = NTPHeader - Extension dissection test
@@ -6556,7 +6557,7 @@ assert(p.more == 0)
 assert(p.op_code == 2)
 assert(len(p.data.load) == 12)
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '3dc23bc7edb9555339d68908c8afa612')
+assert(bytes_hex(p.authenticator.dgst) == b'3dc23bc7edb9555339d68908c8afa612')
 
 
 = NTP Control (mode 6) - CTL_OP_READVAR (5) - response
@@ -6571,7 +6572,7 @@ assert(p.more == 0)
 assert(p.op_code == 2)
 assert(len(p.data.load) == 0)
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '97280249dba07338ed722860db4a580a')
+assert(bytes_hex(p.authenticator.dgst) == b'97280249dba07338ed722860db4a580a')
 
 
 = NTP Control (mode 6) - CTL_OP_WRITEVAR (1) - request
@@ -6586,7 +6587,7 @@ assert(p.more == 0)
 assert(p.op_code == 3)
 assert(len(p.data.load) == 12)
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'aff10cb4c9946dfc4d90094aa170944a')
+assert(bytes_hex(p.authenticator.dgst) == b'aff10cb4c9946dfc4d90094aa170944a')
 
 
 = NTP Control (mode 6) - CTL_OP_WRITEVAR (2) - response
@@ -6604,7 +6605,7 @@ assert(isinstance(p.status_word, NTPErrorStatusPacket))
 assert(p.status_word.error_code == 5)
 assert(len(p.data.load) == 0)
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '807a80fbafc470679853a8e57865811c')
+assert(bytes_hex(p.authenticator.dgst) == b'807a80fbafc470679853a8e57865811c')
 
 
 = NTP Control (mode 6) - CTL_OP_CONFIGURE (1) - request
@@ -6620,7 +6621,7 @@ assert(p.op_code == 8)
 assert(p.count == 12)
 assert(p.data.load == b'controlkey 1')
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'eaa7aca81b6a9cdb58e1530d36fbefa4')
+assert(bytes_hex(p.authenticator.dgst) == b'eaa7aca81b6a9cdb58e1530d36fbefa4')
 
 
 = NTP Control (mode 6) - CTL_OP_CONFIGURE (2) - response
@@ -6636,7 +6637,7 @@ assert(p.op_code == 8)
 assert(p.count == 18)
 assert(p.data.load == b'Config Succeeded\r\n\x00\x00')
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'bfa6d85ff96d1e326c293caceec2a539')
+assert(bytes_hex(p.authenticator.dgst) == b'bfa6d85ff96d1e326c293caceec2a539')
 
 
 = NTP Control (mode 6) - CTL_OP_SAVECONFIG (1) - request
@@ -6652,7 +6653,7 @@ assert(p.op_code == 9)
 assert(p.count == 15)
 assert(p.data.load == b'ntp.test.2.conf\x00')
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'c9fb8abe3c605ffa36d218c3b7648923')
+assert(bytes_hex(p.authenticator.dgst) == b'c9fb8abe3c605ffa36d218c3b7648923')
 
 
 = NTP Control (mode 6) - CTL_OP_SAVECONFIG (2) - response
@@ -6668,7 +6669,7 @@ assert(p.op_code == 9)
 assert(p.count == 42)
 assert(p.data.load == b"Configuration saved to 'ntp.test.2.conf'\r\n\x00\x00")
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '32c2ba59c533fe28f550e5a0860295d9')
+assert(bytes_hex(p.authenticator.dgst) == b'32c2ba59c533fe28f550e5a0860295d9')
 
 
 = NTP Control (mode 6) - CTL_OP_REQ_NONCE (1) - request
@@ -7053,7 +7054,7 @@ assert(p.req_data[0].minpoll == 6)
 assert(p.req_data[0].maxpoll == 10)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '5abafe011c720564a114b129e976448d')
+assert(bytes_hex(p.authenticator.dgst) == b'5abafe011c720564a114b129e976448d')
 
 
 = NTP Private (mode 7) - REQ_CONFIG (2) - response
@@ -7088,7 +7089,7 @@ assert(p.req_data[0].peeraddr == "192.168.122.107")
 assert(p.req_data[0].v6_flag == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '1d4d3bfe5a7e5d5ae34561929a45d825')
+assert(bytes_hex(p.authenticator.dgst) == b'1d4d3bfe5a7e5d5ae34561929a45d825')
 
 
 = NTP Private (mode 7) - REQ_UNCONFIG (2) - response
@@ -7123,7 +7124,7 @@ assert(p.req_data[0].addr == "192.168.122.105")
 assert(p.req_data[0].mask == "255.255.255.255")
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '3e3db7305470eeaee1ad3462efe380c8')
+assert(bytes_hex(p.authenticator.dgst) == b'3e3db7305470eeaee1ad3462efe380c8')
 
 
 = NTP Private (mode 7) - REQ_RESSUBFLAGS (1) - request
@@ -7143,7 +7144,7 @@ assert(p.req_data[0].addr == "192.168.122.105")
 assert(p.req_data[0].mask == "255.255.255.255")
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '3e650ddfdb1e3168d0ca294c076b900a')
+assert(bytes_hex(p.authenticator.dgst) == b'3e650ddfdb1e3168d0ca294c076b900a')
 
 
 = NTP Private (mode 7) - REQ_RESET_PEER (1) - request
@@ -7206,7 +7207,7 @@ assert(isinstance(p.req_data[0], NTPConfTrap))
 assert(p.req_data[0].trap_address == '192.0.2.3')
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '6224b8494d2ea631d085498fa7278992')
+assert(bytes_hex(p.authenticator.dgst) == b'6224b8494d2ea631d085498fa7278992')
 
 
 = NTP Private (mode 7) - REQ_ADD_TRAP (2) - response
@@ -7241,7 +7242,7 @@ assert(isinstance(p.req_data[0], NTPConfTrap))
 assert(p.req_data[0].trap_address == '192.0.2.3')
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'a55f569eb87144921b1c3e5aad5d2a89')
+assert(bytes_hex(p.authenticator.dgst) == b'a55f569eb87144921b1c3e5aad5d2a89')
 
 
 = NTP Private (mode 7) - REQ_CLR_TRAP (2) - response
@@ -7351,7 +7352,7 @@ assert(p.nb_items == 0)
 assert(p.data_item_size == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == '8bfb9075a86164e887cabf96d29ddd49')
+assert(bytes_hex(p.authenticator.dgst) == b'8bfb9075a86164e887cabf96d29ddd49')
 
 
 = NTP Private (mode 7) - REQ_IF_STATS (2) - response
@@ -7406,7 +7407,7 @@ assert(p.nb_items == 0)
 assert(p.data_item_size == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(bytes_hex(p.authenticator.dgst) == 'fb3e962ae74ff78f6568d4074cc008cb')
+assert(bytes_hex(p.authenticator.dgst) == b'fb3e962ae74ff78f6568d4074cc008cb')
 
 
 = NTP Private (mode 7) - REQ_IF_RELOAD (2) - response
@@ -7728,7 +7729,7 @@ s == b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x01\x02\
 
 = RIP - dissection
 p = IP(s)
-RIPEntry in p and RIPAuth in p and p[RIPAuth].password.startswith("scapy")
+RIPEntry in p and RIPAuth in p and p[RIPAuth].password.startswith(b"scapy")
 
 
 ############
@@ -7741,7 +7742,7 @@ s == b'E\x00\x007\x00\x01\x00\x00@\x11|\xb3\x7f\x00\x00\x01\x7f\x00\x00\x01\x07\
 
 = IP/UDP/RADIUS - Dissection
 p = IP(s)
-Radius in p and len(p[Radius].attributes) == 1 and p[Radius].attributes[0].value == "scapy"
+Radius in p and len(p[Radius].attributes) == 1 and p[Radius].attributes[0].value == b"scapy"
 
 = RADIUS - Access-Request - Dissection (1)
 s = b'\x01\xae\x01\x17>k\xd4\xc4\x19V\x0b*1\x99\xc8D\xea\xc2\x94Z\x01\x06leap\x06\x06\x00\x00\x00\x02\x1a\x1b\x00\x00\x00\t\x01\x15service-type=Framed\x0c\x06\x00\x00#\xee\x1e\x13AC-7E-8A-4E-E2-92\x1f\x1300-26-73-9E-0F-D3O\x0b\x02\x01\x00\t\x01leapP\x12U\xbc\x12\xcdM\x00\xf8\xdb4\xf1\x18r\xca_\x8c\xf6f\x02\x1a1\x00\x00\x00\t\x01+audit-session-id=0AC8090E0000001A0354CA00\x1a\x14\x00\x00\x00\t\x01\x0emethod=dot1x\x08\x06\xc0\xa8\n\xb9\x04\x06\xc0\xa8\n\x80\x1a\x1d\x00\x00\x00\t\x02\x17GigabitEthernet1/0/18W\x17GigabitEthernet1/0/18=\x06\x00\x00\x00\x0f\x05\x06\x00\x00\xc3\xc6'
@@ -7753,7 +7754,7 @@ assert(len(radius_packet.attributes) == 17)
 assert(radius_packet.attributes[0].type == 1)
 assert(type(radius_packet.attributes[0]) == RadiusAttribute)
 assert(radius_packet.attributes[0].len == 6)
-assert(radius_packet.attributes[0].value == "leap")
+assert(radius_packet.attributes[0].value == b"leap")
 assert(radius_packet.attributes[1].type == 6)
 assert(type(radius_packet.attributes[1]) == RadiusAttr_Service_Type)
 assert(radius_packet.attributes[1].len == 6)
@@ -7764,7 +7765,7 @@ assert(radius_packet.attributes[2].len == 27)
 assert(radius_packet.attributes[2].vendor_id == 9)
 assert(radius_packet.attributes[2].vendor_type == 1)
 assert(radius_packet.attributes[2].vendor_len == 21)
-assert(radius_packet.attributes[2].value == "service-type=Framed")
+assert(radius_packet.attributes[2].value == b"service-type=Framed")
 assert(radius_packet.attributes[6].type == 79)
 assert(type(radius_packet.attributes[6]) == RadiusAttr_EAP_Message)
 assert(radius_packet.attributes[6].len == 11)
@@ -7774,7 +7775,7 @@ assert(radius_packet.attributes[6].value[EAP].id == 1)
 assert(radius_packet.attributes[6].value[EAP].len == 9)
 assert(radius_packet.attributes[6].value[EAP].type == 1)
 assert(hasattr(radius_packet.attributes[6].value[EAP], "identity"))
-assert(radius_packet.attributes[6].value[EAP].identity == "leap")
+assert(radius_packet.attributes[6].value[EAP].identity == b"leap")
 assert(radius_packet.attributes[7].type == 80)
 assert(type(radius_packet.attributes[7]) == RadiusAttr_Message_Authenticator)
 assert(radius_packet.attributes[7].len == 18)
@@ -7798,7 +7799,7 @@ assert(len(radius_packet.attributes) == 4)
 assert(radius_packet.attributes[0].type == 18)
 assert(type(radius_packet.attributes[0]) == RadiusAttribute)
 assert(radius_packet.attributes[0].len == 13)
-assert(radius_packet.attributes[0].value == "Hello, leap")
+assert(radius_packet.attributes[0].value == b"Hello, leap")
 assert(radius_packet.attributes[1].type == 79)
 assert(type(radius_packet.attributes[1]) == RadiusAttr_EAP_Message)
 assert(radius_packet.attributes[1].len == 22)
@@ -7820,12 +7821,12 @@ s = b'\x01\xaf\x01DC\xbe!J\x08\xdf\xcf\x9f\x00v~,\xfb\x8e`\xc8\x01\x06leap\x06\x
 radius_packet = Radius(s)
 assert(radius_packet.id == 175)
 assert(radius_packet.len == 324)
-assert(radius_packet.authenticator == 'C\xbe!J\x08\xdf\xcf\x9f\x00v~,\xfb\x8e`\xc8')
+assert(radius_packet.authenticator == b'C\xbe!J\x08\xdf\xcf\x9f\x00v~,\xfb\x8e`\xc8')
 assert(len(radius_packet.attributes) == 18)
 assert(radius_packet.attributes[0].type == 1)
 assert(type(radius_packet.attributes[0]) == RadiusAttribute)
 assert(radius_packet.attributes[0].len == 6)
-assert(radius_packet.attributes[0].value == "leap")
+assert(radius_packet.attributes[0].value == b"leap")
 assert(radius_packet.attributes[1].type == 6)
 assert(type(radius_packet.attributes[1]) == RadiusAttr_Service_Type)
 assert(radius_packet.attributes[1].len == 6)
@@ -7836,7 +7837,7 @@ assert(radius_packet.attributes[2].len == 27)
 assert(radius_packet.attributes[2].vendor_id == 9)
 assert(radius_packet.attributes[2].vendor_type == 1)
 assert(radius_packet.attributes[2].vendor_len == 21)
-assert(radius_packet.attributes[2].value == "service-type=Framed")
+assert(radius_packet.attributes[2].value == b"service-type=Framed")
 assert(radius_packet.attributes[6].type == 79)
 assert(type(radius_packet.attributes[6]) == RadiusAttr_EAP_Message)
 assert(radius_packet.attributes[6].len == 38)
@@ -7872,7 +7873,7 @@ assert(len(radius_packet.attributes) == 4)
 assert(radius_packet.attributes[0].type == 18)
 assert(type(radius_packet.attributes[0]) == RadiusAttribute)
 assert(radius_packet.attributes[0].len == 13)
-assert(radius_packet.attributes[0].value == "Hello, leap")
+assert(radius_packet.attributes[0].value == b"Hello, leap")
 assert(radius_packet.attributes[1].type == 79)
 assert(type(radius_packet.attributes[1]) == RadiusAttr_EAP_Message)
 assert(radius_packet.attributes[1].len == 6)
@@ -7894,7 +7895,7 @@ s = b'\x01\xae\x01\x17>k\xd4\xc4\x19V\x0b*1\x99\xc8D\xea\xc2\x94Z\x01\x06leap\x0
 access_request = Radius(s)
 s = b'\x0b\xae\x00[\xc7\xae\xfc6\xa1=\xb5\x99&^\xdf=\xe9\x00\xa6\xe8\x12\rHello, leapO\x16\x01\x02\x00\x14\x11\x01\x00\x08\xb8\xc4\x1a4\x97x\xd3\x82leapP\x12\xd3\x12\x17\xa6\x0c.\x94\x85\x03]t\xd1\xdb\xd0\x13\x8c\x18\x12iQs\xf7iSb@k\x9d,\xa0\x99\x8ehO'
 access_challenge = Radius(s)
-access_challenge.compute_authenticator(access_request.authenticator, "radiuskey") == access_challenge.authenticator
+access_challenge.compute_authenticator(access_request.authenticator, b"radiuskey") == access_challenge.authenticator
 
 = RADIUS - Layers (1)
 radius_attr = RadiusAttr_EAP_Message(value = EAP())
@@ -8024,10 +8025,12 @@ ip6_bad_addrs = ["fe80::2e67:ef2d:7eca::ed8a",
                  "1234:5678:9abc:def0:1234:5678:9abc:def0:1234"]
 for ip6 in ip6_bad_addrs:
     rc = False
+    exc1 = None
     try:
         res1 = inet_pton(socket.AF_INET6, ip6)
-    except Exception as exc1:
+    except Exception as e:
         rc = True
+        exc1 = e
     assert rc
     rc = False
     try:
@@ -8354,7 +8357,7 @@ assert(p.tsn == 0)
 assert(p.stream_id == 0)
 assert(p.stream_seq == 0)
 assert(p.len == (len("data") + 16))
-assert(p.data == "data")
+assert(p.data == b"data")
 
 = basic SCTPChunkInit - Dissection
 ~ sctp
@@ -8429,7 +8432,7 @@ assert(set(params.keys()) == {SCTPChunkParamECNCapable, SCTPChunkParamHostname,
                               SCTPChunkParamFwdTSN, SCTPChunkParamSupportedExtensions,
                               SCTPChunkParamStateCookie})
 assert(params[SCTPChunkParamECNCapable] == SCTPChunkParamECNCapable())
-assert(params[SCTPChunkParamHostname] == SCTPChunkParamHostname(len=13, hostname="localhost"))
+assert(raw(params[SCTPChunkParamHostname]) == raw(SCTPChunkParamHostname(len=13, hostname="localhost")))
 assert(params[SCTPChunkParamFwdTSN] == SCTPChunkParamFwdTSN())
 assert(params[SCTPChunkParamSupportedExtensions] == SCTPChunkParamSupportedExtensions(len=7))
 assert(params[SCTPChunkParamStateCookie].len == 4+16)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -671,9 +671,9 @@ x=SNMP(b'0y\x02\x01\x00\x04\x06public\xa2l\x02\x01)\x02\x01\x00\x02\x01\x000a0!\
 x.show()
 assert(x.community==b"public" and x.version == 0)
 assert(x.PDU.id == 41 and len(x.PDU.varbindlist) == 3)
-assert(x.PDU.varbindlist[0].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
+assert(x.PDU.varbindlist[0].oid == "1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
 assert(x.PDU.varbindlist[0].value == b"172.31.19.2")
-assert(x.PDU.varbindlist[2].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.5.10.14130400")
+assert(x.PDU.varbindlist[2].oid == "1.3.6.1.4.1.253.8.64.4.2.1.5.10.14130400")
 assert(x.PDU.varbindlist[2].value == 1)
 
 
@@ -843,7 +843,7 @@ dns_ans.show2()
 dns_ans[DNS].an.show()
 dns_ans2 = IP(raw(dns_ans))
 DNS in dns_ans2
-assert(raw(dns_ans2) == str(dns_ans))
+assert(raw(dns_ans2) == raw(dns_ans))
 dns_ans2.qd.qname = "www.secdev.org."
 * We need to recalculate these values
 del(dns_ans2[IP].len)
@@ -1232,7 +1232,7 @@ class ATMT9(Automaton):
         self.send(Raw("ENU"))
     @ATMT.ioevent(BEGIN, name="loop")
     def received_sth(self, fd):
-        self.res += fd.recv().load
+        self.res += plain_str(fd.recv().load)
         raise self.END()
     @ATMT.state(final=1)
     def END(self):
@@ -1252,7 +1252,7 @@ a.BEGIN.intercepts()
 while True:
     try:
         x = a.run()
-    except Automaton.InterceptionPoint,p:
+    except Automaton.InterceptionPoint as p:
         a.accept_packet(Raw(p.packet.load.lower()), wait=False)
     else:
         break
@@ -1343,7 +1343,7 @@ raw(p)
 assert(_ == b'\x80!\x01\x00\x00\x16\x81\x06\x01\x02\x03\x04\x83\x06\x05\x06\x07\x08\x84\x06\t\n\x0b\x0c')
 PPP(_)
 q=_
-assert(raw(p) == str(q))
+assert(raw(p) == raw(q))
 assert(PPP(raw(q))==q)
 PPP()/PPP_IPCP(options=[PPP_IPCP_Option_DNS1(data="1.2.3.4"),PPP_IPCP_Option_DNS2(data="5.6.7.8"),PPP_IPCP_Option(type=123,data="ABCDEFG"),PPP_IPCP_Option_NBNS2(data="9.10.11.12")])
 p=_
@@ -1741,7 +1741,7 @@ raw(ICMPv6EchoRequest(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="this
 
 = ICMPv6EchoRequest - Basic dissection
 a=ICMPv6EchoRequest(b'\x80\x00\x00\x00\x00\x00\x00\x00')
-a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == b""
+a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
 
 = ICMPv6EchoRequest - Dissection with specific values 
 a=ICMPv6EchoRequest(b'\x80\xff\x11\x11""33thisissomerawing')
@@ -1767,7 +1767,7 @@ raw(ICMPv6EchoReply(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisis
 
 = ICMPv6EchoReply - Basic dissection
 a=ICMPv6EchoReply(b'\x80\x00\x00\x00\x00\x00\x00\x00')
-a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == b""
+a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
 
 = ICMPv6EchoReply - Dissection with specific values 
 a=ICMPv6EchoReply(b'\x80\xff\x11\x11""33thisissomerawing')
@@ -1866,7 +1866,7 @@ raw(HBHOptUnknown()) == b'\x01\x00'
 
 = HBHOptUnknown - Basic Dissection 
 a=HBHOptUnknown(b'\x01\x00')
-a.otype == 0x01 and a.optlen == 0 and a.optdata == b""
+a.otype == 0x01 and a.optlen == 0 and a.optdata == ""
 
 = HBHOptUnknown - Automatic optlen computation
 raw(HBHOptUnknown(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
@@ -1902,7 +1902,7 @@ raw(PadN(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
 
 = PadN - Basic Dissection
 a=PadN(b'\x01\x00')
-a.otype == 1 and a.optlen == 0 and a.optdata == b''
+a.otype == 1 and a.optlen == 0 and a.optdata == ""
 
 = PadN - Dissection with specific values 
 a=PadN(b'\x01\x0cBBBBBBBBBB')
@@ -2131,7 +2131,7 @@ a.type == 0 and a.len == 2
 
 = ICMPv6NDOptUnknown - Dissection with specific values 
 a=ICMPv6NDOptUnknown(b'\x00\x04somerawing')
-a.type == 0 and a.len==4 and a.data == b"so" and isinstance(a.payload, Raw) and a.payload.load == "merawing"
+a.type == 0 and a.len==4 and a.data == b"so" and isinstance(a.payload, Raw) and a.payload.load == b"merawing"
 
 
 ############
@@ -2552,7 +2552,7 @@ raw(ICMPv6NIQueryNOOP(nonce=b"\x00"*8)) == b'\x8b\x01\x00\x00\x00\x00\x00\x00\x0
 
 = ICMPv6NIQueryNOOP - Basic Dissection
 a = ICMPv6NIQueryNOOP(b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == b""
+a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == ""
 
 
 ############
@@ -4071,14 +4071,14 @@ raw(DHCP6OptRemoteID()) == b'\x00%\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptRemoteID - Basic Dissection
 a = DHCP6OptRemoteID(b'\x00%\x00\x04\x00\x00\x00\x00')
-a.optcode == 37 and a.optlen == 4 and a.enterprisenum == 0 and a.remoteid == ""
+a.optcode == 37 and a.optlen == 4 and a.enterprisenum == 0 and a.remoteid == b""
 
 = DHCP6OptRemoteID - Instantiation with specific values 
 raw(DHCP6OptRemoteID(enterprisenum=0xeeeeeeee, remoteid="someid")) == b'\x00%\x00\n\xee\xee\xee\xeesomeid'
 
 = DHCP6OptRemoteID - Dissection with specific values
 a = DHCP6OptRemoteID(b'\x00%\x00\n\xee\xee\xee\xeesomeid')
-a.optcode == 37 and a.optlen == 10 and a.enterprisenum == 0xeeeeeeee and a.remoteid == "someid"
+a.optcode == 37 and a.optlen == 10 and a.enterprisenum == 0xeeeeeeee and a.remoteid == b"someid"
 
 
 ############
@@ -4090,14 +4090,14 @@ raw(DHCP6OptSubscriberID()) == b'\x00&\x00\x00'
 
 = DHCP6OptSubscriberID - Basic Dissection
 a = DHCP6OptSubscriberID(b'\x00&\x00\x00')
-a.optcode == 38 and a.optlen == 0 and a.subscriberid == ""
+a.optcode == 38 and a.optlen == 0 and a.subscriberid == b""
 
 = DHCP6OptSubscriberID - Instantiation with specific values
 raw(DHCP6OptSubscriberID(subscriberid="someid")) == b'\x00&\x00\x06someid'
 
 = DHCP6OptSubscriberID - Dissection with specific values
 a = DHCP6OptSubscriberID(b'\x00&\x00\x06someid')
-a.optcode == 38 and a.optlen == 6 and a.subscriberid == "someid"
+a.optcode == 38 and a.optlen == 6 and a.subscriberid == b"someid"
 
 
 ############
@@ -4112,7 +4112,7 @@ a = DHCP6OptClientFQDN(b"\x00'\x00\x01\x00")
 a.optcode == 39 and a.optlen == 1 and a.res == 0 and a.flags == 0 and a.fqdn == ""
 
 = DHCP6OptClientFQDN - Instantiation with various flags combinations
-raw(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x01\x01" and str(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x01\x02" and str(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x01\x04" and str(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x01\x07" and str(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x01\x06"
+raw(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x01\x01" and raw(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x01\x02" and raw(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x01\x04" and raw(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x01\x07" and raw(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x01\x06"
 
 = DHCP6OptClientFQDN - Instantiation with one fqdn 
 raw(DHCP6OptClientFQDN(fqdn="toto.example.org")) == b"\x00'\x00\x12\x00\x04toto\x07example\x03org"
@@ -5516,7 +5516,7 @@ eol = TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\
 eol[TCP].options[0][0] == "EOL" and eol[TCP].options[0][1] == None
 
 = TCP options: malformed - build
-raw(TCP(options=[('unknown', '')])) == str(TCP())
+raw(TCP(options=[('unknown', '')])) == raw(TCP())
 
 = TCP options: malformed - dissection
 raw(TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00")) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00"
@@ -6409,7 +6409,7 @@ s = b"!\x0b\x06\xea\x00\x00\x00\x00\x00\x00\xf2\xc1\x7f\x7f\x01\x00\xdb9\xe8\xa2
 p = NTP(s)
 assert(isinstance(p, NTPHeader))
 assert(p[NTPAuthenticator].key_id == 1)
-assert(p[NTPAuthenticator].dgst.encode("hex") == 'ad79f3a1e5fcd032d26a1e27c3c1b60e')
+assert(bytes_hex(p[NTPAuthenticator].dgst) == 'ad79f3a1e5fcd032d26a1e27c3c1b60e')
 
 
 = NTPHeader - KoD
@@ -6523,7 +6523,7 @@ assert(p.status_word.peer_event_code == 1)
 assert(p.association_id == 64655)
 assert(p.offset == 0)
 assert(p.count == 468)
-assert(p.data.load == 'srcadr=192.168.122.1, srcport=123, dstadr=192.168.122.100, dstport=123,\r\nleap=3, stratum=16, precision=-24, rootdelay=0.000, rootdisp=0.000,\r\nrefid=INIT, reftime=0x00000000.00000000, rec=0x00000000.00000000,\r\nreach=0x0, unreach=5, hmode=1, pmode=0, hpoll=6, ppoll=10, headway=62,\r\nflash=0x1200, keyid=1, offset=0.000, delay=0.000, dispersion=15937.500,\r\njitter=0.000, xleave=0.240,\r\nfiltdelay= 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00,\r\nfiltoffset= 0.00 0.00 0.00 0.00 ')
+assert(p.data.load == b'srcadr=192.168.122.1, srcport=123, dstadr=192.168.122.100, dstport=123,\r\nleap=3, stratum=16, precision=-24, rootdelay=0.000, rootdisp=0.000,\r\nrefid=INIT, reftime=0x00000000.00000000, rec=0x00000000.00000000,\r\nreach=0x0, unreach=5, hmode=1, pmode=0, hpoll=6, ppoll=10, headway=62,\r\nflash=0x1200, keyid=1, offset=0.000, delay=0.000, dispersion=15937.500,\r\njitter=0.000, xleave=0.240,\r\nfiltdelay= 0.00 0.00 0.00 0.00 0.00 0.00 0.00 0.00,\r\nfiltoffset= 0.00 0.00 0.00 0.00 ')
  
 
 = NTP Control (mode 6) - CTL_OP_READVAR (3) - reponse (2nd packet)
@@ -6556,7 +6556,7 @@ assert(p.more == 0)
 assert(p.op_code == 2)
 assert(len(p.data.load) == 12)
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '3dc23bc7edb9555339d68908c8afa612')
+assert(bytes_hex(p.authenticator.dgst) == '3dc23bc7edb9555339d68908c8afa612')
 
 
 = NTP Control (mode 6) - CTL_OP_READVAR (5) - response
@@ -6571,7 +6571,7 @@ assert(p.more == 0)
 assert(p.op_code == 2)
 assert(len(p.data.load) == 0)
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '97280249dba07338ed722860db4a580a')
+assert(bytes_hex(p.authenticator.dgst) == '97280249dba07338ed722860db4a580a')
 
 
 = NTP Control (mode 6) - CTL_OP_WRITEVAR (1) - request
@@ -6586,7 +6586,7 @@ assert(p.more == 0)
 assert(p.op_code == 3)
 assert(len(p.data.load) == 12)
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'aff10cb4c9946dfc4d90094aa170944a')
+assert(bytes_hex(p.authenticator.dgst) == 'aff10cb4c9946dfc4d90094aa170944a')
 
 
 = NTP Control (mode 6) - CTL_OP_WRITEVAR (2) - response
@@ -6604,7 +6604,7 @@ assert(isinstance(p.status_word, NTPErrorStatusPacket))
 assert(p.status_word.error_code == 5)
 assert(len(p.data.load) == 0)
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '807a80fbafc470679853a8e57865811c')
+assert(bytes_hex(p.authenticator.dgst) == '807a80fbafc470679853a8e57865811c')
 
 
 = NTP Control (mode 6) - CTL_OP_CONFIGURE (1) - request
@@ -6618,9 +6618,9 @@ assert(p.err == 0)
 assert(p.more == 0)
 assert(p.op_code == 8)
 assert(p.count == 12)
-assert(p.data.load == 'controlkey 1')
+assert(p.data.load == b'controlkey 1')
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'eaa7aca81b6a9cdb58e1530d36fbefa4')
+assert(bytes_hex(p.authenticator.dgst) == 'eaa7aca81b6a9cdb58e1530d36fbefa4')
 
 
 = NTP Control (mode 6) - CTL_OP_CONFIGURE (2) - response
@@ -6636,7 +6636,7 @@ assert(p.op_code == 8)
 assert(p.count == 18)
 assert(p.data.load == b'Config Succeeded\r\n\x00\x00')
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'bfa6d85ff96d1e326c293caceec2a539')
+assert(bytes_hex(p.authenticator.dgst) == 'bfa6d85ff96d1e326c293caceec2a539')
 
 
 = NTP Control (mode 6) - CTL_OP_SAVECONFIG (1) - request
@@ -6652,7 +6652,7 @@ assert(p.op_code == 9)
 assert(p.count == 15)
 assert(p.data.load == b'ntp.test.2.conf\x00')
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'c9fb8abe3c605ffa36d218c3b7648923')
+assert(bytes_hex(p.authenticator.dgst) == 'c9fb8abe3c605ffa36d218c3b7648923')
 
 
 = NTP Control (mode 6) - CTL_OP_SAVECONFIG (2) - response
@@ -6668,7 +6668,7 @@ assert(p.op_code == 9)
 assert(p.count == 42)
 assert(p.data.load == b"Configuration saved to 'ntp.test.2.conf'\r\n\x00\x00")
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '32c2ba59c533fe28f550e5a0860295d9')
+assert(bytes_hex(p.authenticator.dgst) == '32c2ba59c533fe28f550e5a0860295d9')
 
 
 = NTP Control (mode 6) - CTL_OP_REQ_NONCE (1) - request
@@ -6695,7 +6695,7 @@ assert(p.response == 1)
 assert(p.err == 0)
 assert(p.more == 0)
 assert(p.op_code == 12)
-assert(p.data.load == 'nonce=db4186a2e1d9022472e24bc9\r\n')
+assert(p.data.load == b'nonce=db4186a2e1d9022472e24bc9\r\n')
 assert(p.authenticator == '')
 
 
@@ -6709,7 +6709,7 @@ assert(p.response == 0)
 assert(p.err == 0)
 assert(p.op_code == 10)
 assert(p.count == 40)
-assert(p.data.load == 'nonce=db4186a2e1d9022472e24bc9, frags=32')
+assert(p.data.load == b'nonce=db4186a2e1d9022472e24bc9, frags=32')
 assert(p.authenticator == '')
 
 = NTP Control (mode 6) - CTL_OP_READ_MRU (2) - response
@@ -7053,7 +7053,7 @@ assert(p.req_data[0].minpoll == 6)
 assert(p.req_data[0].maxpoll == 10)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '5abafe011c720564a114b129e976448d')
+assert(bytes_hex(p.authenticator.dgst) == '5abafe011c720564a114b129e976448d')
 
 
 = NTP Private (mode 7) - REQ_CONFIG (2) - response
@@ -7088,7 +7088,7 @@ assert(p.req_data[0].peeraddr == "192.168.122.107")
 assert(p.req_data[0].v6_flag == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '1d4d3bfe5a7e5d5ae34561929a45d825')
+assert(bytes_hex(p.authenticator.dgst) == '1d4d3bfe5a7e5d5ae34561929a45d825')
 
 
 = NTP Private (mode 7) - REQ_UNCONFIG (2) - response
@@ -7123,7 +7123,7 @@ assert(p.req_data[0].addr == "192.168.122.105")
 assert(p.req_data[0].mask == "255.255.255.255")
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '3e3db7305470eeaee1ad3462efe380c8')
+assert(bytes_hex(p.authenticator.dgst) == '3e3db7305470eeaee1ad3462efe380c8')
 
 
 = NTP Private (mode 7) - REQ_RESSUBFLAGS (1) - request
@@ -7143,7 +7143,7 @@ assert(p.req_data[0].addr == "192.168.122.105")
 assert(p.req_data[0].mask == "255.255.255.255")
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '3e650ddfdb1e3168d0ca294c076b900a')
+assert(bytes_hex(p.authenticator.dgst) == '3e650ddfdb1e3168d0ca294c076b900a')
 
 
 = NTP Private (mode 7) - REQ_RESET_PEER (1) - request
@@ -7206,7 +7206,7 @@ assert(isinstance(p.req_data[0], NTPConfTrap))
 assert(p.req_data[0].trap_address == '192.0.2.3')
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '6224b8494d2ea631d085498fa7278992')
+assert(bytes_hex(p.authenticator.dgst) == '6224b8494d2ea631d085498fa7278992')
 
 
 = NTP Private (mode 7) - REQ_ADD_TRAP (2) - response
@@ -7241,7 +7241,7 @@ assert(isinstance(p.req_data[0], NTPConfTrap))
 assert(p.req_data[0].trap_address == '192.0.2.3')
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'a55f569eb87144921b1c3e5aad5d2a89')
+assert(bytes_hex(p.authenticator.dgst) == 'a55f569eb87144921b1c3e5aad5d2a89')
 
 
 = NTP Private (mode 7) - REQ_CLR_TRAP (2) - response
@@ -7351,7 +7351,7 @@ assert(p.nb_items == 0)
 assert(p.data_item_size == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == '8bfb9075a86164e887cabf96d29ddd49')
+assert(bytes_hex(p.authenticator.dgst) == '8bfb9075a86164e887cabf96d29ddd49')
 
 
 = NTP Private (mode 7) - REQ_IF_STATS (2) - response
@@ -7370,7 +7370,7 @@ assert(p.data_item_size == 136)
 assert(isinstance(p.data[0], NTPInfoIfStatsIPv6))
 assert(p.data[0].unaddr == "::1")
 assert(p.data[0].unmask == "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-assert(p.data[0].ifname.startswith("lo"))
+assert(p.data[0].ifname.startswith(b"lo"))
 
 
 = NTP Private (mode 7) - REQ_IF_STATS (3) - response
@@ -7389,7 +7389,7 @@ assert(p.data_item_size == 136)
 assert(isinstance(p.data[0], NTPInfoIfStatsIPv4))
 assert(p.data[0].unaddr == "192.168.122.101")
 assert(p.data[0].unmask == "255.255.255.0")
-assert(p.data[0].ifname.startswith("eth1"))
+assert(p.data[0].ifname.startswith(b"eth1"))
 
 
 = NTP Private (mode 7) - REQ_IF_RELOAD (1) - request
@@ -7406,7 +7406,7 @@ assert(p.nb_items == 0)
 assert(p.data_item_size == 0)
 assert(hasattr(p, 'authenticator'))
 assert(p.authenticator.key_id == 1)
-assert(p.authenticator.dgst.encode("hex") == 'fb3e962ae74ff78f6568d4074cc008cb')
+assert(bytes_hex(p.authenticator.dgst) == 'fb3e962ae74ff78f6568d4074cc008cb')
 
 
 = NTP Private (mode 7) - REQ_IF_RELOAD (2) - response
@@ -7425,7 +7425,7 @@ assert(p.data_item_size == 136)
 assert(isinstance(p.data[0], NTPInfoIfStatsIPv4))
 assert(p.data[0].unaddr == "127.0.0.1")
 assert(p.data[0].unmask == "255.0.0.0")
-assert(p.data[0].ifname.startswith("lo"))
+assert(p.data[0].ifname.startswith(b"lo"))
 
 
 ############
@@ -7686,11 +7686,11 @@ VRRP in p and p[VRRP].chksum == 0x7afd
 = VRRP - chksums
 # VRRPv3
 p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRPv3(priority=254,vrid=2,version=3,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
-a = Ether(str(p))
+a = Ether(raw(p))
 assert a[VRRPv3].chksum == 0xb25e
 # VRRPv1
 p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRP(priority=254,vrid=2,version=1,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
-b = Ether(str(p))
+b = Ether(raw(p))
 assert b[VRRP].chksum == 0xc6f4
 
 ############
@@ -8621,7 +8621,7 @@ Dot11 in p and p.addr3 == "00:00:00:00:00:00"
 p.mysummary() == '802.11 Management 0 00:00:00:00:00:00 > 00:00:00:00:00:00'
 
 = Dot11QoS - build
-s = str(Dot11(type=2, subtype=8)/Dot11QoS(TID=4))
+s = raw(Dot11(type=2, subtype=8)/Dot11QoS(TID=4))
 s == b'\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00'
 
 = Dot11QoS - dissection
@@ -8687,7 +8687,7 @@ assert a.src == '00:00:00:00:00:00'
 
 import tempfile
 fd, fname = tempfile.mkstemp()
-os.write(fd, "-- MIB test\nscapy       OBJECT IDENTIFIER ::= {test 2807}\n")
+os.write(fd, b"-- MIB test\nscapy       OBJECT IDENTIFIER ::= {test 2807}\n")
 os.close(fd)
 
 load_mib(fname)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -672,7 +672,7 @@ x.show()
 assert(x.community==b"public" and x.version == 0)
 assert(x.PDU.id == 41 and len(x.PDU.varbindlist) == 3)
 assert(x.PDU.varbindlist[0].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
-assert(x.PDU.varbindlist[0].value == "172.31.19.2")
+assert(x.PDU.varbindlist[0].value == b"172.31.19.2")
 assert(x.PDU.varbindlist[2].oid == b"1.3.6.1.4.1.253.8.64.4.2.1.5.10.14130400")
 assert(x.PDU.varbindlist[2].value == 1)
 
@@ -1365,14 +1365,14 @@ raw(p)
 assert(_ == b'\x80S\x01\x00\x00\n\x00\x06XYZ\x00')
 PPP(_)
 q=_
-assert( raw(p)==str(q) )
+assert( raw(p)==raw(q) )
 PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui="XYZ"),PPP_ECP_Option(type=1,data="ABCDEFG")])
 p=_
 raw(p)
 assert(_ == b'\x80S\x01\x00\x00\x13\x00\x06XYZ\x00\x01\tABCDEFG')
 PPP(_)
 q=_
-assert( raw(p) == str(q) )
+assert( raw(p) == raw(q) )
 assert( q[PPP_ECP_Option].data == "ABCDEFG" )
 
 
@@ -1608,11 +1608,11 @@ for a in six.moves.range(10):
     s1,s2 = in6_getRandomizedIfaceId('20b:93ff:feeb:2d3')
     inet_pton(socket.AF_INET6, '::'+s1)
     tmp2 = inet_pton(socket.AF_INET6, '::'+s2)
-    res = res and ((ord(s1[0]) & 0x04) == 0x04)
+    res = res and ((orb(s1[0]) & 0x04) == 0x04)
     s1,s2 = in6_getRandomizedIfaceId('20b:93ff:feeb:2d3', previous=tmp2)
     tmp = inet_pton(socket.AF_INET6, '::'+s1)
     inet_pton(socket.AF_INET6, '::'+s2)
-    res = res and ((ord(s1[0]) & 0x04) == 0x04)
+    res = res and ((orb(s1[0]) & 0x04) == 0x04)
 
 ########### RFC 1924 related function ###############################
 = Test RFC 1924 function - in6_ctop() basic test
@@ -1741,11 +1741,11 @@ raw(ICMPv6EchoRequest(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="this
 
 = ICMPv6EchoRequest - Basic dissection
 a=ICMPv6EchoRequest(b'\x80\x00\x00\x00\x00\x00\x00\x00')
-a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
+a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == b""
 
 = ICMPv6EchoRequest - Dissection with specific values 
 a=ICMPv6EchoRequest(b'\x80\xff\x11\x11""33thisissomerawing')
-a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomerawing"
+a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == b"thisissomerawing"
 
 = ICMPv6EchoRequest - Automatic checksum computation and field overloading (build)
 raw(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoRequest()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x80\x00\x95\xf1\x00\x00\x00\x00'
@@ -1767,11 +1767,11 @@ raw(ICMPv6EchoReply(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisis
 
 = ICMPv6EchoReply - Basic dissection
 a=ICMPv6EchoReply(b'\x80\x00\x00\x00\x00\x00\x00\x00')
-a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
+a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == b""
 
 = ICMPv6EchoReply - Dissection with specific values 
 a=ICMPv6EchoReply(b'\x80\xff\x11\x11""33thisissomerawing')
-a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomerawing"
+a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == b"thisissomerawing"
 
 = ICMPv6EchoReply - Automatic checksum computation and field overloading (build)
 raw(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoReply()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x81\x00\x94\xf1\x00\x00\x00\x00'
@@ -1866,7 +1866,7 @@ raw(HBHOptUnknown()) == b'\x01\x00'
 
 = HBHOptUnknown - Basic Dissection 
 a=HBHOptUnknown(b'\x01\x00')
-a.otype == 0x01 and a.optlen == 0 and a.optdata == ""
+a.otype == 0x01 and a.optlen == 0 and a.optdata == b""
 
 = HBHOptUnknown - Automatic optlen computation
 raw(HBHOptUnknown(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
@@ -1876,7 +1876,7 @@ raw(HBHOptUnknown(optlen=9, optdata="B"*10)) == b'\x01\tBBBBBBBBBB'
 
 = HBHOptUnknown - Dissection with specific values 
 a=HBHOptUnknown(b'\x01\tBBBBBBBBBB')
-a.otype == 0x01 and a.optlen == 9 and a.optdata == "B"*9 and isinstance(a.payload, Raw) and a.payload.load == "B"
+a.otype == 0x01 and a.optlen == 9 and a.optdata == b"B"*9 and isinstance(a.payload, Raw) and a.payload.load == "B"
 
 
 ############
@@ -1902,11 +1902,11 @@ raw(PadN(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
 
 = PadN - Basic Dissection
 a=PadN(b'\x01\x00')
-a.otype == 1 and a.optlen == 0 and a.optdata == ''
+a.otype == 1 and a.optlen == 0 and a.optdata == b''
 
 = PadN - Dissection with specific values 
 a=PadN(b'\x01\x0cBBBBBBBBBB')
-a.otype == 1 and a.optlen == 12 and a.optdata == 'BBBBBBBBBB'
+a.otype == 1 and a.optlen == 12 and a.optdata == b'BBBBBBBBBB'
 
 = PadN - Instantiation with forced optlen 
 raw(PadN(optdata="B"*10, optlen=9)) == b'\x01\x09BBBBBBBBBB'
@@ -2131,7 +2131,7 @@ a.type == 0 and a.len == 2
 
 = ICMPv6NDOptUnknown - Dissection with specific values 
 a=ICMPv6NDOptUnknown(b'\x00\x04somerawing')
-a.type == 0 and a.len==4 and a.data == "so" and isinstance(a.payload, Raw) and a.payload.load == "merawing"
+a.type == 0 and a.len==4 and a.data == b"so" and isinstance(a.payload, Raw) and a.payload.load == "merawing"
 
 
 ############
@@ -2552,7 +2552,7 @@ raw(ICMPv6NIQueryNOOP(nonce=b"\x00"*8)) == b'\x8b\x01\x00\x00\x00\x00\x00\x00\x0
 
 = ICMPv6NIQueryNOOP - Basic Dissection
 a = ICMPv6NIQueryNOOP(b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == ""
+a.type == 139 and a.code == 1 and a.cksum == 0 and a.qtype == 0 and a.unused == 0 and a.flags == 0 and a.nonce == b"\x00"*8 and a.data == b""
 
 
 ############
@@ -3681,14 +3681,14 @@ raw(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OP
 
 = DHCP6OptVendorSpecificInfo - Dissection with with specific values (one option)
 a = DHCP6OptVendorSpecificInfo(b'\x00\x11\x00\x11\xee\xee\xee\xee\x00+\x00\tsomething')
-a.optcode == 17 and a.optlen == 17 and a.enterprisenum == 0xeeeeeeee and len(a.vso) == 1 and isinstance(a.vso[0], VENDOR_SPECIFIC_OPTION) and a.vso[0].optlen == 9 and a.vso[0].optdata == 'something'
+a.optcode == 17 and a.optlen == 17 and a.enterprisenum == 0xeeeeeeee and len(a.vso) == 1 and isinstance(a.vso[0], VENDOR_SPECIFIC_OPTION) and a.vso[0].optlen == 9 and a.vso[0].optdata == b'something'
 
 = DHCP6OptVendorSpecificInfo - Instantiation with specific values (two options)
 raw(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OPTION(optcode=43, optdata="something"), VENDOR_SPECIFIC_OPTION(optcode=42, optdata="somethingelse")])) == b'\x00\x11\x00"\xee\xee\xee\xee\x00+\x00\tsomething\x00*\x00\rsomethingelse'
 
 = DHCP6OptVendorSpecificInfo - Dissection with with specific values (two options)
 a = DHCP6OptVendorSpecificInfo(b'\x00\x11\x00"\xee\xee\xee\xee\x00+\x00\tsomething\x00*\x00\rsomethingelse')
-a.optcode == 17 and a.optlen == 34 and a.enterprisenum == 0xeeeeeeee and len(a.vso) == 2 and isinstance(a.vso[0], VENDOR_SPECIFIC_OPTION) and isinstance(a.vso[1], VENDOR_SPECIFIC_OPTION) and a.vso[0].optlen == 9 and a.vso[0].optdata == 'something' and a.vso[1].optlen == 13 and a.vso[1].optdata == 'somethingelse'
+a.optcode == 17 and a.optlen == 34 and a.enterprisenum == 0xeeeeeeee and len(a.vso) == 2 and isinstance(a.vso[0], VENDOR_SPECIFIC_OPTION) and isinstance(a.vso[1], VENDOR_SPECIFIC_OPTION) and a.vso[0].optlen == 9 and a.vso[0].optdata == b'something' and a.vso[1].optlen == 13 and a.vso[1].optdata == b'somethingelse'
 
 
 ############
@@ -3707,7 +3707,7 @@ raw(DHCP6OptIfaceId(ifaceid="something")) == b'\x00\x12\x00\x09something'
 
 = DHCP6OptIfaceId - Dissection with specific value
 a = DHCP6OptIfaceId(b'\x00\x12\x00\x09something')
-a.optcode == 18 and a.optlen == 9 and a.ifaceid == "something"
+a.optcode == 18 and a.optlen == 9 and a.ifaceid == b"something"
 
 
 ############
@@ -5043,7 +5043,7 @@ a1, a2 = "2001:db8::1", "2001:db8::2"
 cookie = RandString(8)._fix()
 p1 = IPv6(src=a1, dst=a2)/MIP6MH_HoTI(cookie=cookie)
 p2 = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie=cookie)
-p2_ko = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie="".join(chr((ord(b'\xff') + 1) % 256)))
+p2_ko = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie="".join(chr((orb(b'\xff') + 1) % 256)))
 assert p1.hashret() == p2.hashret() and p2.answers(p1) and not p1.answers(p2)
 assert p1.hashret() != p2_ko.hashret() and not p2_ko.answers(p1) and not p1.answers(p2_ko)
 
@@ -7661,12 +7661,13 @@ for binfrm in ["\x00" * 15, b"\x00" * 17]:
     try:
         inet_ntop(socket.AF_INET6, binfrm)
     except Exception as exc1:
+        _exc1 = exc1
         rc = True
     assert rc
     try:
         _inet6_ntop(binfrm)
     except Exception as exc2:
-        rc = isinstance(exc2, type(exc1))
+        rc = isinstance(exc2, type(_exc1))
     assert rc
 
 
@@ -8060,10 +8061,10 @@ for ip6, res in ip6_good_addrs:
 
 r4 = Route()
 tmp_route = r4.make_route(host="10.12.13.14")
-(tmp_route[0], tmp_route[1], tmp_route[2]) == (168561934, 4294967295L, '0.0.0.0')
+(tmp_route[0], tmp_route[1], tmp_route[2]) == (168561934, 4294967295, '0.0.0.0')
 
 tmp_route = r4.make_route(net="10.12.13.0/24")
-(tmp_route[0], tmp_route[1], tmp_route[2]) == (168561920, 4294967040L, '0.0.0.0')
+(tmp_route[0], tmp_route[1], tmp_route[2]) == (168561920, 4294967040, '0.0.0.0')
 
 = add() & delt()
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -180,10 +180,10 @@ os.remove("scapySession1.dat")
 
 tmpfile = get_temp_file(autoext=".ut")
 if WINDOWS:
-    assert("scapy" in tmpfile and tmpfile.startswith('C:\\Users\\appveyor\\AppData\\Local\\Temp'))
+    assert("scapy" in tmpfile and tmpfile.lower().startswith('c:\\users\\appveyor\\appdata\\local\\temp'))
 else:
     import platform
-    IS_PYPY = platform.python_implementation() == "PyPy"
+    IS_PYPY = platform.python_implementation().lower() == "pypy"
     assert("scapy" in tmpfile and (IS_PYPY == True or "/tmp/" in tmpfile))
 
 assert(conf.temp_files[0].endswith(".ut"))

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -44,7 +44,7 @@ conf.debug_dissector = True
 
 get_if_raw_hwaddr(conf.iface)
 
-get_if_raw_addr(conf.iface).encode("hex")
+bytes_hex(get_if_raw_addr(conf.iface))
 
 def get_dummy_interface():
     """Returns a dummy network interface"""
@@ -218,8 +218,8 @@ sane("A\x00\xFFB") == "A..B"
 
 = Test lhex function
 assert(lhex(42) == "0x2a")
-assert(lhex((28,07)) == "(0x1c, 0x7)")
-assert(lhex([28,07]) == "[0x1c, 0x7]")
+assert(lhex((28,7)) == "(0x1c, 0x7)")
+assert(lhex([28,7]) == "[0x1c, 0x7]")
 
 = Test linehexdump function
 conf_color_theme = conf.color_theme
@@ -373,7 +373,7 @@ conf.netcache
 = Packet class methods
 p = IP()/ICMP()
 ret = p.do_build_ps()                                                                                                                             
-assert(ret[0] == "@\x00\x00\x00\x00\x01\x00\x00@\x01\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\x00\x00\x00\x00\x00\x00")
+assert(ret[0] == b"@\x00\x00\x00\x00\x01\x00\x00@\x01\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\x00\x00\x00\x00\x00\x00")
 assert(len(ret[1]) == 2)
 
 assert(p[ICMP].firstlayer() == p)
@@ -394,7 +394,7 @@ conf.color_theme = conf_color_theme
 
 = split_layers
 p = IP()/ICMP()
-s = str(p)
+s = raw(p)
 split_layers(IP, ICMP, proto=1)
 assert(Raw in IP(s))
 bind_layers(IP, ICMP, frag=0, proto=1)
@@ -402,7 +402,7 @@ bind_layers(IP, ICMP, frag=0, proto=1)
 = fuzz
 ~ not_pypy
 random.seed(0x2807)
-str(fuzz(IP()/ICMP())) == 'u\x14\x00\x1c\xc2\xf6\x80\x00\xde\x01k\xd3\x7f\x00\x00\x01\x7f\x00\x00\x01y\xc9>\xa6\x84\xd8\xc2\xb7'
+raw(fuzz(IP()/ICMP())) == b'u\x14\x00\x1c\xc2\xf6\x80\x00\xde\x01k\xd3\x7f\x00\x00\x01\x7f\x00\x00\x01y\xc9>\xa6\x84\xd8\xc2\xb7'
 
 = Building some packets
 ~ basic IP TCP UDP NTP LLC SNAP Dot11
@@ -547,21 +547,21 @@ assert not p1.answers(p2)
 + Tests on padding
 
 = Padding assembly
-str(Padding("abc"))
-assert( _ == "abc" )
-str(Padding("abc")/Padding("def"))
-assert( _ == "abcdef" )
-str(Raw("ABC")/Padding("abc")/Padding("def"))
-assert( _ == "ABCabcdef" )
-str(Raw("ABC")/Padding("abc")/Raw("DEF")/Padding("def"))
-assert( _ == "ABCDEFabcdef" )
+raw(Padding("abc"))
+assert( _ == b"abc" )
+raw(Padding("abc")/Padding("def"))
+assert( _ == b"abcdef" )
+raw(Raw("ABC")/Padding("abc")/Padding("def"))
+assert( _ == b"ABCabcdef" )
+raw(Raw("ABC")/Padding("abc")/Raw("DEF")/Padding("def"))
+assert( _ == b"ABCDEFabcdef" )
 
 = Padding and length computation
-IP(str(IP()/Padding("abc")))
+IP(raw(IP()/Padding("abc")))
 assert( _.len == 20 and len(_) == 23 )
-IP(str(IP()/Raw("ABC")/Padding("abc")))
+IP(raw(IP()/Raw("ABC")/Padding("abc")))
 assert( _.len == 23 and len(_) == 26 )
-IP(str(IP()/Raw("ABC")/Padding("abc")/Padding("def")))
+IP(raw(IP()/Raw("ABC")/Padding("abc")/Padding("def")))
 assert( _.len == 23 and len(_) == 29 )
 
 = PadField test
@@ -570,7 +570,7 @@ assert( _.len == 23 and len(_) == 29 )
 class TestPad(Packet):
     fields_desc = [ PadField(StrNullField("st", ""),4), StrField("id", "")]
 
-TestPad() == TestPad(str(TestPad()))
+TestPad() == TestPad(raw(TestPad()))
 
 
 ############
@@ -586,7 +586,7 @@ class IPv3(IP):
 a = IPv3()
 a.version, a.ttl
 assert(_ == (3,32))
-str(a)
+raw(a)
 assert(_ == b'5\x00\x00\x14\x00\x01\x00\x00 \x00\xac\xe7\x7f\x00\x00\x01\x7f\x00\x00\x01')
 
 
@@ -609,12 +609,12 @@ _.res2 == 12345
 = ISAKMP assembly
 ~ ISAKMP 
 hexdump(p)
-str(p) == b"E\x00\x00\x96\x00\x01\x00\x00@\x11\xa7\x9f\xc0\xa8\x08\x0e\n\x00\x00\x01\x01\xf4\x01\xf4\x00\x82\xbf\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00z\x00\x00\x00^\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00R\x01\x01\x00\x00\x03\x00\x00'\x00\x01\x00\x00\x80\x01\x00\x07\x80\x02\x00\x01\x80\x03\x00\x01\x80\x04\x00\x05\x80\x0e\x01\x00\x80\x0b\x00\x01\x00\x0c\x00\x03\x01Q\x80\x00\x00\x00#\x00\x0109\x80\x01\x00\x05\x80\x02\x00\x02\x80\x03\x00\x01\x80\x04\x00\x02\x80\x0b\x00\x01\x00\x0c\x00\x03\x01Q\x80"
+raw(p) == b"E\x00\x00\x96\x00\x01\x00\x00@\x11\xa7\x9f\xc0\xa8\x08\x0e\n\x00\x00\x01\x01\xf4\x01\xf4\x00\x82\xbf\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00z\x00\x00\x00^\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00R\x01\x01\x00\x00\x03\x00\x00'\x00\x01\x00\x00\x80\x01\x00\x07\x80\x02\x00\x01\x80\x03\x00\x01\x80\x04\x00\x05\x80\x0e\x01\x00\x80\x0b\x00\x01\x00\x0c\x00\x03\x01Q\x80\x00\x00\x00#\x00\x0109\x80\x01\x00\x05\x80\x02\x00\x02\x80\x03\x00\x01\x80\x04\x00\x02\x80\x0b\x00\x01\x00\x0c\x00\x03\x01Q\x80"
 
 
 = ISAKMP disassembly
 ~ ISAKMP
-q=IP(str(p))
+q=IP(raw(p))
 q.show()
 q[ISAKMP_payload_Transform:2]
 _.res2 == 12345
@@ -626,11 +626,11 @@ _.res2 == 12345
 
 = TFTP Options
 x=IP()/UDP(sport=12345)/TFTP()/TFTP_RRQ(filename="fname")/TFTP_Options(options=[TFTP_Option(oname="blksize", value="8192"),TFTP_Option(oname="other", value="othervalue")])
-assert( str(x) == b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x0109\x00E\x004B6\x00\x01fname\x00octet\x00blksize\x008192\x00other\x00othervalue\x00' )
-y=IP(str(x))
+assert( raw(x) == b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x0109\x00E\x004B6\x00\x01fname\x00octet\x00blksize\x008192\x00other\x00othervalue\x00' )
+y=IP(raw(x))
 y[TFTP_Option].oname
 y[TFTP_Option:2].oname
-assert(len(y[TFTP_Options].options) == 2 and y[TFTP_Option].oname == "blksize")
+assert(len(y[TFTP_Options].options) == 2 and y[TFTP_Option].oname == b"blksize")
 
 
 ############
@@ -641,7 +641,7 @@ assert(len(y[TFTP_Options].options) == 2 and y[TFTP_Option].oname == "blksize")
 = WEP tests
 ~ wifi crypto Dot11 LLC SNAP IP TCP
 conf.wepkey = "Fobar"
-str(Dot11WEP()/LLC()/SNAP()/IP()/TCP(seq=12345678))
+raw(Dot11WEP()/LLC()/SNAP()/IP()/TCP(seq=12345678))
 assert(_ == b'\x00\x00\x00\x00\xe3OjYLw\xc3x_%\xd0\xcf\xdeu-\xc3pH#\x1eK\xae\xf5\xde\xe7\xb8\x1d,\xa1\xfe\xe83\xca\xe1\xfe\xbd\xfe\xec\x00)T`\xde.\x93Td\x95C\x0f\x07\xdd')
 Dot11WEP(_)
 assert(TCP in _ and _[TCP].seq == 12345678)
@@ -659,17 +659,17 @@ assert r.present == 18479
 
 = SNMP assembling
 ~ SNMP ASN1
-str(SNMP())
+raw(SNMP())
 assert(_ == b'0\x18\x02\x01\x01\x04\x06public\xa0\x0b\x02\x01\x00\x02\x01\x00\x02\x01\x000\x00')
 SNMP(version="v2c", community="ABC", PDU=SNMPbulk(id=4,varbindlist=[SNMPvarbind(oid="1.2.3.4",value=ASN1_INTEGER(7)),SNMPvarbind(oid="4.3.2.1.2.3",value=ASN1_IA5_STRING("testing123"))]))
-str(_)
+raw(_)
 assert(_ == b'05\x02\x01\x01\x04\x03ABC\xa5+\x02\x01\x04\x02\x01\x00\x02\x01\x000 0\x08\x06\x03*\x03\x04\x02\x01\x070\x14\x06\x06\x81#\x02\x01\x02\x03\x16\ntesting123')
 
 = SNMP disassembling
 ~ SNMP ASN1
 x=SNMP(b'0y\x02\x01\x00\x04\x06public\xa2l\x02\x01)\x02\x01\x00\x02\x01\x000a0!\x06\x12+\x06\x01\x04\x01\x81}\x08@\x04\x02\x01\x07\n\x86\xde\xb78\x04\x0b172.31.19.20#\x06\x12+\x06\x01\x04\x01\x81}\x08@\x04\x02\x01\x07\n\x86\xde\xb76\x04\r255.255.255.00\x17\x06\x12+\x06\x01\x04\x01\x81}\x08@\x04\x02\x01\x05\n\x86\xde\xb9`\x02\x01\x01')
 x.show()
-assert(x.community=="public" and x.version == 0)
+assert(x.community==b"public" and x.version == 0)
 assert(x.PDU.id == 41 and len(x.PDU.varbindlist) == 3)
 assert(x.PDU.varbindlist[0].oid == "1.3.6.1.4.1.253.8.64.4.2.1.7.10.14130104")
 assert(x.PDU.varbindlist[0].value == "172.31.19.2")
@@ -721,7 +721,7 @@ DNS in dns_ans
 import time
 import socket
 success = False
-for i in xrange(5):
+for i in six.moves.range(5):
     try:
         IP(src="8.8.8.8").whois()
     except socket.error:
@@ -738,7 +738,7 @@ assert success
 
 ret = list()
 success = False
-for i in xrange(5):
+for i in six.moves.range(5):
     try:
         ret = conf.AS_resolver.resolve("8.8.8.8", "8.8.4.4")
     except RuntimeError:
@@ -758,7 +758,7 @@ all(x[1] == "AS15169" for x in ret)
 ret = list()
 success = False
 as_resolver6 = AS_resolver6()
-for i in xrange(5):
+for i in six.moves.range(5):
     try:
         ret = as_resolver6.resolve("2001:4860:4860::8888", "2001:4860:4860::4444")
     except socket.error:
@@ -771,7 +771,7 @@ assert (len(ret) == 2)
 assert all(x[1] == 15169 for x in ret)
 
 success = False
-for i in xrange(5):
+for i in six.moves.range(5):
     try:
         ret = AS_resolver_riswhois().resolve("8.8.8.8")
     except socket.error:
@@ -785,7 +785,7 @@ assert all(x[1] == "AS15169" for x in ret)
 
 # This test is too buggy
 #success = False
-#for i in xrange(5):
+#for i in six.moves.range(5):
 #    try:
 #        ret = AS_resolver_cymru().resolve("8.8.8.8")
 #    except socket.error:
@@ -841,17 +841,17 @@ s.show(2)
 dns_ans.show()
 dns_ans.show2()
 dns_ans[DNS].an.show()
-dns_ans2 = IP(str(dns_ans))
+dns_ans2 = IP(raw(dns_ans))
 DNS in dns_ans2
-assert(str(dns_ans2) == str(dns_ans))
+assert(raw(dns_ans2) == str(dns_ans))
 dns_ans2.qd.qname = "www.secdev.org."
 * We need to recalculate these values
 del(dns_ans2[IP].len)
 del(dns_ans2[IP].chksum)
 del(dns_ans2[UDP].len)
 del(dns_ans2[UDP].chksum)
-assert(b"\x03www\x06secdev\x03org\x00" in str(dns_ans2))
-assert(DNS in IP(str(dns_ans2)))
+assert(b"\x03www\x06secdev\x03org\x00" in raw(dns_ans2))
+assert(DNS in IP(raw(dns_ans2)))
 
 = Arping
 ~ netaccess
@@ -878,20 +878,20 @@ def _send_or_sniff(pkt, timeout, flt, pid, fork, t_other=None):
         else:
             return
     else:
-        spkt = str(pkt)
+        spkt = raw(pkt)
         # We do not want to crash when a packet cannot be parsed
         old_debug_dissector = conf.debug_dissector
         conf.debug_dissector = False
         pkts = sniff(
             timeout=timeout, filter=flt,
-            stop_filter=lambda p: pkt.__class__ in p and str(p[pkt.__class__]) == spkt
+            stop_filter=lambda p: pkt.__class__ in p and raw(p[pkt.__class__]) == spkt
         )
         conf.debug_dissector = old_debug_dissector
         if fork:
             os.waitpid(pid, 0)
         else:
             t_other.join()
-    assert str(pkt) in (str(p[pkt.__class__]) for p in pkts if pkt.__class__ in p)
+    assert raw(pkt) in (str(p[pkt.__class__]) for p in pkts if pkt.__class__ in p)
 
 def send_and_sniff(pkt, timeout=2, flt=None):
     """Send a packet, sniff, and check the packet has been seen"""
@@ -1267,13 +1267,13 @@ assert( _ == "Venus" )
 
 = IP options individual assembly
 ~ IP options
-str(IPOption())
+raw(IPOption())
 assert(_ == b'\x00\x02')
-str(IPOption_NOP())
+raw(IPOption_NOP())
 assert(_ == b'\x01')
-str(IPOption_EOL())
+raw(IPOption_EOL())
 assert(_ == b'\x00')
-str(IPOption_LSRR(routers=["1.2.3.4","5.6.7.8"]))
+raw(IPOption_LSRR(routers=["1.2.3.4","5.6.7.8"]))
 assert(_ == b'\x83\x0b\x04\x01\x02\x03\x04\x05\x06\x07\x08')
 
 = IP options individual dissection
@@ -1292,21 +1292,21 @@ assert(p == q)
 = IP assembly and dissection with options
 ~ IP options
 p = IP(src="9.10.11.12",dst="13.14.15.16",options=IPOption_SDBM(addresses=["1.2.3.4","5.6.7.8"]))/TCP()
-str(p)
+raw(p)
 assert(_ == b'H\x00\x004\x00\x01\x00\x00@\x06\xa2q\t\n\x0b\x0c\r\x0e\x0f\x10\x95\n\x01\x02\x03\x04\x05\x06\x07\x08\x00\x00\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00_K\x00\x00')
 q=IP(_)
 q
 assert( isinstance(q.options[0],IPOption_SDBM) )
 assert( q[IPOption_SDBM].addresses[1] == "5.6.7.8" )
 p.options[0].addresses[0] = '5.6.7.8'
-assert( IP(str(p)).options[0].addresses[0] == '5.6.7.8' )
+assert( IP(raw(p)).options[0].addresses[0] == '5.6.7.8' )
 IP(src="9.10.11.12", dst="13.14.15.16", options=[IPOption_NOP(),IPOption_LSRR(routers=["1.2.3.4","5.6.7.8"]),IPOption_Security(transmission_control_code="XYZ")])/TCP()
-str(_)
+raw(_)
 assert(_ == b'K\x00\x00@\x00\x01\x00\x00@\x06\xf3\x83\t\n\x0b\x0c\r\x0e\x0f\x10\x01\x83\x0b\x04\x01\x02\x03\x04\x05\x06\x07\x08\x82\x0b\x00\x00\x00\x00\x00\x00XYZ\x00\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00_K\x00\x00')
 IP(_)
 q=_
 assert(q[IPOption_LSRR].get_current_router() == "1.2.3.4")
-assert(q[IPOption_Security].transmission_control_code == "XYZ")
+assert(q[IPOption_Security].transmission_control_code == b"XYZ")
 assert(q[TCP].flags == 2)
 
 
@@ -1317,7 +1317,7 @@ assert(q[TCP].flags == 2)
 = PPP/HDLC
 ~ ppp hdlc
 HDLC()/PPP()/PPP_IPCP()
-str(_)
+raw(_)
 s=_
 assert(s == b'\xff\x03\x80!\x01\x00\x00\x04')
 PPP(s)
@@ -1339,15 +1339,15 @@ assert(p[PPP_IPCP].code == 1)
 assert(p[PPP_IPCP_Option_IPAddress].data=="192.168.1.1")
 assert(p[PPP_IPCP_Option].data == b'\x00-\x0f\x01')
 p=PPP()/PPP_IPCP(options=[PPP_IPCP_Option_DNS1(data="1.2.3.4"),PPP_IPCP_Option_DNS2(data="5.6.7.8"),PPP_IPCP_Option_NBNS2(data="9.10.11.12")])
-str(p)
+raw(p)
 assert(_ == b'\x80!\x01\x00\x00\x16\x81\x06\x01\x02\x03\x04\x83\x06\x05\x06\x07\x08\x84\x06\t\n\x0b\x0c')
 PPP(_)
 q=_
-assert(str(p) == str(q))
-assert(PPP(str(q))==q)
+assert(raw(p) == str(q))
+assert(PPP(raw(q))==q)
 PPP()/PPP_IPCP(options=[PPP_IPCP_Option_DNS1(data="1.2.3.4"),PPP_IPCP_Option_DNS2(data="5.6.7.8"),PPP_IPCP_Option(type=123,data="ABCDEFG"),PPP_IPCP_Option_NBNS2(data="9.10.11.12")])
 p=_
-str(p)
+raw(p)
 assert(_ == b'\x80!\x01\x00\x00\x1f\x81\x06\x01\x02\x03\x04\x83\x06\x05\x06\x07\x08{\tABCDEFG\x84\x06\t\n\x0b\x0c')
 PPP(_)
 q=_
@@ -1361,18 +1361,18 @@ assert( q[PPP_IPCP_Option_NBNS2].data == '9.10.11.12' )
 
 PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui="XYZ")])
 p=_
-str(p)
+raw(p)
 assert(_ == b'\x80S\x01\x00\x00\n\x00\x06XYZ\x00')
 PPP(_)
 q=_
-assert( str(p)==str(q) )
+assert( raw(p)==str(q) )
 PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui="XYZ"),PPP_ECP_Option(type=1,data="ABCDEFG")])
 p=_
-str(p)
+raw(p)
 assert(_ == b'\x80S\x01\x00\x00\x13\x00\x06XYZ\x00\x01\tABCDEFG')
 PPP(_)
 q=_
-assert( str(p) == str(q) )
+assert( raw(p) == str(q) )
 assert( q[PPP_ECP_Option].data == "ABCDEFG" )
 
 
@@ -1385,35 +1385,35 @@ assert( q[PPP_ECP_Option].data == "ABCDEFG" )
 a=IPv6() 
 
 = IPv6 Class basic build (default values)
-str(IPv6()) == b'`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(IPv6()) == b'`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = IPv6 Class basic dissection (default values)
-a=IPv6(str(IPv6())) 
+a=IPv6(raw(IPv6())) 
 a.version == 6 and a.tc == 0 and a.fl == 0 and a.plen == 0 and a.nh == 59 and a.hlim ==64 and a.src == "::1" and a.dst == "::1"
 
 = IPv6 Class with basic TCP stacked - build
-str(IPv6()/TCP()) == b'`\x00\x00\x00\x00\x14\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f}\x00\x00'
+raw(IPv6()/TCP()) == b'`\x00\x00\x00\x00\x14\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f}\x00\x00'
 
 = IPv6 Class with basic TCP stacked - dissection
-a=IPv6(str(IPv6()/TCP()))
+a=IPv6(raw(IPv6()/TCP()))
 a.nh == 6 and a.plen == 20 and isinstance(a.payload, TCP) and a.payload.chksum == 0x8f7d
 
 = IPv6 Class with TCP and TCP data - build
-str(IPv6()/TCP()/Raw(load="somedata")) == b'`\x00\x00\x00\x00\x1c\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xd5\xdd\x00\x00somedata'
+raw(IPv6()/TCP()/Raw(load="somedata")) == b'`\x00\x00\x00\x00\x1c\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xd5\xdd\x00\x00somedata'
 
 = IPv6 Class with TCP and TCP data - dissection
-a=IPv6(str(IPv6()/TCP()/Raw(load="somedata")))
-a.nh == 6 and a.plen == 28 and isinstance(a.payload, TCP) and a.payload.chksum == 0xd5dd and isinstance(a.payload.payload, Raw) and a[Raw].load == "somedata"
+a=IPv6(raw(IPv6()/TCP()/Raw(load="somedata")))
+a.nh == 6 and a.plen == 28 and isinstance(a.payload, TCP) and a.payload.chksum == 0xd5dd and isinstance(a.payload.payload, Raw) and a[Raw].load == b"somedata"
 
 = IPv6 Class binding with Ethernet - build
-str(Ether(src="00:00:00:00:00:00", dst="ff:ff:ff:ff:ff:ff")/IPv6()/TCP()) == b'\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x86\xdd`\x00\x00\x00\x00\x14\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f}\x00\x00'
+raw(Ether(src="00:00:00:00:00:00", dst="ff:ff:ff:ff:ff:ff")/IPv6()/TCP()) == b'\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x86\xdd`\x00\x00\x00\x00\x14\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f}\x00\x00'
 
 = IPv6 Class binding with Ethernet - dissection
-a=Ether(str(Ether()/IPv6()/TCP()))
+a=Ether(raw(Ether()/IPv6()/TCP()))
 a.type == 0x86dd
 
 = IPv6 Class binding with GRE - build
-s = str(IP(src="127.0.0.1")/GRE()/Ether(dst="ff:ff:ff:ff:ff:ff", src="00:00:00:00:00:00")/IP()/GRE()/IPv6(src="::1"))
+s = raw(IP(src="127.0.0.1")/GRE()/Ether(dst="ff:ff:ff:ff:ff:ff", src="00:00:00:00:00:00")/IP()/GRE()/IPv6(src="::1"))
 s == b'E\x00\x00f\x00\x01\x00\x00@/|f\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x00eX\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x08\x00E\x00\x00@\x00\x01\x00\x00@/|\x8c\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x00\x86\xdd`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = IPv6 Class binding with GRE - dissection
@@ -1424,24 +1424,24 @@ GRE in p and p[GRE:1].proto == 0x6558 and p[GRE:2].proto == 0x86DD and IPv6 in p
 ########### IPv6ExtHdrRouting Class ###########################
 
 = IPv6ExtHdrRouting Class - No address - build
-str(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=[])/TCP(dport=80)) ==b'`\x00\x00\x00\x00\x1c+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xa5&\x00\x00' 
+raw(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=[])/TCP(dport=80)) ==b'`\x00\x00\x00\x00\x1c+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xa5&\x00\x00' 
 
 = IPv6ExtHdrRouting Class - One address - build
-str(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2022::deca"])/TCP(dport=80)) == b'`\x00\x00\x00\x00,+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x02\x00\x01\x00\x00\x00\x00 "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2022::deca"])/TCP(dport=80)) == b'`\x00\x00\x00\x00,+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x02\x00\x01\x00\x00\x00\x00 "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
 
 = IPv6ExtHdrRouting Class - Multiple Addresses - build
-str(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"])/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x02\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"])/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x02\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
 
 = IPv6ExtHdrRouting Class - Specific segleft (2->1) - build
-str(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"], segleft=1)/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x01\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"], segleft=1)/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x01\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91\x7f\x00\x00'
 
 = IPv6ExtHdrRouting Class - Specific segleft (2->0) - build
-str(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"], segleft=0)/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x00\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xa5&\x00\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/IPv6ExtHdrRouting(addresses=["2001::deca", "2022::deca"], segleft=0)/TCP(dport=80)) == b'`\x00\x00\x00\x00<+@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x06\x04\x00\x00\x00\x00\x00\x00 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xa5&\x00\x00'
 
 ########### IPv6ExtHdrSegmentRouting Class ###########################
 
 = IPv6ExtHdrSegmentRouting Class - default - build & dissect
-s = str(IPv6()/IPv6ExtHdrSegmentRouting()/UDP())
+s = raw(IPv6()/IPv6ExtHdrSegmentRouting()/UDP())
 assert(s == b'`\x00\x00\x00\x00 +@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x11\x02\x04\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x005\x005\x00\x08\xffr')
 
 p = IPv6(s)
@@ -1450,7 +1450,7 @@ assert(len(p[IPv6ExtHdrSegmentRouting].addresses) == 1 and len(p[IPv6ExtHdrSegme
 
 = IPv6ExtHdrSegmentRouting Class - empty lists - build & dissect
 
-s = str(IPv6()/IPv6ExtHdrSegmentRouting(addresses=[], tlv_objects=[])/UDP())
+s = raw(IPv6()/IPv6ExtHdrSegmentRouting(addresses=[], tlv_objects=[])/UDP())
 assert(s == b'`\x00\x00\x00\x00\x10+@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x11\x00\x04\x00\x00\x00\x00\x00\x005\x005\x00\x08\xffr')
 
 p = IPv6(s)
@@ -1459,7 +1459,7 @@ assert(len(p[IPv6ExtHdrSegmentRouting].addresses) == 0 and len(p[IPv6ExtHdrSegme
 
 = IPv6ExtHdrSegmentRouting Class - addresses list - build & dissect
 
-s = str(IPv6()/IPv6ExtHdrSegmentRouting(addresses=["::1", "::2", "::3"])/UDP())
+s = raw(IPv6()/IPv6ExtHdrSegmentRouting(addresses=["::1", "::2", "::3"])/UDP())
 assert(s == b'`\x00\x00\x00\x00@+@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x11\x06\x04\x02\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x005\x005\x00\x08\xffr')
 
 p = IPv6(s)
@@ -1468,7 +1468,7 @@ assert(len(p[IPv6ExtHdrSegmentRouting].addresses) == 3 and len(p[IPv6ExtHdrSegme
 
 = IPv6ExtHdrSegmentRouting Class - TLVs list - build & dissect
 
-s = str(IPv6()/IPv6ExtHdrSegmentRouting(addresses=[], tlv_objects=[IPv6ExtHdrSegmentRoutingTLV()])/TCP())
+s = raw(IPv6()/IPv6ExtHdrSegmentRouting(addresses=[], tlv_objects=[IPv6ExtHdrSegmentRoutingTLV()])/TCP())
 assert(s == b'`\x00\x00\x00\x00$+@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x06\x01\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x02\x00\x00\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f}\x00\x00')
 
 p = IPv6(s)
@@ -1478,7 +1478,7 @@ assert(isinstance(p[IPv6ExtHdrSegmentRouting].tlv_objects[1], IPv6ExtHdrSegmentR
 
 = IPv6ExtHdrSegmentRouting Class - both lists - build & dissect
 
-s = str(IPv6()/IPv6ExtHdrSegmentRouting(addresses=["::1", "::2", "::3"], tlv_objects=[IPv6ExtHdrSegmentRoutingTLVIngressNode(),IPv6ExtHdrSegmentRoutingTLVEgressNode()])/ICMPv6EchoRequest())
+s = raw(IPv6()/IPv6ExtHdrSegmentRouting(addresses=["::1", "::2", "::3"], tlv_objects=[IPv6ExtHdrSegmentRoutingTLVIngressNode(),IPv6ExtHdrSegmentRoutingTLVEgressNode()])/ICMPv6EchoRequest())
 assert(s == b'`\x00\x00\x00\x00h+@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01:\x0b\x04\x02\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03\x01\x12\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x12\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x80\x00\x7f\xbb\x00\x00\x00\x00')
 
 p = IPv6(s)
@@ -1500,7 +1500,7 @@ in6_get6to4Prefix("255.255.255.255") == "2002:ffff:ffff::"
 in6_get6to4Prefix("1.1.1.1") == "2002:101:101::"
 
 = Test in6_get6to4Prefix() - invalid address
-in6_get6to4Prefix("somebadstring") is None
+in6_get6to4Prefix("somebadrawing") is None
 
 
 ############
@@ -1517,7 +1517,7 @@ in6_6to4ExtractAddr("2002:ffff:ffff::") == "255.255.255.255"
 in6_6to4ExtractAddr("2002:101:101::") == "1.1.1.1"
 
 = Test in6_6to4ExtractAddr() - invalid address
-in6_6to4ExtractAddr("somebadstring") is None
+in6_6to4ExtractAddr("somebadrawing") is None
 
 
 ########### RFC 4489 - Link-Scoped IPv6 Multicast address ###########
@@ -1604,7 +1604,7 @@ in6_addrtomac("FE80::" + in6_mactoifaceid("FF:00:00:00:00:00", ulbit=0)) == 'ff:
 import socket
 
 res=True
-for a in xrange(10):
+for a in six.moves.range(10):
     s1,s2 = in6_getRandomizedIfaceId('20b:93ff:feeb:2d3')
     inet_pton(socket.AF_INET6, '::'+s1)
     tmp2 = inet_pton(socket.AF_INET6, '::'+s2)
@@ -1674,51 +1674,51 @@ in6_getAddrType("1000::1") == (IPV6_ADDR_GLOBAL | IPV6_ADDR_UNICAST)
 ########### ICMPv6DestUnreach Class #################################
 
 = ICMPv6DestUnreach Class - Basic Build (no argument)
-str(ICMPv6DestUnreach()) == b'\x01\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6DestUnreach()) == b'\x01\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6DestUnreach Class - Basic Build over IPv6 (for cksum and overload)
-str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()) == b'`\x00\x00\x00\x00\x08:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x01\x00\x14e\x00\x00\x00\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()) == b'`\x00\x00\x00\x00\x08:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x01\x00\x14e\x00\x00\x00\x00'
 
 = ICMPv6DestUnreach Class - Basic Build over IPv6 with some payload
-str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()/IPv6(src="2047::cafe", dst="2048::deca")) == b'`\x00\x00\x00\x000:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x01\x00\x8e\xa3\x00\x00\x00\x00`\x00\x00\x00\x00\x00;@ G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()/IPv6(src="2047::cafe", dst="2048::deca")) == b'`\x00\x00\x00\x000:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x01\x00\x8e\xa3\x00\x00\x00\x00`\x00\x00\x00\x00\x00;@ G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca'
 
 = ICMPv6DestUnreach Class - Dissection with default values and some payload
-a = IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()/IPv6(src="2047::cafe", dst="2048::deca")))
+a = IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach()/IPv6(src="2047::cafe", dst="2048::deca")))
 a.plen == 48 and a.nh == 58 and ICMPv6DestUnreach in a and a[ICMPv6DestUnreach].type == 1 and a[ICMPv6DestUnreach].code == 0 and a[ICMPv6DestUnreach].cksum == 0x8ea3 and a[ICMPv6DestUnreach].unused == 0 and IPerror6 in a
 
 = ICMPv6DestUnreach Class - Dissection with specific values
-a=IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach(code=1, cksum=0x6666, unused=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")))
+a=IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach(code=1, cksum=0x6666, unused=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")))
 a.plen == 48 and a.nh == 58 and ICMPv6DestUnreach in a and a[ICMPv6DestUnreach].type == 1 and a[ICMPv6DestUnreach].cksum == 0x6666 and a[ICMPv6DestUnreach].unused == 0x7777 and IPerror6 in a[ICMPv6DestUnreach]
 
 = ICMPv6DestUnreach Class - checksum computation related stuff
-a=IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach(code=1, cksum=0x6666, unused=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
-b=IPv6(str(IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
+a=IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6DestUnreach(code=1, cksum=0x6666, unused=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
+b=IPv6(raw(IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
 a[ICMPv6DestUnreach][TCPerror].chksum == b.chksum
 
 
 ########### ICMPv6PacketTooBig Class ################################
 
 = ICMPv6PacketTooBig Class - Basic Build (no argument)
-str(ICMPv6PacketTooBig()) == b'\x02\x00\x00\x00\x00\x00\x05\x00'
+raw(ICMPv6PacketTooBig()) == b'\x02\x00\x00\x00\x00\x00\x05\x00'
 
 = ICMPv6PacketTooBig Class - Basic Build over IPv6 (for cksum and overload)
-str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()) == b'`\x00\x00\x00\x00\x08:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x02\x00\x0ee\x00\x00\x05\x00'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()) == b'`\x00\x00\x00\x00\x08:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x02\x00\x0ee\x00\x00\x05\x00'
 
 = ICMPv6PacketTooBig Class - Basic Build over IPv6 with some payload
-str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()/IPv6(src="2047::cafe", dst="2048::deca")) == b'`\x00\x00\x00\x000:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x02\x00\x88\xa3\x00\x00\x05\x00`\x00\x00\x00\x00\x00;@ G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca'
+raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()/IPv6(src="2047::cafe", dst="2048::deca")) == b'`\x00\x00\x00\x000:@ H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x02\x00\x88\xa3\x00\x00\x05\x00`\x00\x00\x00\x00\x00;@ G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca'
 
 = ICMPv6PacketTooBig Class - Dissection with default values and some payload
-a = IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()/IPv6(src="2047::cafe", dst="2048::deca")))
+a = IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig()/IPv6(src="2047::cafe", dst="2048::deca")))
 a.plen == 48 and a.nh == 58 and ICMPv6PacketTooBig in a and a[ICMPv6PacketTooBig].type == 2 and a[ICMPv6PacketTooBig].code == 0 and a[ICMPv6PacketTooBig].cksum == 0x88a3 and a[ICMPv6PacketTooBig].mtu == 1280 and IPerror6 in a
 True
 
 = ICMPv6PacketTooBig Class - Dissection with specific values
-a=IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig(code=2, cksum=0x6666, mtu=1460)/IPv6(src="2047::cafe", dst="2048::deca")))
+a=IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig(code=2, cksum=0x6666, mtu=1460)/IPv6(src="2047::cafe", dst="2048::deca")))
 a.plen == 48 and a.nh == 58 and ICMPv6PacketTooBig in a and a[ICMPv6PacketTooBig].type == 2 and a[ICMPv6PacketTooBig].code == 2 and a[ICMPv6PacketTooBig].cksum == 0x6666 and a[ICMPv6PacketTooBig].mtu == 1460 and IPerror6 in a
 
 = ICMPv6PacketTooBig Class - checksum computation related stuff
-a=IPv6(str(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig(code=1, cksum=0x6666, mtu=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
-b=IPv6(str(IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
+a=IPv6(raw(IPv6(src="2048::deca", dst="2047::cafe")/ICMPv6PacketTooBig(code=1, cksum=0x6666, mtu=0x7777)/IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
+b=IPv6(raw(IPv6(src="2047::cafe", dst="2048::deca")/TCP()))
 a[ICMPv6PacketTooBig][TCPerror].chksum == b.chksum
 
 
@@ -1734,21 +1734,21 @@ a[ICMPv6PacketTooBig][TCPerror].chksum == b.chksum
 + Test ICMPv6EchoRequest Class
 
 = ICMPv6EchoRequest - Basic Instantiation
-str(ICMPv6EchoRequest()) == b'\x80\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6EchoRequest()) == b'\x80\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6EchoRequest - Instantiation with specific values
-str(ICMPv6EchoRequest(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisissomestring")) == b'\x80\xff\x11\x11""33thisissomestring'
+raw(ICMPv6EchoRequest(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisissomestring")) == b'\x80\xff\x11\x11""33thisissomestring'
 
 = ICMPv6EchoRequest - Basic dissection
 a=ICMPv6EchoRequest(b'\x80\x00\x00\x00\x00\x00\x00\x00')
 a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
 
 = ICMPv6EchoRequest - Dissection with specific values 
-a=ICMPv6EchoRequest(b'\x80\xff\x11\x11""33thisissomestring')
-a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomestring"
+a=ICMPv6EchoRequest(b'\x80\xff\x11\x11""33thisissomerawing')
+a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomerawing"
 
 = ICMPv6EchoRequest - Automatic checksum computation and field overloading (build)
-str(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoRequest()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x80\x00\x95\xf1\x00\x00\x00\x00'
+raw(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoRequest()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x80\x00\x95\xf1\x00\x00\x00\x00'
 
 = ICMPv6EchoRequest - Automatic checksum computation and field overloading (dissection)
 a=IPv6(b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x80\x00\x95\xf1\x00\x00\x00\x00')
@@ -1760,21 +1760,21 @@ isinstance(a, IPv6) and a.nh == 58 and isinstance(a.payload, ICMPv6EchoRequest) 
 + Test ICMPv6EchoReply Class
 
 = ICMPv6EchoReply - Basic Instantiation
-str(ICMPv6EchoReply()) == b'\x81\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6EchoReply()) == b'\x81\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6EchoReply - Instantiation with specific values
-str(ICMPv6EchoReply(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisissomestring")) == b'\x81\xff\x11\x11""33thisissomestring'
+raw(ICMPv6EchoReply(code=0xff, cksum=0x1111, id=0x2222, seq=0x3333, data="thisissomestring")) == b'\x81\xff\x11\x11""33thisissomestring'
 
 = ICMPv6EchoReply - Basic dissection
 a=ICMPv6EchoReply(b'\x80\x00\x00\x00\x00\x00\x00\x00')
 a.type == 128 and a.code == 0 and a.cksum == 0 and a.id == 0 and a.seq == 0 and a.data == ""
 
 = ICMPv6EchoReply - Dissection with specific values 
-a=ICMPv6EchoReply(b'\x80\xff\x11\x11""33thisissomestring')
-a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomestring"
+a=ICMPv6EchoReply(b'\x80\xff\x11\x11""33thisissomerawing')
+a.type == 128 and a.code == 0xff and a.cksum == 0x1111 and a.id == 0x2222 and a.seq == 0x3333 and a.data == "thisissomerawing"
 
 = ICMPv6EchoReply - Automatic checksum computation and field overloading (build)
-str(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoReply()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x81\x00\x94\xf1\x00\x00\x00\x00'
+raw(IPv6(dst="2001::cafe", src="2001::deca", hlim=64)/ICMPv6EchoReply()) == b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x81\x00\x94\xf1\x00\x00\x00\x00'
 
 = ICMPv6EchoReply - Automatic checksum computation and field overloading (dissection)
 a=IPv6(b'`\x00\x00\x00\x00\x08:@ \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe\x80\x00\x95\xf1\x00\x00\x00\x00')
@@ -1825,35 +1825,35 @@ assert (a > b)
 ########### ICMPv6MRD* Classes ######################################
 
 = ICMPv6MRD_Advertisement - Basic instantiation
-str(ICMPv6MRD_Advertisement()) == b'\x97\x14\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6MRD_Advertisement()) == b'\x97\x14\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6MRD_Advertisement - Instantiation with specific values
-str(ICMPv6MRD_Advertisement(advinter=0xdd, queryint=0xeeee, robustness=0xffff)) == b'\x97\xdd\x00\x00\xee\xee\xff\xff'
+raw(ICMPv6MRD_Advertisement(advinter=0xdd, queryint=0xeeee, robustness=0xffff)) == b'\x97\xdd\x00\x00\xee\xee\xff\xff'
 
 = ICMPv6MRD_Advertisement - Basic Dissection and overloading mechanisms
-a=Ether(str(Ether()/IPv6()/ICMPv6MRD_Advertisement()))
+a=Ether(raw(Ether()/IPv6()/ICMPv6MRD_Advertisement()))
 a.dst == "33:33:00:00:00:02" and IPv6 in a and a[IPv6].plen == 8 and a[IPv6].nh == 58 and a[IPv6].hlim == 1 and a[IPv6].dst == "ff02::2" and ICMPv6MRD_Advertisement in a and a[ICMPv6MRD_Advertisement].type == 151 and a[ICMPv6MRD_Advertisement].advinter == 20 and a[ICMPv6MRD_Advertisement].queryint == 0 and a[ICMPv6MRD_Advertisement].robustness == 0
 
 
 = ICMPv6MRD_Solicitation - Basic dissection
-str(ICMPv6MRD_Solicitation()) == b'\x98\x00\x00\x00'
+raw(ICMPv6MRD_Solicitation()) == b'\x98\x00\x00\x00'
 
 = ICMPv6MRD_Solicitation - Instantiation with specific values 
-str(ICMPv6MRD_Solicitation(res=0xbb)) == b'\x98\xbb\x00\x00'
+raw(ICMPv6MRD_Solicitation(res=0xbb)) == b'\x98\xbb\x00\x00'
 
 = ICMPv6MRD_Solicitation - Basic Dissection and overloading mechanisms
-a=Ether(str(Ether()/IPv6()/ICMPv6MRD_Solicitation()))
+a=Ether(raw(Ether()/IPv6()/ICMPv6MRD_Solicitation()))
 a.dst == "33:33:00:00:00:02" and IPv6 in a and a[IPv6].plen == 4 and a[IPv6].nh == 58 and a[IPv6].hlim == 1 and a[IPv6].dst == "ff02::2" and ICMPv6MRD_Solicitation in a and a[ICMPv6MRD_Solicitation].type == 152 and a[ICMPv6MRD_Solicitation].res == 0
 
 
 = ICMPv6MRD_Termination Basic instantiation
-str(ICMPv6MRD_Termination()) == b'\x99\x00\x00\x00'
+raw(ICMPv6MRD_Termination()) == b'\x99\x00\x00\x00'
 
 = ICMPv6MRD_Termination - Instantiation with specific values 
-str(ICMPv6MRD_Termination(res=0xbb)) == b'\x99\xbb\x00\x00'
+raw(ICMPv6MRD_Termination(res=0xbb)) == b'\x99\xbb\x00\x00'
 
 = ICMPv6MRD_Termination - Basic Dissection and overloading mechanisms
-a=Ether(str(Ether()/IPv6()/ICMPv6MRD_Termination()))
+a=Ether(raw(Ether()/IPv6()/ICMPv6MRD_Termination()))
 a.dst == "33:33:00:00:00:6a" and IPv6 in a and a[IPv6].plen == 4 and a[IPv6].nh == 58 and a[IPv6].hlim == 1 and a[IPv6].dst == "ff02::6a" and ICMPv6MRD_Termination in a and a[ICMPv6MRD_Termination].type == 153 and a[ICMPv6MRD_Termination].res == 0
 
 
@@ -1862,17 +1862,17 @@ a.dst == "33:33:00:00:00:6a" and IPv6 in a and a[IPv6].plen == 4 and a[IPv6].nh 
 + Test HBHOptUnknown Class
 
 = HBHOptUnknown - Basic Instantiation 
-str(HBHOptUnknown()) == b'\x01\x00'
+raw(HBHOptUnknown()) == b'\x01\x00'
 
 = HBHOptUnknown - Basic Dissection 
 a=HBHOptUnknown(b'\x01\x00')
 a.otype == 0x01 and a.optlen == 0 and a.optdata == ""
 
 = HBHOptUnknown - Automatic optlen computation
-str(HBHOptUnknown(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
+raw(HBHOptUnknown(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
 
 = HBHOptUnknown - Instantiation with specific values
-str(HBHOptUnknown(optlen=9, optdata="B"*10)) == b'\x01\tBBBBBBBBBB'
+raw(HBHOptUnknown(optlen=9, optdata="B"*10)) == b'\x01\tBBBBBBBBBB'
 
 = HBHOptUnknown - Dissection with specific values 
 a=HBHOptUnknown(b'\x01\tBBBBBBBBBB')
@@ -1884,10 +1884,10 @@ a.otype == 0x01 and a.optlen == 9 and a.optdata == "B"*9 and isinstance(a.payloa
 + Test Pad1 Class
 
 = Pad1 - Basic Instantiation
-str(Pad1()) == b'\x00'
+raw(Pad1()) == b'\x00'
 
 = Pad1 - Basic Dissection
-str(Pad1(b'\x00')) == b'\x00'
+raw(Pad1(b'\x00')) == b'\x00'
 
 
 ############
@@ -1895,10 +1895,10 @@ str(Pad1(b'\x00')) == b'\x00'
 + Test PadN Class
 
 = PadN - Basic Instantiation
-str(PadN()) == b'\x01\x00'
+raw(PadN()) == b'\x01\x00'
 
 = PadN - Optlen Automatic computation
-str(PadN(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
+raw(PadN(optdata="B"*10)) == b'\x01\nBBBBBBBBBB'
 
 = PadN - Basic Dissection
 a=PadN(b'\x01\x00')
@@ -1909,7 +1909,7 @@ a=PadN(b'\x01\x0cBBBBBBBBBB')
 a.otype == 1 and a.optlen == 12 and a.optdata == 'BBBBBBBBBB'
 
 = PadN - Instantiation with forced optlen 
-str(PadN(optdata="B"*10, optlen=9)) == b'\x01\x09BBBBBBBBBB'
+raw(PadN(optdata="B"*10, optlen=9)) == b'\x01\x09BBBBBBBBBB'
 
 
 ############
@@ -1917,14 +1917,14 @@ str(PadN(optdata="B"*10, optlen=9)) == b'\x01\x09BBBBBBBBBB'
 + Test RouterAlert Class (RFC 2711)
 
 = RouterAlert - Basic Instantiation 
-str(RouterAlert()) == b'\x05\x02\x00\x00'
+raw(RouterAlert()) == b'\x05\x02\x00\x00'
 
 = RouterAlert - Basic Dissection 
 a=RouterAlert(b'\x05\x02\x00\x00')
 a.otype == 0x05 and a.optlen == 2 and a.value == 00
 
 = RouterAlert - Instantiation with specific values 
-str(RouterAlert(optlen=3, value=0xffff)) == b'\x05\x03\xff\xff' 
+raw(RouterAlert(optlen=3, value=0xffff)) == b'\x05\x03\xff\xff' 
 
 = RouterAlert - Instantiation with specific values
 a=RouterAlert(b'\x05\x03\xff\xff')
@@ -1936,14 +1936,14 @@ a.otype == 0x05 and a.optlen == 3 and a.value == 0xffff
 + Test Jumbo Class (RFC 2675)
 
 = Jumbo - Basic Instantiation 
-str(Jumbo()) == b'\xc2\x04\x00\x00\x00\x00'
+raw(Jumbo()) == b'\xc2\x04\x00\x00\x00\x00'
 
 = Jumbo - Basic Dissection 
 a=Jumbo(b'\xc2\x04\x00\x00\x00\x00')
 a.otype == 0xC2 and a.optlen == 4 and a.jumboplen == 0
 
 = Jumbo - Instantiation with specific values
-str(Jumbo(optlen=6, jumboplen=0xffffffff)) == b'\xc2\x06\xff\xff\xff\xff'
+raw(Jumbo(optlen=6, jumboplen=0xffffffff)) == b'\xc2\x06\xff\xff\xff\xff'
 
 = Jumbo - Dissection with specific values 
 a=Jumbo(b'\xc2\x06\xff\xff\xff\xff')
@@ -1955,14 +1955,14 @@ a.otype == 0xc2 and a.optlen == 6 and a.jumboplen == 0xffffffff
 + Test HAO Class (RFC 3775)
 
 = HAO - Basic Instantiation 
-str(HAO()) == b'\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(HAO()) == b'\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = HAO - Basic Dissection 
 a=HAO(b'\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 a.otype == 0xC9 and a.optlen == 16 and a.hoa == "::"
 
 = HAO - Instantiation with specific values
-str(HAO(optlen=9, hoa="2001::ffff")) == b'\xc9\t \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff'
+raw(HAO(optlen=9, hoa="2001::ffff")) == b'\xc9\t \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff'
 
 = HAO - Dissection with specific values 
 a=HAO(b'\xc9\t \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff')
@@ -1979,40 +1979,40 @@ p.hashret() == b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
 + Test IPv6ExtHdrHopByHop()
 
 = IPv6ExtHdrHopByHop - Basic Instantiation 
-str(IPv6ExtHdrHopByHop()) ==  b';\x00\x01\x04\x00\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop()) ==  b';\x00\x01\x04\x00\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with HAO option
-str(IPv6ExtHdrHopByHop(options=[HAO()])) == b';\x02\x01\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[HAO()])) == b';\x02\x01\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with RouterAlert option
-str(IPv6ExtHdrHopByHop(options=[RouterAlert()])) == b';\x00\x05\x02\x00\x00\x01\x00'
+raw(IPv6ExtHdrHopByHop(options=[RouterAlert()])) == b';\x00\x05\x02\x00\x00\x01\x00'
  
 = IPv6ExtHdrHopByHop - Instantiation with Jumbo option
-str(IPv6ExtHdrHopByHop(options=[Jumbo()])) == b';\x00\xc2\x04\x00\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[Jumbo()])) == b';\x00\xc2\x04\x00\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with Pad1 option
-str(IPv6ExtHdrHopByHop(options=[Pad1()])) == b';\x00\x00\x01\x03\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[Pad1()])) == b';\x00\x00\x01\x03\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with PadN option
-str(IPv6ExtHdrHopByHop(options=[Pad1()])) == b';\x00\x00\x01\x03\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[Pad1()])) == b';\x00\x00\x01\x03\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with Jumbo, RouterAlert, HAO
-str(IPv6ExtHdrHopByHop(options=[Jumbo(), RouterAlert(), HAO()])) == b';\x03\xc2\x04\x00\x00\x00\x00\x05\x02\x00\x00\x01\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[Jumbo(), RouterAlert(), HAO()])) == b';\x03\xc2\x04\x00\x00\x00\x00\x05\x02\x00\x00\x01\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with HAO, Jumbo, RouterAlert
-str(IPv6ExtHdrHopByHop(options=[HAO(), Jumbo(), RouterAlert()])) == b';\x04\x01\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\xc2\x04\x00\x00\x00\x00\x05\x02\x00\x00\x01\x02\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[HAO(), Jumbo(), RouterAlert()])) == b';\x04\x01\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\xc2\x04\x00\x00\x00\x00\x05\x02\x00\x00\x01\x02\x00\x00'
 
 = IPv6ExtHdrHopByHop - Instantiation with RouterAlert, HAO, Jumbo
-str(IPv6ExtHdrHopByHop(options=[RouterAlert(), HAO(), Jumbo()])) == b';\x03\x05\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\xc2\x04\x00\x00\x00\x00'
+raw(IPv6ExtHdrHopByHop(options=[RouterAlert(), HAO(), Jumbo()])) == b';\x03\x05\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\xc2\x04\x00\x00\x00\x00'
 
 = IPv6ExtHdrHopByHop - Basic Dissection
 a=IPv6ExtHdrHopByHop(b';\x00\x01\x04\x00\x00\x00\x00')
 a.nh == 59 and a.len == 0 and len(a.options) == 1 and isinstance(a.options[0], PadN) and a.options[0].otype == 1 and a.options[0].optlen == 4 and a.options[0].optdata == b'\x00'*4
 
 #= IPv6ExtHdrHopByHop - Automatic length computation
-#str(IPv6ExtHdrHopByHop(options=["toto"])) == b'\x00\x00toto'
+#raw(IPv6ExtHdrHopByHop(options=["toto"])) == b'\x00\x00toto'
 #= IPv6ExtHdrHopByHop - Automatic length computation
-#str(IPv6ExtHdrHopByHop(options=["toto"])) == b'\x00\x00tototo'
+#raw(IPv6ExtHdrHopByHop(options=["toto"])) == b'\x00\x00tototo'
 
 
 ############
@@ -2020,10 +2020,10 @@ a.nh == 59 and a.len == 0 and len(a.options) == 1 and isinstance(a.options[0], P
 + Test ICMPv6ND_RS() class - ICMPv6 Type 133 Code 0
 
 = ICMPv6ND_RS - Basic instantiation
-str(ICMPv6ND_RS()) == b'\x85\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6ND_RS()) == b'\x85\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6ND_RS - Basic instantiation with empty dst in IPv6 underlayer
-str(IPv6(src="2001:db8::1")/ICMPv6ND_RS()) == b'`\x00\x00\x00\x00\x08:\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x85\x00M\xfe\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1")/ICMPv6ND_RS()) == b'`\x00\x00\x00\x00\x08:\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x85\x00M\xfe\x00\x00\x00\x00'
 
 = ICMPv6ND_RS - Basic dissection
 a=ICMPv6ND_RS(b'\x85\x00\x00\x00\x00\x00\x00\x00')
@@ -2039,10 +2039,10 @@ isinstance(a, IPv6) and a.nh == 58 and a.hlim == 255 and isinstance(a.payload, I
 + Test ICMPv6ND_RA() class - ICMPv6 Type 134 Code 0
 
 = ICMPv6ND_RA - Basic Instantiation 
-str(ICMPv6ND_RA()) == b'\x86\x00\x00\x00\x00\x08\x07\x08\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6ND_RA()) == b'\x86\x00\x00\x00\x00\x08\x07\x08\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6ND_RA - Basic instantiation with empty dst in IPv6 underlayer
-str(IPv6(src="2001:db8::1")/ICMPv6ND_RA()) == b'`\x00\x00\x00\x00\x10:\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x86\x00E\xe7\x00\x08\x07\x08\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1")/ICMPv6ND_RA()) == b'`\x00\x00\x00\x00\x10:\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x86\x00E\xe7\x00\x08\x07\x08\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6ND_RA - Basic dissection
 a=ICMPv6ND_RA(b'\x86\x00\x00\x00\x00\x08\x07\x08\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2063,10 +2063,10 @@ assert a.answers(b)
 + ICMPv6ND_NS Class Test
 
 = ICMPv6ND_NS - Basic Instantiation
-str(ICMPv6ND_NS()) == b'\x87\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6ND_NS()) == b'\x87\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6ND_NS - Instantiation with specific values
-str(ICMPv6ND_NS(code=0x11, res=3758096385, tgt="ffff::1111")) == b'\x87\x11\x00\x00\xe0\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6ND_NS(code=0x11, res=3758096385, tgt="ffff::1111")) == b'\x87\x11\x00\x00\xe0\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6ND_NS - Basic Dissection
 a=ICMPv6ND_NS(b'\x87\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2077,7 +2077,7 @@ a=ICMPv6ND_NS(b'\x87\x11\x00\x00\xe0\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00
 a.code==0x11 and a.res==3758096385 and a.tgt=="ffff::1111"
 
 = ICMPv6ND_NS - IPv6 layer fields overloading
-a=IPv6(str(IPv6()/ICMPv6ND_NS()))
+a=IPv6(raw(IPv6()/ICMPv6ND_NS()))
 a.nh == 58 and a.dst=="ff02::1" and a.hlim==255
 
 ############
@@ -2085,10 +2085,10 @@ a.nh == 58 and a.dst=="ff02::1" and a.hlim==255
 + ICMPv6ND_NA Class Test
 
 = ICMPv6ND_NA - Basic Instantiation
-str(ICMPv6ND_NA()) == b'\x88\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6ND_NA()) == b'\x88\x00\x00\x00\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6ND_NA - Instantiation with specific values
-str(ICMPv6ND_NA(code=0x11, R=0, S=1, O=0, res=1, tgt="ffff::1111")) == b'\x88\x11\x00\x00@\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6ND_NA(code=0x11, R=0, S=1, O=0, res=1, tgt="ffff::1111")) == b'\x88\x11\x00\x00@\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6ND_NA - Basic Dissection
 a=ICMPv6ND_NA(b'\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2099,7 +2099,7 @@ a=ICMPv6ND_NA(b'\x88\x11\x00\x00@\x00\x00\x01\xff\xff\x00\x00\x00\x00\x00\x00\x0
 a.code==0x11 and a.R==0 and a.S==1 and a.O==0 and a.res==1 and a.tgt=="ffff::1111"
 
 = ICMPv6ND_NS - IPv6 layer fields overloading
-a=IPv6(str(IPv6()/ICMPv6ND_NS()))
+a=IPv6(raw(IPv6()/ICMPv6ND_NS()))
 a.nh == 58 and a.dst=="ff02::1" and a.hlim==255
 
 
@@ -2120,18 +2120,18 @@ b.answers(a)
 + ICMPv6NDOptUnknown Class Test
 
 = ICMPv6NDOptUnknown - Basic Instantiation
-str(ICMPv6NDOptUnknown()) == b'\x00\x02'
+raw(ICMPv6NDOptUnknown()) == b'\x00\x02'
 
 = ICMPv6NDOptUnknown - Instantiation with specific values
-str(ICMPv6NDOptUnknown(len=4, data="somestring")) == b'\x00\x04somestring'
+raw(ICMPv6NDOptUnknown(len=4, data="somestring")) == b'\x00\x04somestring'
 
 = ICMPv6NDOptUnknown - Basic Dissection
 a=ICMPv6NDOptUnknown(b'\x00\x02')
 a.type == 0 and a.len == 2
 
 = ICMPv6NDOptUnknown - Dissection with specific values 
-a=ICMPv6NDOptUnknown(b'\x00\x04somestring')
-a.type == 0 and a.len==4 and a.data == "so" and isinstance(a.payload, Raw) and a.payload.load == "mestring"
+a=ICMPv6NDOptUnknown(b'\x00\x04somerawing')
+a.type == 0 and a.len==4 and a.data == "so" and isinstance(a.payload, Raw) and a.payload.load == "merawing"
 
 
 ############
@@ -2139,10 +2139,10 @@ a.type == 0 and a.len==4 and a.data == "so" and isinstance(a.payload, Raw) and a
 + ICMPv6NDOptSrcLLAddr Class Test
 
 = ICMPv6NDOptSrcLLAddr - Basic Instantiation
-str(ICMPv6NDOptSrcLLAddr()) == b'\x01\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptSrcLLAddr()) == b'\x01\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptSrcLLAddr - Instantiation with specific values
-str(ICMPv6NDOptSrcLLAddr(len=2, lladdr="11:11:11:11:11:11")) == b'\x01\x02\x11\x11\x11\x11\x11\x11'
+raw(ICMPv6NDOptSrcLLAddr(len=2, lladdr="11:11:11:11:11:11")) == b'\x01\x02\x11\x11\x11\x11\x11\x11'
 
 = ICMPv6NDOptSrcLLAddr - Basic Dissection
 a=ICMPv6NDOptSrcLLAddr(b'\x01\x01\x00\x00\x00\x00\x00\x00')
@@ -2158,10 +2158,10 @@ a.type == 1 and a.len == 2 and a.lladdr == "11:11:11:11:11:11"
 + ICMPv6NDOptDstLLAddr Class Test
 
 = ICMPv6NDOptDstLLAddr - Basic Instantiation
-str(ICMPv6NDOptDstLLAddr()) == b'\x02\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptDstLLAddr()) == b'\x02\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptDstLLAddr - Instantiation with specific values
-str(ICMPv6NDOptDstLLAddr(len=2, lladdr="11:11:11:11:11:11")) == b'\x02\x02\x11\x11\x11\x11\x11\x11'
+raw(ICMPv6NDOptDstLLAddr(len=2, lladdr="11:11:11:11:11:11")) == b'\x02\x02\x11\x11\x11\x11\x11\x11'
 
 = ICMPv6NDOptDstLLAddr - Basic Dissection
 a=ICMPv6NDOptDstLLAddr(b'\x02\x01\x00\x00\x00\x00\x00\x00')
@@ -2177,10 +2177,10 @@ a.type == 2 and a.len == 2 and a.lladdr == "11:11:11:11:11:11"
 + ICMPv6NDOptPrefixInfo Class Test
 
 = ICMPv6NDOptPrefixInfo - Basic Instantiation
-str(ICMPv6NDOptPrefixInfo()) == b'\x03\x04\x00\xc0\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptPrefixInfo()) == b'\x03\x04\x00\xc0\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptPrefixInfo - Instantiation with specific values
-str(ICMPv6NDOptPrefixInfo(len=5, prefixlen=64, L=0, A=0, R=1, res1=1, validlifetime=0x11111111, preferredlifetime=0x22222222, res2=0x33333333, prefix="2001:db8::1")) == b'\x03\x05@!\x11\x11\x11\x11""""3333 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(ICMPv6NDOptPrefixInfo(len=5, prefixlen=64, L=0, A=0, R=1, res1=1, validlifetime=0x11111111, preferredlifetime=0x22222222, res2=0x33333333, prefix="2001:db8::1")) == b'\x03\x05@!\x11\x11\x11\x11""""3333 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = ICMPv6NDOptPrefixInfo - Basic Dissection
 a=ICMPv6NDOptPrefixInfo(b'\x03\x04\x00\xc0\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2197,15 +2197,15 @@ a.type == 3 and a.len == 5 and a.prefixlen == 64 and a.L == 0 and a.A == 0 and a
 
 = ICMPv6NDOptRedirectedHdr - Basic Instantiation
 ~ ICMPv6NDOptRedirectedHdr
-str(ICMPv6NDOptRedirectedHdr()) == b'\x04\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptRedirectedHdr()) == b'\x04\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptRedirectedHdr - Instantiation with specific values 
 ~ ICMPv6NDOptRedirectedHdr
-str(ICMPv6NDOptRedirectedHdr(len=0xff, res=0x1111, pkt="somestringthatisnotanipv6packet")) == b'\x04\xff4369\x00\x00somestringthatisnotanipv'
+raw(ICMPv6NDOptRedirectedHdr(len=0xff, res=0x1111, pkt="somestringthatisnotanipv6packet")) == b'\x04\xff4369\x00\x00somestringthatisnotanipv'
 
 = ICMPv6NDOptRedirectedHdr - Instantiation with simple IPv6 packet (no upper layer)
 ~ ICMPv6NDOptRedirectedHdr
-str(ICMPv6NDOptRedirectedHdr(pkt=IPv6())) == b'\x04\x06\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(ICMPv6NDOptRedirectedHdr(pkt=IPv6())) == b'\x04\x06\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = ICMPv6NDOptRedirectedHdr - Basic Dissection
 ~ ICMPv6NDOptRedirectedHdr
@@ -2217,8 +2217,8 @@ assert(a.pkt == "")
 
 = ICMPv6NDOptRedirectedHdr - Disssection with specific values
 ~ ICMPv6NDOptRedirectedHdr
-a=ICMPv6NDOptRedirectedHdr(b'\x04\xff\x11\x11\x00\x00\x00\x00somestringthatisnotanipv6pac')
-a.type == 4 and a.len == 255 and a.res == b'\x11\x11\x00\x00\x00\x00' and isinstance(a.pkt, Raw) and a.pkt.load == "somestringthatisnotanipv6pac"
+a=ICMPv6NDOptRedirectedHdr(b'\x04\xff\x11\x11\x00\x00\x00\x00somerawingthatisnotanipv6pac')
+a.type == 4 and a.len == 255 and a.res == b'\x11\x11\x00\x00\x00\x00' and isinstance(a.pkt, Raw) and a.pkt.load == "somerawingthatisnotanipv6pac"
 
 = ICMPv6NDOptRedirectedHdr - Dissection with cut IPv6 Header
 ~ ICMPv6NDOptRedirectedHdr
@@ -2230,7 +2230,7 @@ a.type == 4 and a.len == 6 and a.res == b"\x00\x00\x00\x00\x00\x00" and isinstan
 x=ICMPv6NDOptRedirectedHdr(b'\x04\x06\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x00\x00;@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 y=x.copy()
 del(y.len)
-x == ICMPv6NDOptRedirectedHdr(str(y))
+x == ICMPv6NDOptRedirectedHdr(raw(y))
 
 # Add more tests
 
@@ -2240,10 +2240,10 @@ x == ICMPv6NDOptRedirectedHdr(str(y))
 + ICMPv6NDOptMTU Class Test 
 
 = ICMPv6NDOptMTU - Basic Instantiation
-str(ICMPv6NDOptMTU()) == b'\x05\x01\x00\x00\x00\x00\x05\x00'
+raw(ICMPv6NDOptMTU()) == b'\x05\x01\x00\x00\x00\x00\x05\x00'
 
 = ICMPv6NDOptMTU - Instantiation with specific values
-str(ICMPv6NDOptMTU(len=2, res=0x1111, mtu=1500)) == b'\x05\x02\x11\x11\x00\x00\x05\xdc'
+raw(ICMPv6NDOptMTU(len=2, res=0x1111, mtu=1500)) == b'\x05\x02\x11\x11\x00\x00\x05\xdc'
  
 = ICMPv6NDOptMTU - Basic dissection
 a=ICMPv6NDOptMTU(b'\x05\x01\x00\x00\x00\x00\x05\x00')
@@ -2259,10 +2259,10 @@ a.type == 5 and a.len == 2 and a.res == 0x1111 and a.mtu == 1500
 + ICMPv6NDOptShortcutLimit Class Test (RFC2491)
 
 = ICMPv6NDOptShortcutLimit - Basic Instantiation
-str(ICMPv6NDOptShortcutLimit()) == b'\x06\x01(\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptShortcutLimit()) == b'\x06\x01(\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptShortcutLimit - Instantiation with specific values
-str(ICMPv6NDOptShortcutLimit(len=2, shortcutlim=0x11, res1=0xee, res2=0xaaaaaaaa)) == b'\x06\x02\x11\xee\xaa\xaa\xaa\xaa'
+raw(ICMPv6NDOptShortcutLimit(len=2, shortcutlim=0x11, res1=0xee, res2=0xaaaaaaaa)) == b'\x06\x02\x11\xee\xaa\xaa\xaa\xaa'
 
 = ICMPv6NDOptShortcutLimit - Basic Dissection
 a=ICMPv6NDOptShortcutLimit(b'\x06\x01(\x00\x00\x00\x00\x00')
@@ -2278,10 +2278,10 @@ a.len==2 and a.shortcutlim==0x11 and a.res1==0xee and a.res2==0xaaaaaaaa
 + ICMPv6NDOptAdvInterval Class Test 
 
 = ICMPv6NDOptAdvInterval - Basic Instantiation
-str(ICMPv6NDOptAdvInterval()) == b'\x07\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptAdvInterval()) == b'\x07\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptAdvInterval - Instantiation with specific values
-str(ICMPv6NDOptAdvInterval(len=2, res=0x1111, advint=0xffffffff)) == b'\x07\x02\x11\x11\xff\xff\xff\xff'
+raw(ICMPv6NDOptAdvInterval(len=2, res=0x1111, advint=0xffffffff)) == b'\x07\x02\x11\x11\xff\xff\xff\xff'
  
 = ICMPv6NDOptAdvInterval - Basic dissection
 a=ICMPv6NDOptAdvInterval(b'\x07\x01\x00\x00\x00\x00\x00\x00')
@@ -2297,10 +2297,10 @@ a.type == 7 and a.len == 2 and a.res == 0x1111 and a.advint == 0xffffffff
 + ICMPv6NDOptHAInfo Class Test
 
 = ICMPv6NDOptHAInfo - Basic Instantiation
-str(ICMPv6NDOptHAInfo()) == b'\x08\x01\x00\x00\x00\x00\x00\x01'
+raw(ICMPv6NDOptHAInfo()) == b'\x08\x01\x00\x00\x00\x00\x00\x01'
 
 = ICMPv6NDOptHAInfo - Instantiation with specific values
-str(ICMPv6NDOptHAInfo(len=2, res=0x1111, pref=0x2222, lifetime=0x3333)) == b'\x08\x02\x11\x11""33'
+raw(ICMPv6NDOptHAInfo(len=2, res=0x1111, pref=0x2222, lifetime=0x3333)) == b'\x08\x02\x11\x11""33'
  
 = ICMPv6NDOptHAInfo - Basic dissection
 a=ICMPv6NDOptHAInfo(b'\x08\x01\x00\x00\x00\x00\x00\x01')
@@ -2316,13 +2316,13 @@ a.type == 8 and a.len == 2 and a.res == 0x1111 and a.pref == 0x2222 and a.lifeti
 + ICMPv6NDOptSrcAddrList Class Test 
 
 = ICMPv6NDOptSrcAddrList - Basic Instantiation
-str(ICMPv6NDOptSrcAddrList()) == b'\t\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptSrcAddrList()) == b'\t\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptSrcAddrList - Instantiation with specific values (auto len)
-str(ICMPv6NDOptSrcAddrList(res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\t\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptSrcAddrList(res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\t\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptSrcAddrList - Instantiation with specific values 
-str(ICMPv6NDOptSrcAddrList(len=3, res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\t\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptSrcAddrList(len=3, res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\t\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptSrcAddrList - Basic Dissection
 a=ICMPv6NDOptSrcAddrList(b'\t\x01\x00\x00\x00\x00\x00\x00')
@@ -2344,13 +2344,13 @@ a.type == 9 and a.len == 3 and a.res == 'BBBBBB' and len(a.addrlist) == 1 and a.
 + ICMPv6NDOptTgtAddrList Class Test 
 
 = ICMPv6NDOptTgtAddrList - Basic Instantiation
-str(ICMPv6NDOptTgtAddrList()) == b'\n\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptTgtAddrList()) == b'\n\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptTgtAddrList - Instantiation with specific values (auto len)
-str(ICMPv6NDOptTgtAddrList(res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\n\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptTgtAddrList(res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\n\x05BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptTgtAddrList - Instantiation with specific values 
-str(ICMPv6NDOptTgtAddrList(len=3, res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\n\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptTgtAddrList(len=3, res="BBBBBB", addrlist=["ffff::ffff", "1111::1111"])) == b'\n\x03BBBBBB\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x11\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptTgtAddrList - Basic Dissection
 a=ICMPv6NDOptTgtAddrList(b'\n\x01\x00\x00\x00\x00\x00\x00')
@@ -2372,10 +2372,10 @@ a.type == 10 and a.len == 3 and a.res == 'BBBBBB' and len(a.addrlist) == 1 and a
 + ICMPv6NDOptIPAddr Class Test (RFC 4068)
 
 = ICMPv6NDOptIPAddr - Basic Instantiation 
-str(ICMPv6NDOptIPAddr()) == b'\x11\x03\x01@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptIPAddr()) == b'\x11\x03\x01@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptIPAddr - Instantiation with specific values
-str(ICMPv6NDOptIPAddr(len=5, optcode=0xff, plen=40, res=0xeeeeeeee, addr="ffff::1111")) == b'\x11\x05\xff(\xee\xee\xee\xee\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptIPAddr(len=5, optcode=0xff, plen=40, res=0xeeeeeeee, addr="ffff::1111")) == b'\x11\x05\xff(\xee\xee\xee\xee\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptIPAddr - Basic Dissection 
 a=ICMPv6NDOptIPAddr(b'\x11\x03\x01@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2391,10 +2391,10 @@ a.type == 17 and a.len == 5 and a.optcode == 0xff and a.plen == 40 and a.res == 
 + ICMPv6NDOptNewRtrPrefix Class Test (RFC 4068)
 
 = ICMPv6NDOptNewRtrPrefix - Basic Instantiation 
-str(ICMPv6NDOptNewRtrPrefix()) == b'\x12\x03\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptNewRtrPrefix()) == b'\x12\x03\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptNewRtrPrefix - Instantiation with specific values
-str(ICMPv6NDOptNewRtrPrefix(len=5, optcode=0xff, plen=40, res=0xeeeeeeee, prefix="ffff::1111")) == b'\x12\x05\xff(\xee\xee\xee\xee\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptNewRtrPrefix(len=5, optcode=0xff, plen=40, res=0xeeeeeeee, prefix="ffff::1111")) == b'\x12\x05\xff(\xee\xee\xee\xee\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptNewRtrPrefix - Basic Dissection 
 a=ICMPv6NDOptNewRtrPrefix(b'\x12\x03\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2410,10 +2410,10 @@ a.type == 18 and a.len == 5 and a.optcode == 0xff and a.plen == 40 and a.res == 
 + ICMPv6NDOptLLA Class Test (RFC 4068)
 
 = ICMPv6NDOptLLA - Basic Instantiation 
-str(ICMPv6NDOptLLA()) == b'\x13\x01\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptLLA()) == b'\x13\x01\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptLLA - Instantiation with specific values
-str(ICMPv6NDOptLLA(len=2, optcode=3, lla="ff:11:ff:11:ff:11")) == b'\x13\x02\x03\xff\x11\xff\x11\xff\x11'
+raw(ICMPv6NDOptLLA(len=2, optcode=3, lla="ff:11:ff:11:ff:11")) == b'\x13\x02\x03\xff\x11\xff\x11\xff\x11'
 
 = ICMPv6NDOptLLA - Basic Dissection 
 a=ICMPv6NDOptLLA(b'\x13\x01\x00\x00\x00\x00\x00\x00\x00')
@@ -2429,25 +2429,25 @@ a.type == 19 and a.len == 2 and a.optcode == 3 and a.lla == "ff:11:ff:11:ff:11"
 + ICMPv6NDOptRouteInfo Class Test
 
 = ICMPv6NDOptRouteInfo - Basic Instantiation
-str(ICMPv6NDOptRouteInfo()) == b'\x18\x01\x00\x00\xff\xff\xff\xff'
+raw(ICMPv6NDOptRouteInfo()) == b'\x18\x01\x00\x00\xff\xff\xff\xff'
 
 = ICMPv6NDOptRouteInfo - Instantiation with forced prefix but no length
-str(ICMPv6NDOptRouteInfo(prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'
+raw(ICMPv6NDOptRouteInfo(prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'
 
 = ICMPv6NDOptRouteInfo - Instantiation with forced length values (1/4)
-str(ICMPv6NDOptRouteInfo(len=1, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x01\x00\x00\xff\xff\xff\xff'
+raw(ICMPv6NDOptRouteInfo(len=1, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x01\x00\x00\xff\xff\xff\xff'
 
 = ICMPv6NDOptRouteInfo - Instantiation with forced length values (2/4)
-str(ICMPv6NDOptRouteInfo(len=2, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x02\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01'
+raw(ICMPv6NDOptRouteInfo(len=2, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x02\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01'
 
 = ICMPv6NDOptRouteInfo - Instantiation with forced length values (3/4)
-str(ICMPv6NDOptRouteInfo(len=3, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'
+raw(ICMPv6NDOptRouteInfo(len=3, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01'
 
 = ICMPv6NDOptRouteInfo - Instantiation with forced length values (4/4)
-str(ICMPv6NDOptRouteInfo(len=4, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x04\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptRouteInfo(len=4, prefix="2001:db8:1:1:1:1:1:1")) == b'\x18\x04\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptRouteInfo - Instantiation with specific values 
-str(ICMPv6NDOptRouteInfo(len=6, plen=0x11, res1=1, prf=3, res2=1, rtlifetime=0x22222222, prefix="2001:db8::1")) == b'\x18\x06\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptRouteInfo(len=6, plen=0x11, res1=1, prf=3, res2=1, rtlifetime=0x22222222, prefix="2001:db8::1")) == b'\x18\x06\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptRouteInfo - Basic dissection
 a=ICMPv6NDOptRouteInfo(b'\x18\x03\x00\x00\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2463,10 +2463,10 @@ a.plen == 0x11 and a.res1 == 1 and a.prf == 3 and a.res2 == 1 and a.rtlifetime =
 + ICMPv6NDOptMAP Class Test
 
 = ICMPv6NDOptMAP - Basic Instantiation
-str(ICMPv6NDOptMAP()) == b'\x17\x03\x1f\x80\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptMAP()) == b'\x17\x03\x1f\x80\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptMAP - Instantiation with specific values
-str(ICMPv6NDOptMAP(len=5, dist=3, pref=10, R=0, res=1, validlifetime=0x11111111, addr="ffff::1111")) == b'\x17\x05:\x01\x11\x11\x11\x11\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
+raw(ICMPv6NDOptMAP(len=5, dist=3, pref=10, R=0, res=1, validlifetime=0x11111111, addr="ffff::1111")) == b'\x17\x05:\x01\x11\x11\x11\x11\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x11\x11'
 
 = ICMPv6NDOptMAP - Basic Dissection
 a=ICMPv6NDOptMAP(b'\x17\x03\x1f\x80\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2482,16 +2482,16 @@ a.type==23 and a.len==5 and a.dist==3 and a.pref==10 and a.R==0 and a.res==1 and
 + ICMPv6NDOptRDNSS Class Test
 
 = ICMPv6NDOptRDNSS - Basic Instantiation
-str(ICMPv6NDOptRDNSS()) == b'\x19\x01\x00\x00\xff\xff\xff\xff'
+raw(ICMPv6NDOptRDNSS()) == b'\x19\x01\x00\x00\xff\xff\xff\xff'
 
 = ICMPv6NDOptRDNSS - Basic instantiation with 1 DNS address
-str(ICMPv6NDOptRDNSS(dns=["2001:db8::1"])) == b'\x19\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(ICMPv6NDOptRDNSS(dns=["2001:db8::1"])) == b'\x19\x03\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = ICMPv6NDOptRDNSS - Basic instantiation with 2 DNS addresses
-str(ICMPv6NDOptRDNSS(dns=["2001:db8::1", "2001:db8::2"])) == b'\x19\x05\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(ICMPv6NDOptRDNSS(dns=["2001:db8::1", "2001:db8::2"])) == b'\x19\x05\x00\x00\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = ICMPv6NDOptRDNSS - Instantiation with specific values
-str(ICMPv6NDOptRDNSS(len=43, res=0xaaee, lifetime=0x11111111, dns=["2001:db8::2"])) == b'\x19+\xaa\xee\x11\x11\x11\x11 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(ICMPv6NDOptRDNSS(len=43, res=0xaaee, lifetime=0x11111111, dns=["2001:db8::2"])) == b'\x19+\xaa\xee\x11\x11\x11\x11 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = ICMPv6NDOptRDNSS - Basic Dissection
 a=ICMPv6NDOptRDNSS(b'\x19\x01\x00\x00\xff\xff\xff\xff')
@@ -2511,16 +2511,16 @@ a.type==25 and a.len==5 and a.res == 0xaaee and len(a.dns) == 2 and a.dns[0] == 
 + ICMPv6NDOptDNSSL Class Test
 
 = ICMPv6NDOptDNSSL - Basic Instantiation
-str(ICMPv6NDOptDNSSL()) == b'\x1f\x01\x00\x00\xff\xff\xff\xff'
+raw(ICMPv6NDOptDNSSL()) == b'\x1f\x01\x00\x00\xff\xff\xff\xff'
 
 = ICMPv6NDOptDNSSL - Instantiation with 1 search domain, as seen in the wild
-str(ICMPv6NDOptDNSSL(lifetime=60, searchlist=["home."])) == b'\x1f\x02\x00\x00\x00\x00\x00<\x04home\x00\x00\x00'
+raw(ICMPv6NDOptDNSSL(lifetime=60, searchlist=["home."])) == b'\x1f\x02\x00\x00\x00\x00\x00<\x04home\x00\x00\x00'
 
 = ICMPv6NDOptDNSSL - Basic instantiation with 2 search domains
-str(ICMPv6NDOptDNSSL(searchlist=["home.", "office."])) == b'\x1f\x03\x00\x00\xff\xff\xff\xff\x04home\x00\x06office\x00\x00\x00'
+raw(ICMPv6NDOptDNSSL(searchlist=["home.", "office."])) == b'\x1f\x03\x00\x00\xff\xff\xff\xff\x04home\x00\x06office\x00\x00\x00'
 
 = ICMPv6NDOptDNSSL - Basic instantiation with 3 search domains
-str(ICMPv6NDOptDNSSL(searchlist=["home.", "office.", "here.there."])) == b'\x1f\x05\x00\x00\xff\xff\xff\xff\x04home\x00\x06office\x00\x04here\x05there\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptDNSSL(searchlist=["home.", "office.", "here.there."])) == b'\x1f\x05\x00\x00\xff\xff\xff\xff\x04home\x00\x06office\x00\x04here\x05there\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptDNSSL - Basic Dissection
 p = ICMPv6NDOptDNSSL(b'\x1f\x01\x00\x00\xff\xff\xff\xff')
@@ -2536,7 +2536,7 @@ p.type == 31 and p.len == 2 and p.res == 0 and p.lifetime == 60 and p.searchlist
 + ICMPv6NDOptEFA Class Test
 
 = ICMPv6NDOptEFA - Basic Instantiation
-str(ICMPv6NDOptEFA()) == b'\x1a\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NDOptEFA()) == b'\x1a\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NDOptEFA - Basic Dissection
 a=ICMPv6NDOptEFA(b'\x1a\x01\x00\x00\x00\x00\x00\x00')
@@ -2548,7 +2548,7 @@ a.type==26 and a.len==1 and a.res == 0
 + Test Node Information Query - ICMPv6NIQueryNOOP
 
 = ICMPv6NIQueryNOOP - Basic Instantiation
-str(ICMPv6NIQueryNOOP(nonce=b"\x00"*8)) == b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NIQueryNOOP(nonce=b"\x00"*8)) == b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NIQueryNOOP - Basic Dissection
 a = ICMPv6NIQueryNOOP(b'\x8b\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -2588,7 +2588,7 @@ type(a) is tuple and len(a) == 2 and a[0] == 2 and a[1] == '169.254.253.252'
 ICMPv6NIQueryName(data="169.254.253.252").data == '169.254.253.252'
 
 = ICMPv6NIQueryName - build & dissection
-s = str(IPv6()/ICMPv6NIQueryName(data="n.d.org"))
+s = raw(IPv6()/ICMPv6NIQueryName(data="n.d.org"))
 p = IPv6(s)
 ICMPv6NIQueryName in p and p[ICMPv6NIQueryName].data == "n.d.org"
 
@@ -2677,13 +2677,13 @@ t.flags == 1 and a.flags == 2 and c.flags == 4 and l.flags == 8 and s.flags == 1
 
 
 = ICMPv6NIQuery* - flags handling (Test 2)
-t = str(ICMPv6NIQueryNOOP(flags="T", nonce="A"*8))[6:8]
-a = str(ICMPv6NIQueryNOOP(flags="A", nonce="A"*8))[6:8]
-c = str(ICMPv6NIQueryNOOP(flags="C", nonce="A"*8))[6:8]
-l = str(ICMPv6NIQueryNOOP(flags="L", nonce="A"*8))[6:8]
-s = str(ICMPv6NIQueryNOOP(flags="S", nonce="A"*8))[6:8]
-g = str(ICMPv6NIQueryNOOP(flags="G", nonce="A"*8))[6:8]
-allflags = str(ICMPv6NIQueryNOOP(flags="TALCLSG", nonce="A"*8))[6:8]
+t = raw(ICMPv6NIQueryNOOP(flags="T", nonce="A"*8))[6:8]
+a = raw(ICMPv6NIQueryNOOP(flags="A", nonce="A"*8))[6:8]
+c = raw(ICMPv6NIQueryNOOP(flags="C", nonce="A"*8))[6:8]
+l = raw(ICMPv6NIQueryNOOP(flags="L", nonce="A"*8))[6:8]
+s = raw(ICMPv6NIQueryNOOP(flags="S", nonce="A"*8))[6:8]
+g = raw(ICMPv6NIQueryNOOP(flags="G", nonce="A"*8))[6:8]
+allflags = raw(ICMPv6NIQueryNOOP(flags="TALCLSG", nonce="A"*8))[6:8]
 t == b'\x00\x01' and a == b'\x00\x02' and c == b'\x00\x04' and l == b'\x00\x08' and s == b'\x00\x10' and g == b'\x00\x20' and allflags == b'\x00\x3F'
 
 
@@ -2699,13 +2699,13 @@ t.flags == 1 and a.flags == 2 and c.flags == 4 and l.flags == 8 and s.flags == 1
 
 
 = ICMPv6NIReply* - flags handling (Test 2)
-t = str(ICMPv6NIReplyNOOP(flags="T", nonce="A"*8))[6:8]
-a = str(ICMPv6NIReplyNOOP(flags="A", nonce="A"*8))[6:8]
-c = str(ICMPv6NIReplyNOOP(flags="C", nonce="A"*8))[6:8]
-l = str(ICMPv6NIReplyNOOP(flags="L", nonce="A"*8))[6:8]
-s = str(ICMPv6NIReplyNOOP(flags="S", nonce="A"*8))[6:8]
-g = str(ICMPv6NIReplyNOOP(flags="G", nonce="A"*8))[6:8]
-allflags = str(ICMPv6NIReplyNOOP(flags="TALCLSG", nonce="A"*8))[6:8]
+t = raw(ICMPv6NIReplyNOOP(flags="T", nonce="A"*8))[6:8]
+a = raw(ICMPv6NIReplyNOOP(flags="A", nonce="A"*8))[6:8]
+c = raw(ICMPv6NIReplyNOOP(flags="C", nonce="A"*8))[6:8]
+l = raw(ICMPv6NIReplyNOOP(flags="L", nonce="A"*8))[6:8]
+s = raw(ICMPv6NIReplyNOOP(flags="S", nonce="A"*8))[6:8]
+g = raw(ICMPv6NIReplyNOOP(flags="G", nonce="A"*8))[6:8]
+allflags = raw(ICMPv6NIReplyNOOP(flags="TALCLSG", nonce="A"*8))[6:8]
 t == b'\x00\x01' and a == b'\x00\x02' and c == b'\x00\x04' and l == b'\x00\x08' and s == b'\x00\x10' and g == b'\x00\x20' and allflags == b'\x00\x3F'
 
 
@@ -2739,87 +2739,87 @@ a.flags == 0 and b.flags == 0 and c.flags == 0 and d.flags == 0 and e.flags == 0
 + Test Node Information Query - Dispatching
 
 = ICMPv6NIQueryIPv6 - dispatch with nothing in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv6)
 
 = ICMPv6NIQueryIPv6 - dispatch with IPv6 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="2001::db8::1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="2001::db8::1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv6)
 
 = ICMPv6NIQueryIPv6 - dispatch with IPv4 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="192.168.0.1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="192.168.0.1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv6)
 
 = ICMPv6NIQueryIPv6 - dispatch with name in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="alfred"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv6(data="alfred"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv6)
 
 = ICMPv6NIQueryName - dispatch with nothing in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryName)
 
 = ICMPv6NIQueryName - dispatch with IPv6 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="2001:db8::1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="2001:db8::1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryName)
 
 = ICMPv6NIQueryName - dispatch with IPv4 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="192.168.0.1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="192.168.0.1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryName)
 
 = ICMPv6NIQueryName - dispatch with name in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="alfred"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryName(data="alfred"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryName)
 
 = ICMPv6NIQueryIPv4 - dispatch with nothing in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv4)
 
 = ICMPv6NIQueryIPv4 - dispatch with IPv6 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="2001:db8::1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="2001:db8::1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv4)
 
 = ICMPv6NIQueryIPv4 - dispatch with IPv6 address in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="192.168.0.1"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="192.168.0.1"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv4)
 
 = ICMPv6NIQueryIPv4 - dispatch with name in data
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="alfred"))
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIQueryIPv4(data="alfred"))
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIQueryIPv4)
 
 = ICMPv6NIReplyName - dispatch
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyName())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyName())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIReplyName)
 
 = ICMPv6NIReplyIPv6 - dispatch
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyIPv6())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyIPv6())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIReplyIPv6)
 
 = ICMPv6NIReplyIPv4 - dispatch
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyIPv4())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyIPv4())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIReplyIPv4)
 
 = ICMPv6NIReplyRefuse - dispatch
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyRefuse())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyRefuse())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIReplyRefuse)
 
 = ICMPv6NIReplyUnknown - dispatch
-s = str(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyUnknown())
+s = raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/ICMPv6NIReplyUnknown())
 p = IPv6(s)
 isinstance(p.payload, ICMPv6NIReplyUnknown)
 
@@ -2861,18 +2861,18 @@ ICMPv6NIReplyNOOP(data="169.254.253.010").data == "169.254.253.010"
 ############
 + Test Node Information Query - ICMPv6NIReplyName
 
-= ICMPv6NIReplyName - single label DNS name as a string (without ttl) (internal)
+= ICMPv6NIReplyName - single label DNS name as a rawing (without ttl) (internal)
 a=ICMPv6NIReplyName(data="abricot").getfieldval("data")
 type(a) is tuple and len(a) == 2 and a[0] == 2 and type(a[1]) is list and len(a[1]) == 2 and a[1][0] == 0 and a[1][1] == b'\x07abricot\x00\x00'
 
-= ICMPv6NIReplyName - single label DNS name as a string (without ttl)
+= ICMPv6NIReplyName - single label DNS name as a rawing (without ttl)
 ICMPv6NIReplyName(data="abricot").data == [0, "abricot"]
 
-= ICMPv6NIReplyName - fqdn name as a string (without ttl) (internal)
+= ICMPv6NIReplyName - fqdn name as a rawing (without ttl) (internal)
 a=ICMPv6NIReplyName(data="n.d.tld").getfieldval("data")
 type(a) is tuple and len(a) == 2 and a[0] == 2 and type(a[1]) is list and len(a[1]) == 2 and a[1][0] == 0 and a[1][1] == b'\x01n\x01d\x03tld\x00'
 
-= ICMPv6NIReplyName - fqdn name as a string (without ttl)
+= ICMPv6NIReplyName - fqdn name as a rawing (without ttl)
 ICMPv6NIReplyName(data="n.d.tld").data == [0, 'n.d.tld']
 
 = ICMPv6NIReplyName - list of 2 single label DNS names (without ttl) (internal)
@@ -2915,11 +2915,11 @@ type(a) is tuple and len(a) == 2 and a[0] == 3 and type(a[1]) is list and len(a[
 = ICMPv6NIReplyIPv6 - one IPv6 address with TTL
 ICMPv6NIReplyIPv6(data=[(0, "2001:db8::1")]).data == [(0, '2001:db8::1')]
 
-= ICMPv6NIReplyIPv6 - two IPv6 addresses as a list of strings (without TTL) (internal)
+= ICMPv6NIReplyIPv6 - two IPv6 addresses as a list of rawings (without TTL) (internal)
 a=ICMPv6NIReplyIPv6(data=["2001:db8::1", "2001:db8::2"]).getfieldval("data")
 type(a) is tuple and len(a) == 2 and a[0] == 3 and type(a[1]) is list and len(a[1]) == 2 and type(a[1][0]) is tuple and len(a[1][0]) == 2 and a[1][0][0] == 0 and a[1][0][1] == "2001:db8::1" and len(a[1][1]) == 2 and a[1][1][0] == 0 and a[1][1][1] == "2001:db8::2" 
 
-= ICMPv6NIReplyIPv6 - two IPv6 addresses as a list of strings (without TTL)
+= ICMPv6NIReplyIPv6 - two IPv6 addresses as a list of rawings (without TTL)
 ICMPv6NIReplyIPv6(data=["2001:db8::1", "2001:db8::2"]).data == [(0, '2001:db8::1'), (0, '2001:db8::2')]
 
 = ICMPv6NIReplyIPv6 - two IPv6 addresses as a list (first with ttl, second without) (internal)
@@ -2931,7 +2931,7 @@ ICMPv6NIReplyIPv6(data=[(42, "2001:db8::1"), "2001:db8::2"]).data == [(42, "2001
 
 = ICMPv6NIReplyIPv6 - build & dissection
 
-s = str(IPv6()/ICMPv6NIReplyIPv6(data="2001:db8::1"))
+s = raw(IPv6()/ICMPv6NIReplyIPv6(data="2001:db8::1"))
 p = IPv6(s)
 ICMPv6NIReplyIPv6 in p and p.data == [(0, '2001:db8::1')]
 
@@ -2960,11 +2960,11 @@ type(a) is tuple and len(a) == 2 and a[0] == 4 and type(a[1]) is list and len(a[
 = ICMPv6NIReplyIPv4 - one IPv4 address with TTL (internal)
 ICMPv6NIReplyIPv4(data=[(0, "169.254.253.252")]).data == [(0, '169.254.253.252')]
 
-= ICMPv6NIReplyIPv4 - two IPv4 addresses as a list of strings (without TTL)
+= ICMPv6NIReplyIPv4 - two IPv4 addresses as a list of rawings (without TTL)
 a=ICMPv6NIReplyIPv4(data=["169.254.253.252", "169.254.253.253"]).getfieldval("data")
 type(a) is tuple and len(a) == 2 and a[0] == 4 and type(a[1]) is list and len(a[1]) == 2 and type(a[1][0]) is tuple and len(a[1][0]) == 2 and a[1][0][0] == 0 and a[1][0][1] == "169.254.253.252" and len(a[1][1]) == 2 and a[1][1][0] == 0 and a[1][1][1] == "169.254.253.253" 
 
-= ICMPv6NIReplyIPv4 - two IPv4 addresses as a list of strings (without TTL) (internal)
+= ICMPv6NIReplyIPv4 - two IPv4 addresses as a list of rawings (without TTL) (internal)
 ICMPv6NIReplyIPv4(data=["169.254.253.252", "169.254.253.253"]).data == [(0, '169.254.253.252'), (0, '169.254.253.253')]
 
 = ICMPv6NIReplyIPv4 - two IPv4 addresses as a list (first with ttl, second without)
@@ -2976,11 +2976,11 @@ ICMPv6NIReplyIPv4(data=[(42, "169.254.253.252"), "169.254.253.253"]).data == [(4
 
 = ICMPv6NIReplyIPv4 - build & dissection
 
-s = str(IPv6()/ICMPv6NIReplyIPv4(data="192.168.0.1"))
+s = raw(IPv6()/ICMPv6NIReplyIPv4(data="192.168.0.1"))
 p = IPv6(s)
 ICMPv6NIReplyIPv4 in p and p.data == [(0, '192.168.0.1')]
 
-s = str(IPv6()/ICMPv6NIReplyIPv4(data=[(2807, "192.168.0.1")]))
+s = raw(IPv6()/ICMPv6NIReplyIPv4(data=[(2807, "192.168.0.1")]))
 p = IPv6(s)
 ICMPv6NIReplyIPv4 in p and p.data == [(2807, "192.168.0.1")]
 
@@ -2989,7 +2989,7 @@ ICMPv6NIReplyIPv4 in p and p.data == [(2807, "192.168.0.1")]
 ############
 + Test Node Information Query - ICMPv6NIReplyRefuse
 = ICMPv6NIReplyRefuse - basic instantiation
-str(ICMPv6NIReplyRefuse())[:8] == b'\x8c\x01\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NIReplyRefuse())[:8] == b'\x8c\x01\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NIReplyRefuse - basic dissection
 a=ICMPv6NIReplyRefuse(b'\x8c\x01\x00\x00\x00\x00\x00\x00\xf1\xe9\xab\xc9\x8c\x0by\x18')
@@ -3001,7 +3001,7 @@ a.type == 140 and a.code == 1 and a.cksum == 0 and a.unused == 0 and a.flags == 
 + Test Node Information Query - ICMPv6NIReplyUnknown
 
 = ICMPv6NIReplyUnknown - basic instantiation
-str(ICMPv6NIReplyUnknown(nonce=b'\x00'*8)) == b'\x8c\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(ICMPv6NIReplyUnknown(nonce=b'\x00'*8)) == b'\x8c\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = ICMPv6NIReplyRefuse - basic dissection
 a=ICMPv6NIReplyRefuse(b'\x8c\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -3021,10 +3021,10 @@ computeNIGroupAddr("scapy") == "ff02::2:f886:2f66"
 + IPv6ExtHdrFragment Class Test
 
 = IPv6ExtHdrFragment - Basic Instantiation
-str(IPv6ExtHdrFragment()) == b';\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6ExtHdrFragment()) == b';\x00\x00\x00\x00\x00\x00\x00'
 
 = IPv6ExtHdrFragment - Instantiation with specific values
-str(IPv6ExtHdrFragment(nh=0xff, res1=0xee, offset=0x1fff, res2=1, m=1, id=0x11111111)) == b'\xff\xee\xff\xfb\x11\x11\x11\x11'
+raw(IPv6ExtHdrFragment(nh=0xff, res1=0xee, offset=0x1fff, res2=1, m=1, id=0x11111111)) == b'\xff\xee\xff\xfb\x11\x11\x11\x11'
 
 = IPv6ExtHdrFragment - Basic Dissection 
 a=IPv6ExtHdrFragment(b';\x00\x00\x00\x00\x00\x00\x00')
@@ -3041,7 +3041,7 @@ a.nh == 0xff and a.res1 == 0xee and a.offset==0x1fff and a.res2==1 and a.m == 1 
 
 = fragment6 - test against a long TCP packet with a 1280 MTU
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280) 
-len(l) == 33 and len(str(l[-1])) == 644
+len(l) == 33 and len(raw(l[-1])) == 644
 
 
 ############
@@ -3050,7 +3050,7 @@ len(l) == 33 and len(str(l[-1])) == 644
 
 = defragment6 - test against a long TCP packet fragmented with a 1280 MTU
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280) 
-str(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 'A'*40000)
+raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 'A'*40000)
 
 
 = defragment6 - test against a large TCP packet fragmented with a 1280 bytes MTU and missing fragments
@@ -3059,14 +3059,14 @@ del(l[2])
 del(l[4])
 del(l[12])
 del(l[18])
-str(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 2444*'A' + 1232*'X' + 2464*'A' + 1232*'X' + 9856*'A' + 1232*'X' + 7392*'A' + 1232*'X' + 12916*'A')
+raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + 2444*'A' + 1232*'X' + 2464*'A' + 1232*'X' + 9856*'A' + 1232*'X' + 7392*'A' + 1232*'X' + 12916*'A')
 
 
 = defragment6 - test against a TCP packet fragmented with a 800 bytes MTU and missing fragments
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*4000), 800) 
 del(l[4])
 del(l[2])
-str(defragment6(l)) == b'`\x00\x00\x00\x0f\xb4\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xb2\x0f\x00\x00AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+raw(defragment6(l)) == b'`\x00\x00\x00\x0f\xb4\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xb2\x0f\x00\x00AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 
 
 ############
@@ -3151,7 +3151,7 @@ assert _ICMPv6Error().guess_payload_class(None) == IPerror6
 + ICMPv6ML
 
 = ICMPv6MLQuery - build & dissection
-s = str(IPv6()/ICMPv6MLQuery())
+s = raw(IPv6()/ICMPv6MLQuery())
 s == b"`\x00\x00\x00\x00\x18:\x01\xfe\x80\x00\x00\x00\x00\x00\x00\xba\xca:\xff\xfer\xb0\x8b\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x82\x00\xb4O'\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 p = IPv6(s)
@@ -3185,7 +3185,7 @@ p.show()
 + TracerouteResult6
 
 = get_trace()
-ip6_hlim = [("2001:db8::%d" % i, i) for i in xrange(1, 10)]
+ip6_hlim = [("2001:db8::%d" % i, i) for i in six.moves.range(1, 10)]
 
 tr6_packets = [ (IPv6(dst="2001:db8::1", src="2001:db8::254", hlim=hlim)/UDP()/"scapy",
                  IPv6(dst="2001:db8::254", src=ip)/ICMPv6TimeExceeded()/IPerror6(dst="2001:db8::1", src="2001:db8::254", hlim=0)/UDPerror()/"scapy")
@@ -3256,13 +3256,13 @@ conf.AS_resolver = conf.AS_resolver
 a=DUID_LLT() 
 
 = DUID_LLT basic build
-str(DUID_LLT()) == b'\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DUID_LLT()) == b'\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DUID_LLT build with specific values
-str(DUID_LLT(lladdr="ff:ff:ff:ff:ff:ff", timeval=0x11111111, hwtype=0x2222)) == b'\x00\x01""\x11\x11\x11\x11\xff\xff\xff\xff\xff\xff'
+raw(DUID_LLT(lladdr="ff:ff:ff:ff:ff:ff", timeval=0x11111111, hwtype=0x2222)) == b'\x00\x01""\x11\x11\x11\x11\xff\xff\xff\xff\xff\xff'
 
 = DUID_LLT basic dissection 
-a=DUID_LLT(str(DUID_LLT()))
+a=DUID_LLT(raw(DUID_LLT()))
 a.type == 1 and a.hwtype == 1 and a.timeval == 0 and a.lladdr == "00:00:00:00:00:00"
 
 = DUID_LLT dissection with specific values
@@ -3278,18 +3278,18 @@ a.type == 1 and a.hwtype == 0x2222 and a.timeval == 0x11111111 and a.lladdr == "
 a=DUID_EN() 
 
 = DUID_EN basic build
-str(DUID_EN()) == b'\x00\x02\x00\x00\x017'
+raw(DUID_EN()) == b'\x00\x02\x00\x00\x017'
 
 = DUID_EN build with specific values
-str(DUID_EN(enterprisenum=0x11111111, id="iamastring")) == b'\x00\x02\x11\x11\x11\x11iamastring'
+raw(DUID_EN(enterprisenum=0x11111111, id="iamastring")) == b'\x00\x02\x11\x11\x11\x11iamastring'
 
 = DUID_EN basic dissection 
 a=DUID_EN(b'\x00\x02\x00\x00\x017')
 a.type == 2 and a.enterprisenum == 311 
 
 = DUID_EN dissection with specific values 
-a=DUID_EN(b'\x00\x02\x11\x11\x11\x11iamastring')
-a.type == 2 and a.enterprisenum == 0x11111111 and a.id =="iamastring"
+a=DUID_EN(b'\x00\x02\x11\x11\x11\x11iamarawing')
+a.type == 2 and a.enterprisenum == 0x11111111 and a.id =="iamarawing"
 
 
 ############
@@ -3300,13 +3300,13 @@ a.type == 2 and a.enterprisenum == 0x11111111 and a.id =="iamastring"
 a=DUID_LL() 
 
 = DUID_LL basic build
-str(DUID_LL()) == b'\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
+raw(DUID_LL()) == b'\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
 
 = DUID_LL build with specific values
-str(DUID_LL(hwtype=1, lladdr="ff:ff:ff:ff:ff:ff")) == b'\x00\x03\x00\x01\xff\xff\xff\xff\xff\xff'
+raw(DUID_LL(hwtype=1, lladdr="ff:ff:ff:ff:ff:ff")) == b'\x00\x03\x00\x01\xff\xff\xff\xff\xff\xff'
 
 = DUID_LL basic dissection
-a=DUID_LL(str(DUID_LL()))
+a=DUID_LL(raw(DUID_LL()))
 a.type == 3 and a.hwtype == 1 and a.lladdr == "00:00:00:00:00:00"
 
 = DUID_LL with specific values 
@@ -3322,10 +3322,10 @@ a.hwtype == 1 and a.lladdr == "ff:ff:ff:ff:ff:ff"
 a=DHCP6OptUnknown()
 
 = DHCP6 Opt Unknown basic build (default values)
-str(DHCP6OptUnknown()) == b'\x00\x00\x00\x00'
+raw(DHCP6OptUnknown()) == b'\x00\x00\x00\x00'
 
 = DHCP6 Opt Unknown - len computation test
-str(DHCP6OptUnknown(data="shouldbe9")) == b'\x00\x00\x00\tshouldbe9'
+raw(DHCP6OptUnknown(data="shouldbe9")) == b'\x00\x00\x00\tshouldbe9'
 
 
 ############
@@ -3336,36 +3336,36 @@ str(DHCP6OptUnknown(data="shouldbe9")) == b'\x00\x00\x00\tshouldbe9'
 a=DHCP6OptClientId()
 
 = DHCP6OptClientId basic build
-str(DHCP6OptClientId()) == b'\x00\x01\x00\x00'
+raw(DHCP6OptClientId()) == b'\x00\x01\x00\x00'
 
 = DHCP6OptClientId instantiation with specific values 
-str(DHCP6OptClientId(duid="toto")) == b'\x00\x01\x00\x04toto'
+raw(DHCP6OptClientId(duid="toto")) == b'\x00\x01\x00\x04toto'
 
 = DHCP6OptClientId instantiation with DUID_LL
-str(DHCP6OptClientId(duid=DUID_LL())) == b'\x00\x01\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptClientId(duid=DUID_LL())) == b'\x00\x01\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptClientId instantiation with DUID_LLT
-str(DHCP6OptClientId(duid=DUID_LLT())) == b'\x00\x01\x00\x0e\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptClientId(duid=DUID_LLT())) == b'\x00\x01\x00\x0e\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptClientId instantiation with DUID_EN
-str(DHCP6OptClientId(duid=DUID_EN())) == b'\x00\x01\x00\x06\x00\x02\x00\x00\x017'
+raw(DHCP6OptClientId(duid=DUID_EN())) == b'\x00\x01\x00\x06\x00\x02\x00\x00\x017'
 
 = DHCP6OptClientId instantiation with specified length
-str(DHCP6OptClientId(optlen=80, duid="somestring")) == b'\x00\x01\x00Psomestring'
+raw(DHCP6OptClientId(optlen=80, duid="somestring")) == b'\x00\x01\x00Psomestring'
 
 = DHCP6OptClientId basic dissection
 a=DHCP6OptClientId(b'\x00\x01\x00\x00') 
 a.optcode == 1 and a.optlen == 0
 
 = DHCP6OptClientId instantiation with specified length
-str(DHCP6OptClientId(optlen=80, duid="somestring")) == b'\x00\x01\x00Psomestring'
+raw(DHCP6OptClientId(optlen=80, duid="somestring")) == b'\x00\x01\x00Psomestring'
 
 = DHCP6OptClientId basic dissection
 a=DHCP6OptClientId(b'\x00\x01\x00\x00') 
 a.optcode == 1 and a.optlen == 0
 
 = DHCP6OptClientId dissection with specific duid value
-a=DHCP6OptClientId(b'\x00\x01\x00\x04somestring')
+a=DHCP6OptClientId(b'\x00\x01\x00\x04somerawing')
 a.optcode == 1 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == 'some' and isinstance(a.payload, DHCP6OptUnknown)
 
 = DHCP6OptClientId dissection with specific DUID_LL as duid value
@@ -3389,29 +3389,29 @@ a.optcode == 1 and a.optlen == 6 and isinstance(a.duid, DUID_EN) and a.duid.type
 a=DHCP6OptServerId()
 
 = DHCP6OptServerId basic build 
-str(DHCP6OptServerId()) == b'\x00\x02\x00\x00'
+raw(DHCP6OptServerId()) == b'\x00\x02\x00\x00'
 
 = DHCP6OptServerId basic build with specific values
-str(DHCP6OptServerId(duid="toto")) == b'\x00\x02\x00\x04toto'
+raw(DHCP6OptServerId(duid="toto")) == b'\x00\x02\x00\x04toto'
 
 = DHCP6OptServerId instantiation with DUID_LL
-str(DHCP6OptServerId(duid=DUID_LL())) == b'\x00\x02\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptServerId(duid=DUID_LL())) == b'\x00\x02\x00\n\x00\x03\x00\x01\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptServerId instantiation with DUID_LLT
-str(DHCP6OptServerId(duid=DUID_LLT())) == b'\x00\x02\x00\x0e\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptServerId(duid=DUID_LLT())) == b'\x00\x02\x00\x0e\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptServerId instantiation with DUID_EN
-str(DHCP6OptServerId(duid=DUID_EN())) == b'\x00\x02\x00\x06\x00\x02\x00\x00\x017'
+raw(DHCP6OptServerId(duid=DUID_EN())) == b'\x00\x02\x00\x06\x00\x02\x00\x00\x017'
 
 = DHCP6OptServerId instantiation with specified length
-str(DHCP6OptServerId(optlen=80, duid="somestring")) == b'\x00\x02\x00Psomestring'
+raw(DHCP6OptServerId(optlen=80, duid="somestring")) == b'\x00\x02\x00Psomestring'
 
 = DHCP6OptServerId basic dissection
 a=DHCP6OptServerId(b'\x00\x02\x00\x00') 
 a.optcode == 2 and a.optlen == 0
 
 = DHCP6OptServerId dissection with specific duid value
-a=DHCP6OptServerId(b'\x00\x02\x00\x04somestring')
+a=DHCP6OptServerId(b'\x00\x02\x00\x04somerawing')
 a.optcode == 2 and a.optlen == 4 and isinstance(a.duid, Raw) and a.duid.load == 'some' and isinstance(a.payload, DHCP6OptUnknown)
 
 = DHCP6OptServerId dissection with specific DUID_LL as duid value
@@ -3432,21 +3432,21 @@ a.optcode == 2 and a.optlen == 6 and isinstance(a.duid, DUID_EN) and a.duid.type
 + Test DHCP6 IA Address Option (IA_TA or IA_NA suboption)
 
 = DHCP6OptIAAddress - Basic Instantiation
-str(DHCP6OptIAAddress()) == b'\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIAAddress()) == b'\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptIAAddress - Basic Dissection
 a = DHCP6OptIAAddress(b'\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 a.optcode == 5 and a.optlen == 24 and a.addr == "::" and a.preflft == 0 and a. validlft == 0 and a.iaaddropts == ""
 
 = DHCP6OptIAAddress - Instantiation with specific values
-str(DHCP6OptIAAddress(optlen=0x1111, addr="2222:3333::5555", preflft=0x66666666, validlft=0x77777777, iaaddropts="somestring")) == b'\x00\x05\x11\x11""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring'
+raw(DHCP6OptIAAddress(optlen=0x1111, addr="2222:3333::5555", preflft=0x66666666, validlft=0x77777777, iaaddropts="somestring")) == b'\x00\x05\x11\x11""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring'
 
 = DHCP6OptIAAddress - Instantiation with specific values (default optlen computation)
-str(DHCP6OptIAAddress(addr="2222:3333::5555", preflft=0x66666666, validlft=0x77777777, iaaddropts="somestring")) == b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring'
+raw(DHCP6OptIAAddress(addr="2222:3333::5555", preflft=0x66666666, validlft=0x77777777, iaaddropts="somestring")) == b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring'
 
 = DHCP6OptIAAddress - Dissection with specific values 
-a = DHCP6OptIAAddress(b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring')
-a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts == "somestring"
+a = DHCP6OptIAAddress(b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomerawing')
+a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts == "somerawing"
 
 
 ############
@@ -3454,20 +3454,20 @@ a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft 
 + Test DHCP6 Identity Association for Non-temporary Addresses Option
 
 = DHCP6OptIA_NA - Basic Instantiation
-str(DHCP6OptIA_NA()) == b'\x00\x03\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIA_NA()) == b'\x00\x03\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptIA_NA - Basic Dissection
 a = DHCP6OptIA_NA(b'\x00\x03\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 a.optcode == 3 and a.optlen == 12 and a.iaid == 0 and a.T1 == 0 and a.T2==0 and a.ianaopts == []
 
 = DHCP6OptIA_NA - Instantiation with specific values (keep automatic length computation) 
-str(DHCP6OptIA_NA(iaid=0x22222222, T1=0x33333333, T2=0x44444444)) == b'\x00\x03\x00\x0c""""3333DDDD'
+raw(DHCP6OptIA_NA(iaid=0x22222222, T1=0x33333333, T2=0x44444444)) == b'\x00\x03\x00\x0c""""3333DDDD'
 
 = DHCP6OptIA_NA - Instantiation with specific values (forced optlen)
-str(DHCP6OptIA_NA(optlen=0x1111, iaid=0x22222222, T1=0x33333333, T2=0x44444444)) == b'\x00\x03\x11\x11""""3333DDDD'
+raw(DHCP6OptIA_NA(optlen=0x1111, iaid=0x22222222, T1=0x33333333, T2=0x44444444)) == b'\x00\x03\x11\x11""""3333DDDD'
 
 = DHCP6OptIA_NA - Instantiation with a list of IA Addresses (optlen automatic computation)
-str(DHCP6OptIA_NA(iaid=0x22222222, T1=0x33333333, T2=0x44444444, ianaopts=[DHCP6OptIAAddress(), DHCP6OptIAAddress()])) == b'\x00\x03\x00D""""3333DDDD\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIA_NA(iaid=0x22222222, T1=0x33333333, T2=0x44444444, ianaopts=[DHCP6OptIAAddress(), DHCP6OptIAAddress()])) == b'\x00\x03\x00D""""3333DDDD\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptIA_NA - Dissection with specific values
 a = DHCP6OptIA_NA(b'\x00\x03\x00L""""3333DDDD\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -3479,14 +3479,14 @@ a.optcode == 3 and a.optlen == 76 and a.iaid == 0x22222222 and a.T1 == 0x3333333
 + Test DHCP6 Identity Association for Temporary Addresses Option
 
 = DHCP6OptIA_TA - Basic Instantiation
-str(DHCP6OptIA_TA()) == b'\x00\x04\x00\x04\x00\x00\x00\x00'
+raw(DHCP6OptIA_TA()) == b'\x00\x04\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptIA_TA - Basic Dissection
 a = DHCP6OptIA_TA(b'\x00\x04\x00\x04\x00\x00\x00\x00')
 a.optcode == 4 and a.optlen == 4 and a.iaid == 0 and a.iataopts == []
 
 = DHCP6OptIA_TA - Instantiation with specific values
-str(DHCP6OptIA_TA(optlen=0x1111, iaid=0x22222222, iataopts=[DHCP6OptIAAddress(), DHCP6OptIAAddress()])) == b'\x00\x04\x11\x11""""\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIA_TA(optlen=0x1111, iaid=0x22222222, iataopts=[DHCP6OptIAAddress(), DHCP6OptIAAddress()])) == b'\x00\x04\x11\x11""""\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptIA_TA - Dissection with specific values
 a = DHCP6OptIA_TA(b'\x00\x04\x11\x11""""\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -3498,13 +3498,13 @@ a.optcode == 4 and a.optlen == 0x1111 and a.iaid == 0x22222222 and len(a.iataopt
 + Test DHCP6 Option Request Option
 
 = DHCP6OptOptReq - Basic Instantiation
-str(DHCP6OptOptReq()) ==  b'\x00\x06\x00\x04\x00\x17\x00\x18'
+raw(DHCP6OptOptReq()) ==  b'\x00\x06\x00\x04\x00\x17\x00\x18'
 
 = DHCP6OptOptReq - optlen field computation
-str(DHCP6OptOptReq(reqopts=[1,2,3,4])) == b'\x00\x06\x00\x08\x00\x01\x00\x02\x00\x03\x00\x04'
+raw(DHCP6OptOptReq(reqopts=[1,2,3,4])) == b'\x00\x06\x00\x08\x00\x01\x00\x02\x00\x03\x00\x04'
 
 = DHCP6OptOptReq - instantiation with empty list
-str(DHCP6OptOptReq(reqopts=[])) == b'\x00\x06\x00\x00'
+raw(DHCP6OptOptReq(reqopts=[])) == b'\x00\x06\x00\x00'
 
 = DHCP6OptOptReq - Basic dissection
 a=DHCP6OptOptReq(b'\x00\x06\x00\x00')
@@ -3523,10 +3523,10 @@ a.show()
 + Test DHCP6 Option - Preference option
 
 = DHCP6OptPref - Basic instantiation
-str(DHCP6OptPref()) == b'\x00\x07\x00\x01\xff'
+raw(DHCP6OptPref()) == b'\x00\x07\x00\x01\xff'
 
 = DHCP6OptPref - Instantiation with specific values 
-str(DHCP6OptPref(optlen=0xffff, prefval= 0x11)) == b'\x00\x07\xff\xff\x11'
+raw(DHCP6OptPref(optlen=0xffff, prefval= 0x11)) == b'\x00\x07\xff\xff\x11'
 
 = DHCP6OptPref - Basic Dissection
 a=DHCP6OptPref(b'\x00\x07\x00\x01\xff')
@@ -3542,10 +3542,10 @@ a.optcode == 7 and a.optlen == 0xffff and a.prefval == 0x11
 + Test DHCP6 Option - Elapsed Time
 
 = DHCP6OptElapsedTime - Basic Instantiation
-str(DHCP6OptElapsedTime()) == b'\x00\x08\x00\x02\x00\x00'
+raw(DHCP6OptElapsedTime()) == b'\x00\x08\x00\x02\x00\x00'
 
 = DHCP6OptElapsedTime - Instantiation with specific elapsedtime value
-str(DHCP6OptElapsedTime(elapsedtime=421)) == b'\x00\x08\x00\x02\x01\xa5'
+raw(DHCP6OptElapsedTime(elapsedtime=421)) == b'\x00\x08\x00\x02\x01\xa5'
 
 = DHCP6OptElapsedTime - Basic Dissection
 a=DHCP6OptElapsedTime(b'\x00\x08\x00\x02\x00\x00') 
@@ -3564,13 +3564,13 @@ a.show()
 + Test DHCP6 Option - Server Unicast Address
 
 = DHCP6OptServerUnicast - Basic Instantiation
-str(DHCP6OptServerUnicast()) == b'\x00\x0c\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptServerUnicast()) == b'\x00\x0c\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6OptServerUnicast - Instantiation with specific values (test 1)
-str(DHCP6OptServerUnicast(srvaddr="2001::1")) == b'\x00\x0c\x00\x10 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptServerUnicast(srvaddr="2001::1")) == b'\x00\x0c\x00\x10 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptServerUnicast - Instantiation with specific values (test 2)
-str(DHCP6OptServerUnicast(srvaddr="2001::1", optlen=42)) == b'\x00\x0c\x00* \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptServerUnicast(srvaddr="2001::1", optlen=42)) == b'\x00\x0c\x00* \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptServerUnicast - Dissection with default values
 a=DHCP6OptServerUnicast(b'\x00\x0c\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -3590,13 +3590,13 @@ a.optcode == 12 and a.optlen == 42 and a.srvaddr == "2001::1"
 + Test DHCP6 Option - Status Code
 
 = DHCP6OptStatusCode - Basic Instantiation
-str(DHCP6OptStatusCode()) == b'\x00\r\x00\x02\x00\x00' 
+raw(DHCP6OptStatusCode()) == b'\x00\r\x00\x02\x00\x00' 
 
 = DHCP6OptStatusCode - Instantiation with specific values
-str(DHCP6OptStatusCode(optlen=42, statuscode=0xff, statusmsg="Hello")) == b'\x00\r\x00*\x00\xffHello'
+raw(DHCP6OptStatusCode(optlen=42, statuscode=0xff, statusmsg="Hello")) == b'\x00\r\x00*\x00\xffHello'
 
 = DHCP6OptStatusCode - Automatic Length computation
-str(DHCP6OptStatusCode(statuscode=0xff, statusmsg="Hello")) == b'\x00\r\x00\x07\x00\xffHello'
+raw(DHCP6OptStatusCode(statuscode=0xff, statusmsg="Hello")) == b'\x00\r\x00\x07\x00\xffHello'
 
 # Add tests to verify Unicode behavior
 
@@ -3606,7 +3606,7 @@ str(DHCP6OptStatusCode(statuscode=0xff, statusmsg="Hello")) == b'\x00\r\x00\x07\
 + Test DHCP6 Option - Rapid Commit
 
 = DHCP6OptRapidCommit - Basic Instantiation
-str(DHCP6OptRapidCommit()) == b'\x00\x0e\x00\x00'
+raw(DHCP6OptRapidCommit()) == b'\x00\x0e\x00\x00'
 
 = DHCP6OptRapidCommit - Basic Dissection
 a=DHCP6OptRapidCommit(b'\x00\x0e\x00\x00')
@@ -3618,23 +3618,23 @@ a.optcode == 14 and a.optlen == 0
 + Test DHCP6 Option - User class
 
 = DHCP6OptUserClass - Basic Instantiation
-str(DHCP6OptUserClass()) == b'\x00\x0f\x00\x00'
+raw(DHCP6OptUserClass()) == b'\x00\x0f\x00\x00'
 
 = DHCP6OptUserClass - Basic Dissection
 a = DHCP6OptUserClass(b'\x00\x0f\x00\x00')
 a.optcode == 15 and a.optlen == 0 and a.userclassdata == []
 
-= DHCP6OptUserClass - Instantiation with one user class data structure
-str(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something")])) == b'\x00\x0f\x00\x0b\x00\tsomething'
+= DHCP6OptUserClass - Instantiation with one user class data rawucture
+raw(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something")])) == b'\x00\x0f\x00\x0b\x00\tsomething'
 
-= DHCP6OptUserClass - Dissection with one user class data structure
+= DHCP6OptUserClass - Dissection with one user class data rawucture
 a = DHCP6OptUserClass(b'\x00\x0f\x00\x0b\x00\tsomething')
 a.optcode == 15 and a.optlen == 11 and len(a.userclassdata) == 1 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == 'something'
 
-= DHCP6OptUserClass - Instantiation with two user class data structures
-str(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something"), USER_CLASS_DATA(data="somethingelse")])) == b'\x00\x0f\x00\x1a\x00\tsomething\x00\rsomethingelse'
+= DHCP6OptUserClass - Instantiation with two user class data rawuctures
+raw(DHCP6OptUserClass(userclassdata=[USER_CLASS_DATA(data="something"), USER_CLASS_DATA(data="somethingelse")])) == b'\x00\x0f\x00\x1a\x00\tsomething\x00\rsomethingelse'
 
-= DHCP6OptUserClass - Dissection with two user class data structures
+= DHCP6OptUserClass - Dissection with two user class data rawuctures
 a = DHCP6OptUserClass(b'\x00\x0f\x00\x1a\x00\tsomething\x00\rsomethingelse')
 a.optcode == 15 and a.optlen == 26 and len(a.userclassdata) == 2 and isinstance(a.userclassdata[0], USER_CLASS_DATA) and isinstance(a.userclassdata[1], USER_CLASS_DATA) and a.userclassdata[0].len == 9 and a.userclassdata[0].data == 'something' and a.userclassdata[1].len == 13 and a.userclassdata[1].data == 'somethingelse'
 
@@ -3644,23 +3644,23 @@ a.optcode == 15 and a.optlen == 26 and len(a.userclassdata) == 2 and isinstance(
 + Test DHCP6 Option - Vendor class
 
 = DHCP6OptVendorClass - Basic Instantiation
-str(DHCP6OptVendorClass()) == b'\x00\x10\x00\x04\x00\x00\x00\x00'
+raw(DHCP6OptVendorClass()) == b'\x00\x10\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptVendorClass - Basic Dissection
 a = DHCP6OptVendorClass(b'\x00\x10\x00\x04\x00\x00\x00\x00')
 a.optcode == 16 and a.optlen == 4 and a.enterprisenum == 0 and a.vcdata == []
 
-= DHCP6OptVendorClass - Instantiation with one vendor class data structure
-str(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something")])) == b'\x00\x10\x00\x0f\x00\x00\x00\x00\x00\tsomething'
+= DHCP6OptVendorClass - Instantiation with one vendor class data rawucture
+raw(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something")])) == b'\x00\x10\x00\x0f\x00\x00\x00\x00\x00\tsomething'
 
-= DHCP6OptVendorClass - Dissection with one vendor class data structure
+= DHCP6OptVendorClass - Dissection with one vendor class data rawucture
 a = DHCP6OptVendorClass(b'\x00\x10\x00\x0f\x00\x00\x00\x00\x00\tsomething')
 a.optcode == 16 and a.optlen == 15 and a.enterprisenum == 0 and len(a.vcdata) == 1 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == 'something'
 
-= DHCP6OptVendorClass - Instantiation with two vendor class data structures
-str(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something"), VENDOR_CLASS_DATA(data="somethingelse")])) == b'\x00\x10\x00\x1e\x00\x00\x00\x00\x00\tsomething\x00\rsomethingelse'
+= DHCP6OptVendorClass - Instantiation with two vendor class data rawuctures
+raw(DHCP6OptVendorClass(vcdata=[VENDOR_CLASS_DATA(data="something"), VENDOR_CLASS_DATA(data="somethingelse")])) == b'\x00\x10\x00\x1e\x00\x00\x00\x00\x00\tsomething\x00\rsomethingelse'
 
-= DHCP6OptVendorClass - Dissection with two vendor class data structures
+= DHCP6OptVendorClass - Dissection with two vendor class data rawuctures
 a = DHCP6OptVendorClass(b'\x00\x10\x00\x1e\x00\x00\x00\x00\x00\tsomething\x00\rsomethingelse')
 a.optcode == 16 and a.optlen == 30 and a.enterprisenum == 0 and len(a.vcdata) == 2 and isinstance(a.vcdata[0], VENDOR_CLASS_DATA) and isinstance(a.vcdata[1], VENDOR_CLASS_DATA) and a.vcdata[0].len == 9 and a.vcdata[0].data == 'something' and a.vcdata[1].len == 13 and a.vcdata[1].data == 'somethingelse'
 
@@ -3670,21 +3670,21 @@ a.optcode == 16 and a.optlen == 30 and a.enterprisenum == 0 and len(a.vcdata) ==
 + Test DHCP6 Option - Vendor-specific information
 
 = DHCP6OptVendorSpecificInfo - Basic Instantiation
-str(DHCP6OptVendorSpecificInfo()) == b'\x00\x11\x00\x04\x00\x00\x00\x00'
+raw(DHCP6OptVendorSpecificInfo()) == b'\x00\x11\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptVendorSpecificInfo - Basic Dissection
 a = DHCP6OptVendorSpecificInfo(b'\x00\x11\x00\x04\x00\x00\x00\x00')
 a.optcode == 17 and a.optlen == 4 and a.enterprisenum == 0
 
 = DHCP6OptVendorSpecificInfo - Instantiation with specific values (one option)
-str(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OPTION(optcode=43, optdata="something")])) == b'\x00\x11\x00\x11\xee\xee\xee\xee\x00+\x00\tsomething'
+raw(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OPTION(optcode=43, optdata="something")])) == b'\x00\x11\x00\x11\xee\xee\xee\xee\x00+\x00\tsomething'
 
 = DHCP6OptVendorSpecificInfo - Dissection with with specific values (one option)
 a = DHCP6OptVendorSpecificInfo(b'\x00\x11\x00\x11\xee\xee\xee\xee\x00+\x00\tsomething')
 a.optcode == 17 and a.optlen == 17 and a.enterprisenum == 0xeeeeeeee and len(a.vso) == 1 and isinstance(a.vso[0], VENDOR_SPECIFIC_OPTION) and a.vso[0].optlen == 9 and a.vso[0].optdata == 'something'
 
 = DHCP6OptVendorSpecificInfo - Instantiation with specific values (two options)
-str(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OPTION(optcode=43, optdata="something"), VENDOR_SPECIFIC_OPTION(optcode=42, optdata="somethingelse")])) == b'\x00\x11\x00"\xee\xee\xee\xee\x00+\x00\tsomething\x00*\x00\rsomethingelse'
+raw(DHCP6OptVendorSpecificInfo(enterprisenum=0xeeeeeeee, vso=[VENDOR_SPECIFIC_OPTION(optcode=43, optdata="something"), VENDOR_SPECIFIC_OPTION(optcode=42, optdata="somethingelse")])) == b'\x00\x11\x00"\xee\xee\xee\xee\x00+\x00\tsomething\x00*\x00\rsomethingelse'
 
 = DHCP6OptVendorSpecificInfo - Dissection with with specific values (two options)
 a = DHCP6OptVendorSpecificInfo(b'\x00\x11\x00"\xee\xee\xee\xee\x00+\x00\tsomething\x00*\x00\rsomethingelse')
@@ -3696,14 +3696,14 @@ a.optcode == 17 and a.optlen == 34 and a.enterprisenum == 0xeeeeeeee and len(a.v
 + Test DHCP6 Option - Interface-Id 
 
 = DHCP6OptIfaceId - Basic Instantiation
-str(DHCP6OptIfaceId()) == b'\x00\x12\x00\x00'
+raw(DHCP6OptIfaceId()) == b'\x00\x12\x00\x00'
 
 = DHCP6OptIfaceId - Basic Dissection
 a = DHCP6OptIfaceId(b'\x00\x12\x00\x00')
 a.optcode == 18 and a.optlen == 0
 
 = DHCP6OptIfaceId - Instantiation with specific value
-str(DHCP6OptIfaceId(ifaceid="something")) == b'\x00\x12\x00\x09something'
+raw(DHCP6OptIfaceId(ifaceid="something")) == b'\x00\x12\x00\x09something'
 
 = DHCP6OptIfaceId - Dissection with specific value
 a = DHCP6OptIfaceId(b'\x00\x12\x00\x09something')
@@ -3715,14 +3715,14 @@ a.optcode == 18 and a.optlen == 9 and a.ifaceid == "something"
 + Test DHCP6 Option - Reconfigure Message
 
 = DHCP6OptReconfMsg - Basic Instantiation
-str(DHCP6OptReconfMsg()) == b'\x00\x13\x00\x01\x0b'
+raw(DHCP6OptReconfMsg()) == b'\x00\x13\x00\x01\x0b'
 
 = DHCP6OptReconfMsg - Basic Dissection
 a = DHCP6OptReconfMsg(b'\x00\x13\x00\x01\x0b')
 a.optcode == 19 and a.optlen == 1 and a.msgtype == 11
 
 = DHCP6OptReconfMsg - Instantiation with specific values
-str(DHCP6OptReconfMsg(optlen=4, msgtype=5)) == b'\x00\x13\x00\x04\x05'
+raw(DHCP6OptReconfMsg(optlen=4, msgtype=5)) == b'\x00\x13\x00\x04\x05'
 
 = DHCP6OptReconfMsg - Dissection with specific values
 a = DHCP6OptReconfMsg(b'\x00\x13\x00\x04\x05')
@@ -3734,14 +3734,14 @@ a.optcode == 19 and a.optlen == 4 and a.msgtype == 5
 + Test DHCP6 Option - Reconfigure Accept
 
 = DHCP6OptReconfAccept - Basic Instantiation
-str(DHCP6OptReconfAccept()) == b'\x00\x14\x00\x00'
+raw(DHCP6OptReconfAccept()) == b'\x00\x14\x00\x00'
 
 = DHCP6OptReconfAccept - Basic Dissection
 a = DHCP6OptReconfAccept(b'\x00\x14\x00\x00')
 a.optcode == 20 and a.optlen == 0
 
 = DHCP6OptReconfAccept - Instantiation with specific values
-str(DHCP6OptReconfAccept(optlen=23)) == b'\x00\x14\x00\x17'
+raw(DHCP6OptReconfAccept(optlen=23)) == b'\x00\x14\x00\x17'
 
 = DHCP6OptReconfAccept - Dssection with specific values
 a = DHCP6OptReconfAccept(b'\x00\x14\x00\x17')
@@ -3753,28 +3753,28 @@ a.optcode == 20 and a.optlen == 23
 + Test DHCP6 Option - SIP Servers Domain Name List
 
 = DHCP6OptSIPDomains - Basic Instantiation
-str(DHCP6OptSIPDomains()) == b'\x00\x15\x00\x00'
+raw(DHCP6OptSIPDomains()) == b'\x00\x15\x00\x00'
 
 = DHCP6OptSIPDomains - Basic Dissection
 a = DHCP6OptSIPDomains(b'\x00\x15\x00\x00') 
 a.optcode == 21 and a.optlen == 0 and a.sipdomains == []
 
 = DHCP6OptSIPDomains - Instantiation with one domain
-str(DHCP6OptSIPDomains(sipdomains=["toto.example.org"])) == b'\x00\x15\x00\x12\x04toto\x07example\x03org\x00'
+raw(DHCP6OptSIPDomains(sipdomains=["toto.example.org"])) == b'\x00\x15\x00\x12\x04toto\x07example\x03org\x00'
 
 = DHCP6OptSIPDomains - Dissection with one domain
 a = DHCP6OptSIPDomains(b'\x00\x15\x00\x12\x04toto\x07example\x03org\x00')
 a.optcode == 21 and a.optlen == 18 and len(a.sipdomains) == 1 and a.sipdomains[0] == "toto.example.org."
 
 = DHCP6OptSIPDomains - Instantiation with two domains
-str(DHCP6OptSIPDomains(sipdomains=["toto.example.org", "titi.example.org"])) == b'\x00\x15\x00$\x04toto\x07example\x03org\x00\x04titi\x07example\x03org\x00'
+raw(DHCP6OptSIPDomains(sipdomains=["toto.example.org", "titi.example.org"])) == b'\x00\x15\x00$\x04toto\x07example\x03org\x00\x04titi\x07example\x03org\x00'
 
 = DHCP6OptSIPDomains - Dissection with two domains
 a = DHCP6OptSIPDomains(b'\x00\x15\x00$\x04toto\x07example\x03org\x00\x04TITI\x07example\x03org\x00')
 a.optcode == 21 and a.optlen == 36 and len(a.sipdomains) == 2 and a.sipdomains[0] == "toto.example.org." and a.sipdomains[1] == "TITI.example.org."
 
 = DHCP6OptSIPDomains - Enforcing only one dot at end of domain
-str(DHCP6OptSIPDomains(sipdomains=["toto.example.org."])) == b'\x00\x15\x00\x12\x04toto\x07example\x03org\x00'
+raw(DHCP6OptSIPDomains(sipdomains=["toto.example.org."])) == b'\x00\x15\x00\x12\x04toto\x07example\x03org\x00'
 
 
 ############
@@ -3782,21 +3782,21 @@ str(DHCP6OptSIPDomains(sipdomains=["toto.example.org."])) == b'\x00\x15\x00\x12\
 + Test DHCP6 Option - SIP Servers IPv6 Address List
 
 = DHCP6OptSIPServers - Basic Instantiation
-str(DHCP6OptSIPServers()) == b'\x00\x16\x00\x00'
+raw(DHCP6OptSIPServers()) == b'\x00\x16\x00\x00'
 
 = DHCP6OptSIPServers - Basic Dissection
 a = DHCP6OptSIPServers(b'\x00\x16\x00\x00')
 a.optcode == 22 and a. optlen == 0 and a.sipservers == []
 
 = DHCP6OptSIPServers - Instantiation with specific values (1 address)
-str(DHCP6OptSIPServers(sipservers = ["2001:db8::1"] )) == b'\x00\x16\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptSIPServers(sipservers = ["2001:db8::1"] )) == b'\x00\x16\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptSIPServers - Dissection with specific values (1 address)
 a = DHCP6OptSIPServers(b'\x00\x16\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 22 and a.optlen == 16 and len(a.sipservers) == 1 and a.sipservers[0] == "2001:db8::1" 
 
 = DHCP6OptSIPServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptSIPServers(sipservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x16\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptSIPServers(sipservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x16\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptSIPServers - Dissection with specific values (2 addresses)
 a = DHCP6OptSIPServers(b'\x00\x16\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -3808,21 +3808,21 @@ a.optcode == 22 and a.optlen == 32 and len(a.sipservers) == 2 and a.sipservers[0
 + Test DHCP6 Option - DNS Recursive Name Server
 
 = DHCP6OptDNSServers - Basic Instantiation
-str(DHCP6OptDNSServers()) == b'\x00\x17\x00\x00'
+raw(DHCP6OptDNSServers()) == b'\x00\x17\x00\x00'
 
 = DHCP6OptDNSServers - Basic Dissection
 a = DHCP6OptDNSServers(b'\x00\x17\x00\x00')
 a.optcode == 23 and a. optlen == 0 and a.dnsservers == []
 
 = DHCP6OptDNSServers - Instantiation with specific values (1 address)
-str(DHCP6OptDNSServers(dnsservers = ["2001:db8::1"] )) == b'\x00\x17\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptDNSServers(dnsservers = ["2001:db8::1"] )) == b'\x00\x17\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptDNSServers - Dissection with specific values (1 address)
 a = DHCP6OptDNSServers(b'\x00\x17\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 23 and a.optlen == 16 and len(a.dnsservers) == 1 and a.dnsservers[0] == "2001:db8::1" 
 
 = DHCP6OptDNSServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptDNSServers(dnsservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x17\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptDNSServers(dnsservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x17\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptDNSServers - Dissection with specific values (2 addresses)
 a = DHCP6OptDNSServers(b'\x00\x17\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -3834,21 +3834,21 @@ a.optcode == 23 and a.optlen == 32 and len(a.dnsservers) == 2 and a.dnsservers[0
 + Test DHCP6 Option - DNS Domain Search List Option
 
 = DHCP6OptDNSDomains - Basic Instantiation
-str(DHCP6OptDNSDomains()) == b'\x00\x18\x00\x00'
+raw(DHCP6OptDNSDomains()) == b'\x00\x18\x00\x00'
 
 = DHCP6OptDNSDomains - Basic Dissection
 a = DHCP6OptDNSDomains(b'\x00\x18\x00\x00')
 a.optcode == 24 and a.optlen == 0 and a.dnsdomains == []
 
 = DHCP6OptDNSDomains - Instantiation with specific values (1 domain) 
-str(DHCP6OptDNSDomains(dnsdomains=["toto.example.com."])) == b'\x00\x18\x00\x12\x04toto\x07example\x03com\x00'
+raw(DHCP6OptDNSDomains(dnsdomains=["toto.example.com."])) == b'\x00\x18\x00\x12\x04toto\x07example\x03com\x00'
 
 = DHCP6OptDNSDomains - Dissection with specific values (1 domain) 
 a = DHCP6OptDNSDomains(b'\x00\x18\x00\x12\x04toto\x07example\x03com\x00')
 a.optcode == 24 and a.optlen == 18 and len(a.dnsdomains) == 1 and a.dnsdomains[0] == "toto.example.com."
 
 = DHCP6OptDNSDomains - Instantiation with specific values (2 domains) 
-str(DHCP6OptDNSDomains(dnsdomains=["toto.example.com.", "titi.example.com."])) == b'\x00\x18\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00'
+raw(DHCP6OptDNSDomains(dnsdomains=["toto.example.com.", "titi.example.com."])) == b'\x00\x18\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00'
 
 = DHCP6OptDNSDomains - Dissection with specific values (2 domains) 
 a = DHCP6OptDNSDomains(b'\x00\x18\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00')
@@ -3860,7 +3860,7 @@ a.optcode == 24 and a.optlen == 36 and len(a.dnsdomains) == 2 and a.dnsdomains[0
 + Test DHCP6 Option - IA_PD Prefix Option
 
 = DHCP6OptIAPrefix - Basic Instantiation
-str(DHCP6OptIAPrefix()) == b'\x00\x1a\x00\x19\x00\x00\x00\x00\x00\x00\x00\x000 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIAPrefix()) == b'\x00\x1a\x00\x19\x00\x00\x00\x00\x00\x00\x00\x000 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 #TODO : finish me
 
@@ -3870,7 +3870,7 @@ str(DHCP6OptIAPrefix()) == b'\x00\x1a\x00\x19\x00\x00\x00\x00\x00\x00\x00\x000 \
 + Test DHCP6 Option - Identity Association for Prefix Delegation
 
 = DHCP6OptIA_PD - Basic Instantiation
-str(DHCP6OptIA_PD()) == b'\x00\x19\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6OptIA_PD()) == b'\x00\x19\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 #TODO : finish me
 
@@ -3880,21 +3880,21 @@ str(DHCP6OptIA_PD()) == b'\x00\x19\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x
 + Test DHCP6 Option - NIS Servers
 
 = DHCP6OptNISServers - Basic Instantiation
-str(DHCP6OptNISServers()) == b'\x00\x1b\x00\x00'
+raw(DHCP6OptNISServers()) == b'\x00\x1b\x00\x00'
 
 = DHCP6OptNISServers - Basic Dissection
 a = DHCP6OptNISServers(b'\x00\x1b\x00\x00')
 a.optcode == 27 and a. optlen == 0 and a.nisservers == []
 
 = DHCP6OptNISServers - Instantiation with specific values (1 address)
-str(DHCP6OptNISServers(nisservers = ["2001:db8::1"] )) == b'\x00\x1b\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptNISServers(nisservers = ["2001:db8::1"] )) == b'\x00\x1b\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptNISServers - Dissection with specific values (1 address)
 a = DHCP6OptNISServers(b'\x00\x1b\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 27 and a.optlen == 16 and len(a.nisservers) == 1 and a.nisservers[0] == "2001:db8::1" 
 
 = DHCP6OptNISServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptNISServers(nisservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1b\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptNISServers(nisservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1b\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptNISServers - Dissection with specific values (2 addresses)
 a = DHCP6OptNISServers(b'\x00\x1b\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -3906,21 +3906,21 @@ a.optcode == 27 and a.optlen == 32 and len(a.nisservers) == 2 and a.nisservers[0
 + Test DHCP6 Option - NIS+ Servers
 
 = DHCP6OptNISPServers - Basic Instantiation
-str(DHCP6OptNISPServers()) == b'\x00\x1c\x00\x00'
+raw(DHCP6OptNISPServers()) == b'\x00\x1c\x00\x00'
 
 = DHCP6OptNISPServers - Basic Dissection
 a = DHCP6OptNISPServers(b'\x00\x1c\x00\x00')
 a.optcode == 28 and a. optlen == 0 and a.nispservers == []
 
 = DHCP6OptNISPServers - Instantiation with specific values (1 address)
-str(DHCP6OptNISPServers(nispservers = ["2001:db8::1"] )) == b'\x00\x1c\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptNISPServers(nispservers = ["2001:db8::1"] )) == b'\x00\x1c\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptNISPServers - Dissection with specific values (1 address)
 a = DHCP6OptNISPServers(b'\x00\x1c\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 28 and a.optlen == 16 and len(a.nispservers) == 1 and a.nispservers[0] == "2001:db8::1" 
 
 = DHCP6OptNISPServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptNISPServers(nispservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1c\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptNISPServers(nispservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1c\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptNISPServers - Dissection with specific values (2 addresses)
 a = DHCP6OptNISPServers(b'\x00\x1c\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -3932,21 +3932,21 @@ a.optcode == 28 and a.optlen == 32 and len(a.nispservers) == 2 and a.nispservers
 + Test DHCP6 Option - NIS Domain Name
 
 = DHCP6OptNISDomain - Basic Instantiation
-str(DHCP6OptNISDomain()) == b'\x00\x1d\x00\x00'
+raw(DHCP6OptNISDomain()) == b'\x00\x1d\x00\x00'
 
 = DHCP6OptNISDomain - Basic Dissection
 a = DHCP6OptNISDomain(b'\x00\x1d\x00\x00')
 a.optcode == 29 and a.optlen == 0 and a.nisdomain == ""
 
 = DHCP6OptNISDomain - Instantiation with one domain name
-str(DHCP6OptNISDomain(nisdomain="toto.example.org")) == b'\x00\x1d\x00\x11\x04toto\x07example\x03org'
+raw(DHCP6OptNISDomain(nisdomain="toto.example.org")) == b'\x00\x1d\x00\x11\x04toto\x07example\x03org'
 
 = DHCP6OptNISDomain - Dissection with one domain name
 a = DHCP6OptNISDomain(b'\x00\x1d\x00\x11\x04toto\x07example\x03org\x00')
 a.optcode == 29 and a.optlen == 17 and a.nisdomain == "toto.example.org"
 
 = DHCP6OptNISDomain - Instantiation with one domain with trailing dot
-str(DHCP6OptNISDomain(nisdomain="toto.example.org.")) == b'\x00\x1d\x00\x12\x04toto\x07example\x03org\x00'
+raw(DHCP6OptNISDomain(nisdomain="toto.example.org.")) == b'\x00\x1d\x00\x12\x04toto\x07example\x03org\x00'
 
 
 ############
@@ -3954,21 +3954,21 @@ str(DHCP6OptNISDomain(nisdomain="toto.example.org.")) == b'\x00\x1d\x00\x12\x04t
 + Test DHCP6 Option - NIS+ Domain Name
 
 = DHCP6OptNISPDomain - Basic Instantiation
-str(DHCP6OptNISPDomain()) == b'\x00\x1e\x00\x00'
+raw(DHCP6OptNISPDomain()) == b'\x00\x1e\x00\x00'
 
 = DHCP6OptNISPDomain - Basic Dissection
 a = DHCP6OptNISPDomain(b'\x00\x1e\x00\x00')
 a.optcode == 30 and a.optlen == 0 and a.nispdomain == ""
 
 = DHCP6OptNISPDomain - Instantiation with one domain name
-str(DHCP6OptNISPDomain(nispdomain="toto.example.org")) == b'\x00\x1e\x00\x11\x04toto\x07example\x03org'
+raw(DHCP6OptNISPDomain(nispdomain="toto.example.org")) == b'\x00\x1e\x00\x11\x04toto\x07example\x03org'
 
 = DHCP6OptNISPDomain - Dissection with one domain name
 a = DHCP6OptNISPDomain(b'\x00\x1e\x00\x11\x04toto\x07example\x03org\x00')
 a.optcode == 30 and a.optlen == 17 and a.nispdomain == "toto.example.org"
 
 = DHCP6OptNISPDomain - Instantiation with one domain with trailing dot
-str(DHCP6OptNISPDomain(nispdomain="toto.example.org.")) == b'\x00\x1e\x00\x12\x04toto\x07example\x03org\x00'
+raw(DHCP6OptNISPDomain(nispdomain="toto.example.org.")) == b'\x00\x1e\x00\x12\x04toto\x07example\x03org\x00'
 
 
 ############
@@ -3976,21 +3976,21 @@ str(DHCP6OptNISPDomain(nispdomain="toto.example.org.")) == b'\x00\x1e\x00\x12\x0
 + Test DHCP6 Option - SNTP Servers
 
 = DHCP6OptSNTPServers - Basic Instantiation
-str(DHCP6OptSNTPServers()) == b'\x00\x1f\x00\x00'
+raw(DHCP6OptSNTPServers()) == b'\x00\x1f\x00\x00'
 
 = DHCP6OptSNTPServers - Basic Dissection
 a = DHCP6OptSNTPServers(b'\x00\x1f\x00\x00')
 a.optcode == 31 and a. optlen == 0 and a.sntpservers == []
 
 = DHCP6OptSNTPServers - Instantiation with specific values (1 address)
-str(DHCP6OptSNTPServers(sntpservers = ["2001:db8::1"] )) == b'\x00\x1f\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptSNTPServers(sntpservers = ["2001:db8::1"] )) == b'\x00\x1f\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptSNTPServers - Dissection with specific values (1 address)
 a = DHCP6OptSNTPServers(b'\x00\x1f\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 31 and a.optlen == 16 and len(a.sntpservers) == 1 and a.sntpservers[0] == "2001:db8::1" 
 
 = DHCP6OptSNTPServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptSNTPServers(sntpservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1f\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptSNTPServers(sntpservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\x1f\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptSNTPServers - Dissection with specific values (2 addresses)
 a = DHCP6OptSNTPServers(b'\x00\x1f\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -4001,35 +4001,35 @@ a.optcode == 31 and a.optlen == 32 and len(a.sntpservers) == 2 and a.sntpservers
 + Test DHCP6 Option - Information Refresh Time
 
 = DHCP6OptInfoRefreshTime - Basic Instantiation
-str(DHCP6OptInfoRefreshTime()) == b'\x00 \x00\x04\x00\x01Q\x80'
+raw(DHCP6OptInfoRefreshTime()) == b'\x00 \x00\x04\x00\x01Q\x80'
 
 = DHCP6OptInfoRefreshTime - Basic Dissction
 a = DHCP6OptInfoRefreshTime(b'\x00 \x00\x04\x00\x01Q\x80')
 a.optcode == 32 and a.optlen == 4 and a.reftime == 86400
 
 = DHCP6OptInfoRefreshTime - Instantiation with specific values
-str(DHCP6OptInfoRefreshTime(optlen=7, reftime=42)) == b'\x00 \x00\x07\x00\x00\x00*'
+raw(DHCP6OptInfoRefreshTime(optlen=7, reftime=42)) == b'\x00 \x00\x07\x00\x00\x00*'
 
 ############
 ############
 + Test DHCP6 Option - BCMCS Servers
 
 = DHCP6OptBCMCSServers - Basic Instantiation
-str(DHCP6OptBCMCSServers()) == b'\x00"\x00\x00'
+raw(DHCP6OptBCMCSServers()) == b'\x00"\x00\x00'
 
 = DHCP6OptBCMCSServers - Basic Dissection
 a = DHCP6OptBCMCSServers(b'\x00"\x00\x00')
 a.optcode == 34 and a. optlen == 0 and a.bcmcsservers == []
 
 = DHCP6OptBCMCSServers - Instantiation with specific values (1 address)
-str(DHCP6OptBCMCSServers(bcmcsservers = ["2001:db8::1"] )) == b'\x00"\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+raw(DHCP6OptBCMCSServers(bcmcsservers = ["2001:db8::1"] )) == b'\x00"\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
 
 = DHCP6OptBCMCSServers - Dissection with specific values (1 address)
 a = DHCP6OptBCMCSServers(b'\x00"\x00\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.optcode == 34 and a.optlen == 16 and len(a.bcmcsservers) == 1 and a.bcmcsservers[0] == "2001:db8::1" 
 
 = DHCP6OptBCMCSServers - Instantiation with specific values (2 addresses)
-str(DHCP6OptBCMCSServers(bcmcsservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00"\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
+raw(DHCP6OptBCMCSServers(bcmcsservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00"\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
 
 = DHCP6OptBCMCSServers - Dissection with specific values (2 addresses)
 a = DHCP6OptBCMCSServers(b'\x00"\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
@@ -4041,21 +4041,21 @@ a.optcode == 34 and a.optlen == 32 and len(a.bcmcsservers) == 2 and a.bcmcsserve
 + Test DHCP6 Option - BCMCS Domains
 
 = DHCP6OptBCMCSDomains - Basic Instantiation
-str(DHCP6OptBCMCSDomains()) == b'\x00!\x00\x00'
+raw(DHCP6OptBCMCSDomains()) == b'\x00!\x00\x00'
 
 = DHCP6OptBCMCSDomains - Basic Dissection
 a = DHCP6OptBCMCSDomains(b'\x00!\x00\x00')
 a.optcode == 33 and a.optlen == 0 and a.bcmcsdomains == []
 
 = DHCP6OptBCMCSDomains - Instantiation with specific values (1 domain) 
-str(DHCP6OptBCMCSDomains(bcmcsdomains=["toto.example.com."])) == b'\x00!\x00\x12\x04toto\x07example\x03com\x00'
+raw(DHCP6OptBCMCSDomains(bcmcsdomains=["toto.example.com."])) == b'\x00!\x00\x12\x04toto\x07example\x03com\x00'
 
 = DHCP6OptBCMCSDomains - Dissection with specific values (1 domain) 
 a = DHCP6OptBCMCSDomains(b'\x00!\x00\x12\x04toto\x07example\x03com\x00')
 a.optcode == 33 and a.optlen == 18 and len(a.bcmcsdomains) == 1 and a.bcmcsdomains[0] == "toto.example.com."
 
 = DHCP6OptBCMCSDomains - Instantiation with specific values (2 domains) 
-str(DHCP6OptBCMCSDomains(bcmcsdomains=["toto.example.com.", "titi.example.com."])) == b'\x00!\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00'
+raw(DHCP6OptBCMCSDomains(bcmcsdomains=["toto.example.com.", "titi.example.com."])) == b'\x00!\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00'
 
 = DHCP6OptBCMCSDomains - Dissection with specific values (2 domains) 
 a = DHCP6OptBCMCSDomains(b'\x00!\x00$\x04toto\x07example\x03com\x00\x04titi\x07example\x03com\x00')
@@ -4067,14 +4067,14 @@ a.optcode == 33 and a.optlen == 36 and len(a.bcmcsdomains) == 2 and a.bcmcsdomai
 + Test DHCP6 Option - Relay Agent Remote-ID
 
 = DHCP6OptRemoteID - Basic Instantiation
-str(DHCP6OptRemoteID()) == b'\x00%\x00\x04\x00\x00\x00\x00'
+raw(DHCP6OptRemoteID()) == b'\x00%\x00\x04\x00\x00\x00\x00'
 
 = DHCP6OptRemoteID - Basic Dissection
 a = DHCP6OptRemoteID(b'\x00%\x00\x04\x00\x00\x00\x00')
 a.optcode == 37 and a.optlen == 4 and a.enterprisenum == 0 and a.remoteid == ""
 
 = DHCP6OptRemoteID - Instantiation with specific values 
-str(DHCP6OptRemoteID(enterprisenum=0xeeeeeeee, remoteid="someid")) == b'\x00%\x00\n\xee\xee\xee\xeesomeid'
+raw(DHCP6OptRemoteID(enterprisenum=0xeeeeeeee, remoteid="someid")) == b'\x00%\x00\n\xee\xee\xee\xeesomeid'
 
 = DHCP6OptRemoteID - Dissection with specific values
 a = DHCP6OptRemoteID(b'\x00%\x00\n\xee\xee\xee\xeesomeid')
@@ -4086,14 +4086,14 @@ a.optcode == 37 and a.optlen == 10 and a.enterprisenum == 0xeeeeeeee and a.remot
 + Test DHCP6 Option - Subscriber ID
 
 = DHCP6OptSubscriberID - Basic Instantiation
-str(DHCP6OptSubscriberID()) == b'\x00&\x00\x00'
+raw(DHCP6OptSubscriberID()) == b'\x00&\x00\x00'
 
 = DHCP6OptSubscriberID - Basic Dissection
 a = DHCP6OptSubscriberID(b'\x00&\x00\x00')
 a.optcode == 38 and a.optlen == 0 and a.subscriberid == ""
 
 = DHCP6OptSubscriberID - Instantiation with specific values
-str(DHCP6OptSubscriberID(subscriberid="someid")) == b'\x00&\x00\x06someid'
+raw(DHCP6OptSubscriberID(subscriberid="someid")) == b'\x00&\x00\x06someid'
 
 = DHCP6OptSubscriberID - Dissection with specific values
 a = DHCP6OptSubscriberID(b'\x00&\x00\x06someid')
@@ -4105,17 +4105,17 @@ a.optcode == 38 and a.optlen == 6 and a.subscriberid == "someid"
 + Test DHCP6 Option - Client FQDN
 
 = DHCP6OptClientFQDN - Basic Instantiation
-str(DHCP6OptClientFQDN()) == b"\x00'\x00\x01\x00"
+raw(DHCP6OptClientFQDN()) == b"\x00'\x00\x01\x00"
 
 = DHCP6OptClientFQDN - Basic Dissection
 a = DHCP6OptClientFQDN(b"\x00'\x00\x01\x00")
 a.optcode == 39 and a.optlen == 1 and a.res == 0 and a.flags == 0 and a.fqdn == ""
 
 = DHCP6OptClientFQDN - Instantiation with various flags combinations
-str(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x01\x01" and str(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x01\x02" and str(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x01\x04" and str(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x01\x07" and str(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x01\x06"
+raw(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x01\x01" and str(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x01\x02" and str(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x01\x04" and str(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x01\x07" and str(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x01\x06"
 
 = DHCP6OptClientFQDN - Instantiation with one fqdn 
-str(DHCP6OptClientFQDN(fqdn="toto.example.org")) == b"\x00'\x00\x12\x00\x04toto\x07example\x03org"
+raw(DHCP6OptClientFQDN(fqdn="toto.example.org")) == b"\x00'\x00\x12\x00\x04toto\x07example\x03org"
 
 = DHCP6OptClientFQDN - Dissection with one fqdn 
 a = DHCP6OptClientFQDN(b"\x00'\x00\x12\x00\x04toto\x07example\x03org\x00")
@@ -4127,13 +4127,13 @@ a.optcode == 39 and a.optlen == 18 and a.res == 0 and a.flags == 0 and a.fqdn ==
 + Test DHCP6 Option Relay Agent Echo Request Option
 
 = DHCP6OptRelayAgentERO - Basic Instantiation
-str(DHCP6OptRelayAgentERO()) ==  b'\x00+\x00\x04\x00\x17\x00\x18'
+raw(DHCP6OptRelayAgentERO()) ==  b'\x00+\x00\x04\x00\x17\x00\x18'
 
 = DHCP6OptRelayAgentERO - optlen field computation
-str(DHCP6OptRelayAgentERO(reqopts=[1,2,3,4])) == b'\x00+\x00\x08\x00\x01\x00\x02\x00\x03\x00\x04'
+raw(DHCP6OptRelayAgentERO(reqopts=[1,2,3,4])) == b'\x00+\x00\x08\x00\x01\x00\x02\x00\x03\x00\x04'
 
 = DHCP6OptRelayAgentERO - instantiation with empty list
-str(DHCP6OptRelayAgentERO(reqopts=[])) == b'\x00+\x00\x00'
+raw(DHCP6OptRelayAgentERO(reqopts=[])) == b'\x00+\x00\x00'
 
 = DHCP6OptRelayAgentERO - Basic dissection
 a=DHCP6OptRelayAgentERO(b'\x00+\x00\x00')
@@ -4149,7 +4149,7 @@ a.optcode == 43 and a.optlen == 8 and a.reqopts == [1,2,3,4]
 + Test DHCP6 Option Client Link Layer address
 
 = Basic build & dissect
-s = str(DHCP6OptClientLinkLayerAddr())
+s = raw(DHCP6OptClientLinkLayerAddr())
 assert(s == b"\x00O\x00\x07\x00\x01\x00\x00\x00\x00\x00\x00")
 
 p = DHCP6OptClientLinkLayerAddr(s)
@@ -4161,7 +4161,7 @@ assert(p.clladdr == "00:00:00:00:00:00")
 + Test DHCP6 Option Virtual Subnet Selection
 
 = Basic build & dissect
-s = str(DHCP6OptVSS())
+s = raw(DHCP6OptVSS())
 assert(s == b"\x00D\x00\x01\xff")
 
 p = DHCP6OptVSS(s)
@@ -4173,7 +4173,7 @@ assert(p.type == 255)
 + Test DHCP6 Messages - DHCP6_Solicit
 
 = DHCP6_Solicit - Basic Instantiation
-str(DHCP6_Solicit()) == b'\x01\x00\x00\x00'
+raw(DHCP6_Solicit()) == b'\x01\x00\x00\x00'
 
 = DHCP6_Solicit - Basic Dissection
 a = DHCP6_Solicit(b'\x01\x00\x00\x00')
@@ -4190,7 +4190,7 @@ a=UDP()/DHCP6_Solicit()
 a.sport == 546 and a.dport == 547
 
 = DHCP6_Solicit - Dispatch based on UDP port 
-a=UDP(str(UDP()/DHCP6_Solicit()))
+a=UDP(raw(UDP()/DHCP6_Solicit()))
 isinstance(a.payload, DHCP6_Solicit)
 
 
@@ -4199,7 +4199,7 @@ isinstance(a.payload, DHCP6_Solicit)
 + Test DHCP6 Messages - DHCP6_Advertise
 
 = DHCP6_Advertise - Basic Instantiation
-str(DHCP6_Advertise()) == b'\x02\x00\x00\x00'
+raw(DHCP6_Advertise()) == b'\x02\x00\x00\x00'
 
 = DHCP6_Advertise - Basic test of DHCP6_solicit.hashret() 
 DHCP6_Advertise().hashret() == b'\x00\x00\x00'
@@ -4227,7 +4227,7 @@ a.sport == 547 and a.dport == 546
 + Test DHCP6 Messages - DHCP6_Request
 
 = DHCP6_Request - Basic Instantiation
-str(DHCP6_Request()) == b'\x03\x00\x00\x00'
+raw(DHCP6_Request()) == b'\x03\x00\x00\x00'
 
 = DHCP6_Request - Basic Dissection
 a=DHCP6_Request(b'\x03\x00\x00\x00')
@@ -4243,7 +4243,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Confirm
 
 = DHCP6_Confirm - Basic Instantiation
-str(DHCP6_Confirm()) == b'\x04\x00\x00\x00'
+raw(DHCP6_Confirm()) == b'\x04\x00\x00\x00'
 
 = DHCP6_Confirm - Basic Dissection
 a=DHCP6_Confirm(b'\x04\x00\x00\x00')
@@ -4259,7 +4259,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Renew
 
 = DHCP6_Renew - Basic Instantiation
-str(DHCP6_Renew()) == b'\x05\x00\x00\x00'
+raw(DHCP6_Renew()) == b'\x05\x00\x00\x00'
 
 = DHCP6_Renew - Basic Dissection
 a=DHCP6_Renew(b'\x05\x00\x00\x00')
@@ -4275,7 +4275,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Rebind
 
 = DHCP6_Rebind - Basic Instantiation
-str(DHCP6_Rebind()) == b'\x06\x00\x00\x00'
+raw(DHCP6_Rebind()) == b'\x06\x00\x00\x00'
 
 = DHCP6_Rebind - Basic Dissection
 a=DHCP6_Rebind(b'\x06\x00\x00\x00')
@@ -4291,7 +4291,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Reply
 
 = DHCP6_Reply - Basic Instantiation
-str(DHCP6_Reply()) == b'\x07\x00\x00\x00'
+raw(DHCP6_Reply()) == b'\x07\x00\x00\x00'
 
 = DHCP6_Reply - Basic Dissection
 a=DHCP6_Reply(b'\x07\x00\x00\x00')
@@ -4312,7 +4312,7 @@ assert DHCP6_Reply(trid=1).answers(DHCP6_Request(trid=1))
 + Test DHCP6 Messages - DHCP6_Release
 
 = DHCP6_Release - Basic Instantiation
-str(DHCP6_Release()) == b'\x08\x00\x00\x00'
+raw(DHCP6_Release()) == b'\x08\x00\x00\x00'
 
 = DHCP6_Release - Basic Dissection
 a=DHCP6_Release(b'\x08\x00\x00\x00')
@@ -4328,7 +4328,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Decline
 
 = DHCP6_Decline - Basic Instantiation
-str(DHCP6_Decline()) == b'\x09\x00\x00\x00'
+raw(DHCP6_Decline()) == b'\x09\x00\x00\x00'
 
 = DHCP6_Confirm - Basic Dissection
 a=DHCP6_Confirm(b'\x09\x00\x00\x00')
@@ -4344,7 +4344,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_Reconf
 
 = DHCP6_Reconf - Basic Instantiation
-str(DHCP6_Reconf()) == b'\x0A\x00\x00\x00'
+raw(DHCP6_Reconf()) == b'\x0A\x00\x00\x00'
 
 = DHCP6_Reconf - Basic Dissection
 a=DHCP6_Reconf(b'\x0A\x00\x00\x00')
@@ -4360,7 +4360,7 @@ a.sport == 547 and a.dport == 546
 + Test DHCP6 Messages - DHCP6_InfoRequest
 
 = DHCP6_InfoRequest - Basic Instantiation
-str(DHCP6_InfoRequest()) == b'\x0B\x00\x00\x00'
+raw(DHCP6_InfoRequest()) == b'\x0B\x00\x00\x00'
 
 = DHCP6_InfoRequest - Basic Dissection
 a=DHCP6_InfoRequest(b'\x0B\x00\x00\x00')
@@ -4376,7 +4376,7 @@ a.sport == 546 and a.dport == 547
 + Test DHCP6 Messages - DHCP6_RelayForward
 
 = DHCP6_RelayForward - Basic Instantiation
-str(DHCP6_RelayForward()) == b'\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6_RelayForward()) == b'\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6_RelayForward - Basic Dissection
 a=DHCP6_RelayForward(b'\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -4407,7 +4407,7 @@ isinstance(p.message, DHCP6)
 + Test DHCP6 Messages - DHCP6_RelayReply
 
 = DHCP6_RelayReply - Basic Instantiation
-str(DHCP6_RelayReply()) == b'\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(DHCP6_RelayReply()) == b'\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = DHCP6_RelayReply - Basic Dissection
 a=DHCP6_RelayReply(b'\r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -4422,11 +4422,11 @@ a.msgtype == 13 and a.hopcount == 0 and a.linkaddr == "::" and a.peeraddr == "::
 in6_getha('2001:db8::') == '2001:db8::fdff:ffff:ffff:fffe'
 
 = ICMPv6HAADRequest - build/dissection
-p = IPv6(str(IPv6(dst=in6_getha('2001:db8::'), src='2001:db8::1')/ICMPv6HAADRequest(id=42)))
+p = IPv6(raw(IPv6(dst=in6_getha('2001:db8::'), src='2001:db8::1')/ICMPv6HAADRequest(id=42)))
 p.cksum == 0x9620 and p.dst == '2001:db8::fdff:ffff:ffff:fffe' and p.R == 1
 
 = ICMPv6HAADReply - build/dissection
-p = IPv6(str(IPv6(dst='2001:db8::1', src='2001:db8::42')/ICMPv6HAADReply(id=42, addresses=['2001:db8::2', '2001:db8::3'])))
+p = IPv6(raw(IPv6(dst='2001:db8::1', src='2001:db8::42')/ICMPv6HAADReply(id=42, addresses=['2001:db8::2', '2001:db8::3'])))
 p.cksum = 0x3747 and p.addresses == [ '2001:db8::2', '2001:db8::3' ]
 
 = ICMPv6HAADRequest / ICMPv6HAADReply - build/dissection
@@ -4442,7 +4442,7 @@ not a < b and a > b
 = ICMPv6MPSol - build (default values)
 
 s = b'`\x00\x00\x00\x00\x08:@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x92\x00m\xbb\x00\x00\x00\x00'
-str(IPv6()/ICMPv6MPSol()) == s
+raw(IPv6()/ICMPv6MPSol()) == s
 
 = ICMPv6MPSol - dissection (default values)
 p = IPv6(s)
@@ -4450,7 +4450,7 @@ p[ICMPv6MPSol].type == 146 and p[ICMPv6MPSol].cksum == 0x6dbb and p[ICMPv6MPSol]
 
 = ICMPv6MPSol - build
 s = b'`\x00\x00\x00\x00\x08:@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x92\x00(\x08\x00\x08\x00\x00'
-str(IPv6()/ICMPv6MPSol(cksum=0x2808, id=8)) == s
+raw(IPv6()/ICMPv6MPSol(cksum=0x2808, id=8)) == s
 
 = ICMPv6MPSol - dissection
 p = IPv6(s)
@@ -4458,7 +4458,7 @@ p[ICMPv6MPSol].cksum == 0x2808 and p[ICMPv6MPSol].id == 8
 
 = ICMPv6MPAdv - build (default values)
 s = b'`\x00\x00\x00\x00(:@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x93\x00\xe8\xd6\x00\x00\x80\x00\x03\x04\x00\xc0\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(IPv6()/ICMPv6MPAdv()/ICMPv6NDOptPrefixInfo()) == s
+raw(IPv6()/ICMPv6MPAdv()/ICMPv6NDOptPrefixInfo()) == s
 
 = ICMPv6MPAdv - dissection (default values)
 p = IPv6(s)
@@ -4466,7 +4466,7 @@ p[ICMPv6MPAdv].type == 147 and p[ICMPv6MPAdv].cksum == 0xe8d6 and p[ICMPv6NDOptP
 
 = ICMPv6MPAdv - build
 s = b'`\x00\x00\x00\x00(:@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x93\x00(\x07\x00*@\x00\x03\x04\x00@\xff\xff\xff\xff\x00\x00\x00\x0c\x00\x00\x00\x00 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
-str(IPv6()/ICMPv6MPAdv(cksum=0x2807, flags=1, id=42)/ICMPv6NDOptPrefixInfo(prefix='2001:db8::1', L=0, preferredlifetime=12)) == s
+raw(IPv6()/ICMPv6MPAdv(cksum=0x2807, flags=1, id=42)/ICMPv6NDOptPrefixInfo(prefix='2001:db8::1', L=0, preferredlifetime=12)) == s
 
 = ICMPv6MPAdv - dissection
 p = IPv6(s)
@@ -4478,7 +4478,7 @@ p[ICMPv6MPAdv].cksum == 0x2807 and p[ICMPv6MPAdv].flags == 1 and p[ICMPv6MPAdv].
 + Type 2 Routing Header
 
 = IPv6ExtHdrRouting - type 2 - build/dissection
-p = IPv6(str(IPv6(dst='2001:db8::1', src='2001:db8::2')/IPv6ExtHdrRouting(type=2, addresses=['2001:db8::3'])/ICMPv6EchoRequest()))
+p = IPv6(raw(IPv6(dst='2001:db8::1', src='2001:db8::2')/IPv6ExtHdrRouting(type=2, addresses=['2001:db8::3'])/ICMPv6EchoRequest()))
 p.type == 2 and len(p.addresses) == 1 and p.cksum == 0x2446
 
 = IPv6ExtHdrRouting - type 2 - hashret
@@ -4493,7 +4493,7 @@ p.hashret() == b" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00:\x0
 
 = MIP6OptBRAdvice - build (default values)
 s = b'\x02\x02\x00\x00'
-str(MIP6OptBRAdvice()) == s
+raw(MIP6OptBRAdvice()) == s
 
 = MIP6OptBRAdvice - dissection (default values)
 p = MIP6OptBRAdvice(s)
@@ -4501,7 +4501,7 @@ p.otype == 2 and p.olen == 2 and p.rinter == 0
 
 = MIP6OptBRAdvice - build
 s = b'\x03*\n\xf7'
-str(MIP6OptBRAdvice(otype=3, olen=42, rinter=2807)) == s
+raw(MIP6OptBRAdvice(otype=3, olen=42, rinter=2807)) == s
 
 = MIP6OptBRAdvice - dissection
 p = MIP6OptBRAdvice(s)
@@ -4514,7 +4514,7 @@ p.otype == 3 and p.olen == 42 and p.rinter == 2807
 
 = MIP6OptAltCoA - build (default values)
 s = b'\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(MIP6OptAltCoA()) == s
+raw(MIP6OptAltCoA()) == s
 
 = MIP6OptAltCoA - dissection (default values)
 p = MIP6OptAltCoA(s)
@@ -4522,7 +4522,7 @@ p.otype == 3 and p.olen == 16 and p.acoa == '::'
 
 = MIP6OptAltCoA - build
 s = b'*\x08 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
-str(MIP6OptAltCoA(otype=42, olen=8, acoa='2001:db8::1')) == s
+raw(MIP6OptAltCoA(otype=42, olen=8, acoa='2001:db8::1')) == s
 
 = MIP6OptAltCoA - dissection
 p = MIP6OptAltCoA(s)
@@ -4535,7 +4535,7 @@ p.otype == 42 and p.olen == 8 and p.acoa == '2001:db8::1'
 
 = MIP6OptNonceIndices - build (default values)
 s = b'\x04\x10\x00\x00\x00\x00'
-str(MIP6OptNonceIndices()) == s
+raw(MIP6OptNonceIndices()) == s
 
 = MIP6OptNonceIndices - dissection (default values)
 p = MIP6OptNonceIndices(s)
@@ -4543,7 +4543,7 @@ p.otype == 4 and p.olen == 16 and p.hni == 0 and p.coni == 0
 
 = MIP6OptNonceIndices - build
 s = b'\x04\x12\x00\x13\x00\x14'
-str(MIP6OptNonceIndices(olen=18, hni=19, coni=20)) == s
+raw(MIP6OptNonceIndices(olen=18, hni=19, coni=20)) == s
 
 = MIP6OptNonceIndices - dissection
 p = MIP6OptNonceIndices(s)
@@ -4556,7 +4556,7 @@ p.hni == 19 and p.coni == 20
 
 = MIP6OptBindingAuthData - build (default values)
 s = b'\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(MIP6OptBindingAuthData()) == s
+raw(MIP6OptBindingAuthData()) == s
 
 = MIP6OptBindingAuthData - dissection (default values)
 p = MIP6OptBindingAuthData(s)
@@ -4564,7 +4564,7 @@ p.otype == 5 and p.olen == 16 and p.authenticator == 0
 
 = MIP6OptBindingAuthData - build
 s = b'\x05*\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n\xf7'
-str(MIP6OptBindingAuthData(olen=42, authenticator=2807)) == s
+raw(MIP6OptBindingAuthData(olen=42, authenticator=2807)) == s
 
 = MIP6OptBindingAuthData - dissection
 p = MIP6OptBindingAuthData(s)
@@ -4577,7 +4577,7 @@ p.otype == 5 and p.olen == 42 and p.authenticator == 2807
 
 = MIP6OptMobNetPrefix - build (default values)
 s = b'\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(MIP6OptMobNetPrefix()) == s
+raw(MIP6OptMobNetPrefix()) == s
 
 = MIP6OptMobNetPrefix - dissection (default values)
 p = MIP6OptMobNetPrefix(s)
@@ -4585,7 +4585,7 @@ p.otype == 6 and p.olen == 18 and p.plen == 64 and p.prefix == '::'
 
 = MIP6OptMobNetPrefix - build
 s = b'\x06*\x02  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(MIP6OptMobNetPrefix(olen=42, reserved=2, plen=32, prefix='2001:db8::')) == s
+raw(MIP6OptMobNetPrefix(olen=42, reserved=2, plen=32, prefix='2001:db8::')) == s
 
 = MIP6OptMobNetPrefix - dissection
 p = MIP6OptMobNetPrefix(s)
@@ -4597,19 +4597,19 @@ p.olen ==  42 and p.reserved  == 2 and p.plen == 32 and p.prefix == '2001:db8::'
 + Mobility Options - Link-Layer Address (MH-LLA)
 
 = MIP6OptLLAddr - basic build
-str(MIP6OptLLAddr()) == b'\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00'
+raw(MIP6OptLLAddr()) == b'\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6OptLLAddr - basic dissection
 p = MIP6OptLLAddr(b'\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00')
 p.otype == 7 and p.olen == 7 and p.ocode == 2 and p.pad == 0 and p.lla == "00:00:00:00:00:00"
 
 = MIP6OptLLAddr - build with specific values
-str(MIP6OptLLAddr(olen=42, ocode=4, pad=0xff, lla='EE:EE:EE:EE:EE:EE')) == b'\x07*\x04\xff\xee\xee\xee\xee\xee\xee'
+raw(MIP6OptLLAddr(olen=42, ocode=4, pad=0xff, lla='EE:EE:EE:EE:EE:EE')) == b'\x07*\x04\xff\xee\xee\xee\xee\xee\xee'
 
 = MIP6OptLLAddr - dissection with specific values
 p = MIP6OptLLAddr(b'\x07*\x04\xff\xee\xee\xee\xee\xee\xee')
 
-str(MIP6OptLLAddr(olen=42, ocode=4, pad=0xff, lla='EE:EE:EE:EE:EE:EE'))
+raw(MIP6OptLLAddr(olen=42, ocode=4, pad=0xff, lla='EE:EE:EE:EE:EE:EE'))
 p.otype == 7 and p.olen == 42 and p.ocode == 4 and p.pad == 0xff and p.lla == "ee:ee:ee:ee:ee:ee"
 
 
@@ -4618,14 +4618,14 @@ p.otype == 7 and p.olen == 42 and p.ocode == 4 and p.pad == 0xff and p.lla == "e
 + Mobility Options - Mobile Node Identifier
 
 = MIP6OptMNID - basic build
-str(MIP6OptMNID()) == b'\x08\x01\x01'
+raw(MIP6OptMNID()) == b'\x08\x01\x01'
 
 = MIP6OptMNID - basic dissection
 p = MIP6OptMNID(b'\x08\x01\x01')
 p.otype == 8 and p.olen == 1 and p.subtype == 1 and p.id == ""
 
 = MIP6OptMNID - build with specific values
-str(MIP6OptMNID(subtype=42, id="someid")) == b'\x08\x07*someid'
+raw(MIP6OptMNID(subtype=42, id="someid")) == b'\x08\x07*someid'
 
 = MIP6OptMNID - dissection with specific values
 p = MIP6OptMNID(b'\x08\x07*someid')
@@ -4638,14 +4638,14 @@ p.otype == 8 and p.olen == 7 and p.subtype == 42 and p.id == "someid"
 + Mobility Options - Message Authentication
 
 = MIP6OptMsgAuth - basic build
-str(MIP6OptMsgAuth()) == b'\x09\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+raw(MIP6OptMsgAuth()) == b'\x09\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
 
 = MIP6OptMsgAuth - basic dissection
 p = MIP6OptMsgAuth(b'\x09\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA')
 p.otype == 9 and p.olen == 17 and p.subtype == 1 and p.mspi == 0 and p.authdata == "A"*12
 
 = MIP6OptMsgAuth - build with specific values
-str(MIP6OptMsgAuth(authdata="B"*16, mspi=0xeeeeeeee, subtype=0xff)) == b'\t\x15\xff\xee\xee\xee\xeeBBBBBBBBBBBBBBBB'
+raw(MIP6OptMsgAuth(authdata="B"*16, mspi=0xeeeeeeee, subtype=0xff)) == b'\t\x15\xff\xee\xee\xee\xeeBBBBBBBBBBBBBBBB'
 
 = MIP6OptMsgAuth - dissection with specific values
 p = MIP6OptMsgAuth(b'\t\x15\xff\xee\xee\xee\xeeBBBBBBBBBBBBBBBB')
@@ -4657,14 +4657,14 @@ p.otype == 9 and p.olen == 21 and p.subtype == 255 and p.mspi == 0xeeeeeeee and 
 + Mobility Options - Replay Protection
 
 = MIP6OptReplayProtection - basic build
-str(MIP6OptReplayProtection()) == b'\n\x08\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(MIP6OptReplayProtection()) == b'\n\x08\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6OptReplayProtection - basic dissection
 p = MIP6OptReplayProtection(b'\n\x08\x00\x00\x00\x00\x00\x00\x00\x00')
 p.otype == 10 and p.olen == 8 and p.timestamp == 0
 
 = MIP6OptReplayProtection - build with specific values
-s = str(MIP6OptReplayProtection(olen=42, timestamp=(72*31536000)<<32))
+s = raw(MIP6OptReplayProtection(olen=42, timestamp=(72*31536000)<<32))
 s == b'\n*\x87V|\x00\x00\x00\x00\x00'
 
 = MIP6OptReplayProtection - dissection with specific values
@@ -4707,30 +4707,30 @@ p.fields_desc[-1].i2repr("", p.timestamp) == 'Mon, 13 Dec 1971 23:50:39 +0000 (9
 ############
 + Mobility Options - Automatic Padding - MIP6OptBRAdvice
 =  Mobility Options - Automatic Padding - MIP6OptBRAdvice
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptBRAdvice()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x02\x02\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptBRAdvice()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x02\x02\x00\x00\x01\x04\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x02\x02\x00\x00\x01\x04\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x00\x02\x02\x00\x00\x01\x02\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x02\x02\x00\x00\x01\x02\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x02\x02\x00\x00\x01\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x02\x02\x00\x00\x01\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x02\x02\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x02\x02\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptBRAdvice()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x02\x02\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptBRAdvice()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x02\x02\x00\x00\x01\x04\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x02\x02\x00\x00\x01\x04\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x00\x02\x02\x00\x00\x01\x02\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x02\x02\x00\x00\x01\x02\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x02\x02\x00\x00\x01\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x02\x02\x00\x00\x01\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x02\x02\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptBRAdvice()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x02\x02\x00\x00'
 a and b and c and d and e and g and h and i and j
                                                 
 ############
 ############
 + Mobility Options - Automatic Padding - MIP6OptAltCoA           
 =  Mobility Options - Automatic Padding - MIP6OptAltCoA          
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptAltCoA()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptAltCoA()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptAltCoA()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x05\x00\x00\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x04\x00\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x01\x03\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x02\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptAltCoA()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptAltCoA()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptAltCoA()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x05\x00\x00\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x04\x00\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x01\x03\x00\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x02\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptAltCoA()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4738,15 +4738,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptNonceIndices                             
 =  Mobility Options - Automatic Padding - MIP6OptNonceIndices                            
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptNonceIndices()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptNonceIndices()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x04\x10\x00\x00\x00\x00\x01\x02\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x04\x10\x00\x00\x00\x00\x01\x02\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x00\x04\x10\x00\x00\x00\x00\x01\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x04\x10\x00\x00\x00\x00\x01\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptNonceIndices()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptNonceIndices()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptNonceIndices()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptNonceIndices()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x00\x04\x10\x00\x00\x00\x00\x01\x02\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x04\x10\x00\x00\x00\x00\x01\x02\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x00\x04\x10\x00\x00\x00\x00\x01\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x04\x10\x00\x00\x00\x00\x01\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptNonceIndices()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptNonceIndices()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptNonceIndices()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x04\x10\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4754,15 +4754,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptBindingAuthData                          
 =  Mobility Options - Automatic Padding - MIP6OptBindingAuthData                                 
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptBindingAuthData()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptBindingAuthData()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x03\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x02\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x01\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptBindingAuthData()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptBindingAuthData()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptBindingAuthData()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptBindingAuthData()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x03\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x02\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x01\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptBindingAuthData()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptBindingAuthData()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptBindingAuthData()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00\x05\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4770,15 +4770,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptMobNetPrefix                             
 =  Mobility Options - Automatic Padding - MIP6OptMobNetPrefix                            
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptMobNetPrefix()]))                        == b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMobNetPrefix()]))                 == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x05\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x04\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x03\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x02\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x01\x01\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptMobNetPrefix()]))                        == b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMobNetPrefix()]))                 == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x05\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x04\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x03\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x02\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x01\x01\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMobNetPrefix()])) == b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4786,15 +4786,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptLLAddr                           
 =  Mobility Options - Automatic Padding - MIP6OptLLAddr                          
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptLLAddr()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptLLAddr()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptLLAddr()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptLLAddr()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptLLAddr()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptLLAddr()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptLLAddr()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4802,15 +4802,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptMNID                             
 =  Mobility Options - Automatic Padding - MIP6OptMNID                            
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptMNID()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x08\x01\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMNID()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x08\x01\x01'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x08\x01\x01\x01\x05\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x08\x01\x01\x01\x04\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x08\x01\x01\x01\x03\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x08\x01\x01\x01\x02\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x08\x01\x01\x01\x01\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x08\x01\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x08\x01\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptMNID()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x08\x01\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMNID()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x08\x01\x01'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x08\x01\x01\x01\x05\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x08\x01\x01\x01\x04\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x08\x01\x01\x01\x03\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x08\x01\x01\x01\x02\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x08\x01\x01\x01\x01\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x08\x01\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMNID()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x08\x01\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4818,15 +4818,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptMsgAuth                          
 =  Mobility Options - Automatic Padding - MIP6OptMsgAuth                                 
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptMsgAuth()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMsgAuth()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptMsgAuth()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptMsgAuth()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA\x01\x02\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x01\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptMsgAuth()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x00\t\x11\x01\x00\x00\x00\x00AAAAAAAAAAAA'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4834,15 +4834,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptReplayProtection                                 
 =  Mobility Options - Automatic Padding - MIP6OptReplayProtection                                
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptReplayProtection()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptReplayProtection()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x03\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x02\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x01\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptReplayProtection()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptReplayProtection()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptReplayProtection()]))                        ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptReplayProtection()]))                 ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x01\x03\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x01\x02\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x01\x01\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x01\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptReplayProtection()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptReplayProtection()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptReplayProtection()])) ==b';\x04\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00\n\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4850,15 +4850,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptCGAParamsReq                             
 =  Mobility Options - Automatic Padding - MIP6OptCGAParamsReq                            
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptCGAParamsReq()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0b\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCGAParamsReq()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0b\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCGAParamsReq()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0b\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0b\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0b\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0b\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0b\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0b\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0b\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptCGAParamsReq()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0b\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCGAParamsReq()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0b\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCGAParamsReq()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0b\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0b\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0b\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0b\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0b\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0b\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCGAParamsReq()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0b\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
                                                 
 
@@ -4866,15 +4866,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptCGAParams                                
 =  Mobility Options - Automatic Padding - MIP6OptCGAParams                               
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptCGAParams()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0c\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCGAParams()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0c\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCGAParams()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0c\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0c\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0c\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0c\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0c\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0c\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0c\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptCGAParams()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0c\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCGAParams()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0c\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCGAParams()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0c\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0c\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0c\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0c\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0c\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0c\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCGAParams()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0c\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4882,15 +4882,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptSignature                                
 =  Mobility Options - Automatic Padding - MIP6OptSignature                               
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptSignature()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\r\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptSignature()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\r\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptSignature()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\r\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\r\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\r\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\r\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\r\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\r\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\r\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptSignature()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\r\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptSignature()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\r\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptSignature()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\r\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\r\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\r\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\r\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\r\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\r\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptSignature()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\r\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4898,15 +4898,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptHomeKeygenToken                          
 =  Mobility Options - Automatic Padding - MIP6OptHomeKeygenToken                                 
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptHomeKeygenToken()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0e\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptHomeKeygenToken()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0e\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptHomeKeygenToken()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0e\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0e\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0e\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0e\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0e\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0e\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0e\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptHomeKeygenToken()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0e\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptHomeKeygenToken()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0e\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptHomeKeygenToken()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0e\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0e\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0e\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0e\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0e\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0e\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptHomeKeygenToken()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0e\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4914,15 +4914,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptCareOfTestInit                           
 =  Mobility Options - Automatic Padding - MIP6OptCareOfTestInit                          
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptCareOfTestInit()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0f\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCareOfTestInit()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0f\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCareOfTestInit()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0f\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0f\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0f\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0f\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0f\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0f\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptCareOfTestInit()]))                        ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x0f\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCareOfTestInit()]))                 ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x0f\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCareOfTestInit()])) ==b';\x01\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x0f\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x0f\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x0f\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x0f\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x0f\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x0f\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCareOfTestInit()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
                                                 
@@ -4930,15 +4930,15 @@ a and b and c and d and e and g and h and i and j
 ############
 + Mobility Options - Automatic Padding - MIP6OptCareOfTest                               
 =  Mobility Options - Automatic Padding - MIP6OptCareOfTest                              
-a = str(MIP6MH_BU(seq=0x4242, options=[MIP6OptCareOfTest()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00'
-b = str(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCareOfTest()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-c = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCareOfTest()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00'
-d = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00'
-e = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
-g = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x03\x00\x00\x00'
-h = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
-i = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x00'
-j = str(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00'
+a = raw(MIP6MH_BU(seq=0x4242, options=[MIP6OptCareOfTest()]))                        ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00'
+b = raw(MIP6MH_BU(seq=0x4242, options=[Pad1(),MIP6OptCareOfTest()]))                 ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+c = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*0),MIP6OptCareOfTest()])) ==b';\x02\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00'
+d = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*1),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x01\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x05\x00\x00\x00\x00\x00'
+e = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*2),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x02\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x04\x00\x00\x00\x00'
+g = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*3),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x03\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x03\x00\x00\x00'
+h = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*4),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x04\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00'
+i = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*5),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x05\x00\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x00'
+j = raw(MIP6MH_BU(seq=0x4242, options=[PadN(optdata=b'\x00'*6),MIP6OptCareOfTest()])) ==b';\x03\x05\x00\x00\x00BB\xd0\x00\x00\x03\x01\x06\x00\x00\x00\x00\x00\x00\x10\x08\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00'
 a and b and c and d and e and g and h and i and j
 
 
@@ -4946,10 +4946,10 @@ a and b and c and d and e and g and h and i and j
 ############
 + Binding Refresh Request Message
 = MIP6MH_BRR - Build (default values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_BRR()) == b'`\x00\x00\x00\x00\x08\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x00\x00\x00h\xfb\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_BRR()) == b'`\x00\x00\x00\x00\x08\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x00\x00\x00h\xfb\x00\x00'
 
 = MIP6MH_BRR - Build with specific values
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_BRR(nh=0xff, res=0xee, res2=0xaaaa, options=[MIP6OptLLAddr(), MIP6OptAltCoA()])) == b'`\x00\x00\x00\x00(\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\xff\x04\x00\xee\xec$\xaa\xaa\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_BRR(nh=0xff, res=0xee, res2=0xaaaa, options=[MIP6OptLLAddr(), MIP6OptAltCoA()])) == b'`\x00\x00\x00\x00(\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\xff\x04\x00\xee\xec$\xaa\xaa\x07\x07\x02\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6MH_BRR - Basic dissection
 a=IPv6(b'`\x00\x00\x00\x00\x08\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x00\x00\x00h\xfb\x00\x00')
@@ -4966,10 +4966,10 @@ hoa="2001:db8:9999::1"
 coa="2001:db8:7777::1"
 cn="2001:db8:8888::1"
 ha="2001db8:6666::1"
-a=IPv6(str(IPv6(src=cn, dst=hoa)/MIP6MH_BRR()))
-b=IPv6(str(IPv6(src=coa, dst=cn)/IPv6ExtHdrDestOpt(options=HAO(hoa=hoa))/MIP6MH_BU(flags=0x01)))
-b2=IPv6(str(IPv6(src=coa, dst=cn)/IPv6ExtHdrDestOpt(options=HAO(hoa=hoa))/MIP6MH_BU(flags=~0x01)))
-c=IPv6(str(IPv6(src=cn, dst=coa)/IPv6ExtHdrRouting(type=2, addresses=[hoa])/MIP6MH_BA()))
+a=IPv6(raw(IPv6(src=cn, dst=hoa)/MIP6MH_BRR()))
+b=IPv6(raw(IPv6(src=coa, dst=cn)/IPv6ExtHdrDestOpt(options=HAO(hoa=hoa))/MIP6MH_BU(flags=0x01)))
+b2=IPv6(raw(IPv6(src=coa, dst=cn)/IPv6ExtHdrDestOpt(options=HAO(hoa=hoa))/MIP6MH_BU(flags=~0x01)))
+c=IPv6(raw(IPv6(src=cn, dst=coa)/IPv6ExtHdrRouting(type=2, addresses=[hoa])/MIP6MH_BA()))
 b.answers(a) and not a.answers(b) and c.answers(b) and not b.answers(c) and not c.answers(b2)
 
 len(b[IPv6ExtHdrDestOpt].options) == 2
@@ -4980,7 +4980,7 @@ len(b[IPv6ExtHdrDestOpt].options) == 2
 + Home Test Init Message
 
 = MIP6MH_HoTI - Build (default values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoTI()) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01\x00g\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoTI()) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01\x00g\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6MH_HoTI - Dissection (default values)
 a=IPv6(b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01\x00g\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -4989,7 +4989,7 @@ a.nh == 135 and isinstance(b, MIP6MH_HoTI) and b.nh==59 and b.mhtype == 1 and b.
 
 
 = MIP6MH_HoTI - Build (specific values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoTI(res=0x77, cksum=0x8899, cookie=b"\xAA"*8)) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoTI(res=0x77, cksum=0x8899, cookie=b"\xAA"*8)) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa'
 
 = MIP6MH_HoTI - Dissection (specific values)
 a=IPv6(b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x01w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa')
@@ -5002,7 +5002,7 @@ a.nh == 135 and isinstance(b, MIP6MH_HoTI) and b.nh==59 and b.mhtype == 1 and b.
 + Care-of Test Init Message
 
 = MIP6MH_CoTI - Build (default values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoTI()) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02\x00f\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoTI()) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02\x00f\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6MH_CoTI - Dissection (default values)
 a=IPv6(b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02\x00f\xf2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -5010,7 +5010,7 @@ b = a.payload
 a.nh == 135 and isinstance(b, MIP6MH_CoTI) and b.nh==59 and b.mhtype == 2 and b.len== 1 and b.res == 0 and b.cksum == 0x66f2 and b.cookie == b'\x00'*8
 
 = MIP6MH_CoTI - Build (specific values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoTI(res=0x77, cksum=0x8899, cookie=b"\xAA"*8)) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoTI(res=0x77, cksum=0x8899, cookie=b"\xAA"*8)) == b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa'
 
 = MIP6MH_CoTI - Dissection (specific values)
 a=IPv6(b'`\x00\x00\x00\x00\x10\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x01\x02w\x88\x99\x00\x00\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa')
@@ -5023,7 +5023,7 @@ a.nh == 135 and isinstance(b, MIP6MH_CoTI) and b.nh==59 and b.mhtype == 2 and b.
 + Home Test Message
 
 = MIP6MH_HoT - Build (default values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoT()) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03\x00e\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoT()) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03\x00e\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6MH_HoT - Dissection (default values)
 a=IPv6(b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03\x00e\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -5031,7 +5031,7 @@ b = a.payload
 a.nh == 135 and isinstance(b, MIP6MH_HoT) and b.nh==59 and b.mhtype == 3 and b.len== 2 and b.res == 0 and b.cksum == 0x65e9 and b.index == 0 and b.cookie == b'\x00'*8 and b.token == b'\x00'*8
 
 = MIP6MH_HoT - Build (specific values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoT(res=0x77, cksum=0x8899, cookie=b"\xAA"*8, index=0xAABB, token=b'\xCC'*8)) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_HoT(res=0x77, cksum=0x8899, cookie=b"\xAA"*8, index=0xAABB, token=b'\xCC'*8)) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc'
 
 = MIP6MH_HoT - Dissection (specific values)
 a=IPv6(b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x03w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc')
@@ -5053,7 +5053,7 @@ assert p1.hashret() != p2_ko.hashret() and not p2_ko.answers(p1) and not p1.answ
 + Care-of Test Message
 
 = MIP6MH_CoT - Build (default values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoT()) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04\x00d\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoT()) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04\x00d\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = MIP6MH_CoT - Dissection (default values)
 a=IPv6(b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04\x00d\xe9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
@@ -5061,7 +5061,7 @@ b = a.payload
 a.nh == 135 and isinstance(b, MIP6MH_HoT) and b.nh==59 and b.mhtype == 4 and b.len== 2 and b.res == 0 and b.cksum == 0x64e9 and b.index == 0 and b.cookie == b'\x00'*8 and b.token == b'\x00'*8
 
 = MIP6MH_CoT - Build (specific values)
-str(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoT(res=0x77, cksum=0x8899, cookie=b"\xAA"*8, index=0xAABB, token=b'\xCC'*8)) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc'
+raw(IPv6(src="2001:db8::1", dst="2001:db8::2")/MIP6MH_CoT(res=0x77, cksum=0x8899, cookie=b"\xAA"*8, index=0xAABB, token=b'\xCC'*8)) == b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc'
 
 = MIP6MH_CoT - Dissection (specific values)
 a=IPv6(b'`\x00\x00\x00\x00\x18\x87@ \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02;\x02\x04w\x88\x99\xaa\xbb\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xcc')
@@ -5075,7 +5075,7 @@ a.nh == 135 and isinstance(b, MIP6MH_CoT) and b.nh==59 and b.mhtype == 4 and b.l
 
 = MIP6MH_BU - build (default values)
 s= b'`\x00\x00\x00\x00(<@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x87\x02\x01\x02\x00\x00\xc9\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00;\x01\x05\x00\xee`\x00\x00\xd0\x00\x00\x03\x01\x02\x00\x00'
-str(IPv6()/IPv6ExtHdrDestOpt(options=[HAO()])/MIP6MH_BU()) == s
+raw(IPv6()/IPv6ExtHdrDestOpt(options=[HAO()])/MIP6MH_BU()) == s
 
 = MIP6MH_BU - dissection (default values)
 p = IPv6(s)
@@ -5083,7 +5083,7 @@ p[MIP6MH_BU].len == 1
 
 = MIP6MH_BU - build
 s = b'`\x00\x00\x00\x00P<@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x87\x02\x01\x02\x00\x00\xc9\x10 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe;\x06\x05\x00\xea\xf2\x00\x00\xd0\x00\x00*\x01\x00\x03\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x00\x00\x06\x12\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-str(IPv6()/IPv6ExtHdrDestOpt(options=[HAO(hoa='2001:db8::cafe')])/MIP6MH_BU(mhtime=42, options=[MIP6OptAltCoA(),MIP6OptMobNetPrefix()])) == s
+raw(IPv6()/IPv6ExtHdrDestOpt(options=[HAO(hoa='2001:db8::cafe')])/MIP6MH_BU(mhtime=42, options=[MIP6OptAltCoA(),MIP6OptMobNetPrefix()])) == s
 
 = MIP6MH_BU - dissection
 p = IPv6(s)
@@ -5096,7 +5096,7 @@ p[MIP6MH_BU].cksum == 0xeaf2 and p[MIP6MH_BU].len == 6 and len(p[MIP6MH_BU].opti
 
 =  MIP6MH_BA - build
 s = b'`\x00\x00\x00\x00\x10\x87@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01;\x01\x06\x00\xbc\xb9\x00\x80\x00\x00\x00*\x01\x02\x00\x00'
-str(IPv6()/MIP6MH_BA(mhtime=42)) == s
+raw(IPv6()/MIP6MH_BA(mhtime=42)) == s
 
 =  MIP6MH_BA - dissection
 p = IPv6(s)
@@ -5109,7 +5109,7 @@ p[MIP6MH_BA].cksum == 0xbcb9 and p[MIP6MH_BA].len == 1 and len(p[MIP6MH_BA].opti
 
 =  MIP6MH_BE - build
 s = b'`\x00\x00\x00\x00\x18\x87@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01;\x02\x07\x00\xbbY\x02\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02'
-str(IPv6()/MIP6MH_BE(status=2, ha='1::2')) == s
+raw(IPv6()/MIP6MH_BE(status=2, ha='1::2')) == s
 
 =  MIP6MH_BE - dissection
 p = IPv6(s)
@@ -5122,13 +5122,13 @@ p[MIP6MH_BE].cksum=0xba10 and p[MIP6MH_BE].len == 1 and len(p[MIP6MH_BE].options
 
 = NetflowHeaderV5 - basic building
 
-str(NetflowHeader()/NetflowHeaderV5()) == b'\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(NetflowHeader()/NetflowHeaderV5()) == b'\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
-str(NetflowHeaderV5(engineID=42)) == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00*\x00\x00'
+raw(NetflowHeaderV5(engineID=42)) == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00*\x00\x00'
 
-str(NetflowRecordV5(dst="192.168.0.1")) == b'\x7f\x00\x00\x01\xc0\xa8\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(NetflowRecordV5(dst="192.168.0.1")) == b'\x7f\x00\x00\x01\xc0\xa8\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
-str(NetflowHeader()/NetflowHeaderV5(count=1)/NetflowRecordV5(dst="192.168.0.1")) == b'\x00\x05\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x7f\x00\x00\x01\xc0\xa8\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(NetflowHeader()/NetflowHeaderV5(count=1)/NetflowRecordV5(dst="192.168.0.1")) == b'\x00\x05\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x7f\x00\x00\x01\xc0\xa8\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00<\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 
 = NetflowHeaderV5 - basic dissection
@@ -5247,7 +5247,7 @@ assert isinstance(pkt, NoPayload)
 * No very specific tests because we do not want to depend on tcpdump output
 pcapfile = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00e\x00\x00\x00\xcf\xc5\xacVo*\n\x00(\x00\x00\x00(\x00\x00\x00E\x00\x00(\x00\x01\x00\x00@\x06|\xcd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91|\x00\x00\xcf\xc5\xacV_-\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r\xcf\xc5\xacV\xf90\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x01|\xde\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\xf7\xff\x00\x00\x00\x00')
 data = tcpdump(pcapfile, dump=True, args=['-n']).split('\n')
-print data
+print(data)
 assert 'IP 127.0.0.1.20 > 127.0.0.1.80:' in data[0]
 assert 'IP 127.0.0.1.53 > 127.0.0.1.53:' in data[1]
 assert 'IP 127.0.0.1 > 127.0.0.1:' in data[2]
@@ -5277,7 +5277,7 @@ assert pkt.dport == 5355
 assert pkt[LLMNRQuery].opcode == 0
 
 = Packet build / dissection
-pkt = UDP(str(UDP()/LLMNRResponse()))
+pkt = UDP(raw(UDP()/LLMNRResponse()))
 assert LLMNRResponse in pkt
 assert pkt.qr == 1
 assert pkt.c == 0
@@ -5315,7 +5315,7 @@ assert pkt.hostname == "TEST-AP"
 assert isinstance(pkt[LLTDAttributeEOP].payload, NoPayload)
 
 = Packet build / dissection
-pkt = Ether(str(Ether(dst=ETHER_BROADCAST, src=RandMAC()) / LLTD(tos=0, function=0)))
+pkt = Ether(raw(Ether(dst=ETHER_BROADCAST, src=RandMAC()) / LLTD(tos=0, function=0)))
 assert LLTD in pkt
 assert pkt.dst == pkt.real_dst
 assert pkt.src == pkt.real_src
@@ -5324,9 +5324,9 @@ assert pkt.function == 0
 
 = Attribute build / dissection
 assert isinstance(LLTDAttribute(), LLTDAttribute)
-assert isinstance(LLTDAttribute(str(LLTDAttribute())), LLTDAttribute)
-assert all(isinstance(LLTDAttribute(type=i), LLTDAttribute) for i in xrange(256))
-assert all(isinstance(LLTDAttribute(str(LLTDAttribute(type=i))), LLTDAttribute) for i in xrange(256))
+assert isinstance(LLTDAttribute(raw(LLTDAttribute())), LLTDAttribute)
+assert all(isinstance(LLTDAttribute(type=i), LLTDAttribute) for i in six.moves.range(256))
+assert all(isinstance(LLTDAttribute(raw(LLTDAttribute(type=i))), LLTDAttribute) for i in six.moves.range(256))
 
 = Large TLV
 m1, m2, seq = RandMAC()._fix(), RandMAC()._fix(), 123
@@ -5337,20 +5337,20 @@ prespbase = Ether(src=m2, dst=m1) / LLTD() / \
 plist = []
 pkt = preqbase.copy()
 pkt.seq = seq
-plist.append(Ether(str(pkt)))
+plist.append(Ether(raw(pkt)))
 pkt = prespbase.copy()
 pkt.seq = seq
 pkt.flags = "M"
 pkt.value = "abcd"
-plist.append(Ether(str(pkt)))
+plist.append(Ether(raw(pkt)))
 pkt = preqbase.copy()
 pkt.seq = seq + 1
 pkt.offset = 4
-plist.append(Ether(str(pkt)))
+plist.append(Ether(raw(pkt)))
 pkt = prespbase.copy()
 pkt.seq = seq + 1
 pkt.value = "efg"
-plist.append(Ether(str(pkt)))
+plist.append(Ether(raw(pkt)))
 builder = LargeTlvBuilder()
 builder.parse(plist)
 data = builder.get_data()
@@ -5384,7 +5384,7 @@ assert len(frags[-1].payload) == ((payloadlen % fragsize) or fragsize)
 = fragment() and overloaded_fields
 pkt1 = Ether() / IP() / UDP()
 pkt2 = fragment(pkt1)[0]
-pkt3 = pkt2.__class__(str(pkt2))
+pkt3 = pkt2.__class__(raw(pkt2))
 assert pkt1[IP].proto == pkt2[IP].proto == pkt3[IP].proto
 
 = fragment() already fragmented packets
@@ -5414,7 +5414,7 @@ defrags = defragment(frags)
 * we should have one single packet
 assert len(defrags) == 1
 * which should be the same as pkt reconstructed
-assert defrags[0] == IP(str(pkt))
+assert defrags[0] == IP(raw(pkt))
 
 = defrag() / defragment() - Real DNS packets
 
@@ -5463,7 +5463,7 @@ assert len(frags[-1].payload) == ((payloadlen % fragsize) or fragsize)
 = Packet().fragment() and overloaded_fields
 pkt1 = Ether() / IP() / UDP()
 pkt2 = pkt1.fragment()[0]
-pkt3 = pkt2.__class__(str(pkt2))
+pkt3 = pkt2.__class__(raw(pkt2))
 assert pkt1[IP].proto == pkt2[IP].proto == pkt3[IP].proto
 
 = Packet().fragment() already fragmented packets
@@ -5488,122 +5488,122 @@ assert plen == payloadlen
 + TCP/IP tests
 
 = TCP options: UTO - basic build
-str(TCP(options=[("UTO", 0xffff)])) == b"\x00\x14\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\x60\x02\x20\x00\x00\x00\x00\x00\x1c\x04\xff\xff"
+raw(TCP(options=[("UTO", 0xffff)])) == b"\x00\x14\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\x60\x02\x20\x00\x00\x00\x00\x00\x1c\x04\xff\xff"
 
 = TCP options: UTO - basic dissection
 uto = TCP(b"\x00\x14\x00\x50\x00\x00\x00\x00\x00\x00\x00\x00\x60\x02\x20\x00\x00\x00\x00\x00\x1c\x04\xff\xff")
 uto[TCP].options[0][0] == "UTO" and uto[TCP].options[0][1] == 0xffff
 
 = TCP options: SAck - basic build
-str(TCP(options=[(5, "abcdefgh")])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00\x80\x02 \x00\x00\x00\x00\x00\x05\nabcdefgh\x00\x00"
+raw(TCP(options=[(5, "abcdefgh")])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00\x80\x02 \x00\x00\x00\x00\x00\x05\nabcdefgh\x00\x00"
 
 = TCP options: SAck - basic dissection
 sack = TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00\x80\x02 \x00\x00\x00\x00\x00\x05\nabcdefgh\x00\x00")
 sack[TCP].options[0][0] == "SAck" and sack[TCP].options[0][1] == (1633837924, 1701209960)
 
 = TCP options: SAckOK - basic build
-str(TCP(options=[('SAckOK', '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x04\x02\x00\x00"
+raw(TCP(options=[('SAckOK', '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x04\x02\x00\x00"
 
 = TCP options: SAckOK - basic dissection
 sackok = TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x04\x02\x00\x00")
 sackok[TCP].options[0][0] == "SAckOK" and sackok[TCP].options[0][1] == ''
 
 = TCP options: EOL - basic build
-str(TCP(options=[(0, '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x00\x02\x00\x00"
+raw(TCP(options=[(0, '')])) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x00\x02\x00\x00"
 
 = TCP options: EOL - basic dissection
 eol = TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x00\x02\x00\x00")
 eol[TCP].options[0][0] == "EOL" and eol[TCP].options[0][1] == None
 
 = TCP options: malformed - build
-str(TCP(options=[('unknown', '')])) == str(TCP())
+raw(TCP(options=[('unknown', '')])) == str(TCP())
 
 = TCP options: malformed - dissection
-str(TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00")) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00"
+raw(TCP(b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00")) == b"\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00`\x02 \x00\x00\x00\x00\x00\x03\x00\x00\x00"
 
 = IP, TCP & UDP checksums (these tests highly depend on default values)
 pkt = IP() / TCP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7ccd and bpkt.payload.chksum == 0x917c
 
 pkt = IP(len=40) / TCP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7ccd and bpkt.payload.chksum == 0x917c
 
 pkt = IP(len=40, ihl=5) / TCP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7ccd and bpkt.payload.chksum == 0x917c
 
 pkt = IP() / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc3 and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=50) / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc3 and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=50, ihl=5) / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc3 and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(options=[IPOption_RR()]) / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=54, options=[IPOption_RR()]) / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP(len=54, ihl=6, options=[IPOption_RR()]) / TCP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bc and bpkt.payload.chksum == 0x4b2c
 
 pkt = IP() / UDP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cce and bpkt.payload.chksum == 0x0172
 
 pkt = IP(len=28) / UDP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cce and bpkt.payload.chksum == 0x0172
 
 pkt = IP(len=28, ihl=5) / UDP()
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cce and bpkt.payload.chksum == 0x0172
 
 pkt = IP() / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc4 and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=38) / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc4 and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=38, ihl=5) / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x7cc4 and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(options=[IPOption_RR()]) / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=42, options=[IPOption_RR()]) / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 pkt = IP(len=42, ihl=6, options=[IPOption_RR()]) / UDP() / ("A" * 10)
-bpkt = IP(str(pkt))
+bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
 = DNS
 
 * DNS over UDP
-pkt = IP(str(IP(src="10.0.0.1", dst="8.8.8.8")/UDP(sport=RandShort(), dport=53)/DNS(qd=DNSQR(qname="secdev.org."))))
+pkt = IP(raw(IP(src="10.0.0.1", dst="8.8.8.8")/UDP(sport=RandShort(), dport=53)/DNS(qd=DNSQR(qname="secdev.org."))))
 assert UDP in pkt and isinstance(pkt[UDP].payload, DNS)
 assert pkt[UDP].dport == 53 and pkt[UDP].length is None
 assert pkt[DNS].qdcount == 1 and pkt[DNS].qd.qname == "secdev.org."
 
 * DNS over TCP
-pkt = IP(str(IP(src="10.0.0.1", dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="P")/DNS(qd=DNSQR(qname="secdev.org."))))
+pkt = IP(raw(IP(src="10.0.0.1", dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="P")/DNS(qd=DNSQR(qname="secdev.org."))))
 assert TCP in pkt and isinstance(pkt[TCP].payload, DNS)
 assert pkt[TCP].dport == 53 and pkt[DNS].length is not None
 assert pkt[DNS].qdcount == 1 and pkt[DNS].qd.qname == "secdev.org."
@@ -5611,7 +5611,7 @@ assert pkt[DNS].qdcount == 1 and pkt[DNS].qd.qname == "secdev.org."
 = Layer binding
 
 * Test DestMACField & DestIPField
-pkt = Ether(str(Ether()/IP()/UDP(dport=5353)/DNS()))
+pkt = Ether(raw(Ether()/IP()/UDP(dport=5353)/DNS()))
 assert isinstance(pkt, Ether) and pkt.dst == '01:00:5e:00:00:fb'
 pkt = pkt.payload
 assert isinstance(pkt, IP) and pkt.dst == '224.0.0.251'
@@ -5621,7 +5621,7 @@ pkt = pkt.payload
 assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)
 
 * Same with IPv6
-pkt = Ether(str(Ether()/IPv6()/UDP(dport=5353)/DNS()))
+pkt = Ether(raw(Ether()/IPv6()/UDP(dport=5353)/DNS()))
 assert isinstance(pkt, Ether) and pkt.dst == '33:33:00:00:00:fb'
 pkt = pkt.payload
 assert isinstance(pkt, IPv6) and pkt.dst == 'ff02::fb'
@@ -5759,7 +5759,7 @@ ff02::%en0/32                           link#4                          UmCI    
     from scapy.arch.unix import read_routes6
     routes = read_routes6()
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 6)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -5807,7 +5807,7 @@ ff02::%lo0/32                           ::1                             UmCI    
     routes = read_routes6()
     assert(valid_output_read_routes6(routes))
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 11)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -5847,7 +5847,7 @@ ff02::%en0/32                           link#4                          UmCI    
     from scapy.arch.unix import read_routes6
     routes = read_routes6()
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 5)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -5886,7 +5886,7 @@ ff02::%lo0/32                     ::1                           U           lo0
     from scapy.arch.unix import read_routes6
     routes = read_routes6()
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 3)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -5944,7 +5944,7 @@ ff02::%lo0/32                      fe80::1%lo0                    UC         0  
     from scapy.arch.unix import read_routes6
     routes = read_routes6()
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 5)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -5997,7 +5997,7 @@ ff02::%lo0/32                      ::1                            UC          - 
     from scapy.arch.unix import read_routes6
     routes = read_routes6()
     for r in routes:
-        print r
+        print(r)
     assert(len(routes) == 5)
     assert(check_mandatory_ipv6_routes(routes))
 
@@ -6008,7 +6008,7 @@ test_netbsd_7_0()
 + STP tests
 
 = STP - Basic Instantiation
-assert str(STP()) == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00\x02\x00\x0f\x00'
+assert raw(STP()) == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00\x02\x00\x0f\x00'
 
 = STP - Basic Dissection
 
@@ -6022,10 +6022,10 @@ assert s.hellotime == 5
 + EAPOL class tests
 
 = EAPOL - Basic Instantiation
-str(EAPOL()) == b'\x01\x00\x00\x00'
+raw(EAPOL()) == b'\x01\x00\x00\x00'
 
 = EAPOL - Instantiation with specific values
-str(EAPOL(version = 3, type = 5)) == b'\x03\x05\x00\x00'
+raw(EAPOL(version = 3, type = 5)) == b'\x03\x05\x00\x00'
 
 = EAPOL - Dissection (1)
 s = b'\x03\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -6156,10 +6156,10 @@ assert(eapol[MKAPDU][MKAICVSet].icv == b"\xb0H\xcf\xe0:\xa1\x94RD'\x03\xe67\xe1U
 + EAP class tests
 
 = EAP - Basic Instantiation
-str(EAP()) == b'\x04\x00\x00\x04'
+raw(EAP()) == b'\x04\x00\x00\x04'
 
 = EAP - Instantiation with specific values
-str(EAP(code = 1, id = 1, len = 5, type = 1)) == b'\x01\x01\x00\x05\x01'
+raw(EAP(code = 1, id = 1, len = 5, type = 1)) == b'\x01\x01\x00\x05\x01'
 
 = EAP - Dissection (1)
 s = b'\x01\x01\x00\x05\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -6254,16 +6254,16 @@ assert(eap[EAP_TTLS].S == 0)
 assert(eap[EAP_TTLS].version == 0)
 
 = EAP - EAP_TLS - Basic Instantiation
-str(EAP_TLS()) == b'\x01\x00\x00\x06\r\x00'
+raw(EAP_TLS()) == b'\x01\x00\x00\x06\r\x00'
 
 = EAP - EAP_FAST - Basic Instantiation
-str(EAP_FAST()) == b'\x01\x00\x00\x06+\x00'
+raw(EAP_FAST()) == b'\x01\x00\x00\x06+\x00'
 
 = EAP - EAP_TTLS - Basic Instantiation
-str(EAP_TTLS()) == b'\x01\x00\x00\x06\x15\x00'
+raw(EAP_TTLS()) == b'\x01\x00\x00\x06\x15\x00'
 
 = EAP - EAP_MD5 - Basic Instantiation
-str(EAP_MD5()) == b'\x01\x00\x00\x06\x04\x00'
+raw(EAP_MD5()) == b'\x01\x00\x00\x06\x04\x00'
 
 = EAP - EAP_MD5 - Request - Dissection (8)
 s = b'\x01\x02\x00\x16\x04\x10\x86\xf9\x89\x94\x81\x01\xb3 nHh\x1b\x8d\xe7^\xdb\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -6290,7 +6290,7 @@ assert(eap[EAP_MD5].value == b'\xfd\x1e\xffe\xf5\x80y\xa8\xe3\xc8\xf1\xbd\xc2\x8
 assert(eap[EAP_MD5].optional_name == '')
 
 = EAP - LEAP - Basic Instantiation
-str(LEAP()) == b'\x01\x00\x00\x08\x11\x01\x00\x00'
+raw(LEAP()) == b'\x01\x00\x00\x08\x11\x01\x00\x00'
 
 = EAP - LEAP - Request - Dissection (10)
 s = b'\x01D\x00\x1c\x11\x01\x00\x088\xb6\xd7\xa1E<!\x15supplicant-1'
@@ -6401,7 +6401,7 @@ assert(type(p[NTP]) == NTPPrivate)
 + NTPHeader tests
 
 = NTPHeader - Basic checks
-len(str(NTP())) == 48
+len(raw(NTP())) == 48
 
 
 = NTPHeader - Dissection
@@ -7433,7 +7433,7 @@ assert(p.data[0].ifname.startswith("lo"))
 + VXLAN layer
 
 = Build a VXLAN packet with VNI of 42
-str(UDP(sport=1024, dport=4789, len=None, chksum=None)/VXLAN(flags=0x08, vni=42)) == b'\x04\x00\x12\xb5\x00\x10\x00\x00\x08\x00\x00\x00\x00\x00\x2a\x00'
+raw(UDP(sport=1024, dport=4789, len=None, chksum=None)/VXLAN(flags=0x08, vni=42)) == b'\x04\x00\x12\xb5\x00\x10\x00\x00\x08\x00\x00\x00\x00\x00\x2a\x00'
 
 = Verify VXLAN Ethernet Binding
 pkt = VXLAN(raw(VXLAN(vni=23)/Ether(dst="11:11:11:11:11:11", src="11:11:11:11:11:11", type=0x800)))
@@ -7443,7 +7443,7 @@ pkt.flags.NextProtocol and pkt.NextProtocol == 3
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
 p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
 p /= VXLAN(flags=0x8, vni=42) / Ether() / IP()
-p = Ether(str(p))
+p = Ether(raw(p))
 assert(p[UDP].dport == 4789)
 assert(p[Ether:2].type == 0x800)
 
@@ -7451,7 +7451,7 @@ assert(p[Ether:2].type == 0x800)
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
 p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
 p /= VXLAN(flags=0xC, vni=42, NextProtocol=3) / Ether() / IP()
-p = Ether(str(p))
+p = Ether(raw(p))
 assert(p[UDP].dport == 4789)
 assert(p[VXLAN].reserved0 == 0x0)
 assert(p[VXLAN].NextProtocol == 3)
@@ -7461,7 +7461,7 @@ assert(p[Ether:2].type == 0x800)
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
 p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
 p /= VXLAN(flags=0x8, vni=42) / Ether() / IP()
-p = Ether(str(p))
+p = Ether(raw(p))
 assert(p[VXLAN].reserved1 == 0x0)
 assert(p[VXLAN].gpid is None)
 assert(p[Ether:2].type == 0x800)
@@ -7470,7 +7470,7 @@ assert(p[Ether:2].type == 0x800)
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
 p /= IP(src="1.1.1.1", dst="2.2.2.2") / UDP(sport=1111)
 p /= VXLAN(flags=0x88, gpid=42, vni=42) / Ether() / IP()
-p = Ether(str(p))
+p = Ether(raw(p))
 assert(p[VXLAN].gpid == 42)
 assert(p[VXLAN].reserved1 is None)
 assert(p[Ether:2].type == 0x800)
@@ -7480,8 +7480,8 @@ assert(p[Ether:2].type == 0x800)
 ############
 + Tests of SSLStreamContext
 
-= Test with recv() calls that return exact packet-length strings
-~ sslstreamsocket
+= Test with recv() calls that return exact packet-length rawings
+~ sslraweamsocket
 
 import socket
 class MockSocket(object):
@@ -7518,7 +7518,7 @@ except socket.error:
 assert(ret)
 
 = Test with recv() calls that return twice as much data as the exact packet-length
-~ sslstreamsocket
+~ sslraweamsocket
 
 import socket
 class MockSocket(object):
@@ -7557,7 +7557,7 @@ except socket.error:
 assert(ret)
 
 = Test with recv() calls that return not enough data
-~ sslstreamsocket
+~ sslraweamsocket
 
 import socket
 class MockSocket(object):
@@ -7617,9 +7617,9 @@ assert(p.data == 3)
 
 ############
 ############
-+ Test correct conversion from binary to string of IPv6 addresses
++ Test correct conversion from binary to rawing of IPv6 addresses
 
-= IPv6 bin to string conversion
+= IPv6 bin to rawing conversion
 from scapy.pton_ntop import _inet6_ntop, inet_ntop
 import socket
 for binfrm, address in [
@@ -7645,7 +7645,7 @@ for binfrm, address in [
     addr2 = _inet6_ntop(binfrm)
     assert address == addr1 == addr2
 
-= IPv6 bin to string conversion - Zero-block of length 1
+= IPv6 bin to rawing conversion - Zero-block of length 1
 binfrm = b'\x11\x11\x22\x22\x33\x33\x44\x44\x55\x55\x66\x66\x00\x00\x88\x88'
 addr1, addr2 = inet_ntop(socket.AF_INET6, binfrm), _inet6_ntop(binfrm)
 # On Mac OS socket.inet_ntop is not fully compliant with RFC 5952 and
@@ -7655,7 +7655,7 @@ assert(addr1 in ['1111:2222:3333:4444:5555:6666:0:8888',
                  '1111:2222:3333:4444:5555:6666::8888'])
 assert(addr2 == '1111:2222:3333:4444:5555:6666:0:8888')
 
-= IPv6 bin to string conversion - Illegal sizes
+= IPv6 bin to rawing conversion - Illegal sizes
 for binfrm in ["\x00" * 15, b"\x00" * 17]:
     rc = False
     try:
@@ -7675,7 +7675,7 @@ for binfrm in ["\x00" * 15, b"\x00" * 17]:
 + VRRP tests
 
 = VRRP - build
-s = str(IP()/VRRP())
+s = raw(IP()/VRRP())
 s == b'E\x00\x00$\x00\x01\x00\x00@p|g\x7f\x00\x00\x01\x7f\x00\x00\x01!\x01d\x00\x00\x01z\xfd\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = VRRP - dissection
@@ -7697,7 +7697,7 @@ assert b[VRRP].chksum == 0xc6f4
 + L2TP tests
 
 = L2TP - build
-s = str(IP()/UDP()/L2TP())
+s = raw(IP()/UDP()/L2TP())
 s == b'E\x00\x00*\x00\x01\x00\x00@\x11|\xc0\x7f\x00\x00\x01\x7f\x00\x00\x01\x06\xa5\x06\xa5\x00\x16\xf4e\x00\x02\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = L2TP - dissection
@@ -7711,7 +7711,7 @@ L2TP in p and p[L2TP].len == 14 and p.tunnel_id == 0 and p[UDP].chksum == 0xf465
 
 = HSRP - build & dissection
 defaddr = conf.route.route('0.0.0.0')[1]
-pkt = IP(str(IP()/UDP(dport=1985, sport=1985)/HSRP()/HSRPmd5()))
+pkt = IP(raw(IP()/UDP(dport=1985, sport=1985)/HSRP()/HSRPmd5()))
 assert pkt[IP].dst == "224.0.0.2" and pkt[UDP].sport == pkt[UDP].dport == 1985
 assert pkt[HSRP].opcode == 0 and pkt[HSRP].state == 16
 assert pkt[HSRPmd5].type == 4 and pkt[HSRPmd5].sourceip == defaddr
@@ -7722,7 +7722,7 @@ assert pkt[HSRPmd5].type == 4 and pkt[HSRPmd5].sourceip == defaddr
 + RIP tests
 
 = RIP - build
-s = str(IP()/UDP(sport=520)/RIP()/RIPEntry()/RIPAuth(authtype=2, password="scapy"))
+s = raw(IP()/UDP(sport=520)/RIP()/RIPEntry()/RIPAuth(authtype=2, password="scapy"))
 s == b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x01\x02\x08\x02\x08\x004\xae\x99\x01\x01\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\xff\x00\x02scapy\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = RIP - dissection
@@ -7735,7 +7735,7 @@ RIPEntry in p and RIPAuth in p and p[RIPAuth].password.startswith("scapy")
 + RADIUS tests
 
 = IP/UDP/RADIUS - Build
-s = str(IP()/UDP(sport=1812)/Radius(authenticator="scapy")/RadiusAttribute(value="scapy"))
+s = raw(IP()/UDP(sport=1812)/Radius(authenticator="scapy")/RadiusAttribute(value="scapy"))
 s == b'E\x00\x007\x00\x01\x00\x00@\x11|\xb3\x7f\x00\x00\x01\x7f\x00\x00\x01\x07\x14\x07\x15\x00#U\xb2\x01\x00\x00\x1bscapy\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x07scapy'
 
 = IP/UDP/RADIUS - Dissection
@@ -8153,10 +8153,10 @@ re == 'vmuvr @ 906 \x9e g'
 
 random.seed(0x2807)
 cb = CorruptedBytes("ABCDE", p=0.5)
-assert(sane(str(cb)) == ".BCD)")
+assert(sane(raw(cb)) == ".BCD)")
 
 cb = CorruptedBits("ABCDE", p=0.2)
-assert(sane(str(cb)) == "ECk@Y")
+assert(sane(raw(cb)) == "ECk@Y")
 
 = RandEnumKeys
 ~ not_pypy
@@ -8178,7 +8178,7 @@ assert(rss == "CON:")
 
 random.seed(0x2807)
 rts = RandTermString(4, "scapy")
-assert(sane(str(rts)) == "...[scapy")
+assert(sane(raw(rts)) == "...[scapy")
 
 
 ############
@@ -8257,7 +8257,7 @@ assert repr(pkt.flags) == '<Flag 50 (SAU)>'
 = Flag values mutation with .raw_packet_cache
 ~ IP TCP
 
-pkt = IP(str(IP(flags="MF")/TCP(flags="SA")))
+pkt = IP(raw(IP(flags="MF")/TCP(flags="SA")))
 assert pkt.raw_packet_cache is not None
 assert pkt[TCP].raw_packet_cache is not None
 assert pkt.flags.MF
@@ -8273,7 +8273,7 @@ pkt.flags.MF = 0
 pkt.flags.DF = 1
 pkt[TCP].flags.U = True
 pkt[TCP].flags.S = False
-pkt = IP(str(pkt))
+pkt = IP(raw(pkt))
 assert not pkt.flags.MF
 assert pkt.flags.DF
 assert not pkt.flags.evil
@@ -8312,7 +8312,7 @@ assert [p[TCP].flags for p in plist] == [2, 18, 16]
 + SCTP
 
 = SCTP - Chunk Init - build
-s = str(IP()/SCTP()/SCTPChunkInit(params=[SCTPChunkParamIPv4Addr()]))
+s = raw(IP()/SCTP()/SCTPChunkInit(params=[SCTPChunkParamIPv4Addr()]))
 s == b'E\x00\x00<\x00\x01\x00\x00@\x84|;\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00@,\x0b_\x01\x00\x00\x1c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x08\x7f\x00\x00\x01'
 
 = SCTP - Chunk Init - dissection
@@ -8320,7 +8320,7 @@ p = IP(s)
 SCTPChunkParamIPv4Addr in p and p[SCTP].chksum == 0x402c0b5f and p[SCTPChunkParamIPv4Addr].addr == "127.0.0.1"
 
 = SCTP - SCTPChunkSACK - build
-s = str(IP()/SCTP()/SCTPChunkSACK(gap_ack_list=["7:28"]))
+s = raw(IP()/SCTP()/SCTPChunkSACK(gap_ack_list=["7:28"]))
 s == b'E\x00\x004\x00\x01\x00\x00@\x84|C\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00;\x01\xd4\x04\x03\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x07\x00\x1c'
 
 = SCTP - SCTPChunkSACK - dissection
@@ -8573,7 +8573,7 @@ BOOTP().hashret() == b"\x00\x00\x00\x00"
 
 import random
 random.seed(0x2807)
-str(RandDHCPOptions()) == "[('WWW_server', '90.219.239.175')]"
+raw(RandDHCPOptions()) == "[('WWW_server', '90.219.239.175')]"
 
 value = ("hostname", "scapy")
 dof = DHCPOptionsField("options", value)
@@ -8589,7 +8589,7 @@ udof = DHCPOptionsField("options", unknown_value_pad)
 udof.m2i("", unknown_value_pad) == [(254, '\xff'*255), 'pad']
 
 = DHCP - build
-s = str(IP()/UDP()/BOOTP(chaddr="00:01:02:03:04:05")/DHCP(options=[("message-type","discover"),"end"]))
+s = raw(IP()/UDP()/BOOTP(chaddr="00:01:02:03:04:05")/DHCP(options=[("message-type","discover"),"end"]))
 s == b'E\x00\x01\x10\x00\x01\x00\x00@\x11{\xda\x7f\x00\x00\x01\x7f\x00\x00\x01\x00C\x00D\x00\xfcf\xea\x01\x01\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0000:01:02:03:04:0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00c\x82Sc5\x01\x01\xff'
 
 = DHCP - dissection
@@ -8611,7 +8611,7 @@ dpl_ether = dpl.toEthernet()
 len(dpl_ether) == 1 and Ether in dpl_ether[0]
 
 = Dot11 - build
-s = str(Dot11())
+s = raw(Dot11())
 s == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = Dot11 - dissection
@@ -8638,9 +8638,9 @@ assert Dot11Elt(ID=1).mysummary() == ""
 = Dot11WEP - build
 ~ crypto
 conf.wepkey = ""
-assert str(PPI()/Dot11(FCfield=0x40)/Dot11WEP()) == b'\x00\x00\x08\x00i\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+assert raw(PPI()/Dot11(FCfield=0x40)/Dot11WEP()) == b'\x00\x00\x08\x00i\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 conf.wepkey = "test123"
-assert str(PPI()/Dot11(type=2, subtype=8, FCfield=0x40)/Dot11QoS()/Dot11WEP()) == b'\x00\x00\x08\x00i\x00\x00\x00\x88@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x008(^a'
+assert raw(PPI()/Dot11(type=2, subtype=8, FCfield=0x40)/Dot11QoS()/Dot11WEP()) == b'\x00\x00\x08\x00i\x00\x00\x00\x88@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x008(^a'
 
 = Dot11WEP - dissect
 ~ crypto
@@ -8664,8 +8664,8 @@ assert (Dot11()/LLC(dsap=2, ctrl=4)).answers(Dot11()/LLC(dsap=1, ctrl=5))
 
 = Test detection
 
-assert isinstance(Dot3(str(Ether())),Ether)
-assert isinstance(Ether(str(Dot3())),Dot3)
+assert isinstance(Dot3(raw(Ether())),Ether)
+assert isinstance(Ether(raw(Dot3())),Dot3)
 
 a = Ether(b'\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00')
 assert isinstance(a,Dot3)
@@ -8752,7 +8752,7 @@ value == 26908070
 test.i2repr("", value) == '7:28:28.70'
 
 = IPv4 - UDP null checksum
-IP(str(IP()/UDP()/Raw(b"\xff\xff\x01\x6a")))[UDP].chksum == 0xFFFF
+IP(raw(IP()/UDP()/Raw(b"\xff\xff\x01\x6a")))[UDP].chksum == 0xFFFF
 
 = IPv4 - (IP|UDP|TCP|ICMP)Error
 query = IP(dst="192.168.0.1", src="192.168.0.254", ttl=1)/UDP()/DNS()
@@ -8780,11 +8780,11 @@ assert a.hashret() == b"\x00"
 = IPv4 - utilities
 l = overlap_frag(IP(dst="1.2.3.4")/ICMP()/("AB"*8), ICMP()/("CD"*8))
 assert(len(l) == 6)
-assert([len(str(p[IP].payload)) for p in l] == [8, 8, 8, 8, 8, 8])
-assert([(p.frag, p.flags.MF) for p in [IP(str(p)) for p in l]] == [(0, True), (1, True), (2, True), (0, True), (1, True), (2, False)])
+assert([len(raw(p[IP].payload)) for p in l] == [8, 8, 8, 8, 8, 8])
+assert([(p.frag, p.flags.MF) for p in [IP(raw(p)) for p in l]] == [(0, True), (1, True), (2, True), (0, True), (1, True), (2, False)])
 
 = IPv4 - traceroute utilities
-ip_ttl = [("192.168.0.%d" % i, i) for i in xrange(1, 10)]
+ip_ttl = [("192.168.0.%d" % i, i) for i in six.moves.range(1, 10)]
 
 tr_packets = [ (IP(dst="192.168.0.1", src="192.168.0.254", ttl=ttl)/TCP(options=[("Timestamp", "00:00:%.2d.00" % ttl)])/"scapy",
                 IP(dst="192.168.0.254", src=ip)/ICMP(type=11)/IPerror(dst="192.168.0.1", src="192.168.0.254", ttl=0)/TCPerror()/"scapy")
@@ -8829,7 +8829,7 @@ def test_timeskew_graph(mock_plt):
     def fake_plot(data, **kwargs):
         return data
     mock_plt.plot = fake_plot
-    srl = SndRcvList([(a, a) for a in [IP(str(p[0])) for p in tr_packets]])
+    srl = SndRcvList([(a, a) for a in [IP(raw(p[0])) for p in tr_packets]])
     ret = srl.timeskew_graph("192.168.0.254")
     assert(len(ret) == 9)
     assert(ret[0][1] == 0.0)
@@ -8897,7 +8897,7 @@ class Test(Packet):
                        count_from=lambda pkt: pkt.BitCount),
     ]
 
-pkt = Test(str(Test(Values=[0, 0, 0, 0, 1, 1, 1, 1])))
+pkt = Test(raw(Test(Values=[0, 0, 0, 0, 1, 1, 1, 1])))
 assert(pkt.BitCount == 8)
 assert(pkt.ByteCount == 1)
 

--- a/test/run_tests3
+++ b/test/run_tests3
@@ -1,0 +1,9 @@
+#! /bin/sh
+DIR=$(dirname $0)/..
+PYTHON=python3
+if [ -z "$*" ]
+then
+    PYTHONPATH=$DIR exec $PYTHON ${DIR}/scapy/tools/UTscapy.py -t regression.uts -f html -K ipv6 -l -o /tmp/scapy_regression_test_$(date +%Y%m%d-%H%M%S).html
+else
+    PYTHONPATH=$DIR exec $PYTHON ${DIR}/scapy/tools/UTscapy.py "$@"
+fi


### PR DESCRIPTION
**Python 3 support major PR. It's big, but most of it are regression.uts tests fixes.**

- Requires https://github.com/secdev/scapy/pull/674
- Scapy boots and most of its major functions work 

This PR:
- fixes a lot of ord/orb, bytes chr/chb, compat bugs
- fixes a few .next() / next()
- fixes most layers
- the fixes are mostly in `regression.uts`

Current status (updated):
- regression.uts: 1069/1091 tests passing