### PR TITLE
Use flake8 to find and fix undefined names

### DIFF
--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -211,4 +211,3 @@ def _tls_aead_auth_decrypt(alg, c, read_seq_num):
         return None
     return p
 
-

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -6,7 +6,9 @@
 """
 TLS helpers, provided as out-of-context methods.
 """
+import struct
 
+from scapy.compat import raw
 from scapy.error import warning
 from scapy.fields import (ByteEnumField, ShortEnumField,
                           FieldLenField, StrLenField)
@@ -172,11 +174,11 @@ def _tls_aead_auth_encrypt(alg, p, write_seq_num):
     authenticated data. Note that it is the caller's responsibility to increment
     write_seq_num afterwards.
     """
-    P = str(p)
+    P = raw(p)
     write_seq_num = struct.pack("!Q", write_seq_num)
     A = write_seq_num + P[:5]
 
-    c = TLCCiphertext()
+    c = TLSCiphertext()
     c.type = p.type
     c.version = p.version
     c.fragment = alg.auth_encrypt(P, A)
@@ -208,4 +210,3 @@ def _tls_aead_auth_decrypt(alg, c, read_seq_num):
     if p.fragment is None: # Verification failed.
         return None
     return p
-

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -210,3 +210,5 @@ def _tls_aead_auth_decrypt(alg, c, read_seq_num):
     if p.fragment is None: # Verification failed.
         return None
     return p
+
+

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -55,11 +55,11 @@ def _probe_config_file(cf):
 def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True):
     """Read a config file: execute a python file while loading scapy, that may contain
     some pre-configured values.
-
+     
     If _globals or _locals are specified, they will be updated with the loaded vars.
     This allows an external program to use the function. Otherwise, vars are only available
     from inside the scapy console.
-
+     
     params:
     - _globals: the globals() vars
     - _locals: the locals() vars
@@ -84,7 +84,7 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True
         if interactive:
             raise
         log_loading.exception("Error during evaluation of config file [%s]", cf)
-
+        
 def _validate_local(x):
     """Returns whether or not a variable should be imported.
     Will return False for any default modules (sys), or if
@@ -191,8 +191,8 @@ def list_contrib(name=None):
 
 
 
-
-
+	
+	
 
 ##############################
 ## Session saving/restoring ##
@@ -245,7 +245,7 @@ def save_session(fname=None, session=None, pickleProto=-1):
          os.rename(fname, fname+".bak")
     except OSError:
          pass
-
+    
     f=gzip.open(fname,"wb")
     six.moves.cPickle.dump(to_be_saved, f, pickleProto)
     f.close()
@@ -274,7 +274,7 @@ def load_session(fname=None):
     update_ipython_session(scapy_session)
 
     log_loading.info("Loaded session [%s]" % fname)
-
+    
 def update_session(fname=None):
     """Update current Scapy session from the file specified in the fname arg.
 
@@ -293,13 +293,13 @@ def update_session(fname=None):
 def init_session(session_name, mydict=None):
     global SESSION
     global GLOBKEYS
-
+    
     scapy_builtins = {k: v for k, v in six.iteritems(importlib.import_module(".all", "scapy").__dict__) if _validate_local(k)}
     six.moves.builtins.__dict__.update(scapy_builtins)
     GLOBKEYS.extend(scapy_builtins)
     GLOBKEYS.append("scapy_session")
     scapy_builtins=None # XXX replace with "with" statement
-
+    
     if session_name:
         try:
             os.stat(session_name)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -189,10 +189,10 @@ def list_contrib(name=None):
                 desc[key] = value
         print("%(name)-20s: %(description)-40s status=%(status)s" % desc)
 
+                        
 
 
-
-
+    
 
 ##############################
 ## Session saving/restoring ##

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -55,11 +55,11 @@ def _probe_config_file(cf):
 def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True):
     """Read a config file: execute a python file while loading scapy, that may contain
     some pre-configured values.
-     
+    
     If _globals or _locals are specified, they will be updated with the loaded vars.
     This allows an external program to use the function. Otherwise, vars are only available
     from inside the scapy console.
-     
+    
     params:
     - _globals: the globals() vars
     - _locals: the locals() vars
@@ -191,8 +191,8 @@ def list_contrib(name=None):
 
 
 
-	
-	
+
+
 
 ##############################
 ## Session saving/restoring ##

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -123,7 +123,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
     def show(self, *args, **kargs):
         """Best way to display the packet list. Defaults to nsummary() method"""
         return self.nsummary(*args, **kargs)
-
+    
     def filter(self, func):
         """Returns a packet list filtered by a truth function"""
         return self.__class__([x for x in self.res if func(x)],
@@ -283,7 +283,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                         p.sprintf("%.time%"),
                                         self._elt2sum(res)))
                     hexdump(p.getlayer(conf.padding_layer).load)
-
+        
 
     def conversations(self, getsrcdst=None,**kargs):
         """Graphes a conversations between sources and destinations and display it
@@ -326,7 +326,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             gr += '\t "%s" -> "%s" [label="%s"]\n' % (
                 s, d, ', '.join(str(x) for x in l) if isinstance(l, set) else l
             )
-        gr += "}\n"
+        gr += "}\n"        
         return do_graph(gr, **kargs)
 
     def afterglow(self, src=None, event=None, dst=None, **kargs):
@@ -381,7 +381,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         mins, maxs = minmax(x for x, _ in six.itervalues(sl))
         mine, maxe = minmax(x for x, _ in six.itervalues(el))
         mind, maxd = minmax(six.itervalues(dl))
-
+    
         gr = 'digraph "afterglow" {\n\tedge [len=2.5];\n'
 
         gr += "# src nodes\n"
@@ -400,12 +400,12 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         for s in sl:
             n,l = sl[s]
             for e in l:
-                gr += ' "src.%s" -> "evt.%s";\n' % (repr(s),repr(e))
+                gr += ' "src.%s" -> "evt.%s";\n' % (repr(s),repr(e)) 
         for e in el:
             n,l = el[e]
             for d in l:
-                gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d))
-
+                gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d)) 
+        
         gr += "}"
         return do_graph(gr, **kargs)
 
@@ -424,8 +424,8 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                        margin=1*pyx.unit.t_cm,
                                        fittosize=1))
         return d
-
-
+                    
+                
 
     def psdump(self, filename = None, **kargs):
         """Creates a multi-page postcript file with a psdump of every packet
@@ -440,7 +440,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         else:
             d.writePSfile(filename)
         print()
-
+        
     def pdfdump(self, filename = None, **kargs):
         """Creates a PDF file with a psdump of every packet
         filename: name of the file to write to. If empty, a temporary file is used and
@@ -516,7 +516,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             sess = session_extractor(self._elt2pkt(p))
             sessions[sess].append(p)
         return dict(sessions)
-
+    
     def replace(self, *args, **kargs):
         """
         lst.replace(<field>,[<oldvalue>,]<newvalue>)
@@ -558,4 +558,4 @@ class SndRcvList(PacketList):
     def _elt2pkt(self, elt):
         return elt[1]
     def _elt2sum(self, elt):
-        return "%s ==> %s" % (elt[0].summary(),elt[1].summary())
+        return "%s ==> %s" % (elt[0].summary(),elt[1].summary()) 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -15,8 +15,8 @@ from collections import defaultdict
 
 from scapy.config import conf
 from scapy.base_classes import BasePacket,BasePacketList
-from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table, \
-    get_temp_file, issubtype
+from scapy.utils import ContextManagerSubprocess,do_graph,hexdump,make_table, \
+    make_lined_table,make_tex_table,get_temp_file,issubtype
 from scapy.extlib import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
 import scapy.modules.six as six
@@ -123,7 +123,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
     def show(self, *args, **kargs):
         """Best way to display the packet list. Defaults to nsummary() method"""
         return self.nsummary(*args, **kargs)
-    
+
     def filter(self, func):
         """Returns a packet list filtered by a truth function"""
         return self.__class__([x for x in self.res if func(x)],
@@ -283,7 +283,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                         p.sprintf("%.time%"),
                                         self._elt2sum(res)))
                     hexdump(p.getlayer(conf.padding_layer).load)
-        
+
 
     def conversations(self, getsrcdst=None,**kargs):
         """Graphes a conversations between sources and destinations and display it
@@ -326,7 +326,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             gr += '\t "%s" -> "%s" [label="%s"]\n' % (
                 s, d, ', '.join(str(x) for x in l) if isinstance(l, set) else l
             )
-        gr += "}\n"        
+        gr += "}\n"
         return do_graph(gr, **kargs)
 
     def afterglow(self, src=None, event=None, dst=None, **kargs):
@@ -381,7 +381,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         mins, maxs = minmax(x for x, _ in six.itervalues(sl))
         mine, maxe = minmax(x for x, _ in six.itervalues(el))
         mind, maxd = minmax(six.itervalues(dl))
-    
+
         gr = 'digraph "afterglow" {\n\tedge [len=2.5];\n'
 
         gr += "# src nodes\n"
@@ -400,12 +400,12 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         for s in sl:
             n,l = sl[s]
             for e in l:
-                gr += ' "src.%s" -> "evt.%s";\n' % (repr(s),repr(e)) 
+                gr += ' "src.%s" -> "evt.%s";\n' % (repr(s),repr(e))
         for e in el:
             n,l = el[e]
             for d in l:
-                gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d)) 
-            
+                gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d))
+
         gr += "}"
         return do_graph(gr, **kargs)
 
@@ -424,8 +424,8 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                        margin=1*pyx.unit.t_cm,
                                        fittosize=1))
         return d
-                     
-                 
+
+
 
     def psdump(self, filename = None, **kargs):
         """Creates a multi-page postcript file with a psdump of every packet
@@ -440,7 +440,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         else:
             d.writePSfile(filename)
         print()
-        
+
     def pdfdump(self, filename = None, **kargs):
         """Creates a PDF file with a psdump of every packet
         filename: name of the file to write to. If empty, a temporary file is used and
@@ -516,7 +516,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             sess = session_extractor(self._elt2pkt(p))
             sessions[sess].append(p)
         return dict(sessions)
-    
+
     def replace(self, *args, **kargs):
         """
         lst.replace(<field>,[<oldvalue>,]<newvalue>)
@@ -558,4 +558,4 @@ class SndRcvList(PacketList):
     def _elt2pkt(self, elt):
         return elt[1]
     def _elt2sum(self, elt):
-        return "%s ==> %s" % (elt[0].summary(),elt[1].summary()) 
+        return "%s ==> %s" % (elt[0].summary(),elt[1].summary())

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -405,7 +405,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             n,l = el[e]
             for d in l:
                 gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d)) 
-        
+             
         gr += "}"
         return do_graph(gr, **kargs)
 
@@ -424,8 +424,8 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
                                        margin=1*pyx.unit.t_cm,
                                        fittosize=1))
         return d
-                    
-                
+                     
+                 
 
     def psdump(self, filename = None, **kargs):
         """Creates a multi-page postcript file with a psdump of every packet

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from scapy.config import conf
 from scapy.base_classes import BasePacket,BasePacketList
 from scapy.utils import ContextManagerSubprocess,do_graph,hexdump,make_table, \
-    make_lined_table,make_tex_table,get_temp_file,issubtype
+    make_lined_table,make_tex_table,get_temp_file, issubtype
 from scapy.extlib import plt, MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
 import scapy.modules.six as six
@@ -405,7 +405,7 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             n,l = el[e]
             for d in l:
                 gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e),repr(d)) 
-             
+            
         gr += "}"
         return do_graph(gr, **kargs)
 


### PR DESCRIPTION
$ __python3 -m flake8 . --count --select=E9,F82 --show-source --statistics__

This is a great way to find syntax errors and undefined names in a code base when ensuring compatibility with both Python 2 and Python 3.  This PR uses this approach to find and fix issues that have the potential to raise __NameError__ at runtime.