### PR TITLE
Fix routes generators #1135

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -275,7 +275,7 @@ class SourceIPField(IPField):
         dst = ("0.0.0.0" if self.dstname is None
                else getattr(pkt, self.dstname))
         if isinstance(dst, (Gen, list)):
-            r = {conf.route.route(daddr) for daddr in dst}
+            r = {conf.route.route(str(daddr)) for daddr in dst}
             if len(r) > 1:
                 warning("More than one possible route for %r" % (dst,))
             return min(r)[1]

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -234,13 +234,15 @@ class IP6Field(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "16s")
     def h2i(self, pkt, x):
+        if isinstance(x, bytes):
+            x = plain_str(x)
         if isinstance(x, str):
             try:
                 x = in6_ptop(x)
             except socket.error:
                 x = Net6(x)
         elif isinstance(x, list):
-            x = [Net6(a) for a in x]
+            x = [self.h2i(pkt, n) for n in x]
         return x
     def i2m(self, pkt, x):
         return inet_pton(socket.AF_INET6, plain_str(x))
@@ -280,7 +282,7 @@ class SourceIP6Field(IP6Field):
                 import scapy.route6
             dst = ("::" if self.dstname is None else getattr(pkt, self.dstname))
             if isinstance(dst, (Gen, list)):
-                r = {conf.route6.route(daddr) for daddr in dst}
+                r = {conf.route6.route(str(daddr)) for daddr in dst}
                 if len(r) > 1:
                     warning("More than one possible route for %r" % (dst,))
                 x = min(r)[1]

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -132,8 +132,6 @@ class Route:
 
 
     def route(self,dest,verbose=None):
-        if isinstance(dest, list) and dest:
-            dest = dest[0]
         if dest in self.cache:
             return self.cache[dest]
         if verbose is None:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8428,6 +8428,16 @@ assert isinstance(n1, Net)
 assert n1.ip_regex.match(str(n1))
 ip.show()
 
+= Multiple IP addresses test
+~ netaccess
+
+ip = IP(dst=['192.168.0.1', 'www.google.fr'],ihl=(1,5))
+assert ip.dst[0] == '192.168.0.1'
+assert isinstance(ip.dst[1], Net)
+src = ip.src
+assert src
+assert isinstance(src, str)
+
 = OID
 
 oid = OID("1.2.3.4.5.6-8")
@@ -8446,6 +8456,16 @@ n1 = ip.dst
 assert isinstance(n1, Net6)
 assert n1.ip_regex.match(str(n1))
 ip.show()
+
+= Multiple IPv6 addresses test
+~ netaccess ipv6
+
+ip = IPv6(dst=['2001:db8::1', 'www.google.fr'],hlim=(1,5))
+assert ip.dst[0] == '2001:db8::1'
+assert isinstance(ip.dst[1], Net6)
+src = ip.src
+assert src
+assert isinstance(src, str)
 
 = Test repr on Net
 ~ netaccess


### PR DESCRIPTION
Fixes https://github.com/secdev/scapy/issues/1135

List of fixed bugs:
- `IPv6(dst=['2001:db8::1','2001:db8::2'],hlim=(1,5)).show()` fails
![image](https://user-images.githubusercontent.com/10530980/35926877-9125f66a-0c29-11e8-91be-38166684a376.png)

- list of IPv6 are not properly detected:
![image](https://user-images.githubusercontent.com/10530980/35926834-731fbdae-0c29-11e8-9b3e-49002ecec282.png)

- IPs combined with Net/Net6
![image](https://user-images.githubusercontent.com/10530980/35927017-ea840292-0c29-11e8-9532-0fb462fb487a.png)
![image](https://user-images.githubusercontent.com/10530980/35927062-03bd7450-0c2a-11e8-92d8-1dbbb6205219.png)
