### PR TITLE
Add support for GENEVE tunnel

### DIFF
--- a/scapy/layers/geneve.py
+++ b/scapy/layers/geneve.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python
+# (GENEVE):
+# A Framework for Overlaying Virtualized Layer 2 Networks over Layer 3 Networks
+
+from scapy.packet import Packet, bind_layers
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP, UDP
+from scapy.layers.inet6 import IPv6
+from scapy.fields import FlagsField, XByteField, ThreeBytesField, \
+    ConditionalField, ShortField, ByteEnumField, X3BytesField
+
+#
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |Ver|  Opt Len  |O|C|    Rsvd.  |          Protocol Type        |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |        Virtual Network Identifier (VNI)       |    Reserved   |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |                    Variable Length Options                    |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+#
+
+class GENEVE(Packet):
+    name = "GENEVE"
+
+    fields_desc = [
+        # INIT = ver + optlen + o + c + rsvd (all zeros)
+        ShortField("init", 0x0),
+        # PROTOCOL is a 2-bytes field
+        ShortField("protocol", 0x6558),
+        ThreeBytesField("vni", 0),
+        XByteField("reserved2", 0),
+    ]
+
+    def mysummary(self):
+        return self.sprintf("GENEVE (vni=%GENEVE.vni%)")
+
+bind_layers(UDP, GENEVE, dport=6081)  # RFC standard port
+bind_layers(UDP, GENEVE, dport=6081)  # New IANA assigned port for use with NSH
+bind_layers(UDP, GENEVE, dport=8472)  # Linux implementation port
+# By default, set both ports to the RFC standard
+bind_layers(UDP, GENEVE, sport=6081, dport=6081)
+
+bind_layers(GENEVE, Ether)
+bind_layers(GENEVE, IP, NextProtocol=1)
+bind_layers(GENEVE, IPv6, NextProtocol=2)
+bind_layers(GENEVE, Ether, flags=4, NextProtocol=0)
+bind_layers(GENEVE, IP, flags=4, NextProtocol=1)
+bind_layers(GENEVE, IPv6, flags=4, NextProtocol=2)
+bind_layers(GENEVE, Ether, flags=4, NextProtocol=3)
+


### PR DESCRIPTION
This patch adds the support for GENEVE tunnel to the existing set of
overlay protocols (e.g. VXLAN).

Signed-off-by: Marco Varlese <marco.varlese@suse.com>