### PR TITLE
Fix timeout in sndrcv

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -118,9 +118,9 @@ def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
         try:
             while True:
                 r = _get_pkt()
+                if stopevent.is_set():
+                    break
                 if r is None:
-                    if stopevent.is_set():
-                        break
                     continue
                 ok = False
                 h = r.hashret()


### PR DESCRIPTION
Weird bug in sndrcv, where the timeout check moved in the part only called when no packet is received. 
The timeout check isn't called until scapy receives no packets, otherwise, he continues to sniff.

e.g. I was downloading a file when I noticed this (tons of packets)

There are not really regression tests to set up, there already are some, that surely didn't work.