### PR TITLE
[coverage] reduce randomness of coverage

### DIFF
--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -4,6 +4,19 @@
 
 ############
 ############
++ Networking tests
+
+= Automaton - SelectableSelector system timeout
+
+class TimeOutSelector(SelectableObject):
+    def check_recv(self):
+        return False
+
+assert select_objects([TimeOutSelector()], 0) == []
+assert select_objects([TimeOutSelector()], 1) == []
+
+############
+############
 + Mocked read_routes6() calls
 
 = Windows with fake IPv6 adapter

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -272,6 +272,11 @@ def test_hexdiff():
 
 test_hexdiff()
 
+= Test mysummary functions - Ether
+
+Ether(dst="ff:ff:ff:ff:ff:ff", src="ff:ff:ff:ff:ff:ff", type=0x9000)
+assert _.mysummary() == 'ff:ff:ff:ff:ff:ff > ff:ff:ff:ff:ff:ff (0x9000)'
+
 = Test fletcher16_* functions
 assert(fletcher16_checksum("\x28\x07") == 22319)
 assert(fletcher16_checkbytes("ABCDEF", 2) == "\x89\x67")


### PR DESCRIPTION
This PR:
- adds automaton timeout tests: random timeout was happening
- adds single Ether() mysummary test, that was not always triggered