### PR TITLE
Support monitor mode on windows

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1087,7 +1087,7 @@ Provided that your wireless card and driver are correctly configured for frame i
 On Windows, if using Npcap, the equivalent would be to call
 
     # Of course, conf.iface can be replaced by any interfaces accessed through IFACES
-    >>> conf.iface.setmode(1)
+    >>> conf.iface.setmonitor(True)
 
 you can have a kind of FakeAP::
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -518,14 +518,31 @@ class NetworkInterface(object):
         """Get the interface operation mode.
         Only available with Npcap."""
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "mode"], stdout=sp.PIPE).communicate()[0].strip()
+        return plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "mode"], stdout=sp.PIPE).communicate()[0].strip())
+
+    def ismonitor(self):
+        """Returns True if the interface is in monitor mode.
+        Only available with Npcap."""
+        try:
+            self._check_npcap_requirement()
+            return self.mode() == "monitor"
+        except Scapy_Exception:
+            return False
+
+    def setmonitor(self, enable=True):
+        """Alias for setmode('monitor') or setmode('managed')
+        Only availble with Npcap"""
+        if enable:
+            return self.setmode('monitor')
+        else:
+            return self.setmode('managed')
 
     def availablemodes(self):
         """Get all available interface modes.
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "modes"], stdout=sp.PIPE).communicate()[0].strip().split(",")
+        return plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "modes"], stdout=sp.PIPE).communicate()[0].strip()).split(",")
 
     def setmode(self, mode):
         """Set the interface mode. It can be:
@@ -547,50 +564,51 @@ class NetworkInterface(object):
             5: "wfd_client"
         }
         m = _modes.get(mode, "unknown") if isinstance(mode, int) else mode
-        return sp.call(_WlanHelper + " " + self.guid[1:-1] + " mode " + m)
+        return not POWERSHELL_PROCESS.query([_encapsulate_admin(_WlanHelper + " " + self.guid[1:-1] + " mode " + m)])
 
     def channel(self):
         """Get the channel of the interface.
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "channel"],
-                        stdout=sp.PIPE).communicate()[0].strip()
+        x = plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "channel"],
+                        stdout=sp.PIPE).communicate()[0].strip())
+        return int(x)
 
     def setchannel(self, channel):
         """Set the channel of the interface (1-14):
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.call(_WlanHelper + " " + self.guid[1:-1] + " channel " + str(channel))
+        return not POWERSHELL_PROCESS.query([_encapsulate_admin(_WlanHelper + " " + self.guid[1:-1] + " channel " + str(channel))])
 
     def frequence(self):
         """Get the frequence of the interface.
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "freq"], stdout=sp.PIPE).communicate()[0].strip()
+        return plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "freq"], stdout=sp.PIPE).communicate()[0].strip())
 
     def setfrequence(self, freq):
         """Set the channel of the interface (1-14):
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.call(_WlanHelper + " " + self.guid[1:-1] + " freq " + str(freq))
+        return not POWERSHELL_PROCESS.query([_encapsulate_admin(_WlanHelper + " " + self.guid[1:-1] + " freq " + str(freq))])
 
     def availablemodulations(self):
         """Get all available 802.11 interface modulations.
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "modus"], stdout=sp.PIPE).communicate()[0].strip().split(",")
+        return plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "modus"], stdout=sp.PIPE).communicate()[0].strip()).split(",")
 
     def modulation(self):
         """Get the 802.11 modulation of the interface.
         Only available with Npcap."""
         # According to https://nmap.org/npcap/guide/npcap-devguide.html#npcap-feature-dot11
         self._check_npcap_requirement()
-        return sp.Popen([_WlanHelper, self.guid[1:-1], "modu"], stdout=sp.PIPE).communicate()[0].strip()
+        return plain_str(sp.Popen([_WlanHelper, self.guid[1:-1], "modu"], stdout=sp.PIPE).communicate()[0].strip())
 
     def setmodulation(self, modu):
         """Set the interface modulation. It can be:
@@ -622,7 +640,7 @@ class NetworkInterface(object):
             10: "mimo-ofdm",
         }
         m = _modus.get(modu, "unknown") if isinstance(modu, int) else modu
-        return sp.call(_WlanHelper + " " + self.guid[1:-1] + " mode " + m)
+        return not POWERSHELL_PROCESS.query([_encapsulate_admin(_WlanHelper + " " + self.guid[1:-1] + " mode " + m)])
 
     def __repr__(self):
         return "<%s %s %s>" % (self.__class__.__name__, self.name, self.guid)
@@ -814,7 +832,11 @@ def show_interfaces(resolve_mac=True):
     return IFACES.show(resolve_mac)
 
 _orig_open_pcap = pcapdnet.open_pcap
-pcapdnet.open_pcap = lambda iface,*args,**kargs: _orig_open_pcap(pcapname(iface),*args,**kargs)
+def open_pcap(iface, *args, **kargs):
+    if iface.ismonitor():
+        kargs["monitor"] = True
+    return _orig_open_pcap(pcapname(iface), *args, **kargs)
+pcapdnet.open_pcap = open_pcap
 
 get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr = lambda iface, *args, **kargs: (
     ARPHDR_ETHER, mac2str(IFACES.dev_from_pcapname(pcapname(iface)).mac)

--- a/scapy/modules/winpcapy.py
+++ b/scapy/modules/winpcapy.py
@@ -271,6 +271,45 @@ pcap_open_offline = _lib.pcap_open_offline
 pcap_open_offline.restype = POINTER(pcap_t)
 pcap_open_offline.argtypes = [STRING, STRING]
 
+try:  # NPCAP ONLY function
+    #int pcap_set_rfmon (pcap_t *p)
+    #   sets whether monitor mode should be set on a capture handle when the handle is activated.
+    pcap_set_rfmon = _lib.pcap_set_rfmon
+    pcap_set_rfmon.restype = c_int
+    pcap_set_rfmon.argtypes = [POINTER(pcap_t), c_int]
+
+    #int pcap_create (pcap_t *p)
+    #   create a packet capture handle to look at packets on the network.
+    pcap_create = _lib.pcap_create
+    pcap_create.restype = POINTER(pcap_t)
+    pcap_create.argtypes = [STRING, STRING]
+
+    #int pcap_set_snaplen(pcap_t *p, int snaplen)
+    #   set the snapshot length for a not-yet-activated capture handle
+    pcap_set_snaplen = _lib.pcap_set_snaplen
+    pcap_set_snaplen.restype = c_int
+    pcap_set_snaplen.argtypes = [POINTER(pcap_t), c_int]
+
+    #int pcap_set_promisc(pcap_t *p, int promisc)
+    #   set promiscuous mode for a not-yet-activated capture handle
+    pcap_set_promisc = _lib.pcap_set_promisc
+    pcap_set_promisc.restype = c_int
+    pcap_set_promisc.argtypes = [POINTER(pcap_t), c_int]
+
+    #int pcap_set_timeout(pcap_t *p, int to_ms)
+    #   set the packet buffer timeout for a not-yet-activated capture handle
+    pcap_set_timeout = _lib.pcap_set_timeout
+    pcap_set_timeout.restype = c_int
+    pcap_set_timeout.argtypes = [POINTER(pcap_t), c_int]
+
+    #int pcap_activate(pcap_t *p)
+    #   activate a capture handle
+    pcap_activate = _lib.pcap_activate
+    pcap_activate.restype = c_int
+    pcap_activate.argtypes = [POINTER(pcap_t)]
+except AttributeError:
+    pass
+
 #pcap_dumper_t *   pcap_dump_open (pcap_t *p, const char *fname)
 #   Open a file to write packets.
 pcap_dump_open = _lib.pcap_dump_open


### PR DESCRIPTION
This PR adds monitor mode support to Windows, allowing to sniff raw Wifi packets.

![image](https://user-images.githubusercontent.com/10530980/36454845-e099d45e-169d-11e8-8339-27f779633373.png)

Content:
- use/improve already existing npcap utils
- add monitored socket support (+ adds missing npcap API calls)
- updates kracks module to use this API