### PR TITLE
fix command line parameter in test\run_tests_py2/3.bat

### DIFF
--- a/test/run_tests_py2.bat
+++ b/test/run_tests_py2.bat
@@ -5,6 +5,6 @@ set PYTHONPATH=%MYDIR%
 if [%1]==[] (
   python "%MYDIR%\scapy\tools\UTscapy.py" -c configs\\windows2.utsc -T bpf.uts -T linux.uts -o scapy_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
-  python "%MYDIR%\scapy\tools\UTscapy.py" %@
+  python "%MYDIR%\scapy\tools\UTscapy.py" %*
 )
 PAUSE

--- a/test/run_tests_py3.bat
+++ b/test/run_tests_py3.bat
@@ -6,6 +6,6 @@ set PYTHONDONTWRITEBYTECODE=True
 if [%1]==[] (
   python3 "%MYDIR%\scapy\tools\UTscapy.py" -c configs\\windows2.utsc -T bpf.uts -T linux.uts -o scapy_py3_regression_test_%date:~6,4%_%date:~3,2%_%date:~0,2%.html
 ) else (
-  python3 "%MYDIR%\scapy\tools\UTscapy.py" %@
+  python3 "%MYDIR%\scapy\tools\UTscapy.py" %*
 )
 PAUSE


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-62
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Fix command line parameter in test\run_tests_py2.bat and test\run_tests_py3.bat:
%@ -> %*