### PR TITLE
[fix] id in LLDPDUChassisID was from type XStrLenField but this seems…

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -310,7 +310,7 @@ class LLDPDUChassisID(LLDPDU):
         BitFieldLenField('_length', None, 9, length_of='id',
                          adjust=lambda pkt, x: len(pkt.id) + 1),
         ByteEnumField('subtype', 0x00, LLDP_CHASSIS_ID_TLV_SUBTYPES),
-        XStrLenField('id', '', length_from=lambda pkt: pkt._length - 1)
+        StrLenField('id', '', length_from=lambda pkt: pkt._length - 1)
     ]
 
     def _check(self):


### PR DESCRIPTION
if you create a LLDPDUChassisID packet with subtype 0x04 (MAC address) there was no MAC address in 'show()' but an long integer value

e.g. for chosen chassis id: "ff:dd:ee:bb:aa:99" this is the output:

--- XStrLenField ---
...
        _type     = chassis id
        _length   = 18
        subtype   = MAC address
        id        = 66663a64643a65653a62623a61613a3939
...

LLDPDUPortID has a similar structure of the packet and at the end there was a MAC address

So I changed XStrLenField to StrLenField like in LLDPDUPortID:

--- StrLenField ---
...
     _type     = chassis id
     _length   = None
     subtype   = MAC address
     id        = 'ff:dd:ee:bb:aa:99'
...

Nevertheless there are some more problems in this file.
wireshark marks all packets as corrupt
-> original lldpd linux daemon creates chassis id tlv with a length of 7 -> here it is always 18
-> when manually setting _length attribute to 7, this will work so far, but the packet is still not correct