### PR TITLE
Some variables were not deleted and remained in the namespace

### DIFF
--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -271,10 +271,7 @@ class Route6:
         return res[0][1]
 
 conf.route6 = Route6()
-
-_res = conf.route6.route("::/0")
-if _res:
-    iff, gw, addr = _res
-    conf.iface6 = iff
-del(_res)
-
+try:
+    conf.iface6 = conf.route6.route("::/0")[0]
+except:
+    pass


### PR DESCRIPTION
The temporary variables `iff`, `gw` & `addr` were not deleted. I've used this opportunity to change the way we set `conf.iface6` to a try-catch approach which is [recommended](https://docs.python.org/2/glossary.html?highlight=eafp#term-eafp), particularly here: it's faster since the exception usually won't happen, and the code is easier to read.