### PR TITLE
Fix a backward compatibility bug in open_pcap (on Windows)

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -544,7 +544,6 @@ class NetworkInterface(object):
         """Returns True if the interface is in monitor mode.
         Only available with Npcap."""
         try:
-            self._check_npcap_requirement()
             return self.mode() == "monitor"
         except Scapy_Exception:
             return False
@@ -853,9 +852,12 @@ def show_interfaces(resolve_mac=True):
 
 _orig_open_pcap = pcapdnet.open_pcap
 def open_pcap(iface, *args, **kargs):
-    if iface.ismonitor():
+    iface_pcap_name = pcapname(iface)
+    if not isinstance(iface, NetworkInterface) and iface_pcap_name is not None:
+        iface = IFACES.dev_from_name(iface)
+    if isinstance(iface, NetworkInterface) and iface.ismonitor():
         kargs["monitor"] = True
-    return _orig_open_pcap(pcapname(iface), *args, **kargs)
+    return _orig_open_pcap(iface_pcap_name, *args, **kargs)
 pcapdnet.open_pcap = open_pcap
 
 get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr = lambda iface, *args, **kargs: (


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-5
System: Windows10
Python Version: 2.7.14

Fix a backward compatibility bug in the wrapping of pcapdnet.open_pcap in scapy/arch/windows/\_\_init\_\_.py
Now scapy 2.4.x correctly works as previously also if iface is of a different type than NetworkInterface (e.g. string).
PS: Also hide 'open_pcap' wrapper (a name changed to '_open_pcap') for full backward compatibility.
      Previously a name 'open_pcap' has not been exhibited at all by this module. 

Thanks,
Adam Karpierz