### PR TITLE
Better default for TLS ClientHello

### DIFF
--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -337,6 +337,11 @@ class TLSServerHello(TLSClientHello):
                 return TLS13ServerHello
         return TLSServerHello
 
+    def post_build(self, p, pay):
+        if self.random_bytes is None:
+            p = p[:10] + randstring(28) + p[10+28:]
+        return super(TLSClientHello, self).post_build(p, pay)
+
     def tls_session_update(self, msg_str):
         """
         Either for parsing or building, we store the server_random


### PR DESCRIPTION
This PR defines better default values for ClientHello messages. If the user did not provide any ciphersuites nor extensions, the message is post-built with a dozen common ciphersuites and the appropriate minimal extensions, so that the message could be immediately sent to a server if needed.

To retrieve a TLS answer (including X.509 certificates) from most servers, one could try:
```
# Connect to secdev.org on 443/tcp                                              
domain = "secdev.org"                                                           
sck = socket.socket(socket.AF_INET, socket.SOCK_STREAM)                         
sck.connect((domain, 443))                                                      
                                                                                
# Define a ClientHello with default values                                                                                               
ch = TLSClientHello(TLSClientHello().build())                                                    
                                                                                
# Prepare to recompute all lengths with the new domain                          
ch.msglen = ch.extlen = None                                                    
sni = ch.ext[1]                                                                 
sni.len = sni.servernameslen = sni.servernames[0].namelen = None                
sni.servernames[0].servername = domain                                          
                                                                                
t = TLS(msg=ch)                                                                                                                                       
sck.send(raw(t))                                                                
                                                                                
# Receive data                                                                  
data = sck.recv(8192) 
TLS(data).show()
```

(Actually the default domain put in the SNI extension is already secdev.org.)