### PR TITLE
Scapy 2.4, Windows: fix for 'IFACES' backward incompatibility with scapy v.2.3.2

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -780,7 +780,7 @@ class NetworkInterfaceDict(UserDict):
 # Init POWERSHELL_PROCESS
 POWERSHELL_PROCESS = _PowershellManager()
 
-IFACES = NetworkInterfaceDict()
+IFACES = ifaces = NetworkInterfaceDict()
 IFACES.load_from_powershell()
 
 def pcapname(dev):


### PR DESCRIPTION
In scapy v.2.3.2 'ifaces' name was used but in new scapy v.2.3.3 and v.2.4.4 it has been renamed to 'IFACES'.
Unfortunately in many places of our users code the name 'ifaces' already exists.
Is it possible to restore compatibility by 'aliasing' of both names?