### PR TITLE
Fix get_if_list() undefined error when importing in Windows without winpcap

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -101,6 +101,9 @@ if conf.use_winpcapy:
           iflist = winpcapy_get_if_list()
           conf.cache_iflist = iflist
           return iflist
+  else:
+    get_if_list = winpcapy_get_if_list
+
   def in6_getifaddr_raw():
     """Returns all available IPv6 on the computer, read from winpcap."""
     err = create_string_buffer(PCAP_ERRBUF_SIZE)


### PR DESCRIPTION
I get "get_if_list() undefined" error from "from scapy.all import *" in either python 2.7 or 3.6. This fixes the error in python 3.6

PS: first time creating a pull request. Hopefully I didn't mees things up.