### PR TITLE
Fix OSPF LSA list dissection

### DIFF
--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -260,7 +260,7 @@ class OSPF_Link(Packet):
 def _LSAGuessPayloadClass(p, **kargs):
     """ Guess the correct LSA class for a given payload """
     # This is heavily based on scapy-cdp.py by Nicolas Bareil and Arnaud Ebalard
-    # XXX: This only works if all payload
+    
     cls = conf.raw_layer
     if len(p) >= 4:
         typ = struct.unpack("!B", p[3])[0]
@@ -410,7 +410,7 @@ class OSPF_LSReq(Packet):
 class OSPF_LSUpd(Packet):
     name = "OSPF Link State Update"
     fields_desc = [FieldLenField("lsacount", None, fmt="!I", count_of="lsalist"),
-                   PacketListField("lsalist", [], _LSAGuessPayloadClass,
+                   PacketListField("lsalist", None, _LSAGuessPayloadClass,
                                 count_from = lambda pkt: pkt.lsacount,
                                 length_from = lambda pkt: pkt.underlayer.len - 24)]
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -439,7 +439,6 @@ class PacketListField(PacketField):
         self.count_from = count_from
         self.length_from = length_from
 
-
     def any2i(self, pkt, x):
         if not isinstance(x, list):
             return [x]

--- a/test/ospf.uts
+++ b/test/ospf.uts
@@ -1,0 +1,23 @@
+##############################
+% OSPF Related regression tests
+##############################
+
+data = '\x01\x00^\x00\x00\x05\x00\xe0\x18\xb1\x0c\xad\x08\x00E\xc0\x00T\x08\x19\x00\x00\x01Ye\xc2\xc0\xa8\xaa\x08\xe0\x00\x00\x05\x02\x04\x00@\xc0\xa8\xaa\x08\x00\x00\x00\x01\x96\x1f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x03\xe2\x02\x01\xc0\xa8\xaa\x08\xc0\xa8\xaa\x08\x80\x00\r\xc3%\x06\x00$\x02\x00\x00\x01\xc0\xa8\xaa\x00\xff\xff\xff\x00\x03\x00\x00\n'
+
+p = Ether(data)
+
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].age == 994)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].type == 1)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].id == '192.168.170.8')
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].adrouter == '192.168.170.8')
+assert (hex(p[OSPF_LSUpd][OSPF_Router_LSA].seq) == '0x80000dc3')
+assert (hex(p[OSPF_LSUpd][OSPF_Router_LSA].chksum) == '0x2506')
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].len == 36)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].reserved == 0)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linkcount == 1)
+
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linklist[0][OSPF_Link].id == '192.168.170.0')
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linklist[0][OSPF_Link].data == '255.255.255.0')
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linklist[0][OSPF_Link].type == 3)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linklist[0][OSPF_Link].toscount == 0)
+assert (p[OSPF_LSUpd][OSPF_Router_LSA].linklist[0][OSPF_Link].metric == 10)


### PR DESCRIPTION
In the PacketListField constructor, inside the OSPF_LSUpd class, an empty list was passed as argument. This resulted into strange behaviour, leading to the LSA list being displayed and managed as a raw set of bytes.

Substituting the empty list with None let the PacketListField constructor create its own empty list, resulting with the dissection process working as expected.