### PR TITLE
Scapy 2.4.0: fix a bug in 'snmpwalk()'

### DIFF
--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -248,11 +248,11 @@ def snmpwalk(dst, oid="1", community="public"):
     try:
         while True:
             r = sr1(IP(dst=dst)/UDP(sport=RandShort())/SNMP(community=community, PDU=SNMPnext(varbindlist=[SNMPvarbind(oid=oid)])),timeout=2, chainCC=1, verbose=0, retry=2)
-            if ICMP in r:
-                print(repr(r))
-                break
             if r is None:
                 print("No answers")
+                break
+            if ICMP in r:
+                print(repr(r))
                 break
             print("%-40s: %r" % (r[SNMPvarbind].oid.val,r[SNMPvarbind].value))
             oid = r[SNMPvarbind].oid

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -810,8 +810,9 @@ x = UDP()/SNMP()
 assert x.sport == x.dport == 161
 
 = Test snmpwalk()
-snmpwalk(dst="0.0.0.0")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
-True
+if WINDOWS or os.getenv("SCAPY_SUDO") == "sudo":
+    snmpwalk(dst="0.0.0.0")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
+    assert True
 
 = ASN1 - ASN1_Object
 assert ASN1_Object(1) == ASN1_Object(1)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -810,7 +810,7 @@ x = UDP()/SNMP()
 assert x.sport == x.dport == 161
 
 = Test snmpwalk()
-snmpwalk("8.8.8.8")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
+snmpwalk("192.168.0.1")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
 True
 
 = ASN1 - ASN1_Object

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -809,6 +809,10 @@ assert SNMP in z
 x = UDP()/SNMP()
 assert x.sport == x.dport == 161
 
+= Test snmpwalk()
+snmpwalk("8.8.8.8")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
+True
+
 = ASN1 - ASN1_Object
 assert ASN1_Object(1) == ASN1_Object(1)
 assert ASN1_Object(1) > ASN1_Object(0)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -810,7 +810,7 @@ x = UDP()/SNMP()
 assert x.sport == x.dport == 161
 
 = Test snmpwalk()
-snmpwalk("192.168.0.1")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
+snmpwalk(dst="0.0.0.0")  # Crashed on commit: c2acc60e985340884b50bcf05764dcb4eabea1dc
 True
 
 = ASN1 - ASN1_Object


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-31
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Thanks,
Adam Karpierz