### PR TITLE
Fix DLT_* constant values

### DIFF
--- a/scapy/contrib/chdlc.py
+++ b/scapy/contrib/chdlc.py
@@ -17,6 +17,7 @@
 
 # This layer is based on information from http://www.nethelp.no/net/cisco-hdlc.txt
 
+from scapy.data import DLT_C_HDLC
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import *
@@ -51,4 +52,4 @@ bind_layers( CHDLC, IPv6,  proto=0x86dd)
 bind_layers( CHDLC, SLARP, proto=0x8035)
 bind_layers( CHDLC, STP,   proto=0x4242)
 
-conf.l2types.register(104, CHDLC)
+conf.l2types.register(DLT_C_HDLC, CHDLC)

--- a/scapy/contrib/ppi.py
+++ b/scapy/contrib/ppi.py
@@ -21,8 +21,12 @@
 """
 PPI (Per-Packet Information).
 """
-import logging,struct
+import logging
+import struct
+
+
 from scapy.config import conf
+from scapy.data import DLT_EN10MB, DLT_IEEE802_11, DLT_PPI
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.l2 import Ether
@@ -88,10 +92,7 @@ class PPI(Packet):
 #Register PPI
 addPPIType("default", PPIGenericFldHdr)
 
-conf.l2types.register(192, PPI)
-conf.l2types.register_num2layer(192, PPI)
+conf.l2types.register(DLT_PPI, PPI)
 
-bind_layers(PPI, Dot11, dlt=conf.l2types.get(Dot11))
-bind_layers(Dot11, PPI)
-bind_layers(PPI, Ether, dlt=conf.l2types.get(Ether))
-bind_layers(Dot11, Ether)
+bind_layers(PPI, Dot11, dlt=DLT_IEEE802_11)
+bind_layers(PPI, Ether, dlt=DLT_EN10MB)

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -7,10 +7,18 @@
 Global variables and functions for handling external data sets.
 """
 
-import os, sys, re, time
+
+import os
+import re
+import sys
+import time
+
+
 from scapy.dadict import DADict
+from scapy.consts import DARWIN, FREEBSD, NETBSD, OPENBSD
 from scapy.error import log_loading
 from scapy.compat import *
+
 
 ############
 ## Consts ##
@@ -33,10 +41,51 @@ ARPHDR_TUN = 65534
 
 # From pcap/dlt.h
 DLT_NULL = 0
+DLT_EN10MB = 1
+DLT_EN3MB = 2
+DLT_AX25 = 3
+DLT_PRONET = 4
+DLT_CHAOS = 5
+DLT_IEEE802 = 6
+DLT_ARCNET = 7
+DLT_SLIP = 8
 DLT_PPP = 9
+DLT_FDDI = 10
+if OPENBSD:
+    DLT_RAW = 14
+else:
+    DLT_RAW = 12
+DLT_RAW_ALT = 101  # At least in Argus
+if FREEBSD or NETBSD:
+    DLT_SLIP_BSDOS = 13
+    DLT_PPP_BSDOS = 14
+else:
+    DLT_SLIP_BSDOS = 15
+    DLT_PPP_BSDOS = 16
+if FREEBSD:
+    DLT_PFSYNC = 121
+else:
+    DLT_PFSYNC = 18
+    DLT_HHDLC = 121
+DLT_ATM_CLIP = 19
 DLT_PPP_SERIAL = 50
 DLT_PPP_ETHER = 51
-DLT_RAW = 101
+DLT_SYMANTEC_FIREWALL = 99
+DLT_C_HDLC = 104
+DLT_IEEE802_11 = 105
+if OPENBSD:
+    DLT_LOOP = 12
+    DLT_ENC = 13
+else:
+    DLT_LOOP = 108
+    DLT_ENC = 109
+DLT_LINUX_SLL = 113
+DLT_PFLOG = 117
+DLT_PRISM_HEADER = 119
+DLT_AIRONET_HEADER = 120
+DLT_IEEE802_11_RADIO = 127
+DLT_LINUX_IRDA  = 144
+DLT_PPI   = 192
 DLT_IPV4 = 228
 DLT_IPV6 = 229
 

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -365,13 +365,13 @@ bind_layers( Dot11Auth,       Dot11Elt,    )
 bind_layers( Dot11Elt,        Dot11Elt,    )
 
 
-conf.l2types.register(105, Dot11)
+conf.l2types.register(DLT_IEEE802_11, Dot11)
 conf.l2types.register_num2layer(801, Dot11)
-conf.l2types.register(119, PrismHeader)
+conf.l2types.register(DLT_PRISM_HEADER, PrismHeader)
 conf.l2types.register_num2layer(802, PrismHeader)
-conf.l2types.register(127, RadioTap)
-conf.l2types.register(0xc0, PPI)
+conf.l2types.register(DLT_IEEE802_11_RADIO, RadioTap)
 conf.l2types.register_num2layer(803, RadioTap)
+conf.l2types.register(DLT_PPI, PPI)
 
 
 class WiFi_am(AnsweringMachine):

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -19,7 +19,7 @@ from scapy.data import *
 from scapy.layers.l2 import *
 from scapy.compat import *
 from scapy.config import conf
-from scapy.consts import OPENBSD, WINDOWS
+from scapy.consts import WINDOWS
 from scapy.fields import *
 from scapy.packet import *
 from scapy.volatile import *
@@ -809,10 +809,8 @@ bind_layers( IP,            TCP,           frag=0, proto=6)
 bind_layers( IP,            UDP,           frag=0, proto=17)
 bind_layers( IP,            GRE,           frag=0, proto=47)
 
-conf.l2types.register(101, IP)
-if not OPENBSD:
-    # see scapy.layers.l2.py
-    conf.l2types.register_num2layer(12, IP)
+conf.l2types.register(DLT_RAW, IP)
+conf.l2types.register_num2layer(DLT_RAW_ALT, IP)
 conf.l2types.register(DLT_IPV4, IP)
 
 conf.l3types.register(ETH_P_IP, IP)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3888,6 +3888,7 @@ conf.l3types.register(ETH_P_IPV6, IPv6)
 conf.l2types.register(31, IPv6)
 conf.l2types.register(DLT_IPV6, IPv6)
 conf.l2types.register(DLT_RAW, _IPv46)
+conf.l2types.register_num2layer(DLT_RAW_ALT, _IPv46)
 
 bind_layers(Ether,     IPv6,     type = 0x86dd )
 bind_layers(CookedLinux, IPv6,   proto = 0x86dd )

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -13,7 +13,6 @@ import os, struct, time, socket
 
 from scapy.base_classes import Net
 from scapy.config import conf
-from scapy.consts import OPENBSD
 from scapy.data import *
 from scapy.compat import *
 from scapy.packet import *
@@ -446,12 +445,10 @@ conf.l2types.register(ARPHDR_ETHER, Ether)
 conf.l2types.register_num2layer(ARPHDR_METRICOM, Ether)
 conf.l2types.register_num2layer(ARPHDR_LOOPBACK, Ether)
 conf.l2types.register_layer2num(ARPHDR_ETHER, Dot3)
-conf.l2types.register(144, CookedLinux)  # called LINUX_IRDA, similar to CookedLinux
-conf.l2types.register(113, CookedLinux)
-conf.l2types.register(DLT_NULL, Loopback)
-# Under OpenBSD, for some reason, DLT_NULL == 12
-if OPENBSD:
-    conf.l2types.register(12, Loopback)
+conf.l2types.register(DLT_LINUX_SLL, CookedLinux)
+conf.l2types.register_num2layer(DLT_LINUX_IRDA, CookedLinux)
+conf.l2types.register(DLT_LOOP, Loopback)
+conf.l2types.register_num2layer(DLT_NULL, Loopback)
 
 conf.l3types.register(ETH_P_ARP, ARP)
 

--- a/scapy/layers/pflog.py
+++ b/scapy/layers/pflog.py
@@ -7,6 +7,7 @@
 PFLog: OpenBSD PF packet filter logging.
 """
 
+from scapy.data import DLT_PFLOG
 from scapy.packet import *
 from scapy.fields import *
 from scapy.layers.inet import IP
@@ -56,4 +57,4 @@ bind_layers(PFLog, IP, addrfamily=socket.AF_INET)
 if conf.ipv6_enabled:
     bind_layers(PFLog, IPv6, addrfamily=socket.AF_INET6)
 
-conf.l2types.register(117, PFLog)
+conf.l2types.register(DLT_PFLOG, PFLog)


### PR DESCRIPTION
This PR updates DLT_* constant values (based on `pcap/dlt.h`) and uses them to register associations in `conf.l2types`.