### PR TITLE
TLS automaton PY3 fixes

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,7 +27,7 @@ if [ ! -z $SCAPY_USE_PCAPDNET ]
 then
   if [ "$TRAVIS_OS_NAME" = "linux" ]
   then
-    $SCAPY_SUDO apt-get install python-libpcap python-dumbnet openssl
+    $SCAPY_SUDO apt-get install python-libpcap python-dumbnet
   elif [ "$TRAVIS_OS_NAME" = "osx" ]
   then
     mkdir -p /Users/travis/Library/Python/2.7/lib/python/site-packages
@@ -42,5 +42,5 @@ fi
 # Install wireshark data
 if [ ! -z "$SCAPY_SUDO" ] && [ "$TRAVIS_OS_NAME" = "linux" ]
 then
-  $SCAPY_SUDO apt-get install libwireshark-data
+  $SCAPY_SUDO apt-get install libwireshark-data openssl
 fi

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1460,7 +1460,10 @@ class UTCTimeField(IntField):
         elif self.use_nano:
             x = x/1e9
         x = int(x) + self.delta
-        t = time.strftime(self.strf, time.gmtime(x))
+        try:
+            t = time.strftime(self.strf, time.gmtime(x))
+        except:
+            t = "error"
         return "%s (%d)" % (t, x)
     def i2m(self, pkt, x):
         return int(x) if x != None else 0

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -119,7 +119,7 @@ class TLSServerAutomaton(_TLSAutomaton):
         s += "Master secret : %s\n" % repr_hex(ms)
         body = "<html><body><pre>%s</pre></body></html>\r\n\r\n" % s
         answer = (header+body) % len(body)
-        return answer
+        return answer.encode()
 
 
     @ATMT.state(initial=True)
@@ -487,14 +487,14 @@ class TLSServerAutomaton(_TLSAutomaton):
         p = self.buffer_in[0]
         self.buffer_in = self.buffer_in[1:]
 
-        recv_data = ""
+        recv_data = b""
         if isinstance(p, TLSApplicationData):
             print("> Received: %s" % p.data)
             recv_data = p.data
-            lines = recv_data.split("\n")
+            lines = recv_data.split(b"\n")
             stop = False
             for l in lines:
-                if l.startswith("stop_server"):
+                if l.startswith(b"stop_server"):
                     stop = True
                     break
             if stop:
@@ -505,10 +505,10 @@ class TLSServerAutomaton(_TLSAutomaton):
         else:
             print("> Received: %r" % p)
 
-        if recv_data.startswith("GET / HTTP/1.1"):
+        if recv_data.startswith(b"GET / HTTP/1.1"):
             p = TLSApplicationData(data=self.http_sessioninfo())
 
-        if self.is_echo_server or recv_data.startswith("GET / HTTP/1.1"):
+        if self.is_echo_server or recv_data.startswith(b"GET / HTTP/1.1"):
             self.add_record()
             self.add_msg(p)
             raise self.ADDED_SERVERDATA()
@@ -797,20 +797,20 @@ class TLSServerAutomaton(_TLSAutomaton):
             cli_data = str(p)
             print("> Received: %r" % p)
 
-        lines = cli_data.split("\n")
+        lines = cli_data.split(b"\n")
         stop = False
         for l in lines:
-            if l.startswith("stop_server"):
+            if l.startswith(b"stop_server"):
                 stop = True
                 break
         if stop:
             raise self.SSLv2_CLOSE_NOTIFY_FINAL()
 
-        answer = ""
-        if cli_data.startswith("GET / HTTP/1.1"):
+        answer = b""
+        if cli_data.startswith(b"GET / HTTP/1.1"):
             p = Raw(self.http_sessioninfo())
 
-        if self.is_echo_server or recv_data.startswith("GET / HTTP/1.1"):
+        if self.is_echo_server or recv_data.startswith(b"GET / HTTP/1.1"):
             self.add_record(is_sslv2=True)
             self.add_msg(p)
             raise self.SSLv2_ADDED_SERVERDATA()

--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -271,14 +271,14 @@ class PRF(object):
             if self.tls_version <= 0x0302:
                 s1 = _tls_hash_algs["MD5"]().digest(handshake_msg)
                 s2 = _tls_hash_algs["SHA"]().digest(handshake_msg)
-                verify_data = self.prf(master_secret, label, s1 + s2, 12)
+                verify_data = self.prf(master_secret, label.encode(), s1 + s2, 12)
             else:
                 if self.hash_name in ["MD5", "SHA"]:
                     h = _tls_hash_algs["SHA256"]()
                 else:
                     h = _tls_hash_algs[self.hash_name]()
                 s = h.digest(handshake_msg)
-                verify_data = self.prf(master_secret, label, s, 12)
+                verify_data = self.prf(master_secret, label.encode(), s, 12)
 
         return verify_data
 
@@ -306,7 +306,7 @@ class PRF(object):
             else:
                 tag = "server write key"
             export_key = self.prf(key,
-                                  tag,
+                                  tag.encode(),
                                   client_random + server_random,
                                   req_len)
         return export_key
@@ -331,7 +331,7 @@ class PRF(object):
             iv = _tls_hash_algs["MD5"]().digest(tbh)[:req_len]
         else:
             iv_block = self.prf("",
-                                "IV block",
+                                b"IV block",
                                 client_random + server_random,
                                 2*req_len)
             if s:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -192,14 +192,11 @@ class L2ListenTcpdump(SuperSocket):
         self.outs = None
         args = ['-w', '-', '-s', '65535']
         if iface is not None:
-            if WINDOWS:
-                try:
-                    args.extend(['-i', iface.pcap_name])
-                except AttributeError:
-                    args.extend(['-i', iface])
-            else:
+            try:
+                args.extend(['-i', iface.pcap_name])
+            except AttributeError:
                 args.extend(['-i', iface])
-        elif WINDOWS or DARWIN:
+        else:  # For safety, we don't let tcpdump decide which iface to use
             args.extend(['-i', conf.iface.pcap_name if WINDOWS else conf.iface])
         if not promisc:
             args.append('-p')

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -18,7 +18,7 @@ sys.path.append(os.path.abspath("./tls"))
 from travis_test_server import *
 
 def test_tls_server(suite="", version=""):
-    msg = "TestS_" + suite + "_data"
+    msg = "TestS_%s_data" % suite
     # Run server
     q_ = multiprocessing.Manager().Queue()
     th_ = multiprocessing.Process(target=run_tls_test_server, args=(msg, q_))
@@ -30,9 +30,9 @@ def test_tls_server(suite="", version=""):
     CA_f = os.path.abspath("./tls/pki/ca_cert.pem")
     p = subprocess.Popen("openssl s_client -cipher " + suite + " " + version + " -CAfile " + CA_f, stdout=subprocess.PIPE, universal_newlines=True,
                             stdin=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
-    msg += b"\nstop_server"
+    msg += "\nstop_server"
     out, err = p.communicate(input=msg)
-    print out
+    print(out)
     if p.returncode != 0:
         th_.terminate()
         raise RuntimeError("OpenSSL returned with error code")
@@ -55,7 +55,7 @@ def test_tls_server(suite="", version=""):
         th_.terminate()
         raise RuntimeError("Test timed out")
     # Analyse values
-    print q_.get()
+    print(q_.get())
     assert th_.exitcode == 0
     
 
@@ -83,7 +83,8 @@ test_tls_server("ECDHE-RSA-AES256-GCM-SHA384", "-tls1_2")
 
 = Load client utils functions
 
-import sys, os, threading, Queue
+import sys, os, threading
+from scapy.modules.six.moves.queue import Queue
 
 sys.path.append(os.path.abspath("./tls"))
 
@@ -91,18 +92,18 @@ from travis_test_client import *
 
 def perform_tls_client_test(suite, version):
     # Run test_tls_client in an other thread
-    q = Queue.Queue()
+    q = Queue()
     p = threading.Thread(target=test_tls_client, args=(suite, version, q))
     p.start()
     # Wait for the function to end
     p.join()
     # Analyse data and return
     if not q.empty():
-        print q.get()
+        print(q.get())
     if not q.empty():
         assert q.get() == 0
     else:
-        print "ERROR: Missing one of the return value detected !"
+        print("ERROR: Missing one of the return value detected !")
         assert False
 
 = Testing TLS server and client with SSLv2 and SSL_CK_DES_192_EDE3_CBC_WITH_MD5


### PR DESCRIPTION
- Complement to https://github.com/secdev/scapy/pull/861
- Fixes TLS automaton for Python 3
- Fixes some crashes occuring on L2ListenTcpdump socket