### PR TITLE
Allow non-matching string arguments in haslayer methods.

### DIFF
--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -241,7 +241,7 @@ class EAP(Packet):
         if cls == "EAP":
             if isinstance(self, EAP):
                 return True
-        elif issubclass(cls, EAP):
+        elif isinstance(cls, type) and issubclass(cls, EAP):
             if isinstance(self, cls):
                 return True
         return super(EAP, self).haslayer(cls)

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -214,7 +214,7 @@ class NTP(Packet):
         if cls == "NTP":
             if isinstance(self, NTP):
                 return True
-        elif issubclass(cls, NTP):
+        elif isinstance(cls, type) and issubclass(cls, NTP):
             if isinstance(self, cls):
                 return True
         return super(NTP, self).haslayer(cls)

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -261,7 +261,7 @@ class RadiusAttribute(Packet):
         if cls == "RadiusAttribute":
             if isinstance(self, RadiusAttribute):
                 return True
-        elif issubclass(cls, RadiusAttribute):
+        elif isinstance(cls, type) and issubclass(cls, RadiusAttribute):
             if isinstance(self, cls):
                 return True
         return super(RadiusAttribute, self).haslayer(cls)


### PR DESCRIPTION
These methods already recognize specific string arguments, e.g.
`EAP.haslayer()` recognizes "EAP" as an argument. However, non-matching
string arguments would get passed to `issubclass()`, which is invalid.

This issue was discovered when running `PacketList.sessions()` on a pcap
containing only NTP packets. That would end up calling
`NTP.haslayer("TCP")`, which in turn would attempt to call
`issubclass("TCP", NTP)`.