### PR TITLE
add IEC 60870-5-104 layer

### DIFF
--- a/scapy/contrib/iec104.uts
+++ b/scapy/contrib/iec104.uts
@@ -1,0 +1,458 @@
+% IEC 60870-5-104 test campaign
+
+#
+# execute test:
+# > test/run_tests -t scapy/contrib/iec104.uts
+#
+
++ iec104 infrastructure
+
+= load the iec104 layer
+
+load_contrib('scada.iec104')
+
+= class attribute generator
+
+assert(IEC104_IE_QOC.QU_FLAG_RESERVED_COMPATIBLE_4 == 4)
+assert(IEC104_IE_QOC.QU_FLAG_RESERVED_COMPATIBLE_8 == 8)
+assert(IEC104_IE_QOC.QU_FLAG_RESERVED_PREDEFINED_FUNCTION_9 == 9)
+assert(IEC104_IE_QOC.QU_FLAG_RESERVED_PREDEFINED_FUNCTION_15 == 15)
+
+= IEC60870_5_4_NormalizedFixPoint
+
+test_data = [
+    (b'\x9c\x84',  -0.963989,     -31588),
+    (b'\x46\xf6',  -0.075989,    -2490),
+    (b'\xc9\xf6',  -0.071991,     -2359),
+    (b'\x40\xf5',  -0.083984,    -2752),
+    (b'\x89\x01',   0.011993,     393),
+    (b'\xd2\x0d',   0.107971,      3538),
+    (b'\xd7\x23',   0.279999,      9175),
+    (b'\x76\x3e',   0.487976,      15990),
+    (b'\x08\x6c',   0.843994,      27656),
+    (b'\xff\x7f',   0.999969,      32767)
+]
+
+nfp = IEC60870_5_4_NormalizedFixPoint('foo', 0)
+
+for num_raw, num_fp, num_ss in test_data:
+    i_val = nfp.getfield(None, num_raw)[1]
+    assert(i_val == num_ss)
+    assert(round(nfp.i2h(None, i_val), 6) == round(num_fp, 6))
+
+
+= Iec104SequenceNumber field
+
+iec104_seq_num = IEC104SequenceNumber('rx_seq', 0)
+
+test_data = {
+    1: b'\x02\x00',
+    2: b'\x04\x00',
+    14 : b'\x1c\x00',
+    16 : b'\x20\x00',
+    73 : b'\x92\x00',
+    127: b'\xfe\x00',
+    128: b'\x00\x01',
+    129: b'\x02\x01',
+    253: b'\xfa\x01',
+    254: b'\xfc\x01',
+    255: b'\xfe\x01',
+    5912: b'\x30\x2e',
+    31282: b'\x64\xf4',
+    32767: b'\xfe\xff'
+}
+
+for key in test_data:
+    assert(iec104_seq_num.getfield(None, test_data[key])[1] == key)
+    assert(iec104_seq_num.addfield(None, b'', key) == test_data[key])
+
++ raw layer dissection
+
+= IEC104_U_Message
+
+raw_u_msg = b'\x68\x04\x83\x00\x00\x00'
+
+lyr = iec104_decode(b'\x68\x04\x83\x00\x00\x00')
+assert(lyr.__class__ == IEC104_U_Message)
+
+= IEC104_S_Message
+
+raw_s_msg = b'\x68\x04\x01\x00\xa6\x17'
+
+lyr = iec104_decode(raw_s_msg)
+assert(lyr.__class__ == IEC104_S_Message)
+
+= IEC104_I_Message_SeqIOA
+
+raw_i_msg_seq_ioa = b'\x68\x1f\x2c\x00\x04\x00'  # APCI
+raw_i_msg_seq_ioa += b'\x01\x92\x14\x00\x23\x00\x12\x54\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # ASDU
+
+lyr = iec104_decode(raw_i_msg_seq_ioa)
+assert(lyr.__class__ == IEC104_I_Message_SeqIOA)
+
+= IEC104_I_Message_SingleIOA
+
+raw_i_msg_single_ioa = b'\x68\x0e\x00\x00\x00\x00\x64\x01\x06\x00\x0a\x00\x00\x00\x00\x14'
+
+lyr = iec104_decode(raw_i_msg_single_ioa)
+assert(lyr.__class__ == IEC104_I_Message_SingleIOA)
+
++ IEC104 S Message
+
+= single IEC104 S Message
+
+s_msg = b'\x68\x04\x01\x00\xa6\x17'
+
+s_msg = IEC104_S_Message(s_msg)
+
+assert(s_msg.rx_seq_num == 3027)
+
+raw_s_message = b'\x00\x14\xab\x00\x3c\x13\x00\x1b\x8d\xf1\xdc\x12\x08\x00\x45\x10\x00\x3a\x8d\xdb\x40\x00\x3d\x06\x54\x46\x1a\x52\x01\xde\xc1\x28\x15\x5c\xaa\x56\x09\x64\x16\x67\x6c\xd7\x53\x07\x28\x98\x80\x18\x79\x5e\x9b\x14\x00\x00\x01\x01\x08\x0a\x9e\x08\xaa\x23\x73\xe8\x6c\xc3\x68\x04\x01\x00\xc2\x3a'
+
+frm = Ether(raw_s_message)
+
+s_msg = frm.getlayer(IEC104_S_Message)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7521)
+
+frm = Ether(frm.do_build())
+
+s_msg = frm.getlayer(IEC104_S_Message)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7521)
+
+= double IEC104 S Message (test layer binding)
+
+raw_double_s_message = b'\x00\x14\xab\x00\x3c\x13\x00\x1b\x8d\xf1\xdc\x12\x08\x00\x45\x10\x00\x40\x8d\xdb\x40\x00\x3d\x06\x54\x46\x0c\x35\x1b\x33\xc1\x28\x15\x44\xaa\x56\x09\x64\x16\x67\x6c\xd7\x53\x07\x28\x98\x80\x18\x79\x5e\x9b\x14\x00\x00\x01\x01\x08\x0a\x9e\x08\xaa\x23\x73\xe8\x6c\xc3\x68\x04\x01\x00\xc2\x3a\x68\x04\x01\x00\xc2\x3b'
+
+frm = Ether(raw_double_s_message)
+
+s_msg = frm.getlayer(IEC104_S_Message)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7521)
+
+s_msg = frm.getlayer(IEC104_S_Message, nb=2)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7649)
+
+frm = Ether(frm.do_build())
+
+s_msg = frm.getlayer(IEC104_S_Message)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7521)
+
+s_msg = frm.getlayer(IEC104_S_Message, nb=2)
+assert(s_msg)
+assert(s_msg.rx_seq_num == 7649)
+
++ IEC104 U Message
+
+= single IEC104 U Message
+
+frm = Ether()/IP()/TCP()/IEC104_U_Message(startdt_act = 1, stopdt_con = 1, testfr_act=1)
+frm = Ether(frm.do_build())
+u_msg = frm.getlayer(IEC104_U_Message)
+assert(u_msg)
+assert(u_msg.startdt_act == 1)
+assert(u_msg.startdt_con == 0)
+assert(u_msg.stopdt_con == 1)
+assert(u_msg.stopdt_act == 0)
+assert(u_msg.testfr_act == 1)
+assert(u_msg.testfr_con == 0)
+
+u_msg_tst_act = b'\x68\x04\x43\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_tst_act)
+assert(u_msg.testfr_act == 1)
+
+u_msg_tst_con = b'\x68\x04\x83\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_tst_con)
+assert(u_msg.testfr_con == 1)
+
+u_msg_startdt_act = b'\x68\x04\x07\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_startdt_act)
+assert(u_msg.startdt_act == 1)
+
+u_msg_startdt_con = b'\x68\x04\x0b\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_startdt_con)
+assert(u_msg.startdt_con == 1)
+
+u_msg_stopdt_act = b'\x68\x04\x13\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_stopdt_act)
+assert(u_msg.stopdt_act == 1)
+
+u_msg_stopdt_con = b'\x68\x04\x23\x00\x00\x00'
+u_msg = IEC104_U_Message(u_msg_stopdt_con)
+assert(u_msg.stopdt_con == 1)
+
+= double IEC104 U Message
+
+frm = Ether()/IP()/TCP()/\
+      IEC104_U_Message(startdt_act = 1, stopdt_con = 1, testfr_act=1)/\
+      IEC104_U_Message(startdt_con = 1, stopdt_act = 1, testfr_con=1)
+
+frm = Ether(frm.do_build())
+u_msg = frm.getlayer(IEC104_U_Message)
+assert(u_msg)
+assert(u_msg.startdt_act == 1)
+assert(u_msg.stopdt_con == 1)
+assert(u_msg.testfr_act == 1)
+
+u_msg = frm.getlayer(IEC104_U_Message, nb=2)
+assert(u_msg)
+assert(u_msg.startdt_con == 1)
+assert(u_msg.stopdt_act == 1)
+assert(u_msg.testfr_con == 1)
+
++ IEC104 I Message
+
+= Sequence IOA, single IO - information object types dissection
+
+for io_id in IEC104_IO_CLASSES:
+    io_class = IEC104_IO_CLASSES[io_id]
+    frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/IEC104_I_Message_SeqIOA(io=io_class())
+    frm = Ether(frm.do_build())
+    io_layer = frm.getlayer(io_class)
+    assert(io_layer)
+
+= Single IOA, single IO - information object types dissection
+
+for io_id in IEC104_IO_WITH_IOA_CLASSES:
+    io_class = IEC104_IO_WITH_IOA_CLASSES[io_id]
+    frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/IEC104_I_Message_SingleIOA(io=io_class())
+    frm = Ether(frm.do_build())
+    io_layer = frm.getlayer(io_class)
+    assert(io_layer)
+
+= Sequence IOA, multiple IOs - information object types dissection
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/IEC104_I_Message_SeqIOA(information_object_address=1234, io=[IEC104_IO_C_RC_TA_1(minutes = 1, sec_milli = 2),IEC104_IO_C_RC_TA_1(minutes = 3, sec_milli = 4)])
+frm = Ether(frm.do_build())
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert(i_msg_lyr)
+
+assert(i_msg_lyr.information_object_address == 1234)
+
+m_sp_ta_1_lyr = i_msg_lyr.io[0]
+assert (m_sp_ta_1_lyr.minutes == 1)
+assert (m_sp_ta_1_lyr.sec_milli == 2)
+
+m_sp_ta_1_lyr = i_msg_lyr.io[1]
+assert (m_sp_ta_1_lyr.minutes == 3)
+assert (m_sp_ta_1_lyr.sec_milli == 4)
+
+= Single IOA, multiple IOs - information object types dissection
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/\
+      IEC104_I_Message_SingleIOA(io=[IEC104_IO_C_RC_TA_1_IOA(information_object_address=1111, minutes = 1, sec_milli = 2),
+                                     IEC104_IO_C_RC_TA_1_IOA(information_object_address=2222,minutes = 3, sec_milli = 4)])
+frm = Ether(frm.do_build())
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SingleIOA)
+assert(i_msg_lyr)
+
+m_sp_ta_1_lyr = i_msg_lyr.io[0]
+assert (m_sp_ta_1_lyr.information_object_address==1111)
+assert (m_sp_ta_1_lyr.minutes == 1)
+assert (m_sp_ta_1_lyr.sec_milli == 2)
+
+
+m_sp_ta_1_lyr = i_msg_lyr.io[1]
+assert (m_sp_ta_1_lyr.information_object_address==2222)
+assert (m_sp_ta_1_lyr.minutes == 3)
+assert (m_sp_ta_1_lyr.sec_milli == 4)
+
+= Sequence IOA, multiple  APDUs
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/\
+      IEC104_I_Message_SeqIOA(information_object_address=1234,
+                              io=[IEC104_IO_C_RC_TA_1(minutes = 1, sec_milli = 2),
+                                  IEC104_IO_C_RC_TA_1(minutes = 3, sec_milli = 4)])/ \
+      IEC104_I_Message_SeqIOA(information_object_address=5432,
+                              io=[IEC104_IO_C_RC_TA_1(minutes = 5, sec_milli = 6),
+                                     IEC104_IO_C_RC_TA_1(minutes = 7, sec_milli = 8)])
+
+frm = Ether(frm.do_build())
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SeqIOA, nb=1)
+assert(i_msg_lyr)
+assert (i_msg_lyr.information_object_address == 1234)
+assert(len(i_msg_lyr.io) == 2)
+assert(i_msg_lyr.io[0].minutes == 1)
+assert(i_msg_lyr.io[0].sec_milli == 2)
+assert(i_msg_lyr.io[1].minutes == 3)
+assert(i_msg_lyr.io[1].sec_milli == 4)
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SeqIOA, nb=2)
+assert(i_msg_lyr)
+assert (i_msg_lyr.information_object_address == 5432)
+assert(len(i_msg_lyr.io) == 2)
+assert(i_msg_lyr.io[0].minutes == 5)
+assert(i_msg_lyr.io[0].sec_milli == 6)
+assert(i_msg_lyr.io[1].minutes == 7)
+assert(i_msg_lyr.io[1].sec_milli == 8)
+
+= Single IOA, multiple  APDUs
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/\
+      IEC104_I_Message_SingleIOA(io=[IEC104_IO_C_RC_TA_1_IOA(information_object_address=1111,
+                                                             minutes = 1, sec_milli = 2),
+                                     IEC104_IO_C_RC_TA_1_IOA(information_object_address=2222,
+                                                             minutes = 3, sec_milli = 4)])/ \
+      IEC104_I_Message_SingleIOA(io=[IEC104_IO_C_RC_TA_1_IOA(information_object_address=3333,
+                                                             minutes = 5, sec_milli = 6),
+                                     IEC104_IO_C_RC_TA_1_IOA(information_object_address=4444,
+                                                             minutes = 7, sec_milli = 8)])
+
+frm = Ether(frm.do_build())
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SingleIOA, nb=1)
+assert(i_msg_lyr)
+assert(len(i_msg_lyr.io) == 2)
+assert (i_msg_lyr.io[0].information_object_address == 1111)
+assert(i_msg_lyr.io[0].minutes == 1)
+assert(i_msg_lyr.io[0].sec_milli == 2)
+assert (i_msg_lyr.io[1].information_object_address == 2222)
+assert(i_msg_lyr.io[1].minutes == 3)
+assert(i_msg_lyr.io[1].sec_milli == 4)
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SingleIOA, nb=2)
+assert(i_msg_lyr)
+assert(len(i_msg_lyr.io) == 2)
+assert (i_msg_lyr.io[0].information_object_address == 3333)
+assert(i_msg_lyr.io[0].minutes == 5)
+assert(i_msg_lyr.io[0].sec_milli == 6)
+assert (i_msg_lyr.io[1].information_object_address == 4444)
+assert(i_msg_lyr.io[1].minutes == 7)
+assert(i_msg_lyr.io[1].sec_milli == 8)
+
+= Mixed Single and Sequence IOA, multiple APDU
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/\
+      IEC104_I_Message_SeqIOA(information_object_address=1111,
+                              io=[IEC104_IO_C_RC_TA_1_IOA(minutes = 1, sec_milli = 2),
+                                  IEC104_IO_C_RC_TA_1_IOA(minutes = 3, sec_milli = 4)])/ \
+      IEC104_I_Message_SingleIOA(io=[IEC104_IO_C_RC_TA_1_IOA(information_object_address=3333,
+                                                             minutes = 5, sec_milli = 6),
+                                     IEC104_IO_C_RC_TA_1_IOA(information_object_address=4444,
+                                                             minutes = 7, sec_milli = 8)])/ \
+      IEC104_I_Message_SeqIOA(information_object_address=5555,
+                              io=[IEC104_IO_C_RC_TA_1_IOA(minutes = 1, sec_milli = 9),
+                                  IEC104_IO_C_RC_TA_1_IOA(minutes = 3, sec_milli = 10)])/ \
+      IEC104_I_Message_SingleIOA(io=IEC104_IO_C_RP_NA_1_IOA(information_object_address=5555))
+
+frm = Ether(frm.do_build())
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SeqIOA, nb=1)
+assert(i_msg_lyr)
+assert (i_msg_lyr.information_object_address == 1111)
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SeqIOA, nb=2)
+assert(i_msg_lyr)
+assert (i_msg_lyr.information_object_address == 5555)
+
+i_msg_lyr = frm.getlayer(IEC104_I_Message_SingleIOA, nb=1)
+assert(i_msg_lyr)
+assert (i_msg_lyr.io[0].information_object_address == 3333)
+
++ mixed APDU types in one packet
+
+= I/U/S Message sequence (mixed APDUs)
+
+frm = Ether()/IP()/TCP(sport=IEC_104_IANA_PORT, dport=56780)/\
+      IEC104_I_Message_SeqIOA(information_object_address=1111,
+                              rx_seq_num=1234,
+                              tx_seq_num=6789,
+                              io=[IEC104_IO_C_RC_TA_1_IOA(minutes = 1, sec_milli = 2),
+                                  IEC104_IO_C_RC_TA_1_IOA(minutes = 3, sec_milli = 4)])/\
+    IEC104_U_Message()/ \
+    IEC104_S_Message(rx_seq_num=666)
+
+frm = Ether(frm.do_build())
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert(i_msg)
+u_msg = frm.getlayer(IEC104_U_Message)
+assert(u_msg)
+s_msg = frm.getlayer(IEC104_S_Message)
+assert(s_msg)
+
++ information elements & objects
+
+= ASDU allowed in given standard (examples)
+
+layer = IEC104_IO_M_SP_NA_1()
+assert(layer.defined_for_iec_101() is True)
+assert(layer.defined_for_iec_104() is True)
+
+layer = IEC104_IO_M_DP_TA_1()
+assert(layer.defined_for_iec_101() is True)
+assert(layer.defined_for_iec_104() is False)
+
+layer = IEC104_IO_C_SC_TA_1()
+assert(layer.defined_for_iec_101() is False)
+assert(layer.defined_for_iec_104() is True)
+
+
+= BCR - binary counter reading / IEC104_IO_M_IT_NA_1 - integrated totals
+
+# (counter , sequence) test datas
+values = [(1, 1), (1111, 17), (23456, 21), (31234, 30), (32767, 31)]
+m_it_na = []
+for value, sequence in values:
+    m_it_na.append(IEC104_IO_M_IT_NA_1(counter_value=value, sq=sequence))
+
+frm = Ether()/IP()/TCP()/IEC104_I_Message_SeqIOA(io=m_it_na)
+frm = Ether(frm.do_build())
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert(i_msg)
+
+for idx, value in enumerate(values):
+    value, sequence = value
+    assert(i_msg.io[idx].counter_value == value)
+    assert (i_msg.io[idx].sq == sequence)
+
+= DIQ - double-point information with quality descriptor / IEC104_IO_M_DP_NA_1 - double-point information without time tag
+
+frm = Ether() / IP() / TCP() / IEC104_I_Message_SeqIOA(io=IEC104_IO_M_DP_NA_1(dpi_value=IEC104_IE_DIQ.DPI_FLAG_STATE_UNDEFINED))
+frm = Ether(frm.do_build())
+
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert(i_msg)
+assert(i_msg.io[0].dpi_value==IEC104_IE_DIQ.DPI_FLAG_STATE_UNDEFINED)
+
+= VTI - value with transient state indication / IEC104_IO_M_ST_NA_1 - step position information
+
+values = [0, 1, 2, 62, 63, -1, -2, -63, -64]
+m_st_na_1 = []
+for value in values:
+    m_st_na_1.append(IEC104_IO_M_ST_NA_1(value=value))
+
+frm = Ether() / IP() / TCP() / IEC104_I_Message_SeqIOA(io=m_st_na_1)
+frm = Ether(frm.do_build())
+
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert (i_msg)
+
+for idx, value in enumerate(values):
+    assert (i_msg.io[idx].value == value)
+
+= IEC104_IO_C_RD_NA_1 - read command (zero byte field)
+
+frm = Ether() / IP() / TCP() / IEC104_I_Message_SeqIOA(information_object_address=0x112233,
+                                                       io=[
+                                                           IEC104_IO_C_RD_NA_1(),
+                                                           IEC104_IO_C_RD_NA_1()
+                                                       ])/ \
+      IEC104_I_Message_SeqIOA(information_object_address=0x445566,
+                              io=[IEC104_IO_M_DP_NA_1(dpi_value=IEC104_IE_DIQ.DPI_FLAG_STATE_UNDEFINED)])/ \
+      IEC104_I_Message_SeqIOA(information_object_address=0x445567,
+                              io=[IEC104_IO_C_RD_NA_1()])
+
+frm = Ether(frm.do_build())
+
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA)
+assert (i_msg)
+assert (i_msg.information_object_address == 0x112233)
+assert (len(i_msg.io) == 2)
+
+i_msg = frm.getlayer(IEC104_I_Message_SeqIOA, nb=2)
+assert (i_msg)
+assert (i_msg.information_object_address == 0x445566)

--- a/scapy/contrib/scada/__init__.py
+++ b/scapy/contrib/scada/__init__.py
@@ -1,0 +1,14 @@
+"""contains packages related to SCADA protocol layers."""
+
+from scapy.contrib.scada.iec104 import *  # noqa F403,F401
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+#
+# scapy.contrib.description = SCADA related layers
+# scapy.contrib.status = loads
+
+
+# Package of contrib SCADA modules.

--- a/scapy/contrib/scada/iec104/__init__.py
+++ b/scapy/contrib/scada/iec104/__init__.py
@@ -1,0 +1,17 @@
+"""contains the IEC 60870-5-104 package."""
+
+from scapy.contrib.scada.iec104.iec104_fields import *  # noqa F403,F401
+from scapy.contrib.scada.iec104.iec104_information_elements import *  # noqa F403,F401
+from scapy.contrib.scada.iec104.iec104_information_objects import *  # noqa F403,F401
+from scapy.contrib.scada.iec104.iec104 import *  # noqa F403,F401
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+#
+# scapy.contrib.description = IEC-60870-5-104 APCI / APDU layer definitions
+# scapy.contrib.status = loads
+
+
+# Package of contrib SCADA IEC-60870-5-104 specific modules

--- a/scapy/contrib/scada/iec104/iec104.py
+++ b/scapy/contrib/scada/iec104/iec104.py
@@ -1,0 +1,645 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+#
+# scapy.contrib.description = IEC-60870-5-104 APCI / APDU layer definitions
+# scapy.contrib.status = loads
+
+"""
+    IEC 60870-5-104
+    ~~~~~~~~~~~~~~~
+
+    :description:
+
+        This module provides the IEC 60870-5-104 (common short name: iec104)
+        layer, the information objects and related information element
+        definitions.
+
+        normative references:
+            - IEC 60870-5-4:1994 (atomic base types / data format)
+            - IEC 60870-5-101:2003 (information elements (sec. 7.2.6) and
+              ASDU definition (sec. 7.3))
+            - IEC 60870-5-104:2006 (information element TSC (sec. 8.8, p. 44))
+
+    :TODO:
+        - add allowed direction to IO attributes
+          (but this could be derived from the name easily <--> )
+        - information elements / objects need more testing
+          (e.g. on live traffic w comparison against tshark)
+
+    :NOTES:
+        - bit and octet numbering is used as in the related standards
+          (they usually start with index one instead of zero)
+        - some of the information objects are only valid for IEC 60870-5-101 -
+          so usually they should never appear on the network as iec101 uses
+          serial connections. I added them if decoding of those messages is
+          needed cause one goes to implement a iec101<-->iec104 gateway or
+          hits such a gateway that acts not standard conform (e.g. by
+          forwarding 101 messages to a 104 network)
+"""
+
+from scapy.compat import orb
+
+from scapy.contrib.scada.iec104.iec104_fields import LEThreeBytesField, \
+    IEC104SequenceNumber
+from scapy.contrib.scada.iec104.iec104_information_objects import \
+    IEC104_IO_NAMES, IEC104_IO_WITH_IOA_CLASSES, \
+    IEC104_IO_CLASSES, IEC104_IO_ID_C_RD_NA_1, IEC104_IO_C_RD_NA_1
+
+from scapy.config import conf
+from scapy.contrib.scada.iec104.iec104_information_objects import \
+    IEC104_IO_Packet
+from scapy.error import warning, Scapy_Exception
+from scapy.fields import ByteField, BitField, ByteEnumField, PacketListField, \
+    BitEnumField, XByteField, FieldLenField, LEShortField, BitFieldLenField
+
+from scapy.layers.inet import TCP
+from scapy.packet import Raw
+from scapy.packet import Packet, bind_layers
+
+IEC_104_IANA_PORT = 2404
+
+# direction - from the central station to the substation
+IEC104_CONTROL_DIRECTION = 0
+IEC104_CENTRAL_2_SUB_DIR = IEC104_CONTROL_DIRECTION
+
+# direction - from the substation to the central station
+IEC104_MONITOR_DIRECTION = 1
+IEC104_SUB_2_CENTRAL_DIR = IEC104_MONITOR_DIRECTION
+
+IEC104_DIRECTIONS = {
+    IEC104_MONITOR_DIRECTION: 'monitor direction (sub -> central)',
+    IEC104_CONTROL_DIRECTION: 'control direction (central -> sub)',
+}
+
+# COT - cause of transmission
+IEC104_COT_UNDEFINED = 0
+IEC104_COT_CYC = 1
+IEC104_COT_BACK = 2
+IEC104_COT_SPONT = 3
+IEC104_COT_INIT = 4
+IEC104_COT_REQ = 5
+IEC104_COT_ACT = 6
+IEC104_COT_ACTCON = 7
+IEC104_COT_DEACT = 8
+IEC104_COT_DEACTCON = 9
+IEC104_COT_ACTTERM = 10
+IEC104_COT_RETREM = 11
+IEC104_COT_RETLOC = 12
+IEC104_COT_FILE = 13
+IEC104_COT_RESERVED_14 = 14
+IEC104_COT_RESERVED_15 = 15
+IEC104_COT_RESERVED_16 = 16
+IEC104_COT_RESERVED_17 = 17
+IEC104_COT_RESERVED_18 = 18
+IEC104_COT_RESERVED_19 = 19
+IEC104_COT_INROGEN = 20
+IEC104_COT_INRO1 = 21
+IEC104_COT_INRO2 = 22
+IEC104_COT_INRO3 = 23
+IEC104_COT_INRO4 = 24
+IEC104_COT_INRO5 = 25
+IEC104_COT_INRO6 = 26
+IEC104_COT_INRO7 = 27
+IEC104_COT_INRO8 = 28
+IEC104_COT_INRO9 = 29
+IEC104_COT_INRO10 = 30
+IEC104_COT_INRO11 = 31
+IEC104_COT_INRO12 = 32
+IEC104_COT_INRO13 = 33
+IEC104_COT_INRO14 = 34
+IEC104_COT_INRO15 = 35
+IEC104_COT_INRO16 = 36
+IEC104_COT_REQCOGEN = 37
+IEC104_COT_REQCO1 = 38
+IEC104_COT_REQCO2 = 39
+IEC104_COT_REQCO3 = 40
+IEC104_COT_REQCO4 = 41
+IEC104_COT_RESERVED_42 = 42
+IEC104_COT_RESERVED_43 = 43
+IEC104_COT_UNKNOWN_TYPE_CODE = 44
+IEC104_COT_UNKNOWN_TRANSMIT_REASON = 45
+IEC104_COT_UNKNOWN_COMMON_ADDRESS_OF_ASDU = 46
+IEC104_COT_UNKNOWN_ADDRESS_OF_INFORMATION_OBJECT = 47
+IEC104_COT_PRIVATE_48 = 48
+IEC104_COT_PRIVATE_49 = 49
+IEC104_COT_PRIVATE_50 = 50
+IEC104_COT_PRIVATE_51 = 51
+IEC104_COT_PRIVATE_52 = 52
+IEC104_COT_PRIVATE_53 = 53
+IEC104_COT_PRIVATE_54 = 54
+IEC104_COT_PRIVATE_55 = 55
+IEC104_COT_PRIVATE_56 = 56
+IEC104_COT_PRIVATE_57 = 57
+IEC104_COT_PRIVATE_58 = 58
+IEC104_COT_PRIVATE_59 = 59
+IEC104_COT_PRIVATE_60 = 60
+IEC104_COT_PRIVATE_61 = 61
+IEC104_COT_PRIVATE_62 = 62
+IEC104_COT_PRIVATE_63 = 63
+
+CAUSE_OF_TRANSMISSIONS = {
+    IEC104_COT_UNDEFINED: 'undefined',
+    IEC104_COT_CYC: 'cyclic (per/cyc)',
+    IEC104_COT_BACK: 'background (back)',
+    IEC104_COT_SPONT: 'spontaneous (spont)',
+    IEC104_COT_INIT: 'initialized (init)',
+    IEC104_COT_REQ: 'request (req)',
+    IEC104_COT_ACT: 'activation (act)',
+    IEC104_COT_ACTCON: 'activation confirmed (actcon)',
+    IEC104_COT_DEACT: 'activation canceled (deact)',
+    IEC104_COT_DEACTCON: 'activation cancellation confirmed (deactcon)',
+    IEC104_COT_ACTTERM: 'activation finished (actterm)',
+    IEC104_COT_RETREM: 'feedback caused by remote command (retrem)',
+    IEC104_COT_RETLOC: 'feedback caused by local command (retloc)',
+    IEC104_COT_FILE: 'file transfer (file)',
+    IEC104_COT_RESERVED_14: 'reserved_14',
+    IEC104_COT_RESERVED_15: 'reserved_15',
+    IEC104_COT_RESERVED_16: 'reserved_16',
+    IEC104_COT_RESERVED_17: 'reserved_17',
+    IEC104_COT_RESERVED_18: 'reserved_18',
+    IEC104_COT_RESERVED_19: 'reserved_19',
+    IEC104_COT_INROGEN: 'queried by station (inrogen)',
+    IEC104_COT_INRO1: 'queried by query to group 1 (inro1)',
+    IEC104_COT_INRO2: 'queried by query to group 2 (inro2)',
+    IEC104_COT_INRO3: 'queried by query to group 3 (inro3)',
+    IEC104_COT_INRO4: 'queried by query to group 4 (inro4)',
+    IEC104_COT_INRO5: 'queried by query to group 5 (inro5)',
+    IEC104_COT_INRO6: 'queried by query to group 6 (inro6)',
+    IEC104_COT_INRO7: 'queried by query to group 7 (inro7)',
+    IEC104_COT_INRO8: 'queried by query to group 8 (inro8)',
+    IEC104_COT_INRO9: 'queried by query to group 9 (inro9)',
+    IEC104_COT_INRO10: 'queried by query to group 10 (inro10)',
+    IEC104_COT_INRO11: 'queried by query to group 11 (inro11)',
+    IEC104_COT_INRO12: 'queried by query to group 12 (inro12)',
+    IEC104_COT_INRO13: 'queried by query to group 13 (inro13)',
+    IEC104_COT_INRO14: 'queried by query to group 14 (inro14)',
+    IEC104_COT_INRO15: 'queried by query to group 15 (inro15)',
+    IEC104_COT_INRO16: 'queried by query to group 16 (inro16)',
+    IEC104_COT_REQCOGEN: 'queried by counter general interrogation (reqcogen)',
+    IEC104_COT_REQCO1: 'queried by query to counter group 1 (reqco1)',
+    IEC104_COT_REQCO2: 'queried by query to counter group 2 (reqco2)',
+    IEC104_COT_REQCO3: 'queried by query to counter group 3 (reqco3)',
+    IEC104_COT_REQCO4: 'queried by query to counter group 4 (reqco4)',
+    IEC104_COT_RESERVED_42: 'reserved_42',
+    IEC104_COT_RESERVED_43: 'reserved_43',
+    IEC104_COT_UNKNOWN_TYPE_CODE: 'unknown type code',
+    IEC104_COT_UNKNOWN_TRANSMIT_REASON: 'unknown transmit reason',
+    IEC104_COT_UNKNOWN_COMMON_ADDRESS_OF_ASDU:
+        'unknown common address of ASDU',
+    IEC104_COT_UNKNOWN_ADDRESS_OF_INFORMATION_OBJECT:
+        'unknown address of information object',
+    IEC104_COT_PRIVATE_48: 'private_48',
+    IEC104_COT_PRIVATE_49: 'private_49',
+    IEC104_COT_PRIVATE_50: 'private_50',
+    IEC104_COT_PRIVATE_51: 'private_51',
+    IEC104_COT_PRIVATE_52: 'private_52',
+    IEC104_COT_PRIVATE_53: 'private_53',
+    IEC104_COT_PRIVATE_54: 'private_54',
+    IEC104_COT_PRIVATE_55: 'private_55',
+    IEC104_COT_PRIVATE_56: 'private_56',
+    IEC104_COT_PRIVATE_57: 'private_57',
+    IEC104_COT_PRIVATE_58: 'private_58',
+    IEC104_COT_PRIVATE_59: 'private_59',
+    IEC104_COT_PRIVATE_60: 'private_60',
+    IEC104_COT_PRIVATE_61: 'private_61',
+    IEC104_COT_PRIVATE_62: 'private_62',
+    IEC104_COT_PRIVATE_63: 'private_63'
+}
+
+IEC104_APDU_TYPE_UNKNOWN = 0x00
+IEC104_APDU_TYPE_I_SEQ_IOA = 0x01
+IEC104_APDU_TYPE_I_SINGLE_IOA = 0x02
+IEC104_APDU_TYPE_U = 0x03
+IEC104_APDU_TYPE_S = 0x04
+
+
+def _iec104_apci_type_from_packet(data):
+    """
+    the type of the message is encoded in octet 1..4
+
+                 oct 1, bit 1   2       oct 3, bit 1
+    I Message               0  1|0                 0
+    S Message               1   0                  0
+    U Message               1   1                  0
+
+
+    see EN 60870-5-104:2006, sec. 5 (p. 13, fig. 6,7,8)
+    """
+
+    oct_1 = orb(data[2])
+    oct_3 = orb(data[4])
+
+    oct_1_bit_1 = bool(oct_1 & 1)
+    oct_1_bit_2 = bool(oct_1 & 2)
+    oct_3_bit_1 = bool(oct_3 & 1)
+
+    if oct_1_bit_1 is False and oct_3_bit_1 is False:
+        if len(data) < 8:
+            return IEC104_APDU_TYPE_UNKNOWN
+
+        is_seq_ioa = ((orb(data[7]) & 0x80) == 0x80)
+
+        if is_seq_ioa:
+            return IEC104_APDU_TYPE_I_SEQ_IOA
+        else:
+            return IEC104_APDU_TYPE_I_SINGLE_IOA
+
+    if oct_1_bit_1 and oct_1_bit_2 is False and oct_3_bit_1 is False:
+        return IEC104_APDU_TYPE_S
+
+    if oct_1_bit_1 and oct_1_bit_2 and oct_3_bit_1 is False:
+        return IEC104_APDU_TYPE_U
+
+    return IEC104_APDU_TYPE_UNKNOWN
+
+
+class IEC104_APDU(Packet):
+    """
+    basic Application Protocol Data Unit definition used by S/U/I messages
+    """
+
+    def guess_payload_class(self, payload):
+
+        payload_len = len(payload)
+
+        if payload_len < 6:
+            return self.default_payload_class(payload)
+
+        if orb(payload[0]) != 0x68:
+            self.default_payload_class(payload)
+
+        # the length field contains the number of bytes starting from the
+        # first control octet
+        apdu_length = 2 + orb(payload[1])
+
+        if payload_len < apdu_length:
+            warning(
+                'invalid len of APDU. given len: {} available len: {}'.format(
+                    apdu_length, payload_len))
+            return self.default_payload_class(payload)
+
+        apdu_type = _iec104_apci_type_from_packet(payload)
+
+        return IEC104_APDU_CLASSES.get(apdu_type,
+                                       self.default_payload_class(payload))
+
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        """
+        detect type of the message by checking packet data
+        :param _pkt: raw bytes of the packet layer data to be checked
+        :param args: unused
+        :param kargs: unused
+        :return: class of the detected message type
+        """
+
+        if _iec104_is_i_apdu_seq_ioa(_pkt):
+            return IEC104_I_Message_SeqIOA
+
+        if _iec104_is_i_apdu_single_ioa(_pkt):
+            return IEC104_I_Message_SingleIOA
+
+        if _iec104_is_u_apdu(_pkt):
+            return IEC104_U_Message
+
+        if _iec104_is_s_apdu(_pkt):
+            return IEC104_S_Message
+
+        return Raw
+
+
+class IEC104_S_Message(IEC104_APDU):
+    """
+    message used for ack of received I-messages
+    """
+    name = 'IEC-104 S APDU'
+
+    fields_desc = [
+
+        XByteField('start', 0x68),
+        ByteField("apdu_length", 4),
+
+        ByteField('octet_1', 0x01),
+        ByteField('octet_2', 0),
+        IEC104SequenceNumber('rx_seq_num', 0),
+    ]
+
+
+class IEC104_U_Message(IEC104_APDU):
+    """
+    message used for connection tx control (start/stop)  and monitoring (test)
+    """
+    name = 'IEC-104 U APDU'
+
+    fields_desc = [
+
+        XByteField('start', 0x68),
+        ByteField("apdu_length", 4),
+
+        BitField('testfr_con', 0, 1),
+        BitField('testfr_act', 0, 1),
+        BitField('stopdt_con', 0, 1),
+        BitField('stopdt_act', 0, 1),
+        BitField('startdt_con', 0, 1),
+        BitField('startdt_act', 0, 1),
+        BitField('octet_1_1_2', 3, 2),
+
+        ByteField('octet_2', 0),
+        ByteField('octet_3', 0),
+        ByteField('octet_4', 0)
+    ]
+
+
+def _i_msg_io_dispatcher_sequence(pkt, next_layer_data):
+    """
+    get the type id and return the matching ASDU instance
+    """
+    next_layer_class_type = IEC104_IO_CLASSES.get(pkt.type_id, conf.raw_layer)
+
+    return next_layer_class_type(next_layer_data)
+
+
+def _i_msg_io_dispatcher_single(pkt, next_layer_data):
+    """
+    get the type id and return the matching ASDU instance
+    (information object address + regular ASDU information object fields)
+    """
+    next_layer_class_type = IEC104_IO_WITH_IOA_CLASSES.get(pkt.type_id,
+                                                           conf.raw_layer)
+
+    return next_layer_class_type(next_layer_data)
+
+
+class IEC104ASDUPacketListField(PacketListField):
+    """
+    used to add a list of information objects to an I-message
+    """
+    def m2i(self, pkt, m):
+        """
+        add calling layer instance to the cls()-signature
+        :param pkt: calling layer instance
+        :param m: raw data forming the next layer
+        :return: instance of the class representing the next layer
+        """
+        return self.cls(pkt, m)
+
+
+class IEC104_I_Message_StructureException(Scapy_Exception):
+    """
+    Exception raised if payload is not of type Information Object
+    """
+    pass
+
+
+class IEC104_I_Message(IEC104_APDU):
+    """
+    message used for transmitting data (APDU - Application Protocol Data Unit)
+
+    APDU: MAGIC + APCI + ASDU
+    MAGIC: 0x68
+    APCI : Control Information (rx/tx seq/ack numbers)
+    ASDU : Application Service Data Unit - information object related data
+
+    see EN 60870-5-104:2006, sec. 5 (p. 12)
+    """
+    name = 'IEC-104 I APDU'
+
+    IEC_104_MAGIC = 0x68  # dec -> 104
+
+    SQ_FLAG_SINGLE = 0
+    SQ_FLAG_SEQUENCE = 1
+
+    SQ_FLAGS = {
+        SQ_FLAG_SINGLE: 'single',
+        SQ_FLAG_SEQUENCE: 'sequence'
+    }
+
+    TEST_DISABLED = 0
+    TEST_ENABLED = 1
+
+    TEST_FLAGS = {
+        TEST_DISABLED: 'disabled',
+        TEST_ENABLED: 'enabled'
+    }
+
+    ACK_POSITIVE = 0
+    ACK_NEGATIVE = 1
+
+    ACK_FLAGS = {
+        ACK_POSITIVE: 'positive',
+        ACK_NEGATIVE: 'negative'
+    }
+
+    fields_desc = []
+
+    def __init__(self, _pkt=b"", post_transform=None, _internal=0,
+                 _underlayer=None, **fields):
+
+        super(IEC104_I_Message, self).__init__(_pkt=_pkt,
+                                               post_transform=post_transform,
+                                               _internal=_internal,
+                                               _underlayer=_underlayer,
+                                               **fields)
+
+        if 'io' in fields and fields['io']:
+            self._information_object_update(fields['io'])
+
+    def _information_object_update(self, io_instances):
+        """
+        set the type_id in the ASDU header based on the given information
+        object (io) and check for valid structure
+        :param io_instances: information object
+        """
+
+        if not isinstance(io_instances, list):
+            io_instances = [io_instances]
+
+        first_io = io_instances[0]
+        first_io_class = first_io.__class__
+
+        if not issubclass(first_io_class, IEC104_IO_Packet):
+            raise IEC104_I_Message_StructureException(
+                'information object payload must be a subclass of '
+                'IEC104_IO_Packet')
+
+        self.type_id = first_io.iec104_io_type_id()
+
+        # ensure all io elements within the ASDU share the same class type
+        for io_inst in io_instances[1:]:
+            if io_inst.__class__ != first_io_class:
+                raise IEC104_I_Message_StructureException(
+                    'each information object within the ASDU must be of '
+                    'the same class type (first io: {}, '
+                    'current io: {})'.format(first_io_class._name,
+                                             io_inst._name))
+
+
+class IEC104_I_Message_SeqIOA(IEC104_I_Message):
+    """
+    all information objects share a base information object address field
+
+    sq = 1, see EN 60870-5-101:2003, sec. 7.2.2.1 (p. 33)
+    """
+    name = 'IEC-104 I APDU (Seq IOA)'
+
+    fields_desc = [
+        # APCI
+        XByteField('start', IEC104_I_Message.IEC_104_MAGIC),
+        FieldLenField("apdu_length", None, fmt="!B", length_of='io',
+                      adjust=lambda pkt, x: x + 13),
+
+        IEC104SequenceNumber('tx_seq_num', 0),
+        IEC104SequenceNumber('rx_seq_num', 0),
+
+        # ASDU
+        ByteEnumField('type_id', 0, IEC104_IO_NAMES),
+
+        BitEnumField('sq', IEC104_I_Message.SQ_FLAG_SEQUENCE, 1,
+                     IEC104_I_Message.SQ_FLAGS),
+        BitFieldLenField('num_io', None, 7, count_of='io'),
+
+        BitEnumField('test', 0, 1, IEC104_I_Message.TEST_FLAGS),
+        BitEnumField('ack', 0, 1, IEC104_I_Message.ACK_FLAGS),
+        BitEnumField('cot', 0, 6, CAUSE_OF_TRANSMISSIONS),
+
+        ByteField('origin_address', 0),
+
+        LEShortField('common_asdu_address', 0),
+
+        LEThreeBytesField('information_object_address', 0),
+
+        IEC104ASDUPacketListField('io',
+                                  conf.raw_layer(),
+                                  _i_msg_io_dispatcher_sequence,
+                                  length_from=lambda pkt: pkt.apdu_length - 13)
+    ]
+
+    def post_dissect(self, s):
+        if self.type_id == IEC104_IO_ID_C_RD_NA_1:
+
+            # IEC104_IO_ID_C_RD_NA_1 has no payload. we will add the layer
+            # manually to the stack right now. we do this num_io times
+            # as - even if it makes no sense - someone could decide
+            # to add more than one read commands in a sequence...
+            setattr(self, 'io', [IEC104_IO_C_RD_NA_1()] * self.num_io)
+
+        return s
+
+
+class IEC104_I_Message_SingleIOA(IEC104_I_Message):
+    """
+    every information object contains an individual information object
+    address field
+
+    sq = 0, see EN 60870-5-101:2003, sec. 7.2.2.1 (p. 33)
+    """
+    name = 'IEC-104 I APDU (single IOA)'
+
+    fields_desc = [
+        # APCI
+        XByteField('start', IEC104_I_Message.IEC_104_MAGIC),
+        FieldLenField("apdu_length", None, fmt="!B", length_of='io',
+                      adjust=lambda pkt, x: x + 10),
+
+        IEC104SequenceNumber('tx_seq_num', 0),
+        IEC104SequenceNumber('rx_seq_num', 0),
+
+        # ASDU
+        ByteEnumField('type_id', 0, IEC104_IO_NAMES),
+
+        BitEnumField('sq', IEC104_I_Message.SQ_FLAG_SINGLE, 1,
+                     IEC104_I_Message.SQ_FLAGS),
+        BitFieldLenField('num_io', None, 7, count_of='io'),
+
+        BitEnumField('test', 0, 1, IEC104_I_Message.TEST_FLAGS),
+        BitEnumField('ack', 0, 1, IEC104_I_Message.ACK_FLAGS),
+        BitEnumField('cot', 0, 6, CAUSE_OF_TRANSMISSIONS),
+
+        ByteField('origin_address', 0),
+
+        LEShortField('common_asdu_address', 0),
+
+        IEC104ASDUPacketListField('io',
+                                  conf.raw_layer(),
+                                  _i_msg_io_dispatcher_single,
+                                  length_from=lambda pkt: pkt.apdu_length - 10)
+    ]
+
+
+IEC104_APDU_CLASSES = {
+    IEC104_APDU_TYPE_UNKNOWN: conf.raw_layer,
+    IEC104_APDU_TYPE_I_SEQ_IOA: IEC104_I_Message_SeqIOA,
+    IEC104_APDU_TYPE_I_SINGLE_IOA: IEC104_I_Message_SingleIOA,
+    IEC104_APDU_TYPE_U: IEC104_U_Message,
+    IEC104_APDU_TYPE_S: IEC104_S_Message
+}
+
+
+def _iec104_is_i_apdu_seq_ioa(payload):
+    len_payload = len(payload)
+    if len_payload < 6:
+        return False
+
+    if orb(payload[0]) != 0x68 or (
+            orb(payload[1]) + 2) > len_payload or len_payload < 8:
+        return False
+
+    return IEC104_APDU_TYPE_I_SEQ_IOA == _iec104_apci_type_from_packet(payload)
+
+
+def _iec104_is_i_apdu_single_ioa(payload):
+    len_payload = len(payload)
+    if len_payload < 6:
+        return False
+
+    if orb(payload[0]) != 0x68 or (
+            orb(payload[1]) + 2) > len_payload or len_payload < 8:
+        return False
+
+    return IEC104_APDU_TYPE_I_SINGLE_IOA == _iec104_apci_type_from_packet(
+        payload)
+
+
+def _iec104_is_u_apdu(payload):
+    if len(payload) < 6:
+        return False
+
+    if orb(payload[0]) != 0x68 or orb(payload[1]) != 4:
+        return False
+
+    return IEC104_APDU_TYPE_U == _iec104_apci_type_from_packet(payload)
+
+
+def _iec104_is_s_apdu(payload):
+    if len(payload) < 6:
+        return False
+
+    if orb(payload[0]) != 0x68 or orb(payload[1]) != 4:
+        return False
+
+    return IEC104_APDU_TYPE_S == _iec104_apci_type_from_packet(payload)
+
+
+def iec104_decode(payload):
+    """
+    can be used to dissect payload of a TCP connection
+    :param payload: the application layer data (IEC104-APDU(s))
+    :return: iec104 (I/U/S) message instance, conf.raw_layer() if unknown
+    """
+
+    if _iec104_is_i_apdu_seq_ioa(payload):
+        return IEC104_I_Message_SeqIOA(payload)
+    elif _iec104_is_i_apdu_single_ioa(payload):
+        return IEC104_I_Message_SingleIOA(payload)
+    elif _iec104_is_s_apdu(payload):
+        return IEC104_S_Message(payload)
+    elif _iec104_is_u_apdu(payload):
+        return IEC104_U_Message(payload)
+    else:
+        return conf.raw_layer(payload)
+
+
+bind_layers(TCP, IEC104_APDU, sport=IEC_104_IANA_PORT)
+bind_layers(TCP, IEC104_APDU, dport=IEC_104_IANA_PORT)

--- a/scapy/contrib/scada/iec104/iec104_fields.py
+++ b/scapy/contrib/scada/iec104/iec104_fields.py
@@ -1,0 +1,144 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+
+# scapy.contrib.description = IEC-60870-5-104 layer specific fields
+# scapy.contrib.status = loads
+
+"""
+    field type definitions used by iec 60870-5-104 layer (iec104)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :description:
+
+        This file provides field definitions used by the IEC-60870-5-104
+        implementation. Some of those fields are used exclusively by iec104
+        (e.g. IEC104SequenceNumber) while others (LESignedShortField) are
+        more common an may be moved to fields.py.
+
+        normative references:
+            - EN 60870-5-104:2006
+            - EN 60870-5-4:1993
+            - EN 60870-5-4:1994
+"""
+import struct
+
+from scapy.compat import orb
+from scapy.fields import Field, ThreeBytesField, BitField
+from scapy.volatile import RandSShort
+
+
+class LESignedShortField(Field):
+    """
+    little endian signed short field
+    """
+    def __init__(self, name, default):
+        Field.__init__(self, name, default, "<h")
+
+
+class IEC60870_5_4_NormalizedFixPoint(LESignedShortField):
+    """
+    defined as typ 4.1 in EN 60870-5-4:1993, sec. 5.4.1 (p. 10)
+    """
+
+    def i2repr(self, pkt, x):
+        """
+        show the fixed fp-number and its signed short representation
+        """
+
+        return '{} ({})'.format(self.i2h(pkt, x), x)
+
+    def i2h(self, pkt, x):
+        return x / 32768.
+
+    def randval(self):
+        # ToDo: this could also be implemented by adding fmt h+RandSShort to
+        # randval@class Field - should we ?!?
+        return RandSShort()
+
+
+class LEIEEEFloatField(Field):
+    """
+    little endian IEEE float field
+    """
+    def __init__(self, name, default):
+        Field.__init__(self, name, default, "<f")
+
+
+class LEThreeBytesField(ThreeBytesField):
+    """
+    little endian three bytes field
+    """
+    def __init__(self, name, default):
+        ThreeBytesField.__init__(self, name, default)
+
+    def addfield(self, pkt, s, val):
+        data = struct.pack(self.fmt, self.i2m(pkt, val))[1:4][::-1]
+        return s + data
+
+    def getfield(self, pkt, s):
+        data = s[:3][::-1]
+        return s[3:], self.m2i(pkt, struct.unpack(self.fmt, b"\x00" + data)[0])
+
+
+class IEC104SequenceNumber(Field):
+    """
+
+    IEC 60870-5-104 uses the following encoding for sequence numbers
+    (see EN 60870-5-104:2006, p. 13):
+
+      bit ->7   6   5   4   3   2   1   0
+          +---+---+---+---+---+---+---+---+
+          |   |   |   |   |   |   |LSB| 0 |  byte 0
+          +---+---+---+---+---+---+---+---+
+          |MSB|   |   |   |   |   |   |   |  byte 1
+          +---+---+---+---+---+---+---+---+
+
+    """
+
+    def __init__(self, name, default):
+        Field.__init__(self, name, default, "!I")
+
+    def addfield(self, pkt, s, val):
+        b0 = (val << 1) & 0xfe
+        b1 = val >> 7
+
+        return s + bytes(bytearray([b0, b1]))
+
+    def getfield(self, pkt, s):
+        b0 = (orb(s[0]) & 0xfe) >> 1
+        b1 = orb(s[1])
+
+        seq_num = b0 + (b1 << 7)
+
+        return s[2:], seq_num
+
+
+class IEC104SignedSevenBitValue(BitField):
+    """
+    Typ 2.1, 7 Bit, [-64..63]
+
+    see EN 60870-5-4:1994, Typ 2.1 (p. 13)
+    """
+
+    def __init__(self, name, default):
+        BitField.__init__(self, name, default, 7)
+
+    def m2i(self, pkt, x):
+
+        if x & 64:
+            x = x - 128
+
+        return x
+
+    def i2m(self, pkt, x):
+
+        sign = 0
+        if x < 0:
+            sign = 64
+            x = x + 64
+
+        x = x | sign
+
+        return x

--- a/scapy/contrib/scada/iec104/iec104_information_elements.py
+++ b/scapy/contrib/scada/iec104/iec104_information_elements.py
@@ -1,0 +1,1438 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+
+# scapy.contrib.description = IEC-60870-5-104 information elements
+# scapy.contrib.status = loads
+
+"""
+    information element definitions used by IEC 60870-5-101/104
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :description:
+
+        This module provides the information element (IE) definitions used to
+        compose the ASDUs (Application Service Data Units) used within the
+        IEC 60870-5-101 and IEC 60870-5-104 protocol.
+
+        normative references:
+            - IEC 60870-5-4:1993 (atomic base types / data format)
+            - IEC 60870-5-101:2003 (information elements (sec. 7.2.6) and
+              ASDU definition (sec. 7.3))
+            - IEC 60870-5-104:2006 (information element TSC (sec. 8.8, p. 44))
+
+    :TODO:
+        - some definitions should use signed types as outlined in the standard
+        - normed value element should use a float type
+
+"""
+from scapy.contrib.scada.iec104.iec104_fields import \
+    IEC60870_5_4_NormalizedFixPoint, IEC104SignedSevenBitValue, \
+    LESignedShortField, LEIEEEFloatField
+from scapy.fields import BitEnumField, ByteEnumField, ByteField, \
+    ThreeBytesField, \
+    BitField, LEShortField, LESignedIntField
+
+
+def _generate_attributes_and_dicts(cls):
+    """
+    create class attributes and dict entries for range-based attributes
+
+    class attributes will take the form: cls.<attribute_name_prefix>_<index>
+
+    dictionary entries will be generated as:
+
+      the_dict[index] = "<dict_entry_prefix> (<index>)"
+
+    expects a GENERATED_ATTRIBUTES attribute within the class that contains a
+    list of the specification for the attributes and dictionary entries to be
+    generated. each list entry must have this format:
+
+        (attribute_name_prefix, dict_entry_prefix, dictionary, first_index,
+         last_index)
+
+    with
+        <attribute_name_prefix> - the prefix of the attribute name
+        first_index - index of the first attribute to be generated
+        last_index - index of the last attribute to be generated
+    :param cls: the class the attributes should be added to
+    :return: cls extended by generated attributes
+    """
+
+    for attribute_name_prefix, dict_entry_prefix, the_dict, first_index, \
+        last_index \
+            in cls.GENERATED_ATTRIBUTES:
+
+        for index in range(first_index, last_index + 1):
+            the_dict[index] = '{} ({})'.format(dict_entry_prefix, index)
+
+            setattr(cls, '{}_{}'.format(attribute_name_prefix, index), index)
+
+    return cls
+
+
+class IEC104_IE_CommonQualityFlags:
+    """
+    common / shared information element quality flags
+    """
+    IV_FLAG_VALID = 0
+    IV_FLAG_INVALID = 1
+    IV_FLAGS = {
+        IV_FLAG_VALID: 'valid',
+        IV_FLAG_INVALID: 'invalid'
+    }
+
+    NT_FLAG_CURRENT_VALUE = 0
+    NT_FLAG_OLD_VALUE = 1
+    NT_FLAGS = {
+        NT_FLAG_CURRENT_VALUE: 'current value',
+        NT_FLAG_OLD_VALUE: 'old value'
+    }
+
+    SB_FLAG_NOT_SUBSTITUTED = 0
+    SB_FLAG_SUBSTITUTED = 1
+    SB_FLAGS = {
+        SB_FLAG_NOT_SUBSTITUTED: 'not substituted',
+        SB_FLAG_SUBSTITUTED: 'substituted'
+    }
+
+    BL_FLAG_NOT_BLOCKED = 0
+    BL_FLAG_BLOCKED = 1
+    BL_FLAGS = {
+        BL_FLAG_NOT_BLOCKED: 'not blocked',
+        BL_FLAG_BLOCKED: 'blocked'
+    }
+
+    EI_FLAG_ELAPSED_TIME_VALID = 0
+    EI_FLAG_ELAPSED_TIME_INVALID = 1
+    EI_FLAGS = {
+        EI_FLAG_ELAPSED_TIME_VALID: 'elapsed time valid',
+        EI_FLAG_ELAPSED_TIME_INVALID: 'elapsed time invalid'
+    }
+
+
+class IEC104_IE_SIQ(IEC104_IE_CommonQualityFlags):
+    """
+    SIQ - single point information with quality descriptor
+
+    EN 60870-5-101:2003, sec. 7.2.6.1 (p. 44)
+    """
+
+    SPI_FLAG_STATE_OFF = 0
+    SPI_FLAG_STATE_ON = 1
+
+    SPI_FLAGS = {
+        SPI_FLAG_STATE_OFF: 'off',
+        SPI_FLAG_STATE_ON: 'on'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('nt', 0, 1, IEC104_IE_CommonQualityFlags.NT_FLAGS),
+        # live or cached old value
+        BitEnumField('sb', 0, 1, IEC104_IE_CommonQualityFlags.SB_FLAGS),
+        # value substituted
+        BitEnumField('bl', 0, 1, IEC104_IE_CommonQualityFlags.BL_FLAGS),
+        # blocked
+        BitField('reserved', 0, 3),
+        BitEnumField('spi_value', 0, 1, SPI_FLAGS)
+    ]
+
+
+class IEC104_IE_DIQ(IEC104_IE_CommonQualityFlags):
+    """
+    DIQ - double-point information with quality descriptor
+
+    EN 60870-5-101:2003, sec. 7.2.6.2 (p. 44)
+    """
+
+    DPI_FLAG_STATE_UNDEFINED_OR_TRANSIENT = 0
+    DPI_FLAG_STATE_OFF = 1
+    DPI_FLAG_STATE_ON = 2
+    DPI_FLAG_STATE_UNDEFINED = 3
+
+    DPI_FLAGS = {
+        DPI_FLAG_STATE_UNDEFINED_OR_TRANSIENT: 'undefined/transient',
+        DPI_FLAG_STATE_OFF: 'off',
+        DPI_FLAG_STATE_ON: 'on',
+        DPI_FLAG_STATE_UNDEFINED: 'undefined'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('nt', 0, 1, IEC104_IE_CommonQualityFlags.NT_FLAGS),
+        # live or cached old value
+        BitEnumField('sb', 0, 1, IEC104_IE_CommonQualityFlags.SB_FLAGS),
+        # value substituted
+        BitEnumField('bl', 0, 1, IEC104_IE_CommonQualityFlags.BL_FLAGS),
+        # blocked
+        BitField('reserved', 0, 2),
+        BitEnumField('dpi_value', 0, 2, DPI_FLAGS)
+    ]
+
+
+class IEC104_IE_QDS(IEC104_IE_CommonQualityFlags):
+    """
+    QDS - quality descriptor separate object
+
+    EN 60870-5-101:2003, sec. 7.2.6.3 (p. 45)
+    """
+
+    OV_FLAG_NO_OVERFLOW = 0
+    OV_FLAG_OVERFLOW = 1
+    OV_FLAGS = {
+        OV_FLAG_NO_OVERFLOW: 'no overflow',
+        OV_FLAG_OVERFLOW: 'overflow'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('nt', 0, 1, IEC104_IE_CommonQualityFlags.NT_FLAGS),
+        # live or cached old value
+        BitEnumField('sb', 0, 1, IEC104_IE_CommonQualityFlags.SB_FLAGS),
+        # value substituted
+        BitEnumField('bl', 0, 1, IEC104_IE_CommonQualityFlags.BL_FLAGS),
+        # blocked
+        BitField('reserved', 0, 3),
+        BitEnumField('ov', 0, 1, OV_FLAGS),  # overflow
+    ]
+
+
+class IEC104_IE_QDP(IEC104_IE_CommonQualityFlags):
+    """
+    QDP - quality descriptor protection equipment separate object
+
+    EN 60870-5-101:2003, sec. 7.2.6.4 (p. 46)
+    """
+
+    informantion_element_fields = [
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('nt', 0, 1, IEC104_IE_CommonQualityFlags.NT_FLAGS),
+        # live or cached old value
+        BitEnumField('sb', 0, 1, IEC104_IE_CommonQualityFlags.SB_FLAGS),
+        # value substituted
+        BitEnumField('bl', 0, 1, IEC104_IE_CommonQualityFlags.BL_FLAGS),
+        # blocked
+        BitEnumField('ei', 0, 1, IEC104_IE_CommonQualityFlags.EI_FLAGS),
+        # blocked
+        BitField('reserved', 0, 3)
+    ]
+
+
+class IEC104_IE_VTI:
+    """
+    VTI - value with transient state indication
+
+    EN 60870-5-101:2003, sec. 7.2.6.5 (p. 47)
+    """
+
+    TRANSIENT_STATE_DISABLED = 0
+    TRANSIENT_STATE_ENABLED = 1
+
+    TRANSIENT_STATE_FLAGS = {
+        TRANSIENT_STATE_DISABLED: 'device not in transient state',
+        TRANSIENT_STATE_ENABLED: 'device in transient state'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('transient_state', 0, 1, TRANSIENT_STATE_FLAGS),
+        IEC104SignedSevenBitValue('value', 0)
+    ]
+
+
+class IEC104_IE_NVA:
+    """
+    NVA - normed value
+
+    EN 60870-5-101:2003, sec. 7.2.6.6 (p. 47)
+    """
+
+    informantion_element_fields = [
+        IEC60870_5_4_NormalizedFixPoint('normed_value', 0)
+    ]
+
+
+class IEC104_IE_SVA:
+    """
+    SVA - scaled value
+
+    EN 60870-5-101:2003, sec. 7.2.6.7 (p. 47)
+    """
+
+    informantion_element_fields = [
+        LESignedShortField('scaled_value', 0)
+    ]
+
+
+class IEC104_IE_R32_IEEE_STD_754:
+    """
+    R32-IEEE STD 754 - short floating point value
+
+    EN 60870-5-101:2003, sec. 7.2.6.8 (p. 47)
+    """
+
+    informantion_element_fields = [
+        LEIEEEFloatField('scaled_value', 0)
+    ]
+
+
+class IEC104_IE_BCR:
+    """
+    BCR - binary counter reading
+
+    EN 60870-5-101:2003, sec. 7.2.6.9 (p. 47)
+    """
+    CA_FLAG_COUNTER_NOT_ADJUSTED = 0
+    CA_FLAG_COUNTER_ADJUSTED = 1
+    CA_FLAGS = {
+        CA_FLAG_COUNTER_NOT_ADJUSTED: 'counter not adjusted',
+        CA_FLAG_COUNTER_ADJUSTED: 'counter adjusted'
+    }
+
+    CY_FLAG_NO_OVERFLOW = 0
+    CY_FLAG_OVERFLOW = 1
+    CY_FLAGS = {
+        CY_FLAG_NO_OVERFLOW: 'no overflow',
+        CY_FLAG_OVERFLOW: 'overflow'
+    }
+
+    informantion_element_fields = [
+        LESignedIntField('counter_value', 0),
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('ca', 0, 1, CA_FLAGS),  # counter adjusted
+        BitEnumField('cy', 0, 1, CY_FLAGS),  # carry flag / overflow
+        BitField('sq', 0, 5)  # sequence
+    ]
+
+
+class IEC104_IE_SEP(IEC104_IE_CommonQualityFlags):
+    """
+    SEP - single event of protection equipment
+
+    EN 60870-5-101:2003, sec. 7.2.6.10 (p. 48)
+    """
+
+    ES_FLAG_STATE_UNDEFINED_0 = 0
+    ES_FLAG_STATE_OFF = 1
+    ES_FLAG_STATE_ON = 2
+    ES_FLAG_STATE_UNDEFINED_3 = 3
+    ES_FLAGS = {
+        ES_FLAG_STATE_UNDEFINED_0: 'undefined (0)',
+        ES_FLAG_STATE_OFF: 'off',
+        ES_FLAG_STATE_ON: 'on',
+        ES_FLAG_STATE_UNDEFINED_3: 'undefined (3)',
+    }
+
+    informantion_element_fields = [
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        # invalid
+        BitEnumField('nt', 0, 1, IEC104_IE_CommonQualityFlags.NT_FLAGS),
+        # live or cached old value
+        BitEnumField('sb', 0, 1, IEC104_IE_CommonQualityFlags.SB_FLAGS),
+        # value substituted
+        BitEnumField('bl', 0, 1, IEC104_IE_CommonQualityFlags.BL_FLAGS),
+        # blocked
+        BitEnumField('ei', 0, 1, IEC104_IE_CommonQualityFlags.EI_FLAGS),
+        # time valid
+        BitField('reserved', 0, 1),
+        BitEnumField('es', 0, 2, ES_FLAGS),  # event state
+    ]
+
+
+class IEC104_IE_SPE:
+    """
+    SPE - start events of protection equipment
+
+    EN 60870-5-101:2003, sec. 7.2.6.11 (p. 48)
+    """
+    GS_FLAG_NO_GENERAL_TRIGGER = 0
+    GS_FLAG_GENERAL_TRIGGER = 1
+    GS_FLAGS = {
+        GS_FLAG_NO_GENERAL_TRIGGER: 'general trigger',
+        GS_FLAG_GENERAL_TRIGGER: 'no general trigger'
+    }
+
+    # protection relays - start of operation - fault detection per phase
+    SL_FLAG_START_OPR_PHASE_L1_NO_TRIGGER = 0
+    SL_FLAG_START_OPR_PHASE_L1_TRIGGER = 1
+    SL_FLAG_START_OPR_PHASE_L2_NO_TRIGGER = 0
+    SL_FLAG_START_OPR_PHASE_L2_TRIGGER = 1
+    SL_FLAG_START_OPR_PHASE_L3_NO_TRIGGER = 0
+    SL_FLAG_START_OPR_PHASE_L3_TRIGGER = 1
+    SL_FLAGS = {
+        SL_FLAG_START_OPR_PHASE_L1_NO_TRIGGER: 'no start of operation',
+        SL_FLAG_START_OPR_PHASE_L1_TRIGGER: 'start of operation'
+    }
+
+    # protection event start caused by earth current
+    SIE_FLAG_START_OPR_PHASE_IE_NO_TRIGGER = 0
+    SIE_FLAG_START_OPR_PHASE_IE_TRIGGER = 1
+    SIE_FLAGS = {
+        SIE_FLAG_START_OPR_PHASE_IE_NO_TRIGGER: 'no start of operation',
+        SIE_FLAG_START_OPR_PHASE_IE_TRIGGER: 'start of operation'
+    }
+
+    # direction of the started protection event
+    SRD_FLAG_DIRECTION_FORWARD = 0
+    SRD_FLAG_DIRECTION_BACKWARD = 1
+    SRD_FLAGS = {
+        SRD_FLAG_DIRECTION_FORWARD: 'forward',
+        SRD_FLAG_DIRECTION_BACKWARD: 'backward'
+    }
+
+    informantion_element_fields = [
+        BitField('reserved', 0, 2),
+        BitEnumField('srd', 0, 1, SRD_FLAGS),
+        BitEnumField('sie', 0, 1, SIE_FLAGS),
+        BitEnumField('sl3', 0, 1, SL_FLAGS),
+        BitEnumField('sl2', 0, 1, SL_FLAGS),
+        BitEnumField('sl1', 0, 1, SL_FLAGS),
+        BitEnumField('gs', 0, 1, GS_FLAGS)
+    ]
+
+
+class IEC104_IE_OCI:
+    """
+    OCI - output circuit information of protection equipment
+
+    EN 60870-5-101:2003, sec. 7.2.6.12 (p. 49)
+    """
+    # all 3 phases off command
+    GC_FLAG_NO_GENERAL_COMMAND_OFF = 0
+    GC_FLAG_GENERAL_COMMAND_OFF = 1
+    GC_FLAGS = {
+        GC_FLAG_NO_GENERAL_COMMAND_OFF: 'no general off',
+        GC_FLAG_GENERAL_COMMAND_OFF: 'general off'
+    }
+    # phase based off command
+    # protection relays - start of operation - fault detection per phase
+    CL_FLAG_NO_COMMAND_L1_OFF = 0
+    CL_FLAG_COMMAND_L1_OFF = 1
+    CL_FLAG_NO_COMMAND_L2_OFF = 0
+    CL_FLAG_COMMAND_L2_OFF = 1
+    CL_FLAG_NO_COMMAND_L3_OFF = 0
+    CL_FLAG_COMMAND_L3_OFF = 1
+    CL_FLAGS = {
+        CL_FLAG_NO_COMMAND_L1_OFF: 'no command off',
+        CL_FLAG_COMMAND_L1_OFF: 'no command off'
+    }
+
+    informantion_element_fields = [
+        BitField('reserved', 0, 4),
+        BitEnumField('cl3', 0, 1, CL_FLAGS),  # command Lx
+        BitEnumField('cl2', 0, 1, CL_FLAGS),
+        BitEnumField('cl1', 0, 1, CL_FLAGS),
+        BitEnumField('gc', 0, 1, GC_FLAGS),  # general off
+    ]
+
+
+class IEC104_IE_BSI:
+    """
+    BSI - binary state information
+
+    EN 60870-5-101:2003, sec. 7.2.6.13 (p. 49)
+    """
+    informantion_element_fields = [
+        BitField('bsi', 0, 32)
+    ]
+
+
+class IEC104_IE_FBP:
+    """
+    FBP - fixed test bit pattern
+
+    EN 60870-5-101:2003, sec. 7.2.6.14 (p. 49)
+    """
+    informantion_element_fields = [
+        LEShortField('fbp', 0)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QOC:
+    """
+    QOC - qualifier of command
+
+    EN 60870-5-101:2003, sec. 7.2.6.26 (p. 54)
+    """
+
+    QU_FLAG_NO_ADDITIONAL_PARAMETERS = 0
+    QU_FLAG_SHORT_COMMAND_EXEC_TIME = 1  # e.g. controlling a power switch
+    QU_FLAG_LONG_COMMAND_EXEC_TIME = 2
+    QU_FLAG_PERMANENT_COMMAND = 3
+
+    QU_FLAGS = {
+        QU_FLAG_NO_ADDITIONAL_PARAMETERS: 'no additional parameter',
+        QU_FLAG_SHORT_COMMAND_EXEC_TIME: 'short execution time',
+        QU_FLAG_LONG_COMMAND_EXEC_TIME: 'long execution time',
+        QU_FLAG_PERMANENT_COMMAND: 'permanent command',
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('QU_FLAG_RESERVED_COMPATIBLE', 'reserved - compatible', QU_FLAGS, 4,
+         8),
+        ('QU_FLAG_RESERVED_PREDEFINED_FUNCTION',
+         'reserved - predefined function', QU_FLAGS, 9, 15),
+        ('QU_FLAG_RESERVED_PRIVATE', 'reserved - private', QU_FLAGS, 16, 31)
+    ]
+
+    SE_FLAG_EXECUTE = 0
+    SE_FLAG_SELECT = 1
+    SE_FLAGS = {
+        SE_FLAG_EXECUTE: 'execute',
+        SE_FLAG_SELECT: 'select'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('s/e', 0, 1, SE_FLAGS),
+        BitEnumField('qu', 0, 5, QU_FLAGS)
+    ]
+
+
+class IEC104_IE_SCO(IEC104_IE_QOC):
+    """
+    SCO - single command
+
+    EN 60870-5-101:2003, sec. 7.2.6.15 (p. 50)
+    """
+    SCS_FLAG_STATE_OFF = 0
+    SCS_FLAG_STATE_ON = 1
+    SCS_FLAGS = {
+        SCS_FLAG_STATE_OFF: 'off',
+        SCS_FLAG_STATE_ON: 'on'
+    }
+
+    informantion_element_fields = IEC104_IE_QOC.informantion_element_fields + [
+        BitField('reserved', 0, 1),
+        BitEnumField('scs', 0, 1, SCS_FLAGS)
+    ]
+
+
+class IEC104_IE_DCO(IEC104_IE_QOC):
+    """
+    DCO - double command
+
+    EN 60870-5-101:2003, sec. 7.2.6.16 (p. 50)
+    """
+    DCS_FLAG_STATE_INVALID_0 = 0
+    DCS_FLAG_STATE_OFF = 1
+    DCS_FLAG_STATE_ON = 2
+    DCS_FLAG_STATE_INVALID_3 = 3
+    DCS_FLAGS = {
+        DCS_FLAG_STATE_INVALID_0: 'invalid (0)',
+        DCS_FLAG_STATE_OFF: 'off',
+        DCS_FLAG_STATE_ON: 'on',
+        DCS_FLAG_STATE_INVALID_3: 'invalid (3)',
+    }
+
+    informantion_element_fields = IEC104_IE_QOC.informantion_element_fields + [
+        BitEnumField('dcs', 0, 2, DCS_FLAGS)
+    ]
+
+
+class IEC104_IE_RCO(IEC104_IE_QOC):
+    """
+    RCO - regulating step command
+
+    EN 60870-5-101:2003, sec. 7.2.6.17 (p. 50)
+    """
+    RCO_FLAG_STATE_INVALID_0 = 0
+    RCO_FLAG_STATE_STEP_DOWN = 1
+    RCO_FLAG_STATE_STEP_UP = 2
+    RCO_FLAG_STATE_INVALID_3 = 3
+    RCO_FLAGS = {
+        RCO_FLAG_STATE_INVALID_0: 'invalid (0)',
+        RCO_FLAG_STATE_STEP_DOWN: 'step down',
+        RCO_FLAG_STATE_STEP_UP: 'step up',
+        RCO_FLAG_STATE_INVALID_3: 'invalid (3)',
+    }
+
+    informantion_element_fields = IEC104_IE_QOC.informantion_element_fields + [
+        BitEnumField('rcs', 0, 2, RCO_FLAGS)
+    ]
+
+
+class IEC104_IE_CP56TIME2A(IEC104_IE_CommonQualityFlags):
+    """
+    CP56Time2a - dual time, 7 octets
+                 (milliseconds, valid flag, minutes, hours,
+                  summer-time-indicator, day of month, weekday, years)
+
+    well, someone should have talked to them about the idea of the
+    unix timestamp...
+
+    EN 60870-5-101:2003, sec. 7.2.6.18 (p. 50)
+
+    time representation format according IEC 60870-5-4:1993, sec. 6.8, p. 23
+    """
+    WEEK_DAY_FLAG_UNUSED = 0
+    WEEK_DAY_FLAG_MONDAY = 1
+    WEEK_DAY_FLAG_TUESDAY = 2
+    WEEK_DAY_FLAG_WEDNESDAY = 3
+    WEEK_DAY_FLAG_THURSDAY = 4
+    WEEK_DAY_FLAG_FRIDAY = 5
+    WEEK_DAY_FLAG_SATURDAY = 6
+    WEEK_DAY_FLAG_SUNDAY = 7
+    WEEK_DAY_FLAGS = {
+        WEEK_DAY_FLAG_UNUSED: 'unused',
+        WEEK_DAY_FLAG_MONDAY: 'Monday',
+        WEEK_DAY_FLAG_TUESDAY: 'Tuesday',
+        WEEK_DAY_FLAG_WEDNESDAY: 'Wednesday',
+        WEEK_DAY_FLAG_THURSDAY: 'Thursday',
+        WEEK_DAY_FLAG_FRIDAY: 'Friday',
+        WEEK_DAY_FLAG_SATURDAY: 'Saturday',
+        WEEK_DAY_FLAG_SUNDAY: 'Sunday'
+    }
+
+    GEN_FLAG_REALTIME = 0
+    GEN_FLAG_SUBSTITUTED_TIME = 1
+    GEN_FLAGS = {
+        GEN_FLAG_REALTIME: 'real time',
+        GEN_FLAG_SUBSTITUTED_TIME: 'substituted time'
+    }
+
+    SU_FLAG_NORMAL_TIME = 0
+    SU_FLAG_SUMMER_TIME = 1
+    SU_FLAGS = {
+        SU_FLAG_NORMAL_TIME: 'normal time',
+        SU_FLAG_SUMMER_TIME: 'summer time'
+    }
+
+    informantion_element_fields = [
+        LEShortField('sec_milli', 0),
+        BitEnumField('iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        BitEnumField('gen', 0, 1, GEN_FLAGS),
+        # only valid in monitor direction ToDo: special treatment needed?
+        BitField('minutes', 0, 6),
+        BitEnumField('su', 0, 1, SU_FLAGS),
+        BitField('reserved_2', 0, 2),
+        BitField('hours', 0, 5),
+        BitEnumField('weekday', 0, 3, WEEK_DAY_FLAGS),
+        BitField('day-of-month', 0, 5),
+        BitField('reserved_3', 0, 4),
+        BitField('month', 0, 4),
+        BitField('reserved_4', 0, 1),
+        BitField('year', 0, 7),
+    ]
+
+
+class IEC104_IE_CP56TIME2A_START_TIME(IEC104_IE_CP56TIME2A):
+    """
+    derived IE, used for ASDU that requires two CP56TIME2A timestamps for
+    defining a range
+    """
+    _DERIVED_IE = True
+    informantion_element_fields = [
+        LEShortField('start_sec_milli', 0),
+        BitEnumField('start_iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        BitEnumField('start_gen', 0, 1, IEC104_IE_CP56TIME2A.GEN_FLAGS),
+        # only valid in monitor direction ToDo: special treatment needed?
+        BitField('start_minutes', 0, 6),
+        BitEnumField('start_su', 0, 1, IEC104_IE_CP56TIME2A.SU_FLAGS),
+        BitField('start_reserved_2', 0, 2),
+        BitField('start_hours', 0, 5),
+        BitEnumField('start_weekday', 0, 3,
+                     IEC104_IE_CP56TIME2A.WEEK_DAY_FLAGS),
+        BitField('start_day-of-month', 0, 5),
+        BitField('start_reserved_3', 0, 4),
+        BitField('start_month', 0, 4),
+        BitField('start_reserved_4', 0, 1),
+        BitField('start_year', 0, 7),
+    ]
+
+
+class IEC104_IE_CP56TIME2A_STOP_TIME(IEC104_IE_CP56TIME2A):
+    """
+    derived IE, used for ASDU that requires two CP56TIME2A timestamps for
+    defining a range
+    """
+    _DERIVED_IE = True
+    informantion_element_fields = [
+        LEShortField('stop_sec_milli', 0),
+        BitEnumField('stop_iv', 0, 1, IEC104_IE_CommonQualityFlags.IV_FLAGS),
+        BitEnumField('stop_gen', 0, 1, IEC104_IE_CP56TIME2A.GEN_FLAGS),
+        # only valid in monitor direction ToDo: special treatment needed?
+        BitField('stop_minutes', 0, 6),
+        BitEnumField('stop_su', 0, 1, IEC104_IE_CP56TIME2A.SU_FLAGS),
+        BitField('stop_reserved_2', 0, 2),
+        BitField('stop_hours', 0, 5),
+        BitEnumField('stop_weekday', 0, 3,
+                     IEC104_IE_CP56TIME2A.WEEK_DAY_FLAGS),
+        BitField('stop_day-of-month', 0, 5),
+        BitField('stop_reserved_3', 0, 4),
+        BitField('stop_month', 0, 4),
+        BitField('stop_reserved_4', 0, 1),
+        BitField('stop_year', 0, 7),
+    ]
+
+
+class IEC104_IE_CP24TIME2A(IEC104_IE_CP56TIME2A):
+    """
+    CP24Time2a - dual time, 3 octets
+                 (milliseconds, valid flag, minutes)
+
+    EN 60870-5-101:2003, sec. 7.2.6.19 (p. 51)
+
+    time representation format according IEC 60870-5-4:1993, sec. 6.8, p. 23,
+    octet 4..7 discarded
+    """
+
+    informantion_element_fields = \
+        IEC104_IE_CP56TIME2A.informantion_element_fields[:4]
+
+
+class IEC104_IE_CP16TIME2A:
+    """
+    CP16Time2a - dual time, 2 octets
+                (milliseconds)
+
+    EN 60870-5-101:2003, sec. 7.2.6.20 (p. 51)
+    """
+    informantion_element_fields = [
+        LEShortField('sec_milli', 0)
+    ]
+
+
+class IEC104_IE_CP16TIME2A_ELAPSED:
+    """
+    derived IE, used in ASDU using more than one CP* field and this one is
+    used to show an elapsed time
+    """
+    _DERIVED_IE = True
+
+    informantion_element_fields = [
+        LEShortField('elapsed_sec_milli', 0)
+    ]
+
+
+class IEC104_IE_CP16TIME2A_PROTECTION_ACTIVE:
+    """
+    derived IE, used in ASDU using more than one CP* field and this one is
+    used to show an protection activation time
+    """
+    _DERIVED_IE = True
+
+    informantion_element_fields = [
+        LEShortField('prot_act_sec_milli', 0)
+    ]
+
+
+class IEC104_IE_CP16TIME2A_PROTECTION_COMMAND:
+    """
+    derived IE, used in ASDU using more than one CP* field and this one is
+    used to show an protection command time
+    """
+    _DERIVED_IE = True
+
+    informantion_element_fields = [
+        LEShortField('prot_cmd_sec_milli', 0)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_COI:
+    """
+    COI - cause of initialization
+
+    EN 60870-5-101:2003, sec. 7.2.6.21 (p. 51)
+    """
+    LPC_FLAG_LOCAL_PARAMETER_UNCHANGED = 0
+    LPC_FLAG_LOCAL_PARAMETER_CHANGED = 1
+    LPC_FLAGS = {
+        LPC_FLAG_LOCAL_PARAMETER_UNCHANGED: 'unchanged',
+        LPC_FLAG_LOCAL_PARAMETER_CHANGED: 'changed'
+    }
+
+    COI_FLAG_LOCAL_POWER_ON = 0
+    COI_FLAG_LOCAL_MANUAL_RESET = 1
+    COI_FLAG_REMOTE_RESET = 2
+
+    COI_FLAGS = {
+        COI_FLAG_LOCAL_POWER_ON: 'local power on',
+        COI_FLAG_LOCAL_MANUAL_RESET: 'manual reset',
+        COI_FLAG_REMOTE_RESET: 'remote reset'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('COI_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', COI_FLAGS, 3,
+         31),
+        ('COI_FLAG_PRIVATE_RESERVED', 'private reserved', COI_FLAGS, 32, 127)
+    ]
+
+    informantion_element_fields = [
+        BitEnumField('local_param_state', 0, 1, LPC_FLAGS),
+        BitEnumField('coi', 0, 7, COI_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QOI:
+    """
+    QOI - qualifier of interrogation
+
+    EN 60870-5-101:2003, sec. 7.2.6.22 (p. 52)
+    """
+    QOI_FLAG_UNUSED = 0
+    QOI_FLAG_STATION_INTERROGATION = 20
+    QOI_FLAG_GROUP_1_INTERROGATION = 21
+    QOI_FLAG_GROUP_2_INTERROGATION = 22
+    QOI_FLAG_GROUP_3_INTERROGATION = 23
+    QOI_FLAG_GROUP_4_INTERROGATION = 24
+    QOI_FLAG_GROUP_5_INTERROGATION = 25
+    QOI_FLAG_GROUP_6_INTERROGATION = 26
+    QOI_FLAG_GROUP_7_INTERROGATION = 27
+    QOI_FLAG_GROUP_8_INTERROGATION = 28
+    QOI_FLAG_GROUP_9_INTERROGATION = 29
+    QOI_FLAG_GROUP_10_INTERROGATION = 30
+    QOI_FLAG_GROUP_11_INTERROGATION = 31
+    QOI_FLAG_GROUP_12_INTERROGATION = 32
+    QOI_FLAG_GROUP_13_INTERROGATION = 33
+    QOI_FLAG_GROUP_14_INTERROGATION = 34
+    QOI_FLAG_GROUP_15_INTERROGATION = 35
+    QOI_FLAG_GROUP_16_INTERROGATION = 36
+
+    QOI_FLAGS = {
+        QOI_FLAG_UNUSED: 'unused',
+        QOI_FLAG_STATION_INTERROGATION: 'station interrogation',
+        QOI_FLAG_GROUP_1_INTERROGATION: 'group 1 interrogation',
+        QOI_FLAG_GROUP_2_INTERROGATION: 'group 2 interrogation',
+        QOI_FLAG_GROUP_3_INTERROGATION: 'group 3 interrogation',
+        QOI_FLAG_GROUP_4_INTERROGATION: 'group 4 interrogation',
+        QOI_FLAG_GROUP_5_INTERROGATION: 'group 5 interrogation',
+        QOI_FLAG_GROUP_6_INTERROGATION: 'group 6 interrogation',
+        QOI_FLAG_GROUP_7_INTERROGATION: 'group 7 interrogation',
+        QOI_FLAG_GROUP_8_INTERROGATION: 'group 8 interrogation',
+        QOI_FLAG_GROUP_9_INTERROGATION: 'group 9 interrogation',
+        QOI_FLAG_GROUP_10_INTERROGATION: 'group 10 interrogation',
+        QOI_FLAG_GROUP_11_INTERROGATION: 'group 11 interrogation',
+        QOI_FLAG_GROUP_12_INTERROGATION: 'group 12 interrogation',
+        QOI_FLAG_GROUP_13_INTERROGATION: 'group 13 interrogation',
+        QOI_FLAG_GROUP_14_INTERROGATION: 'group 14 interrogation',
+        QOI_FLAG_GROUP_15_INTERROGATION: 'group 15 interrogation',
+        QOI_FLAG_GROUP_16_INTERROGATION: 'group 16 interrogation'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('QOI_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', QOI_FLAGS, 1,
+         19),
+        ('QOI_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', QOI_FLAGS, 37,
+         63),
+        ('QOI_FLAG_PRIVATE_RESERVED', 'private reserved', QOI_FLAGS, 64, 255)
+    ]
+
+    informantion_element_fields = [
+        ByteEnumField('qoi', 0, QOI_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QCC:
+    """
+    QCC - qualifier of counter interrogation command
+
+    EN 60870-5-101:2003, sec. 7.2.6.23 (p. 52)
+    """
+
+    # request flags
+    RQT_FLAG_UNUSED = 0
+    RQT_FLAG_GROUP_1_COUNTER_INTERROGATION = 1
+    RQT_FLAG_GROUP_2_COUNTER_INTERROGATION = 2
+    RQT_FLAG_GROUP_3_COUNTER_INTERROGATION = 3
+    RQT_FLAG_GROUP_4_COUNTER_INTERROGATION = 4
+    RQT_FLAG_GENERAL_COUNTER_INTERROGATION = 5
+
+    RQT_FLAGS = {
+        RQT_FLAG_UNUSED: 'unused',
+        RQT_FLAG_GROUP_1_COUNTER_INTERROGATION: 'counter group 1 '
+                                                'interrogation',
+        RQT_FLAG_GROUP_2_COUNTER_INTERROGATION: 'counter group 2 '
+                                                'interrogation',
+        RQT_FLAG_GROUP_3_COUNTER_INTERROGATION: 'counter group 3 '
+                                                'interrogation',
+        RQT_FLAG_GROUP_4_COUNTER_INTERROGATION: 'counter group 4 '
+                                                'interrogation',
+        RQT_FLAG_GENERAL_COUNTER_INTERROGATION: 'general counter '
+                                                'interrogation',
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('RQT_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', RQT_FLAGS, 6,
+         31),
+        ('RQT_FLAG_PRIVATE_RESERVED', 'private reserved', RQT_FLAGS, 32, 63),
+    ]
+
+    FRZ_FLAG_QUERY = 0
+    FRZ_FLAG_SAVE_COUNTER_WITHOUT_RESET = 1
+    FRZ_FLAG_SAVE_COUNTER_AND_RESET = 2
+    FRZ_FLAG_COUNTER_RESET = 3
+
+    FRZ_FLAGS = {
+        FRZ_FLAG_QUERY: 'query',
+        FRZ_FLAG_SAVE_COUNTER_WITHOUT_RESET: 'save counter, no counter reset',
+        FRZ_FLAG_SAVE_COUNTER_AND_RESET: 'save counter and reset counter',
+        FRZ_FLAG_COUNTER_RESET: 'reset counter'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('frz', 0, 2, FRZ_FLAGS),
+        BitEnumField('rqt', 0, 6, RQT_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QPM:
+    """
+    QPM - qualifier of parameter of measured values
+
+    EN 60870-5-101:2003, sec. 7.2.6.24 (p. 53)
+    """
+
+    KPA_FLAG_UNUSED = 0
+    KPA_FLAG_THRESHOLD = 1
+    KPA_FLAG_SMOOTHING_FACTOR = 2
+    KPA_FLAG_LOWER_LIMIT_FOR_MEAS_TX = 3
+    KPA_FLAG_UPPER_LIMIT_FOR_MEAS_TX = 4
+    GENERATED_ATTRIBUTES = [
+        ('KPA_FLAG_COMPATIBLE_RESERVED', 5, 31),
+        ('KPA_FLAG_PRIVATE_RESERVED', 32, 63)
+    ]
+
+    KPA_FLAGS = {
+        KPA_FLAG_UNUSED: 'unused',
+        KPA_FLAG_THRESHOLD: 'threshold',
+        KPA_FLAG_SMOOTHING_FACTOR: 'smoothing factor',
+        KPA_FLAG_LOWER_LIMIT_FOR_MEAS_TX: 'lower limit meas transmit',
+        KPA_FLAG_UPPER_LIMIT_FOR_MEAS_TX: 'upper limit meas transmit'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('KPA_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', KPA_FLAGS, 5,
+         31),
+        ('KPA_FLAG_PRIVATE_RESERVED', 'private reserved', KPA_FLAGS, 32, 63)
+    ]
+
+    LPC_FLAG_LOCAL_PARAMETER_MOT_CHANGED = 0
+    LPC_FLAG_LOCAL_PARAMETER_CHANGED = 1
+    LPC_FLAGS = {
+        LPC_FLAG_LOCAL_PARAMETER_MOT_CHANGED: 'local parameter not changed',
+        LPC_FLAG_LOCAL_PARAMETER_CHANGED: 'local parameter changed'
+    }
+
+    POP_FLAG_PARAM_EFFECTIVE = 0
+    POP_FLAG_PARAM_INEFFECTIVE = 1
+    POP_FLAGS = {
+        POP_FLAG_PARAM_EFFECTIVE: 'parameter effective',
+        POP_FLAG_PARAM_INEFFECTIVE: 'parameter ineffective',
+    }
+
+    informantion_element_fields = [
+        BitEnumField('pop', 0, 1, POP_FLAGS),  # usually unused, should be zero
+        BitEnumField('lpc', 0, 1, LPC_FLAGS),  # usually unused, should be zero
+        BitEnumField('kpa', 0, 6, KPA_FLAGS),
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QPA:
+    """
+    QPA - qualifier of parameter activation
+
+    EN 60870-5-101:2003, sec. 7.2.6.25 (p. 53)
+    """
+    QPA_FLAG_UNUSED = 0
+    QPA_FLAG_ACT_DEACT_LOADED_PARAM_OA_0 = 1
+    QPA_FLAG_ACT_DEACT_LOADED_PARAM = 2
+    QPA_FLAG_ACT_DEACT_CYCLIC_TX = 3
+
+    QPA_FLAGS = {
+        QPA_FLAG_UNUSED: 'unused',
+        QPA_FLAG_ACT_DEACT_LOADED_PARAM_OA_0: 'act/deact loaded parameters '
+                                              'for object addr 0',
+        QPA_FLAG_ACT_DEACT_LOADED_PARAM: 'act/deact loaded parameters for '
+                                         'given object addr',
+        QPA_FLAG_ACT_DEACT_CYCLIC_TX: 'act/deact cyclic transfer of object '
+                                      'given by object addr',
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('QPA_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', QPA_FLAGS, 4,
+         127),
+        ('QPA_FLAG_PRIVATE_RESERVED', 'private reserved', QPA_FLAGS, 128, 255)
+    ]
+
+    informantion_element_fields = [
+        ByteEnumField('qpa', 0, QPA_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QRP:
+    """
+    QRP - Qualifier of reset process command
+
+    EN 60870-5-101:2003, sec. 7.2.6.27 (p. 54)
+    """
+    QRP_FLAG_UNUSED = 0
+    QRP_FLAG_GENERAL_PROCESS_RESET = 1
+    QRP_FLAG_RESET_EVENT_BUFFER = 2
+
+    QRP_FLAGS = {
+        QRP_FLAG_UNUSED: 'unsued',
+        QRP_FLAG_GENERAL_PROCESS_RESET: 'general process reset',
+        QRP_FLAG_RESET_EVENT_BUFFER: 'reset event buffer'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('QRP_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', QRP_FLAGS, 3,
+         127),
+        ('QRP_FLAG_PRIVATE_RESERVED', 'private reserved', QRP_FLAGS, 128, 255),
+    ]
+
+    informantion_element_fields = [
+        ByteEnumField('qrp', 0, QRP_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_FRQ:
+    """
+    FRQ - file ready qualifier
+
+    EN 60870-5-101:2003, sec. 7.2.6.28 (p. 54)
+    """
+    FR_FLAG_UNUSED = 0
+
+    FR_FLAGS = {
+        FR_FLAG_UNUSED: 'unused'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('FR_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         FR_FLAGS, 1, 63),
+        ('FR_FLAG_PRIVATE_RESERVED', 'private reserved', FR_FLAGS, 64, 127),
+    ]
+
+    FRACK_FLAG_POSITIVE_ACK = 0
+    FRACK_FLAG_NEGATIVE_ACK = 1
+    FRACK_FLAGS = {
+        FRACK_FLAG_POSITIVE_ACK: 'positive ack',
+        FRACK_FLAG_NEGATIVE_ACK: 'negative ack'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('fr_ack', 0, 1, FRACK_FLAGS),
+        BitEnumField('fr', 0, 7, FR_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_SRQ:
+    """
+    SRQ - sequence ready qualifier
+
+    EN 60870-5-101:2003, sec. 7.2.6.29 (p. 54)
+    """
+    SR_FLAG_UNUSED = 0
+
+    SR_FLAGS = {
+        SR_FLAG_UNUSED: 'unused'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('SR_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         SR_FLAGS, 1, 63),
+        ('SR_FLAG_PRIVATE_RESERVED', 'private reserved', SR_FLAGS, 64, 127),
+    ]
+
+    SLOAD_FLAG_SECTION_READY = 0
+    SLOAD_FLAG_SECTION_NOT_READY = 1
+    SLAOD_FLAGS = {
+        SLOAD_FLAG_SECTION_READY: 'section ready',
+        SLOAD_FLAG_SECTION_NOT_READY: 'section not ready'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('section_load_state', 0, 1, SLAOD_FLAGS),
+        BitEnumField('sr', 0, 7, SR_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_SCQ:
+    """
+    SCQ - select and call qualifier
+
+    EN 60870-5-101:2003, sec. 7.2.6.30 (p. 55)
+    """
+    SEL_CALL_FLAG_UNUSED = 0
+    SEL_CALL_FLAG_FILE_SELECT = 1
+    SEL_CALL_FLAG_FILE_REQUEST = 2
+    SEL_CALL_FLAG_FILE_ABORT = 3
+    SEL_CALL_FLAG_FILE_DELETE = 4
+    SEL_CALL_FLAG_SECTION_SELECTION = 5
+    SEL_CALL_FLAG_SECTION_REQUEST = 6
+    SEL_CALL_FLAG_SECTION_ABORT = 7
+
+    SEL_CALL_FLAGS = {
+        SEL_CALL_FLAG_UNUSED: 'unused',
+        SEL_CALL_FLAG_FILE_SELECT: 'file select',
+        SEL_CALL_FLAG_FILE_REQUEST: 'file request',
+        SEL_CALL_FLAG_FILE_ABORT: 'file abort',
+        SEL_CALL_FLAG_FILE_DELETE: 'file delete',
+        SEL_CALL_FLAG_SECTION_SELECTION: 'section selection',
+        SEL_CALL_FLAG_SECTION_REQUEST: 'section request',
+        SEL_CALL_FLAG_SECTION_ABORT: 'section abort'
+    }
+
+    SEL_CALL_ERR_FLAG_UNUSED = 0
+    SEL_CALL_ERR_FLAG_REQ_MEM_AREA_NO_AVAIL = 1
+    SEL_CALL_ERR_FLAG_INVALID_CHECKSUM = 2
+    SEL_CALL_ERR_FLAG_UNEXPECTED_COMMUNICATION_SERVICE = 3
+    SEL_CALL_ERR_FLAG_UNEXPECTED_FILENAME = 4
+    SEL_CALL_ERR_FLAG_UNEXPECTED_SECTION_NAME = 5
+    SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED_6 = 6
+    SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED_7 = 7
+    SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED_8 = 8
+    SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED_9 = 9
+    SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED_10 = 10
+    SEL_CALL_ERR_FLAG_PRIVATE_RESERVED_11 = 11
+    SEL_CALL_ERR_FLAG_PRIVATE_RESERVED_12 = 12
+    SEL_CALL_ERR_FLAG_PRIVATE_RESERVED_13 = 13
+    SEL_CALL_ERR_FLAG_PRIVATE_RESERVED_14 = 14
+    SEL_CALL_ERR_FLAG_PRIVATE_RESERVED_15 = 15
+
+    SEL_CALL_ERR_FLAGS = {
+        SEL_CALL_ERR_FLAG_UNUSED: 'unused',
+        SEL_CALL_ERR_FLAG_REQ_MEM_AREA_NO_AVAIL: 'requested memory area '
+                                                 'not available',
+        SEL_CALL_ERR_FLAG_INVALID_CHECKSUM: 'invalid checksum',
+        SEL_CALL_ERR_FLAG_UNEXPECTED_COMMUNICATION_SERVICE: 'unexpected '
+                                                            'communication '
+                                                            'service',
+        SEL_CALL_ERR_FLAG_UNEXPECTED_FILENAME: 'unexpected file name',
+        SEL_CALL_ERR_FLAG_UNEXPECTED_SECTION_NAME: 'unexpected section name'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('SEL_CALL_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         SEL_CALL_FLAGS, 8, 10),
+        ('SEL_CALL_FLAG_PRIVATE_RESERVED', 'private reserved', SEL_CALL_FLAGS,
+         11, 15),
+        ('SEL_CALL_ERR_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         SEL_CALL_ERR_FLAGS, 6, 10),
+        ('SEL_CALL_ERR_FLAG_PRIVATE_RESERVED', 'private reserved',
+         SEL_CALL_ERR_FLAGS, 11, 15)
+    ]
+
+    informantion_element_fields = [
+        BitEnumField('errors', 0, 4, SEL_CALL_ERR_FLAGS),
+        BitEnumField('select_call', 0, 4, SEL_CALL_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_LSQ:
+    """
+    LSQ - last section or segment qualifier
+
+    EN 60870-5-101:2003, sec. 7.2.6.31 (p. 55)
+    """
+    LSQ_FLAG_UNUSED = 0
+    LSQ_FLAG_FILE_TRANSFER_NO_ABORT = 1
+    LSQ_FLAG_FILE_TRANSFER_ABORT = 2
+    LSQ_FLAG_SECTION_TRANSFER_NO_ABORT = 3
+    LSQ_FLAG_SECTION_TRANSFER_ABORT = 4
+
+    LSQ_FLAGS = {
+        LSQ_FLAG_UNUSED: 'unused',
+        LSQ_FLAG_FILE_TRANSFER_NO_ABORT: 'file transfer - no abort',
+        LSQ_FLAG_FILE_TRANSFER_ABORT: 'file transfer - aborted',
+        LSQ_FLAG_SECTION_TRANSFER_NO_ABORT: 'section transfer - no abort',
+        LSQ_FLAG_SECTION_TRANSFER_ABORT: 'section transfer - aborted',
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('LSQ_FLAG_COMPATIBLE_RESERVED', 'compatible reserved', LSQ_FLAGS, 5,
+         127),
+        ('LSQ_FLAG_PRIVATE_RESERVED', 'private reserved', LSQ_FLAGS, 128, 255),
+    ]
+
+    informantion_element_fields = [
+        ByteEnumField('lsq', 0, LSQ_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_AFQ:
+    """
+    AFQ - acknowledge file or section qualifier
+
+    EN 60870-5-101:2003, sec. 7.2.6.32 (p. 55)
+    """
+    ACK_FILE_OR_SEC_FLAG_UNUSED = 0
+    ACK_FILE_OR_SEC_FLAG_POSITIVE_ACK_FILE_TRANSFER = 1
+    ACK_FILE_OR_SEC_FLAG_NEGATIVE_ACK_FILE_TRANSFER = 2
+    ACK_FILE_OR_SEC_FLAG_POSITIVE_ACK_SECTION_TRANSFER = 3
+    ACK_FILE_OR_SEC_FLAG_NEGATIVE_ACK_SECTION_TRANSFER = 4
+
+    ACK_FILE_OR_SEC_FLAGS = {
+        ACK_FILE_OR_SEC_FLAG_UNUSED: 'unused',
+        ACK_FILE_OR_SEC_FLAG_POSITIVE_ACK_FILE_TRANSFER: 'positive acknowledge'
+                                                         ' file transfer',
+        ACK_FILE_OR_SEC_FLAG_NEGATIVE_ACK_FILE_TRANSFER: 'negative acknowledge'
+                                                         ' file transfer',
+        ACK_FILE_OR_SEC_FLAG_POSITIVE_ACK_SECTION_TRANSFER: 'positive '
+                                                            'acknowledge '
+                                                            'section transfer',
+        ACK_FILE_OR_SEC_FLAG_NEGATIVE_ACK_SECTION_TRANSFER: 'negative '
+                                                            'acknowledge '
+                                                            'section transfer'
+    }
+
+    ACK_FILE_OR_SEC_ERR_FLAG_UNUSED = 0
+    ACK_FILE_OR_SEC_ERR_FLAG_REQ_MEM_AREA_NO_AVAIL = 1
+    ACK_FILE_OR_SEC_ERR_FLAG_INVALID_CHECKSUM = 2
+    ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_COMMUNICATION_SERVICE = 3
+    ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_FILENAME = 4
+    ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_SECTION_NAME = 5
+
+    ACK_FILE_OR_SEC_ERR_FLAGS = {
+        ACK_FILE_OR_SEC_ERR_FLAG_UNUSED: 'unused',
+        ACK_FILE_OR_SEC_ERR_FLAG_REQ_MEM_AREA_NO_AVAIL: 'requested memory '
+                                                        'area not available',
+        ACK_FILE_OR_SEC_ERR_FLAG_INVALID_CHECKSUM: 'invalid checksum',
+        ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_COMMUNICATION_SERVICE: 'unexpected'
+                                                                   ' communica'
+                                                                   'tion '
+                                                                   'service',
+        ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_FILENAME: 'unexpected file name',
+        ACK_FILE_OR_SEC_ERR_FLAG_UNEXPECTED_SECTION_NAME: 'unexpected '
+                                                          'section name'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('ACK_FILE_OR_SEC_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         ACK_FILE_OR_SEC_FLAGS, 5, 10),
+        ('ACK_FILE_OR_SEC_FLAG_PRIVATE_RESERVED', 'private reserved',
+         ACK_FILE_OR_SEC_FLAGS, 11, 15),
+
+        ('ACK_FILE_OR_SEC_ERR_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         ACK_FILE_OR_SEC_ERR_FLAGS, 6, 10),
+        ('ACK_FILE_OR_SEC_ERR_FLAG_PRIVATE_RESERVED', 'private reserved',
+         ACK_FILE_OR_SEC_ERR_FLAGS, 11, 15)
+    ]
+
+    informantion_element_fields = [
+        BitEnumField('errors', 0, 4, ACK_FILE_OR_SEC_ERR_FLAGS),
+        BitEnumField('ack_file_or_sec', 0, 4, ACK_FILE_OR_SEC_FLAGS)
+    ]
+
+
+class IEC104_IE_NOF:
+    """
+    NOF - name of file
+
+    EN 60870-5-101:2003, sec. 7.2.6.33 (p. 56)
+    """
+    informantion_element_fields = [
+        LEShortField('file_name', 0)
+    ]
+
+
+class IEC104_IE_NOS:
+    """
+    NOS - name of section
+
+    EN 60870-5-101:2003, sec. 7.2.6.34 (p. 56)
+    """
+    informantion_element_fields = [
+        ByteField('section_name', 0)
+    ]
+
+
+class IEC104_IE_LOF:
+    """
+    LOF - length of file or section
+
+    EN 60870-5-101:2003, sec. 7.2.6.35 (p. 55)
+    """
+    informantion_element_fields = [
+        ThreeBytesField('file_length', 0)
+    ]
+
+
+class IEC104_IE_LOS:
+    """
+    LOS - length of segment
+
+    EN 60870-5-101:2003, sec. 7.2.6.36 (p. 56)
+    """
+    informantion_element_fields = [
+        ByteField('segment_length', 0)
+    ]
+
+
+class IEC104_IE_CHS:
+    """
+    CHS - checksum
+
+    EN 60870-5-101:2003, sec. 7.2.6.37 (p. 56)
+    """
+    informantion_element_fields = [
+        ByteField('checksum', 0)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_SOF:
+    """
+    SOF - status of file
+
+    EN 60870-5-101:2003, sec. 7.2.6.38 (p. 56)
+    """
+    STATUS_FLAG_UNUSED = 0
+
+    STATUS_FLAGS = {
+        STATUS_FLAG_UNUSED: 'unused'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('STATUS_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         STATUS_FLAGS, 1, 15),
+        ('STATUS_FLAG_PRIVATE_RESERVED', 'private reserved',
+         STATUS_FLAGS, 16, 32)
+    ]
+
+    LFD_FLAG_NEXT_FILE_OF_DIR_FOLLOWS = 0
+    LFD_FLAG_LAST_FILE_OF_DIR = 1
+    LFD_FLAGS = {
+        LFD_FLAG_NEXT_FILE_OF_DIR_FOLLOWS: 'next file of dir follows',
+        LFD_FLAG_LAST_FILE_OF_DIR: 'last file of dir'
+    }
+
+    FOR_FLAG_NAME_DEFINES_FILE = 0
+    FOR_FLAG_NAME_DEFINES_SUBDIR = 1
+    FOR_FLAGS = {
+        FOR_FLAG_NAME_DEFINES_FILE: 'name defines file',
+        FOR_FLAG_NAME_DEFINES_SUBDIR: 'name defines subdirectory'
+    }
+
+    FA_FLAG_FILE_WAITS_FOR_TRANSFER = 0
+    FA_FLAG_FILE_TRANSFER_IS_ACTIVE = 1
+    FA_FLAGS = {
+        FA_FLAG_FILE_WAITS_FOR_TRANSFER: 'file waits for transfer',
+        FA_FLAG_FILE_TRANSFER_IS_ACTIVE: 'transfer of file active'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('fa', 0, 1, FA_FLAGS),
+        BitEnumField('for', 0, 1, FOR_FLAGS),
+        BitEnumField('lfd', 0, 1, LFD_FLAGS),
+        BitEnumField('status', 0, 5, STATUS_FLAGS)
+    ]
+
+
+@_generate_attributes_and_dicts
+class IEC104_IE_QOS:
+    """
+    QOS - qualifier of set-point command
+
+    EN 60870-5-101:2003, sec. 7.2.6.39 (p. 57)
+    """
+    QL_FLAG_UNUSED = 0
+
+    QL_FLAGS = {
+        QL_FLAG_UNUSED: 'unused'
+    }
+
+    GENERATED_ATTRIBUTES = [
+        ('QL_FLAG_COMPATIBLE_RESERVED', 'compatible reserved',
+         QL_FLAGS, 1, 63),
+        ('QL_FLAG_PRIVATE_RESERVED', 'private reserved',
+         QL_FLAGS, 64, 127)
+    ]
+
+    SE_FLAG_EXECUTE = 0
+    SE_FLAG_SELECT = 1
+    SE_FLAGS = {
+        SE_FLAG_EXECUTE: 'execute',
+        SE_FLAG_SELECT: 'select'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('action', 0, 1, SE_FLAGS),
+        BitEnumField('ql', 0, 7, QL_FLAGS)
+    ]
+
+
+class IEC104_IE_SCD:
+    """
+    SCD - status and status change detection
+
+    EN 60870-5-101:2003, sec. 7.2.6.40 (p. 57)
+    """
+    ST_FLAG_STATE_OFF = 0
+    ST_FLAG_STATE_ON = 1
+    ST_FLAGS = {
+        ST_FLAG_STATE_OFF: 'off',
+        ST_FLAG_STATE_ON: 'on'
+    }
+
+    CD_FLAG_STATE_NOT_CHANGED = 0
+    CD_FLAG_STATE_CHANGED = 1
+    CD_FLAGS = {
+        CD_FLAG_STATE_NOT_CHANGED: 'state not changed',
+        CD_FLAG_STATE_CHANGED: 'state changed'
+    }
+
+    informantion_element_fields = [
+        BitEnumField('cd_16', 0, 1, CD_FLAGS),
+        BitEnumField('cd_15', 0, 1, CD_FLAGS),
+        BitEnumField('cd_14', 0, 1, CD_FLAGS),
+        BitEnumField('cd_13', 0, 1, CD_FLAGS),
+        BitEnumField('cd_12', 0, 1, CD_FLAGS),
+        BitEnumField('cd_11', 0, 1, CD_FLAGS),
+        BitEnumField('cd_10', 0, 1, CD_FLAGS),
+        BitEnumField('cd_9', 0, 1, CD_FLAGS),
+        BitEnumField('cd_8', 0, 1, CD_FLAGS),
+        BitEnumField('cd_7', 0, 1, CD_FLAGS),
+        BitEnumField('cd_6', 0, 1, CD_FLAGS),
+        BitEnumField('cd_5', 0, 1, CD_FLAGS),
+        BitEnumField('cd_4', 0, 1, CD_FLAGS),
+        BitEnumField('cd_3', 0, 1, CD_FLAGS),
+        BitEnumField('cd_2', 0, 1, CD_FLAGS),
+        BitEnumField('cd_1', 0, 1, CD_FLAGS),
+        BitEnumField('st_16', 0, 1, ST_FLAGS),
+        BitEnumField('st_15', 0, 1, ST_FLAGS),
+        BitEnumField('st_14', 0, 1, ST_FLAGS),
+        BitEnumField('st_13', 0, 1, ST_FLAGS),
+        BitEnumField('st_12', 0, 1, ST_FLAGS),
+        BitEnumField('st_11', 0, 1, ST_FLAGS),
+        BitEnumField('st_10', 0, 1, ST_FLAGS),
+        BitEnumField('st_9', 0, 1, ST_FLAGS),
+        BitEnumField('st_8', 0, 1, ST_FLAGS),
+        BitEnumField('st_7', 0, 1, ST_FLAGS),
+        BitEnumField('st_6', 0, 1, ST_FLAGS),
+        BitEnumField('st_5', 0, 1, ST_FLAGS),
+        BitEnumField('st_4', 0, 1, ST_FLAGS),
+        BitEnumField('st_3', 0, 1, ST_FLAGS),
+        BitEnumField('st_2', 0, 1, ST_FLAGS),
+        BitEnumField('st_1', 0, 1, ST_FLAGS),
+    ]
+
+
+class IEC104_IE_TSC:
+    """
+    TSC - test sequence counter
+
+    EN 60870-5-104:2006, sec. 8.8 (p. 44)
+    """
+    informantion_element_fields = [
+        LEShortField('tsc', 0)
+    ]

--- a/scapy/contrib/scada/iec104/iec104_information_objects.py
+++ b/scapy/contrib/scada/iec104/iec104_information_objects.py
@@ -1,0 +1,2248 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+#
+# scapy.contrib.description = IEC-60870-5-104 ASDU layers / IO definitions
+# scapy.contrib.status = loads
+
+"""
+    application service data units used by  IEC 60870-5-101/104
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :description:
+
+        This module provides the information object (IO) definitions used
+        within the IEC 60870-5-101 and IEC 60870-5-104 protocol.
+
+        normative references:
+            - IEC 60870-5-101:2003 (sec. 7.3)
+            - IEC 60870-5-104:2006 (sec. 8))
+
+
+    :NOTES:
+        - this file contains all IO definitions from 101 and 104 - even if an
+          IO is not used within 104
+"""
+from scapy.config import conf
+from scapy.contrib.scada.iec104.iec104_fields import LEThreeBytesField
+from scapy.contrib.scada.iec104.iec104_information_elements import \
+    IEC104_IE_SIQ, IEC104_IE_CP24TIME2A, IEC104_IE_DIQ, IEC104_IE_VTI, \
+    IEC104_IE_QDS, IEC104_IE_BSI, IEC104_IE_NVA, IEC104_IE_SVA, \
+    IEC104_IE_R32_IEEE_STD_754, IEC104_IE_BCR, IEC104_IE_CP16TIME2A_ELAPSED, \
+    IEC104_IE_SEP, IEC104_IE_SPE, IEC104_IE_CP16TIME2A_PROTECTION_ACTIVE, \
+    IEC104_IE_QDP, IEC104_IE_CP16TIME2A_PROTECTION_COMMAND, IEC104_IE_OCI, \
+    IEC104_IE_SCD, IEC104_IE_CP56TIME2A, IEC104_IE_SCO, IEC104_IE_DCO, \
+    IEC104_IE_RCO, IEC104_IE_QOS, IEC104_IE_QOI, IEC104_IE_QCC, \
+    IEC104_IE_FBP, IEC104_IE_QRP, IEC104_IE_CP16TIME2A, IEC104_IE_QPM, \
+    IEC104_IE_QPA, IEC104_IE_NOF, IEC104_IE_LOF, IEC104_IE_FRQ, \
+    IEC104_IE_NOS, IEC104_IE_SRQ, IEC104_IE_SCQ, IEC104_IE_CHS, \
+    IEC104_IE_LSQ, IEC104_IE_AFQ, IEC104_IE_SOF, IEC104_IE_COI, \
+    IEC104_IE_CP56TIME2A_START_TIME, IEC104_IE_CP56TIME2A_STOP_TIME, \
+    IEC104_IE_TSC
+
+from scapy.fields import XStrLenField, BitFieldLenField
+from scapy.packet import Packet
+
+IEC104_IO_ID_UNDEFINED = 0x00
+IEC104_IO_ID_M_SP_NA_1 = 0x01
+IEC104_IO_ID_M_SP_TA_1 = 0x02
+IEC104_IO_ID_M_DP_NA_1 = 0x03
+IEC104_IO_ID_M_DP_TA_1 = 0x04
+IEC104_IO_ID_M_ST_NA_1 = 0x05
+IEC104_IO_ID_M_ST_TA_1 = 0x06
+IEC104_IO_ID_M_BO_NA_1 = 0x07
+IEC104_IO_ID_M_BO_TA_1 = 0x08
+IEC104_IO_ID_M_ME_NA_1 = 0x09
+IEC104_IO_ID_M_ME_TA_1 = 0x0a
+IEC104_IO_ID_M_ME_NB_1 = 0x0b
+IEC104_IO_ID_M_ME_TB_1 = 0x0c
+IEC104_IO_ID_M_ME_NC_1 = 0x0d
+IEC104_IO_ID_M_ME_TC_1 = 0x0e
+IEC104_IO_ID_M_IT_NA_1 = 0x0f
+IEC104_IO_ID_M_IT_TA_1 = 0x10
+IEC104_IO_ID_M_EP_TA_1 = 0x11
+IEC104_IO_ID_M_EP_TB_1 = 0x12
+IEC104_IO_ID_M_EP_TC_1 = 0x13
+IEC104_IO_ID_M_PS_NA_1 = 0x14
+IEC104_IO_ID_M_ME_ND_1 = 0x15
+IEC104_IO_ID_M_SP_TB_1 = 0x1e
+IEC104_IO_ID_M_DP_TB_1 = 0x1f
+IEC104_IO_ID_M_ST_TB_1 = 0x20
+IEC104_IO_ID_M_BO_TB_1 = 0x21
+IEC104_IO_ID_M_ME_TD_1 = 0x22
+IEC104_IO_ID_M_ME_TE_1 = 0x23
+IEC104_IO_ID_M_ME_TF_1 = 0x24
+IEC104_IO_ID_M_IT_TB_1 = 0x25
+IEC104_IO_ID_M_EP_TD_1 = 0x26
+IEC104_IO_ID_M_EP_TE_1 = 0x27
+IEC104_IO_ID_M_EP_TF_1 = 0x28
+IEC104_IO_ID_C_SC_NA_1 = 0x2d
+IEC104_IO_ID_C_DC_NA_1 = 0x2e
+IEC104_IO_ID_C_RC_NA_1 = 0x2f
+IEC104_IO_ID_C_SE_NA_1 = 0x30
+IEC104_IO_ID_C_SE_NB_1 = 0x31
+IEC104_IO_ID_C_SE_NC_1 = 0x32
+IEC104_IO_ID_C_BO_NA_1 = 0x33
+IEC104_IO_ID_M_EI_NA_1 = 0x46
+IEC104_IO_ID_C_IC_NA_1 = 0x64
+IEC104_IO_ID_C_CI_NA_1 = 0x65
+IEC104_IO_ID_C_RD_NA_1 = 0x66
+IEC104_IO_ID_C_CS_NA_1 = 0x67
+IEC104_IO_ID_C_TS_NA_1 = 0x68
+IEC104_IO_ID_C_RP_NA_1 = 0x69
+IEC104_IO_ID_C_CD_NA_1 = 0x6a
+IEC104_IO_ID_P_ME_NA_1 = 0x6e
+IEC104_IO_ID_P_ME_NB_1 = 0x6f
+IEC104_IO_ID_P_ME_NC_1 = 0x70
+IEC104_IO_ID_P_AC_NA_1 = 0x71
+IEC104_IO_ID_F_FR_NA_1 = 0x78
+IEC104_IO_ID_F_SR_NA_1 = 0x79
+IEC104_IO_ID_F_SC_NA_1 = 0x7a
+IEC104_IO_ID_F_LS_NA_1 = 0x7b
+IEC104_IO_ID_F_AF_NA_1 = 0x7c
+IEC104_IO_ID_F_SG_NA_1 = 0x7d
+IEC104_IO_ID_F_DR_TA_1 = 0x7e
+# specific IOs from 60870-5-104:2006, sec. 8 (p. 37 ff)
+IEC104_IO_ID_C_SC_TA_1 = 0x3a
+IEC104_IO_ID_C_DC_TA_1 = 0x3b
+IEC104_IO_ID_C_RC_TA_1 = 0x3c
+IEC104_IO_ID_C_SE_TA_1 = 0x3d
+IEC104_IO_ID_C_SE_TB_1 = 0x3e
+IEC104_IO_ID_C_SE_TC_1 = 0x3f
+IEC104_IO_ID_C_BO_TA_1 = 0x40
+IEC104_IO_ID_C_TS_TA_1 = 0x6b
+IEC104_IO_ID_F_SC_NB_1 = 0x7f
+
+
+def _dict_add_reserved_range(d, start, end):
+    for idx in range(start, end + 1):
+        d[idx] = 'reserved_{}'.format(idx)
+
+
+IEC104_IO_DESCRIPTIONS = {
+    0: 'undefined',
+    IEC104_IO_ID_M_SP_NA_1: 'M_SP_NA_1 (single point report)',
+    IEC104_IO_ID_M_SP_TA_1: 'M_SP_TA_1 (single point report with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_DP_NA_1: 'M_DP_NA_1 (double point report)',
+    IEC104_IO_ID_M_DP_TA_1: 'M_DP_TA_1 (double point report with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_ST_NA_1: 'M_ST_NA_1 (step control report)',
+    IEC104_IO_ID_M_ST_TA_1: 'M_ST_TA_1 (step control report with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_BO_NA_1: 'M_BO_NA_1 (bitmask 32 bit)',
+    IEC104_IO_ID_M_BO_TA_1: 'M_BO_TA_1 (bitmask 32 bit with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_ME_NA_1: 'M_ME_NA_1 (meas, normed value)',
+    IEC104_IO_ID_M_ME_TA_1: 'M_ME_TA_1 (meas, normed value with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_ME_NB_1: 'M_ME_NB_1 (meas, scaled value)',
+    IEC104_IO_ID_M_ME_TB_1: 'M_ME_TB_1 (meas, scaled value with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_ME_NC_1: 'M_ME_NC_1 (meas, shortened floating point value)',
+    IEC104_IO_ID_M_ME_TC_1: 'M_ME_TC_1 (meas, shortened floating point value '
+                            'with timestamp) # 60870-4-101 only',
+    IEC104_IO_ID_M_IT_NA_1: 'M_IT_NA_1 (counter value)',
+    IEC104_IO_ID_M_IT_TA_1: 'M_IT_TA_1 (counter value with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_EP_TA_1: 'M_EP_TA_1 (protection event  with timestamp) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_M_EP_TB_1: 'M_EP_TB_1 (blocked protection trigger with '
+                            'timestamp) # 60870-4-101 only',
+    IEC104_IO_ID_M_EP_TC_1: 'M_EP_TC_1 (blocked protection action with '
+                            'timestamp) # 60870-4-101 only',
+    IEC104_IO_ID_M_PS_NA_1: 'M_PS_NA_1 (blocked single report with '
+                            'change indication)',
+    IEC104_IO_ID_M_ME_ND_1: 'M_ME_ND_1 (meas, normed value, no quality '
+                            'indication)',
+    IEC104_IO_ID_M_SP_TB_1: 'M_SP_TB_1 (single point report with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_DP_TB_1: 'M_DP_TB_1 (double point report with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_ST_TB_1: 'M_ST_TB_1 (step control report with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_BO_TB_1: 'M_BO_TB_1 (bitmask 32 bit with CP56Time2a time '
+                            'field)',
+    IEC104_IO_ID_M_ME_TD_1: 'M_ME_TD_1 (meas, normed value with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_ME_TE_1: 'M_ME_TE_1 (meas, scaled value with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_ME_TF_1: 'M_ME_TF_1 (meas, shortened floating point value '
+                            'with CP56Time2a time field)',
+    IEC104_IO_ID_M_IT_TB_1: 'M_IT_TB_1 (counter with CP56Time2a time field)',
+    IEC104_IO_ID_M_EP_TD_1: 'M_EP_TD_1 (protection event with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_M_EP_TE_1: 'M_EP_TE_1 (blocked protection trigger with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_M_EP_TF_1: 'M_EP_TF_1 (blocked protection action with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_SC_NA_1: 'C_SC_NA_1 (single command)',
+    IEC104_IO_ID_C_DC_NA_1: 'C_DC_NA_1 (double command)',
+    IEC104_IO_ID_C_RC_NA_1: 'C_RC_NA_1 (step control command)',
+    IEC104_IO_ID_C_SE_NA_1: 'C_SE_NA_1 (setpoint control command, '
+                            'normed value)',
+    IEC104_IO_ID_C_SE_NB_1: 'C_SE_NB_1 (setpoint control command, '
+                            'scaled value)',
+    IEC104_IO_ID_C_SE_NC_1: 'C_SE_NC_1 (setpoint control command, '
+                            'shortened floating point value)',
+    IEC104_IO_ID_C_BO_NA_1: 'C_BO_NA_1 (bitmask 32 bit)',
+    IEC104_IO_ID_C_SC_TA_1: 'C_SC_TA_1 (single point command with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_DC_TA_1: 'C_DC_TA_1 (double point command with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_RC_TA_1: 'C_RC_TA_1 (step control command with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_SE_TA_1: 'C_SE_TA_1 (setpoint command, normed value with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_SE_TB_1: 'C_SE_TB_1 (setpoint command, scaled value with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_C_SE_TC_1: 'C_SE_TC_1 (setpoint command, shortened floating '
+                            'point value with CP56Time2a time field)',
+    IEC104_IO_ID_C_BO_TA_1: 'C_BO_TA_1 (bitmask 32 command bit with '
+                            'CP56Time2a time field)',
+    IEC104_IO_ID_M_EI_NA_1: 'M_EI_NA_1 (init done)',
+    IEC104_IO_ID_C_IC_NA_1: 'C_IC_NA_1 (general interrogation command)',
+    IEC104_IO_ID_C_CI_NA_1: 'C_CI_NA_1 (counter interrogation command)',
+    IEC104_IO_ID_C_RD_NA_1: 'C_RD_NA_1 (interrogation)',
+    IEC104_IO_ID_C_CS_NA_1: 'C_CS_NA_1 (time synchronisation command)',
+    IEC104_IO_ID_C_TS_NA_1: 'C_TS_NA_1 (test command) # 60870-4-101 only',
+    IEC104_IO_ID_C_RP_NA_1: 'C_RP_NA_1 (process reset command)',
+    IEC104_IO_ID_C_CD_NA_1: 'C_CD_NA_1 (meas telegram transit time command) '
+                            '# 60870-4-101 only',
+    IEC104_IO_ID_C_TS_TA_1: 'C_TS_TA_1 (test command with CP56Time2a '
+                            'time field)',
+    IEC104_IO_ID_P_ME_NA_1: 'P_ME_NA_1 (meas parameter, normed value)',
+    IEC104_IO_ID_P_ME_NB_1: 'P_ME_NB_1 (meas parameter, scaled value)',
+    IEC104_IO_ID_P_ME_NC_1: 'P_ME_NC_1 (meas parameter, shortened floating '
+                            'point value)',
+    IEC104_IO_ID_P_AC_NA_1: 'P_AC_NA_1 (parameter for activation)',
+    IEC104_IO_ID_F_FR_NA_1: 'F_FR_NA_1 (file ready)',
+    IEC104_IO_ID_F_SR_NA_1: 'F_SR_NA_1 (section ready)',
+    IEC104_IO_ID_F_SC_NA_1: 'F_SC_NA_1 (query directory, selection, section)',
+    IEC104_IO_ID_F_LS_NA_1: 'F_LS_NA_1 (last part/segment)',
+    IEC104_IO_ID_F_AF_NA_1: 'F_AF_NA_1 (file/section acknowledgement)',
+    IEC104_IO_ID_F_SG_NA_1: 'F_SG_NA_1 (segment)',
+    IEC104_IO_ID_F_DR_TA_1: 'F_DR_TA_1 (directory)',
+    IEC104_IO_ID_F_SC_NB_1: 'F_SC_NB_1 (query log - request archive file)'
+}
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 22, 29)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 41, 44)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 52, 57)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 65, 69)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 71, 99)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 108, 109)
+_dict_add_reserved_range(IEC104_IO_DESCRIPTIONS, 114, 119)
+
+IEC104_IO_NAMES = {
+    0: 'undefined',
+    IEC104_IO_ID_M_SP_NA_1: 'M_SP_NA_1',
+    IEC104_IO_ID_M_SP_TA_1: 'M_SP_TA_1',
+    IEC104_IO_ID_M_DP_NA_1: 'M_DP_NA_1',
+    IEC104_IO_ID_M_DP_TA_1: 'M_DP_TA_1',
+    IEC104_IO_ID_M_ST_NA_1: 'M_ST_NA_1',
+    IEC104_IO_ID_M_ST_TA_1: 'M_ST_TA_1',
+    IEC104_IO_ID_M_BO_NA_1: 'M_BO_NA_1',
+    IEC104_IO_ID_M_BO_TA_1: 'M_BO_TA_1',
+    IEC104_IO_ID_M_ME_NA_1: 'M_ME_NA_1',
+    IEC104_IO_ID_M_ME_TA_1: 'M_ME_TA_1',
+    IEC104_IO_ID_M_ME_NB_1: 'M_ME_NB_1',
+    IEC104_IO_ID_M_ME_TB_1: 'M_ME_TB_1',
+    IEC104_IO_ID_M_ME_NC_1: 'M_ME_NC_1',
+    IEC104_IO_ID_M_ME_TC_1: 'M_ME_TC_1',
+    IEC104_IO_ID_M_IT_NA_1: 'M_IT_NA_1',
+    IEC104_IO_ID_M_IT_TA_1: 'M_IT_TA_1',
+    IEC104_IO_ID_M_EP_TA_1: 'M_EP_TA_1',
+    IEC104_IO_ID_M_EP_TB_1: 'M_EP_TB_1',
+    IEC104_IO_ID_M_EP_TC_1: 'M_EP_TC_1',
+    IEC104_IO_ID_M_PS_NA_1: 'M_PS_NA_1',
+    IEC104_IO_ID_M_ME_ND_1: 'M_ME_ND_1',
+    IEC104_IO_ID_M_SP_TB_1: 'M_SP_TB_1',
+    IEC104_IO_ID_M_DP_TB_1: 'M_DP_TB_1',
+    IEC104_IO_ID_M_ST_TB_1: 'M_ST_TB_1',
+    IEC104_IO_ID_M_BO_TB_1: 'M_BO_TB_1',
+    IEC104_IO_ID_M_ME_TD_1: 'M_ME_TD_1',
+    IEC104_IO_ID_M_ME_TE_1: 'M_ME_TE_1',
+    IEC104_IO_ID_M_ME_TF_1: 'M_ME_TF_1',
+    IEC104_IO_ID_M_IT_TB_1: 'M_IT_TB_1',
+    IEC104_IO_ID_M_EP_TD_1: 'M_EP_TD_1',
+    IEC104_IO_ID_M_EP_TE_1: 'M_EP_TE_1',
+    IEC104_IO_ID_M_EP_TF_1: 'M_EP_TF_1',
+    IEC104_IO_ID_C_SC_NA_1: 'C_SC_NA_1',
+    IEC104_IO_ID_C_DC_NA_1: 'C_DC_NA_1',
+    IEC104_IO_ID_C_RC_NA_1: 'C_RC_NA_1',
+    IEC104_IO_ID_C_SE_NA_1: 'C_SE_NA_1',
+    IEC104_IO_ID_C_SE_NB_1: 'C_SE_NB_1',
+    IEC104_IO_ID_C_SE_NC_1: 'C_SE_NC_1',
+    IEC104_IO_ID_C_BO_NA_1: 'C_BO_NA_1',
+    IEC104_IO_ID_C_SC_TA_1: 'C_SC_TA_1',
+    IEC104_IO_ID_C_DC_TA_1: 'C_DC_TA_1',
+    IEC104_IO_ID_C_RC_TA_1: 'C_RC_TA_1',
+    IEC104_IO_ID_C_SE_TA_1: 'C_SE_TA_1',
+    IEC104_IO_ID_C_SE_TB_1: 'C_SE_TB_1',
+    IEC104_IO_ID_C_SE_TC_1: 'C_SE_TC_1',
+    IEC104_IO_ID_C_BO_TA_1: 'C_BO_TA_1',
+    IEC104_IO_ID_M_EI_NA_1: 'M_EI_NA_1',
+    IEC104_IO_ID_C_IC_NA_1: 'C_IC_NA_1',
+    IEC104_IO_ID_C_CI_NA_1: 'C_CI_NA_1',
+    IEC104_IO_ID_C_RD_NA_1: 'C_RD_NA_1',
+    IEC104_IO_ID_C_CS_NA_1: 'C_CS_NA_1',
+    IEC104_IO_ID_C_TS_NA_1: 'C_TS_NA_1',
+    IEC104_IO_ID_C_RP_NA_1: 'C_RP_NA_1',
+    IEC104_IO_ID_C_CD_NA_1: 'C_CD_NA_1',
+    IEC104_IO_ID_C_TS_TA_1: 'C_TS_TA_1',
+    IEC104_IO_ID_P_ME_NA_1: 'P_ME_NA_1',
+    IEC104_IO_ID_P_ME_NB_1: 'P_ME_NB_1',
+    IEC104_IO_ID_P_ME_NC_1: 'P_ME_NC_1',
+    IEC104_IO_ID_P_AC_NA_1: 'P_AC_NA_1',
+    IEC104_IO_ID_F_FR_NA_1: 'F_FR_NA_1',
+    IEC104_IO_ID_F_SR_NA_1: 'F_SR_NA_1',
+    IEC104_IO_ID_F_SC_NA_1: 'F_SC_NA_1',
+    IEC104_IO_ID_F_LS_NA_1: 'F_LS_NA_1',
+    IEC104_IO_ID_F_AF_NA_1: 'F_AF_NA_1',
+    IEC104_IO_ID_F_SG_NA_1: 'F_SG_NA_1',
+    IEC104_IO_ID_F_DR_TA_1: 'F_DR_TA_1',
+    IEC104_IO_ID_F_SC_NB_1: 'F_SC_NB_1'
+}
+_dict_add_reserved_range(IEC104_IO_NAMES, 22, 29)
+_dict_add_reserved_range(IEC104_IO_NAMES, 41, 44)
+_dict_add_reserved_range(IEC104_IO_NAMES, 52, 57)
+_dict_add_reserved_range(IEC104_IO_NAMES, 65, 69)
+_dict_add_reserved_range(IEC104_IO_NAMES, 71, 99)
+_dict_add_reserved_range(IEC104_IO_NAMES, 108, 109)
+_dict_add_reserved_range(IEC104_IO_NAMES, 114, 119)
+
+
+class IEC104_IO_InvalidPayloadException(Exception):
+    """
+    raised if payload is not of the same type, raw() or a child of IEC104_APDU
+    """
+    pass
+
+
+class IEC104_IO_Packet(Packet):
+    """
+    base class of all information object representations
+    """
+    DEFINED_IN_IEC_101 = 0x01
+    DEFINED_IN_IEC_104 = 0x02
+
+    _DEFINED_IN = []
+
+    def guess_payload_class(self, payload):
+        return conf.padding_layer
+
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_UNDEFINED
+
+    def iec104_io_type_id(self):
+        """
+        get individual type id of the information object instance
+        :return: information object type id (IEC104_IO_ID_*)
+        """
+        return self._IEC104_IO_TYPE_ID
+
+    def defined_for_iec_101(self):
+        """
+        information object ASDU allowed for IEC 60870-5-101
+        :return: True if the information object is defined within
+                 IEC 60870-5-101, else False
+        """
+        return IEC104_IO_Packet.DEFINED_IN_IEC_101 in self._DEFINED_IN
+
+    def defined_for_iec_104(self):
+        """
+        information object ASDU allowed for IEC 60870-5-104
+        :return: True if the information object is defined within
+                 IEC 60870-5-104, else False
+        """
+        return IEC104_IO_Packet.DEFINED_IN_IEC_104 in self._DEFINED_IN
+
+
+class IEC104_IO_M_SP_NA_1(IEC104_IO_Packet):
+    """
+    single-point information without time tag]
+
+    EN 60870-5-101:2003, sec. 7.3.1.1 (p. 58)
+    """
+    name = 'M_SP_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_SP_NA_1
+
+    fields_desc = IEC104_IE_SIQ.informantion_element_fields
+
+
+class IEC104_IO_M_SP_TA_1(IEC104_IO_Packet):
+    """
+    single-point information with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.2 (p. 59)
+    """
+    name = 'M_SP_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_SP_TA_1
+
+    fields_desc = IEC104_IE_SIQ.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_DP_NA_1(IEC104_IO_Packet):
+    """
+    double-point information without time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.3 (p. 60)
+    """
+    name = 'M_DP_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_DP_NA_1
+
+    fields_desc = IEC104_IE_DIQ.informantion_element_fields
+
+
+class IEC104_IO_M_DP_TA_1(IEC104_IO_Packet):
+    """
+    double-point information with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.4 (p. 61)
+    """
+    name = 'M_DP_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_DP_TA_1
+
+    fields_desc = IEC104_IE_DIQ.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ST_NA_1(IEC104_IO_Packet):
+    """
+    step position information
+
+    EN 60870-5-101:2003, sec. 7.3.1.5 (p. 62)
+    """
+    name = 'M_ST_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ST_NA_1
+
+    fields_desc = IEC104_IE_VTI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_ST_TA_1(IEC104_IO_Packet):
+    """
+    step position information with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.6 (p. 63)
+    """
+    name = 'M_ST_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ST_TA_1
+
+    fields_desc = IEC104_IE_VTI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_BO_NA_1(IEC104_IO_Packet):
+    """
+    bitstring of 32 bit
+
+    EN 60870-5-101:2003, sec. 7.3.1.7 (p. 64)
+    """
+    name = 'M_BO_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_BO_NA_1
+
+    fields_desc = IEC104_IE_BSI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_BO_TA_1(IEC104_IO_Packet):
+    """
+    bitstring of 32 bit with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.8 (p. 66)
+    """
+    name = 'M_BO_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_BO_TA_1
+
+    fields_desc = IEC104_IE_BSI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_NA_1(IEC104_IO_Packet):
+    """
+    measured value, normalized value
+
+    EN 60870-5-101:2003, sec. 7.3.1.9 (p. 67)
+    """
+    name = 'M_ME_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_NA_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TA_1(IEC104_IO_Packet):
+    """
+    measured value, normalized value with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.10 (p. 68)
+    """
+    name = 'M_ME_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TA_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_NB_1(IEC104_IO_Packet):
+    """
+    measured value, scaled value
+
+    EN 60870-5-101:2003, sec. 7.3.1.11 (p. 69)
+    """
+    name = 'M_ME_NB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_NB_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TB_1(IEC104_IO_Packet):
+    """
+    measured value, scaled value with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.12 (p. 71)
+    """
+    name = 'M_ME_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TB_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_NC_1(IEC104_IO_Packet):
+    """
+    measured value, short floating point number
+
+    EN 60870-5-101:2003, sec. 7.3.1.13 (p. 72)
+    """
+    name = 'M_ME_NC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_NC_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TC_1(IEC104_IO_Packet):
+    """
+    measured value, short floating point number with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.14 (p. 74)
+    """
+    name = 'M_ME_TC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TC_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_IT_NA_1(IEC104_IO_Packet):
+    """
+    integrated totals
+
+    EN 60870-5-101:2003, sec. 7.3.1.15 (p. 75)
+    """
+    name = 'M_IT_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_IT_NA_1
+
+    fields_desc = IEC104_IE_BCR.informantion_element_fields
+
+
+class IEC104_IO_M_IT_TA_1(IEC104_IO_Packet):
+    """
+    integrated totals with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.16 (p. 77)
+    """
+    name = 'M_IT_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_IT_TA_1
+
+    fields_desc = IEC104_IE_BCR.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TA_1(IEC104_IO_Packet):
+    """
+    event of protection equipment with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.17 (p. 78)
+    """
+    name = 'M_EP_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TA_1
+
+    fields_desc = IEC104_IE_SEP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_ELAPSED.informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TB_1(IEC104_IO_Packet):
+    """
+    packed start events of protection equipment with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.18 (p. 79)
+    """
+    name = 'M_EP_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TB_1
+
+    fields_desc = IEC104_IE_SPE.informantion_element_fields + \
+        IEC104_IE_QDP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_PROTECTION_ACTIVE.\
+        informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TC_1(IEC104_IO_Packet):
+    """
+    packed output circuit information of protection equipment with time tag
+
+    EN 60870-5-101:2003, sec. 7.3.1.19 (p. 80)
+    """
+    name = 'M_EP_TC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TC_1
+
+    fields_desc = IEC104_IE_OCI.informantion_element_fields + \
+        IEC104_IE_QDP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_PROTECTION_COMMAND.\
+        informantion_element_fields + \
+        IEC104_IE_CP24TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_PS_NA_1(IEC104_IO_Packet):
+    """
+    packed single-point information with status change detection
+
+    EN 60870-5-101:2003, sec. 7.3.1.20 (p. 81)
+    """
+    name = 'M_PS_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_PS_NA_1
+
+    fields_desc = IEC104_IE_SCD.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields
+
+
+class IEC104_IO_M_ME_ND_1(IEC104_IO_Packet):
+    """
+    measured value, normalized value without quality descriptor
+
+    EN 60870-5-101:2003, sec. 7.3.1.21 (p. 83)
+    """
+    name = 'M_ME_ND_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_ND_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields
+
+
+class IEC104_IO_M_SP_TB_1(IEC104_IO_Packet):
+    """
+    single-point information with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.22 (p. 84)
+    """
+    name = 'M_SP_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_SP_TB_1
+
+    fields_desc = IEC104_IE_SIQ.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_DP_TB_1(IEC104_IO_Packet):
+    """
+    double-point information with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.23 (p. 85)
+    """
+    name = 'M_DP_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_DP_TB_1
+
+    fields_desc = IEC104_IE_DIQ.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ST_TB_1(IEC104_IO_Packet):
+    """
+    step position information with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.24 (p. 87)
+    """
+    name = 'M_ST_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ST_TB_1
+
+    fields_desc = IEC104_IE_VTI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_BO_TB_1(IEC104_IO_Packet):
+    """
+    bitstring of 32 bits with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.25 (p. 89)
+    """
+    name = 'M_BO_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_BO_TB_1
+
+    fields_desc = IEC104_IE_BSI.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TD_1(IEC104_IO_Packet):
+    """
+    measured value, normalized value with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.26 (p. 91)
+    """
+    name = 'M_ME_TD_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TD_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TE_1(IEC104_IO_Packet):
+    """
+    measured value, scaled value with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.27 (p. 93)
+    """
+    name = 'M_ME_TE_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TE_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_ME_TF_1(IEC104_IO_Packet):
+    """
+    measured value, short floating point number with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.28 (p. 95)
+    """
+    name = 'M_ME_TF_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_ME_TF_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QDS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_IT_TB_1(IEC104_IO_Packet):
+    """
+    integrated totals with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.29 (p. 97)
+    """
+    name = 'M_IT_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_IT_TB_1
+
+    fields_desc = IEC104_IE_BCR.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TD_1(IEC104_IO_Packet):
+    """
+    event of protection equipment with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.30 (p. 99)
+    """
+    name = 'M_EP_TD_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TD_1
+
+    fields_desc = IEC104_IE_SEP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_ELAPSED.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TE_1(IEC104_IO_Packet):
+    """
+    packed start events of protection equipment with time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.31 (p. 100)
+    """
+    name = 'M_EP_TE_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TE_1
+
+    fields_desc = IEC104_IE_SPE.informantion_element_fields + \
+        IEC104_IE_QDP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_PROTECTION_ACTIVE.\
+        informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_M_EP_TF_1(IEC104_IO_Packet):
+    """
+    packed output circuit information of protection equipment with
+    time tag cp56time2a
+
+    EN 60870-5-101:2003, sec. 7.3.1.32 (p. 101)
+    """
+    name = 'M_EP_TF_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EP_TF_1
+
+    fields_desc = IEC104_IE_OCI.informantion_element_fields + \
+        IEC104_IE_QDP.informantion_element_fields + \
+        IEC104_IE_CP16TIME2A_PROTECTION_COMMAND.\
+        informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_SC_NA_1(IEC104_IO_Packet):
+    """
+    single command
+
+    EN 60870-5-101:2003, sec. 7.3.2.1 (p. 102)
+    """
+    name = 'C_SC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SC_NA_1
+
+    fields_desc = IEC104_IE_SCO.informantion_element_fields
+
+
+class IEC104_IO_C_DC_NA_1(IEC104_IO_Packet):
+    """
+    double command
+
+    EN 60870-5-101:2003, sec. 7.3.2.2 (p. 102)
+    """
+    name = 'C_DC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_DC_NA_1
+
+    fields_desc = IEC104_IE_DCO.informantion_element_fields
+
+
+class IEC104_IO_C_RC_NA_1(IEC104_IO_Packet):
+    """
+    regulating step command
+
+    EN 60870-5-101:2003, sec. 7.3.2.3 (p. 103)
+    """
+    name = 'C_RC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_RC_NA_1
+
+    fields_desc = IEC104_IE_RCO.informantion_element_fields
+
+
+class IEC104_IO_C_SE_NA_1(IEC104_IO_Packet):
+    """
+    set-point command, normalized value
+
+    EN 60870-5-101:2003, sec. 7.3.2.4 (p. 104)
+    """
+    name = 'C_SE_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_NA_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields
+
+
+class IEC104_IO_C_SE_NB_1(IEC104_IO_Packet):
+    """
+    set-point command, scaled value
+
+    EN 60870-5-101:2003, sec. 7.3.2.5 (p. 104)
+    """
+    name = 'C_SE_NB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_NB_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields
+
+
+class IEC104_IO_C_SE_NC_1(IEC104_IO_Packet):
+    """
+    set-point command, short floating point number
+
+    EN 60870-5-101:2003, sec. 7.3.2.6 (p. 105)
+    """
+    name = 'C_SE_NC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_NC_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields
+
+
+class IEC104_IO_C_BO_NA_1(IEC104_IO_Packet):
+    """
+    bitstring of 32 bit
+
+    EN 60870-5-101:2003, sec. 7.3.2.7 (p. 106)
+    """
+    name = 'C_BO_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_BO_NA_1
+
+    fields_desc = IEC104_IE_BSI.informantion_element_fields
+
+
+class IEC104_IO_M_EI_NA_1(IEC104_IO_Packet):
+    """
+    end of initialization
+
+    EN 60870-5-101:2003, sec. 7.3.3.1 (p. 106)
+    """
+    name = 'M_EI_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_M_EI_NA_1
+
+    fields_desc = IEC104_IE_COI.informantion_element_fields
+
+
+class IEC104_IO_C_IC_NA_1(IEC104_IO_Packet):
+    """
+    interrogation command
+
+    EN 60870-5-101:2003, sec. 7.3.4.1 (p. 107)
+    """
+    name = 'C_IC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_IC_NA_1
+
+    fields_desc = IEC104_IE_QOI.informantion_element_fields
+
+
+class IEC104_IO_C_CI_NA_1(IEC104_IO_Packet):
+    """
+    counter interrogation command
+
+    EN 60870-5-101:2003, sec. 7.3.4.2 (p. 108)
+    """
+    name = 'C_CI_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_CI_NA_1
+
+    fields_desc = IEC104_IE_QCC.informantion_element_fields
+
+
+class IEC104_IO_C_RD_NA_1(IEC104_IO_Packet):
+    """
+    read command
+
+    EN 60870-5-101:2003, sec. 7.3.4.3 (p. 108)
+    """
+    name = 'C_RD_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_RD_NA_1
+
+    # this information object contains no data
+    fields_desc = []
+
+
+class IEC104_IO_C_CS_NA_1(IEC104_IO_Packet):
+    """
+    clock synchronization command
+
+    EN 60870-5-101:2003, sec. 7.3.4.4 (p. 109)
+    """
+    name = 'C_CS_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_CS_NA_1
+
+    fields_desc = IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_TS_NA_1(IEC104_IO_Packet):
+    """
+    test command
+
+    EN 60870-5-101:2003, sec. 7.3.4.5 (p. 110)
+    """
+    name = 'C_TS_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_TS_NA_1
+
+    fields_desc = IEC104_IE_FBP.informantion_element_fields
+
+
+class IEC104_IO_C_RP_NA_1(IEC104_IO_Packet):
+    """
+    reset process command
+
+    EN 60870-5-101:2003, sec. 7.3.4.6 (p. 110)
+    """
+    name = 'C_RP_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_RP_NA_1
+
+    fields_desc = IEC104_IE_QRP.informantion_element_fields
+
+
+class IEC104_IO_C_CD_NA_1(IEC104_IO_Packet):
+    """
+    (telegram) delay acquisition command
+
+    EN 60870-5-101:2003, sec. 7.3.4.7 (p. 111)
+    """
+    name = 'C_CD_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_CD_NA_1
+
+    fields_desc = IEC104_IE_CP16TIME2A.informantion_element_fields
+
+
+class IEC104_IO_P_ME_NA_1(IEC104_IO_Packet):
+    """
+    parameter of measured values, normalized value
+
+    EN 60870-5-101:2003, sec. 7.3.5.1 (p. 112)
+    """
+    name = 'P_ME_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_P_ME_NA_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QPM.informantion_element_fields
+
+
+class IEC104_IO_P_ME_NB_1(IEC104_IO_Packet):
+    """
+    parameter of measured values, scaled value
+
+    EN 60870-5-101:2003, sec. 7.3.5.2 (p. 113)
+    """
+    name = 'P_ME_NB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_P_ME_NB_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QPM.informantion_element_fields
+
+
+class IEC104_IO_P_ME_NC_1(IEC104_IO_Packet):
+    """
+    parameter of measured values, short floating point number
+
+    EN 60870-5-101:2003, sec. 7.3.5.3 (p. 114)
+    """
+    name = 'P_ME_NC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_P_ME_NC_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QPM.informantion_element_fields
+
+
+class IEC104_IO_P_AC_NA_1(IEC104_IO_Packet):
+    """
+    parameter activation
+
+    EN 60870-5-101:2003, sec. 7.3.5.4 (p. 115)
+    """
+    name = 'P_AC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_P_AC_NA_1
+
+    fields_desc = IEC104_IE_QPA.informantion_element_fields
+
+
+class IEC104_IO_F_FR_NA_1(IEC104_IO_Packet):
+    """
+    file ready
+
+    EN 60870-5-101:2003, sec. 7.3.6.1 (p. 116)
+    """
+    name = 'F_FR_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_FR_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_LOF.informantion_element_fields + \
+        IEC104_IE_FRQ.informantion_element_fields
+
+
+class IEC104_IO_F_SR_NA_1(IEC104_IO_Packet):
+    """
+    section ready
+
+    EN 60870-5-101:2003, sec. 7.3.6.2 (p. 117)
+    """
+    name = 'F_SR_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_SR_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_NOS.informantion_element_fields + \
+        IEC104_IE_LOF.informantion_element_fields + \
+        IEC104_IE_SRQ.informantion_element_fields
+
+
+class IEC104_IO_F_SC_NA_1(IEC104_IO_Packet):
+    """
+    call directory, select file, call file, call section
+
+    EN 60870-5-101:2003, sec. 7.3.6.3 (p. 118)
+    """
+    name = 'F_SC_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_SC_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_NOS.informantion_element_fields + \
+        IEC104_IE_SCQ.informantion_element_fields
+
+
+class IEC104_IO_F_LS_NA_1(IEC104_IO_Packet):
+    """
+    last section, last segment
+
+    EN 60870-5-101:2003, sec. 7.3.6.4 (p. 119)
+    """
+    name = 'F_LS_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_LS_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_NOS.informantion_element_fields + \
+        IEC104_IE_LSQ.informantion_element_fields + \
+        IEC104_IE_CHS.informantion_element_fields
+
+
+class IEC104_IO_F_AF_NA_1(IEC104_IO_Packet):
+    """
+    ack file, ack section
+
+    EN 60870-5-101:2003, sec. 7.3.6.5 (p. 119)
+    """
+    name = 'F_AF_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_AF_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_NOS.informantion_element_fields + \
+        IEC104_IE_AFQ.informantion_element_fields
+
+
+class IEC104_IO_F_SG_NA_1(IEC104_IO_Packet):
+    """
+    file / section data octets
+
+    EN 60870-5-101:2003, sec. 7.3.6.6 (p. 120)
+    """
+    name = 'F_SG_NA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_SG_NA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_NOS.informantion_element_fields + [
+            BitFieldLenField('segment_length', None, 8,
+                             length_of='data'),  # repr IEC104_IE_LOS
+            XStrLenField('data', '',
+                         length_from=lambda pkt: pkt.segment_length)
+        ]
+
+
+class IEC104_IO_F_DR_TA_1(IEC104_IO_Packet):
+    """
+    directory
+
+    EN 60870-5-101:2003, sec. 7.3.6.7 (p. 121)
+    """
+    name = 'F_DR_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_101,
+                   IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_DR_TA_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_LOF.informantion_element_fields + \
+        IEC104_IE_SOF.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_SC_TA_1(IEC104_IO_Packet):
+    """
+    single command with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.1 (p. 37)
+    """
+    name = 'C_SC_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SC_TA_1
+
+    fields_desc = IEC104_IE_SCO.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_DC_TA_1(IEC104_IO_Packet):
+    """
+    double command with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.2 (p. 38)
+    """
+    name = 'C_DC_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_DC_TA_1
+
+    fields_desc = IEC104_IE_DCO.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_RC_TA_1(IEC104_IO_Packet):
+    """
+    step control command with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.3 (p. 39)
+    """
+    name = 'C_RC_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_RC_TA_1
+
+    fields_desc = IEC104_IE_RCO.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_SE_TA_1(IEC104_IO_Packet):
+    """
+    set point command, normed value with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.4 (p. 40)
+    """
+    name = 'C_SE_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_TA_1
+
+    fields_desc = IEC104_IE_NVA.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_SE_TB_1(IEC104_IO_Packet):
+    """
+    set point command, scaled value with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.5 (p. 41)
+    """
+    name = 'C_SE_TB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_TB_1
+
+    fields_desc = IEC104_IE_SVA.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_SE_TC_1(IEC104_IO_Packet):
+    """
+    set point command, shortened floating point value with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.6 (p. 42)
+    """
+    name = 'C_SE_TC_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_SE_TC_1
+
+    fields_desc = IEC104_IE_R32_IEEE_STD_754.informantion_element_fields + \
+        IEC104_IE_QOS.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_BO_TA_1(IEC104_IO_Packet):
+    """
+    bitmask 32 bit with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.7 (p. 43)
+    """
+    name = 'C_BO_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_BO_TA_1
+
+    fields_desc = IEC104_IE_BSI.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_C_TS_TA_1(IEC104_IO_Packet):
+    """
+    test command with timestamp CP56Time2a
+
+    EN 60870-5-104:2006, sec. 8.8 (p. 44)
+    """
+    name = 'C_TS_TA_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_C_TS_TA_1
+
+    fields_desc = IEC104_IE_TSC.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A.informantion_element_fields
+
+
+class IEC104_IO_F_SC_NB_1(IEC104_IO_Packet):
+    """
+    request archive file
+
+    EN 60870-5-104:2006, sec. 8.9 (p. 45)
+    """
+    name = 'F_SC_NB_1'
+
+    _DEFINED_IN = [IEC104_IO_Packet.DEFINED_IN_IEC_104]
+    _IEC104_IO_TYPE_ID = IEC104_IO_ID_F_SC_NB_1
+
+    fields_desc = IEC104_IE_NOF.informantion_element_fields + \
+        IEC104_IE_CP56TIME2A_START_TIME.\
+        informantion_element_fields + \
+        IEC104_IE_CP56TIME2A_STOP_TIME.informantion_element_fields
+
+
+IEC104_IO_CLASSES = {
+    IEC104_IO_ID_M_SP_NA_1: IEC104_IO_M_SP_NA_1,
+    IEC104_IO_ID_M_SP_TA_1: IEC104_IO_M_SP_TA_1,
+    IEC104_IO_ID_M_DP_NA_1: IEC104_IO_M_DP_NA_1,
+    IEC104_IO_ID_M_DP_TA_1: IEC104_IO_M_DP_TA_1,
+    IEC104_IO_ID_M_ST_NA_1: IEC104_IO_M_ST_NA_1,
+    IEC104_IO_ID_M_ST_TA_1: IEC104_IO_M_ST_TA_1,
+    IEC104_IO_ID_M_BO_NA_1: IEC104_IO_M_BO_NA_1,
+    IEC104_IO_ID_M_BO_TA_1: IEC104_IO_M_BO_TA_1,
+    IEC104_IO_ID_M_ME_NA_1: IEC104_IO_M_ME_NA_1,
+    IEC104_IO_ID_M_ME_TA_1: IEC104_IO_M_ME_TA_1,
+    IEC104_IO_ID_M_ME_NB_1: IEC104_IO_M_ME_NB_1,
+    IEC104_IO_ID_M_ME_TB_1: IEC104_IO_M_ME_TB_1,
+    IEC104_IO_ID_M_ME_NC_1: IEC104_IO_M_ME_NC_1,
+    IEC104_IO_ID_M_ME_TC_1: IEC104_IO_M_ME_TC_1,
+    IEC104_IO_ID_M_IT_NA_1: IEC104_IO_M_IT_NA_1,
+    IEC104_IO_ID_M_IT_TA_1: IEC104_IO_M_IT_TA_1,
+    IEC104_IO_ID_M_EP_TA_1: IEC104_IO_M_EP_TA_1,
+    IEC104_IO_ID_M_EP_TB_1: IEC104_IO_M_EP_TB_1,
+    IEC104_IO_ID_M_EP_TC_1: IEC104_IO_M_EP_TC_1,
+    IEC104_IO_ID_M_PS_NA_1: IEC104_IO_M_PS_NA_1,
+    IEC104_IO_ID_M_ME_ND_1: IEC104_IO_M_ME_ND_1,
+    IEC104_IO_ID_M_SP_TB_1: IEC104_IO_M_SP_TB_1,
+    IEC104_IO_ID_M_DP_TB_1: IEC104_IO_M_DP_TB_1,
+    IEC104_IO_ID_M_ST_TB_1: IEC104_IO_M_ST_TB_1,
+    IEC104_IO_ID_M_BO_TB_1: IEC104_IO_M_BO_TB_1,
+    IEC104_IO_ID_M_ME_TD_1: IEC104_IO_M_ME_TD_1,
+    IEC104_IO_ID_M_ME_TE_1: IEC104_IO_M_ME_TE_1,
+    IEC104_IO_ID_M_ME_TF_1: IEC104_IO_M_ME_TF_1,
+    IEC104_IO_ID_M_IT_TB_1: IEC104_IO_M_IT_TB_1,
+    IEC104_IO_ID_M_EP_TD_1: IEC104_IO_M_EP_TD_1,
+    IEC104_IO_ID_M_EP_TE_1: IEC104_IO_M_EP_TE_1,
+    IEC104_IO_ID_M_EP_TF_1: IEC104_IO_M_EP_TF_1,
+    IEC104_IO_ID_C_SC_NA_1: IEC104_IO_C_SC_NA_1,
+    IEC104_IO_ID_C_DC_NA_1: IEC104_IO_C_DC_NA_1,
+    IEC104_IO_ID_C_RC_NA_1: IEC104_IO_C_RC_NA_1,
+    IEC104_IO_ID_C_SE_NA_1: IEC104_IO_C_SE_NA_1,
+    IEC104_IO_ID_C_SE_NB_1: IEC104_IO_C_SE_NB_1,
+    IEC104_IO_ID_C_SE_NC_1: IEC104_IO_C_SE_NC_1,
+    IEC104_IO_ID_C_BO_NA_1: IEC104_IO_C_BO_NA_1,
+    IEC104_IO_ID_C_SC_TA_1: IEC104_IO_C_SC_TA_1,
+    IEC104_IO_ID_C_DC_TA_1: IEC104_IO_C_DC_TA_1,
+    IEC104_IO_ID_C_RC_TA_1: IEC104_IO_C_RC_TA_1,
+    IEC104_IO_ID_C_SE_TA_1: IEC104_IO_C_SE_TA_1,
+    IEC104_IO_ID_C_SE_TB_1: IEC104_IO_C_SE_TB_1,
+    IEC104_IO_ID_C_SE_TC_1: IEC104_IO_C_SE_TC_1,
+    IEC104_IO_ID_C_BO_TA_1: IEC104_IO_C_BO_TA_1,
+    IEC104_IO_ID_M_EI_NA_1: IEC104_IO_M_EI_NA_1,
+    IEC104_IO_ID_C_IC_NA_1: IEC104_IO_C_IC_NA_1,
+    IEC104_IO_ID_C_CI_NA_1: IEC104_IO_C_CI_NA_1,
+    IEC104_IO_ID_C_RD_NA_1: IEC104_IO_C_RD_NA_1,
+    IEC104_IO_ID_C_CS_NA_1: IEC104_IO_C_CS_NA_1,
+    IEC104_IO_ID_C_TS_NA_1: IEC104_IO_C_TS_NA_1,
+    IEC104_IO_ID_C_RP_NA_1: IEC104_IO_C_RP_NA_1,
+    IEC104_IO_ID_C_CD_NA_1: IEC104_IO_C_CD_NA_1,
+    IEC104_IO_ID_C_TS_TA_1: IEC104_IO_C_TS_TA_1,
+    IEC104_IO_ID_P_ME_NA_1: IEC104_IO_P_ME_NA_1,
+    IEC104_IO_ID_P_ME_NB_1: IEC104_IO_P_ME_NB_1,
+    IEC104_IO_ID_P_ME_NC_1: IEC104_IO_P_ME_NC_1,
+    IEC104_IO_ID_P_AC_NA_1: IEC104_IO_P_AC_NA_1,
+    IEC104_IO_ID_F_FR_NA_1: IEC104_IO_F_FR_NA_1,
+    IEC104_IO_ID_F_SR_NA_1: IEC104_IO_F_SR_NA_1,
+    IEC104_IO_ID_F_SC_NA_1: IEC104_IO_F_SC_NA_1,
+    IEC104_IO_ID_F_LS_NA_1: IEC104_IO_F_LS_NA_1,
+    IEC104_IO_ID_F_AF_NA_1: IEC104_IO_F_AF_NA_1,
+    IEC104_IO_ID_F_SG_NA_1: IEC104_IO_F_SG_NA_1,
+    IEC104_IO_ID_F_DR_TA_1: IEC104_IO_F_DR_TA_1,
+    IEC104_IO_ID_F_SC_NB_1: IEC104_IO_F_SC_NB_1
+}
+
+
+class IEC104_IO_M_SP_NA_1_IOA(IEC104_IO_M_SP_NA_1):
+    """
+    extended version of IEC104_IO_M_SP_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_SP_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_SP_NA_1.fields_desc
+
+
+class IEC104_IO_M_SP_TA_1_IOA(IEC104_IO_M_SP_TA_1):
+    """
+    extended version of IEC104_IO_M_SP_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_SP_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_SP_TA_1.fields_desc
+
+
+class IEC104_IO_M_DP_NA_1_IOA(IEC104_IO_M_DP_NA_1):
+    """
+    extended version of IEC104_IO_M_DP_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_DP_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_DP_NA_1.fields_desc
+
+
+class IEC104_IO_M_DP_TA_1_IOA(IEC104_IO_M_DP_TA_1):
+    """
+    extended version of IEC104_IO_M_DP_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_DP_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_DP_TA_1.fields_desc
+
+
+class IEC104_IO_M_ST_NA_1_IOA(IEC104_IO_M_ST_NA_1):
+    """
+    extended version of IEC104_IO_M_ST_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_ST_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ST_NA_1.fields_desc
+
+
+class IEC104_IO_M_ST_TA_1_IOA(IEC104_IO_M_ST_TA_1):
+    """
+    extended version of IEC104_IO_M_ST_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_ST_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ST_TA_1.fields_desc
+
+
+class IEC104_IO_M_BO_NA_1_IOA(IEC104_IO_M_BO_NA_1):
+    """
+    extended version of IEC104_IO_M_BO_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_BO_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_BO_NA_1.fields_desc
+
+
+class IEC104_IO_M_BO_TA_1_IOA(IEC104_IO_M_BO_TA_1):
+    """
+    extended version of IEC104_IO_M_BO_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_BO_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_BO_TA_1.fields_desc
+
+
+class IEC104_IO_M_ME_NA_1_IOA(IEC104_IO_M_ME_NA_1):
+    """
+    extended version of IEC104_IO_M_ME_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_NA_1.fields_desc
+
+
+class IEC104_IO_M_ME_TA_1_IOA(IEC104_IO_M_ME_TA_1):
+    """
+    extended version of IEC104_IO_M_ME_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TA_1.fields_desc
+
+
+class IEC104_IO_M_ME_NB_1_IOA(IEC104_IO_M_ME_NB_1):
+    """
+    extended version of IEC104_IO_M_ME_NB_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_NB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_NB_1.fields_desc
+
+
+class IEC104_IO_M_ME_TB_1_IOA(IEC104_IO_M_ME_TB_1):
+    """
+    extended version of IEC104_IO_M_ME_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TB_1.fields_desc
+
+
+class IEC104_IO_M_ME_NC_1_IOA(IEC104_IO_M_ME_NC_1):
+    """
+    extended version of IEC104_IO_M_ME_NC_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_NC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_NC_1.fields_desc
+
+
+class IEC104_IO_M_ME_TC_1_IOA(IEC104_IO_M_ME_TC_1):
+    """
+    extended version of IEC104_IO_M_ME_TC_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TC_1.fields_desc
+
+
+class IEC104_IO_M_IT_NA_1_IOA(IEC104_IO_M_IT_NA_1):
+    """
+    extended version of IEC104_IO_M_IT_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_IT_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_IT_NA_1.fields_desc
+
+
+class IEC104_IO_M_IT_TA_1_IOA(IEC104_IO_M_IT_TA_1):
+    """
+    extended version of IEC104_IO_M_IT_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_IT_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_IT_TA_1.fields_desc
+
+
+class IEC104_IO_M_EP_TA_1_IOA(IEC104_IO_M_EP_TA_1):
+    """
+    extended version of IEC104_IO_M_EP_TA_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TA_1.fields_desc
+
+
+class IEC104_IO_M_EP_TB_1_IOA(IEC104_IO_M_EP_TB_1):
+    """
+    extended version of IEC104_IO_M_EP_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TB_1.fields_desc
+
+
+class IEC104_IO_M_EP_TC_1_IOA(IEC104_IO_M_EP_TC_1):
+    """
+    extended version of IEC104_IO_M_EP_TC_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TC_1.fields_desc
+
+
+class IEC104_IO_M_PS_NA_1_IOA(IEC104_IO_M_PS_NA_1):
+    """
+    extended version of IEC104_IO_M_PS_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_PS_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_PS_NA_1.fields_desc
+
+
+class IEC104_IO_M_ME_ND_1_IOA(IEC104_IO_M_ME_ND_1):
+    """
+    extended version of IEC104_IO_M_ME_ND_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_ND_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_ND_1.fields_desc
+
+
+class IEC104_IO_M_SP_TB_1_IOA(IEC104_IO_M_SP_TB_1):
+    """
+    extended version of IEC104_IO_M_SP_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_SP_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_SP_TB_1.fields_desc
+
+
+class IEC104_IO_M_DP_TB_1_IOA(IEC104_IO_M_DP_TB_1):
+    """
+    extended version of IEC104_IO_M_DP_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_DP_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_DP_TB_1.fields_desc
+
+
+class IEC104_IO_M_ST_TB_1_IOA(IEC104_IO_M_ST_TB_1):
+    """
+    extended version of IEC104_IO_M_ST_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_ST_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ST_TB_1.fields_desc
+
+
+class IEC104_IO_M_BO_TB_1_IOA(IEC104_IO_M_BO_TB_1):
+    """
+    extended version of IEC104_IO_M_BO_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_BO_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_BO_TB_1.fields_desc
+
+
+class IEC104_IO_M_ME_TD_1_IOA(IEC104_IO_M_ME_TD_1):
+    """
+    extended version of IEC104_IO_M_ME_TD_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TD_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TD_1.fields_desc
+
+
+class IEC104_IO_M_ME_TE_1_IOA(IEC104_IO_M_ME_TE_1):
+    """
+    extended version of IEC104_IO_M_ME_TE_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TE_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TE_1.fields_desc
+
+
+class IEC104_IO_M_ME_TF_1_IOA(IEC104_IO_M_ME_TF_1):
+    """
+    extended version of IEC104_IO_M_ME_TF_1 containing an individual
+    information object address
+    """
+    name = 'M_ME_TF_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_ME_TF_1.fields_desc
+
+
+class IEC104_IO_M_IT_TB_1_IOA(IEC104_IO_M_IT_TB_1):
+    """
+    extended version of IEC104_IO_M_IT_TB_1 containing an individual
+    information object address
+    """
+    name = 'M_IT_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_IT_TB_1.fields_desc
+
+
+class IEC104_IO_M_EP_TD_1_IOA(IEC104_IO_M_EP_TD_1):
+    """
+    extended version of IEC104_IO_M_EP_TD_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TD_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TD_1.fields_desc
+
+
+class IEC104_IO_M_EP_TE_1_IOA(IEC104_IO_M_EP_TE_1):
+    """
+    extended version of IEC104_IO_M_EP_TE_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TE_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TE_1.fields_desc
+
+
+class IEC104_IO_M_EP_TF_1_IOA(IEC104_IO_M_EP_TF_1):
+    """
+    extended version of IEC104_IO_M_EP_TF_1 containing an individual
+    information object address
+    """
+    name = 'M_EP_TF_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EP_TF_1.fields_desc
+
+
+class IEC104_IO_C_SC_NA_1_IOA(IEC104_IO_C_SC_NA_1):
+    """
+    extended version of IEC104_IO_C_SC_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_SC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SC_NA_1.fields_desc
+
+
+class IEC104_IO_C_DC_NA_1_IOA(IEC104_IO_C_DC_NA_1):
+    """
+    extended version of IEC104_IO_C_DC_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_DC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_DC_NA_1.fields_desc
+
+
+class IEC104_IO_C_RC_NA_1_IOA(IEC104_IO_C_RC_NA_1):
+    """
+    extended version of IEC104_IO_C_RC_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_RC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_RC_NA_1.fields_desc
+
+
+class IEC104_IO_C_SE_NA_1_IOA(IEC104_IO_C_SE_NA_1):
+    """
+    extended version of IEC104_IO_C_SE_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_NA_1.fields_desc
+
+
+class IEC104_IO_C_SE_NB_1_IOA(IEC104_IO_C_SE_NB_1):
+    """
+    extended version of IEC104_IO_C_SE_NB_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_NB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_NB_1.fields_desc
+
+
+class IEC104_IO_C_SE_NC_1_IOA(IEC104_IO_C_SE_NC_1):
+    """
+    extended version of IEC104_IO_C_SE_NC_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_NC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_NC_1.fields_desc
+
+
+class IEC104_IO_C_BO_NA_1_IOA(IEC104_IO_C_BO_NA_1):
+    """
+    extended version of IEC104_IO_C_BO_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_BO_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_BO_NA_1.fields_desc
+
+
+class IEC104_IO_C_SC_TA_1_IOA(IEC104_IO_C_SC_TA_1):
+    """
+    extended version of IEC104_IO_C_SC_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_SC_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SC_TA_1.fields_desc
+
+
+class IEC104_IO_C_DC_TA_1_IOA(IEC104_IO_C_DC_TA_1):
+    """
+    extended version of IEC104_IO_C_DC_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_DC_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_DC_TA_1.fields_desc
+
+
+class IEC104_IO_C_RC_TA_1_IOA(IEC104_IO_C_RC_TA_1):
+    """
+    extended version of IEC104_IO_C_RC_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_RC_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_RC_TA_1.fields_desc
+
+
+class IEC104_IO_C_SE_TA_1_IOA(IEC104_IO_C_SE_TA_1):
+    """
+    extended version of IEC104_IO_C_SE_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_TA_1.fields_desc
+
+
+class IEC104_IO_C_SE_TB_1_IOA(IEC104_IO_C_SE_TB_1):
+    """
+    extended version of IEC104_IO_C_SE_TB_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_TB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_TB_1.fields_desc
+
+
+class IEC104_IO_C_SE_TC_1_IOA(IEC104_IO_C_SE_TC_1):
+    """
+    extended version of IEC104_IO_C_SE_TC_1 containing an individual
+    information object address
+    """
+    name = 'C_SE_TC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_SE_TC_1.fields_desc
+
+
+class IEC104_IO_C_BO_TA_1_IOA(IEC104_IO_C_BO_TA_1):
+    """
+    extended version of IEC104_IO_C_BO_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_BO_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_BO_TA_1.fields_desc
+
+
+class IEC104_IO_M_EI_NA_1_IOA(IEC104_IO_M_EI_NA_1):
+    """
+    extended version of IEC104_IO_M_EI_NA_1 containing an individual
+    information object address
+    """
+    name = 'M_EI_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_M_EI_NA_1.fields_desc
+
+
+class IEC104_IO_C_IC_NA_1_IOA(IEC104_IO_C_IC_NA_1):
+    """
+    extended version of IEC104_IO_C_IC_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_IC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_IC_NA_1.fields_desc
+
+
+class IEC104_IO_C_CI_NA_1_IOA(IEC104_IO_C_CI_NA_1):
+    """
+    extended version of IEC104_IO_C_CI_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_CI_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_CI_NA_1.fields_desc
+
+
+class IEC104_IO_C_RD_NA_1_IOA(IEC104_IO_C_RD_NA_1):
+    """
+    extended version of IEC104_IO_C_RD_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_RD_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_RD_NA_1.fields_desc
+
+
+class IEC104_IO_C_CS_NA_1_IOA(IEC104_IO_C_CS_NA_1):
+    """
+    extended version of IEC104_IO_C_CS_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_CS_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_CS_NA_1.fields_desc
+
+
+class IEC104_IO_C_TS_NA_1_IOA(IEC104_IO_C_TS_NA_1):
+    """
+    extended version of IEC104_IO_C_TS_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_TS_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_TS_NA_1.fields_desc
+
+
+class IEC104_IO_C_RP_NA_1_IOA(IEC104_IO_C_RP_NA_1):
+    """
+    extended version of IEC104_IO_C_RP_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_RP_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_RP_NA_1.fields_desc
+
+
+class IEC104_IO_C_CD_NA_1_IOA(IEC104_IO_C_CD_NA_1):
+    """
+    extended version of IEC104_IO_C_CD_NA_1 containing an individual
+    information object address
+    """
+    name = 'C_CD_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_CD_NA_1.fields_desc
+
+
+class IEC104_IO_C_TS_TA_1_IOA(IEC104_IO_C_TS_TA_1):
+    """
+    extended version of IEC104_IO_C_TS_TA_1 containing an individual
+    information object address
+    """
+    name = 'C_TS_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_C_TS_TA_1.fields_desc
+
+
+class IEC104_IO_P_ME_NA_1_IOA(IEC104_IO_P_ME_NA_1):
+    """
+    extended version of IEC104_IO_P_ME_NA_1 containing an individual
+    information object address
+    """
+    name = 'P_ME_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_P_ME_NA_1.fields_desc
+
+
+class IEC104_IO_P_ME_NB_1_IOA(IEC104_IO_P_ME_NB_1):
+    """
+    extended version of IEC104_IO_P_ME_NB_1 containing an individual
+    information object address
+    """
+    name = 'P_ME_NB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_P_ME_NB_1.fields_desc
+
+
+class IEC104_IO_P_ME_NC_1_IOA(IEC104_IO_P_ME_NC_1):
+    """
+    extended version of IEC104_IO_P_ME_NC_1 containing an individual
+    information object address
+    """
+    name = 'P_ME_NC_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_P_ME_NC_1.fields_desc
+
+
+class IEC104_IO_P_AC_NA_1_IOA(IEC104_IO_P_AC_NA_1):
+    """
+    extended version of IEC104_IO_P_AC_NA_1 containing an individual
+    information object address
+    """
+    name = 'P_AC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_P_AC_NA_1.fields_desc
+
+
+class IEC104_IO_F_FR_NA_1_IOA(IEC104_IO_F_FR_NA_1):
+    """
+    extended version of IEC104_IO_F_FR_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_FR_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_FR_NA_1.fields_desc
+
+
+class IEC104_IO_F_SR_NA_1_IOA(IEC104_IO_F_SR_NA_1):
+    """
+    extended version of IEC104_IO_F_SR_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_SR_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_SR_NA_1.fields_desc
+
+
+class IEC104_IO_F_SC_NA_1_IOA(IEC104_IO_F_SC_NA_1):
+    """
+    extended version of IEC104_IO_F_SC_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_SC_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_SC_NA_1.fields_desc
+
+
+class IEC104_IO_F_LS_NA_1_IOA(IEC104_IO_F_LS_NA_1):
+    """
+    extended version of IEC104_IO_F_LS_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_LS_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_LS_NA_1.fields_desc
+
+
+class IEC104_IO_F_AF_NA_1_IOA(IEC104_IO_F_AF_NA_1):
+    """
+    extended version of IEC104_IO_F_AF_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_AF_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_AF_NA_1.fields_desc
+
+
+class IEC104_IO_F_SG_NA_1_IOA(IEC104_IO_F_SG_NA_1):
+    """
+    extended version of IEC104_IO_F_SG_NA_1 containing an individual
+    information object address
+    """
+    name = 'F_SG_NA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_SG_NA_1.fields_desc
+
+
+class IEC104_IO_F_DR_TA_1_IOA(IEC104_IO_F_DR_TA_1):
+    """
+    extended version of IEC104_IO_F_DR_TA_1 containing an individual
+    information object address
+    """
+    name = 'F_DR_TA_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_DR_TA_1.fields_desc
+
+
+class IEC104_IO_F_SC_NB_1_IOA(IEC104_IO_F_SC_NB_1):
+    """
+    extended version of IEC104_IO_F_SC_NB_1 containing an individual
+    information object address
+    """
+    name = 'F_SC_NB_1 (+ioa)'
+    fields_desc = [LEThreeBytesField('information_object_address', 0)] + \
+        IEC104_IO_F_SC_NB_1.fields_desc
+
+
+IEC104_IO_WITH_IOA_CLASSES = {
+    IEC104_IO_ID_M_SP_NA_1: IEC104_IO_M_SP_NA_1_IOA,
+    IEC104_IO_ID_M_SP_TA_1: IEC104_IO_M_SP_TA_1_IOA,
+    IEC104_IO_ID_M_DP_NA_1: IEC104_IO_M_DP_NA_1_IOA,
+    IEC104_IO_ID_M_DP_TA_1: IEC104_IO_M_DP_TA_1_IOA,
+    IEC104_IO_ID_M_ST_NA_1: IEC104_IO_M_ST_NA_1_IOA,
+    IEC104_IO_ID_M_ST_TA_1: IEC104_IO_M_ST_TA_1_IOA,
+    IEC104_IO_ID_M_BO_NA_1: IEC104_IO_M_BO_NA_1_IOA,
+    IEC104_IO_ID_M_BO_TA_1: IEC104_IO_M_BO_TA_1_IOA,
+    IEC104_IO_ID_M_ME_NA_1: IEC104_IO_M_ME_NA_1_IOA,
+    IEC104_IO_ID_M_ME_TA_1: IEC104_IO_M_ME_TA_1_IOA,
+    IEC104_IO_ID_M_ME_NB_1: IEC104_IO_M_ME_NB_1_IOA,
+    IEC104_IO_ID_M_ME_TB_1: IEC104_IO_M_ME_TB_1_IOA,
+    IEC104_IO_ID_M_ME_NC_1: IEC104_IO_M_ME_NC_1_IOA,
+    IEC104_IO_ID_M_ME_TC_1: IEC104_IO_M_ME_TC_1_IOA,
+    IEC104_IO_ID_M_IT_NA_1: IEC104_IO_M_IT_NA_1_IOA,
+    IEC104_IO_ID_M_IT_TA_1: IEC104_IO_M_IT_TA_1_IOA,
+    IEC104_IO_ID_M_EP_TA_1: IEC104_IO_M_EP_TA_1_IOA,
+    IEC104_IO_ID_M_EP_TB_1: IEC104_IO_M_EP_TB_1_IOA,
+    IEC104_IO_ID_M_EP_TC_1: IEC104_IO_M_EP_TC_1_IOA,
+    IEC104_IO_ID_M_PS_NA_1: IEC104_IO_M_PS_NA_1_IOA,
+    IEC104_IO_ID_M_ME_ND_1: IEC104_IO_M_ME_ND_1_IOA,
+    IEC104_IO_ID_M_SP_TB_1: IEC104_IO_M_SP_TB_1_IOA,
+    IEC104_IO_ID_M_DP_TB_1: IEC104_IO_M_DP_TB_1_IOA,
+    IEC104_IO_ID_M_ST_TB_1: IEC104_IO_M_ST_TB_1_IOA,
+    IEC104_IO_ID_M_BO_TB_1: IEC104_IO_M_BO_TB_1_IOA,
+    IEC104_IO_ID_M_ME_TD_1: IEC104_IO_M_ME_TD_1_IOA,
+    IEC104_IO_ID_M_ME_TE_1: IEC104_IO_M_ME_TE_1_IOA,
+    IEC104_IO_ID_M_ME_TF_1: IEC104_IO_M_ME_TF_1_IOA,
+    IEC104_IO_ID_M_IT_TB_1: IEC104_IO_M_IT_TB_1_IOA,
+    IEC104_IO_ID_M_EP_TD_1: IEC104_IO_M_EP_TD_1_IOA,
+    IEC104_IO_ID_M_EP_TE_1: IEC104_IO_M_EP_TE_1_IOA,
+    IEC104_IO_ID_M_EP_TF_1: IEC104_IO_M_EP_TF_1_IOA,
+    IEC104_IO_ID_C_SC_NA_1: IEC104_IO_C_SC_NA_1_IOA,
+    IEC104_IO_ID_C_DC_NA_1: IEC104_IO_C_DC_NA_1_IOA,
+    IEC104_IO_ID_C_RC_NA_1: IEC104_IO_C_RC_NA_1_IOA,
+    IEC104_IO_ID_C_SE_NA_1: IEC104_IO_C_SE_NA_1_IOA,
+    IEC104_IO_ID_C_SE_NB_1: IEC104_IO_C_SE_NB_1_IOA,
+    IEC104_IO_ID_C_SE_NC_1: IEC104_IO_C_SE_NC_1_IOA,
+    IEC104_IO_ID_C_BO_NA_1: IEC104_IO_C_BO_NA_1_IOA,
+    IEC104_IO_ID_C_SC_TA_1: IEC104_IO_C_SC_TA_1_IOA,
+    IEC104_IO_ID_C_DC_TA_1: IEC104_IO_C_DC_TA_1_IOA,
+    IEC104_IO_ID_C_RC_TA_1: IEC104_IO_C_RC_TA_1_IOA,
+    IEC104_IO_ID_C_SE_TA_1: IEC104_IO_C_SE_TA_1_IOA,
+    IEC104_IO_ID_C_SE_TB_1: IEC104_IO_C_SE_TB_1_IOA,
+    IEC104_IO_ID_C_SE_TC_1: IEC104_IO_C_SE_TC_1_IOA,
+    IEC104_IO_ID_C_BO_TA_1: IEC104_IO_C_BO_TA_1_IOA,
+    IEC104_IO_ID_M_EI_NA_1: IEC104_IO_M_EI_NA_1_IOA,
+    IEC104_IO_ID_C_IC_NA_1: IEC104_IO_C_IC_NA_1_IOA,
+    IEC104_IO_ID_C_CI_NA_1: IEC104_IO_C_CI_NA_1_IOA,
+    IEC104_IO_ID_C_RD_NA_1: IEC104_IO_C_RD_NA_1_IOA,
+    IEC104_IO_ID_C_CS_NA_1: IEC104_IO_C_CS_NA_1_IOA,
+    IEC104_IO_ID_C_TS_NA_1: IEC104_IO_C_TS_NA_1_IOA,
+    IEC104_IO_ID_C_RP_NA_1: IEC104_IO_C_RP_NA_1_IOA,
+    IEC104_IO_ID_C_CD_NA_1: IEC104_IO_C_CD_NA_1_IOA,
+    IEC104_IO_ID_C_TS_TA_1: IEC104_IO_C_TS_TA_1_IOA,
+    IEC104_IO_ID_P_ME_NA_1: IEC104_IO_P_ME_NA_1_IOA,
+    IEC104_IO_ID_P_ME_NB_1: IEC104_IO_P_ME_NB_1_IOA,
+    IEC104_IO_ID_P_ME_NC_1: IEC104_IO_P_ME_NC_1_IOA,
+    IEC104_IO_ID_P_AC_NA_1: IEC104_IO_P_AC_NA_1_IOA,
+    IEC104_IO_ID_F_FR_NA_1: IEC104_IO_F_FR_NA_1_IOA,
+    IEC104_IO_ID_F_SR_NA_1: IEC104_IO_F_SR_NA_1_IOA,
+    IEC104_IO_ID_F_SC_NA_1: IEC104_IO_F_SC_NA_1_IOA,
+    IEC104_IO_ID_F_LS_NA_1: IEC104_IO_F_LS_NA_1_IOA,
+    IEC104_IO_ID_F_AF_NA_1: IEC104_IO_F_AF_NA_1_IOA,
+    IEC104_IO_ID_F_SG_NA_1: IEC104_IO_F_SG_NA_1_IOA,
+    IEC104_IO_ID_F_DR_TA_1: IEC104_IO_F_DR_TA_1_IOA,
+    IEC104_IO_ID_F_SC_NB_1: IEC104_IO_F_SC_NB_1_IOA
+}


### PR DESCRIPTION
This PR adds a IEC 60870-5-104 layer based on 
- IEC 60870-5-4, 
- IEC 60870-5-101 and (surprise) 
- IEC 60870-5-104.

I kept the basic building blocks in separate files as it will be easier to navigate while applying 
the upcoming storm of change requests <-> I will merge all parts in iec104.py if done.

Few remarks about the implementation:

1. 647ea90 / 6c29629 extends the stock guess_payload_class() by adding a special attribute *payload_dispatcher* that can be used to supply a function for guessing next layers class based on the payload. This becomes handy if one needs to dispatch the class type following a standard layer (e.g. TCP or UDP) - usually connected via bind_layer(). Up to now one would need to add a dispatch layer - e.g. IEC104 would look like

```
TCP
..
IEC104
IEC104_I_Message
...
```

instead of 

```
TCP
..
IEC104_I_Message
..
```
For now this is a kwargs attribute - maybe this should be converted to an explicit named attribute of bind_layers().

2. There are a lot of information object definitions in the code only used within IEC 60870-5-101. This is on purpose so one is able to decode invalid messages forwarded by a faulty IEC101/104 gateway and for testing that kind of a gateway.
