### PR TITLE
Dump UT_FLAGS right before starting tests

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -123,6 +123,9 @@ then
   UT_FLAGS+=" -K osx"
 fi
 
+# Dump UT_FLAGS
+echo "UT_FLAGS=$UT_FLAGS"
+
 # Run all normal and contrib tests
 PYTHON="$PYTHON" $SCAPY_SUDO ./run_tests -c ./configs/travis.utsc -T "bpf.uts" -T "mock_windows.uts" $UT_FLAGS || exit $?
 


### PR DESCRIPTION
`UT_FLAGS` are not all configured when currently dumping them. This PR prints them right before starting the tests.