### PR TITLE
CAN layer progress

### DIFF
--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -9,13 +9,20 @@ Wireshark dissectors. See https://wiki.wireshark.org/CANopen
 
 """
 
-
+import struct
+import scapy.modules.six as six
+from scapy.compat import *
 from scapy.config import conf
 from scapy.data import DLT_CAN_SOCKETCAN
 from scapy.fields import BitField, FieldLenField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_layers, RawVal
 from scapy.layers.l2 import CookedLinux
+
+
+# Mimics the Wireshark CAN dissector parameter 'Byte-swap the CAN ID/flags field'
+#   set to True when working with PF_CAN sockets
+conf.contribs['CAN'] = {'swap-bytes': False}
 
 
 class CAN(Packet):
@@ -31,6 +38,43 @@ class CAN(Packet):
         StrLenField('data', '', length_from=lambda pkt: pkt.length),
         StrLenField('padding', '', length_from=lambda pkt: 8 - pkt.length),
     ]
+
+    def pre_dissect(self, s):
+        """ Implements the swap-bytes functionality when dissecting """
+        if conf.contribs['CAN']['swap-bytes']:
+            return struct.pack('<I12s', *struct.unpack('>I12s', s))
+        return s
+
+    def self_build(self, field_pos_list=None):
+        """ Implements the swap-bytes functionality when building
+
+        this is based on a copy of the Packet.self_build default method.
+        The goal is to affect only the CAN layer data and keep
+        under layers (e.g LinuxCooked) unchanged
+        """
+        if self.raw_packet_cache is not None:
+            for fname, fval in six.iteritems(self.raw_packet_cache_fields):
+                if self.getfieldval(fname) != fval:
+                    self.raw_packet_cache = None
+                    self.raw_packet_cache_fields = None
+                    break
+            if self.raw_packet_cache is not None:
+                if conf.contribs['CAN']['swap-bytes']:
+                    return struct.pack('<I12s', *struct.unpack('>I12s', self.raw_packet_cache))
+                return self.raw_packet_cache
+        p = b""
+        for f in self.fields_desc:
+            val = self.getfieldval(f.name)
+            if isinstance(val, RawVal):
+                sval = raw(val)
+                p += sval
+                if field_pos_list is not None:
+                    field_pos_list.append((f.name, sval.encode('string_escape'), len(p), len(sval)))
+            else:
+                p = f.addfield(self, p, val)
+        if conf.contribs['CAN']['swap-bytes']:
+            return struct.pack('<I12s', *struct.unpack('>I12s', p))
+        return p
 
 
 conf.l2types.register(DLT_CAN_SOCKETCAN, CAN)

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -14,7 +14,8 @@ from scapy.config import conf
 from scapy.data import DLT_CAN_SOCKETCAN
 from scapy.fields import BitField, FieldLenField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField
-from scapy.packet import Packet
+from scapy.packet import Packet, bind_layers
+from scapy.layers.l2 import CookedLinux
 
 
 class CAN(Packet):
@@ -23,14 +24,14 @@ class CAN(Packet):
 
     """
     fields_desc = [
-        FlagsField("flags", 0, 3, ["extended", "remote_transmission_request",
-                                   "error"]),
-        BitField("unknown", 0, 18),
-        XBitField("identifier", 0, 11),
-        FieldLenField("length", None, length_of="data", fmt="B"),
-        ThreeBytesField("reserved", 0),
-        StrLenField("data", "", length_from=lambda pkt: pkt.length),
+        FlagsField('flags', 0, 3, ['error', 'remote_transmission_request', 'extended']),
+        XBitField('identifier', 0, 29),
+        FieldLenField('length', None, length_of='data', fmt='B'),
+        ThreeBytesField('reserved', 0),
+        StrLenField('data', '', length_from=lambda pkt: pkt.length),
+        StrLenField('padding', '', length_from=lambda pkt: 8 - pkt.length),
     ]
 
 
 conf.l2types.register(DLT_CAN_SOCKETCAN, CAN)
+bind_layers(CookedLinux, CAN, proto=12)

--- a/test/can.uts
+++ b/test/can.uts
@@ -21,6 +21,12 @@ pkt = CAN(flags="error", identifier=1234, data="test")
 pkt = CAN(raw(pkt))
 pkt.flags == "error" and pkt.identifier == 1234 and pkt.length == 4 and pkt.data == b"test"
 
+= Check flags values
+
+pkt = CAN(flags="remote_transmission_request")
+pkt.flags == 0x2
+pkt = CAN(flags="extended")
+pkt.flags == 0x4
 
 ############
 ############

--- a/test/can.uts
+++ b/test/can.uts
@@ -59,3 +59,40 @@ set(pkt.flags for pkt in packets) == {0}
 = Data length
 
 set(pkt.length for pkt in packets) == {1, 2, 8}
+
+
+############
+############
+
++ swap-bytes functionality (for PF_CAN socket interactions)
+
+= read PCAP of a CookedLinux/SocketCAN capture (CAN standard and extended)
+
+conf.contribs['CAN']['swap-bytes'] = True
+pcap_fd_can_a = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00q\x00\x00\x00\x15f`Zv\xde\n\x00 \x00\x00\x00 \x00\x00\x00\x00\x01\x01\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\xdf\x07\x00\x00\x03\x00\x00\x00\x02\x01\r\x00\x00\x00\x00\x00')
+packets_can_a = rdpcap(pcap_fd_can_a)
+pcap_fd_can_b = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00q\x00\x00\x00\xf4i`Z\xf3\x99\x07\x00 \x00\x00\x00 \x00\x00\x00\x00\x01\x01\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\xf13\xdb\x98\x03\x00\x00\x00\x02\x01\r\x00\x00\x00\x00\x00')
+packets_can_b = rdpcap(pcap_fd_can_b)
+
+= check CAN is detected over CookedLinux (each packet has both layers)
+
+all(CAN in pkt for pkt in packets_can_a)
+all(CAN in pkt for pkt in packets_can_b)
+all(CookedLinux in pkt for pkt in packets_can_a)
+all(CookedLinux in pkt for pkt in packets_can_b)
+
+= Check if parsing worked: no packet has a Raw or Padding layer
+
+not any(Raw in pkt or Padding in pkt for pkt in packets)
+
+= Check byte swap for dissection
+
+packets_can_a[0].identifier == 0x7df
+packets_can_a[0].flags == 0x0
+packets_can_b[0].identifier == 0x18db33f1
+packets_can_b[0].flags == "extended"
+
+= Check byte swap-back for building
+
+raw(packets_can_a[0]) == b'\x00\x01\x01\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\xdf\x07\x00\x00\x03\x00\x00\x00\x02\x01\r\x00\x00\x00\x00\x00'
+raw(packets_can_b[0]) == b'\x00\x01\x01\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\xf13\xdb\x98\x03\x00\x00\x00\x02\x01\r\x00\x00\x00\x00\x00'


### PR DESCRIPTION
Hello,

The first commit is an easy improvement of the current CAN layer (fixes FlagsField definition, support extended CAN identifier format, include the padding and bind to CookedLinux layer).

The second is more experimental and implement the Wireshark "swap flags/id" functionality to properly dissect/build messages for the SocketCAN implementation.

Seb.