### PR TITLE
Utils: fix do_graph() (proc.stdin was not closed)

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -520,6 +520,7 @@ def do_graph(graph,prog=None,format=None,target=None,type=None,string=None,optio
     proc = subprocess.Popen("\"%s\" %s %s" % (prog, options or "", format or ""),
                             shell=True, stdin=subprocess.PIPE, stdout=target)
     proc.stdin.write(raw(graph))
+    proc.stdin.close()
     try:
         target.close()
     except:


### PR DESCRIPTION
Graphs were broken, at least under Linux when using direct display (i.e., when not target is specified).