### PR TITLE
Fix SSLv2 context update

### DIFF
--- a/scapy/layers/tls/handshake_sslv2.py
+++ b/scapy/layers/tls/handshake_sslv2.py
@@ -351,7 +351,7 @@ class SSLv2ClientMasterKey(_SSLv2Handshake):
         else:
             cs_cls = _tls_cipher_suites_cls[cs_val]
 
-        tls_version = s.tls_version
+        tls_version = s.tls_version or 0x0002
         connection_end = s.connection_end
         wcs_seq_num = s.wcs.seq_num
         s.pwcs = writeConnState(ciphersuite=cs_cls,

--- a/test/sslv2.uts
+++ b/test/sslv2.uts
@@ -79,6 +79,8 @@ assert(mk_enc.clearkeylen == 11)
 assert(mk_enc.encryptedkeylen == 256)
 assert(mk_enc.clearkey == binascii.unhexlify('7ec2f99e946902feedc4dc'))
 assert(mk_enc.encryptedkey[:3] == b"\x9b\xe0\xe7" and mk_enc.encryptedkey[-3:] == b"\xea\x57\x2e")
+assert(t_enc.tls_session.pwcs.tls_version == 0x0002)
+assert(t_enc.tls_session.prcs.tls_version == 0x0002)
 mk_enc.decryptedkey is None
 
 = Reading SSLv2 session - Importing server compromised key


### PR DESCRIPTION
We should not assume that a SSLv2ClientMasterKey context has been updated beforehand by SSLv2ServerHello methods. The tls_version may not be set here.