### PR TITLE
Remove the bind_layers for GTP for UDP source port

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -864,7 +864,6 @@ class GTPmorethan1500(Packet):
 
 # Bind GTP-C
 bind_layers(UDP, GTPHeader, dport = 2123)
-bind_layers(UDP, GTPHeader, sport = 2123)
 bind_layers(GTPHeader, GTPEchoRequest, gtp_type=1, S=1)
 bind_layers(GTPHeader, GTPEchoResponse, gtp_type=2, S=1)
 bind_layers(GTPHeader, GTPCreatePDPContextRequest, gtp_type=16)
@@ -880,7 +879,6 @@ bind_layers(GTPHeader, GTP_PDCP_PDU_ExtensionHeader, next_ex=192, E=1)
 
 # Bind GTP-U
 bind_layers(UDP, GTP_U_Header, dport = 2152)
-bind_layers(UDP, GTP_U_Header, sport = 2152)
 bind_layers(GTP_U_Header, GTPErrorIndication, gtp_type=26, S=1)
 bind_layers(GTP_U_Header, IP, gtp_type = 255)
 


### PR DESCRIPTION
UDP source port for GTP is supposed to be locally allocated, not binded to the well known protocol ports.  Plus I don't think the two consecutive binds to the same layer works as intended.