### PR TITLE
lldp fixes 

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -466,7 +466,7 @@ class LLDPDUSystemDescription(LLDPDU):
     """
     fields_desc = [
         BitEnumField('_type', 0x06, 7, LLDPDU.TYPES),
-        BitFieldLenField('_length', None, 9, length_of='name'),
+        BitFieldLenField('_length', None, 9, length_of='description'),
         StrLenField('description', '', length_from=lambda pkt: pkt._length)
     ]
 

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -455,8 +455,8 @@ class LLDPDUSystemName(LLDPDU):
     """
     fields_desc = [
         BitEnumField('_type', 0x05, 7, LLDPDU.TYPES),
-        BitFieldLenField('_length', None, 9, length_of='name'),
-        StrLenField('name', '', length_from=lambda pkt: pkt._length)
+        BitFieldLenField('_length', None, 9, length_of='system_name'),
+        StrLenField('system_name', '', length_from=lambda pkt: pkt._length)
     ]
 
 

--- a/scapy/contrib/lldp.uts
+++ b/scapy/contrib/lldp.uts
@@ -162,3 +162,69 @@ frm = Ether(frm.build())
 
 frm = Ether() / LLDPDUChassisID() / LLDPDUPortID() / LLDPDUTimeToLive() / LLDPDUEndOfLLDPDU(_length=8)
 frm = Ether(frm.build())
+
+= test attribute values
+
+conf.contribs['LLDP'].strict_mode_enable()
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/ \
+      LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01') / \
+      LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+      LLDPDUTimeToLive()/\
+      LLDPDUSystemName(system_name='things will')/\
+      LLDPDUSystemCapabilities(telephone_available=1,
+                               router_available=1,
+                               telephone_enabled=1,
+                               router_enabled=1)/\
+      LLDPDUManagementAddress(
+            management_address_subtype=LLDPDUManagementAddress.SUBTYPE_MANAGEMENT_ADDRESS_IPV4,
+            management_address='1.2.3.4',
+            interface_numbering_subtype=LLDPDUManagementAddress.SUBTYPE_INTERFACE_NUMBER_IF_INDEX,
+            interface_number=23,
+            object_id='burn') / \
+      LLDPDUSystemDescription(description='without tests.') / \
+      LLDPDUPortDescription(description='always!') / \
+      LLDPDUEndOfLLDPDU()
+
+frm = Ether(frm.build())
+
+assert str2mac(frm[LLDPDUChassisID].id) == '06:05:04:03:02:01'
+assert str2mac(frm[LLDPDUPortID].id) == '01:02:03:04:05:06'
+sys_capabilities = frm[LLDPDUSystemCapabilities]
+assert sys_capabilities.reserved_5_available == 0
+assert sys_capabilities.reserved_4_available == 0
+assert sys_capabilities.reserved_3_available == 0
+assert sys_capabilities.reserved_2_available == 0
+assert sys_capabilities.reserved_1_available == 0
+assert sys_capabilities.two_port_mac_relay_available == 0
+assert sys_capabilities.s_vlan_component_available == 0
+assert sys_capabilities.c_vlan_component_available == 0
+assert sys_capabilities.station_only_available == 0
+assert sys_capabilities.docsis_cable_device_available == 0
+assert sys_capabilities.telephone_available == 1
+assert sys_capabilities.router_available == 1
+assert sys_capabilities.wlan_access_point_available == 0
+assert sys_capabilities.mac_bridge_available == 0
+assert sys_capabilities.repeater_available == 0
+assert sys_capabilities.other_available == 0
+assert sys_capabilities.reserved_5_enabled == 0
+assert sys_capabilities.reserved_4_enabled == 0
+assert sys_capabilities.reserved_3_enabled == 0
+assert sys_capabilities.reserved_2_enabled == 0
+assert sys_capabilities.reserved_1_enabled == 0
+assert sys_capabilities.two_port_mac_relay_enabled == 0
+assert sys_capabilities.s_vlan_component_enabled == 0
+assert sys_capabilities.c_vlan_component_enabled == 0
+assert sys_capabilities.station_only_enabled == 0
+assert sys_capabilities.docsis_cable_device_enabled == 0
+assert sys_capabilities.telephone_enabled == 1
+assert sys_capabilities.router_enabled == 1
+assert sys_capabilities.wlan_access_point_enabled == 0
+assert sys_capabilities.mac_bridge_enabled == 0
+assert sys_capabilities.repeater_enabled == 0
+assert sys_capabilities.other_enabled == 0
+assert frm[LLDPDUManagementAddress].management_address == '1.2.3.4'
+assert frm[LLDPDUSystemName].system_name == 'things will'
+assert frm[LLDPDUManagementAddress].object_id == 'burn'
+assert frm[LLDPDUSystemDescription].description == 'without tests.'
+assert frm[LLDPDUPortDescription].description == 'always!'

--- a/scapy/contrib/lldp.uts
+++ b/scapy/contrib/lldp.uts
@@ -13,7 +13,7 @@ frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/ \
       LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01') / \
       LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
       LLDPDUTimeToLive()/\
-      LLDPDUSystemName(name='mate')/\
+      LLDPDUSystemName(system_name='mate')/\
       LLDPDUSystemCapabilities(telephone_available=1, router_available=1, telephone_enabled=1)/\
       LLDPDUManagementAddress(
             management_address_subtype=LLDPDUManagementAddress.SUBTYPE_MANAGEMENT_ADDRESS_IPV4,


### PR DESCRIPTION
- in LLDPDUSystemName field name 'name' was covered by class attribute 'name' - instead of the system name a query to frame[LLDPDUSystemName].name returned the class name. won't explode but still bad.
- seems I copy-pasted the class LLDPDUSystemDescription (two lines below LLDPDUSystemName) - the length field reference pointed to name - but should be description. this is a real bug.

sorry.