### PR TITLE
Add BlockAck Request subtype for addr2 conditional field clause

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -123,7 +123,7 @@ class Dot11(Packet):
         ConditionalField(
             MACField("addr2", ETHER_ANY),
             lambda pkt: (pkt.type != 1 or
-                         pkt.subtype in [0x9, 0xb, 0xa, 0xe, 0xf]),
+                         pkt.subtype in [0x8, 0x9, 0xa, 0xb, 0xe, 0xf]),
         ),
         ConditionalField(
             MACField("addr3", ETHER_ANY),

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -9195,6 +9195,7 @@ Dot11(type=0, subtype=1).answers(query) == True
 = Dot11 - misc
 assert Dot11Elt(info="scapy").summary() == "SSID='scapy'"
 assert Dot11Elt(ID=1).mysummary() == ""
+assert Dot11(b'\x84\x00\x00\x00\x00\x11\x22\x33\x44\x55\x00\x11\x22\x33\x44\x55').addr2 == '00:11:22:33:44:55'
 
 = Multiple Dot11Elt layers
 pkt = Dot11() / Dot11Beacon() / Dot11Elt(ID="Rates") / Dot11Elt(ID="SSID", info="Scapy")


### PR DESCRIPTION
BlockAck Request frames have RA (addr1) and TA (addr2) addresses. Only addr1 was being parsed. Also, sorted list of subtypes that have an addr2 field for legibility.