### PR TITLE
Fix Simple Error when Converting IPv6 Address in Python 3

### DIFF
--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -81,7 +81,10 @@ def inet_pton(af, addr):
     """Convert an IP address from text representation into binary form."""
     # Will replace Net/Net6 objects
     if not isinstance(addr, str):
-        addr = str(addr)
+        if isinstance(addr, bytes):
+            addr = addr.decode()
+        else:
+            addr = str(addr)
     # Use inet_pton if available
     addr = plain_str(addr)
     try:


### PR DESCRIPTION
Hi, I was encountering this problem when I try running Scapy with Python 3.5:

```
<hidden>@<hidden>:~/git/scapy$ ./run_scapy3
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/<hidden>/git/scapy/scapy/__init__.py", line 93, in <module>
    interact()
  File "/home/<hidden>/git/scapy/scapy/main.py", line 412, in interact
    init_session(session_name, mydict)
  File "/home/<hidden>/git/scapy/scapy/main.py", line 285, in init_session
    scapy_builtins = {k: v for k, v in six.iteritems(importlib.import_module(".all", "scapy").__dict__) if _validate_local(k)}
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/<hidden>/git/scapy/scapy/all.py", line 28, in <module>
    from scapy.route6 import *
  File "/home/<hidden>/git/scapy/scapy/route6.py", line 273, in <module>
    conf.route6 = Route6()
  File "/home/<hidden>/git/scapy/scapy/route6.py", line 34, in __init__
    self.resync()
  File "/home/<hidden>/git/scapy/scapy/route6.py", line 47, in resync
    self.routes = read_routes6()
  File "/home/<hidden>/git/scapy/scapy/arch/linux.py", line 328, in read_routes6
    lifaddr = in6_getifaddr() 
  File "/home/<hidden>/git/scapy/scapy/arch/linux.py", line 303, in in6_getifaddr
    addr = scapy.utils6.in6_ptop(b':'.join(addr))
  File "/home/<hidden>/git/scapy/scapy/utils6.py", line 613, in in6_ptop
    return inet_ntop(socket.AF_INET6, inet_pton(socket.AF_INET6, str))
  File "/home/<hidden>/git/scapy/scapy/pton_ntop.py", line 89, in inet_pton
    return socket.inet_pton(af, addr)
OSError: illegal IP address string passed to inet_pton
```

Then I located the code and found that `addr = str(addr)` was not doing as expected - it returns something like
```
>>> str(addr)
"b'0000:0000:0000:0000:0000:0000:0000:0001'"
```
instead of 
```
>>> addr.decode()
'0000:0000:0000:0000:0000:0000:0000:0001'
```

And this commit fixes this problem.