### PR TITLE
[Krack windows] Add Npcap WLAN util functions: monitor mode

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -23,6 +23,7 @@ import scapy.arch
 import scapy.consts
 
 if conf.use_winpcapy:
+  NPCAP_PATH = os.environ["WINDIR"] + "\\System32\\Npcap"
   #mostly code from https://github.com/phaethon/scapy translated to python2.X
   try:
       from scapy.modules.winpcapy import *
@@ -45,7 +46,7 @@ if conf.use_winpcapy:
       # Detect Pcap version
       version = pcap_lib_version()
       if b"winpcap" in version.lower():
-          if os.path.exists(os.environ["WINDIR"] + "\\System32\\Npcap\\wpcap.dll"):
+          if os.path.exists(NPCAP_PATH + "\\wpcap.dll"):
               warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", onlyOnce=True)
           elif platform.release() != "XP":
               warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", onlyOnce=True)

--- a/scapy/modules/winpcapy.py
+++ b/scapy/modules/winpcapy.py
@@ -28,6 +28,7 @@ if WINDOWS:
     if os.path.exists(npcap_folder):
         # Try to load npcap
         os.environ['PATH'] = npcap_folder + ";" + os.environ['PATH']
+    del npcap_folder
     _lib=CDLL("wpcap.dll")
 else:
     SOCKET = c_int


### PR DESCRIPTION
This PR:
- adds a control over npcap advanced functions to edit 802.11 options
e.g.: set an interface in monitor mode.
Will be used for instance before running Krack AP: `iface.setmode(1)`