### PR TITLE
Fix IPython: check for old versions

### DIFF
--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -291,7 +291,14 @@ class HTMLTheme2(HTMLTheme):
 def apply_ipython_style(shell):
     """Updates the specified IPython console shell with
     the conf.color_theme scapy theme."""
-    from IPython.terminal.prompts import Prompts, Token
+    try:
+        from IPython.terminal.prompts import Prompts, Token
+    except:
+        from scapy.error import log_loading
+        log_loading.warning(
+            "IPython too old. Some Scapy shell features won't be available."
+            )
+        return
     from scapy.config import conf
     if isinstance(conf.prompt, Prompts):
         shell.prompts_class = conf.prompt # Set custom prompt style


### PR DESCRIPTION
With old versions of IPython (FYI, Ubuntu 16.04.3 LTS packages IPython 2.4.1), Scapy tries to use IPython but fails, making Scapy unusable. Also, this PR makes `traitlets` a soft dependency when IPython is used.