### PR TITLE
More accurate ContextManagerSubprocess error messages

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -497,7 +497,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
         if filename is None:
             fname = get_temp_file(autoext=".eps")
             canvas.writeEPSfile(fname)
-            with ContextManagerSubprocess("psdump()"):
+            with ContextManagerSubprocess("psdump()", conf.prog.psreader):
                 subprocess.Popen([conf.prog.psreader, fname])
         else:
             canvas.writeEPSfile(filename)
@@ -515,7 +515,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
         if filename is None:
             fname = get_temp_file(autoext=".pdf")
             canvas.writePDFfile(fname)
-            with ContextManagerSubprocess("pdfdump()"):
+            with ContextManagerSubprocess("pdfdump()", conf.prog.pdfreader):
                 subprocess.Popen([conf.prog.pdfreader, fname])
         else:
             canvas.writePDFfile(filename)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -429,10 +429,9 @@ class ContextManagerSubprocess(object):
     >>>     subprocess.Popen(["unknown_command"])
 
     """
-    def __init__(self, name, prog, _raise=True):
+    def __init__(self, name, prog):
         self.name = name
         self.prog = prog
-        self._raise = _raise
 
     def __enter__(self):
         pass
@@ -440,7 +439,7 @@ class ContextManagerSubprocess(object):
     def __exit__(self, exc_type, exc_value, traceback):
         if isinstance(exc_value, (OSError, TypeError)):
             msg = "%s: executing %r failed" % (self.name, self.prog) if self.prog else "Could not execute %s, is it installed ?" % self.name
-            if self._raise:
+            if not conf.interactive:
                 raise OSError(msg)
             else:
                 log_runtime.error(msg, exc_info=True)
@@ -505,7 +504,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
             target = get_temp_file(autoext="."+format)
             start_viewer = True
         else:
-            with ContextManagerSubprocess("do_graph()", conf.prog.display, _raise=False):
+            with ContextManagerSubprocess("do_graph()", conf.prog.display):
                 target = subprocess.Popen([conf.prog.display],
                                           stdin=subprocess.PIPE).stdin
     if format is not None:


### PR DESCRIPTION
Now prints messages such as:
```
>>> tcpdump(None)
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-2-cc1b8638924f> in <module>()
----> 1 tcpdump(None)

Z:\Coding\github\scapy\scapy\utils.py in tcpdump(pktlist, dump, getfd, args, prog, getproc, quiet)
   1280                 prog + (args if args is not None else []),
   1281                 stdout=subprocess.PIPE if dump or getfd else None,
-> 1282                 stderr=open(os.devnull) if quiet else None,
   1283             )
   1284     elif isinstance(pktlist, six.string_types):

Z:\Coding\github\scapy\scapy\utils.py in __exit__(self, exc_type, exc_value, traceback)
    442             msg = "%s: executing %r failed" % (self.name, self.prog) if self.prog else "Could not execute %s, is it installed ?" % self.name
    443             if self._raise:
--> 444                 raise OSError(msg)
    445             else:
    446                 log_runtime.error(msg, exc_info=True)

OSError: Could not execute windump(), is it installed ?
```

Instead of
`TypeError: argument of type 'NoneType' is not iterable`
https://github.com/secdev/scapy/issues/981
or
https://github.com/secdev/scapy/issues/999 (before it was edited, it was the same bug than the previous issue).
