### PR TITLE
Fix netflowv9.pcap path

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -5514,7 +5514,11 @@ nf5.version == 5 and nf5[NetflowHeaderV5].count == 2 and isinstance(nf5[NetflowR
 
 = NetflowV9 - advanced dissection
 
-a = rdpcap("./test/pcaps/netflowv9.pcap" if WINDOWS else "./pcaps/netflowv9.pcap")
+import os
+tmp = "/test/pcaps/netflowv9.pcap"
+filename = os.path.abspath(os.path.join(os.path.dirname(__file__),"../")) + tmp
+filename = os.getenv("SCAPY_ROOT_DIR")+tmp if not os.path.exists(filename) else filename
+a = rdpcap(filename)
 a = netflowv9_defragment(a)
 
 nfv9_fl = a[4]


### PR DESCRIPTION
This should fix the currently failing test on osx with Python 3.6