### PR TITLE
[coverage] Interface alias routing table unit test

### DIFF
--- a/test/linux.uts
+++ b/test/linux.uts
@@ -69,3 +69,20 @@ assert(success)
 #socket = conf.L2listen()
 #select.select([socket],[],[],2)
 #_flush_fd(socket.ins)
+
+= Interface aliases
+~ linux needs_root
+
+import os
+exit_status = os.system("ip link add name scapy0 type dummy")
+exit_status = os.system("ip addr add 192.0.2.1/24 dev scapy0")
+exit_status = os.system("ip link set scapy0 up")
+exit_status = os.system("ifconfig scapy0:0 inet 198.51.100.1/24 up")
+exit_status = os.system("ip addr show scapy0")
+print(get_if_list())
+conf.route.resync()
+exit_status = os.system("ip link del name dev scapy0")
+print(conf.route.routes)
+assert(conf.route.route("198.51.100.254") == ("scapy0", "198.51.100.1", "0.0.0.0"))
+route_alias = (3325256704, 4294967040, "0.0.0.0", "scapy0", "198.51.100.1")
+assert(route_alias in conf.route.routes)


### PR DESCRIPTION
This PR adds a unit test to check that Scapy correctly adds a routing entry when dealing with interface aliases.

It will help fixing #614 by ensuring that we do no introduce a regression.