### PR TITLE
Fix sr*() functions with retry parameter

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -167,7 +167,8 @@ def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
     debug.recv = plist.PacketList([],"Unanswered")
     debug.sent = plist.PacketList([],"Sent")
     debug.match = plist.SndRcvList([])
-    nbrecv=0
+    nbrecv = 0
+    ans = []
     # do it here to fix random fields, so that parent and child have the same
     tobesent = [p for p in pkt]
     notans = len(tobesent)
@@ -189,8 +190,11 @@ def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
         )
         thread.start()
 
-        hsent, ans, nbrecv, notans = _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC, multi)
+        hsent, newans, nbrecv, notans = _sndrcv_rcv(
+            pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC, multi,
+        )
         thread.join()
+        ans.extend(newans)
 
         remain = list(itertools.chain(*six.itervalues(hsent)))
         if multi:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -934,6 +934,14 @@ ans,unans=sr(IP(dst="www.google.com/30")/TCP(dport=[80,443]),timeout=2)
 conf.debug_dissector = old_debug_dissector
 ans.make_table(lambda s_r: (s_r[0].dst, s_r[0].dport, s_r[1].sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))
 
+= Send & receive with retry
+~ netaccess IP ICMP
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / ICMP(), timeout=2, retry=1)
+conf.debug_dissector = old_debug_dissector
+len(ans) == 1 and len(unans) == 1
+
 = Traceroute function
 ~ netaccess
 * Let's test traceroute


### PR DESCRIPTION
The functions sr*(), when used with a `retry=` parameter, only return answers received during the last try.

This bug has been introduced in 730c47b (merged in #845). A new test has been added to trigger it.