### PR TITLE
Fix PyPy attach_filter function

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -326,6 +326,14 @@ def isCryptographyAdvanced():
     else:
         return True
 
+def isPyPy():
+    """Returns either scapy is running under PyPy or not"""
+    try:
+        import __pypy__
+        return True
+    except ImportError:
+        return False
+
 def _prompt_changer(attr, val):
     """Change the current prompt theme"""
     try:
@@ -416,6 +424,7 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     resolve = Resolve()
     noenum = Resolve()
     emph = Emphasize()
+    use_pypy = isPyPy()
     use_pcap = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
     use_dnet = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
     use_bpf = False

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -85,6 +85,20 @@ x is not None and ICMP in x and x[ICMP].type == 0
 #select.select([socket],[],[],2)
 #_flush_fd(socket.ins)
 
+= Test legacy attach_filter function
+~ linux needs_root
+from scapy.arch.common import get_bpf_pointer
+
+old_pypy = conf.use_pypy
+conf.use_pypy = True
+
+tcpdump_lines = ['12\n', '40 0 0 12\n', '21 0 5 34525\n', '48 0 0 20\n', '21 6 0 6\n', '21 0 6 44\n', '48 0 0 54\n', '21 3 4 6\n', '21 0 3 2048\n', '48 0 0 23\n', '21 0 1 6\n', '6 0 0 1600\n', '6 0 0 0\n']
+pointer = get_bpf_pointer(tcpdump_lines)
+assert isinstance(pointer, str)
+assert len(pointer) > 1
+
+conf.use_pypy = old_pypy
+
 = Interface aliases & sub-interfaces
 ~ linux needs_root
 


### PR DESCRIPTION
- Fixes https://github.com/secdev/scapy/issues/842
PyPy has a different id() system that did not worked as expected. Also, it does not accept the new C-object system (as python 2.7 or 3+ does)