### PR TITLE
Python 2/3: replace .next() method calls with next() built-in calls

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -529,7 +529,7 @@ random  choice  as  all   the  functions  building  the  packet  calls
 ``Packet.__str__()``. However, ``__str__()`` calls another method: ``build()``::
 
     def __str__(self):
-        return self.__iter__().next().build()
+        return next(iter(self)).build()
 
 What is important also to understand  is that usually, you do not care
 about the machine  representation, that is why the  human and internal

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -60,7 +60,7 @@ conf.netcache.new_cache("arp_cache", 120) # cache entries expire after 120s
 def getmacbyip(ip, chainCC=0):
     """Return MAC address corresponding to a given IP address"""
     if isinstance(ip, Net):
-        ip = iter(ip).next()
+        ip = next(iter(ip))
     ip = inet_ntoa(inet_aton(ip))
     tmp = [orb(e) for e in inet_aton(ip)]
     if (tmp[0] & 0xf0) == 0xe0: # mcast @
@@ -299,7 +299,7 @@ class ARP(Packet):
     def route(self):
         dst = self.pdst
         if isinstance(dst,Gen):
-            dst = iter(dst).next()
+            dst = next(iter(dst))
         return conf.route.route(dst)
     def extract_padding(self, s):
         return "",s

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -151,7 +151,7 @@ class RandEnum(RandNum):
     def __init__(self, min, max, seed=None):
         self.seq = RandomEnumeration(min,max,seed)
     def _fix(self):
-        return self.seq.next()
+        return next(self.seq)
 
 class RandByte(RandNum):
     def __init__(self):
@@ -224,7 +224,7 @@ class RandEnumKeys(RandEnum):
         self.seq = RandomEnumeration(0, len(self.enum) - 1, seed)
 
     def _fix(self):
-        return self.enum[self.seq.next()]
+        return self.enum[next(self.seq)]
 
 class RandChoice(RandField):
     def __init__(self, *args):


### PR DESCRIPTION
Fixes #936