### PR TITLE
Fix inet_pton PY3

### DIFF
--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -77,7 +77,7 @@ if six.PY2:
 
     def plain_str(x):
         """Convert basic byte objects to str"""
-        return x
+        return x if isinstance(x, basestring) else str(x)
 
     def chb(x):
         """Same than chr() but encode as bytes.
@@ -101,7 +101,7 @@ else:
         """Convert basic byte objects to str"""
         if isinstance(x, bytes):
             return x.decode('utf8')
-        return x
+        return x if isinstance(x, str) else str(x)
 
     def chb(x):
         """Same than chr() but encode as bytes.

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -80,10 +80,8 @@ _INET_PTON = {
 def inet_pton(af, addr):
     """Convert an IP address from text representation into binary form."""
     # Will replace Net/Net6 objects
-    if not isinstance(addr, str):
-        addr = str(addr)
-    # Use inet_pton if available
     addr = plain_str(addr)
+    # Use inet_pton if available
     try:
         return socket.inet_pton(af, addr)
     except AttributeError:

--- a/test/dnssecRR.uts
+++ b/test/dnssecRR.uts
@@ -117,6 +117,11 @@ t.rrname == b'isc.org.' and t.keytag == 12892 and t.algorithm == 5 and t.digestt
 = DNSRR(type="TXT") instanciation
 t = DNSRR(type="TXT", rdata="test")
 
+= Build DNSRR
+an = DNSRR(type='AAAA', rdata='2001::1')
+an = DNSRR(raw(an))
+assert an.rdata == '2001::1'
+
 = DNSRRR(), check parameters
 t = DNSRR(b'\x04test\x00\x00\x10\x00\x01\x00\x00\x00\x00\x018\xffScapy is an interactive packet manipulation program that enables you to sniff, mangle, send network packets ; test equipments ; probe and discover networks ; quickly develop new protocols. It can easily handle most classical tasks like scanning, tracerout7ing, probing, unit tests, attacks or network discovery.')
 t.type == 16 and t.rdlen == 312 and t.rdata[:5] == b"Scapy" and t.rdata[-10:] == b"discovery."


### PR DESCRIPTION
This PR fixes IPv6 address encoding when passed as bytes to inet_pton

![image](https://user-images.githubusercontent.com/10530980/34958967-62a9c502-fa34-11e7-9c89-9a3545a59ab5.png)
```
[...]
Z:\Coding\github\scapy\scapy\pton_ntop.py in inet_pton(af, addr)
     86     addr = plain_str(addr)
     87     try:
---> 88         return socket.inet_pton(af, addr)
     89     except AttributeError:
     90         try:

OSError: [WinError 10022] Un argument non valide a été fourni
```