### PR TITLE
ContextManagerSubprocess fix

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -364,9 +364,9 @@ class WinProgPath(ConfClass):
         self._reload()
 
     def _reload(self):
+        self.pdfreader = None
+        self.psreader = None
         # We try some magic to find the appropriate executables
-        self.pdfreader = win_find_exe("AcroRd32") 
-        self.psreader = win_find_exe("gsview32")
         self.dot = win_find_exe("dot")
         self.tcpdump = win_find_exe("windump")
         self.tshark = win_find_exe("tshark")

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -14,6 +14,7 @@ import os,subprocess
 from collections import defaultdict
 
 from scapy.config import conf
+from scapy.consts import WINDOWS
 from scapy.base_classes import BasePacket,BasePacketList
 from scapy.utils import do_graph,hexdump,make_table,make_lined_table,make_tex_table, \
     get_temp_file, issubtype
@@ -435,8 +436,11 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         if filename is None:
             filename = get_temp_file(autoext=".ps")
             d.writePSfile(filename)
-            with ContextManagerSubprocess("psdump()"):
-                subprocess.Popen([conf.prog.psreader, filename+".ps"])
+            if WINDOWS and conf.prog.psreader is None:
+                os.startfile(filename)
+            else:
+                with ContextManagerSubprocess("psdump()", conf.prog.psreader):
+                    subprocess.Popen([conf.prog.psreader, filename])
         else:
             d.writePSfile(filename)
         print()
@@ -449,8 +453,11 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         if filename is None:
             filename = get_temp_file(autoext=".pdf")
             d.writePDFfile(filename)
-            with ContextManagerSubprocess("psdump()"):
-                subprocess.Popen([conf.prog.pdfreader, filename+".pdf"])
+            if WINDOWS and conf.prog.pdfreader is None:
+                os.startfile(filename)
+            else:
+                with ContextManagerSubprocess("pdfdump()", conf.prog.pdfreader):
+                    subprocess.Popen([conf.prog.pdfreader, filename])
         else:
             d.writePDFfile(filename)
         print()

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -435,7 +435,7 @@ class ContextManagerSubprocess(object):
     Context manager that eases checking for unknown command.
 
     Example:
-    >>> with ContextManagerSubprocess("my custom message"):
+    >>> with ContextManagerSubprocess("my custom message", "unknown_command"):
     >>>     subprocess.Popen(["unknown_command"])
 
     """


### PR DESCRIPTION
- This PR: adds a `os.startfile` fallback on psdump and pdfdump when no program is available
- fixes ContextManagerSubprocess calls in plist
- missing safety `print()` to avoid `....>>>`