### PR TITLE
Fix L2ListenTcpdump tests (windows)

### DIFF
--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -14,7 +14,7 @@ import struct
 import time
 
 from scapy.config import conf
-from scapy.consts import LINUX, OPENBSD, BSD
+from scapy.consts import LINUX, OPENBSD, BSD, DARWIN, WINDOWS
 from scapy.data import *
 from scapy.compat import *
 from scapy.error import warning, log_runtime
@@ -199,8 +199,8 @@ class L2ListenTcpdump(SuperSocket):
                     args.extend(['-i', iface])
             else:
                 args.extend(['-i', iface])
-        elif WINDOWS:
-            args.extend(['-i', conf.iface.pcap_name])
+        elif WINDOWS or DARWIN:
+            args.extend(['-i', conf.iface.pcap_name if WINDOWS else conf.iface])
         if not promisc:
             args.append('-p')
         if not nofilter:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1032,10 +1032,18 @@ send_and_sniff(IP(dst="secdev.org")/ICMP())
 send_and_sniff(IP(dst="secdev.org")/ICMP(), flt="icmp")
 send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 
-a = L2ListenTcpdump()
-icmp_r = IP(dst="secdev.org")/ICMP()
-send_and_sniff(icmp_r, timeout=10, opened_socket=a)
-a.close()
+= Test L2ListenTcpdump socket
+~ netaccess
+
+read_s = L2ListenTcpdump()
+out_s = conf.L2socket()
+icmp_r = Ether()/IP(dst="secdev.org")/ICMP()
+res = sndrcv(out_s, icmp_r, timeout=5, rcv_pks=read_s)
+read_s.close()
+out_s.close()
+
+response = res[0][0][1]
+assert response[ICMP].type == 0
 
 ############
 ############


### PR DESCRIPTION
This PR:
- fixes the often failing TCPdump test on **windows**
- fixes OSX crashing on longer term https://github.com/secdev/scapy/pull/970
- may be used as an easy workaround in https://github.com/secdev/scapy/issues/870