### PR TITLE
TLS continuous data

### DIFF
--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -288,6 +288,11 @@ class TLS(_GenericTLSSessionInheritance):
                     if s.rcs and not isinstance(s.rcs.cipher, Cipher_NULL):
                         from scapy.layers.tls.record_tls13 import TLS13
                         return TLS13
+        if _pkt and len(_pkt) < 5:
+                # Layer detected as TLS but too small to be a real packet (len<5).
+                # Those packets appear when sessions are interrupted or to flush buffers.
+                # Scapy should not try to decode them
+            return conf.raw_layer
         return TLS
 
     ### Parsing methods

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -968,6 +968,9 @@ assert(not t7.pad and not t7.padlen)
 assert(isinstance(t7.msg[0], _TLSEncryptedContent))
 len(t7.msg[0].load) == 478
 
+= Reading TLS msg dissect - Packet too small
+assert isinstance(TLS(b"\x00"), Raw)
+
 = Reading TLS msg dissect - Wrong data
 from scapy.layers.tls.record import _TLSMsgListField
 assert isinstance(_TLSMsgListField.m2i(_TLSMsgListField("", []), TLS(type=0), '\x00\x03\x03\x00\x03abc'), Raw)


### PR DESCRIPTION
I'm often getting those packets, which fail to be dissected on scapy.

They are dissected as so on wireshark, and fail on scapy:
![image](https://user-images.githubusercontent.com/10530980/35062286-0a45c712-fbc4-11e7-9191-63475cd9c151.png)

[failing.pcap.zip](https://github.com/secdev/scapy/files/1640328/failing.pcap.zip)
