### PR TITLE
Remove duplicate call to init_session + fix conf.session not updated

### DIFF
--- a/scapy/main.py
+++ b/scapy/main.py
@@ -317,7 +317,10 @@ def init_session(session_name, mydict=None):
         if SESSION:
             if "conf" in SESSION:
                 conf.configure(SESSION["conf"])
+                conf.session = session_name
                 SESSION["conf"] = conf
+            else:
+                conf.session = session_name
         else:
             conf.session = session_name
             SESSION = {"conf":conf}
@@ -490,8 +493,6 @@ def interact(mydict=None,argv=None,mybanner=None,loglevel=20):
             IPYTHON = True
     else:
         IPYTHON = False
-
-    init_session(session_name, mydict)
 
     if IPYTHON:
         banner = the_banner + " using IPython %s\n" % IPython.__version__


### PR DESCRIPTION
- `init_session` is called twice: it's already called [here](https://github.com/secdev/scapy/compare/master...gpotter2:session-dupli?expand=1#diff-415fdc55feac2ca441c303d363c789aeR420)
- conf.session would remain `''` when loading an already created session file, resulting in the session not beeing saved on closing