### PR TITLE
sniff - don't delete socket on recv NULL if in promisc mode #1190

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -647,10 +647,6 @@ class ScapyInvalidPlatformException(Scapy_Exception):
     pass
 
 
-class VEthPairManagementException(Scapy_Exception):
-    pass
-
-
 class VEthPair(object):
     """
     encapsulates a virtual Ethernet interface pair
@@ -664,55 +660,46 @@ class VEthPair(object):
 
         self.ifaces = [iface_name, peer_name]
 
-        self._setup()
-
     def iface(self):
         return self.ifaces[0]
 
     def peer(self):
         return self.ifaces[1]
 
-    def _setup(self):
+    def setup(self):
         """
-        create virtual Ethernet Interface pair
-        :raises VEthPairManagementException() if operation failed
+        create veth pair links
+        :raises subprocess.CalledProcessError if operation fails
         """
-        ret = subprocess.check_call(['ip', 'link', 'add', self.ifaces[0], 'type', 'veth', 'peer', 'name', self.ifaces[1]])
-        if ret:
-            raise VEthPairManagementException('failed to create veth pair: {}'.format(','.join(self.ifaces)))
+        subprocess.check_call(['ip', 'link', 'add', self.ifaces[0], 'type', 'veth', 'peer', 'name', self.ifaces[1]])
 
-    def _destroy(self):
+    def destroy(self):
         """
-        remove virtual interface pair
-        :raises VEthPairManagementException() if operation failed
+        remove veth pair links
+        :raises subprocess.CalledProcessError if operation failes
         """
-        ret = subprocess.check_call(['ip', 'link', 'del', self.ifaces[0]])
-        if ret:
-            raise VEthPairManagementException('failed to remove veth pair: {}'.format(','.join(self.ifaces)))
+        subprocess.check_call(['ip', 'link', 'del', self.ifaces[0]])
 
-    def _up(self):
+    def up(self):
         """
-        set both interfaces link up
-        :raises VEthPairManagementException() if operation failed
+        set veth pair links up
+        :raises subprocess.CalledProcessError if operation failes
         """
         for idx in [0, 1]:
-            ret = subprocess.check_call(["ip", "link", "set", self.ifaces[idx], "up"])
-            if ret:
-                raise VEthPairManagementException('failed to set veth {} link up'.format(self.ifaces[idx]))
+            subprocess.check_call(["ip", "link", "set", self.ifaces[idx], "up"])
 
-    def _down(self):
+    def down(self):
         """
-        set both interfaces link down
-        :raises VEthPairManagementException() if operation failed
+        set veth pair links down
+        :raises subprocess.CalledProcessError if operation failes
         """
         for idx in [0, 1]:
-            ret = subprocess.check_call(["ip", "link", "set", self.ifaces[idx], "down"])
-            if ret:
-                raise VEthPairManagementException('failed to set veth {} link down'.format(self.ifaces[idx]))
+            subprocess.check_call(["ip", "link", "set", self.ifaces[idx], "down"])
 
     def __enter__(self):
-        self._up()
+        self.setup()
+        self.up()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._destroy()
+        self.destroy()

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -767,6 +767,11 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                 except read_allowed_exceptions:
                     continue
                 if p is None:
+                    try:
+                        if s.promisc:
+                            continue
+                    except AttributeError:
+                        pass
                     del sniff_sockets[s]
                     break
                 if lfilter and not lfilter(p):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -640,7 +640,7 @@ iface:    listen answers only on the given interface"""
 @conf.commands.register
 def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
           L2socket=None, timeout=None, opened_socket=None,
-          stop_filter=None, iface=None, *arg, **karg):
+          stop_filter=None, iface=None, started_callback=None, *arg, **karg):
     """
     Sniff packets and return a list of packets.
 
@@ -666,6 +666,8 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
         iface: interface or list of interfaces (default: None for sniffing
                on all interfaces).
         monitor: use monitor mode. May not be available on all OS
+        started_callback: called as soon as the sniffer starts sniffing
+                          (default: None).
 
     The iface, offline and opened_socket parameters can be either an
     element, a list of elements, or a dict object mapping an element to a
@@ -755,6 +757,8 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                     return []
                 raise
     try:
+        if started_callback:
+            started_callback()
         while sniff_sockets:
             if timeout is not None:
                 remain = stoptime - time.time()

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -193,3 +193,31 @@ with patch("scapy.layers.l2.get_if_hwaddr") as mgih:
 
 conf.route6.routes = bck_conf_route6_routes
 conf.iface = bck_conf_iface
+
+= virtual Ethernet interface handling (veth)
+~ linux needs_root veth
+
+with VEthPair('veth_scapy_0', 'veth_scapy_1') as veth:
+    if_list = get_if_list()
+    assert ('veth_scapy_0' in if_list)
+    assert ('veth_scapy_1' in if_list)
+    frm_count = 0
+    def _sniffer():
+        sniffed = sniff(iface='veth_scapy_1',
+                        store=True,
+                        count=2,
+                        lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
+        global frm_count
+        frm_count = 2
+    t_sniffer = Thread(target=_sniffer)
+    t_sniffer.start()
+    time.sleep(1)
+    sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
+          iface='veth_scapy_0',
+          count=2)
+    t_sniffer.join(1)
+    assert(frm_count == 2)
+
+if_list = get_if_list()
+assert ('veth_scapy_0' not in if_list)
+assert ('veth_scapy_1' not in if_list)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -209,6 +209,19 @@ except Exception:
 = veth interface usage - ctx manager
 ~ linux needs_root veth
 
+from threading import Condition
+
+cond_started = Condition()
+
+def _sniffer_started():
+
+    global cond_started
+    cond_started.acquire()
+    cond_started.notify()
+    cond_started.release()
+
+cond_started.acquire()
+
 try:
     with VEthPair('veth_scapy_0', 'veth_scapy_1') as veth:
         if_list = get_if_list()
@@ -219,12 +232,13 @@ try:
             sniffed = sniff(iface='veth_scapy_1',
                             store=True,
                             count=2,
-                            lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
+                            lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
+                            started_callback=_sniffer_started)
             global frm_count
             frm_count = 2
         t_sniffer = Thread(target=_sniffer)
         t_sniffer.start()
-        time.sleep(1)
+        cond_started.wait()
         sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
               iface='veth_scapy_0',
               count=2)
@@ -241,6 +255,20 @@ except Exception:
 
 = veth interface usage - manual interface handling
 ~ linux needs_root veth
+
+from threading import Condition
+
+cond_started = Condition()
+
+def _sniffer_started():
+
+    global cond_started
+    cond_started.acquire()
+    cond_started.notify()
+    cond_started.release()
+
+cond_started.acquire()
+
 
 veth = VEthPair('veth_scapy_0', 'veth_scapy_1')
 try:
@@ -260,13 +288,14 @@ def _sniffer():
     sniffed = sniff(iface='veth_scapy_1',
                     store=True,
                     count=2,
-                    lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
+                    lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
+                    started_callback=_sniffer_started)
     global frm_count
     frm_count = 2
 
 t_sniffer = Thread(target=_sniffer)
 t_sniffer.start()
-time.sleep(1)
+cond_started.wait()
 sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
       iface='veth_scapy_0',
       count=2)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -194,7 +194,19 @@ with patch("scapy.layers.l2.get_if_hwaddr") as mgih:
 conf.route6.routes = bck_conf_route6_routes
 conf.iface = bck_conf_iface
 
-= virtual Ethernet interface handling (veth)
+= veth interface error handling
+~ linux needs_root veth
+
+try:
+    veth = VEthPair('this_IF_name_is_to_long_and_will_cause_an_error', 'veth_scapy_1')
+    veth.setup()
+    assert False
+except subprocess.CalledProcessError:
+    pass
+except Exception:
+    assert False
+
+= veth interface usage
 ~ linux needs_root veth
 
 with VEthPair('veth_scapy_0', 'veth_scapy_1') as veth:

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -206,30 +206,81 @@ except subprocess.CalledProcessError:
 except Exception:
     assert False
 
-= veth interface usage
+= veth interface usage - ctx manager
 ~ linux needs_root veth
 
-with VEthPair('veth_scapy_0', 'veth_scapy_1') as veth:
+try:
+    with VEthPair('veth_scapy_0', 'veth_scapy_1') as veth:
+        if_list = get_if_list()
+        assert ('veth_scapy_0' in if_list)
+        assert ('veth_scapy_1' in if_list)
+        frm_count = 0
+        def _sniffer():
+            sniffed = sniff(iface='veth_scapy_1',
+                            store=True,
+                            count=2,
+                            lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
+            global frm_count
+            frm_count = 2
+        t_sniffer = Thread(target=_sniffer)
+        t_sniffer.start()
+        time.sleep(1)
+        sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
+              iface='veth_scapy_0',
+              count=2)
+        t_sniffer.join(1)
+        assert(frm_count == 2)
+
     if_list = get_if_list()
-    assert ('veth_scapy_0' in if_list)
-    assert ('veth_scapy_1' in if_list)
-    frm_count = 0
-    def _sniffer():
-        sniffed = sniff(iface='veth_scapy_1',
-                        store=True,
-                        count=2,
-                        lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
-        global frm_count
-        frm_count = 2
-    t_sniffer = Thread(target=_sniffer)
-    t_sniffer.start()
-    time.sleep(1)
-    sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
-          iface='veth_scapy_0',
-          count=2)
-    t_sniffer.join(1)
-    assert(frm_count == 2)
+    assert ('veth_scapy_0' not in if_list)
+    assert ('veth_scapy_1' not in if_list)
+except subprocess.CalledProcessError:
+    assert False
+except Exception:
+    assert False
+
+= veth interface usage - manual interface handling
+~ linux needs_root veth
+
+veth = VEthPair('veth_scapy_0', 'veth_scapy_1')
+try:
+    veth.setup()
+    veth.up()
+except subprocess.CalledProcessError:
+    assert False
+except Exception:
+    assert False
 
 if_list = get_if_list()
-assert ('veth_scapy_0' not in if_list)
-assert ('veth_scapy_1' not in if_list)
+assert ('veth_scapy_0' in if_list)
+assert ('veth_scapy_1' in if_list)
+
+frm_count = 0
+def _sniffer():
+    sniffed = sniff(iface='veth_scapy_1',
+                    store=True,
+                    count=2,
+                    lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef)
+    global frm_count
+    frm_count = 2
+
+t_sniffer = Thread(target=_sniffer)
+t_sniffer.start()
+time.sleep(1)
+sendp(Ether(type=0xbeef)/Raw(b'0123456789'),
+      iface='veth_scapy_0',
+      count=2)
+t_sniffer.join(1)
+assert(frm_count == 2)
+
+try:
+    veth.down()
+    veth.destroy()
+
+    if_list = get_if_list()
+    assert ('veth_scapy_0' not in if_list)
+    assert ('veth_scapy_1' not in if_list)
+except subprocess.CalledProcessError:
+    assert False
+except Exception:
+    assert False

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -167,3 +167,45 @@ t_sniff.join()
 
 = Delete the tun interfaces
 del tun0, tun1
+
+############
+############
++ Test bridge_and_sniff() using veth pairs
+~ linux needs_root veth
+
+= Ensure bridge_and_sniff does not close sockets if data is send within xfrm on ingress interface
+
+with VEthPair('a_0', 'a_1') as veth_0:
+    with VEthPair('b_0', 'b_1') as veth_1:
+        xfrm_count = {
+            'a_0':0,
+            'b_0': 0
+        }
+        def xfrm_x(pkt):
+            pkt_tx = pkt.copy()
+            ether_lyr = pkt_tx[Ether]
+            ether_lyr.type = 0x1234  # we send to peer interface - avoid loop
+            # send on receiving interface - triggers return None on recv() in L2Socket
+            sendp(pkt_tx, iface=pkt.sniffed_on)
+            global xfrm_count
+            xfrm_count[pkt.sniffed_on] = xfrm_count[pkt.sniffed_on] + 1
+            return True
+        t_bridge = Thread(target=bridge_and_sniff,
+                          args=('a_0', 'b_0'),
+                          kwargs={
+                              'xfrm12': xfrm_x,
+                              'xfrm21': xfrm_x,
+                              'store': False,
+                              'count': 4,
+                              'lfilter': lambda p: Ether in p and p[Ether].type == 0xbeef})
+        t_bridge.start()
+        time.sleep(1)
+        # send frames in both directions
+        for if_name in ['a_1', 'b_1', 'a_1', 'b_1']:
+            sendp([Ether(type=0xbeef) /
+                   Raw(b'On a scale from one to ten what is your favourite colour of the alphabet?')],
+                  iface=if_name)
+        t_bridge.join(1)
+        # now test of the socket used in bridge_and_sniff() was alive all the time
+        assert (xfrm_count['a_0'] == 2)
+        assert (xfrm_count['b_0'] == 2)


### PR DESCRIPTION
Linux L2Socket returns NULL on recv for outgoing frames <=>
if one sends frames on the interfaces used by bridge_n_sniff
the socket was deleted and bridge_n_sniff stopped working

This is an ugly workaround. Would be much cleaner if recv would
throw an Exception (e.g. ScapyRecvFrameIgnored) - but I guess
this would break the interface...



fixes #1190 