### PR TITLE
Fix handle inheritance for Python2 (more appropriate and safe version of #1138 hack, fixes #1136)

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -83,7 +83,7 @@ def _windows_title(title=None):
         title = title or "Scapy v" + conf.version
         ctypes.windll.kernel32.SetConsoleTitleW(title)
 
-def _suppress_handles_inheritance(r=1000):
+def _suppress_file_handles_inheritance(r=1000):
     """HACK: python 2.7 file descriptors.
 
     This magic hack fixes https://bugs.python.org/issue19575
@@ -122,7 +122,7 @@ def _suppress_handles_inheritance(r=1000):
 
     return handles
 
-def _restore_handles_inheritance(handles):
+def _restore_file_handles_inheritance(handles):
     """HACK: python 2.7 file descriptors.
 
     This magic hack fixes https://bugs.python.org/issue19575
@@ -153,7 +153,7 @@ class _PowershellManager(Thread):
     Will be instantiated on loading and automatically stopped.
     """
     def __init__(self):
-        opened_handles = _suppress_handles_inheritance()
+        opened_handles = _suppress_file_handles_inheritance()
         try:
             # Start & redirect input
             if conf.prog.powershell:
@@ -165,7 +165,7 @@ class _PowershellManager(Thread):
             self.process = sp.Popen(cmd, stdout=sp.PIPE, stdin=sp.PIPE, stderr=sp.STDOUT)
             self.cmd = not conf.prog.powershell
         finally:
-            _restore_handles_inheritance(opened_handles)
+            _restore_file_handles_inheritance(opened_handles)
         self.buffer = []
         self.running = True
         self.query_complete = Event()

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -87,13 +87,11 @@ def _suppress_file_handles_inheritance(r=1000):
     """HACK: python 2.7 file descriptors.
 
     This magic hack fixes https://bugs.python.org/issue19575
+    and https://github.com/secdev/scapy/issues/1136
     by suppressing the HANDLE_FLAG_INHERIT flag to a range of
     already opened file descriptors.
+    Bug was fixed on python 3.4+
     """
-    # Fix https://bugs.python.org/issue19575
-    # and https://github.com/secdev/scapy/issues/1136
-    # Bug was fixed on python 3.4+
-
     if sys.version_info[0:2] >= (3, 4):
         return []
 
@@ -126,12 +124,11 @@ def _restore_file_handles_inheritance(handles):
     """HACK: python 2.7 file descriptors.
 
     This magic hack fixes https://bugs.python.org/issue19575
+    and https://github.com/secdev/scapy/issues/1136
     by suppressing the HANDLE_FLAG_INHERIT flag to a range of
     already opened file descriptors.
+    Bug was fixed on python 3.4+
     """
-    # See https://github.com/secdev/scapy/issues/1136
-    # Bug was fixed on python 3.4+
-
     if sys.version_info[0:2] >= (3, 4):
         return
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -29,6 +29,10 @@ import scapy.modules.six as six
 from scapy.modules.six.moves import range, zip, input, winreg
 from scapy.compat import plain_str
 
+_winapi_SetConsoleTitle = ctypes.windll.kernel32.SetConsoleTitleW
+_winapi_SetConsoleTitle.restype = wintypes.BOOL
+_winapi_SetConsoleTitle.argtypes = [wintypes.LPWSTR]
+
 _winapi_GetHandleInformation = ctypes.windll.kernel32.GetHandleInformation
 _winapi_GetHandleInformation.restype = wintypes.BOOL
 _winapi_GetHandleInformation.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
@@ -90,8 +94,7 @@ def _windows_title(title=None):
     """Updates the terminal title with the default one or with `title`
     if provided."""
     if conf.interactive:
-        title = title or "Scapy v" + conf.version
-        ctypes.windll.kernel32.SetConsoleTitleW(title)
+        _winapi_SetConsoleTitle(title or "Scapy v{}".format(conf.version))
 
 def _suppress_file_handles_inheritance(r=1000):
     """HACK: python 2.7 file descriptors.

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -83,7 +83,7 @@ def _windows_title(title=None):
         title = title or "Scapy v" + conf.version
         ctypes.windll.kernel32.SetConsoleTitleW(title)
 
-def _suppress_handles_inheritance(r=100):
+def _suppress_handles_inheritance(r=1000):
     """HACK: python 2.7 file descriptors.
 
     This magic hack fixes https://bugs.python.org/issue19575


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-30
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4