### PR TITLE
fix usage example

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1386,7 +1386,7 @@ Use Scapy to send a DHCP discover request and analyze the replies::
 
 In this case we got 2 replies, so there were two active DHCP servers on the test network::
 
-    >>> ans.summarize()
+    >>> ans.summary()
     Ether / IP / UDP 0.0.0.0:bootpc > 255.255.255.255:bootps / BOOTP / DHCP ==> Ether / IP / UDP 192.168.1.1:bootps > 255.255.255.255:bootpc / BOOTP / DHCP
     Ether / IP / UDP 0.0.0.0:bootpc > 255.255.255.255:bootps / BOOTP / DHCP ==> Ether / IP / UDP 192.168.1.11:bootps > 255.255.255.255:bootpc / BOOTP / DHCP
     }}}


### PR DESCRIPTION
There's a mistake in this function name in the documentation. This corrects it.

Following the example in the documentation leads to an error:

>>> ans, unans = srp(dhcp_discover, multi=True)
Begin emission:
Finished to send 1 packets.
*.....................................^C
Received 38 packets, got 1 answers, remaining 0 packets
>>> ans.summarize()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/scapy/plist.py", line 76, in __getattr__
    return getattr(self.res, attr)
AttributeError: 'list' object has no attribute 'summarize'
>>> ans.summary()
Ether / IP / UDP 0.0.0.0:bootpc > 255.255.255.255:bootps / BOOTP / DHCP ==> Ether / IP / UDP 192.168.1.1:bootps > 192.168.65.2:bootpc / BOOTP / DHCP
