### PR TITLE
Fix TLS default behaviour

### DIFF
--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -119,7 +119,8 @@ class _TLSMsgListField(PacketListField):
             remain, ret = s[:l], s[l:]
 
         if remain == b"":
-            if pkt.tls_session.tls_version > 0x0200 and pkt.type == 23:
+            if ((pkt.tls_session.tls_version or 0x0303 > 0x0200) and
+                hasattr(pkt, "type") and pkt.type == 23):
                 return ret, [TLSApplicationData(data=b"")]
             else:
                 return ret, [Raw(load=b"")]
@@ -182,7 +183,7 @@ class _TLSMsgListField(PacketListField):
         for p in val:
             res += self.i2m(pkt, p)
         if (isinstance(pkt, _GenericTLSSessionInheritance) and
-            pkt.tls_session.tls_version >= 0x0304 and
+            (pkt.tls_session.tls_version or 0x0303 >= 0x0304) and
             not isinstance(pkt, TLS13ServerHello)):
                 return s + res
         if not pkt.type:

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1069,7 +1069,7 @@ raw(t) == b'\xde\xad\xbe\xef\xff\x01'
 
 
 = Building packets - TLS record with bad data
-a = TLS(b'\x00\x03\x03\x00\x03data')
+a = TLS(b'\x17\x03\x03\x00\x03data')
 assert a.haslayer(Raw)
 
 


### PR DESCRIPTION
This should fix #945. However, TLS being a complex protocol, I don't think we can cover every Error which might rise from the parsing of random packets. That's why I changed the test which used a non-valid (zero) record type.

(@gpotter2 I happened to come here but I won't be involved much further in scapy development.)