### PR TITLE
[oneline] Print IPs correctly

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -258,7 +258,8 @@ class IPField(Field):
     def any2i(self, pkt, x):
         return self.h2i(pkt,x)
     def i2repr(self, pkt, x):
-        return self.resolve(self.i2h(pkt, x))
+        r = self.resolve(self.i2h(pkt, x))
+        return r if isinstance(r, str) else repr(r)
     def randval(self):
         return RandIP()
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -258,7 +258,8 @@ class IP6Field(Field):
             elif in6_isaddr6to4(x):   # print encapsulated address
                 vaddr = in6_6to4ExtractAddr(x)
                 return "%s [6to4 GW: %s]" % (self.i2h(pkt, x), vaddr)
-        return self.i2h(pkt, x)       # No specific information to return
+        r = self.i2h(pkt, x)          # No specific information to return
+        return r if isinstance(r, str) else repr(r)
     def randval(self):
         return RandIP6()
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8447,6 +8447,18 @@ assert isinstance(n1, Net6)
 assert n1.ip_regex.match(str(n1))
 ip.show()
 
+= Test repr on Net
+~ netaccess
+
+conf.color_theme = BlackAndWhite()
+assert "Net('www.google.com')" in repr(IP(src="www.google.com"))
+
+= Test repr on Net
+~ netaccess ipv6
+
+conf.color_theme = BlackAndWhite()
+assert "Net6('www.google.com')" in repr(IPv6(src="www.google.com"))
+
 ############
 ############
 + IPv6 helpers


### PR DESCRIPTION
This PR fixes a regression from before python 3 support:
- Net/Net6 are being processed when printing IP

secdev/master:
![image](https://user-images.githubusercontent.com/10530980/35930407-16f24048-0c32-11e8-80b0-a6456a86b3de.png)
![image](https://user-images.githubusercontent.com/10530980/35931384-c97c5ad0-0c34-11e8-8a32-b011b053c58f.png)


Scapy 2.2.0 & with this PR
![image](https://user-images.githubusercontent.com/10530980/35930357-fa7f2778-0c31-11e8-845c-aaf774ab3da5.png)
![image](https://user-images.githubusercontent.com/10530980/35931363-ba83f06a-0c34-11e8-8722-198018340899.png)
