### PR TITLE
Segment Routing: fixing pseudo-header computation

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -692,6 +692,11 @@ def in6_chksum(nh, u, p):
             final_dest_addr_found == 0):
             rthdr = u.addresses[-1]
             final_dest_addr_found = 1
+        elif (isinstance(u, IPv6ExtHdrSegmentRouting) and
+            u.segleft != 0 and len(u.addresses) != 0 and
+            final_dest_addr_found == 0):
+            rthdr = u.addresses[0]
+            final_dest_addr_found = 1
         elif (isinstance(u, IPv6ExtHdrDestOpt) and (len(u.options) == 1) and
              isinstance(u.options[0], HAO)):
              hahdr  = u.options[0].hoa

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1544,6 +1544,11 @@ p = IPv6(s)
 assert(ICMPv6EchoRequest in p and IPv6ExtHdrSegmentRouting in p)
 assert(len(p[IPv6ExtHdrSegmentRouting].addresses) == 3 and len(p[IPv6ExtHdrSegmentRouting].tlv_objects) == 2)
 
+= IPv6ExtHdrSegmentRouting Class - UDP pseudo-header checksum - build & dissect
+
+s= raw(IPv6(src="fc00::1", dst="fd00::42")/IPv6ExtHdrSegmentRouting(addresses=["fd00::42", "fc13::1337"][::-1], segleft=1, lastentry=1) / UDP(sport=11000, dport=4242) / Raw('foobar'))
+assert(s == b'`\x00\x00\x00\x006+@\xfc\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00B\x11\x04\x04\x01\x01\x00\x00\x00\xfc\x13\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x137\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00B*\xf8\x10\x92\x00\x0e\x81\xb7foobar')
+
 
 ############
 ############


### PR DESCRIPTION
With IPv6 Segment Routing (https://tools.ietf.org/html/draft-ietf-6man-segment-routing-header-07), the pseudo-header for UDP and TCP checksums should use as source address the address of the last traversed node. In contrast with the deprecated routing header extension, the last traversed segment is actually the first in the SRH, with index 0 (see IETF draft).

This wasn't implemented so far, leading to an incorrect checksum computation.