### PR TITLE
Use inet_pton to convert IPv4 addresses

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -224,7 +224,7 @@ class RDataField(StrLenField):
     def i2m(self, pkt, s):
         if pkt.type == 1: # A
             if s:
-                s = inet_aton(s)
+                s = inet_pton(socket.AF_INET, s)
         elif pkt.type in [2, 3, 4, 5, 12]: # NS, MD, MF, CNAME, PTR
             s = b"".join(chb(len(x)) + x for x in s.split(b'.'))
             if orb(s[-1]):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1079,6 +1079,7 @@ del(dns_ans2[UDP].len)
 del(dns_ans2[UDP].chksum)
 assert(b"\x03www\x06secdev\x03org\x00" in raw(dns_ans2))
 assert(DNS in IP(raw(dns_ans2)))
+assert raw(DNSRR(type='A', rdata='1.2.3.4')) == b'\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x01\x02\x03\x04'
 
 = Arping
 ~ netaccess


### PR DESCRIPTION
This PR fixes #1084.

The issue could also be fixed using `plain_str()` but I think that this solution is better.