### PR TITLE
Scapy 2.4.0: fix a bug in 'snmpwalk()'

### DIFF
--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -248,11 +248,11 @@ def snmpwalk(dst, oid="1", community="public"):
     try:
         while True:
             r = sr1(IP(dst=dst)/UDP(sport=RandShort())/SNMP(community=community, PDU=SNMPnext(varbindlist=[SNMPvarbind(oid=oid)])),timeout=2, chainCC=1, verbose=0, retry=2)
-            if ICMP in r:
-                print(repr(r))
-                break
             if r is None:
                 print("No answers")
+                break
+            if ICMP in r:
+                print(repr(r))
                 break
             print("%-40s: %r" % (r[SNMPvarbind].oid.val,r[SNMPvarbind].value))
             oid = r[SNMPvarbind].oid

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10086,3 +10086,15 @@ assert raw(created) == b'\x80\x11\x124\x00\xbcaN\xab\xcd\xef\x01'
 parsed = RTP(raw(created))
 assert parsed.sourcesync == 0xabcdef01
 assert "RTPExtension" not in parsed
+
+= Test snmpwalk()
+
+~ netaccess
+def test_snmpwalk(dst):
+    with ContextManagerCaptureOutput() as cmco:
+        snmpwalk(dst=dst)
+        output = cmco.get_output()
+    expected = "No answers\n"
+    assert(output == expected)
+
+test_snmpwalk("secdev.org")


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-31
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Simple fix to avoid:
```
if ICMP in r:
    TypeError: argument of type 'NoneType' is not iterable
```
where is no answer from destination.

Thanks,
Adam Karpierz