### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1329,7 +1329,7 @@ Wireless sniffing
 
 The following command will display information similar to most wireless sniffers::
 
->>> sniff(iface="ath0",prn=lambda x:x.sprintf("{Dot11Beacon:%Dot11.addr3%\t%Dot11Beacon.info%\t%PrismHeader.channel%\tDot11Beacon.cap%}"))
+>>> sniff(iface="ath0",prn=lambda x:x.sprintf("{Dot11Beacon:%Dot11.addr3%\t%Dot11Beacon.info%\t%PrismHeader.channel%\t%Dot11Beacon.cap%}"))
 
 The above command will produce output similar to the one below::
 


### PR DESCRIPTION
Fix a typo the usage section of the documentation. I happen to find this while running the test in documentation which gave me an error.