### PR TITLE
Fix lldp org specific dissection clean #1151

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -50,7 +50,6 @@ from scapy.layers.l2 import Ether, Dot1Q, bind_layers, \
 from scapy.modules.six.moves import range
 from scapy.data import ETHER_TYPES
 from scapy.compat import orb, raw
-from scapy.packet import Raw
 
 LLDP_NEAREST_BRIDGE_MAC = '01:80:c2:00:00:0e'
 LLDP_NEAREST_NON_TPMR_BRIDGE_MAC = '01:80:c2:00:00:03'
@@ -126,9 +125,9 @@ class LLDPDU(Packet):
         # type is a 7-bit bitfield spanning bits 1..7 -> div 2
         try:
             lldpdu_tlv_type = orb(payload[0]) // 2
-            return LLDPDU_CLASS_TYPES.get(lldpdu_tlv_type, Raw)
+            return LLDPDU_CLASS_TYPES.get(lldpdu_tlv_type, conf.raw_layer)
         except IndexError:
-            return Raw
+            return conf.raw_layer
 
     @staticmethod
     def _dot1q_headers_size(layer):

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -46,7 +46,7 @@ from scapy.layers.dot11 import Packet
 from scapy.layers.l2 import Ether, Dot1Q, bind_layers, \
     BitField, StrLenField, ByteEnumField, BitEnumField, \
     BitFieldLenField, ShortField, Padding, Scapy_Exception, \
-    XStrLenField, ByteField, ThreeBytesEnumField
+    XStrLenField, ByteField, EnumField, ThreeBytesField
 from scapy.modules.six.moves import range
 from scapy.data import ETHER_TYPES
 from scapy.compat import orb, raw
@@ -667,6 +667,12 @@ class LLDPDUManagementAddress(LLDPDU):
     def do_build(self):
         self._check()
         return super(LLDPDUManagementAddress, self).do_build()
+
+
+class ThreeBytesEnumField(EnumField, ThreeBytesField):
+
+    def __init__(self, name, default, enum):
+        EnumField.__init__(self, name, default, enum, "!I")
 
 
 class LLDPDUGenericOrganisationSpecific(LLDPDU):

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -45,11 +45,11 @@ from scapy.config import conf
 from scapy.layers.dot11 import Packet
 from scapy.layers.l2 import Ether, Dot1Q, bind_layers, \
     BitField, StrLenField, ByteEnumField, BitEnumField, \
-    BitFieldLenField, ShortField, Padding, Scapy_Exception, \
+    BitFieldLenField, ShortField, Scapy_Exception, \
     XStrLenField, ByteField, EnumField, ThreeBytesField
 from scapy.modules.six.moves import range
 from scapy.data import ETHER_TYPES
-from scapy.compat import orb, raw
+from scapy.compat import orb
 
 LLDP_NEAREST_BRIDGE_MAC = '01:80:c2:00:00:0e'
 LLDP_NEAREST_NON_TPMR_BRIDGE_MAC = '01:80:c2:00:00:03'

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -126,11 +126,9 @@ class LLDPDU(Packet):
         # type is a 7-bit bitfield spanning bits 1..7 -> div 2
         try:
             lldpdu_tlv_type = orb(payload[0]) // 2
-            return LLDPDU_CLASS_TYPES[lldpdu_tlv_type]
-        except (KeyError, IndexError):
-            pass
-
-        return Raw
+            return LLDPDU_CLASS_TYPES.get(lldpdu_tlv_type, Raw)
+        except IndexError:
+            return Raw
 
     @staticmethod
     def _dot1q_headers_size(layer):

--- a/scapy/contrib/lldp.uts
+++ b/scapy/contrib/lldp.uts
@@ -228,3 +228,26 @@ assert frm[LLDPDUSystemName].system_name == b'things will'
 assert frm[LLDPDUManagementAddress].object_id == b'burn'
 assert frm[LLDPDUSystemDescription].description == b'without tests.'
 assert frm[LLDPDUPortDescription].description == b'always!'
+
++ organisation specific layers
+
+= LLDPDUGenericOrganisationSpecific tests
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+      LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+      LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+      LLDPDUTimeToLive()/\
+      LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                        subtype=0x42,
+                                        data=b'FooBar'*5
+                                        )/\
+      LLDPDUEndOfLLDPDU()
+
+frm = frm.build()
+frm = Ether(frm)
+org_spec_layer = frm[LLDPDUGenericOrganisationSpecific]
+assert(org_spec_layer)
+assert(org_spec_layer._type == 127)
+assert(org_spec_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO)
+assert(org_spec_layer.subtype == 0x42)
+assert(org_spec_layer._length == 34)

--- a/scapy/contrib/lldp.uts
+++ b/scapy/contrib/lldp.uts
@@ -231,6 +231,27 @@ assert frm[LLDPDUPortDescription].description == b'always!'
 
 + organisation specific layers
 
+= ThreeBytesEnumField tests
+
+three_b_enum_field = ThreeBytesEnumField('test', 0x00,
+                                         {
+                                             0x0e: 'fourteen',
+                                             0x00: 'zero',
+                                             0x5566: 'five-six',
+                                             0x0e0000: 'fourteen-zero-zero',
+                                             0x0e0100: 'fourteen-one-zero',
+                                             0x112233: '1#2#3'
+                                         })
+
+assert(three_b_enum_field.i2repr(None, 0) == 'zero')
+assert(three_b_enum_field.i2repr(None, 0x0e) == 'fourteen')
+assert(three_b_enum_field.i2repr(None, 0x5566) == 'five-six')
+assert(three_b_enum_field.i2repr(None, 0x112233) == '1#2#3')
+assert(three_b_enum_field.i2repr(None, 0x0e0000) == 'fourteen-zero-zero')
+assert(three_b_enum_field.i2repr(None, 0x0e0100) == 'fourteen-one-zero')
+assert(three_b_enum_field.i2repr(None, 0x01) == '1')
+assert(three_b_enum_field.i2repr(None, 0x49763) == '300899')
+
 = LLDPDUGenericOrganisationSpecific tests
 
 frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1050,6 +1050,12 @@ class XShortEnumField(ShortEnumField):
         return lhex(x)
 
 
+class ThreeBytesEnumField(EnumField, ThreeBytesField):
+
+    def __init__(self, name, default, enum):
+        EnumField.__init__(self, name, default, enum, "!I")
+
+
 class _MultiEnumField(_EnumField):
     def __init__(self, name, default, enum, depends_on, fmt = "H"):
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1049,13 +1049,6 @@ class XShortEnumField(ShortEnumField):
                     return ret
         return lhex(x)
 
-
-class ThreeBytesEnumField(EnumField, ThreeBytesField):
-
-    def __init__(self, name, default, enum):
-        EnumField.__init__(self, name, default, enum, "!I")
-
-
 class _MultiEnumField(_EnumField):
     def __init__(self, name, default, enum, depends_on, fmt = "H"):
 

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1036,3 +1036,29 @@ try:
     assert(False)
 except (Scapy_Exception, IndexError):
     pass
+
+
+############
+############
++ Three3BytesEnumField tests
+
+= Test proper value substitution
+
+three_b_enum_field = ThreeBytesEnumField('test', 0x00,
+                                         {
+                                             0x0e: 'fourteen',
+                                             0x00: 'zero',
+                                             0x5566: 'five-six',
+                                             0x0e0000: 'fourteen-zero-zero',
+                                             0x0e0100: 'fourteen-one-zero',
+                                             0x112233: '1#2#3'
+                                         })
+
+assert(three_b_enum_field.i2repr(None, 0) == 'zero')
+assert(three_b_enum_field.i2repr(None, 0x0e) == 'fourteen')
+assert(three_b_enum_field.i2repr(None, 0x5566) == 'five-six')
+assert(three_b_enum_field.i2repr(None, 0x112233) == '1#2#3')
+assert(three_b_enum_field.i2repr(None, 0x0e0000) == 'fourteen-zero-zero')
+assert(three_b_enum_field.i2repr(None, 0x0e0100) == 'fourteen-one-zero')
+assert(three_b_enum_field.i2repr(None, 0x01) == '1')
+assert(three_b_enum_field.i2repr(None, 0x49763) == '300899')

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1036,29 +1036,3 @@ try:
     assert(False)
 except (Scapy_Exception, IndexError):
     pass
-
-
-############
-############
-+ Three3BytesEnumField tests
-
-= Test proper value substitution
-
-three_b_enum_field = ThreeBytesEnumField('test', 0x00,
-                                         {
-                                             0x0e: 'fourteen',
-                                             0x00: 'zero',
-                                             0x5566: 'five-six',
-                                             0x0e0000: 'fourteen-zero-zero',
-                                             0x0e0100: 'fourteen-one-zero',
-                                             0x112233: '1#2#3'
-                                         })
-
-assert(three_b_enum_field.i2repr(None, 0) == 'zero')
-assert(three_b_enum_field.i2repr(None, 0x0e) == 'fourteen')
-assert(three_b_enum_field.i2repr(None, 0x5566) == 'five-six')
-assert(three_b_enum_field.i2repr(None, 0x112233) == '1#2#3')
-assert(three_b_enum_field.i2repr(None, 0x0e0000) == 'fourteen-zero-zero')
-assert(three_b_enum_field.i2repr(None, 0x0e0100) == 'fourteen-one-zero')
-assert(three_b_enum_field.i2repr(None, 0x01) == '1')
-assert(three_b_enum_field.i2repr(None, 0x49763) == '300899')


### PR DESCRIPTION
- adds a new field ThreeBytesEnumField
- decodes organisation specific TLVs in a generic way
- ensure that if something unexpected appears the remaining payload is put into a Raw() layer

fixes #1151 