### PR TITLE
Fix ordering of bit fields in the Dot11QoS QoS Control field

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -178,10 +178,10 @@ class Dot11(Packet):
 
 class Dot11QoS(Packet):
     name = "802.11 QoS"
-    fields_desc = [ BitField("TID",None,4),
-                    BitField("EOSP",None,1),
+    fields_desc = [ BitField("Reserved",None,1),
                     BitField("Ack Policy",None,2),
-                    BitField("Reserved",None,1),
+                    BitField("EOSP",None,1),
+                    BitField("TID",None,4),
                     ByteField("TXOP",None) ]
     def guess_payload_class(self, payload):
         if isinstance(self.underlayer, Dot11):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8611,8 +8611,8 @@ Dot11 in p and p.addr3 == "00:00:00:00:00:00"
 p.mysummary() == '802.11 Management 0 00:00:00:00:00:00 > 00:00:00:00:00:00'
 
 = Dot11QoS - build
-s = str(Dot11(type=2, subtype=8)/Dot11QoS())
-s == b'\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+s = str(Dot11(type=2, subtype=8)/Dot11QoS(TID=4))
+s == b'\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00'
 
 = Dot11QoS - dissection
 p = Dot11(s)


### PR DESCRIPTION
The QoS control fields in Dot11QoS appear to be in reverse order.  I will file an issue and reference this pull request.
Fixes #786