### PR TITLE
Fix Dot11WEP icv in Python2

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -313,7 +313,7 @@ class Dot11WEP(Packet):
             key = conf.wepkey
         if key:
             if self.icv is None:
-                pay += struct.pack("<I", crc32(pay))
+                pay += struct.pack("<I", crc32(pay) & 0xffffffff)
                 icv = b""
             else:
                 icv = p[4:8]


### PR DESCRIPTION
The method crc32 may return nagative value in python2, made it unsigned.