### PR TITLE
[logging] Fix logging params

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -40,13 +40,13 @@ def get_if_raw_addr(ifname):
     try:
         fd = os.popen("%s %s" % (conf.prog.ifconfig, ifname))
     except OSError as msg:
-        warning("Failed to execute ifconfig: (%s)" % msg)
+        warning("Failed to execute ifconfig: (%s)", msg)
         return b"\0\0\0\0"
 
     # Get IPv4 addresses
     addresses = [l for l in fd if l.find("netmask") >= 0]
     if not addresses:
-        warning("No IPv4 address found on %s !" % ifname)
+        warning("No IPv4 address found on %s !", ifname)
         return b"\0\0\0\0"
 
     # Pack the first address
@@ -159,7 +159,7 @@ def get_working_ifaces():
         try:
             result = get_if(ifname, SIOCGIFFLAGS)
         except IOError as msg:
-            warning("ioctl(SIOCGIFFLAGS) failed on %s !" % ifname)
+            warning("ioctl(SIOCGIFFLAGS) failed on %s !", ifname)
             continue
 
         # Convert flags

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -251,7 +251,7 @@ def read_routes():
             if addrfamily == socket.AF_INET:
                 ifaddr = scapy.utils.inet_ntoa(ifreq[20:24])
             else:
-                warning("Interface %s: unkown address family (%i)"%(iff, addrfamily))
+                warning("Interface %s: unkown address family (%i)", iff, addrfamily)
                 continue
 
         # Attempt to detect an interface alias based on addresses inconsistencies
@@ -430,7 +430,7 @@ class L3PacketSocket(SuperSocket):
             lvl = 3
         else:
             cls = conf.default_l2
-            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s" % (sa_ll[0],sa_ll[1],sa_ll[3],cls.name))
+            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3], cls.name)
             lvl = 2
 
         try:
@@ -504,7 +504,7 @@ class L2Socket(SuperSocket):
             self.LL = conf.l3types[sa_ll[1]]
         else:
             self.LL = conf.default_l2
-            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s" % (sa_ll[0],sa_ll[1],sa_ll[3],self.LL.name))
+            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3], self.LL.name)
     def close(self):
         if self.closed:
             return
@@ -586,8 +586,8 @@ class L2ListenSocket(SuperSocket):
         else:
             cls = conf.default_l2
             warning("Unable to guess type (interface=%s protocol=%#x "
-                    "family=%i). Using %s" % (sa_ll[0], sa_ll[1], sa_ll[3],
-                                              cls.name))
+                    "family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3],
+                                              cls.name)
 
         try:
             pkt = cls(pkt)

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -46,9 +46,9 @@ if conf.use_winpcapy:
       version = pcap_lib_version()
       if b"winpcap" in version.lower():
           if os.path.exists(os.environ["WINDIR"] + "\\System32\\Npcap\\wpcap.dll"):
-              warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", True)
+              warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", onlyOnce=True)
           elif platform.release() != "XP":
-              warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", True)
+              warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", onlyOnce=True)
       elif b"npcap" in version.lower():
           conf.use_npcap = True
           LOOPBACK_NAME = scapy.consts.LOOPBACK_NAME = "Npcap Loopback Adapter"
@@ -165,11 +165,11 @@ if conf.use_winpcapy:
       def setfilter(self, f):
           filter_exp = create_string_buffer(f.encode('ascii'))
           if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:
-            log_loading.error("Could not compile filter expression %s" % f)
+            log_loading.error("Could not compile filter expression %s", f)
             return False
           else:
             if pcap_setfilter(self.pcap, byref(self.bpf_program)) == -1:
-              log_loading.error("Could not install filter %s" % f)
+              log_loading.error("Could not install filter %s", f)
               return False
           return True
       def setnonblock(self, i):
@@ -216,7 +216,7 @@ if conf.use_winpcapy:
               cls = conf.l2types[ll]
           else:
               cls = conf.default_l2
-              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
 
           pkt = None
           while pkt is None:
@@ -289,7 +289,7 @@ if conf.use_winpcapy:
               cls = conf.l2types[ll]
           else:
               cls = conf.default_l2
-              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
   
           pkt = self.ins.next()
           if pkt is not None:
@@ -339,7 +339,7 @@ if conf.use_winpcapy:
               cls = conf.l2types[ll]
           else:
               cls = conf.default_l2
-              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+              warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
           sx = raw(cls()/x)
           if hasattr(x, "sent_time"):
               x.sent_time = time.time()
@@ -355,7 +355,7 @@ if conf.use_pcap:
             import pcapy as pcap
         except ImportError as e2:
             if conf.interactive:
-                log_loading.error("Unable to import pcap module: %s/%s" % (e,e2))
+                log_loading.error("Unable to import pcap module: %s/%s", e, e2)
                 conf.use_pcap = False
             else:
                 raise
@@ -468,7 +468,7 @@ if conf.use_pcap:
                     cls = conf.l2types[ll]
                 else:
                     cls = conf.default_l2
-                    warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+                    warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
         
                 pkt = self.ins.next()
                 if scapy.arch.WINDOWS and pkt is None:
@@ -503,7 +503,7 @@ if conf.use_dnet:
             import dumbnet as dnet
     except ImportError as e:
         if conf.interactive:
-            log_loading.error("Unable to import dnet module: %s" % e)
+            log_loading.error("Unable to import dnet module: %s", e)
             conf.use_dnet = False
             def get_if_raw_hwaddr(iff):
                 "dummy"
@@ -622,7 +622,7 @@ if conf.use_pcap and conf.use_dnet:
                 cls = conf.l2types[ll]
             else:
                 cls = conf.default_l2
-                warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+                warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
     
             pkt = self.ins.next()
             if pkt is not None:
@@ -694,7 +694,7 @@ if conf.use_pcap and conf.use_dnet:
                 cls = conf.l2types[ll]
             else:
                 cls = conf.default_l2
-                warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s" % (self.iface, ll, cls.name))
+                warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
     
             pkt = self.ins.next()
             if pkt is not None:

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -110,7 +110,7 @@ def read_routes():
                         ifaddr = get_if_addr(guessed_netif)
                         routes.append((dest, netmask, gw, guessed_netif, ifaddr))
                     else:
-                        warning("Could not guess partial interface name: %s" % netif)
+                        warning("Could not guess partial interface name: %s", netif)
                 else:
                     raise
         else:
@@ -132,7 +132,7 @@ def read_routes():
         if gw_if:
             routes.append((dest,netmask,gw,gw_if,gw_if_addr))
         else:
-            warning("Did not find output interface to reach gateway %s" % gw)
+            warning("Did not find output interface to reach gateway %s", gw)
 
     return routes
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -606,7 +606,7 @@ def read_routes():
         else:
             routes = _read_routes_7()
     except Exception as e:    
-        warning("Error building scapy IPv4 routing table : %s" % str(e), True)
+        warning("Error building scapy IPv4 routing table : %s", e, onlyOnce=True)
     else:
         if not routes:
             warning("No default IPv4 routes found. Your Windows release may no be supported and you have to enter your routes manually", True)
@@ -636,7 +636,7 @@ def _read_routes_post2008():
             # try:
             #     intf = pcapdnet.dnet.intf().get_dst(pcapdnet.dnet.addr(type=2, addrtxt=dest))
             # except OSError:
-            #     log_loading.warning("Building Scapy's routing table: Couldn't get outgoing interface for destination %s" % dest)
+            #     log_loading.warning("Building Scapy's routing table: Couldn't get outgoing interface for destination %s", dest)
             #     continue               
             routes.append((atol(match.group(2)), itom(int(match.group(3))),
                            match.group(4), iface, iface.ip))
@@ -759,7 +759,7 @@ def read_routes6():
         else:
             routes6 = _read_routes6_7()
     except Exception as e:    
-        warning("Error building scapy IPv6 routing table : %s" % str(e), True)
+        warning("Error building scapy IPv6 routing table : %s", e, onlyOnce=True)
     return routes6
 
 def get_working_if():

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -256,7 +256,7 @@ class NewDefaultValues(Packet_metaclass):
         except:
             f,l="??",-1
             raise
-        log_loading.warning("Deprecated (no more needed) use of NewDefaultValues  (%s l. %i)." % (f,l))
+        log_loading.warning("Deprecated (no more needed) use of NewDefaultValues  (%s l. %i).", f, l)
         
         return super(NewDefaultValues, cls).__new__(cls, name, bases, dct)
 

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -41,20 +41,20 @@ class Fixed3_6Field(LEIntField):
     def i2h(self, pkt, x):
         if x is not None:
             if (x < 0):
-                warning("Fixed3_6: Internal value too negative: %d" % x)
+                warning("Fixed3_6: Internal value too negative: %d", x)
                 x = 0
             elif (x > 999999999):
-                warning("Fixed3_6: Internal value too positive: %d" % x)
+                warning("Fixed3_6: Internal value too positive: %d", x)
                 x = 999999999
             x = x * 1e-6
         return x
     def h2i(self, pkt, x):
         if x is not None:
             if (x <= -0.5e-6):
-                warning("Fixed3_6: Input value too negative: %.7f" % x)
+                warning("Fixed3_6: Input value too negative: %.7f", x)
                 x = 0
             elif (x >= 999.9999995):
-                warning("Fixed3_6: Input value too positive: %.7f" % x)
+                warning("Fixed3_6: Input value too positive: %.7f", x)
                 x = 999.999999
             x = int(round(x * 1e6))
         return x
@@ -75,20 +75,20 @@ class Fixed3_7Field(LEIntField):
     def i2h(self, pkt, x):
         if x is not None:
             if (x < 0):
-                warning("Fixed3_7: Internal value too negative: %d" % x)
+                warning("Fixed3_7: Internal value too negative: %d",  x)
                 x = 0
             elif (x > 3600000000):
-                warning("Fixed3_7: Internal value too positive: %d" % x)
+                warning("Fixed3_7: Internal value too positive: %d",  x)
                 x = 3600000000
             x = (x - 1800000000) * 1e-7
         return x
     def h2i(self, pkt, x):
         if x is not None:
             if (x <= -180.00000005):
-                warning("Fixed3_7: Input value too negative: %.8f" % x)
+                warning("Fixed3_7: Input value too negative: %.8f",  x)
                 x = -180.0
             elif (x >= 180.00000005):
-                warning("Fixed3_7: Input value too positive: %.8f" % x)
+                warning("Fixed3_7: Input value too positive: %.8f",  x)
                 x = 180.0
             x = int(round((x + 180.0) * 1e7))
         return x
@@ -109,20 +109,20 @@ class Fixed6_4Field(LEIntField):
     def i2h(self, pkt, x):
         if x is not None:
             if (x < 0):
-                warning("Fixed6_4: Internal value too negative: %d" % x)
+                warning("Fixed6_4: Internal value too negative: %d",  x)
                 x = 0
             elif (x > 3600000000):
-                warning("Fixed6_4: Internal value too positive: %d" % x)
+                warning("Fixed6_4: Internal value too positive: %d",  x)
                 x = 3600000000
             x = (x - 1800000000) * 1e-4
         return x
     def h2i(self, pkt, x):
         if x is not None:
             if (x <= -180000.00005):
-                warning("Fixed6_4: Input value too negative: %.5f" % x)
+                warning("Fixed6_4: Input value too negative: %.5f",  x)
                 x = -180000.0
             elif (x >= 180000.00005):
-                warning("Fixed6_4: Input value too positive: %.5f" % x)
+                warning("Fixed6_4: Input value too positive: %.5f",  x)
                 x = 180000.0
             x = int(round((x + 180000.0) * 1e4))
         return x
@@ -144,20 +144,20 @@ class NSCounter_Field(LEIntField):
     def i2h(self, pkt, x): #converts nano-seconds to seconds for output
         if x is not None:
             if (x < 0):
-                warning("NSCounter_Field: Internal value too negative: %d" % x)
+                warning("NSCounter_Field: Internal value too negative: %d",  x)
                 x = 0
             elif (x >= 2**32):
-                warning("NSCounter_Field: Internal value too positive: %d" % x)
+                warning("NSCounter_Field: Internal value too positive: %d",  x)
                 x = 2**32-1
             x = (x / 1e9)
         return x
     def h2i(self, pkt, x): #converts input in seconds into nano-seconds for storage
         if x is not None:
             if (x < 0):
-                warning("NSCounter_Field: Input value too negative: %.10f" % x)
+                warning("NSCounter_Field: Input value too negative: %.10f",  x)
                 x = 0
             elif (x >= (2**32) / 1e9):
-                warning("NSCounter_Field: Input value too positive: %.10f" % x)
+                warning("NSCounter_Field: Input value too positive: %.10f",  x)
                 x = (2**32-1) / 1e9
             x = int(round((x * 1e9)))
         return x
@@ -224,7 +224,7 @@ class VectorFlags_Field(XLEIntField):
                     y &= (~self._relmask)
                     y |= self._relvals[i]
                 else:
-                    #logging.warning("Unknown VectorFlags Argument: %s" % value)
+                    #logging.warning("Unknown VectorFlags Argument: %s",  value)
                     pass
         else:
             y = x

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -132,9 +132,9 @@ def load_protocols(filename):
                     continue
                 dct[lt[0]] = int(lt[1])
             except Exception as e:
-                log_loading.info("Couldn't parse file [%s]: line [%r] (%s)" % (filename,l,e))
+                log_loading.info("Couldn't parse file [%s]: line [%r] (%s)", filename, l, e)
     except IOError:
-        log_loading.info("Can't open %s file" % filename)
+        log_loading.info("Can't open %s file", filename)
     return dct
 
 def load_ethertypes(filename):
@@ -155,7 +155,7 @@ def load_ethertypes(filename):
                     continue
                 dct[lt[0]] = int(lt[1], 16)
             except Exception as e:
-                log_loading.info("Couldn't parse file [%s]: line [%r] (%s)" % (filename,l,e))
+                log_loading.info("Couldn't parse file [%s]: line [%r] (%s)", filename, l, e)
         f.close()
     except IOError as msg:
         pass
@@ -183,7 +183,7 @@ def load_services(filename):
                 elif lt[1].endswith(b"/udp"):
                     udct[lt[0]] = int(lt[1].split(b'/')[0])
             except Exception as e:
-                log_loading.warning("Couldn't file [%s]: line [%r] (%s)" % (filename,l,e))
+                log_loading.warning("Couldn't parse file [%s]: line [%r] (%s)", filename, l, e)
         f.close()
     except IOError:
         log_loading.info("Can't open /etc/services file")

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -104,7 +104,7 @@ class Field(six.with_metaclass(Field_metaclass, object)):
                 l = int(self.fmt[1:-1])
             return RandBin(l)
         else:
-            warning("no random class for [%s] (fmt=%s)." % (self.name, self.fmt))
+            warning("no random class for [%s] (fmt=%s).", self.name, self.fmt)
 
 
 

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -23,7 +23,6 @@ for _l in conf.load_layers:
     try:
         load_layer(_l, globals_dict=globals(), symb_list=__all__)
     except Exception as e:
-        raise
-        log.warning("can't import layer %s: %s" % (_l,e))
+        log.warning("can't import layer %s: %s", _l, e)
 
 del _l

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -263,7 +263,7 @@ class DHCPOptionsField(StrField):
                         lval = [f.addfield(pkt,b"",f.any2i(pkt,val)) for val in lval]
                     oval = b"".join(lval)
                 else:
-                    warning("Unknown field option %s" % name)
+                    warning("Unknown field option %s", name)
                     continue
 
                 s += chb(onum)
@@ -278,7 +278,7 @@ class DHCPOptionsField(StrField):
             elif isinstance(o, (str, bytes)):
                 s += raw(o)
             else:
-                warning("Malformed option %s" % o)
+                warning("Malformed option %s", o)
         return s
 
 

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -149,7 +149,7 @@ class DNSRRField(StrField):
         ret = None
         c = getattr(pkt, self.countfld)
         if c > len(s):
-            warning("wrong value: DNS.%s=%i" % (self.countfld,c))
+            warning("wrong value: DNS.%s=%i", self.countfld, c)
             return s,b""
         while c:
             c -= 1

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -310,7 +310,7 @@ class TCPOptionsField(StrField):
                             oval = (oval,)
                         oval = struct.pack(ofmt, *oval)
                 else:
-                    warning("option [%s] unknown. Skipped."%oname)
+                    warning("option [%s] unknown. Skipped.", oname)
                     continue
             else:
                 onum = oname

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -125,7 +125,7 @@ if conf.crypto_valid:
         elif padStr == "oaep":
             return padding.OAEP(mgf=mgf(h), algorithm=h, label=label)
         else:
-            warning("Key.encrypt(): Unknown padding type (%s)" % padStr)
+            warning("Key.encrypt(): Unknown padding type (%s)", padStr)
             return None
 
 

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -128,7 +128,7 @@ def _tls_del_pad(p):
         return False
 
     if (p.fragment[-padlen:] != p.fragment[-1] * padlen):
-        warning("Padding content is invalid %s" % repr(p.fragment[-padlen:]))
+        warning("Padding content is invalid %s", repr(p.fragment[-padlen:]))
         return False
 
     p.fragment = p.fragment[:-padlen]

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -75,17 +75,17 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True
         >>> conf.verb
         42
     """
-    log_loading.debug("Loading config file [%s]" % cf)
+    log_loading.debug("Loading config file [%s]", cf)
     try:
         exec(compile(open(cf).read(), cf, 'exec'), _globals, _locals)
     except IOError as e:
         if interactive:
             raise
-        log_loading.warning("Cannot read config file [%s] [%s]" % (cf,e))
+        log_loading.warning("Cannot read config file [%s] [%s]", cf, e)
     except Exception as e:
         if interactive:
             raise
-        log_loading.exception("Error during evaluation of config file [%s]" % cf)
+        log_loading.exception("Error during evaluation of config file [%s]", cf)
         
 def _validate_local(x):
     """Returns whether or not a variable should be imported.
@@ -228,7 +228,7 @@ def save_session(fname=None, session=None, pickleProto=-1):
             del(to_be_saved[k])
         elif isinstance(i, (type, type, types.ModuleType)):
             if k[0] != "_":
-                log_interactive.error("[%s] (%s) can't be saved." % (k, type(to_be_saved[k])))
+                log_interactive.error("[%s] (%s) can't be saved.", k, type(to_be_saved[k]))
             del(to_be_saved[k])
 
     try:

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -57,7 +57,7 @@ None.
                          if self.filename is None else
                          self.filename, "rb")
         except (IOError, TypeError):
-            warning("Cannot open nmap database [%s]" % self.filename)
+            warning("Cannot open nmap database [%s]", self.filename)
             self.filename = None
             return
 
@@ -160,7 +160,7 @@ def nmap_sig(target, oport=80, cport=81, ucport=1):
         else:
             test = "T%i" % (snd.sport - 5000)
             if rcv is not None and ICMP in rcv:
-                warning("Test %s answered by an ICMP" % test)
+                warning("Test %s answered by an ICMP", test)
                 rcv = None
             res[test] = rcv
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -58,7 +58,7 @@ class p0fKnowledgeBase(KnowledgeBase):
         try:
             f=open(self.filename)
         except IOError:
-            warning("Can't open base %s" % self.filename)
+            warning("Can't open base %s", self.filename)
             return
         try:
             self.base = []

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -178,7 +178,7 @@ class Route:
                 continue
             bcast = atol(addr)|(~msk&0xffffffff); # FIXME: check error in atol()
             return ltoa(bcast)
-        warning("No broadcast address found for iface %s\n" % iff);
+        warning("No broadcast address found for iface %s\n", iff);
 
 conf.route=Route()
 

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -219,7 +219,7 @@ class Route6:
                 pathes.append((plen, (iface, cset, gw)))
 
         if not pathes:
-            warning("No route found for IPv6 destination %s (no default route?)" % dst)
+            warning("No route found for IPv6 destination %s (no default route?)", dst)
             return (scapy.consts.LOOPBACK_INTERFACE, "::", "::")
 
         # Sort with longest prefix first
@@ -236,7 +236,7 @@ class Route6:
                 res.append((p[0], (tmp[0], srcaddr, tmp[2])))
 
         if res == []:
-            warning("Found a route for IPv6 destination '%s', but no possible source address." % dst)
+            warning("Found a route for IPv6 destination '%s', but no possible source address.", dst)
             return (scapy.consts.LOOPBACK_INTERFACE, "::", "::")
 
         # Symptom  : 2 routes with same weight (our weight is plen)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -317,7 +317,7 @@ def sendpfast(x, pps=None, mbps=None, realtime=None, loop=0, file_cache=False, i
     except KeyboardInterrupt:
         log_interactive.info("Interrupted by user")
     except Exception as e:
-        log_interactive.error("while trying to exec [%s]: %s" % (argv[0],e))
+        log_interactive.error("while trying to exec [%s]: %s", argv[0], e)
     finally:
         os.unlink(f)
 

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -91,7 +91,7 @@ class L3RawSocket(SuperSocket):
             lvl = 3
         else:
             cls = conf.default_l2
-            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s" % (sa_ll[0],sa_ll[1],sa_ll[3],cls.name))
+            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3], cls.name)
             lvl = 3
 
         try:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -507,7 +507,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
         while not os.path.exists(tempfile):
             time.sleep(0.1)
             if time.time() - waiting_start > 3:
-                warning("Temporary file '%s' could not be written. Graphic will not be displayed." % tempfile)
+                warning("Temporary file '%s' could not be written. Graphic will not be displayed.", tempfile)
                 break
         else:  
             if conf.prog.display == conf.prog._default:
@@ -1153,7 +1153,7 @@ class PcapWriter(RawPcapWriter):
             try:
                 self.linktype = conf.l2types[pkt.__class__]
             except KeyError:
-                warning("PcapWriter: unknown LL type for %s. Using type 1 (Ethernet)" % pkt.__class__.__name__)
+                warning("PcapWriter: unknown LL type for %s. Using type 1 (Ethernet)", pkt.__class__.__name__)
                 self.linktype = 1
         RawPcapWriter._write_header(self, pkt)
 


### PR DESCRIPTION
Update logging.warning/info(), by replacing calls
 `warning('my string %s' % 'hey')` ==> `warning('my string %s', 'hey')`
- let the logging module use its [formatter](https://docs.python.org/2/library/logging.html#logging.Formatter)
- fix https://github.com/secdev/scapy/issues/835