### PR TITLE
Fix TLS layer loading

### DIFF
--- a/scapy/all.py
+++ b/scapy/all.py
@@ -38,11 +38,6 @@ from scapy.autorun import *
 from scapy.main import *
 
 from scapy.layers.all import *
-if "tls" in conf.load_layers:
-    try:
-        from scapy.layers.tls.all import *
-    except ImportError:
-        pass
 
 from scapy.asn1.asn1 import *
 from scapy.asn1.ber import *

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -431,7 +431,7 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     netcache = NetCache()
     geoip_city = '/usr/share/GeoIP/GeoIPCity.dat'
     geoip_city_ipv6 = '/usr/share/GeoIP/GeoIPCityv6.dat'
-    load_layers = ["l2", "inet", "dhcp", "dns", "dot11", "gprs", "tls",
+    load_layers = ["l2", "inet", "dhcp", "dns", "dot11", "gprs",
                    "hsrp", "inet6", "ir", "isakmp", "l2tp", "mgcp",
                    "mobileip", "netbios", "netflow", "ntp", "ppp", "pptp",
                    "radius", "rip", "rtp", "skinny", "smb", "snmp",

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -39,11 +39,14 @@ def _import_star(m):
                 __all__.append(name)
                 globals()[name] = sym
 
+LAYER_ALIASES = {
+    "tls": "tls.all",
+}
+
 for _l in conf.load_layers:
     log_loading.debug("Loading layer %s" % _l)
     try:
-        if _l != "tls":
-            _import_star(_l)
+        _import_star(LAYER_ALIASES.get(_l, _l))
     except Exception as e:
         log.warning("can't import layer %s: %s" % (_l,e))
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -18,6 +18,7 @@ import importlib
 ignored = list(six.moves.builtins.__dict__.keys())
 
 from scapy.error import *
+from scapy.layers.all import LAYER_ALIASES
 
 def _probe_config_file(cf):
     cf_path = os.path.join(os.path.expanduser("~"), cf)
@@ -83,7 +84,7 @@ def load_module(name):
     _load("scapy.modules."+name)
 
 def load_layer(name):
-    _load("scapy.layers."+name)
+    _load("scapy.layers." + LAYER_ALIASES.get(name, name))
 
 def load_contrib(name):
     try:

--- a/test/configs/travis.utsc
+++ b/test/configs/travis.utsc
@@ -5,7 +5,10 @@
   ],
   "onlyfailed": true,
   "preexec": {
-    "../scapy/contrib/*.uts": "load_contrib(\"%name%\")"
+    "../scapy/contrib/*.uts": "load_contrib(\"%name%\")",
+    "cert.uts": "load_layer(\"tls\")",
+    "sslv2.uts": "load_layer(\"tls\")",
+    "tls*.uts": "load_layer(\"tls\")"
   },
   "format": "text"
 }

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -5,7 +5,10 @@
   ],
   "onlyfailed": true,
   "preexec": {
-    "scapy\\contrib\\*.uts": "load_contrib(\"%name%\")"
+    "scapy\\contrib\\*.uts": "load_contrib(\"%name%\")",
+    "test\\cert.uts": "load_layer(\"tls\")",
+    "test\\sslv2.uts": "load_layer(\"tls\")",
+    "test\\tls*.uts": "load_layer(\"tls\")"
   },
   "format": "text",
   "kw_ko": [

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -5,7 +5,10 @@
   ],
   "onlyfailed": true,
   "preexec": {
-    "..\\scapy\\contrib\\*.uts": "load_contrib(\"%name%\")"
+    "..\\scapy\\contrib\\*.uts": "load_contrib(\"%name%\")",
+    "cert.uts": "load_layer(\"tls\")",
+    "sslv2.uts": "load_layer(\"tls\")",
+    "tls*.uts": "load_layer(\"tls\")"
   },
   "format": "html",
   "kw_ko": [


### PR DESCRIPTION
This PR makes it possible to load the TLS layer when it is not loaded by default, using `load_layer()`.

It also removes the TLS layer from the layers loaded by default in Scapy. This is done because the TLS layer parses and verifies certificates in sniffed TLS sessions, which uses a lot of CPU and is probably not what most Scapy users want or expect.

This is a partial fix for #763.
