### PR TITLE
Added IPv6 and IPv4/IPv6 support to GTPv1

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
-## Copyright (C) 2017 Alexis Sultan    <alexis.sultan@sfr.com>
+## Copyright (C) 2018 Leonardo Monteiro <decastromonteiro@gmail.com>
+##               2017 Alexis Sultan    <alexis.sultan@sfr.com>
 ##               2017 Alessio Deiana <adeiana@gmail.com>
 ##               2014 Guillaume Valadon <guillaume.valadon@ssi.gouv.fr>
 ##               2012 ffranz <ffranz@iniqua.com>
@@ -396,7 +397,9 @@ class IE_EndUserAddress(IE_Base):
                     BitField("PDPTypeOrganization", 1, 4),
                     XByteField("PDPTypeNumber", None),
                     ConditionalField(IPField("PDPAddress", RandIP()),
-                                     lambda pkt: pkt.length > 2)]
+                                     lambda pkt: pkt.length == 6 or pkt.length == 22),
+                    ConditionalField(IP6Field("IPv6_PDPAddress", '::1'),
+                                     lambda pkt: pkt.length == 18 or pkt.length == 22)]
 
 
 class APNStrLenField(StrLenField):

--- a/scapy/contrib/gtp.uts
+++ b/scapy/contrib/gtp.uts
@@ -162,10 +162,27 @@ gtp = Ether(hex_bytes(h))
 ie = gtp.IE_list[5]
 ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress == '10.42.0.3'
 
-= IE_EndUserAddress(), basic instantiation
+= IE_EndUserAddress(), IPv4/IPv6 dissect
+h = "00e0fc065f3800e1fc452bf30800450000cf00004000ff11a8afbd28ac11bd28ac0b084b084b00bb0000321100ab645b29420f990000018008fe0e12100270582511027258257f030b15a6800016f18d0a2a00032805021582842522000000000000000084004f80c0230e0200000e0957656c636f6d65210a802110030000108106bd28c6508306bd28c651000310280402148000ffff0000000000000080000310280402148000ffff000000000000008100050101850004bd28ac12850004bd28ac1287000f0223921f9196fefe74f8fefe004a00fb00040acf6976"
+gtp = Ether(hex_bytes(h))
+ie = gtp.IE_list[6]
+ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.PDPAddress == '10.42.0.3' and ie.IPv6_PDPAddress == '2805:215:8284:2522::'
+
+= IE_EndUserAddress(), basic instantiation IPv4
 ie = IE_EndUserAddress(
     length=6, PDPTypeOrganization=1, PDPTypeNumber=0x21, PDPAddress='10.42.0.3')
 ie.ietype == 128 and ie.length == 6 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x21 and ie.PDPAddress == '10.42.0.3'
+
+= IE_EndUserAddress(), basic instantiation IPv6
+ie = IE_EndUserAddress(
+    length=18, PDPTypeOrganization=1, PDPTypeNumber=0x57, IPv6_PDPAddress='2804::')
+ie.ietype == 128 and ie.length == 18 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x57 and ie.IPv6_PDPAddress == '2804::'
+
+= IE_EndUserAddress(), basic instantiation IPv4/IPv6
+ie = IE_EndUserAddress(
+    length=22, PDPTypeOrganization=1, PDPTypeNumber=0x8d, PDPAddress='10.42.0.3', IPv6_PDPAddress ='2804::')
+ie.ietype == 128 and ie.length == 22 and ie.PDPTypeOrganization == 1 and ie.PDPTypeNumber == 0x8d and ie.IPv6_PDPAddress == '2804::' and ie.PDPAddress == '10.42.0.3'
+
 
 = IE_AccessPointName(), dissect
 h = "333333333333222222222222810083840800458800bc00000000fc1184c90a2a00010a2a00024acf084b00a87bbb3210009867fe972185e800000202081132547600000332f42004d27b0ffc1093b20c3f11940eb2bf14051a0400800002f1218300070661616161616184001480802110010000108106000000008306000000008500040a2a00018500040a2a00018600079111111111111187000f0213921f7396d3fe74f2ffff004a0094000120970001019800080132f42004d204d299000240009a000811111111111100001b1212951c5bbe"


### PR DESCRIPTION
Hey guys, I had to close my previous pull request and open a new one because it was so far behind.
@p-l- @guedou  I'm very sorry for the huge delay on fixing everything.

So we don't lose history, below I quote @alexsult :

> Hi @decastromonteiro ,
> 
> First of all, thanks for improving the GTP support. Like @p-l- , I have few things to say :
> 
>     The IE_EndUserAddress field may be already used by other scapy scripts/programms, so changing PDPAdress to PDPAddress_IPv4 (even if it is more appropriate) would break existing code. Could you keep the name PDPAdress for IPv4 and use PDPAddress_IPv6 for IPv6 ?
>     To continuously check if commits don't affect old functions, it is asked to write tests corresponding to (all) the changes you do.
>     Here is how you can check your code is covered (with the coverage module):
>     To update coverage :
> 
>     PYTHONPATH=. coverage run scapy/tools/UTscapy.py -P "load_contrib('gtp')" -t scapy/contrib/gtp.uts
> 
> And to check:
> 
>     $ coverage report scapy/contrib/gtp.py
>     Name Stmts Miss Cover
>     scapy/contrib/gtp.py 301 41 86%
> 
> Before your modifications, it was 87% covered. We don't ask you to add tests for everything, but could you add them for what you did ?
> 
> To see what is covered:
> 
>     $ coverage html scapy/contrib/gtp.py
> 
> It produces an html report in the htmlcov of your current directory.
> 
> About .anwsers and .hashret :
> 
>     Hashret
> 
>     hashret(self)
>     Must returns a string that has the same value for a request and its answer.The result of this function is used as a hash value to speed up the look fora the request matching a given response.
> 
> You are using .seq with does not exist in GTPDeletePDPContextResponse (so it will not work), but this field exists in GTPHeader and I would use it (seq from the GTPHeader) with the sgsn and ggsn IP addresses to construct this hash value.
> 
>     Answers
> 
>     answers(self,other)
>     True if self is an answer from other
> 
> I think that you can compare the results of the .hashret of the two packets
> 
>     I have seen you removed trailing spaces, that's nice regarding the pep8, but it makes difficult to read the diffs and to keep track of the modifications, could you cancel this changes ?
> 
> Alexis


1 - Alexis, I followed your suggestion and kept PDPAddress field, only adding IPv6_PDPAddress Field to support both IPv6 and IPv4/IPv6.

2 - 
> You are using .seq with does not exist in GTPDeletePDPContextResponse (so it will not work), but this field exists in GTPHeader and I would use it (seq from the GTPHeader) with the sgsn and ggsn IP addresses to construct this hash value.

It's true that sequence only exists on GTPHeader, but as GTPCreatePDPContextRequest/Response uses sequence to hashret and answers, and works fine by my tests (I'm using a real GGSN to send those messages to monitor if they're are "healthy") I also added the same methods to GTPDeletePDPContextRequest/Response. It worked fine within my scenario. Before those lines, scapy would not recognize the answer.

When trying to generate a test on scapy to verify hashret and answers, I get the error saying that seq does not exists, as you said it would. So to avoid further trouble I'm pushing this pull request without those changes.

Would you be willing to collaborate with me to solve it? I can provide real traces from GGSN and SGSN.
Let me know if you're interested.

 3 - About coverage, it's maintained on 88% after changes

Name                   Stmts   Miss  Cover
scapy/contrib/gtp.py     292     36    88%

Best regards
