### PR TITLE
Allow non-matching string arguments in haslayer methods (covers #1223, #1186 and other/all layers).

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -35,6 +35,7 @@ from scapy.fields import (Field, BitField, BitEnumField, XBitField, ByteField,
                           MultiEnumField)
 from scapy.layers.inet import TCP
 from scapy.layers.inet6 import IP6Field
+from scapy.utils import issubtype
 from scapy.config import conf, ConfClass
 from scapy.compat import *
 from scapy.error import log_runtime
@@ -608,7 +609,7 @@ class BGPCapability(six.with_metaclass(_BGPCapability_metaclass, Packet)):
         if cls == "BGPCapability":
             if isinstance(self, BGPCapability):
                 return True
-        if issubclass(cls, BGPCapability):
+        elif issubtype(cls, BGPCapability):
             if isinstance(self, cls):
                 return True
         return super(BGPCapability, self).haslayer(cls)

--- a/scapy/contrib/bgp.uts
+++ b/scapy/contrib/bgp.uts
@@ -126,6 +126,18 @@ assert BGPCapability in BGPCapFourBytesASN()
 assert isinstance(BGPCapFourBytesASN().getlayer(BGPCapability), BGPCapFourBytesASN)
 assert isinstance(BGPCapFourBytesASN()[BGPCapability], BGPCapFourBytesASN)
 
+= BGPCapability - sessions (1)
+p = IP()/TCP()/BGPCapability()
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
+
+= BGPCapability - sessions (2)
+p = IP()/UDP()/BGPCapability()
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
+
 
 ############################ BGPCapMultiprotocol ##############################
 + BGPCapMultiprotocol class tests

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -18,6 +18,7 @@ XStrLenField, XStrFixedLenField, LenField, FieldLenField, PacketField,\
 PacketListField, ConditionalField, PadField
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import SourceMACField, Ether, CookedLinux, GRE, SNAP
+from scapy.utils import issubtype
 from scapy.config import conf
 from scapy.compat import orb, chb
 
@@ -241,7 +242,7 @@ class EAP(Packet):
         if cls == "EAP":
             if isinstance(self, EAP):
                 return True
-        elif issubclass(cls, EAP):
+        elif issubtype(cls, EAP):
             if isinstance(self, cls):
                 return True
         return super(EAP, self).haslayer(cls)

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -21,7 +21,7 @@ StrFixedLenEnumField, XStrFixedLenField, PacketField, PacketLenField,\
 PacketListField, FieldListField, ConditionalField, PadField)
 from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet import UDP
-from scapy.utils import lhex
+from scapy.utils import issubtype, lhex
 from scapy.compat import *
 from scapy.config import conf
 import scapy.modules.six as six
@@ -214,7 +214,7 @@ class NTP(Packet):
         if cls == "NTP":
             if isinstance(self, NTP):
                 return True
-        elif not isinstance(cls, str) and issubclass(cls, NTP):
+        elif issubtype(cls, NTP):
             if isinstance(self, cls):
                 return True
         return super(NTP, self).haslayer(cls)

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -19,6 +19,7 @@ from scapy.fields import ByteField, ByteEnumField, IntField, StrLenField,\
     PacketListField, IPField, MultiEnumField
 from scapy.layers.inet import UDP
 from scapy.layers.eap import EAP
+from scapy.utils import issubtype
 from scapy.config import conf
 from scapy.error import Scapy_Exception
 
@@ -261,7 +262,7 @@ class RadiusAttribute(Packet):
         if cls == "RadiusAttribute":
             if isinstance(self, RadiusAttribute):
                 return True
-        elif issubclass(cls, RadiusAttribute):
+        elif issubtype(cls, RadiusAttribute):
             if isinstance(self, cls):
                 return True
         return super(RadiusAttribute, self).haslayer(cls)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -21,7 +21,7 @@ from scapy.compat import *
 from scapy.base_classes import BasePacket, Gen, SetGen, Packet_metaclass
 from scapy.volatile import VolatileValue
 from scapy.utils import import_hexcap,tex_escape,colgen,get_temp_file, \
-    ContextManagerSubprocess
+    issubtype, ContextManagerSubprocess
 from scapy.error import Scapy_Exception, log_runtime
 from scapy.extlib import PYX
 import scapy.modules.six as six
@@ -726,7 +726,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
                 raise
             except:
                 if conf.debug_dissector:
-                    if isinstance(cls,type) and issubclass(cls,Packet):
+                    if issubtype(cls, Packet):
                         log_runtime.error("%s dissector failed" % cls.__name__)
                     else:
                         log_runtime.error("%s.guess_payload_class() returned [%s]" % (self.__class__.__name__,repr(cls)))
@@ -1441,7 +1441,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
 
     else:
         is_pkt = isinstance(obj, Packet)
-        if (isinstance(obj, type) and issubclass(obj, Packet)) or is_pkt:
+        if issubtype(obj, Packet) or is_pkt:
             for f in obj.fields_desc:
                 cur_fld = f
                 attrs = []

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -15,8 +15,8 @@ from collections import defaultdict
 
 from scapy.config import conf
 from scapy.base_classes import BasePacket,BasePacketList
-from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table,get_temp_file
-
+from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table, \
+    get_temp_file, issubtype
 from scapy.extlib import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
 import scapy.modules.six as six
@@ -79,7 +79,7 @@ class PacketList(BasePacketList):
     def __getattr__(self, attr):
         return getattr(self.res, attr)
     def __getitem__(self, item):
-        if isinstance(item,type) and issubclass(item,BasePacket):
+        if issubtype(item, BasePacket):
             return self.__class__([x for x in self.res if item in self._elt2pkt(x)],
                                   name="%s from %s"%(item.__name__,self.listname))
         if isinstance(item, slice):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -33,9 +33,18 @@ from scapy.base_classes import BasePacketList
 ## Tools ##
 ###########
 
+def issubtype(x, t):
+    """issubtype(C, B) -> bool
+
+    Return whether C is a class and if it is a subclass of class B.
+    When using a tuple as the second argument issubtype(X, (A, B, ...)),
+    is a shortcut for issubtype(X, A) or issubtype(X, B) or ... (etc.).
+    """
+    return isinstance(x, type) and issubclass(x, t)
+
 def get_temp_file(keep=False, autoext=""):
     """Create a temporary file and return its name. When keep is False,
-the file is deleted when scapy exits.
+    the file is deleted when scapy exits.
 
     """
     fname = tempfile.NamedTemporaryFile(prefix="scapy", suffix=autoext,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7030,6 +7030,17 @@ assert(type(eap[EAP]) == EAP_PEAP)
 eap = LEAP()
 assert(type(eap[EAP]) == LEAP)
 
+= EAP - sessions (1)
+p = IP()/TCP()/EAP()
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
+
+= EAP - sessions (2)
+p = IP()/UDP()/EAP()
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
 
 
 ############
@@ -8606,6 +8617,18 @@ assert(RadiusAttribute in radius_attr)
 type(radius_attr[RadiusAttribute])
 assert(type(radius_attr[RadiusAttribute]) == RadiusAttr_EAP_Message)
 assert(EAP in radius_attr.value)
+
+= RADIUS - sessions (1)
+p = IP()/TCP(sport=1812)/Radius(authenticator="scapy")/RadiusAttribute(value="scapy")
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
+
+= RADIUS - sessions (2)
+p = IP()/UDP(sport=1812)/Radius(authenticator="scapy")/RadiusAttribute(value="scapy")
+l = PacketList(p)
+s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
+assert len(s) == 1
 
 
 ############


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-5
System: Windows7/Windows10
Python Version: 2.7.14

This is "unification" :) of #1223 and #1186 and my own previous  (not published ealier) fix for other layers (+some lilttle improvement  of code related to use of issubclass().

Thanks,
Adam Karpierz