### PR TITLE
Python3 - Use '.' instead of 'source'

### DIFF
--- a/run_scapy_py2
+++ b/run_scapy_py2
@@ -1,3 +1,3 @@
 #! /bin/sh
 PYTHON=python2
-source $(dirname $0)/run_scapy "$@"
+. $(dirname $0)/run_scapy "$@"

--- a/run_scapy_py3
+++ b/run_scapy_py3
@@ -1,3 +1,3 @@
 #! /bin/sh
 PYTHON=python3
-source $(dirname $0)/run_scapy "$@"
+. $(dirname $0)/run_scapy "$@"


### PR DESCRIPTION
This PR replaces the `source` keyword with the more generic `.`.

FTR, on Ubuntu `/bin/sh` is Dash, and does not support `source`.