### PR TITLE
SEND module fixes & Stuff

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -14,7 +14,7 @@ from scapy.consts import LINUX, OPENBSD, FREEBSD, NETBSD, DARWIN, \
     SOLARIS, WINDOWS, BSD, IS_64BITS, LOOPBACK_NAME
 from scapy.error import *
 import scapy.config
-from scapy.pton_ntop import inet_pton
+from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.data import *
 
 def str2mac(s):
@@ -25,7 +25,7 @@ if not WINDOWS:
         from scapy.arch.bpf.core import get_if_raw_addr
 
 def get_if_addr(iff):
-    return socket.inet_ntoa(get_if_raw_addr(iff))
+    return inet_ntop(socket.AF_INET, get_if_raw_addr(iff))
     
 def get_if_hwaddr(iff):
     addrfamily, mac = get_if_raw_hwaddr(iff)

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -18,7 +18,7 @@
 ##
 
 # Partial support of RFC3971
-# scapy.contrib.description = SEND (ICMPv6)
+# scapy.contrib.description = Secure Neighbor Discovery (SEND) (ICMPv6)
 # scapy.contrib.status = loads
 
 from __future__ import absolute_import
@@ -26,40 +26,12 @@ import socket
 
 from scapy.packet import *
 from scapy.fields import *
-from scapy.layers.inet6 import icmp6typescls, _ICMPv6NDGuessPayload, Net6
-
-send_icmp6typescls = { 11: "ICMPv6NDOptCGA",
-                       12: "ICMPv6NDOptRsaSig",
-                       13: "ICMPv6NDOptTmstp",
-                       14: "ICMPv6NDOptNonce"
-                     }
-icmp6typescls.update(send_icmp6typescls)
-
-class HashField(Field):
-    def __init__(self, name, default):
-        Field.__init__(self, name, default, "16s")
-    def h2i(self, pkt, x):
-        if isinstance(x, str):
-            try:
-                x = in6_ptop(x)
-            except socket.error:
-                x = Net6(x)
-        elif isinstance(x, list):
-            x = [Net6(e) for e in x]
-        return x
-    def i2m(self, pkt, x):
-        return inet_pton(socket.AF_INET6, x)
-    def m2i(self, pkt, x):
-        return inet_ntop(socket.AF_INET6, x)
-    def any2i(self, pkt, x):
-        return self.h2i(pkt,x)
-    def i2repr(self, pkt, x):
-        return self.i2h(pkt, x)    # No specific information to return
+from scapy.layers.inet6 import icmp6ndoptscls, _ICMPv6NDGuessPayload, Net6, IP6Field
 
 class ICMPv6NDOptNonce(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptNonce"
     fields_desc = [ ByteField("type",14),
-                    FieldLenField("len",None,length_of="data",fmt="B", adjust = lambda pkt,x: (x)/8),
+                    FieldLenField("len",None,length_of="nonce",fmt="B", adjust = lambda pkt,x: x//8),
                     StrLenField("nonce","", length_from = lambda pkt: pkt.len*8-2) ]
 
 class ICMPv6NDOptTmstp(_ICMPv6NDGuessPayload, Packet):
@@ -72,20 +44,23 @@ class ICMPv6NDOptTmstp(_ICMPv6NDGuessPayload, Packet):
 class ICMPv6NDOptRsaSig(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptRsaSig"
     fields_desc = [ ByteField("type",12),
-                    FieldLenField("len",None,length_of="data",fmt="B", adjust = lambda pkt,x: (x)/8),
+                    FieldLenField("len",None,length_of="signature_pad",fmt="B", adjust = lambda pkt,x: x//8),
                     ShortField("reserved",0),
-                    HashField("key_hash",None),
+                    IP6Field("key_hash", "::"),
                     StrLenField("signature_pad", "", length_from = lambda pkt: pkt.len*8-20) ]
 
 class ICMPv6NDOptCGA(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptCGA"
     fields_desc = [ ByteField("type",11),
-                    FieldLenField("len",None,length_of="data",fmt="B", adjust = lambda pkt,x: (x)/8),
+                    FieldLenField("len",None,length_of="CGA_PARAMS",fmt="B", adjust = lambda pkt,x: x//8),
                     ByteField("padlength",0),
                     ByteField("reserved",0),
                     StrLenField("CGA_PARAMS", "", length_from = lambda pkt: pkt.len*8 - pkt.padlength - 4),
-                    StrLenField("padding", None, length_from = lambda pkt: pkt.padlength) ]
+                    StrLenField("padding", "", length_from = lambda pkt: pkt.padlength) ]
 
-if __name__ == "__main__":
-    from scapy.all import *
-    interact(mydict=globals(), mybanner="SEND add-on")
+send_icmp6ndoptscls = { 11: ICMPv6NDOptCGA,
+                       12: ICMPv6NDOptRsaSig,
+                       13: ICMPv6NDOptTmstp,
+                       14: ICMPv6NDOptNonce
+                     }
+icmp6ndoptscls.update(send_icmp6ndoptscls)

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -15,7 +15,7 @@
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 ## Copyright (C) 2009 Adline Stephane <adline.stephane@gmail.com>
-##
+## Copyright     2018 Gabriel Potter <gabriel@potter.fr>
 
 # Partial support of RFC3971
 # scapy.contrib.description = Secure Neighbor Discovery (SEND) (ICMPv6)
@@ -26,37 +26,52 @@ import socket
 
 from scapy.packet import *
 from scapy.fields import *
-from scapy.layers.inet6 import icmp6ndoptscls, _ICMPv6NDGuessPayload, Net6, IP6Field
+from scapy.layers.x509 import ASN1F_X509_SubjectPublicKeyInfoRSA
+from scapy.layers.inet6 import icmp6ndoptscls, _ICMPv6NDGuessPayload
 
 class ICMPv6NDOptNonce(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptNonce"
     fields_desc = [ ByteField("type",14),
-                    FieldLenField("len",None,length_of="nonce",fmt="B", adjust = lambda pkt,x: x//8),
-                    StrLenField("nonce","", length_from = lambda pkt: pkt.len*8-2) ]
+                    FieldLenField("len", None, length_of="nonce", fmt="B", adjust = lambda pkt,x: int(round((x+2)/8.))),
+                    StrLenField("nonce", "", length_from = lambda pkt: pkt.len*8-2) ]
 
 class ICMPv6NDOptTmstp(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptTmstp"
     fields_desc = [ ByteField("type",13),
-                    ByteField("len",2),
+                    ByteField("len", 2),
                     BitField("reserved",0, 48),
-                    LongField("timestamp", None) ]
+                    UTCTimeField("timestamp", None) ]
 
 class ICMPv6NDOptRsaSig(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptRsaSig"
     fields_desc = [ ByteField("type",12),
-                    FieldLenField("len",None,length_of="signature_pad",fmt="B", adjust = lambda pkt,x: x//8),
+                    FieldLenField("len", None, length_of="signature_pad", fmt="B", adjust = lambda pkt,x: (x+20)//8),
                     ShortField("reserved",0),
-                    IP6Field("key_hash", "::"),
+                    StrFixedLenField("key_hash", "", length=16),
                     StrLenField("signature_pad", "", length_from = lambda pkt: pkt.len*8-20) ]
+
+class CGA_Params(Packet):
+    name = "CGA Parameters data structure"
+    fields_desc = [ StrFixedLenField("modifier", RandBin(size=16), length=16),
+                    StrFixedLenField("subprefix", "", length=8),
+                    ByteField("cc", 0),
+                    PacketField("pubkey", X509_SubjectPublicKeyInfo(),
+                                          X509_SubjectPublicKeyInfo)  ]
 
 class ICMPv6NDOptCGA(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6NDOptCGA"
     fields_desc = [ ByteField("type",11),
-                    FieldLenField("len",None,length_of="CGA_PARAMS",fmt="B", adjust = lambda pkt,x: x//8),
-                    ByteField("padlength",0),
+                    FieldLenField("len", None, length_of="CGA_PARAMS", fmt="B", adjust = lambda pkt,x: (x+pkt.padlength+4)//8),
+                    FieldLenField("padlength", 0, length_of="padding", fmt="B"),
                     ByteField("reserved",0),
-                    StrLenField("CGA_PARAMS", "", length_from = lambda pkt: pkt.len*8 - pkt.padlength - 4),
+                    PacketLenField("CGA_PARAMS", "", CGA_Params, length_from = lambda pkt: pkt.len*8 - pkt.padlength - 4),
                     StrLenField("padding", "", length_from = lambda pkt: pkt.padlength) ]
+
+    def post_build(self, p, pay):
+        l_ = len(self.CGA_PARAMS)
+        l = -(4+l_) % 8  # Pad to 8 bytes
+        p = p[:1] + chb((4+l_+l)//8) + chb(l) + p[3:4+l_] + b"\x00" * l + pay
+        return p
 
 send_icmp6ndoptscls = { 11: ICMPv6NDOptCGA,
                        12: ICMPv6NDOptRsaSig,

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -26,7 +26,7 @@ import socket
 
 from scapy.packet import *
 from scapy.fields import *
-from scapy.layers.x509 import ASN1F_X509_SubjectPublicKeyInfoRSA
+from scapy.layers.x509 import X509_SubjectPublicKeyInfo
 from scapy.layers.inet6 import icmp6ndoptscls, _ICMPv6NDGuessPayload
 
 class ICMPv6NDOptNonce(_ICMPv6NDGuessPayload, Packet):

--- a/scapy/contrib/send.uts
+++ b/scapy/contrib/send.uts
@@ -1,0 +1,5 @@
++ SEND (IPv6) tests
+
+= Several basic SEND builds
+
+pkt = Ether()/IPv6()/ICMPv6NDOptNonce()

--- a/scapy/contrib/send.uts
+++ b/scapy/contrib/send.uts
@@ -1,5 +1,35 @@
 + SEND (IPv6) tests
 
-= Several basic SEND builds
+= ICMPv6NDOptRsaSig build and dissection
 
-pkt = Ether()/IPv6()/ICMPv6NDOptNonce()
+pkt = Ether()/IPv6()/ICMPv6ND_NS()/ICMPv6NDOptRsaSig(signature_pad = b"\x01" * 12)
+pkt = Ether(raw(pkt))
+
+assert ICMPv6NDOptRsaSig in pkt
+assert pkt[ICMPv6NDOptRsaSig].signature_pad == b"\x01" * 12
+
+= ICMPv6NDOptCGA build and dissection
+
+pkt = Ether()/IPv6()/ICMPv6ND_NS()/ICMPv6NDOptCGA(CGA_PARAMS=CGA_Params())
+pkt = Ether(raw(pkt))
+
+assert ICMPv6NDOptCGA in pkt
+assert isinstance(pkt[ICMPv6NDOptCGA].CGA_PARAMS.pubkey, X509_SubjectPublicKeyInfo)
+assert len(pkt) == 142
+
+= ICMPv6NDOptTmstp build and dissection
+
+pkt = Ether()/IPv6()/ICMPv6ND_NS()/ICMPv6NDOptTmstp(timestamp=int(time.mktime(time.gmtime())))
+pkt = Ether(raw(pkt))
+pkt.show()
+
+assert ICMPv6NDOptTmstp in pkt
+assert pkt[ICMPv6NDOptTmstp].len == 2
+
+= ICMPv6NDOptNonce build and dissection
+
+pkt = Ether()/IPv6()/ICMPv6ND_NS()/ICMPv6NDOptNonce(nonce=b"\x31\x32\x33\x34\x35\x36")
+pkt = Ether(raw(pkt))
+
+assert ICMPv6NDOptNonce in pkt
+assert raw(ICMPv6NDOptNonce(nonce=b"\x31\x32\x33\x34\x35\x36")) == b'\x0e\x01123456'

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -852,12 +852,7 @@ class RawPcapReader(six.with_metaclass(PcapReader_metaclass)):
         res=[]
         while count != 0:
             count -= 1
-            try:
-                p = self.read_packet()
-            except:
-                if conf.debug_dissector:
-                    warning("read_packet failed on packet %s", len(res))
-                raise
+            p = self.read_packet()
             if p is None:
                 break
             res.append(p)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -852,7 +852,12 @@ class RawPcapReader(six.with_metaclass(PcapReader_metaclass)):
         res=[]
         while count != 0:
             count -= 1
-            p = self.read_packet()
+            try:
+                p = self.read_packet()
+            except:
+                if conf.debug_dissector:
+                    warning("read_packet failed on packet %s", len(res))
+                raise
             if p is None:
                 break
             res.append(p)

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -70,7 +70,7 @@ class RandomEnumeration:
     __next__ = next
 
 
-class VolatileValue:
+class VolatileValue(object):
     def __repr__(self):
         return "<%s>" % self.__class__.__name__
     def __eq__(self, other):
@@ -266,41 +266,33 @@ class RandChoice(RandField):
         return random.choice(self._choice)
     
 class RandString(RandField):
-    def __init__(self, size=None, chars="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"):
+    def __init__(self, size=None, chars=b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"):
         if size is None:
             size = RandNumExpo(0.01)
         self.size = size
         self.chars = chars
     def _fix(self):
-        s = ""
-        for _ in range(self.size):
-            s += random.choice(self.chars)
-        return s
-    def __mul__(self, n):
-        return self._fix()*n
-
-class RandBin(RandString, object):
-    def __init__(self, size=None):
-        super(RandBin, self).__init__(size=size, chars=b"".join(chb(c) for c in range(256)))
-    def _fix(self):
         s = b""
         for _ in range(self.size):
             s += chb(random.choice(self.chars))
         return s
-
-
-class RandTermString(RandString):
-    def __init__(self, size, term):
-        RandString.__init__(self, size, "".join(map(chr, range(1,256))))
-        self.term = term
-    def _fix(self):
-        return RandString._fix(self)+self.term
-
     def __str__(self):
-        return str(self._fix())
-
+        return plain_str(self._fix())
     def __bytes__(self):
         return raw(self._fix())
+    def __mul__(self, n):
+        return self._fix()*n
+
+class RandBin(RandString):
+    def __init__(self, size=None):
+        super(RandBin, self).__init__(size=size, chars=b"".join(chb(c) for c in range(256)))
+
+class RandTermString(RandBin):
+    def __init__(self, size, term):
+        self.term = raw(term)
+        super(RandTermString, self).__init__(size=size)
+    def _fix(self):
+        return RandBin._fix(self)+self.term
     
 
 class RandIP(RandString):

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -281,7 +281,12 @@ class RandString(RandField):
 
 class RandBin(RandString):
     def __init__(self, size=None):
-        RandString.__init__(self, size, "".join(map(chr, range(256))))
+        RandString.__init__(self, size, b"".join(map(chb, range(256))))
+    def _fix(self):
+        s = b""
+        for _ in range(self.size):
+            s += chb(random.choice(self.chars))
+        return s
 
 
 class RandTermString(RandString):

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -279,9 +279,9 @@ class RandString(RandField):
     def __mul__(self, n):
         return self._fix()*n
 
-class RandBin(RandString):
+class RandBin(RandString, object):
     def __init__(self, size=None):
-        RandString.__init__(self, size, b"".join(map(chb, range(256))))
+        super(RandBin, self).__init__(size=size, chars=b"".join(chb(c) for c in range(256)))
     def _fix(self):
         s = b""
         for _ in range(self.size):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8899,7 +8899,7 @@ assert(rss == ("CON:" if six.PY2 else "foo.exe:"))
 
 random.seed(0x2807)
 rts = RandTermString(4, "scapy")
-assert(sane(raw(rts)) in ["...[scapy", "......scapy"])
+assert(sane(raw(rts)) in ["...Zscapy", "$#..scapy"])
 
 
 ############


### PR DESCRIPTION
Quite weird PR, every thing is related to the `send`'s module fix
- Fixes SEND module (+ Make it work + tests)
- Fix RandBin on python3 (wrongly created)
- Remove the `get_cls` usages from inet6 and use direct classes instead: this allow us to inject the class from `contrib/send.py` into inet6. It was not possible because of `globals()` restrictions.
- Minor new log in rdpcap

Fixes https://github.com/secdev/scapy/issues/1045