### PR TITLE
Switch Linux Travis test to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,22 @@ matrix:
         - os: linux
           python: 2.7
           env:
-            - SCAPY_COVERAGE=yes
-
-        - os: linux
-          python: 3.3
-          env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=py27-linux_non_root,codecov
 
         - os: linux
           python: 3.4
           env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=py34-linux_non_root,codecov
 
         - os: linux
           python: 3.5
           env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=py35-linux_non_root,codecov
 
         - os: linux
           python: 3.6
           env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=py36-linux_non_root,codecov
 
         - os: linux
           python: pypy
@@ -53,31 +48,25 @@ matrix:
           sudo: required
           python: 2.7
           env:
-            - SCAPY_SUDO=sudo SCAPY_COVERAGE=yes
-
-        - os: linux
-          sudo: required
-          python: 3.3
-          env:
-            - SCAPY_SUDO=sudo SCAPY_COVERAGE=yes
+            - TOXENV=py27-linux_root,codecov
 
         - os: linux
           sudo: required
           python: 3.4
           env:
-            - SCAPY_SUDO=sudo SCAPY_COVERAGE=yes
+            - TOXENV=py34-linux_root,codecov
 
         - os: linux
           sudo: required
           python: 3.5
           env:
-            - SCAPY_SUDO=sudo SCAPY_COVERAGE=yes
+            - TOXENV=py35-linux_root,codecov
 
         - os: linux
           sudo: required
           python: 3.6
           env:
-            - SCAPY_SUDO=sudo SCAPY_COVERAGE=yes
+            - TOXENV=py36-linux_root,codecov
 
         - os: linux
           sudo: required

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,10 +1,26 @@
+# Detect the pip version
 PIP=`which pip || (python --version 2>&1 | grep -q 'Python 2' && which pip2) || (python --version 2>&1 | grep -q 'Python 3' && which pip3)`
 
-# Install Python3 on osx
-if [ "$TRAVIS_OS_NAME" = "osx" ] && [ ! -z "$TOXENV" ]
+if [ ! -z "$TOXENV" ]
 then
-  brew upgrade python
-  pip3 install tox
+  # Install Python3 on osx
+  if [ "$TRAVIS_OS_NAME" = "osx" ] && ! python3
+  then
+    brew upgrade python
+    pip3 install tox
+    exit 0
+  fi
+
+  # Install wireshark data
+  if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_SUDO" = "true" ]
+  then
+    sudo apt-get -qy install tshark
+  fi
+
+  # Make sure tox is installed and up to date
+  $PIP install -U tox
+
+  # Stop here when using tox
   exit 0
 fi
 

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,7 +1,24 @@
-# Test Python3 Scapy on osx
-if [ "$TRAVIS_OS_NAME" = "osx" ] && [ ! -z "$TOXENV" ]
+# Launch tox
+if [ ! -z "$TOXENV" ]
 then
-  tox -- -K tcpdump
+  if [ "$TRAVIS_OS_NAME" = "linux" ]
+  then
+    # Linux 
+    UT_FLAGS=" -K tshark" # TODO: also test as root ?
+    if [ "$TRAVIS_SUDO" != "true" ]
+    then
+      # Linux non root
+      UT_FLAGS+=" -K manufdb"
+    fi
+  elif [ "$TRAVIS_OS_NAME" = "osx" ]
+  then
+    UT_FLAGS=" -K tcpdump"
+  fi
+
+  # Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
+  set
+
+  tox -- $UT_FLAGS
   exit $?
 fi
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ handle, like sending invalid frames, injecting your own 802.11 frames, combining
 techniques (VLAN hopping+ARP cache poisoning, VoIP decoding on WEP protected
 channel, ...), etc.
 
-Scapy supports Python 2.7 and Python 3 (3.3 to 3.6). It's intended to
+Scapy supports Python 2.7 and Python 3 (3.4 to 3.6). It's intended to
 be cross platform, and runs on many different platforms (Linux, OSX,
 *BSD, and Windows).
 

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -7,7 +7,7 @@ Download and Installation
 Overview
 ========
 
- 0. Install `Python 2.7.X or 3.3+ <https://www.python.org/downloads/>`_.
+ 0. Install `Python 2.7.X or 3.4+ <https://www.python.org/downloads/>`_.
  1. `Download and install Scapy. <#installing-scapy-v2-x>`_
  2. `Follow the platform-specific instructions (depedencies) <#platform-specific-instructions>`_.
  3. (Optional): `Install additional software for special features <#optional-software-for-special-features>`_.
@@ -18,7 +18,7 @@ Each of these steps can be done in a different way depending on your platform an
 At the moment, there are two different versions of Scapy:
 
 * **Scapy v2.x**. The current up-to-date version. It consists of several files  packaged in the standard distutils way.
-  Scapy v2 <= 2.3.3 needs Python 2.5, Scapy v2 > 2.3.3 needs Python 2.7 or 3.3+.
+  Scapy v2 <= 2.3.3 needs Python 2.5, Scapy v2 > 2.3.3 needs Python 2.7 or 3.4+.
 * **Scapy v1.x (deprecated)**. It does not support Python 3. It consists of only one file and works on Python 2.4, so it might be easier to install.
   Moreover, your OS may already have specially prepared packages or ports for it. The last version is v1.2.2.
 
@@ -219,7 +219,7 @@ Linux native
 
 Scapy can run natively on Linux, without libdnet and libpcap.
 
-* Install `Python 2.7 or 3.3+ <http://www.python.org>`_.
+* Install `Python 2.7 or 3.4+ <http://www.python.org>`_.
 * Install `tcpdump <http://www.tcpdump.org>`_ and make sure it is in the $PATH. (It's only used to compile BPF filters (``-ddd option``))
 * Make sure your kernel has Packet sockets selected (``CONFIG_PACKET``)
 * If your kernel is < 2.6, make sure that Socket filtering is selected ``CONFIG_FILTER``) 
@@ -382,13 +382,13 @@ Scapy is primarily being developed for Unix-like systems and works best on those
 
 You need the following software packages in order to install Scapy on Windows:
 
-  * `Python <http://www.python.org>`_: `Python 2.7.X or 3.3+ <https://www.python.org/downloads/>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python27`` and ``C:\Python27\Scripts`` respectively.
+  * `Python <http://www.python.org>`_: `Python 2.7.X or 3.4+ <https://www.python.org/downloads/>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python27`` and ``C:\Python27\Scripts`` respectively.
   * `Npcap <https://nmap.org/npcap/>`_: `the latest version <https://nmap.org/npcap/#download>`_. Default values are recommanded. Scapy will also work with Winpcap.
   * `Scapy <http://www.secdev.org/projects/scapy/>`_: `latest development version <https://github.com/secdev/scapy/archive/master.zip>`_ from the `Git repository <https://github.com/secdev/scapy>`_. Unzip the archive, open a command prompt in that directory and run "python setup.py install". 
 
 Just download the files and run the setup program. Choosing the default installation options should be safe.
 
-For your convenience direct links are given to the version that is supported (Python 2.7 and 3.3+). If these links do not work or if you are using a different Python version (which will surely not work), just visit the homepage of the respective package and look for a Windows binary. As a last resort, search the web for the filename.
+For your convenience direct links are given to the version that is supported (Python 2.7 and 3.4+). If these links do not work or if you are using a different Python version (which will surely not work), just visit the homepage of the respective package and look for a Windows binary. As a last resort, search the web for the filename.
 
 After all packages are installed, open a command prompt (cmd.exe) and run Scapy by typing ``scapy``. If you have set the PATH correctly, this will find a little batch file in your ``C:\Python27\Scripts`` directory and instruct the Python interpreter to load Scapy.
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/test/configs/linux.utsc
+++ b/test/configs/linux.utsc
@@ -1,0 +1,23 @@
+{
+  "testfiles": [
+    "test/*.uts",
+    "scapy/contrib/*.uts"
+  ],
+  "remove_testfiles": [
+    "test/mock_windows.uts",
+    "test/bpf.uts"
+  ],
+  "onlyfailed": true,
+  "preexec": {
+    "scapy/contrib/*.uts": "load_contrib(\"%name%\")",
+    "test/cert.uts": "load_layer(\"tls\")",
+    "test/sslv2.uts": "load_layer(\"tls\")",
+    "test/tls*.uts": "load_layer(\"tls\")"
+  },
+  "format": "text",
+  "kw_ko": [
+    "crypto_advanced",
+    "ipv6",
+    "osx"
+  ]
+}

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -171,13 +171,14 @@ assert get_var("init_value") == 123
  
 = Session test with fname
 
-init_session("scapySession2")
+session_name = tempfile.mktemp()
+init_session(session_name)
 set_var("test_value", IP(dst="192.168.0.1")) # test_value = IP(dst="192.168.0.1")
-save_session(fname="scapySession1.dat")
+save_session(fname="%s.dat" % session_name)
 del_var("test_value")
 
 set_var("z", True) #z = True
-load_session(fname="scapySession1.dat")
+load_session(fname="%s.dat" % session_name)
 try:
     get_var("z")
     assert False
@@ -185,13 +186,13 @@ except:
     pass
 
 set_var("z", False) #z = False
-update_session(fname="scapySession1.dat")
+update_session(fname="%s.dat" % session_name)
 assert get_var("test_value").dst == "192.168.0.1" #test_value.dst == "192.168.0.1"
 assert not get_var("z")
 
 = Clear session files
 
-os.remove("scapySession1.dat")
+os.remove("%s.dat" % session_name)
 
 = Test temporary file creation
 ~ appveyor_only

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,8 @@ platform =
   osx_non_root,osx_root: darwin
 
 commands =
-# TODO: linux tests should use test/config/linux.utsc !
-#  linux_non_root: UTscapy -c ./test/configs/travis.utsc -T test/pipetool.uts -T test/mock_windows.uts -T test/bpf.uts -K tcpdump -K not_pypy -K needs_root -K random_weird_py3 {posargs}
-#  linux_root: sudo -E UTscapy -c ./test/configs/travis.utsc -T test/pipetool.uts -T test/mock_windows.uts -T test/bpf.uts -K tcpdump -K not_pypy -K random_weird_py3 {posargs}
+  linux_non_root: coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K not_pypy -K random_weird_py3 -K netaccess -K needs_root {posargs}
+  linux_root: sudo -E {envpython} -m coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K not_pypy -K random_weird_py3 {posargs}
   osx_non_root: coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c test/configs/osx.utsc -K manufdb -K tshark -K random_weird_py3 -K netaccess -K needs_root {posargs}
   osx_root: sudo -E coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c test/configs/osx.utsc -K manufdb -K tshark -K random_weird_py3 {posargs}
   coverage combine


### PR DESCRIPTION
Attempt at replacing the current Travis tests with tox. The ultimate goal is to test locally as done on Travis.

I had to remove Python3.3 support due to a bug with distutils that I could not fix.