### PR TITLE
Use . instead of source shell command.

### DIFF
--- a/test/run_tests_py2
+++ b/test/run_tests_py2
@@ -1,3 +1,3 @@
 #! /bin/sh
 PYTHON=python2
-source $(dirname $0)/run_tests "$@"
+. $(dirname $0)/run_tests "$@"

--- a/test/run_tests_py3
+++ b/test/run_tests_py3
@@ -1,3 +1,3 @@
 #! /bin/sh
 PYTHON=python3
-source $(dirname $0)/run_tests "$@"
+. $(dirname $0)/run_tests "$@"


### PR DESCRIPTION
The source keyword is a bash extension that is not recognized by
every bourne shell.  The . command works everywhere.