### PR TITLE
Attempt to fix #827

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
         - os: linux
           sudo: required
           python: 2.7
+          virtualenv:
+            system_site_packages: true
           env:
             - SCAPY_SUDO=sudo SCAPY_USE_PCAPDNET=yes SCAPY_COVERAGE=yes 
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,4 +1,4 @@
-# Install dependencies using pip
+# Install dependencies using pip
 if [ -z "$SCAPY_SUDO" -o "$SCAPY_SUDO" = "false" ]
 then
   SCAPY_SUDO=""
@@ -22,7 +22,7 @@ then
   $SCAPY_SUDO apt-get install python-pyx
 fi
 
-# Install pcap & dnet
+# Install pcap & dnet
 if [ ! -z $SCAPY_USE_PCAPDNET ]
 then
   if [ "$TRAVIS_OS_NAME" = "linux" ]

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,12 +1,11 @@
 # Report installed versions
 echo "### INSTALLED VERSIONS ###"
 python -c 'import sys; print("sys.path:" , sys.path)'
-for DEPENDENCY in "six" "cryptography" "mock" "pcap" "dumbnet"
+for DEPENDENCY in "six" "cryptography" "mock" "pcap" "dumbnet" "coverage"
 do
   python -c 'import '$DEPENDENCY'; print("'$DEPENDENCY': "+str(getattr('$DEPENDENCY', "__version__", "no __version__ attribute")))'
   echo "----"
 done
-
 
 # Dump environment variables
 echo "SCAPY_SUDO=" $SCAPY_SUDO

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,5 +1,6 @@
 # Report installed versions
 echo "### INSTALLED VERSIONS ###"
+python -c 'import sys; print("sys.path:" , sys.path)'
 for DEPENDENCY in "six" "cryptography" "mock" "pcap" "dumbnet"
 do
   python -c 'import '$DEPENDENCY'; print("'$DEPENDENCY': "+str(getattr('$DEPENDENCY', "__version__", "no __version__ attribute")))'

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,9 +1,11 @@
 # Report installed versions
 echo "### INSTALLED VERSIONS ###"
-for DEPENDENCY in "six" "cryptography" "mock"
+for DEPENDENCY in "six" "cryptography" "mock" "pcap" "dumbnet"
 do
-    python -c 'import '$DEPENDENCY'; print("'$DEPENDENCY': "+str('$DEPENDENCY'.__version__))'
+  python -c 'import '$DEPENDENCY'; print("'$DEPENDENCY': "+str(getattr('$DEPENDENCY', "__version__", "no __version__ attribute")))'
+  echo "----"
 done
+
 
 # Dump environment variables
 echo "SCAPY_SUDO=" $SCAPY_SUDO

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -12,6 +12,7 @@ echo "SCAPY_SUDO=" $SCAPY_SUDO
 echo "TRAVIS_OS_NAME=" $TRAVIS_OS_NAME
 
 # Dump Scapy config
+python --version
 python -c "from scapy.all import *; print conf"
 
 # Don't run tests that require root privileges


### PR DESCRIPTION
This PR fixes #827 and adds improvements to data logged during Travis runs.

Long story short, it seems that tests using `SCAPY_USE_PCAPDNET` never used the `pcap` and `dumbnet` Python modules. We are installing them with `apt` and Travis does not use system packages by default.