### PR TITLE
Fix for issue #1199 (regression against scapy<=2.3.2). [PR is ready for merge to the master]

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1223,6 +1223,34 @@ for i in range(10):
 response = res[0][1]
 assert response[ICMP].type == 0
 
+= Test set of sent_time by sr
+~ netaccess IP ICMP
+packet = IP(dst="8.8.8.8")/ICMP()
+r = sr(packet)
+assert packet.sent_time is not None
+
+= Test set of sent_time by sr (multiple packets)
+~ netaccess IP ICMP
+packet1 = IP(dst="8.8.8.8")/ICMP()
+packet2 = IP(dst="8.8.4.4")/ICMP()
+r = sr([packet1, packet2])
+assert packet1.sent_time is not None
+assert packet2.sent_time is not None
+
+= Test set of sent_time by srflood
+~ netaccess IP ICMP
+packet = IP(dst="8.8.8.8")/ICMP()
+r = srflood(packet)
+assert packet.sent_time is not None
+
+= Test set of sent_time by srflood (multiple packets)
+~ netaccess IP ICMP
+packet1 = IP(dst="8.8.8.8")/ICMP()
+packet2 = IP(dst="8.8.4.4")/ICMP()
+r = srflood([packet1, packet2])
+assert packet1.sent_time is not None
+assert packet2.sent_time is not None
+
 ############
 ############
 + ManuFDB tests


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-64
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

This PR fixes #1199  (regression against scapy<=2.3.2).
(+ some little obvious code improvement in sndrcv())
Please include it in TODO.

See also already closed #1276
