### PR TITLE
Logs: remove duplicated

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -11,8 +11,7 @@ from __future__ import absolute_import
 import socket
 
 from scapy.consts import LINUX, OPENBSD, FREEBSD, NETBSD, DARWIN, \
-    SOLARIS, WINDOWS, BSD, IS_64BITS, LOOPBACK_NAME, plt, MATPLOTLIB_INLINED, \
-    MATPLOTLIB_DEFAULT_PLOT_KARGS, PYX
+    SOLARIS, WINDOWS, BSD, IS_64BITS, LOOPBACK_NAME
 from scapy.error import *
 import scapy.config
 from scapy.pton_ntop import inet_pton

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -15,6 +15,8 @@ from ctypes import c_uint, c_uint32, c_ushort, c_ubyte
 from scapy.config import conf
 import scapy.modules.six as six
 
+## UTILS
+
 def get_if(iff, cmd):
     """Ease SIOCGIF* ioctl calls"""
 
@@ -22,6 +24,8 @@ def get_if(iff, cmd):
     ifreq = ioctl(sck, cmd, struct.pack("16s16x", iff.encode("utf8")))
     sck.close()
     return ifreq
+
+## BPF HANDLERS
 
 class bpf_insn(Structure):
     """"The BPF instruction data structure"""

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -48,9 +48,9 @@ if conf.use_winpcapy:
       version = pcap_lib_version()
       if b"winpcap" in version.lower():
           if os.path.exists(NPCAP_PATH + "\\wpcap.dll"):
-              warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)", onlyOnce=True)
+              warning("Winpcap is installed over Npcap. Will use Winpcap (see 'Winpcap/Npcap conflicts' in scapy's docs)")
           elif platform.release() != "XP":
-              warning("WinPcap is now deprecated (not maintened). Please use Npcap instead", onlyOnce=True)
+              warning("WinPcap is now deprecated (not maintened). Please use Npcap instead")
       elif b"npcap" in version.lower():
           conf.use_npcap = True
           LOOPBACK_NAME = scapy.consts.LOOPBACK_NAME = "Npcap Loopback Adapter"

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -326,7 +326,7 @@ class WinProgPath(ConfClass):
 
 conf.prog = WinProgPath()
 if not conf.prog.os_access:
-    warning("Scapy did not detect powershell and cscript ! Routes, interfaces and much more won't work !", onlyOnce=True)
+    warning("Scapy did not detect powershell and cscript ! Routes, interfaces and much more won't work !")
 
 if conf.prog.tcpdump and conf.use_npcap and conf.prog.os_access:
     def test_windump_npcap():
@@ -340,7 +340,7 @@ if conf.prog.tcpdump and conf.use_npcap and conf.prog.os_access:
             return False
     windump_ok = test_windump_npcap()
     if not windump_ok:
-        warning("The installed Windump version does not work with Npcap ! Refer to 'Winpcap/Npcap conflicts' in scapy's doc", onlyOnce=True)
+        warning("The installed Windump version does not work with Npcap ! Refer to 'Winpcap/Npcap conflicts' in scapy's doc")
     del windump_ok
 
 # Auto-detect release
@@ -673,7 +673,7 @@ class NetworkInterfaceDict(UserDict):
             warning(_error_msg +
                     "You probably won't be able to send packets. "
                     "Deactivating unneeded interfaces and restarting Scapy might help. "
-                    "Check your winpcap and powershell installation, and access rights.", onlyOnce=True)
+                    "Check your winpcap and powershell installation, and access rights.")
         else:
             # Loading state: remove invalid interfaces
             self.remove_invalid_ifaces()
@@ -838,10 +838,10 @@ def read_routes():
         else:
             routes = _read_routes_7()
     except Exception as e:    
-        warning("Error building scapy IPv4 routing table : %s", e, onlyOnce=True)
+        warning("Error building scapy IPv4 routing table : %s", e)
     else:
         if not routes:
-            warning("No default IPv4 routes found. Your Windows release may no be supported and you have to enter your routes manually", onlyOnce=True)
+            warning("No default IPv4 routes found. Your Windows release may no be supported and you have to enter your routes manually")
     return routes
 
 def _get_metrics(ipv6=False):
@@ -1005,7 +1005,7 @@ def read_routes6():
         else:
             routes6 = _read_routes6_7()
     except Exception as e:    
-        warning("Error building scapy IPv6 routing table : %s", e, onlyOnce=True)
+        warning("Error building scapy IPv6 routing table : %s", e)
     return routes6
 
 def get_working_if():

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -462,10 +462,6 @@ if not Conf.ipv6_enabled:
     for m in ["inet6","dhcp6"]:
         if m in Conf.load_layers:
             Conf.load_layers.remove(m)
-    
-if not Conf.crypto_valid:
-    log_scapy.warning("Crypto-related methods disabled for IPsec, Dot11 "
-                      "and TLS layers (needs python-cryptography v1.7+).")
 
 conf=Conf()
 conf.logLevel=30 # 30=Warning

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -422,7 +422,6 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     debug_dissector = 0
     color_theme = Interceptor("color_theme", NoTheme(), _prompt_changer)
     warning_threshold = 5
-    warning_next_only_once = False
     prog = ProgPath()
     resolve = Resolve()
     noenum = Resolve()

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -3,51 +3,9 @@
 ## Copyright (C) Philippe Biondi <phil@secdev.org>
 ## This program is published under a GPLv2 license
 
-import os, inspect
+import os
 from sys import platform, maxsize
 import platform as platform_lib
-from scapy.error import *
-
-import subprocess
-
-try:
-    from matplotlib import get_backend as matplotlib_get_backend
-    import matplotlib.pyplot as plt
-    MATPLOTLIB = 1
-    if "inline" in matplotlib_get_backend():
-        MATPLOTLIB_INLINED = 1
-    else:
-        MATPLOTLIB_INLINED = 0
-    MATPLOTLIB_DEFAULT_PLOT_KARGS = {"marker": "+"}
-# RuntimeError to catch gtk "Cannot open display" error
-except (ImportError, RuntimeError):
-    plt = None
-    MATPLOTLIB = 0
-    MATPLOTLIB_INLINED = 0
-    MATPLOTLIB_DEFAULT_PLOT_KARGS = dict()
-    log_loading.info("Can't import matplotlib. Won't be able to plot.")
-
-def _test_pyx():
-    """Returns if PyX is correctly installed or not"""
-    try:
-        with open(os.devnull, 'wb') as devnull:
-            r = subprocess.check_call(["pdflatex", "--version"], stdout=devnull, stderr=subprocess.STDOUT)
-    except:
-        return False
-    else:
-        return r == 0
-
-try:
-    import pyx
-    if _test_pyx():
-        PYX = 1
-    else:
-        log_loading.warning("PyX dependencies are not installed ! Please install TexLive or MikTeX.")
-        PYX = 0
-except ImportError:
-    log_loading.info("Can't import PyX. Won't be able to use psdump() or pdfdump().")
-    PYX = 0
-
 
 LINUX = platform.startswith("linux")
 OPENBSD = platform.startswith("openbsd")

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -15,7 +15,7 @@ import time
 
 
 from scapy.dadict import DADict
-from scapy.consts import DARWIN, FREEBSD, NETBSD, OPENBSD
+from scapy.consts import DARWIN, FREEBSD, NETBSD, OPENBSD, WINDOWS
 from scapy.error import log_loading
 from scapy.compat import *
 
@@ -111,8 +111,6 @@ IPV6_ADDR_UNSPECIFIED = 0x10000
 EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 3, 1, 0))-86400
 
 MTU = 0xffff # a.k.a give me all you have
-
-WINDOWS=sys.platform.startswith("win")
 
  
 # file parsing to get some values :

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -36,9 +36,6 @@ class ScapyFreqFilter(logging.Filter):
                 tm = ltm
                 nb = 0
             else:
-                if conf.warning_next_only_once:
-                    conf.warning_next_only_once = False
-                    return 0
                 if nb < 2:
                     nb += 1
                     if nb == 2:
@@ -67,10 +64,5 @@ log_loading = logging.getLogger("scapy.loading")          # logs when loading Sc
 def warning(x, *args, **kargs):
     """
     Prints a warning during runtime.
-
-    onlyOnce - if True, the warning will never be printed again.
     """ 
-    if kargs.pop("onlyOnce", False):
-        from scapy.config import conf
-        conf.warning_next_only_once = True
     log_runtime.warning(x, *args, **kargs)

--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -1,0 +1,57 @@
+## This file is part of Scapy
+## See http://www.secdev.org/projects/scapy for more informations
+## Copyright (C) Philippe Biondi <phil@secdev.org>
+## This program is published under a GPLv2 license
+
+"""
+External link to programs
+"""
+
+import os, subprocess
+from scapy.error import *
+
+# Notice: this file must not be called before main.py, if started
+# in interactive mode, because it needs to be called after the
+# logger has been setup, to be able to print the warning messages
+
+## MATPLOTLIB
+
+try:
+    from matplotlib import get_backend as matplotlib_get_backend
+    import matplotlib.pyplot as plt
+    MATPLOTLIB = 1
+    if "inline" in matplotlib_get_backend():
+        MATPLOTLIB_INLINED = 1
+    else:
+        MATPLOTLIB_INLINED = 0
+    MATPLOTLIB_DEFAULT_PLOT_KARGS = {"marker": "+"}
+# RuntimeError to catch gtk "Cannot open display" error
+except (ImportError, RuntimeError):
+    plt = None
+    MATPLOTLIB = 0
+    MATPLOTLIB_INLINED = 0
+    MATPLOTLIB_DEFAULT_PLOT_KARGS = dict()
+    log_loading.info("Can't import matplotlib. Won't be able to plot.")
+
+## PYX
+
+def _test_pyx():
+    """Returns if PyX is correctly installed or not"""
+    try:
+        with open(os.devnull, 'wb') as devnull:
+            r = subprocess.check_call(["pdflatex", "--version"], stdout=devnull, stderr=subprocess.STDOUT)
+    except:
+        return False
+    else:
+        return r == 0
+
+try:
+    import pyx
+    if _test_pyx():
+        PYX = 1
+    else:
+        log_loading.warning("PyX dependencies are not installed ! Please install TexLive or MikTeX.")
+        PYX = 0
+except ImportError:
+    log_loading.info("Can't import PyX. Won't be able to use psdump() or pdfdump().")
+    PYX = 0

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -28,7 +28,7 @@ if conf.crypto_valid:
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 else:
     default_backend = Ciphers = algorithms = None
-    log_loading.info("Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption.")
+    log_loading.info("Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption. (Dot11)")
 
 
 ### Layers

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -19,7 +19,8 @@ from scapy.data import *
 from scapy.layers.l2 import *
 from scapy.compat import *
 from scapy.config import conf
-from scapy.consts import WINDOWS, plt, MATPLOTLIB, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
+from scapy.arch import WINDOWS
+from scapy.extlib import plt, MATPLOTLIB, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from scapy.fields import *
 from scapy.packet import *
 from scapy.volatile import *

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -23,7 +23,7 @@ from scapy.volatile import VolatileValue
 from scapy.utils import import_hexcap,tex_escape,colgen,get_temp_file, \
     ContextManagerSubprocess
 from scapy.error import Scapy_Exception, log_runtime
-from scapy.consts import PYX
+from scapy.extlib import PYX
 import scapy.modules.six as six
 
 try:

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -20,7 +20,7 @@ from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_ta
 from scapy.extlib import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
 import scapy.modules.six as six
-from scapy.modules.six.moves import range
+from scapy.modules.six.moves import range, zip
 
 
 #############

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -17,10 +17,10 @@ from scapy.config import conf
 from scapy.base_classes import BasePacket,BasePacketList
 from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table,get_temp_file
 
-from scapy.consts import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
+from scapy.extlib import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
 import scapy.modules.six as six
-from scapy.modules.six.moves import filter, range, zip
+from scapy.modules.six.moves import range
 
 
 #############


### PR DESCRIPTION
PR:
- remove `onlyOnce` param: dirty implementation (was mine at some point...) + useless with latest versions
- Move PYX and MATPLOTLIB detection to an external file because when loading:
   - config is imported
   - data is imported from config
   - consts is imported from data
   - warnings are triggered before `interact()` setups the logs.

We have moved those functions several time, from arch to consts...
I'm finally dropping them in a dedicated file so they don't interfere with any other part of scapy.