### PR TITLE
scapy v2.4, Windows: Existence of 802.11 should be checked only once

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -479,7 +479,7 @@ class NetworkInterface(object):
             try:
                 dot11adapters = next(iter(_vbs_exec_code("""WScript.Echo CreateObject("WScript.Shell").RegRead("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\npcap\\Parameters\\Dot11Adapters")""")))
             except StopIteration:
-                pass
+                self.raw80211 = False
             else:
                 self.raw80211 = ("\\Device\\" + self.guid).lower() in dot11adapters.lower()
         if not self.raw80211:


### PR DESCRIPTION
NetworkInterface_check_npcap_requirement():
Existence of 802.11 should be checked only once.