### PR TITLE
[Python 2 to 3] Fix iter functions in config

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -362,6 +362,9 @@ _read_config_file(fname)
 assert(conf.verb == 42)
 conf.verb = saved_conf_verb
 
+= Test CacheInstance repr
+
+conf.netcache
 
 
 ############


### PR DESCRIPTION
This PR fixes 2 bugs:
- `self.name = ...` cannot be defined on python 3 as the object only inerates from dict (on python 2, objects inherated automatically from "object"). Fixed using `__getattr__ `and `__setattr__ `with `__slots__`
- fix `self.iter...` calls replaced by `six.iter...` calls. We need to pass `self.__dict__` otherwise six creates a loop calling config.iteritems.