### PR TITLE
Add restart() command

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -63,6 +63,15 @@ def sane(x):
             r=r+chr(j)
     return r
 
+@conf.commands.register
+def restart():
+    """Restarts scapy"""
+    if not conf.interactive or not os.path.isfile(sys.argv[0]):
+        raise OSError("Scapy was not started from console")
+    if WINDOWS:
+        os._exit(subprocess.call([sys.executable] + sys.argv))
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
 def lhex(x):
     if type(x) in six.integer_types:
         return hex(x)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -241,6 +241,30 @@ assert(lhex(42) == "0x2a")
 assert(lhex((28,7)) == "(0x1c, 0x7)")
 assert(lhex([28,7]) == "[0x1c, 0x7]")
 
+= Test restart function
+import mock
+conf.interactive = True
+
+try:
+    from scapy.utils import restart
+    import os
+    @mock.patch("os.execv")
+    @mock.patch("subprocess.call")
+    @mock.patch("os._exit")
+    def _test(e, m, m2):
+        def check(x, y=[]):
+            z = [x] + y if not isinstance(x, list) else x + y
+            assert os.path.isfile(z[0])
+            assert os.path.isfile(z[1])
+            return 0
+        m2.side_effect = check
+        m.side_effect = check
+        e.side_effect = lambda x: None
+        restart()
+    _test()
+finally:
+    conf.interactive = False
+
 = Test linehexdump function
 conf_color_theme = conf.color_theme
 conf.color_theme = BlackAndWhite()


### PR DESCRIPTION
Incredibly useful while testing: this re-loads and restart scapy.

The process is overwriten using python API