### PR TITLE
Pipetool tests

### DIFF
--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -10,9 +10,13 @@ s = PeriodicSource("hello", 1, name="src")
 d1 = Drain(name="d1")
 c = ConsoleSink(name="c")
 tf = TransformDrain(lambda x: "Got %s" % x)
-t = TermSink(name="PipeToolsPeriodicTest", keepterm=False)
 s > d1 > c
-d1 > tf > t
+d1 > tf
+try:
+  t = TermSink(name="PipeToolsPeriodicTest", keepterm=False)
+  tf > t
+except FileNotFoundError:
+  pass
 
 p = PipeEngine(s)
 p.start()

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -223,7 +223,7 @@ assert test_val == "hello"
 + Advanced ScapyPipes pipetools tests
 
 = Test SniffSource
-~ netaccess
+~ netaccess needs_root
 
 p = PipeEngine()
 


### PR DESCRIPTION
This PR makes `pipetool.uts` works fine as non-root and in headless (no X server) environments.