### PR TITLE
Use the key argument with sort()

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -182,8 +182,8 @@ def get_working_ifaces():
             os.close(fd)
 
     # Sort to mimic pcap_findalldevs() order
-    interfaces.sort(lambda ifname_left_and_ifid_left,
-                        ifname_right_and_ifid_right: ifname_left_and_ifid_left[1]-ifname_right_and_ifid_right[1])
+    interfaces.sort(key=lambda elt: elt[1])
+
     return interfaces
 
 

--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -49,10 +49,10 @@ len(iflist) > 0
 
 from scapy.arch.bpf.core import get_working_ifaces
 ifworking = get_working_ifaces()
-len(ifworking)
+assert len(ifworking)
             
 from scapy.arch.bpf.core import get_working_if
-len(ifworking) and get_working_if() == ifworking[0][0]
+assert len(ifworking) and get_working_if() == ifworking[0][0]
 
 
 = Misc functions


### PR DESCRIPTION
Long story short: this PR fixes an issue with Python3 on osx. It was discovered during the first _successful_ automated tests on osx!

I am not happy with the indentation. Ideas are welcome.