### PR TITLE
add support for encapsulating Ethernet frame in MPLS

### DIFF
--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -16,7 +16,7 @@
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers, Padding
-from scapy.fields import BitField,ByteField
+from scapy.fields import BitField,ByteField,ShortField
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IPv6
 from scapy.layers.l2 import Ether, GRE

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -33,27 +33,27 @@ class EoMCW(Packet):
         return Padding
 
 class MPLS(Packet):
-    name = "MPLS"
-    fields_desc = [ BitField("label", 3, 20),
+   name = "MPLS"
+   fields_desc =  [ BitField("label", 3, 20),
                     BitField("cos", 0, 3),
                     BitField("s", 1, 1),
-                    ByteField("ttl", 0) ]
+                    ByteField("ttl", 0)  ]
 
-    def guess_payload_class(self, payload):
-        if len(payload) >= 1:
-            if not self.s:
-               return MPLS
-            ip_version = (orb(payload[0]) >> 4) & 0xF
-            if ip_version == 4:
-                return IP
-            elif ip_version == 6:
-                return IPv6
-            else:
-                if orb(payload[0]) == 0 and orb(payload[1]) == 0:
-                    return EoMCW
-                else:
-                    return Ether
-        return Padding
+   def guess_payload_class(self, payload):
+       if len(payload) >= 1:
+           if not self.s:
+              return MPLS
+           ip_version = (orb(payload[0]) >> 4) & 0xF
+           if ip_version == 4:
+               return IP
+           elif ip_version == 6:
+               return IPv6
+           else:
+               if orb(payload[0]) == 0 and orb(payload[1]) == 0:
+                   return EoMCW
+               else:
+                   return Ether
+       return Padding
 
 bind_layers(Ether, MPLS, type=0x8847)
 bind_layers(GRE, MPLS, proto=0x8847)

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -22,24 +22,41 @@ from scapy.layers.inet6 import IPv6
 from scapy.layers.l2 import Ether, GRE
 from scapy.compat import orb
 
+class EoMCW(Packet):
+    name = "EoMCW"
+    fields_desc = [ BitField("zero", 0, 4),
+                    BitField("reserved", 0, 12),
+                    ShortField("seq", 0) ]
+    def guess_payload_class(self, payload):
+        if len(payload) >= 1:
+            return Ether
+        return Padding
+
 class MPLS(Packet):
-   name = "MPLS"
-   fields_desc =  [ BitField("label", 3, 20),
+    name = "MPLS"
+    fields_desc = [ BitField("label", 3, 20),
                     BitField("cos", 0, 3),
                     BitField("s", 1, 1),
-                    ByteField("ttl", 0)  ]
+                    ByteField("ttl", 0) ]
 
-   def guess_payload_class(self, payload):
-       if len(payload) >= 1:
-           if not self.s:
-              return MPLS
-           ip_version = (orb(payload[0]) >> 4) & 0xF
-           if ip_version == 4:
-               return IP
-           elif ip_version == 6:
-               return IPv6
-       return Padding
+    def guess_payload_class(self, payload):
+        if len(payload) >= 1:
+            if not self.s:
+               return MPLS
+            ip_version = (orb(payload[0]) >> 4) & 0xF
+            if ip_version == 4:
+                return IP
+            elif ip_version == 6:
+                return IPv6
+            else:
+                if orb(payload[0]) == 0 and orb(payload[1]) == 0:
+                    return EoMCW
+                else:
+                    return Ether
+        return Padding
 
 bind_layers(Ether, MPLS, type=0x8847)
 bind_layers(GRE, MPLS, proto=0x8847)
 bind_layers(MPLS, MPLS, s=0)
+bind_layers(MPLS, EoMCW)
+bind_layers(EoMCW, Ether, zero=0, reserved=0)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -9281,7 +9281,7 @@ assert(pkt.ByteCount == 1)
 + MPLS tests
 
 = MPLS - build/dissection
-from scapy.contrib.mpls import MPLS
+from scapy.contrib.mpls import EoMCW, MPLS
 p1 = MPLS()/IP()/UDP()
 assert(p1[MPLS].s == 1)
 p2 = MPLS()/MPLS()/IP()/UDP()
@@ -9293,6 +9293,56 @@ p2[MPLS]
 p2[MPLS:1]
 p2[IP]
 
+= MPLS encapsulated Ethernet with CW - build/dissection
+p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
+p /= MPLS(label=1)/EoMCW(seq=1234)
+p /= Ether(dst="33:33:33:33:33:33", src="44:44:44:44:44:44")/IP()
+p = Ether(raw(p))
+assert(p[EoMCW].zero == 0)
+assert(p[EoMCW].reserved == 0)
+assert(p[EoMCW].seq == 1234)
+
+=  MPLS encapsulated Ethernet without CW - build/dissection
+p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
+p /= MPLS(label=2)/MPLS(label=1)
+p /= Ether(dst="33:33:33:33:33:33", src="44:44:44:44:44:44")/IP()
+p = Ether(raw(p))
+assert(p[Ether:2].type == 0x0800)
+
+try:
+    p[EoMCW]
+except IndexError:
+    ret = True
+else:
+    ret = False
+
+assert(ret)
+assert(p[Ether:2].type == 0x0800)
+
+= MPLS encapsulated IP - build/dissection
+p = Ether(dst="11:11:11:11:11:11", src="22:22:22:22:22:22")
+p /= MPLS(label=1)/IP()
+p = Ether(raw(p))
+
+try:
+    p[EoMCW]
+except IndexError:
+    ret = True
+else:
+    ret = False
+
+assert(ret)
+
+try:
+    p[Ether:2]
+except IndexError:
+    ret = True
+else:
+    ret = False
+
+assert(ret)
+
+p[IP]
 
 + Restore normal routes & Ifaces
 


### PR DESCRIPTION
This commit adds support for encapsulating Ethernet frame in MPLS with control word per rfc 4448. 
You can do something like:
MPLS(label=1)/EoMCW(seq=0x1234)/Ether(dst='00:01:00:11:11:11',src='00::02:00:22:22:22')/IP(dst='10.0.0.1', src='10.0.0.2', proto=252)
or
MPLS(label=1)/Ether(dst='00:01:00:11:11:11',src='00::02:00:22:22:22')/IP(dst='10.0.0.1', src='10.0.0.2', proto=252)