### PR TITLE
Multithread sniff

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -467,8 +467,8 @@ class L3PacketSocket(SuperSocket):
         ts = get_last_packet_timestamp(self.ins)
         return cls, pkt, ts
 
-    def recv(self, x=MTU):
-        pkt = SuperSocket.recv(self, x)
+    def recv(self, **kwargs):
+        pkt = SuperSocket.recv(self, **kwargs)
         if pkt and self.lvl == 2:
             pkt = pkt.payload
         return pkt
@@ -613,14 +613,18 @@ class L2ListenSocket(SuperSocket):
                     cls.name)
 
         ts = get_last_packet_timestamp(self.ins)
-        # direction = sa_ll[2]
-        return cls, pkt, ts  # , direction
+        direction = sa_ll[2]
+        return cls, pkt, ts, direction
 
-    def recv(self, x=MTU):
-        # cls, pkt, ts, direction = self.recv_raw()
-        # [Dissection stuff]
-        pkt = SuperSocket.recv(self, x)
-        # pkt.direction = direction
+    def recv(self, x=MTU, raw_data=None):
+        if raw_data is None:
+            raw_data = self.recv_raw(x)
+            if raw_data is None:
+                return None
+        cls, pkt, ts, direction = raw_data
+        pkt = SuperSocket.recv(self, x=x, raw_data=(cls, pkt, ts))
+        if pkt is not None:
+            pkt.direction = direction
         return pkt
 
     def send(self, x):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1058,7 +1058,7 @@ Arguments:
       See help(sniff) for more.
 
     """
-    for arg in ['opened_socket', 'offline', 'iface']:
+    for arg in ['opened_socket', 'offline', 'iface', 'mthread']:
         if arg in kargs:
             log_runtime.warning("Argument %s cannot be used in "
                                 "bridge_and_sniff() -- ignoring it.", arg)
@@ -1115,7 +1115,7 @@ Arguments:
             return prn_orig(pkt)
 
     return sniff(opened_socket={sckt1: if1, sckt2: if2}, prn=prn,
-                 *args, **kargs)
+                 mthread=False, *args, **kargs)
 
 
 @conf.commands.register

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -24,11 +24,11 @@ from scapy.config import conf
 from scapy.packet import Packet, Gen
 from scapy.utils import get_temp_file, PcapReader, tcpdump, wrpcap
 from scapy import plist
-from scapy.error import log_runtime, log_interactive
+from scapy.error import log_runtime, log_interactive, Scapy_Exception, warning
 from scapy.base_classes import SetGen
 from scapy.supersocket import StreamSocket, L3RawSocket, L2ListenTcpdump
 from scapy.modules import six
-from scapy.modules.six.moves import map
+from scapy.modules.six.moves import map, queue
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route
@@ -793,7 +793,8 @@ iface:    listen answers only on the given interface"""
 @conf.commands.register
 def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
           L2socket=None, timeout=None, opened_socket=None,
-          stop_filter=None, iface=None, started_callback=None, *arg, **karg):
+          stop_filter=None, iface=None, started_callback=None,
+          mthread=None, *arg, **karg):
     """
     Sniff packets and return a list of packets.
 
@@ -818,6 +819,8 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                      --Ex: stop_filter = lambda x: x.haslayer(TCP)
         iface: interface or list of interfaces (default: None for sniffing
                on all interfaces).
+        mthread: Use separate threads to recieve and dissect packets. Decrease
+                 packet drop rate.
         monitor: use monitor mode. May not be available on all OS
         started_callback: called as soon as the sniffer starts sniffing
                           (default: None).
@@ -881,6 +884,12 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
         else:
             sniff_sockets[L2socket(type=ETH_P_ALL, iface=iface,
                                    *arg, **karg)] = iface
+    if mthread is None:
+        mthread = (all(hasattr(x, "recv_raw") for x in sniff_sockets) and not conf.use_bpf)  # noqa: E501
+    elif mthread and (any(not hasattr(x, "recv_raw") for x in sniff_sockets)):
+        warning("Multi-threaded mode is not available on one of the provided "
+                "objects ! (recv_raw does not exist)")
+        mthread = False
     lst = []
     if timeout is not None:
         stoptime = time.time() + timeout
@@ -913,9 +922,90 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                 if exc[0] == errno.EINTR:
                     return []
                 raise
+
+    class _InteruptSniff(Scapy_Exception):
+        """Used to interupt sniffing in multi-threading mode"""
+        pass
+
+    def _process_pkt(p, sniff_sockets, c):
+        """Function to process a recieved packet"""
+        if p is None:
+            try:
+                if s.promisc:
+                    return c
+            except AttributeError:
+                pass
+            del sniff_sockets[s]
+            raise _InteruptSniff
+        if lfilter and not lfilter(p):
+            return c
+        p.sniffed_on = sniff_sockets[s]
+        if store:
+            lst.append(p)
+        c += 1
+        if prn:
+            r = prn(p)
+            if r is not None:
+                print(r)
+        if stop_filter and stop_filter(p):
+            sniff_sockets = []
+            raise _InteruptSniff
+        if 0 < count <= c:
+            sniff_sockets = []
+            raise _InteruptSniff
+        return c
+
+    def _async_process(q, stopevent):
+        """Thread that dissects the packets when multi-threading is on"""
+        c = 0
+        try:
+            while not stopevent.is_set():
+                try:
+                    pkt_a, sniff_sockets = q.get_nowait()
+                except queue.Empty:
+                    continue
+                cls, val, ts = pkt_a
+                try:
+                    pkt = cls(val)
+                except Exception:
+                    if conf.debug_dissector:
+                        log_runtime.error(exc_info=True)
+                        stopevent.set()
+                        break
+                    pkt = conf.raw_layer(val)
+                pkt.time = ts
+                try:
+                    c = _process_pkt(pkt, sniff_sockets, c)
+                except _InteruptSniff:
+                    stopevent.set()
+        except KeyboardInterrupt:
+            stopevent.set()
+        del q
+    se = None
+    if mthread:
+        # When multithreading is enabled, the packets are
+        # recieved on the main thread, and dissected in
+        # another thread.
+        q = queue.Queue()
+        se = threading.Event()
+
+        def _append_pkt(p, sniff_sockets, c=None, q=q):
+            q.put((p, sniff_sockets))
+            if se.is_set():
+                raise _InteruptSniff
+        _action_pkt = _append_pkt
+        _read_next = lambda s: s.recv_raw()
+        t = threading.Thread(target=_async_process, args=(q, se))
+        t.deamon = True
+        t.start()
+    else:
+        # Multi-threading disabled
+        _action_pkt = _process_pkt
+        _read_next = lambda s: s.recv()
     try:
         if started_callback:
             started_callback()
+        c = 0
         while sniff_sockets:
             if timeout is not None:
                 remain = stoptime - time.time()
@@ -924,35 +1014,21 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
             ins = _select(sniff_sockets)
             for s in ins:
                 try:
-                    p = s.recv()
+                    p = _read_next(s)
                 except read_allowed_exceptions:
                     continue
-                if p is None:
-                    try:
-                        if s.promisc:
-                            continue
-                    except AttributeError:
-                        pass
-                    del sniff_sockets[s]
-                    break
-                if lfilter and not lfilter(p):
-                    continue
-                p.sniffed_on = sniff_sockets[s]
-                if store:
-                    lst.append(p)
-                c += 1
-                if prn:
-                    r = prn(p)
-                    if r is not None:
-                        print(r)
-                if stop_filter and stop_filter(p):
-                    sniff_sockets = []
-                    break
-                if 0 < count <= c:
-                    sniff_sockets = []
-                    break
+                c = _action_pkt(p, sniff_sockets, c)
     except KeyboardInterrupt:
         pass
+    except _InteruptSniff:
+        pass
+    finally:
+        if mthread:
+            try:
+                se.set()
+            except:
+                pass
+            t.join()
     if opened_socket is None:
         for s in sniff_sockets:
             s.close()

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -47,10 +47,6 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
             x.sent_time = time.time()
         return self.outs.send(sx)
 
-    def recv_raw(self, x=MTU):
-        """Returns a tuple containing (cls, pkt_data, time)"""
-        return conf.raw_layer, self.ins.recv(x), None
-
     def recv(self, x=MTU):
         cls, val, ts = self.recv_raw(x)
         if not val or not cls:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -47,8 +47,15 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
             x.sent_time = time.time()
         return self.outs.send(sx)
 
-    def recv(self, x=MTU):
-        cls, val, ts = self.recv_raw(x)
+    def recv(self, x=MTU, raw_data=None):
+        """Receive a packet, and process it.
+
+        params:
+         - x: maximum packet size (default: MTU)
+         - raw_data: data received from .recv_raw() (default: None)
+                     if None, will be automatically fetched.
+        """
+        cls, val, ts = raw_data if raw_data is not None else self.recv_raw(x)
         if not val or not cls:
             return
         try:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -835,8 +835,11 @@ sync: do not bufferize writes to the capture file
 def rdpcap(filename, count=-1):
     """Read a pcap or pcapng file and return a packet list
 
-count: read only <count> packets
+    params:
+     - count: read only <count> packets
 
+    For a more efficient function, consider using `sniff(offline=...)`
+    See help(sniff) for more informations.
     """
     with PcapReader(filename) as fdesc:
         return fdesc.read_all(count=count)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -231,6 +231,7 @@ try:
         def _sniffer():
             sniffed = sniff(iface='veth_scapy_1',
                             store=True,
+                            mthread=False,
                             count=2,
                             lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
                             started_callback=_sniffer_started)
@@ -287,6 +288,7 @@ frm_count = 0
 def _sniffer():
     sniffed = sniff(iface='veth_scapy_1',
                     store=True,
+                    mthread=False,
                     count=2,
                     lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
                     started_callback=_sniffer_started)

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -27,7 +27,8 @@ else:
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tap1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"}
+            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4",
+            "mthread": False}
 )
 t_sniff.start()
 
@@ -52,7 +53,8 @@ t_sniff.join()
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tap1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5"}
+            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5",
+            "mthread": False}
 )
 t_sniff.start()
 
@@ -114,7 +116,8 @@ else:
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tun1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"}
+            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4",
+            "mthread": False}
 )
 t_sniff.start()
 
@@ -141,7 +144,8 @@ t_sniff.join()
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tun1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5"}
+            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5",
+            "mthread": False}
 )
 t_sniff.start()
 
@@ -273,7 +277,8 @@ def answer_arp_leak(pkt):
 t_answer = Thread(
     target=sniff,
     kwargs={"prn": answer_arp_leak, "timeout": 10, "store": False,
-            "opened_socket": tap0}
+            "opened_socket": tap0,
+            "mthread": False}
 )
 
 t_answer.start()


### PR DESCRIPTION
## What it does

Split the sniffing process into several threads:
- first one doing pcap/libpcap/whatever calls, and storing data in a shared list
- second one constantly dissecting any available packets

To make this work, it was needed to separate dissecting and recieving in the arch/ hooks: introducing `recv_async` (of course name may be changed), which only recieves the packet as raw bytes. It is called by the older `recv()` functions, which will keep the same behavior

This allows to split scapy's processing part from API calls. It free the buffer of the APIs into scapy's one.

## Benchmark

- Start 2 scapy instances

- In the first one:
```python
def stats():
    try:
        i = [0]
        t = time.time()
        on = [True]
        def _t(t=t):
            while on[0]:
                print(str(i[0]/(max(1, time.time()-t))) + " packets / sec")
                time.sleep(3)
        Thread(target=_t).start()
        def _prn(pkt):
            i[0] += 1
        sniff(prn=_prn)
    except KeyboardInterrupt:
        print("Goodbye")
    finally:
        on = [False]
```
- In the second one
```python
a = raw(Ether()/IP())
sendp(a, loop=1)
```

- Finally, in the first instance, type `stats()`

## Results

- On secdev/master

![no_mthread](https://user-images.githubusercontent.com/10530980/37555865-92c06388-29ee-11e8-985b-b26e9ba1eafe.png)

- This branch

![mthread](https://user-images.githubusercontent.com/10530980/37555866-995f32a0-29ee-11e8-8e4d-c3dcd77debf0.png)

Those results already are an average

| Speed test                      | Secdev/master | This PR |
|---------------------------------|---------------|---------|
| Average: Recieved packets / sec | 647           | 1820    |

Edit: this seems wrong, as we are not using multiprocessing but threading, so the measuring methods are slowed down..

## Conclusion

This PR improves the recieved packet / second rate by 281%


# TODO & discussion
- Switch from threading to multiprocessing ? We need to check the performances of doing so.