### PR TITLE
Six import error in mock

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,9 +10,9 @@ fi
 
 if python --version 2>&1 | grep -q PyPy; then
   # cryptography requires PyPy >= 2.6, Travis CI uses 2.5.0
-  $SCAPY_SUDO pip install $PIP_INSTALL_FLAGS mock
+  $SCAPY_SUDO pip install $PIP_INSTALL_FLAGS -U mock
 else
-  $SCAPY_SUDO pip install $PIP_INSTALL_FLAGS cryptography mock
+  $SCAPY_SUDO pip install $PIP_INSTALL_FLAGS -U cryptography mock
 fi
 
 # Install coverage


### PR DESCRIPTION
Some [travis tests fails](https://travis-ci.org/secdev/scapy/jobs/257874313) with the following error:
```
>>> import mock
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "/usr/local/lib/python2.7/dist-packages/mock/__init__.py", line 2, in <module>
    import mock.mock as _mock
  File "/usr/local/lib/python2.7/dist-packages/mock/mock.py", line 68, in <module>
    from six import wraps
ImportError: cannot import name wraps
```

It seems that six should also be installed using pip. The trick is to ask pip to always install the latest version using the `-U` flag.