### PR TITLE
CANSocket implementation for scapy [ready to merge]

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -60,6 +60,14 @@ if ! python --version 2>&1 | grep -q PyPy; then
   $SCAPY_SUDO $PIP install $PIP_INSTALL_FLAGS -U cryptography
 fi
 
+# Install CANSocket related components
+$SCAPY_SUDO $PIP install $PIP_INSTALL_FLAGS -U python-can
+if [ "$TRAVIS_OS_NAME" = "linux" ]
+then
+  $SCAPY_SUDO apt-get -qy install can-utils
+fi
+
+
 # Install coverage
 if [ "$SCAPY_COVERAGE" = "yes" ]
 then

--- a/doc/scapy/advanced_usage.rst
+++ b/doc/scapy/advanced_usage.rst
@@ -1086,3 +1086,457 @@ To enable the RFC 5061 about dynamic address reconfiguration::
 You may also want to use the dynamic address reconfiguration without necessarily enabling the chunk authentication::
 
     $ sudo echo 1 > /proc/sys/net/sctp/addip_noauth_enable
+
+
+Automotive usage
+================
+
+.. note::
+    All automotive related features work best on Linux systems. CAN and ISOTP sockets in Scapy are based on Linux kernel modules.
+    The python-can project is used to support CAN and CANSockets on other systems, besides Linux.
+    This guide explains the hardware setup on a BeagleBone Black. The BeagleBone Black was chosen because of its two CAN interfaces on the main processor.
+    The presence of two CAN interfaces in one device gives the possibility of CAN MITM attacks and session hijacking.
+    The Cannelloni framework turns a BeagleBone Black into a CAN-to-UDP interface, which gives you the freedom to run Scapy
+    on a more powerful machine.
+
+Examples
+--------
+
+
+Hands-On
+--------
+
+Send a message over Linux SocketCAN::
+
+    load_contrib('cansocket')
+    socket = CANSocket(iface='can0')
+    packet = CAN(identifier=0x123, data=b'01020304')
+
+    socket.sr1(packet, timeout=1)
+
+    srcan(packet, 'can0', timeout=1)
+
+Send a message over a Vector-Interface::
+
+    import can
+    conf.contribs['CANSocket'] = {'use-python-can' : True}
+    load_contrib('cansocket')
+    from can.interfaces.vector import VectorBus
+    socket = CANSocket(iface=VectorBus(0, bitrate=1000000))
+    packet = CAN(identifier=0x123, data=b'01020304')
+    socket.sr1(packet)
+
+    srcan(packet, VectorBus(0, bitrate=1000000))
+
+
+
+CAN Layer
+---------
+
+Setup
+-----
+
+This commands enable a virtual CAN interface on your machine::
+
+    from scapy.layers.can import *
+    import os
+
+    bashCommand = "/bin/bash -c 'sudo modprobe vcan; sudo ip link add name vcan0 type vcan; sudo ip link set dev vcan0 up'"
+    os.system(bashCommand)
+
+If it's required, the CAN interface can be set into an listen-only or loop back mode with ip link set commands::
+
+    ip link set vcan0 type can help  # shows additional information
+
+CAN Frame
+---------
+
+Creating a standard CAN frame::
+
+    frame = CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
+Creating an extended CAN frame::
+
+    frame = CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
+Writing and reading to pcap files::
+
+    x = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    wrpcap('/tmp/scapyPcapTest.pcap', x, append=False)
+    y = rdpcap('/tmp/scapyPcapTest.pcap', 1)
+
+Native CANSocket
+----------------
+
+Creating a simple native CANSocket::
+
+    conf.contribs['CANSocket'] = {'use-python-can': False} #(default)
+    load_contrib('cansocket')
+
+    # Simple Socket
+    socket = CANSocket(iface="vcan0")
+
+ Creating a native CANSocket only listen for messages with Id == 0x200::
+
+    socket = CANSocket(iface="vcan0", canfilters=[{'can_id': 0x200, 'can_mask': 0x7FF}])
+
+Creating a native CANSocket only listen for messages with Id >= 0x200 and Id <= 0x2ff::
+
+    socket = CANSocket(iface="vcan0", canfilters=[{'can_id': 0x200, 'can_mask': 0x700}])
+
+Creating a native CANSocket only listen for messages with Id != 0x200::
+
+    socket = CANSocket(iface="vcan0", canfilters=[{'can_id': 0x200 | CAN_INV_FILTER, 'can_mask': 0x7FF}])
+
+Creating a native CANSocket with multiple canfilters::
+
+    socket = CANSocket(iface='vcan0', canfilters=[{'can_id': 0x200, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x400, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x600, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x7ff, 'can_mask': 0x7ff}])
+
+Creating a native CANSocket which also receives its own messages::
+
+    socket = CANSocket(iface="vcan0", receive_own_messages=True)
+
+
+python-can CANSocket
+--------------------
+
+Ways of creating a python-can CANSocket::
+
+    conf.contribs['CANSocket'] = {'use-python-can': True}
+    load_contrib('cansocket')
+    import can
+
+Creating a simple python-can CANSocket::
+
+    socket = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000
+
+Creating a python-can CANSocket with multiple filters::
+
+    socket = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000,
+                    canfilters=[{'can_id': 0x200, 'can_mask': 0x7ff},
+                                {'can_id': 0x400, 'can_mask': 0x7ff},
+                                {'can_id': 0x600, 'can_mask': 0x7ff},
+                                {'can_id': 0x7ff, 'can_mask': 0x7ff}]))
+
+For further details on python-can check: https://python-can.readthedocs.io/en/2.1.0/
+
+Setup
+-----
+
+Hardware Setup
+^^^^^^^^^^^^^^
+
+Beagle Bone Black Operating System Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. | **Download an Image**
+   | The latest Debian Linux image can be found at the website
+   | ``https://beagleboard.org/latest-images``. Choose the BeagleBone
+     Black IoT version and download it.
+
+   ::
+
+       wget https://debian.beagleboard.org/images/bone-debian-8.7\
+       -iot-armhf-2017-03-19-4gb.img.xz
+
+
+   After the download, copy it to an SD-Card with minimum 4 GB storage.
+
+   ::
+
+       xzcat bone-debian-8.7-iot-armhf-2017-03-19-4gb.img.xz | \
+       sudo dd of=/dev/xvdj
+
+
+#. | **Enable WiFi**
+   | USB-WiFi dongles are well supported by Debian Linux. Login over SSH
+     on the BBB and add the WiFi network credentials to the file
+     ``/var/lib/connman/wifi.config``. If a USB-WiFi dongle is not
+     available, it is also possible to share the host’s internet
+     connection with the Ethernet connection of the BBB emulated over
+     USB. A tutorial to share the host network connection can be found
+     on this page:
+   | ``https://elementztechblog.wordpress.com/2014/12/22/sharing-internet -using-network-over-usb-in-beaglebone-black/``.
+   | Login as root onto the BBB:
+
+   ::
+
+       ssh debian@192.168.7.2
+       sudo su
+
+
+   Provide the WiFi login credentials to connman:
+
+   ::
+
+       echo "[service_home]
+       Type = wifi
+       Name = ssid
+       Security = wpa
+       Passphrase = xxxxxxxxxxxxx" \
+       > /var/lib/connman/wifi.config
+
+
+   Restart the connman service:
+
+   ::
+
+       systemctl restart connman.service
+
+
+#. | **Install Required Packages**
+   | This step is required to install all necessary software packages to
+     continue with the modification of the BBB device tree overlay.
+
+   ::
+
+       apt-get update
+       apt-get -y upgrade
+       exit
+       git clone https://github.com/beagleboard/bb.org-overlays
+       cd ./bb.org-overlays
+
+
+   Verify the installed DTC1 version to ensure that the DTC1 is suitable
+   for the downloaded overlays. Version 1.4.1 or higher is required.
+
+   ::
+
+       dtc --version
+
+
+   Update the installed DTC1 with an update script in the cloned
+   repository.
+
+   ::
+
+       ./dtc-overlay.sh
+
+
+   Compile all delivered DTS files and install the DTBO onto the current
+   system. Again, a delivered script simplifies this job.
+
+   ::
+
+       ./install.sh
+
+
+   Now, the operating system and the device tree are ready for
+   modifications.
+
+Dual-CAN Setup
+~~~~~~~~~~~~~~
+
+#. | **Create a CAN0 Overlay**
+   | Inside the DTS folder, create a file with the content of the
+     following listing.
+
+   ::
+
+       cd ~/bb.org-overlays/src/arm
+       cat <<EOF > BB-CAN0-00A0.dts
+
+       /dts-v1/;
+       /plugin/;
+
+       #include <dt-bindings/board/am335x-bbw-bbb-base.h>
+       #include <dt-bindings/pinctrl/am33xx.h>
+
+       / {
+           compatible = "ti,beaglebone", \
+           "ti,beaglebone-black", "ti,beaglebone-green";
+
+           /* identification */
+           part-number = "BB-CAN0";
+           version = "00A0";
+
+           /* state the resources this cape uses */
+           exclusive-use =
+           /* the pin header uses */
+           "P9.19", /* can0_rx */
+           "P9.20", /* can0_tx */
+           /* the hardware ip uses */
+           "dcan0";
+
+           fragment@0 {
+               target = <&am33xx_pinmux>;
+               __overlay__ {
+                bb_dcan0_pins: pinmux_dcan0_pins {
+                   pinctrl-single,pins = <
+                    0x178 0x12 /* d_can0_tx */
+                    0x17C 0x32 /* d_can0_rx */
+                    >;
+                   };
+               };
+           };
+
+           fragment@1 {
+               target = <&dcan0>;
+               __overlay__ {
+                status = "okay";
+                pinctrl-names = "default";
+                pinctrl-0 = <&bb_dcan0_pins>;
+               };
+           };
+       };
+       EOF
+
+
+   Compile the generated file with the delivered Makefile from the
+   repository.
+
+   ::
+
+       cd ../../
+       make
+       sudo make install
+
+
+#. | **Modify the Boot Device Tree Blob**
+   | Backup and decompile the current device tree blob.
+
+   ::
+
+       cp /boot/dtbs/4.4.54-ti-r93/am335x-boneblack.dtb ~/
+       dtc -I dtb -O dts ~/am335x-boneblack.dtb > ~/am335x-boneblack.dts
+
+
+   To free the CAN0 pins of the BBB, used I2C2 pins need to be disabled.
+   This can be done by commenting out the appropriate lines in the DTS
+   file. Search for the pinmux\_i2c2\_pins section and save the modified
+   file with a new name. The BeagleBone community uses the I2C2
+   peripheral module for the communication and identification of
+   extension modules, so called capes. This modification disables the
+   compatibility to any of these capes.
+
+   ::
+
+       vim am335x-boneblack.dts
+
+       895 /* pinmux_i2c2_pins {
+       896     pinctrl-single,pins = <0x178 0x33 0x17c 0x33>;
+       897     linux,phandle = <0x35>;
+       898     phandle = <0x35>;
+       899 };*/
+
+       : wq am335x-boneblack_new.dts
+
+
+   Compile the modified DTS file and replace the original file in the
+   boot partition of the BBB. Reboot the BBB after the replacement.
+
+   ::
+
+       dtc -O dtb -o ~/am335x-boneblack_new.dtb -b 0 ~/am335x-boneblack_new.dts
+
+       cp ~/am335x-boneblack_new.dtb /boot/dtbs/4.4.54-ti-r93/am335x-boneblack.dtb
+
+       reboot
+
+
+#. | **Test the Dual-CAN Setup**
+   | Load the CAN kernel modules and the overlays.
+
+   ::
+
+       sudo su
+       modprobe can
+       modprobe can-dev
+       modprobe can-raw
+
+       echo BB-CAN0 > /sys/devices/platform/bone_capemgr/slots
+       echo BB-CAN1 > /sys/devices/platform/bone_capemgr/slots
+
+
+   Check the output of the Capemanager if both CAN interfaces have been
+   loaded.
+
+   ::
+
+       cat /sys/devices/platform/bone_capemgr/slots
+
+       0: PF----  -1
+       1: PF----  -1
+       2: PF----  -1
+       3: PF----  -1
+       4: P-O-L-   0 Override Board Name,00A0,Override Manuf, BB-CAN0
+       5: P-O-L-   1 Override Board Name,00A0,Override Manuf, BB-CAN1
+
+
+   If something went wrong, ``dmesg`` provides kernel messages to
+   analyze the root of failure.
+
+#. **Optional: Enable Dual-CAN Setup at Boot**
+
+   ::
+
+       echo "modprobe can \
+       modprobe can-dev \
+       modprobe can-raw" >> /etc/modules
+
+       echo "cape_enable=bone_capemgr.enable_partno=BB-CAN0,BB-CAN1" >> /boot/uEnv.txt
+
+       update-initramfs -u
+
+
+ISO-TP Kernel Module Installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A Linux ISO-TP kernel module can be downloaded from this website:
+``https://github.com/ hartkopp/can-isotp.git``. The file
+``README.isotp`` in this repository provides all information and
+necessary steps for downloading and building this kernel module. The
+ISO-TP kernel module should also be added to the ``/etc/modules`` file,
+to load this module automatically at system boot of the BBB.
+
+CAN-Interface Setup
+~~~~~~~~~~~~~~~~~~~
+
+As final step to prepare the BBB’s CAN interfaces for usage, these
+interfaces have to be setup through some terminal commands. The bitrate
+can be chosen to fit the bitrate of a CAN bus under test.
+
+::
+
+    ip link set can0 up type can bitrate 500000
+    ip link set can1 up type can bitrate 500000
+    ifconfig can0 up
+    ifconfig can1 up
+
+Software Setup
+^^^^^^^^^^^^^^
+
+Cannelloni Framework Installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Cannelloni framework is a small application written in C++ to
+transfer CAN data over UDP. In this way, a researcher can map the CAN
+communication of a remote device to its workstation, or even combine
+multiple remote CAN devices on his machine. The framework can be
+downloaded from this website:
+``https://github.com/mguentner/cannelloni.git``. The ``README.md`` file
+explains the installation and usage in detail. Cannelloni needs virtual
+CAN interfaces on the operators machine. The next listing shows the
+setup of virtual CAN interfaces.
+
+::
+
+    modprobe vcan
+
+    ip link add name vcan0 type vcan
+    ip link add name vcan1 type vcan
+
+    ip link set dev vcan0 up
+    ip link set dev vcan1 up
+
+    tc qdisc add dev vcan0 root tbf rate 300kbit latency 100ms burst 1000
+    tc qdisc add dev vcan1 root tbf rate 300kbit latency 100ms burst 1000
+
+    cannelloni -I vcan0 -R <remote-IP> -r 20000 -l 20000 &
+    cannelloni -I vcan1 -R <remote-IP> -r 20001 -l 20001 &
+
+
+

--- a/scapy/contrib/cansocket.py
+++ b/scapy/contrib/cansocket.py
@@ -1,0 +1,40 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more informations
+# Copyright (C) Nils Weiss <nils@we155.de>
+# This program is published under a GPLv2 license
+
+
+"""
+CANSocket.
+"""
+
+from scapy.error import log_loading
+from scapy.consts import LINUX
+from scapy.config import conf
+import scapy.modules.six as six
+
+PYTHON_CAN = False
+
+try:
+    if conf.contribs['CANSocket']['use-python-can']:
+        from can import BusABC as can_BusABC    # noqa: F401
+        PYTHON_CAN = True
+except ImportError:
+    log_loading.info("Can't import python-can.")
+except KeyError:
+    log_loading.info("Specify 'conf.contribs['CANSocket'] = "
+                     "{'use-python-can': True}' to enable python-can.")
+
+
+if PYTHON_CAN:
+    from scapy.contrib.cansocket_python_can import (CANSocket,   # noqa: F401
+                                                    srcan, CANSocketTimeoutElapsed, CAN_FRAME_SIZE, CAN_INV_FILTER)
+elif LINUX and six.PY3:
+    log_loading.info("Use native CANSocket. Specify "
+                     "'conf.contribs['CANSocket'] = "
+                     "{'use-python-can': True}' to enable python-can.")
+    from scapy.contrib.cansocket_native import (CANSocket,   # noqa: F401
+                                                srcan, CAN_FRAME_SIZE, CAN_INV_FILTER)
+else:
+    log_loading.info("No CAN support available. Install python-can or "
+                     "use Linux and python3.")

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -1,0 +1,118 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more informations
+# Copyright (C) Nils Weiss <nils@we155.de>
+# This program is published under a GPLv2 license
+
+
+"""
+Native CANSocket.
+"""
+
+import struct
+import socket
+import time
+from scapy.config import conf
+from scapy.supersocket import SuperSocket
+from scapy.error import Scapy_Exception, warning
+from scapy.layers.can import CAN
+from scapy.packet import Padding
+from scapy.arch.linux import get_last_packet_timestamp
+
+conf.contribs['NativeCANSocket'] = {'iface': "can0"}
+
+CAN_FRAME_SIZE = 16
+CAN_INV_FILTER = 0x20000000
+
+
+class CANSocket(SuperSocket):
+    desc = "read/write packets at a given CAN interface using PF_CAN sockets"
+
+    def __init__(self, iface=None, receive_own_messages=False,
+                 can_filters=None, remove_padding=True):
+        self.remove_padding = remove_padding
+        self.iface = conf.contribs['NativeCANSocket']['iface'] if \
+            iface is None else iface
+        self.ins = socket.socket(socket.PF_CAN,
+                                 socket.SOCK_RAW,
+                                 socket.CAN_RAW)
+        try:
+            self.ins.setsockopt(socket.SOL_CAN_RAW,
+                                socket.CAN_RAW_RECV_OWN_MSGS,
+                                struct.pack("i", receive_own_messages))
+        except Exception as exception:
+            Scapy_Exception("Could not modify receive own messages (%s)",
+                            exception)
+
+        if can_filters is None:
+            can_filters = [{
+                "can_id": 0,
+                "can_mask": 0
+            }]
+
+        can_filter_fmt = "={}I".format(2 * len(can_filters))
+        filter_data = []
+        for can_filter in can_filters:
+            filter_data.append(can_filter["can_id"])
+            filter_data.append(can_filter["can_mask"])
+
+        self.ins.setsockopt(socket.SOL_CAN_RAW,
+                            socket.CAN_RAW_FILTER,
+                            struct.pack(can_filter_fmt, *filter_data))
+
+        self.ins.bind((iface,))
+        self.outs = self.ins
+
+    def recv(self, x=CAN_FRAME_SIZE):
+        try:
+            pkt, sa_ll = self.ins.recvfrom(x)
+        except BlockingIOError:
+            warning("Captured no data, socket in non-blocking mode.")
+            return None
+        except socket.timeout:
+            warning("Captured no data, socket read timed out.")
+            return None
+        except OSError:
+            # something bad happened (e.g. the interface went down)
+            warning("Captured no data.")
+            return None
+
+        # need to change the byteoder of the first four bytes,
+        # required by the underlaying Linux SocketCAN frame format
+        pkt = struct.pack("<I12s", *struct.unpack(">I12s", pkt))
+        len = pkt[4]
+        canpkt = CAN(pkt[:len + 8])
+        canpkt.time = get_last_packet_timestamp(self.ins)
+        if self.remove_padding:
+            return canpkt
+        else:
+            return canpkt / Padding(pkt[len + 8:])
+
+    def send(self, x):
+        try:
+            if hasattr(x, "sent_time"):
+                x.sent_time = time.time()
+
+            # need to change the byteoder of the first four bytes,
+            # required by the underlaying Linux SocketCAN frame format
+            bs = bytes(x)
+            bs = bs + b'\x00' * (CAN_FRAME_SIZE - len(bs))
+            bs = struct.pack("<I12s", *struct.unpack(">I12s", bs))
+            return SuperSocket.send(self, bs)
+        except socket.error as msg:
+            raise msg
+
+    @staticmethod
+    def is_python_can_socket():
+        """Function used to determine if a socket is a python-can CANSocket.
+        This is used from sendrecv, to determine if a non standard _get_pkt()
+        and _select() function needs to be used."""
+        return False
+
+
+@conf.commands.register
+def srcan(pkt, iface=None, receive_own_messages=False,
+          canfilter=None, *args, **kargs):
+    s = CANSocket(iface, receive_own_messages, canfilter)
+    a, b = s.sr(pkt, *args, **kargs)
+    s.close()
+    return a, b

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -1,0 +1,84 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more informations
+# Copyright (C) Nils Weiss <nils@we155.de>
+# This program is published under a GPLv2 license
+
+
+"""
+Python-CAN CANSocket Wrapper.
+"""
+
+import time
+from scapy.config import conf
+from scapy.supersocket import SuperSocket
+from scapy.error import warning, Scapy_Exception
+from scapy.layers.can import CAN
+from can import BusABC as can_BusABC
+from can import Message as can_Message
+from can import CanError as can_Error
+
+CAN_FRAME_SIZE = 16
+CAN_INV_FILTER = 0x20000000
+
+
+class CANSocketTimeoutElapsed(Scapy_Exception):
+    pass
+
+
+class CANSocket(SuperSocket):
+    desc = "read/write packets at a given CAN interface " \
+           "using a python-can bus object"
+
+    def __init__(self, iface=None):
+        if issubclass(type(iface), can_BusABC):
+            self.iface = iface
+            self.ins = None
+            self.outs = None
+        else:
+            warning("Provide a python-can interface")
+
+    def recv(self):
+        msg = self.iface.recv(timeout=1)
+        if msg is None:
+            raise CANSocketTimeoutElapsed
+        frame = CAN(identifier=msg.arbitration_id,
+                    length=msg.dlc,
+                    data=bytes(msg.data))
+        if msg.is_error_frame:
+            frame.flags |= 0x1
+        if msg.is_remote_frame:
+            frame.flags |= 0x2
+        if msg.is_extended_id:
+            frame.flags |= 0x4
+        frame.time = msg.timestamp
+        return frame
+
+    def send(self, x):
+        try:
+            if hasattr(x, "sent_time"):
+                x.sent_time = time.time()
+
+            msg = can_Message(is_remote_frame=x.flags == 0x2,
+                              extended_id=x.flags == 0x4,
+                              is_error_frame=x.flags == 0x1,
+                              arbitration_id=x.identifier,
+                              dlc=x.length,
+                              data=x.data)
+            return self.iface.send(msg)
+        except can_Error as ex:
+            raise ex
+
+    @staticmethod
+    def is_python_can_socket():
+        """Function used to determine if a socket is a python-can CANSocket.
+        This is used from sendrecv, to determine if a non standard _get_pkt()
+        and _select() function needs to be used."""
+        return True
+
+
+@conf.commands.register
+def srcan(pkt, iface=None, *args, **kargs):
+    s = CANSocket(iface)
+    a, b = s.sr(pkt, *args, **kargs)
+    s.close()
+    return a, b

--- a/test/cansocket_native.uts
+++ b/test/cansocket_native.uts
@@ -1,0 +1,333 @@
+% Regression tests for nativecansocket
+
+# More informations at http://www.secdev.org/projects/UTscapy/
+
+
+############
+############
++ Configuration of CAN virtual sockets
+
+= Load module
+~ conf command needs_root linux
+
+import scapy.modules.six as six
+
+if six.PY3:
+    load_layer("can")
+    conf.contribs['CANSocket'] = {'use-python-can': False}
+    from scapy.contrib.cansocket_native import *
+
+= Setup string for vcan
+~ conf command
+    bashCommand = "/bin/bash -c 'sudo modprobe vcan; sudo ip link add name vcan0 type vcan; sudo ip link set dev vcan0 up'"
+
+= Load os
+~ conf command needs_root linux
+
+import os
+import threading
+from time import sleep
+
+= Setup vcan0
+~ conf command needs_root linux
+
+if six.PY3:
+    0 == os.system(bashCommand)
+
++ Basic Packet Tests()
+= CAN Packet init
+~ needs_root linux
+
+if six.PY3:
+    canframe = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    bytes(canframe) == b'\x00\x00\x07\xff\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08'
+
++ Basic Socket Tests()
+= CAN Socket Init
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface="vcan0")
+
+= CAN Socket send recv small packet
+~ needs_root linux
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x7ff,length=1,data=b'\x01'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    rx = sock1.recv()
+    rx == CAN(identifier=0x7ff,length=1,data=b'\x01')
+
+= CAN Socket send recv
+~ needs_root linux
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    rx = sock1.recv()
+    rx == CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
++ Advanced Socket Tests()
+= CAN Socket sr1
+~ needs_root linux
+
+if six.PY3:
+    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
+= CAN Socket sr1 init time
+~ needs_root linux
+
+if six.PY3:
+    tx.sent_time == None
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(tx)
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    rx = None
+    rx = sock1.sr1(tx)
+    rx == tx
+
+= CAN Socket sr1 time check
+~ needs_root linux
+
+if six.PY3:
+    tx.sent_time < rx.time and rx.time > 0
+
+= srcan
+~ needs_root linux
+
+if six.PY3:
+    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
+= srcan check init time
+~ needs_root linux
+
+if six.PY3:
+    tx.sent_time == None
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(tx)
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    rx = None
+    rx = srcan(tx, "vcan0", timeout=1)
+    rx = rx[0][0][1]
+    tx == rx
+
+= srcan check rx and tx
+~ needs_root linux
+
+if six.PY3:
+    tx.sent_time > 0 and rx.time > 0 and tx.sent_time < rx.time
+
+= sniff with filtermask 0x7ff
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 3
+
+= sniff with filtermask 0x700
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x700}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x212, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x2ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x2aa, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 4
+
+= sniff with filtermask 0x0ff
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x0ff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x301, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 4
+
+= sniff with multiple filters
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}, {'can_id': 0x400, 'can_mask': 0x7ff}, {'can_id': 0x600, 'can_mask': 0x7ff},  {'can_id': 0x7ff, 'can_mask': 0x7ff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x400, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x500, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x600, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x7ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 4
+
+= sniff with filtermask 0x7ff and inverse filter
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200 | CAN_INV_FILTER, 'can_mask': 0x7ff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 2
+
+= sniff with filtermask 0x1FFFFFFF
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000, 'can_mask': 0x1fffffff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.1)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 2
+
+= sniff with filtermask 0x1FFFFFFF and inverse filter
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000 | CAN_INV_FILTER, 'can_mask': 0x1fffffff}])
+
+if six.PY3:
+    def sender():
+        sleep(0.2)
+        sock2 = CANSocket(iface="vcan0")
+        sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+if six.PY3:
+    thread = threading.Thread(target=sender)
+    thread.start()
+    packets = sock1.sniff(timeout=0.3)
+    len(packets) == 4
+
+= CAN Socket sr1 with receive own messages
+~ needs_root linux
+
+if six.PY3:
+    sock1 = CANSocket(iface="vcan0", receive_own_messages=True)
+    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    rx = None
+    rx = sock1.sr1(tx)
+    tx == rx
+    tx.sent_time < rx.time and tx == rx and rx.time > 0
+
+= srcan
+~ needs_root linux
+
+if six.PY3:
+    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    rx = None
+    rx = srcan(tx, iface="vcan0", receive_own_messages=True, timeout=1)
+    tx == rx[0][0][1]

--- a/test/cansocket_python_can.uts
+++ b/test/cansocket_python_can.uts
@@ -1,0 +1,272 @@
+% Regression tests for the CANSocket
+
+# More informations at http://www.secdev.org/projects/UTscapy/
+
+
+############
+############
++ Configuration of CAN virtual sockets
+
+= Load module
+~ conf command
+~ needs_root
+~ linux
+
+load_layer("can")
+conf.contribs['CANSocket'] = {'use-python-can': True}
+
+from scapy.contrib.cansocket_python_can import *
+
+import can
+
+= Setup string for vcan
+~ conf command
+bashCommand = "/bin/bash -c 'sudo modprobe vcan; sudo ip link add name vcan0 type vcan; sudo ip link set dev vcan0 up'"
+
+= Load os
+~ conf command
+~ needs_root
+~ linux
+
+import os
+import threading
+from time import sleep
+
+= Setup vcan0
+~ conf command
+~ needs_root
+~ linux
+
+0 == os.system(bashCommand)
+
++ Basic Packet Tests()
+= CAN Packet init
+~ needs_root
+~ linux
+
+canframe = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+bytes(canframe) == b'\x00\x00\x07\xff\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08'
+
++ Basic Socket Tests()
+= CAN Socket Init
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+
+= CAN Socket send recv small packet
+~ needs_root
+~ linux
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x7ff,length=1,data=b'\x01'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+rx = sock1.recv()
+rx.show()
+bytes(rx)
+rx == CAN(identifier=0x7ff,length=1,data=b'\x01')
+
+= CAN Socket send recv
+~ needs_root
+~ linux
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+rx = sock1.recv()
+rx == CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+
+
+= sniff with filtermask 0x7ff
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000, can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 3
+
+= sniff with filtermask 0x700
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000, can_filters=[{'can_id': 0x200, 'can_mask': 0x700}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x212, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x2ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x2aa, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
+
+= sniff with filtermask 0x0ff
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000, can_filters=[{'can_id': 0x200, 'can_mask': 0xff}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x301, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
+
+= sniff with multiple filters
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000,
+                                          can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x400, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x600, 'can_mask': 0x7ff},
+                                                     {'can_id': 0x7ff, 'can_mask': 0x7ff}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x400, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x500, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x600, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x7ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
+
+= sniff with filtermask 0x7ff and inverse filter
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000,
+                                          can_filters=[{'can_id': 0x200 | CAN_INV_FILTER, 'can_mask': 0x7ff}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 2
+
+= sniff with filtermask 0x1FFFFFFF
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000,
+                                          can_filters=[{'can_id': 0x10000000, 'can_mask': 0x1fffffff}]))
+
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 2
+
+= sniff with filtermask 0x1FFFFFFF and inverse filter
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000,
+                                          can_filters=[{'can_id': 0x10000000 | CAN_INV_FILTER, 'can_mask': 0x1fffffff}]))
+
+def sender():
+    sleep(0.2)
+    sock2 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000))
+    sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+
+thread = threading.Thread(target=sender)
+thread.start()
+
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
+
+= CAN Socket sr1 with receive own messages
+~ needs_root
+~ linux
+
+sock1 = CANSocket(iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000, receive_own_messages=True))
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+rx = None
+rx = sock1.sr1(tx)
+tx == rx
+#this test can be enabled after issue #1199 is fixed
+#tx.sent_time < rx.time and tx == rx and rx.time > 0
+
+= srcan
+~ needs_root
+~ linux
+
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+rx = None
+rx = srcan(tx, iface=can.interface.Bus(bustype='socketcan', channel='vcan0', bitrate=250000, receive_own_messages=True), timeout=1)
+tx == rx[0][0][1]

--- a/test/configs/osx.utsc
+++ b/test/configs/osx.utsc
@@ -5,7 +5,9 @@
   ],
   "remove_testfiles": [
     "test/linux.uts",
-    "test/mock_windows.uts"
+    "test/mock_windows.uts",
+    "test/cansocket_native.uts",
+    "test/cansocket_python_can.uts"
   ],
   "onlyfailed": true,
   "preexec": {

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -3,6 +3,10 @@
     "test\\*.uts",
     "scapy\\contrib\\*.uts"
   ],
+  "remove_testfiles": [
+    "test\\cansocket_native.uts",
+    "test\\cansocket_python_can.uts"
+  ],
   "onlyfailed": true,
   "preexec": {
     "scapy\\contrib\\*.uts": "load_contrib(\"%name%\")",

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -3,6 +3,10 @@
     "*.uts",
     "..\\scapy\\contrib\\*.uts"
   ],
+  "remove_testfiles": [
+    "test\\cansocket_native.uts",
+    "test\\cansocket_python_can.uts"
+  ],
   "onlyfailed": true,
   "preexec": {
     "..\\scapy\\contrib\\*.uts": "load_contrib(\"%name%\")",

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv = SCAPY_ROOT_DIR={env:PWD}
 deps = mock
        {py27,py34,py35,py36}: cryptography
        coverage
+       python-can
 
 platform =
   linux_non_root,linux_root: linux


### PR DESCRIPTION
Hi, 
here is a new version of my CANSocket implementation.
This time, I also add a wrapper for python-can. This allows the usage of CANSockets on Python 2.
The padding is now handled, as we discussed it, in the previous pull requests. 
Greetings Nils