### PR TITLE
Automaton: avoid a double call to parse_args

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -670,8 +670,6 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
         for stname in self.states:
             setattr(self, stname, 
                     _instance_state(getattr(self, stname)))
-        
-        self.parse_args(*args, **kargs)
 
         self.start()
 


### PR DESCRIPTION
In automaton, the `parse_args` method seems to be called twice during a "normal use" (inspired from TLS example).

To reproduce:
```Python
from scapy.all import *

class Test(Automaton):

    def parse_args(self, *args, **kwargs):
        super(Test, self).parse_args(**kwargs)
        print "PARSE ARGS CALLED"

x = Test()
```
Output:
```
PARSE ARGS CALLED
PARSE ARGS CALLED
... crash because no initial state is set ...
```

The first call is in `__init__`, the second results from thread starting in `._do_control`
The later being called with extra care on default parameters, I removed the former. Is that correct for you?