### PR TITLE
Enable tab completion with fields

### DIFF
--- a/scapy/main.py
+++ b/scapy/main.py
@@ -480,15 +480,10 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
         banner = the_banner + " using IPython %s\n" % IPython.__version__
         from IPython.terminal.embed import InteractiveShellEmbed
         from IPython.terminal.prompts import Prompts, Token
-        from IPython.utils.generics import complete_object
         from traitlets.config.loader import Config
         from scapy.packet import Packet
 
         cfg = Config()
-
-        @complete_object.when_type(Packet)
-        def complete_packet(obj, prev_completions):
-            return prev_completions + [fld.name for fld in obj.fields_desc]
 
         try:
             get_ipython

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -284,6 +284,25 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             pass
         return object.__delattr__(self, attr)
             
+    def _superdir(self):
+        """
+        Return a list of slots and methods, including those from subclasses.
+        """
+        attrs = set()
+        cls = self.__class__
+        if hasattr(cls, '__all_slots__'):
+            attrs.update(cls.__all_slots__)
+        for bcls in cls.__mro__:
+            if hasattr(bcls, '__dict__'):
+                attrs.update(bcls.__dict__)
+        return attrs
+
+    def __dir__(self):
+        """
+        Add fields to tab completion list.
+        """
+        return sorted(itertools.chain(self._superdir(), self.default_fields))
+
     def __repr__(self):
         s = ""
         ct = conf.color_theme


### PR DESCRIPTION
This is an attempt at enabling tab completion with packet fields. It is not just a matter of quickly referencing long fields: I'd say it's even more useful as a way to remember/find out which fields you can get/set within an interpreter when you don't really know the packet you're dealing with.

I've been bothered by the lack of this feature time and again, so when I received a user request I tried to deal with it. The main issue was to reproduce the result of `dir()`, as Python 2 does not provide something like `super().__dir__()`.

Then we add the list of `default_fields`. I assumed that any value which might appear later on in `overloaded_fields` and `fields` should be present in `default_fields`. Does this seem right to you?

Also, I'm not sure how we could avoid the creation of lists with `keys()`. But I find it definitively good for UX.

Currently, `len(dir(TLSClientHello())) = 135` and `len(TLSClientHello().default_fields) = 13`
With this PR, counting `_superdir` and `__dir__`, you can check `len(dir(TLSClientHello())) = 150`