### PR TITLE
Windows: detect KM-TEST translations

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -414,11 +414,14 @@ As Winpcap is becoming old, it's recommanded to use Npcap instead. Npcap is part
 
 1. If you get the message 'Winpcap is installed over Npcap.' it means that you have installed both winpcap and npcap versions, which isn't recommanded.
 
-You may uninstall winpcap from your Program Files, then you will need to remove:
+You may **uninstall winpcap from your Program Files**, then you will need to remove:
  * C:/Windows/System32/wpcap.dll
  * C:/Windows/System32/Packet.dll
+And if you are on a x64 machine:
+ * C:/Windows/SysWOW64/wpcap.dll
+ * C:/Windows/SysWOW64/Packet.dll
 
-To use npcap instead.
+To use npcap instead. Those files are not removed by the Winpcap un-installer.
 
 2. If you get the message 'The installed Windump version does not work with Npcap' it means that you have installed an old version of Windump.
 Download the correct one on https://github.com/hsluoyz/WinDump/releases

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -349,11 +349,15 @@ NEW_RELEASE = is_new_release()
 class PcapNameNotFoundError(Scapy_Exception):
     pass    
 
-def is_interface_valid(iface):
+def _validate_interface(iface):
     if "guid" in iface and iface["guid"]:
         # Fix '-' instead of ':'
         if "mac" in iface:
             iface["mac"] = iface["mac"].replace("-", ":")
+        # Potentially, the default Microsoft KM-TEST would have been translated
+        if "name" in iface:
+            if "KM-TEST" in iface["name"] and iface["name"] != scapy.consts.LOOPBACK_NAME:
+                scapy.consts.LOOPBACK_NAME = iface["name"]
         return True
     return False
 
@@ -378,7 +382,7 @@ def get_windows_if_list():
         iface for iface in
         (dict(zip(['name', 'win_index', 'description', 'guid', 'mac', 'netid'], line))
          for line in query)
-        if is_interface_valid(iface)
+        if _validate_interface(iface)
     ]
 
 def get_ips(v6=False):


### PR DESCRIPTION
The KM-TEST loopback adapters are extraordinary un-documented.

This Small patch will detect its translated alternatives (since latest updates, on my PC the adapter has been updated from `Microsoft KM-TEST Loopback Adapter` into `Carte de bouclage Microsoft KM-TEST`)