### PR TITLE
Improve VXLAN layer

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1153,6 +1153,11 @@ class FlagsField(BitField):
             return type(x)(None if v is None else FlagValue(v, self.names)
                            for v in x)
         return None if x is None else FlagValue(x, self.names)
+    def i2h(self, pkt, x):
+        if isinstance(x, (list, tuple)):
+            return type(x)(None if v is None else FlagValue(v, self.names)
+                           for v in x)
+        return None if x is None else FlagValue(x, self.names)
     def i2repr(self, pkt, x):
         if isinstance(x, (list, tuple)):
             return repr(type(x)(

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -26,7 +26,7 @@ class VXLAN(Packet):
                     'V1', 'V2', 'R', 'G']),
         ConditionalField(
             ShortField("reserved0", 0),
-            lambda pkt: pkt.flags & 0x04,
+            lambda pkt: pkt.flags.NextProtocol,
         ),
         ConditionalField(
             ByteEnumField('NextProtocol', 0,
@@ -35,22 +35,22 @@ class VXLAN(Packet):
                            2: 'IPv6',
                            3: 'Ethernet',
                            4: 'NSH'}),
-            lambda pkt: pkt.flags & 0x04,
+            lambda pkt: pkt.flags.NextProtocol,
         ),
         ConditionalField(
-            ThreeBytesField("reserved1", 0x000000),
-            lambda pkt: (not pkt.flags & 0x80) and (not pkt.flags & 0x04),
+            ThreeBytesField("reserved1", 0),
+            lambda pkt: (not pkt.flags.G) and (not pkt.flags.NextProtocol),
         ),
         ConditionalField(
-            FlagsField("gpflags", 0x0, 8, _GP_FLAGS),
-            lambda pkt: pkt.flags & 0x80,
+            FlagsField("gpflags", 0, 8, _GP_FLAGS),
+            lambda pkt: pkt.flags.G,
         ),
         ConditionalField(
             ShortField("gpid", 0),
-            lambda pkt: pkt.flags & 0x80,
+            lambda pkt: pkt.flags.G,
         ),
         X3BytesField("vni", 0),
-        XByteField("reserved2", 0x00),
+        XByteField("reserved2", 0),
     ]
 
     # Use default linux implementation port
@@ -59,7 +59,7 @@ class VXLAN(Packet):
     }
 
     def mysummary(self):
-        if self.flags & 0x80:
+        if self.flags.G:
             return self.sprintf("VXLAN (vni=%VXLAN.vni% gpid=%VXLAN.gpid%)")
         else:
             return self.sprintf("VXLAN (vni=%VXLAN.vni%)")

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -68,9 +68,11 @@ bind_layers(UDP, VXLAN, dport=4789)  # RFC standard vxlan port
 bind_layers(UDP, VXLAN, dport=4790)  # RFC standard vxlan-gpe port
 bind_layers(UDP, VXLAN, dport=6633)  # New IANA assigned port for use with NSH
 bind_layers(UDP, VXLAN, dport=8472)  # Linux implementation port
-bind_layers(VXLAN, Ether, {'flags': 0x8})
-bind_layers(VXLAN, Ether, {'flags': 0x88})
-bind_layers(VXLAN, Ether, {'flags': 0xC, 'NextProtocol': 0}, NextProtocol=0)
-bind_layers(VXLAN, IP, {'flags': 0xC, 'NextProtocol': 1}, NextProtocol=1)
-bind_layers(VXLAN, IPv6, {'flags': 0xC, 'NextProtocol': 2}, NextProtocol=2)
-bind_layers(VXLAN, Ether, {'flags': 0xC, 'NextProtocol': 3}, NextProtocol=3)
+
+bind_layers(VXLAN, Ether)
+bind_layers(VXLAN, IP, NextProtocol=1)
+bind_layers(VXLAN, IPv6, NextProtocol=2)
+bind_layers(VXLAN, Ether, flags=4, NextProtocol=0)
+bind_layers(VXLAN, IP, flags=4, NextProtocol=1)
+bind_layers(VXLAN, IPv6, flags=4, NextProtocol=2)
+bind_layers(VXLAN, Ether, flags=4, NextProtocol=3)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -643,8 +643,8 @@ Dot11WEP(_)
 assert(TCP in _ and _[TCP].seq == 12345678)
 
 = RadioTap Big-Small endian dissection
-raw = b'\x00\x00\x1a\x00/H\x00\x00\xe1\xd3\xcb\x05\x00\x00\x00\x00@0x\x14@\x01\xac\x00\x00\x00'
-r = RadioTap(raw)
+data = b'\x00\x00\x1a\x00/H\x00\x00\xe1\xd3\xcb\x05\x00\x00\x00\x00@0x\x14@\x01\xac\x00\x00\x00'
+r = RadioTap(data)
 r.show()
 assert r.present == 18479
 
@@ -7435,7 +7435,8 @@ assert(p.data[0].ifname.startswith("lo"))
 str(UDP(sport=1024, dport=4789, len=None, chksum=None)/VXLAN(flags=0x08, vni=42)) == b'\x04\x00\x12\xb5\x00\x10\x00\x00\x08\x00\x00\x00\x00\x00\x2a\x00'
 
 = Verify VXLAN Ethernet Binding
-str(VXLAN(vni=23)/Ether(dst="11:11:11:11:11:11", src="11:11:11:11:11:11", type=0x800)) == b'\x0c\x00\x00\x03\x00\x00\x17\x00\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x08\x00'
+pkt = VXLAN(raw(VXLAN(vni=23)/Ether(dst="11:11:11:11:11:11", src="11:11:11:11:11:11", type=0x800)))
+pkt.flags.NextProtocol and pkt.NextProtocol == 3
 
 = Verify UDP dport overloading
 p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")


### PR DESCRIPTION
This PR uses the (rather) new flags access (`pkt.flags.NextProtocol` now does the same than `pkt.flags & 0x04`, but is easier to understand) and fixes the (rather complex) layer bindings.