### PR TITLE
[coverage] Scapy version

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -80,9 +80,9 @@ def _version():
             sha1 = git_archive_id.strip().split()[0]
             match = re.search(r'tag:(\S+)', git_archive_id)
             if match:
-                return match.group(1)
+                return "git-archive.dev" + match.group(1)
             elif sha1:
-                return sha1
+                return "git-archive.dev" + sha1
             else:
                 return 'unknown.version'
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -9110,3 +9110,22 @@ if test_pyx():
     plist.pdfdump(filename)
     assert(os.path.exists(filename))
     os.unlink(filename)
+
+############
+############
++ Scapy version
+
+= _version()
+
+import os
+version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
+
+version = scapy._version()
+assert(os.path.exists(version_filename))
+
+import mock
+with mock.patch("scapy._version_from_git_describe") as version_mocked:
+  version_mocked.side_effect = Exception()
+  assert(scapy._version() == version)
+  os.unlink(version_filename)
+  assert(scapy._version() == "git-archive.dev$Format:%h")


### PR DESCRIPTION
This PR extends the coverage of `scapy/__init__.py`. it also provides a better naming scheme when using git archive.