### PR TITLE
Fix #791 - Throw an exception when tcpreplay can not be executed

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -338,7 +338,10 @@ def sendpfast(x, pps=None, mbps=None, realtime=None, loop=0, file_cache=False, i
     except KeyboardInterrupt:
         log_interactive.info("Interrupted by user")
     except Exception as e:
-        log_interactive.error("while trying to exec [%s]: %s", argv[0], e)
+        if conf.interactive:
+            log_interactive.error("Cannot execute [%s]", argv[0], exc_info=True)
+        else:
+            raise
     finally:
         os.unlink(f)
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -995,6 +995,18 @@ for i in six.moves.range(5):
 assert (len(ret) == 2)
 assert all(x[1] == 15169 for x in ret)
 
+= sendpfast
+
+old_interactive = conf.interactive
+conf.interactive = False
+try:
+    sendpfast([])
+    assert False
+except Exception:
+    assert True
+
+conf.interactive = old_interactive
+assert True
 
 ############
 ############


### PR DESCRIPTION
After discussions with @rjarry and @p-l- an exception is now raised when `tcpreplay` can not be executed. Other use of `log_interactive` in Scapy are indeed not similar.

OLD TEXT
After discussuions with @p-l- and @rjarry 

This should fix #791 i.e. no log messages are displayed when using Scapy as a module.

The patch detects a previously acquired logger in order to add a StreamHandler or not.

@rjarry does this look ok ?