### PR TITLE
style: consistently space `ans, unans =`

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -266,7 +266,7 @@ Now, let's try to do some fun things. The sr() function is for sending packets a
 
 ::
 
-    >>> p=sr1(IP(dst="www.slashdot.org")/ICMP()/"XXXXXXXXXXX")
+    >>> p = sr1(IP(dst="www.slashdot.org")/ICMP()/"XXXXXXXXXXX")
     Begin emission:
     ...Finished to send 1 packets.
     .*
@@ -325,7 +325,7 @@ The "send'n'receive" functions family is the heart of scapy. They return a coupl
     >>> sr(IP(dst="192.168.8.1")/TCP(dport=[21,22,23]))
     Received 6 packets, got 3 answers, remaining 0 packets
     (<Results: UDP:0 TCP:3 ICMP:0 Other:0>, <Unanswered: UDP:0 TCP:0 ICMP:0 Other:0>)
-    >>> ans,unans=_
+    >>> ans, unans = _
     >>> ans.summary()
     IP / TCP 192.168.8.14:20 > 192.168.8.1:21 S ==> Ether / IP / TCP 192.168.8.1:21 > 192.168.8.14:20 RA / Padding
     IP / TCP 192.168.8.14:20 > 192.168.8.1:22 S ==> Ether / IP / TCP 192.168.8.1:22 > 192.168.8.14:20 RA / Padding
@@ -379,7 +379,7 @@ or
 
 In order to quickly review responses simply request a summary of collected packets::
 
-    >>> ans,unans = _
+    >>> ans, unans = _
     >>> ans.summary()
     IP / TCP 192.168.1.100:ftp-data > 192.168.1.1:440 S ======> IP / TCP 192.168.1.1:440 > 192.168.1.100:ftp-data RA / Padding
     IP / TCP 192.168.1.100:ftp-data > 192.168.1.1:441 S ======> IP / TCP 192.168.1.1:441 > 192.168.1.100:ftp-data RA / Padding
@@ -396,7 +396,7 @@ The above will display stimulus/response pairs for answered probes. We can displ
 
 Even better, a table can be built using the ``make_table()`` function to display information about multiple targets::
 
-    >>> ans,unans = sr(IP(dst=["192.168.1.1","yahoo.com","slashdot.org"])/TCP(dport=[22,80,443],flags="S"))
+    >>> ans, unans = sr(IP(dst=["192.168.1.1","yahoo.com","slashdot.org"])/TCP(dport=[22,80,443],flags="S"))
     Begin emission:
     .......*.**.......Finished to send 9 packets.
     **.*.*..*..................
@@ -449,7 +449,7 @@ TCP traceroute
 
 A TCP traceroute::
 
-    >>> ans,unans=sr(IP(dst=target, ttl=(4,25),id=RandShort())/TCP(flags=0x2))
+    >>> ans, unans = sr(IP(dst=target, ttl=(4,25),id=RandShort())/TCP(flags=0x2))
     *****.******.*.***..*.**Finished to send 22 packets.
     ***......
     Received 33 packets, got 21 answers, remaining 1 packets
@@ -855,7 +855,7 @@ Now we have a demonstration of the ``make_table()`` presentation function. It ta
 
 Here we can see a multi-parallel traceroute (scapy already has a multi TCP traceroute function. See later)::
 
-    >>> ans,unans=sr(IP(dst="www.test.fr/30", ttl=(1,6))/TCP())
+    >>> ans, unans = sr(IP(dst="www.test.fr/30", ttl=(1,6))/TCP())
     Received 49 packets, got 24 answers, remaining 0 packets
     >>> ans.make_table( lambda (s,r): (s.dst, s.ttl, r.src) )
       216.15.189.192  216.15.189.193  216.15.189.194  216.15.189.195  
@@ -870,7 +870,7 @@ Here is a more complex example to identify machines from their IPID field. We ca
 
 ::
 
-    >>> ans,unans=sr(IP(dst="172.20.80.192/28")/TCP(dport=[20,21,22,25,53,80]))
+    >>> ans, unans = sr(IP(dst="172.20.80.192/28")/TCP(dport=[20,21,22,25,53,80]))
     Received 142 packets, got 25 answers, remaining 71 packets
     >>> ans.make_table(lambda (s,r): (s.dst, s.dport, r.sprintf("%IP.id%")))
        172.20.80.196 172.20.80.197 172.20.80.198 172.20.80.200 172.20.80.201 
@@ -921,7 +921,7 @@ Gnuplot
 We can easily plot some harvested values using Gnuplot. (Make sure that you have Gnuplot-py and Gnuplot installed.)
 For example, we can observe the IP ID patterns to know how many distinct IP stacks are used behind a load balancer::
 
-    >>> a,b=sr(IP(dst="www.target.com")/TCP(sport=[RandShort()]*1000))
+    >>> a, b = sr(IP(dst="www.target.com")/TCP(sport=[RandShort()]*1000))
     >>> a.plot(lambda x:x[1].id)
     <Gnuplot._Gnuplot.Gnuplot instance at 0xb7d6a74c>
 
@@ -963,7 +963,7 @@ Scapy also has a powerful TCP traceroute function. Unlike other traceroute progr
 
 The last line is in fact a the result of the function : a traceroute result object and a packet list of unanswered packets. The traceroute result is a more specialised version (a subclass, in fact) of a classic result object. We can save it to consult the traceroute result again a bit later, or to deeply inspect one of the answers, for example to check padding.
 
-    >>> result,unans=_
+    >>> result, unans = _
     >>> result.show()
        193.45.10.88:80    216.109.118.79:80  64.241.242.243:80  66.94.229.254:80   
     1  192.168.8.1        192.168.8.1        192.168.8.1        192.168.8.1        
@@ -974,7 +974,7 @@ The last line is in fact a the result of the function : a traceroute result obje
 
 Like any result object, traceroute objects can be added :
 
-    >>> r2,unans=traceroute(["www.voila.com"],maxttl=20)
+    >>> r2, unans = traceroute(["www.voila.com"],maxttl=20)
     Received 19 packets, got 19 answers, remaining 1 packets
        195.101.94.25:80   
     1  192.168.8.1        
@@ -1023,7 +1023,7 @@ Like any result object, traceroute objects can be added :
 
 Traceroute result object also have a very neat feature: they can make a directed graph from all the routes they got, and cluster them by AS. You will need graphviz. By default, ImageMagick is used to display the graph.
 
-    >>> res,unans = traceroute(["www.microsoft.com","www.cisco.com","www.yahoo.com","www.wanadoo.fr","www.pacsec.com"],dport=[80,443],maxttl=20,retry=-2)
+    >>> res, unans = traceroute(["www.microsoft.com","www.cisco.com","www.yahoo.com","www.wanadoo.fr","www.pacsec.com"],dport=[80,443],maxttl=20,retry=-2)
     Received 190 packets, got 190 answers, remaining 10 packets
        193.252.122.103:443 193.252.122.103:80 198.133.219.25:443 198.133.219.25:80  207.46...
     1  192.168.8.1         192.168.8.1        192.168.8.1        192.168.8.1        192.16...
@@ -1083,7 +1083,7 @@ ACK Scan
 Using Scapy's powerful packet crafting facilities we can quick replicate classic TCP Scans.
 For example, the following string will be sent to simulate an ACK Scan::
 
-    >>> ans,unans = sr(IP(dst="www.slashdot.org")/TCP(dport=[80,666],flags="A"))
+    >>> ans, unans = sr(IP(dst="www.slashdot.org")/TCP(dport=[80,666],flags="A"))
 
 We can find unfiltered ports in answered packets::
 
@@ -1102,7 +1102,7 @@ Xmas Scan
 
 Xmas Scan can be launched using the following command::
 
-    >>> ans,unans = sr(IP(dst="192.168.1.1")/TCP(dport=666,flags="FPU") )
+    >>> ans, unans = sr(IP(dst="192.168.1.1")/TCP(dport=666,flags="FPU") )
 
 Checking RST responses will reveal closed ports on the target. 
 
@@ -1111,7 +1111,7 @@ IP Scan
 
 A lower level IP Scan can be used to enumerate supported protocols::
 
-    >>> ans,unans=sr(IP(dst="192.168.1.1",proto=(0,255))/"SCAPY",retry=2)
+    >>> ans, unans = sr(IP(dst="192.168.1.1",proto=(0,255))/"SCAPY",retry=2)
 
 
 ARP Ping
@@ -1119,7 +1119,7 @@ ARP Ping
 
 The fastest way to discover hosts on a local ethernet network is to use the ARP Ping method::
 
-    >>> ans,unans=srp(Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(pdst="192.168.1.0/24"),timeout=2)
+    >>> ans, unans = srp(Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(pdst="192.168.1.0/24"),timeout=2)
 
 Answers can be reviewed with the following command::
 
@@ -1135,7 +1135,7 @@ ICMP Ping
 
 Classical ICMP Ping can be emulated using the following command::
 
-    >>> ans,unans=sr(IP(dst="192.168.1.1-254")/ICMP())
+    >>> ans, unans = sr(IP(dst="192.168.1.1-254")/ICMP())
 
 Information on live hosts can be collected with the following request::
 
@@ -1147,7 +1147,7 @@ TCP Ping
 
 In cases where ICMP echo requests are blocked, we can still use various TCP Pings such as TCP SYN Ping below::
 
-    >>> ans,unans=sr( IP(dst="192.168.1.*")/TCP(dport=80,flags="S") )
+    >>> ans, unans = sr( IP(dst="192.168.1.*")/TCP(dport=80,flags="S") )
 
 Any response to our probes will indicate a live host. We can collect results with the following command::
 
@@ -1159,7 +1159,7 @@ UDP Ping
 
 If all else fails there is always UDP Ping which will produce ICMP Port unreachable errors from live hosts. Here you can pick any port which is most likely to be closed, such as port 0::
 
-    >>> ans,unans=sr( IP(dst="192.168.*.1-10")/UDP(dport=0) )
+    >>> ans, unans = sr( IP(dst="192.168.*.1-10")/UDP(dport=0) )
 
 Once again, results can be collected with this command:
 
@@ -1209,7 +1209,7 @@ TCP Port Scanning
  
 Send a TCP SYN on each port. Wait for a SYN-ACK or a RST or an ICMP error:: 
 
-    >>> res,unans = sr( IP(dst="target") 
+    >>> res, unans = sr( IP(dst="target") 
                     /TCP(flags="S", dport=(1,1024)) ) 
 
 Possible result visualization: open ports
@@ -1225,7 +1225,7 @@ IKE Scanning
 We try to identify VPN concentrators by sending ISAKMP Security Association proposals
 and receiving the answers::
 
-    >>> res,unans = sr( IP(dst="192.168.1.*")/UDP()
+    >>> res, unans = sr( IP(dst="192.168.1.*")/UDP()
                     /ISAKMP(init_cookie=RandString(8), exch_type="identity prot.") 
                     /ISAKMP_payload_SA(prop=ISAKMP_payload_Proposal()) 
                   ) 
@@ -1244,7 +1244,7 @@ TCP SYN traceroute
 
 ::
 
-    >>> ans,unans=sr(IP(dst="4.2.2.1",ttl=(1,10))/TCP(dport=53,flags="S"))
+    >>> ans, unans = sr(IP(dst="4.2.2.1",ttl=(1,10))/TCP(dport=53,flags="S"))
 
 Results would be::
 
@@ -1265,7 +1265,7 @@ Tracerouting an UDP application like we do with TCP is not
 reliable, because there's no handshake. We need to give an applicative payload (DNS, ISAKMP, 
 NTP, etc.) to deserve an answer::
 
-    >>> res,unans = sr(IP(dst="target", ttl=(1,20))
+    >>> res, unans = sr(IP(dst="target", ttl=(1,20))
                   /UDP()/DNS(qd=DNSQR(qname="test.com")) 
 
 We can visualize the results as a list of routers::
@@ -1278,7 +1278,7 @@ DNS traceroute
 
 We can perform a DNS traceroute by specifying a complete packet in ``l4`` parameter of ``traceroute()`` function::
 
-    >>> ans,unans=traceroute("4.2.2.1",l4=UDP(sport=RandShort())/DNS(qd=DNSQR(qname="thesprawl.org")))
+    >>> ans, unans = traceroute("4.2.2.1",l4=UDP(sport=RandShort())/DNS(qd=DNSQR(qname="thesprawl.org")))
     Begin emission:
     ..*....******...******.***...****Finished to send 30 packets.
     *****...***...............................
@@ -1487,7 +1487,7 @@ ISN
 
 Scapy can be used to analyze ISN (Initial Sequence Number) increments to possibly discover vulnerable systems. First we will collect target responses by sending a number of SYN probes in a loop::
 
-    >>> ans,unans=srloop(IP(dst="192.168.1.1")/TCP(dport=80,flags="S"))
+    >>> ans, unans = srloop(IP(dst="192.168.1.1")/TCP(dport=80,flags="S"))
 
 Once we obtain a reasonable number of responses we can start analyzing collected data with something like this:
 


### PR DESCRIPTION
When I was reading the docs online I had trouble discerning between `ans.unans` and `ans,unans` because of the font. As a result I mistakenly initially assumed that unans was a property on an object ans. Thinking about it and scrolling through the docs did clear it up somewhat trivially though.

In the hope to prevent others from making the same mistake I've taken the liberty to make insert a space where it was missing.