### PR TITLE
Python 3/Routes : fix read_routes (windows) + tcpdump

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -23,6 +23,7 @@ from scapy.data import MTU, ETHER_BROADCAST, ETH_P_ARP
 
 import scapy.modules.six as six
 from scapy.modules.six.moves import range, zip, input
+from scapy.compat import plain_str
 
 conf.use_pcap = False
 conf.use_dnet = False
@@ -699,8 +700,9 @@ def _read_routes6_post2008():
 
 def _get_i6_metric(index):
     # Returns the INTERFACE metric from the interface index
-    ps = sp.Popen([conf.prog.cmd, '/c', 'netsh interface ipv6 show interfaces level=verbose ' + index], stdout = sp.PIPE, universal_newlines = True)
+    ps = sp.Popen([conf.prog.cmd, '/c', 'netsh interface ipv6 show interfaces level=verbose ' + index], stdout = sp.PIPE)
     stdout, stdin = ps.communicate()
+    stdout = stdout.decode("utf8", "ignore")
     metric_line = stdout.split('\n')[6]
     metric = re.search(re.compile(".*:\s+(\d+)"), metric_line).group(1)
     return int(metric)
@@ -708,8 +710,9 @@ def _get_i6_metric(index):
 def _read_routes6_7():
     # Not supported in powershell, we have to use netsh
     routes = []
-    ps = sp.Popen([conf.prog.cmd, '/c', 'netsh interface ipv6 show route level=verbose'], stdout = sp.PIPE, universal_newlines = True)
+    ps = sp.Popen([conf.prog.cmd, '/c', 'netsh interface ipv6 show route level=verbose'], stdout = sp.PIPE)
     stdout, stdin = ps.communicate()
+    stdout = stdout.decode("utf8", "ignore")
     lifaddr = in6_getifaddr()
     # Define regexes
     r_int = [".*:\s+(\d+)"]

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -299,7 +299,7 @@ def get_windows_if_list():
         # Ethernet                  Killer E2200 Gigabit Ethernet Contro...      13 Up           D0-50-99-56-DD-F9         1 Gbps
         query = exec_query(['Get-NetAdapter'],
                            ['InterfaceDescription', 'InterfaceIndex', 'Name',
-                            'InterfaceGuid', 'MacAddress', 'Name']) # It is normal that it is in this order
+                            'InterfaceGuid', 'MacAddress', 'InterfaceAlias']) # It is normal that it is in this order
     else:
         query = exec_query(['Get-WmiObject', 'Win32_NetworkAdapter'],
                            ['Name', 'InterfaceIndex', 'InterfaceDescription',

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1029,7 +1029,7 @@ send_and_sniff(IP(dst="secdev.org")/ICMP(), flt="icmp")
 send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 
 a = L2ListenTcpdump()
-icmp_r = IP(b'E\x00\x00\x1c\x00\x01\x00\x00@\x01p\xc0\x7f\x00\x00\x01\xd9\x19\xb2\x05\x08\x00\xf7\xff\x00\x00\x00\x00')
+icmp_r = IP(dst="secdev.org")/ICMP()
 send_and_sniff(icmp_r, timeout=10, opened_socket=a)
 a.close()
 


### PR DESCRIPTION
+ fix https://github.com/secdev/scapy/issues/914 
+ read_routes6 on python 3
+ fix tcpdump test bug