### PR TITLE
[Windows] Loading speedup (pcapdnet cache) + cleanup

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -69,8 +69,8 @@ if conf.use_winpcapy:
       pass
 
   def get_if_raw_addr(iff):
-    if iff.guid in conf.cache_ipaddrs:
-        return conf.cache_ipaddrs[iff.pcap_name]
+    if conf.cache_ipaddrs:
+        return conf.cache_ipaddrs.get(iff.pcap_name, None)
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
     ret = b"\0\0\0\0"

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -25,7 +25,7 @@ import scapy.consts
 
 if conf.use_winpcapy:
   NPCAP_PATH = os.environ["WINDIR"] + "\\System32\\Npcap"
-  #mostly code from https://github.com/phaethon/scapy translated to python2.X
+  #  Part of the code from https://github.com/phaethon/scapy translated to python2.X
   try:
       from scapy.modules.winpcapy import *
       def winpcapy_get_if_list():
@@ -74,10 +74,9 @@ if conf.use_winpcapy:
         return conf.cache_ipaddrs.get(iff.pcap_name, None)
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
-    ret = b"\0\0\0\0"
 
     if pcap_findalldevs(byref(devs), err) < 0:
-      return ret
+      return None
     try:
       p = devs
       while p:
@@ -86,7 +85,9 @@ if conf.use_winpcapy:
             if a.contents.addr.contents.sa_family == socket.AF_INET:
               ap = a.contents.addr
               val = cast(ap, POINTER(sockaddr_in))
-              conf.cache_ipaddrs[plain_str(p.contents.name)] = b"".join(chb(x) for x in val.contents.sin_addr[:4])
+              if_raw_addr = b"".join(chb(x) for x in val.contents.sin_addr[:4])
+              if if_raw_addr != b'\x00\x00\x00\x00':
+                  conf.cache_ipaddrs[plain_str(p.contents.name)] = if_raw_addr
             a = a.contents.next
           p = p.contents.next
       return conf.cache_ipaddrs.get(iff.pcap_name, None)

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -69,6 +69,7 @@ if conf.use_winpcapy:
       pass
 
   def get_if_raw_addr(iff):
+    """Returns the raw ip address corresponding to the NetworkInterface."""
     if conf.cache_ipaddrs:
         return conf.cache_ipaddrs.get(iff.pcap_name, None)
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
@@ -93,12 +94,14 @@ if conf.use_winpcapy:
       pcap_freealldevs(devs)
   if conf.use_winpcapy:
       def get_if_list():
+          """Returns all pcap names"""
           if conf.cache_iflist:
               return conf.cache_iflist
           iflist = winpcapy_get_if_list()
           conf.cache_iflist = iflist
           return iflist
   def in6_getifaddr_raw():
+    """Returns all available IPv6 on the computer, read from winpcap."""
     err = create_string_buffer(PCAP_ERRBUF_SIZE)
     devs = POINTER(pcap_if_t)()
     ret = []
@@ -124,6 +127,7 @@ if conf.use_winpcapy:
 
   from ctypes import POINTER, byref, create_string_buffer
   class _PcapWrapper_pypcap:
+      """Wrapper for the WinPcap calls"""
       def __init__(self, device, snaplen, promisc, to_ms):
           self.errbuf = create_string_buffer(PCAP_ERRBUF_SIZE)
           self.iface = create_string_buffer(device.encode("utf8"))

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -126,7 +126,7 @@ if conf.use_winpcapy:
   class _PcapWrapper_pypcap:
       def __init__(self, device, snaplen, promisc, to_ms):
           self.errbuf = create_string_buffer(PCAP_ERRBUF_SIZE)
-          self.iface = create_string_buffer(device)
+          self.iface = create_string_buffer(device.encode("utf8"))
           self.pcap = pcap_open_live(self.iface, snaplen, promisc, to_ms, self.errbuf)
           self.header = POINTER(pcap_pkthdr)()
           self.pkt_data = POINTER(c_ubyte)()
@@ -147,7 +147,7 @@ if conf.use_winpcapy:
             return 0
           return pcap_get_selectable_fd(self.pcap) 
       def setfilter(self, f):
-          filter_exp = create_string_buffer(f)
+          filter_exp = create_string_buffer(f.encode("utf8"))
           if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:
             log_loading.error("Could not compile filter expression %s", f)
             return False

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -86,7 +86,7 @@ class _PowershellManager(Thread):
         Thread.__init__(self)
         self.daemon = True
         self.start()
-        self.query(["$FormatEnumerationLimit=-1"]) # Do not crop long IP lists
+        self.query(["$FormatEnumerationLimit=-1"])  # Do not crop long IP lists
 
     def run(self):
         while self.running:

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -570,8 +570,7 @@ class NetworkInterfaceDict(UserDict):
                         return False
                 return False
             _error_msg = "No match between your pcap and windows network interfaces found. "
-            if _detect[0] and not _detect[2] and ((hasattr(self, "restarted_adapter") and not self.restarted_adapter)
-                                                 or not hasattr(self, "restarted_adapter")):
+            if _detect[0] and not _detect[2] and (not hasattr(self, "restarted_adapter") or self.restarted_adapter):
                 warning("Scapy has detected that your pcap service is not running !")
                 if not conf.interactive or _ask_user():
                     succeed = pcap_service_start(askadmin=conf.interactive)
@@ -895,7 +894,7 @@ def get_working_if():
     try:
         # return the interface associated with the route with smallest
         # mask (route by default if it exists)
-        return min(read_routes(), key=lambda x: x[1])[3]
+        return min(conf.route.routes, key=lambda x: x[1])[3]
     except ValueError:
         # no route
         return scapy.consts.LOOPBACK_INTERFACE

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -89,8 +89,8 @@ class _PowershellManager(Thread):
 
     def run(self):
         while self.running:
-            read_line = self.process.stdout.readline()
-            if read_line == "scapy_end\n":
+            read_line = self.process.stdout.readline().strip()
+            if read_line == "scapy_end":
                 self.event.set()
             else:
                 self.buffer.append(read_line)
@@ -917,7 +917,11 @@ def _read_routes6_7():
                 _ip = current_object[0].split("/")
                 dpref = _ip[0]
                 dp = int(_ip[1])
-                nh = current_object[1].split("/")[0]
+                _match = re.search(r_ipv6[0], current_object[3])
+                nh = "::"
+                if _match: # Detect if Next Hop is specified (if not, it will be the IFName)
+                    _nhg1 = _match.group(1)
+                    nh = _nhg1 if re.match(".*:.*:.*", _nhg1) else "::"
                 metric = int(current_object[6]) + _get_i6_metric(if_index)
                 _append_route6(routes, dpref, dp, nh, iface, lifaddr, metric)
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -96,11 +96,10 @@ class _PowershellManager(Thread):
                 self.buffer.append(read_line)
     def query(self, command, cmd=False):
         self.event.clear()
-        if cmd:
-            prog = [conf.prog.cmd, "/c"]
-        else:
-            prog = [conf.prog.powershell]
+        prog = [conf.prog.powershell]
         if not self.running:
+            if cmd:
+                prog = [conf.prog.cmd, "/c"]
             # Not running: create process for this only query
             stdout, _ = sp.Popen(prog + command,
                    stdout=sp.PIPE).communicate()
@@ -414,8 +413,7 @@ class NetworkInterface(object):
             if not self.ip and self.name == scapy.consts.LOOPBACK_NAME:
                 self.ip = "127.0.0.1"
             if not self.ip:
-                # No IP detected
-                self.invalid = True
+                self.ip = ""
         except (KeyError, AttributeError, NameError) as e:
             print(e)
 
@@ -686,14 +684,14 @@ class NetworkInterfaceDict(UserDict):
     def show(self, resolve_mac=True, print_result=True):
         """Print list of available network interfaces in human readable form"""
         res = []
-        res.append("%s  %s  %s  %s" % ("INDEX".ljust(5), "IFACE".ljust(35), "IP".ljust(15), "MAC"))
         for iface_name in sorted(self.data):
             dev = self.data[iface_name]
             mac = dev.mac
             if resolve_mac and conf.manufdb:
                 mac = conf.manufdb._resolve_MAC(mac)
-            res.append("%s  %s  %s  %s" % (str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac))
-        res = "\n".join(res)
+            res.append((str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac))
+
+        res = pretty_list(res, [("INDEX", "IFACE", "IP", "MAC")])
         if print_result:
             print(res)
         else:

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -379,7 +379,7 @@ class NetworkInterface(object):
     def _update_pcapdata(self):
         if self.is_invalid():
             return
-        for i in winpcapy_get_if_list():
+        for i in get_if_list():
             if i.endswith(self.data['guid']):
                 self.pcap_name = i
                 return
@@ -690,11 +690,9 @@ def show_interfaces(resolve_mac=True):
 _orig_open_pcap = pcapdnet.open_pcap
 pcapdnet.open_pcap = lambda iface,*args,**kargs: _orig_open_pcap(pcapname(iface),*args,**kargs)
 
-_orig_get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr
-pcapdnet.get_if_raw_hwaddr = lambda iface, *args, **kargs: (
+get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr = lambda iface, *args, **kargs: (
     ARPHDR_ETHER, mac2str(IFACES.dev_from_pcapname(pcapname(iface)).mac)
 )
-get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr
 
 def _read_routes_xp():
     # The InterfaceIndex in Win32_IP4RouteTable does not match the
@@ -770,8 +768,9 @@ def _read_routes_post2008():
         #     log_loading.warning("Building Scapy's routing table: Couldn't get outgoing interface for destination %s", dest)
         #     continue
         dest, mask = line[1].split('/')
+        ip = "127.0.0.1" if line[0] == "1" else iface.ip # Force loopback on iface 1
         routes.append((atol(dest), itom(int(mask)),
-                       line[2], iface, iface.ip, int(line[3])+int(line[4])))
+                       line[2], iface, ip, int(line[3])+int(line[4])))
     return routes
 
 ############

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -95,6 +95,7 @@ class _PowershellManager(Thread):
             else:
                 self.buffer.append(read_line)
     def query(self, command, cmd=False):
+        self.event.clear()
         if cmd:
             prog = [conf.prog.cmd, "/c"]
         else:
@@ -112,7 +113,6 @@ class _PowershellManager(Thread):
         self.process.stdin.write(query)
         self.process.stdin.flush()
         self.event.wait()
-        self.event.clear()
         return self.buffer[1:]
 
     def close(self):
@@ -404,8 +404,8 @@ class NetworkInterface(object):
         self._update_pcapdata()
 
         try:
-            self.ip = socket.inet_ntoa(get_if_raw_addr(data))
-        except (KeyError, AttributeError, NameError):
+            self.ip = socket.inet_ntoa(get_if_raw_addr(self))
+        except (TypeError, NameError):
             pass
 
         try:

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -73,7 +73,7 @@ def _encapsulate_admin(cmd):
 
 class _PowershellManager(Thread):
     """Instance used to send multiple commands on the same Powershell process.
-    Will be instanciate on loading and automatically stopped."""
+    Will be instantiated on loading and automatically stopped."""
     def __init__(self):
         self.process = sp.Popen([conf.prog.powershell, "-NoLogo", "-NonInteractive", "-Command", "-"], # Start & redirect input
                          stdout=sp.PIPE,
@@ -371,7 +371,7 @@ def get_ips(v6=False):
     return res
 
 def get_ip_from_name(ifname, v6=False):
-    """Backward compatibility: inderectly calls get_ips
+    """Backward compatibility: indirectly calls get_ips
     Deprecated."""
     return get_ips(v6=v6).get(ifname, "")
         
@@ -882,13 +882,14 @@ def _get_i6_metric():
     stdout = POWERSHELL_PROCESS.query([query_cmd])
     res = {}
     _buffer = []
+    _pattern = re.compile(".*:\s+(\d+)")
     for _line in stdout:
         if not _line.strip():
             continue
         _buffer.append(_line)
         if len(_buffer) == 32: # An interface, with all parameters, is 32 lines long
-            if_index = re.search(re.compile(".*:\s+(\d+)"), _buffer[3]).group(1)
-            if_metric = int(re.search(re.compile(".*:\s+(\d+)"), _buffer[5]).group(1))
+            if_index = re.search(_pattern, _buffer[3]).group(1)
+            if_metric = int(re.search(_pattern, _buffer[5]).group(1))
             res[if_index] = if_metric
             _buffer = []
     return res

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -96,10 +96,11 @@ class _PowershellManager(Thread):
                 self.buffer.append(read_line)
     def query(self, command, cmd=False):
         self.event.clear()
-        prog = [conf.prog.powershell]
         if not self.running:
             if cmd:
                 prog = [conf.prog.cmd, "/c"]
+            else:
+                prog = [conf.prog.powershell]
             # Not running: create process for this only query
             stdout, _ = sp.Popen(prog + command,
                    stdout=sp.PIPE).communicate()

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -414,6 +414,8 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     debug_match = 0
     debug_tls = 0
     wepkey = ""
+    cache_iflist = {}
+    cache_ipaddrs = {}
     route = None # Filed by route.py
     route6 = None # Filed by route6.py
     auto_fragment = 1

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -44,6 +44,7 @@ from scapy.config import conf
 from scapy.base_classes import *
 from scapy.data import *
 from scapy.compat import *
+import scapy.consts
 from scapy.fields import *
 from scapy.packet import *
 from scapy.volatile import *
@@ -117,12 +118,8 @@ def getmacbyip6(ip6, chainCC=0):
 
     iff,a,nh = conf.route6.route(ip6)
 
-    if isinstance(iff, six.string_types):
-        if iff == LOOPBACK_NAME:
-            return "ff:ff:ff:ff:ff:ff"
-    else:
-        if iff.name == LOOPBACK_NAME:
-            return "ff:ff:ff:ff:ff:ff"
+    if iff == scapy.consts.LOOPBACK_INTERFACE:
+        return "ff:ff:ff:ff:ff:ff"
 
     if nh != '::':
         ip6 = nh # Found next hop

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -8,7 +8,7 @@ Routing and handling of network interfaces.
 """
 
 from __future__ import absolute_import
-from scapy.utils import atol, ltoa, itom, pretty_routes
+from scapy.utils import atol, ltoa, itom, pretty_list
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.arch import get_working_if
@@ -43,7 +43,7 @@ class Route:
                       addr,
                       str(metric)))
 
-        return pretty_routes(rtlst,
+        return pretty_list(rtlst,
                              [("Network", "Netmask", "Gateway", "Iface", "Output IP", "Metric")])
 
     def make_route(self, host=None, net=None, gw=None, dev=None, metric=1):

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -11,7 +11,8 @@ from __future__ import absolute_import
 from scapy.utils import atol, ltoa, itom, pretty_routes
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
-from scapy.arch import WINDOWS, get_working_if
+from scapy.arch import get_working_if
+from scapy.consts import WINDOWS
 import scapy.consts
 import scapy.modules.six as six
 
@@ -22,7 +23,7 @@ import scapy.modules.six as six
 class Route:
     def __init__(self):
         self.resync()
-        self.cache = {}
+        self.invalidate_cache()
 
     def invalidate_cache(self):
         self.cache = {}

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -30,8 +30,8 @@ import scapy.modules.six as six
 class Route6:
 
     def __init__(self):
-        self.invalidate_cache()
         self.resync()
+        self.invalidate_cache()
 
     def invalidate_cache(self):
         self.cache = {}

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -54,7 +54,7 @@ class Route6:
         for net, msk, gw, iface, cset, metric in self.routes:
             rtlst.append(('%s/%i'% (net,msk), gw, (iface if isinstance(iface, six.string_types) else iface.name), ", ".join(cset) if len(cset) > 0 else "", str(metric)))
 
-        return pretty_routes(rtlst,
+        return pretty_list(rtlst,
                              [('Destination', 'Next Hop', "Iface", "Src candidates", "Metric")],
                              sortBy = 1)
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1359,7 +1359,7 @@ def get_terminal_width():
         else:
             return None
 
-def pretty_routes(rtlst, header, sortBy=0):
+def pretty_list(rtlst, header, sortBy=0):
     """Pretty route list, and add header"""
     _l_header = len(header[0])
     _space = "  "

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1360,7 +1360,7 @@ def get_terminal_width():
             return None
 
 def pretty_list(rtlst, header, sortBy=0):
-    """Pretty route list, and add header"""
+    """Pretty list to fit the terminal, and add header"""
     _l_header = len(header[0])
     _space = "  "
     # Sort correctly

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -37,6 +37,10 @@ conf.route.delt(net="1.2.3.4/32")
 
 = IPField class
 ~ core field
+
+if WINDOWS:
+    route_add_loopback()
+
 i = IPField("foo", None)
 i.i2m(None, "1.2.3.4")
 assert( _ == b"\x01\x02\x03\x04" )

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -52,7 +52,7 @@ def dev_from_index_custom(if_index):
 @mock.patch("scapy.arch.windows.construct_source_candidate_set")
 @mock.patch("scapy.arch.windows.get_if_list")
 @mock.patch("scapy.arch.windows.dev_from_index")
-@mock.patch("scapy.arch.windows.sp.Popen")
+@mock.patch("scapy.arch.windows.POWERSHELL_PROCESS.query")
 def test_read_routes6_windows(mock_comm, mock_dev_from_index, mock_winpcapylist, mock_utils6cset):
     """Test read_routes6() on Windows"""
     # 'Get-NetRoute -AddressFamily IPV6 | select ifIndex, DestinationPrefix, NextHop'
@@ -141,7 +141,7 @@ NextHop           : fe80::224:d4ff:fea0:a6d7
 RouteMetric       : 0
 InterfaceMetric   : 256
 """
-    mock_comm.return_value = Bunch(communicate=lambda: (get_net_route_output, ""))
+    mock_comm.return_value = get_net_route_output.split("\n")
     mock_winpcapylist.return_value = [u'\\Device\\NPF_{0EC72537-B662-4F5D-B34E-48BFAE799BBE}', u'\\Device\\NPF_{C56DFFB3-992C-4964-B000-3E7C0F76E8BA}']
     # Mocked in6_getifaddr() output
     mock_dev_from_index.side_effect = dev_from_index_custom

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -140,8 +140,8 @@ DestinationPrefix : ::/0
 NextHop           : fe80::224:d4ff:fea0:a6d7
 RouteMetric       : 0
 InterfaceMetric   : 256
-""".split("\n")
-    mock_comm.return_value = Bunch(stdout=get_net_route_output)
+"""
+    mock_comm.return_value = Bunch(communicate=lambda: (get_net_route_output, ""))
     mock_winpcapylist.return_value = [u'\\Device\\NPF_{0EC72537-B662-4F5D-B34E-48BFAE799BBE}', u'\\Device\\NPF_{C56DFFB3-992C-4964-B000-3E7C0F76E8BA}']
     # Mocked in6_getifaddr() output
     mock_dev_from_index.side_effect = dev_from_index_custom

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -49,7 +49,7 @@ def dev_from_index_custom(if_index):
             return iface
     raise ValueError("Unknown network interface index %r" % if_index)
 
-@mock.patch("scapy.utils6.construct_source_candidate_set")
+@mock.patch("scapy.arch.windows.construct_source_candidate_set")
 @mock.patch("scapy.arch.windows.get_if_list")
 @mock.patch("scapy.arch.windows.dev_from_index")
 @mock.patch("scapy.arch.windows.sp.Popen")

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -50,7 +50,7 @@ def dev_from_index_custom(if_index):
     raise ValueError("Unknown network interface index %r" % if_index)
 
 @mock.patch("scapy.utils6.construct_source_candidate_set")
-@mock.patch("scapy.arch.windows.winpcapy_get_if_list")
+@mock.patch("scapy.arch.windows.get_if_list")
 @mock.patch("scapy.arch.windows.dev_from_index")
 @mock.patch("scapy.arch.windows.sp.Popen")
 def test_read_routes6_windows(mock_comm, mock_dev_from_index, mock_winpcapylist, mock_utils6cset):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -37,6 +37,17 @@ test_list_contrib()
 conf.debug_dissector = True
 
 
+###########
+###########
+= UTscapy route check
+* Check that UTscapy has correctly replaced the routes. Many tests won't work otherwise
+
+if WINDOWS:
+    route_add_loopback()
+
+IP().src
+assert _ == "127.0.0.1"
+
 ############
 ############
 + Scapy functions tests
@@ -56,7 +67,10 @@ def get_dummy_interface():
         data["win_index"] = -1
         data["guid"] = "{1XX00000-X000-0X0X-X00X-00XXXX000XXX}"
         data["invalid"] = True
-        return NetworkInterface(data)
+        dummy_int = NetworkInterface(data)
+        dummy_int.pcap_name = "\\Device\\NPF_" + data["guid"]
+        conf.cache_ipaddrs[dummy_int.pcap_name] = b'\x7f\x00\x00\x01'
+        return dummy_int
     else:
         return "dummy0"
 
@@ -3281,18 +3295,6 @@ s == b"`\x00\x00\x00\x00\x18:\x01\xfe\x80\x00\x00\x00\x00\x00\x00\xba\xca:\xff\x
 
 p = IPv6(s)
 ICMPv6MLQuery in p and p[IPv6].dst == "ff02::1"
-
-###########
-###########
-= UTscapy route check
-* Check that UTscapy has correctly replaced the routes. Many tests won't work otherwise
-
-# No more routing/networking tests after this line
-if WINDOWS:
-    route_add_loopback()
-
-IP().src
-assert _ == "127.0.0.1"
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -86,6 +86,8 @@ routes6 = read_routes6()
 if WINDOWS:
     route_add_loopback(routes6, True)
 
+routes6
+
 # Expected results:
 # - one route if there is only the loopback interface
 # - three routes if there is a network interface


### PR DESCRIPTION
This PR speeds up windows booting (by a lot on windows 7):
- pcapdnet cache
- remove useless function
- do not read routes twice in `get_working_if`
- fixes route_add_loopback
- re-uses the same powershell instance while booting by adding a Powershell Manager
- fix long IP lists (especially IPv6 possible IPs): do not crop
- minor bug fixes (python3)

Results:
```
>>> a = time.time()
...:for i in range(1,10):
...:    read_routes[6]()
...:print(time.time()-a)
```
**on Windows 10:**

|  | Normal | After `POWERSHELL_PROCESS.__init__()` (=during of after booting) |
| --|---|---|
| 10 x read_routes | 8.33999991417s | 0.571000051498s |
| 10 x read_routes6 | 9.13199996948s | 0.917000055313s |
| 10 x get_windows_if_list | 12.8439998627s | 1.46499991417s |

POWERSHELL_PROCESS auto-turns off when scapy has finished booting (this could be changed, but do we want to leave a background task powershell open ?)