### PR TITLE
Sending/Recieving: Improve speed

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -12,10 +12,12 @@ Generators and packet meta classes.
 ################
 
 from __future__ import absolute_import
+import operator
 import re
 import random
 import socket
 import types
+from functools import reduce
 from scapy.modules.six.moves import range
 
 
@@ -24,6 +26,9 @@ class Gen(object):
 
     def __iter__(self):
         return iter([])
+
+    def __iterlen__(self):
+        return sum(1 for _ in iter(self))
 
 
 def _get_values(value):
@@ -107,6 +112,9 @@ class Net(Gen):
                     for a in range(*self.parsed[0]):
                         yield "%i.%i.%i.%i" % (a, b, c, d)
 
+    def __iterlen__(self):
+        return reduce(operator.mul, ((y - x) for (x, y) in self.parsed), 1)
+
     def choice(self):
         return ".".join(str(random.randint(v[0], v[1] - 1)) for v in self.parsed)
 
@@ -163,6 +171,9 @@ class OID(Gen):
                 else:
                     ii[i] = self.cmpt[i][0]
                 i += 1
+
+    def __iterlen__(self):
+        return reduce(operator.mul, (max(y - x, 0) + 1 for (x, y) in self.cmpt), 1)
 
 
 ######################################

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -447,7 +447,8 @@ class IP(Packet, IPTools):
         if self.dst == "224.0.0.251":  # mDNS
             return struct.pack("B", self.proto) + self.payload.hashret()
         if conf.checkIPsrc and conf.checkIPaddr:
-            return (strxor(inet_aton(self.src), inet_aton(self.dst))
+            return (strxor(inet_pton(socket.AF_INET, self.src),
+                           inet_pton(socket.AF_INET, self.dst))
                     + struct.pack("B", self.proto) + self.payload.hashret())
         return struct.pack("B", self.proto) + self.payload.hashret()
 
@@ -536,8 +537,8 @@ def in4_chksum(proto, u, p):
     else:
         ln = len(p)
     psdhdr = struct.pack("!4s4sHH",
-                         inet_aton(u.src),
-                         inet_aton(u.dst),
+                         inet_pton(socket.AF_INET, u.src),
+                         inet_pton(socket.AF_INET, u.dst),
                          proto,
                          ln)
     return checksum(psdhdr + p)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -852,31 +852,31 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
 
     def __iterlen__(self):
         """Predict the total length of the iterator"""
-        fields = [k for (k, v) in itertools.chain(six.iteritems(self.default_fields),
+        fields = [key for (key, val) in itertools.chain(six.iteritems(self.default_fields),
                   six.iteritems(self.overloaded_fields))
-                  if isinstance(v, VolatileValue)] + list(self.fields.keys())
-        l = 1
-        for f in fields:
-            v = self.getfieldval(f)
-            if hasattr(v, "__iterlen__"):
-                l *= v.__iterlen__()
-            elif isinstance(v, tuple) and len(v) == 2 and all(isinstance(z, int) for z in v):
-                l *= (v[1] - v[0])
-            elif isinstance(v, list):
-                l2 = 0
-                for x in v:
+                  if isinstance(val, VolatileValue)] + list(self.fields.keys())
+        length = 1
+        for field in fields:
+            val = self.getfieldval(field)
+            if hasattr(val, "__iterlen__"):
+                length *= val.__iterlen__()
+            elif isinstance(val, tuple) and len(val) == 2 and all(hasattr(z, "__int__") for z in val):
+                length *= (val[1] - val[0])
+            elif isinstance(val, list):
+                len2 = 0
+                for x in val:
                     if hasattr(x, "__iterlen__"):
-                        l2 += x.__iterlen__()
-                    elif isinstance(x, tuple) and len(x) == 2 and all(isinstance(z, int) for z in x):
-                        l2 += (x[1] - x[0])
+                        len2 += x.__iterlen__()
+                    elif isinstance(x, tuple) and len(x) == 2 and all(hasattr(z, "__int__") for z in x):
+                        len2 += (x[1] - x[0])
                     elif isinstance(x, list):
-                        l2 += len(x)
+                        len2 += len(x)
                     else:
-                        l2 += 1
-                l *= l2 or 1
+                        len2 += 1
+                length *= len2 or 1
         if not isinstance(self.payload, NoPayload):
-            return l * self.payload.__iterlen__()
-        return l
+            return length * self.payload.__iterlen__()
+        return length
 
     def __gt__(self, other):
         """True if other is an answer from self (self ==> other)."""

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -15,11 +15,12 @@ import os
 from select import select, error as select_error
 import subprocess
 import time
+import types
 
 from scapy.consts import DARWIN, FREEBSD, OPENBSD, WINDOWS
 from scapy.data import ETH_P_ALL, MTU
 from scapy.config import conf
-from scapy.packet import Gen
+from scapy.packet import Packet, Gen
 from scapy.utils import get_temp_file, PcapReader, tcpdump, wrpcap
 from scapy import plist
 from scapy.error import log_runtime, log_interactive
@@ -48,14 +49,23 @@ class debug:
 ####################
 
 
-def _sndrcv_snd(pks, timeout, inter, verbose, tobesent, stopevent):
+def _sndrcv_snd(pks, timeout, inter, verbose, tobesent, hsent, timessent, stopevent):
     """Function used in the sending thread of sndrcv()"""
     try:
         i = 0
+        rec_time = timessent is not None
         if verbose:
             print("Begin emission:")
         for p in tobesent:
+            # Populate the dictionary of _sndrcv_rcv
+            # _sndrcv_rcv wont miss the answer of a packet that has not been sent
+            hsent.setdefault(p.hashret(), []).append(p)
+            if stopevent.is_set():
+                break
+            # Send packet
             pks.send(p)
+            if rec_time:
+                timessent[i] = p.sent_time
             i += 1
             time.sleep(inter)
         if verbose:
@@ -79,14 +89,12 @@ loop
     pass
 
 
-def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
-                multi):
+def _sndrcv_rcv(pks, hsent, stopevent, nbrecv, notans, verbose, chainCC,
+                multi, _storage_policy=None):
     """Function used to recieve packets and check their hashret"""
+    if not _storage_policy:
+        _storage_policy = lambda x, y: (x, y)
     ans = []
-    hsent = {}
-    for i in tobesent:
-        h = i.hashret()
-        hsent.setdefault(i.hashret(), []).append(i)
 
     is_python_can_socket = getattr(pks, "is_python_can_socket", lambda: False)
 
@@ -141,7 +149,7 @@ def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
                     hlst = hsent[h]
                     for i, sentpkt in enumerate(hlst):
                         if r.answers(sentpkt):
-                            ans.append((sentpkt, r))
+                            ans.append(_storage_policy(sentpkt, r))
                             if verbose > 1:
                                 os.write(1, b"*")
                             ok = True
@@ -153,6 +161,7 @@ def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
                                     notans -= 1
                                 sentpkt._answered = 1
                             break
+                del r
                 if notans == 0 and not multi:
                     break
                 if not ok:
@@ -172,7 +181,8 @@ def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
 
 
 def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
-           retry=0, multi=False, rcv_pks=None):
+           retry=0, multi=False, rcv_pks=None, store_unanswered=True,
+           process=None, prebuild=False):
     """Scapy raw function to send a packet and recieve its answer.
     WARNING: This is an internal function. Using sr/srp/sr1/srp is
     more appropriate in many cases.
@@ -186,64 +196,88 @@ def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
               if negative, how many times to retry when no more packets are answered
     timeout:  how much time to wait after the last packet has been sent
     verbose:  set verbosity level
-    multi:    whether to accept multiple answers for the same stimulus"""
-    is_single = isinstance(pkt, Gen)
-    pkts = [pkt] if is_single else pkt
+    multi:    whether to accept multiple answers for the same stimulus
+    store_unanswered:
+              whether to store not-answered packets or not. Default True.
+              setting it to False will increase speed, and will return None
+              as the unans list.
+    process:  if specified, only result from process(pkt) will be stored.
+              the function should follow the following format:
+                lambda sent, recieved: (func(sent), func2(recieved))
+              if the packet is unanswered, `recieved` will be None.
+              if `store_unanswered` is False, the function won't be called on un-answered packets.
+    prebuild: pre-build the packets before starting to send them. Default to False. Automatically used
+              when a generator is passed as the packet
+    """
     if verbose is None:
         verbose = conf.verb
+    use_prn_mode = False
+    _storage_policy = None
+    if process is not None:
+        use_prn_mode = True
+        _storage_policy = lambda x, y: process(x, y)
     debug.recv = plist.PacketList([], "Unanswered")
     debug.sent = plist.PacketList([], "Sent")
     debug.match = plist.SndRcvList([])
     nbrecv = 0
     ans = []
+    listable = (isinstance(pkt, Packet) and pkt.__iterlen__() == 1) or isinstance(pkt, list)
     # do it here to fix random fields, so that parent and child have the same
-    tobesent = [p for p in (pkt if is_single else SetGen(pkt))]
-    notans = len(tobesent)
+    if isinstance(pkt, types.GeneratorType) or prebuild:
+        tobesent = [p for p in pkt]
+        notans = len(tobesent)
+    else:
+        tobesent = SetGen(pkt) if not isinstance(pkt, Gen) else pkt
+        notans = tobesent.__iterlen__()
 
     if retry < 0:
         autostop = retry = -retry
     else:
         autostop = 0
 
-    for pkt in pkts:
-        pkt.sent_time = None
     while retry >= 0:
         if timeout is not None and timeout < 0:
             timeout = None
         stopevent = threading.Event()
 
+        hsent = {}
+        timessent = {} if listable else None
+
         thread = threading.Thread(
             target=_sndrcv_snd,
-            args=(pks, timeout, inter, verbose, tobesent, stopevent),
+            args=(pks, timeout, inter, verbose, tobesent, hsent, timessent, stopevent),
         )
+        thread.setDaemon(True)
         thread.start()
 
         hsent, newans, nbrecv, notans = _sndrcv_rcv(
-            (rcv_pks or pks), tobesent, stopevent, nbrecv, notans, verbose, chainCC, multi,
+            (rcv_pks or pks), hsent, stopevent, nbrecv, notans, verbose, chainCC, multi,
+            _storage_policy=_storage_policy,
         )
         thread.join()
 
         ans.extend(newans)
-        to_set_time = [pkt for pkt in pkts if pkt.sent_time is None]
-        if to_set_time:
-            try:
-                sent_time = min(p.sent_time for p in tobesent if getattr(p, "sent_time", None))
-            except ValueError:
-                pass
-            else:
-                for pkt in to_set_time:
-                    pkt.sent_time = sent_time
 
-        remain = itertools.chain(*six.itervalues(hsent))
-        remain = [p for p in remain if not hasattr(p, '_answered')] if multi else list(remain)
+        # Restore time_sent to original packets
+        if listable:
+            i = 0
+            for p in (pkt if isinstance(pkt, list) else [pkt]):
+               p.sent_time = timessent[i]
+               i += 1
 
-        if not remain:
-            break
+        if store_unanswered:
+            remain = list(itertools.chain(*six.itervalues(hsent)))
+            if multi:
+                remain = [p for p in remain if not hasattr(p, '_answered')]
 
-        if autostop and len(remain) != len(tobesent):
-            retry = autostop
+            if autostop and len(remain) > 0 and len(remain) != len(tobesent):
+                retry = autostop
 
-        tobesent = remain
+            tobesent = remain
+            if len(tobesent) == 0:
+                break
+        else:
+            remain = []
         retry -= 1
 
     if conf.debug_match:
@@ -258,7 +292,13 @@ def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
 
     if verbose:
         print("\nReceived %i packets, got %i answers, remaining %i packets" % (nbrecv + len(ans), len(ans), notans))
-    return plist.SndRcvList(ans), plist.PacketList(remain, "Unanswered")
+
+    if store_unanswered and use_prn_mode:
+        remain = [process(x, None) for x in remain]
+
+    ans_result = ans if use_prn_mode else plist.SndRcvList(ans)
+    unans_result = remain if use_prn_mode else (None if not store_unanswered else plist.PacketList(remain, "Unanswered"))
+    return ans_result, unans_result
 
 
 def __gen_send(s, x, inter=0, loop=0, count=None, verbose=None, realtime=None, return_packets=False, *args, **kargs):
@@ -434,7 +474,16 @@ timeout:  how much time to wait after the last packet has been sent
 verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
-iface:    listen answers only on the given interface"""
+iface:    listen answers only on the given interface
+store_unanswered:
+          whether to store not-answered packets or not. Default True.
+          setting it to False will increase speed, and will return None
+          as the unans list.
+process:  if specified, only result from process(pkt) will be stored.
+          the function should follow the following format:
+            lambda sent, recieved: (func(sent), func2(recieved))
+          if the packet is unanswered, `recieved` will be None.
+          if `store_unanswered` is False, the function won't be called on un-answered packets."""
     s = conf.L3socket(promisc=promisc, filter=filter, iface=iface, nofilter=nofilter)
     result = sndrcv(s, x, *args, **kargs)
     s.close()
@@ -451,7 +500,16 @@ timeout:  how much time to wait after the last packet has been sent
 verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
-iface:    listen answers only on the given interface"""
+iface:    listen answers only on the given interface
+store_unanswered:
+          whether to store not-answered packets or not. Default True.
+          setting it to False will increase speed, and will return None
+          as the unans list.
+process:  if specified, only result from process(pkt) will be stored.
+          the function should follow the following format:
+            lambda sent, recieved: (func(sent), func2(recieved))
+          if the packet is unanswered, `recieved` will be None.
+          if `store_unanswered` is False, the function won't be called on un-answered packets."""
     s = conf.L3socket(promisc=promisc, filter=filter, nofilter=nofilter, iface=iface)
     ans, _ = sndrcv(s, x, *args, **kargs)
     s.close()
@@ -471,7 +529,16 @@ timeout:  how much time to wait after the last packet has been sent
 verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
-iface:    work only on the given interface"""
+iface:    work only on the given interface
+store_unanswered:
+          whether to store not-answered packets or not. Default True.
+          setting it to False will increase speed, and will return None
+          as the unans list.
+process:  if specified, only result from process(pkt) will be stored.
+          the function should follow the following format:
+            lambda sent, recieved: (func(sent), func2(recieved))
+          if the packet is unanswered, `recieved` will be None.
+          if `store_unanswered` is False, the function won't be called on un-answered packets."""
     if iface is None and iface_hint is not None:
         iface = conf.route.route(iface_hint)[0]
     s = conf.L2socket(promisc=promisc, iface=iface, filter=filter, nofilter=nofilter, type=type)
@@ -490,7 +557,16 @@ timeout:  how much time to wait after the last packet has been sent
 verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
-iface:    work only on the given interface"""
+iface:    work only on the given interface
+store_unanswered:
+          whether to store not-answered packets or not. Default True.
+          setting it to False will increase speed, and will return None
+          as the unans list.
+process:  if specified, only result from process(pkt) will be stored.
+          the function should follow the following format:
+            lambda sent, recieved: (func(sent), func2(recieved))
+          if the packet is unanswered, `recieved` will be None.
+          if `store_unanswered` is False, the function won't be called on un-answered packets."""
     ans, _ = srp(*args, **kargs)
     if len(ans) > 0:
         return ans[0][1]
@@ -569,15 +645,22 @@ srloop(pkts, [prn], [inter], [count], ...) --> None"""
 # SEND/RECV FLOOD METHODS
 
 
-def sndrcvflood(pks, pkt, inter=0, verbose=None, chainCC=False, prn=lambda x: x):
+def sndrcvflood(pks, pkt, inter=0, verbose=None, chainCC=False, store_unanswered=True, process=None):
     if not verbose:
         verbose = conf.verb
-    is_single = isinstance(pkt, Gen)
-    pkts = [pkt] if is_single else pkt
-    tobesent = [p for p in (pkt if is_single else SetGen(pkt))]
+    listable = (isinstance(pkt, Packet) and pkt.__iterlen__() == 1) or isinstance(pkt, list)
+    tobesent = pkt
+
+    use_prn_mode = False
+    _storage_policy = None
+    if process is not None:
+        use_prn_mode = True
+        _storage_policy = lambda x, y: process(x, y)
 
     stopevent = threading.Event()
     count_packets = six.moves.queue.Queue()
+    hsent = {}
+    timessent = {} if listable else None
 
     def send_in_loop(tobesent, stopevent, count_packets=count_packets):
         """Infinite generator that produces the same packet until stopevent is triggered."""
@@ -590,37 +673,43 @@ def sndrcvflood(pks, pkt, inter=0, verbose=None, chainCC=False, prn=lambda x: x)
 
     infinite_gen = send_in_loop(tobesent, stopevent)
 
-    for pkt in pkts:
-        pkt.sent_time = None
     # We don't use _sndrcv_snd verbose (it messes the logs up as in a thread that ends after recieving)
     thread = threading.Thread(
         target=_sndrcv_snd,
-        args=(pks, None, inter, False, infinite_gen, stopevent),
+        args=(pks, None, inter, False, infinite_gen, hsent, timessent, stopevent),
     )
     thread.start()
 
-    hsent, ans, nbrecv, notans = _sndrcv_rcv(pks, tobesent, stopevent, 0, len(tobesent), verbose, chainCC, False)
+    hsent, ans, nbrecv, notans = _sndrcv_rcv(
+        pks, hsent, stopevent, 0, len(tobesent), verbose, chainCC, False,
+        _storage_policy=_storage_policy
+    )
     thread.join()
 
-    ans = [(x, prn(y)) for (x, y) in ans]  # Apply prn
-    to_set_time = [pkt for pkt in pkts if pkt.sent_time is None]
-    if to_set_time:
-        try:
-            sent_time = min(p.sent_time for p in tobesent if getattr(p, "sent_time", None))
-        except ValueError:
-            pass
-        else:
-            for pkt in to_set_time:
-                pkt.sent_time = sent_time
+    # Restore time_sent to original packets
+    if listable:
+        i = 0
+        for p in (pkt if isinstance(pkt, list) else [pkt]):
+           p.sent_time = timessent[i]
+           i += 1
 
-    remain = list(itertools.chain(*six.itervalues(hsent)))
+    if process is not None:
+        ans = [(x, process(y)) for (x, y) in ans]  # Apply process
+
+    if store_unanswered:
+        if use_prn_mode:
+            remain = [process(x, None) for x in itertools.chain(*six.itervalues(hsent))]
+        else:
+            remain = list(itertools.chain(*six.itervalues(hsent)))
 
     if verbose:
         print("\nReceived %i packets, got %i answers, remaining %i packets. Sent a total of %i packets." % (nbrecv + len(ans), len(ans), notans, count_packets.qsize()))
     count_packets.empty()
     del count_packets
 
-    return plist.SndRcvList(ans), plist.PacketList(remain, "Unanswered")
+    ans_result = ans if use_prn_mode else plist.SndRcvList(ans)
+    unans_result = remain if use_prn_mode else (None if not store_unanswered else plist.PacketList(remain, "Unanswered"))
+    return ans_result, unans_result
 
 
 @conf.commands.register

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -198,10 +198,9 @@ def sndrcv(pks, pkt, timeout=None, inter=0, verbose=None, chainCC=False,
     timeout:  how much time to wait after the last packet has been sent
     verbose:  set verbosity level
     multi:    whether to accept multiple answers for the same stimulus
-    store_unanswered:
-              whether to store not-answered packets or not. Default True.
-              setting it to False will increase speed, and will return None
-              as the unans list.
+    store_unanswered: whether to store not-answered packets or not. Default True.
+                      setting it to False will increase speed, and will return None
+                      as the unans list.
     process:  if specified, only result from process(pkt) will be stored.
               the function should follow the following format:
                 lambda sent, recieved: (func(sent), func2(recieved))
@@ -477,10 +476,9 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface
-store_unanswered:
-          whether to store not-answered packets or not. Default True.
-          setting it to False will increase speed, and will return None
-          as the unans list.
+store_unanswered: whether to store not-answered packets or not. Default True.
+                  setting it to False will increase speed, and will return None
+                  as the unans list.
 process:  if specified, only result from process(pkt) will be stored.
           the function should follow the following format:
             lambda sent, recieved: (func(sent), func2(recieved))
@@ -503,10 +501,9 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface
-store_unanswered:
-          whether to store not-answered packets or not. Default True.
-          setting it to False will increase speed, and will return None
-          as the unans list.
+store_unanswered: whether to store not-answered packets or not. Default True.
+                  setting it to False will increase speed, and will return None
+                  as the unans list.
 process:  if specified, only result from process(pkt) will be stored.
           the function should follow the following format:
             lambda sent, recieved: (func(sent), func2(recieved))
@@ -532,10 +529,9 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface
-store_unanswered:
-          whether to store not-answered packets or not. Default True.
-          setting it to False will increase speed, and will return None
-          as the unans list.
+store_unanswered: whether to store not-answered packets or not. Default True.
+                  setting it to False will increase speed, and will return None
+                  as the unans list.
 process:  if specified, only result from process(pkt) will be stored.
           the function should follow the following format:
             lambda sent, recieved: (func(sent), func2(recieved))
@@ -560,10 +556,9 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface
-store_unanswered:
-          whether to store not-answered packets or not. Default True.
-          setting it to False will increase speed, and will return None
-          as the unans list.
+store_unanswered: whether to store not-answered packets or not. Default True.
+                  setting it to False will increase speed, and will return None
+                  as the unans list.
 process:  if specified, only result from process(pkt) will be stored.
           the function should follow the following format:
             lambda sent, recieved: (func(sent), func2(recieved))

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -4,8 +4,8 @@
     "..\\scapy\\contrib\\*.uts"
   ],
   "remove_testfiles": [
-    "test\\cansocket_native.uts",
-    "test\\cansocket_python_can.uts"
+    "cansocket_native.uts",
+    "cansocket_python_can.uts"
   ],
   "onlyfailed": true,
   "preexec": {

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1117,6 +1117,24 @@ ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / ICMP(), timeout=2, retry=1)
 conf.debug_dissector = old_debug_dissector
 len(ans) == 1 and len(unans) == 1
 
+= Send & receive with process
+~ netaccess IP ICMP
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), process=lambda x, y: (x[IP].dst, y[IP].src))
+conf.debug_dissector = old_debug_dissector
+assert all(x == y for x, y in ans)
+assert isinstance(unans, list)
+
+= Send & receive with store_unanswered=False
+~ netaccess IP ICMP
+old_debug_dissector = conf.debug_dissector
+conf.debug_dissector = False
+ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), store_unanswered=False)
+conf.debug_dissector = old_debug_dissector
+assert isinstance(ans, PacketList)
+assert unans == None
+
 = Traceroute function
 ~ netaccess
 * Let's test traceroute
@@ -6489,6 +6507,8 @@ test_openbsd_6_3()
 + Mocked _parse_tcpreplay_result(stdout, stderr, argv, results_dict)
 ~ mock_parse_tcpreplay_result
 
+= Test mocked _parse_tcpreplay_result
+
 # This is tested with tcpreplay version: 3.4.4
 
 stdout = """Actual: 1024 packets (198929 bytes) sent in 67.88 seconds.              Rated: 2930.6 bps, 0.02 Mbps, 15.09 pps
@@ -8895,9 +8915,11 @@ n1 = Net("192.168.0.0/31")
 
 n2 = Net("192.168.0.*")
 len([ip for ip in n2]) == 256
+assert n2.__iterlen__() == 256
 
 n3 = Net("192.168.0.1-5")
 len([ip for ip in n3]) == 5
+assert n3.__iterlen__() == 5
 
 (n1 == n3) == False
 
@@ -8925,11 +8947,16 @@ assert isinstance(src, str)
 
 oid = OID("1.2.3.4.5.6-8")
 len([ o for o in oid ]) == 3
+assert oid.__iterlen__() == 3
 
 = Net6
 
 n1 = Net6("2001:db8::/127")
 len([ip for ip in n1]) == 2
+
+n2 = Net6("fec0::/110")
+#len([x for x in n2]) returns 262144 (very slow)
+assert n2.__iterlen__() == 262144
 
 = Net6 using web address
 ~ netaccess ipv6

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6509,7 +6509,7 @@ test_openbsd_6_3()
 
 = Test mocked _parse_tcpreplay_result
 
-# This is tested with tcpreplay version: 3.4.4
+from scapy.sendrecv import _parse_tcpreplay_result
 
 stdout = """Actual: 1024 packets (198929 bytes) sent in 67.88 seconds.              Rated: 2930.6 bps, 0.02 Mbps, 15.09 pps
 Statistics for network device: mon0
@@ -6525,8 +6525,9 @@ sending out mon0
 processing file: replay-example.pcap"""
 
 argv = ['tcpreplay' '--intf1=mon0' '--multiplier=1.00' '--timer=nano' 'replay-example.pcap']
-results_dict = {}
-_parse_tcpreplay_result(stdout, stderr, argv, results_dict)
+results_dict = _parse_tcpreplay_result(stdout, stderr, argv)
+
+results_dict
 
 assert(results_dict["packets"] == 1024)
 assert(results_dict["bytes"] == 198929)
@@ -6539,8 +6540,8 @@ assert(results_dict["successful"] == 1024)
 assert(results_dict["failed"] == 0)
 assert(results_dict["retried_enobufs"] == 0)
 assert(results_dict["retried_eagain"] == 0)
-assert(results_dict["command"] == argv)
-assert(len(results_dict["warnings"]) == 4)
+assert(results_dict["command"] == str(argv))
+assert(len(results_dict["warnings"]) == 3)
 
 
 ############


### PR DESCRIPTION
This PR improves speed of the `sr` suite by:
- using generators. This requires to equip the generators with `__iterlen__` functions to predict the size of big generators.
- sharing the `hsent` key, between the `_sndrcv_rcv` and `_sndrcv_snd` functions. It was previously generated twice, in each of them.
- remove useless `timeout` case
- adds new `process` mode, which allows to select (if enabled) which data to return from the packets. This mode ignores unanswers and stores only wanted data, which uses way less memory. This is intended to be used in very big scans, E.g:
```
ans, unans = sr(IP(dst="www.google.fr")/TCP(dport=(1, 49151), flags='S'), timeout=3, process=lambda x,y: y[TCP].sport, store_unanswered=False)
```
`ans` is `[21, 80, 443]` and `unans` is `None`.

## Results

| Speed test                                                                     | Secdev/master | This PR |
|--------------------------------------------------------------------------------|---------------|---------|
| %timeit -r 1 -n 10 srp(Ether(dst="ff:ff:ff:ff:ff:ff")/ARP(pdst="192.168.0.1/24"),timeout=2) | 21sec         | 21sec   |
| %timeit -r 1 -n 1 sr(IP(dst="www.google.fr")/TCP(dport=(1, 49151), flags='S'), timeout=3)        | 93sec         | 49sec   |