### PR TITLE
Fix nmap name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and replies, and much more. It is designed to allow fast packet prototyping by
 using default values that work.
 
 It can easily handle most classical tasks like scanning, tracerouting, probing,
-unit tests, attacks or network discovery (it can replace `hping`, 85% of `nmap̀`,
+unit tests, attacks or network discovery (it can replace `hping`, 85% of `nmap`,
 `arpspoof`, `arp-sk`, `arping`, `tcpdump`, `wireshark`, `p0f`, etc.). It also
 performs very well at a lot of other specific tasks that most other tools can't
 handle, like sending invalid frames, injecting your own 802.11 frames, combining


### PR DESCRIPTION
Is there any reason not to fix this? Was this previously a typo?