### PR TITLE
Scapy2.4.0rc5-46: Disabling the snmpwalk test due to unknown instabilities

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10109,4 +10109,4 @@ def test_snmpwalk(dst):
     expected = "No answers\n"
     assert(output == expected)
 
-test_snmpwalk("secdev.org")
+assert True #test_snmpwalk("secdev.org")


### PR DESCRIPTION
Disabling the snmpwalk test due to an unknown but very frequent impact on the instability of other tests  on Apveyor CI and accidentally also on Travis CI.
