### PR TITLE
[coverage] plist on python 3

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -551,7 +551,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
         def hexstr(x):
             s = []
             for c in x:
-                s.append("%02x" % ord(c))
+                s.append("%02x" % orb(c))
             return " ".join(s)
 
                 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8947,7 +8947,7 @@ def test_plot(mock_plt):
     def fake_plot(data, **kwargs):
         return data
     mock_plt.plot = fake_plot
-    plist = PacketList([IP(id=i)/TCP() for i in xrange(10)])
+    plist = PacketList([IP(id=i)/TCP() for i in range(10)])
     lines = plist.plot(lambda p: (p.time, p.id))
     assert(len(lines) == 10)
 
@@ -8961,7 +8961,7 @@ def test_diffplot(mock_plt):
     def fake_plot(data, **kwargs):
         return data
     mock_plt.plot = fake_plot
-    plist = PacketList([IP(id=i)/TCP() for i in xrange(10)])
+    plist = PacketList([IP(id=i)/TCP() for i in range(10)])
     lines = plist.diffplot(lambda x,y: (x.time, y.id-x.id))
     assert(len(lines) == 9)
 
@@ -8975,8 +8975,8 @@ def test_multiplot(mock_plt):
     def fake_plot(data, **kwargs):
         return data
     mock_plt.plot = fake_plot
-    tmp = [IP(id=i)/TCP() for i in xrange(10)]
-    plist = PacketList([tuple(tmp[i-2:i]) for i in xrange(2, 10, 2)])
+    tmp = [IP(id=i)/TCP() for i in range(10)]
+    plist = PacketList([tuple(tmp[i-2:i]) for i in range(2, 10, 2)])
     lines = plist.multiplot(lambda x: (x[1][IP].src, (x[1].time, x[1][IP].id)))
     assert(len(lines) == 1)
     assert(len(lines[0]) == 4)
@@ -8987,7 +8987,7 @@ test_multiplot()
 
 def test_rawhexdump():
     with ContextManagerCaptureOutput() as cmco:
-        p = PacketList([IP()/TCP() for i in xrange(2)])
+        p = PacketList([IP()/TCP() for i in range(2)])
         p.rawhexdump()
         result_pl_rawhexdump = cmco.get_output()
     assert(len(result_pl_rawhexdump.split('\n')) == 7)
@@ -8999,7 +8999,7 @@ test_rawhexdump()
 
 def test_hexraw():
     with ContextManagerCaptureOutput() as cmco:
-        p = PacketList([IP()/Raw(str(i)) for i in xrange(2)])
+        p = PacketList([IP()/Raw(str(i)) for i in range(2)])
         p.hexraw()
         result_pl_hexraw = cmco.get_output()
     assert(len(result_pl_hexraw.split('\n')) == 5)
@@ -9011,7 +9011,7 @@ test_hexraw()
 
 def test_hexdump():
     with ContextManagerCaptureOutput() as cmco:
-        p = PacketList([IP()/Raw(str(i)) for i in xrange(2)])
+        p = PacketList([IP()/Raw(str(i)) for i in range(2)])
         p.hexdump()
         result_pl_hexdump = cmco.get_output()
     assert(len(result_pl_hexdump.split('\n')) == 7)
@@ -9023,7 +9023,7 @@ test_hexdump()
 
 def test_padding():
     with ContextManagerCaptureOutput() as cmco:
-        p = PacketList([IP()/conf.padding_layer(str(i)) for i in xrange(2)])
+        p = PacketList([IP()/conf.padding_layer(str(i)) for i in range(2)])
         p.padding()
         result_pl_padding = cmco.get_output()
     assert(len(result_pl_padding.split('\n')) == 5)
@@ -9035,7 +9035,7 @@ test_padding()
 
 def test_nzpadding():
     with ContextManagerCaptureOutput() as cmco:
-        p = PacketList([IP()/conf.padding_layer("A%s" % i) for i in xrange(2)])
+        p = PacketList([IP()/conf.padding_layer("A%s" % i) for i in range(2)])
         p.nzpadding()
         result_pl_nzpadding = cmco.get_output()
     assert(len(result_pl_nzpadding.split('\n')) == 5)
@@ -9051,8 +9051,8 @@ def test_conversations(mock_do_graph):
     def fake_do_graph(graph, **kwargs):
         return graph
     mock_do_graph.side_effect = fake_do_graph
-    plist = PacketList([IP(dst="127.0.0.2")/TCP(dport=i) for i in xrange(2)])
-    plist.extend([IP(src="127.0.0.2")/TCP(sport=i) for i in xrange(2)])
+    plist = PacketList([IP(dst="127.0.0.2")/TCP(dport=i) for i in range(2)])
+    plist.extend([IP(src="127.0.0.2")/TCP(sport=i) for i in range(2)])
     result_conversations = plist.conversations()
     assert(len(result_conversations.split('\n')) == 5)
     assert(result_conversations.startswith('digraph "conv" {'))
@@ -9067,8 +9067,8 @@ def test_afterglow(mock_do_graph):
     def fake_do_graph(graph, **kwargs):
         return graph
     mock_do_graph.side_effect = fake_do_graph
-    plist = PacketList([IP(dst="127.0.0.2")/TCP(dport=i) for i in xrange(2)])
-    plist.extend([IP(src="127.0.0.2")/TCP(sport=i) for i in xrange(2)])
+    plist = PacketList([IP(dst="127.0.0.2")/TCP(dport=i) for i in range(2)])
+    plist.extend([IP(src="127.0.0.2")/TCP(sport=i) for i in range(2)])
     result_afterglow = plist.afterglow()
     assert(len(result_afterglow.split('\n')) == 19)
     assert(result_afterglow.startswith('digraph "afterglow" {'))


### PR DESCRIPTION
Tiny fixes:
- xrange not available on python 3 (range gets imported via six)