### PR TITLE
Fix scapy used with Winpcap on Windows

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -143,7 +143,7 @@ if conf.use_winpcapy:
               if pcap_set_rfmon(self.pcap, 1) != 0:
                   warning("Could not set monitor mode")
               if pcap_activate(self.pcap) != 0:
-                  warning("Could not activate the handler")
+                  raise OSError("Could not activate the pcap handler")
           else:
               self.pcap = pcap_open_live(self.iface, snaplen, promisc, to_ms, self.errbuf)
           self.header = POINTER(pcap_pkthdr)()

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -855,7 +855,7 @@ def open_pcap(iface, *args, **kargs):
     iface_pcap_name = pcapname(iface)
     if not isinstance(iface, NetworkInterface) and iface_pcap_name is not None:
         iface = IFACES.dev_from_name(iface)
-    if isinstance(iface, NetworkInterface) and iface.ismonitor():
+    if conf.use_npcap and isinstance(iface, NetworkInterface) and iface.ismonitor():
         kargs["monitor"] = True
     return _orig_open_pcap(iface_pcap_name, *args, **kargs)
 pcapdnet.open_pcap = open_pcap


### PR DESCRIPTION
Fix bug created by https://github.com/secdev/scapy/pull/1198: no backward compatibility with winpcap

(Forgot to check if the code was Winpcap compatible)

fixes https://github.com/secdev/scapy/issues/1221