### PR TITLE
Python 2/3: handle lambda (x,y) + update notebooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Scapy's performances.
 The project aims to provide code that works both on Python 2 and Python 3. Therefore, some rules need to be applied to achieve compatibility:
 - byte-string must be defined as `b"\x00\x01\x02"`
 - exceptions must comply with the new Python 3 format: `except SomeError as e:`
-- lambdas must be written using a single argument when using tuples: use `lambda x_y: x_y[0] + f(x_y[1])` instead of `lambda (x, y): x + f(y)`.
+- lambdas must be written using a single argument when using tuples: use `lambda x, y: x + f(y)` instead of `lambda (x, y): x + f(y)`.
 - use int instead of long
 - use list comprehension instead of map() and filter()
 - use scapy.modules.six.range instead of xrange and range

--- a/doc/notebooks/Scapy in 15 minutes.ipynb
+++ b/doc/notebooks/Scapy in 15 minutes.ipynb
@@ -82,7 +82,7 @@
    ],
    "source": [
     "ans = sr([IP(dst=\"8.8.8.8\", ttl=(1, 8), options=IPOption_RR())/ICMP(seq=RandShort()), IP(dst=\"8.8.8.8\", ttl=(1, 8), options=IPOption_Traceroute())/ICMP(seq=RandShort()), IP(dst=\"8.8.8.8\", ttl=(1, 8))/ICMP(seq=RandShort())], verbose=False, timeout=3)[0]\n",
-    "ans.make_table(lambda x_y: (\", \".join(z.summary() for z in x_y[0][IP].options) or '-', x_y[0][IP].ttl, x_y[1].sprintf(\"%IP.src% %ICMP.type%\")))"
+    "ans.make_table(lambda x, y: (\", \".join(z.summary() for z in x[IP].options) or '-', x[IP].ttl, y.sprintf(\"%IP.src% %ICMP.type%\")))"
    ]
   },
   {
@@ -658,7 +658,7 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "ans.multiplot(lambda x_y: (x_y[1][IP].src, (x_y[1].time, x_y[1][IP].id)), plot_xy=True)"
+    "ans.multiplot(lambda x, y: (y[IP].src, (y.time, y[IP].id)), plot_xy=True)"
    ]
   },
   {
@@ -944,7 +944,7 @@
    "source": [
     "ans = sr(IP(dst=[\"scanme.nmap.org\", \"nmap.org\"])/TCP(dport=[22, 80, 443, 31337]), timeout=3, verbose=False)[0]\n",
     "ans.extend(sr(IP(dst=[\"scanme.nmap.org\", \"nmap.org\"])/UDP(dport=53)/DNS(qd=DNSQR()), timeout=3, verbose=False)[0])\n",
-    "ans.make_table(lambda x_y: (x_y[0][IP].dst, x_y[0].sprintf('%IP.proto%/{TCP:%r,TCP.dport%}{UDP:%r,UDP.dport%}'), x_y[1].sprintf('{TCP:%TCP.flags%}{ICMP:%ICMP.type%}')))"
+    "ans.make_table(lambda x, y: (x[IP].dst, x.sprintf('%IP.proto%/{TCP:%r,TCP.dport%}{UDP:%r,UDP.dport%}'), y.sprintf('{TCP:%TCP.flags%}{ICMP:%ICMP.type%}')))"
    ]
   },
   {

--- a/doc/notebooks/graphs-ipids.ipynb
+++ b/doc/notebooks/graphs-ipids.ipynb
@@ -550,7 +550,7 @@
      "collapsed": false,
      "input": [
       "%matplotlib inline\n",
-      "ans.multiplot(lambda p_q: (p_q[1][IP].src, (p_q[1].time, p_q[1][IP].id)), plot_xy=True)"
+      "ans.multiplot(lambda p, q: (q[IP].src, (q.time, q[IP].id)), plot_xy=True)"
      ],
      "language": "python",
      "metadata": {},
@@ -579,7 +579,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "ans.multiplot(lambda p_q: (p_q[1][IP].src, p_q[1][IP].id))"
+      "ans.multiplot(lambda p, q: (q[IP].src, q[IP].id))"
      ],
      "language": "python",
      "metadata": {},

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -56,6 +56,7 @@ def cmp(a, b):
     """Old Python 2 function"""
     return (a > b) - (a < b)
 
+
 def lambda_tuple_converter(func):
     """
     Converts a Python 2 function as
@@ -67,6 +68,7 @@ def lambda_tuple_converter(func):
         return lambda *args: func(args[0] if len(args) == 1 else args)
     else:
         return func
+
 
 if six.PY2:
     def orb(x):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -56,6 +56,17 @@ def cmp(a, b):
     """Old Python 2 function"""
     return (a > b) - (a < b)
 
+def lambda_tuple_converter(func):
+    """
+    Converts a Python 2 function as
+      lambda (x,y): x + y
+    In the Python 3 format:
+      lambda x,y : x + y
+    """
+    if func is not None and func.__code__.co_argcount == 1:
+        return lambda *args: func(args[0] if len(args) == 1 else args)
+    else:
+        return func
 
 if six.PY2:
     def orb(x):

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1129,9 +1129,9 @@ class TracerouteResult(SndRcvList):
         self.nloc = None
 
     def show(self):
-        return self.make_table(lambda s,r: (s.sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
-                                            s.ttl,
-                                            r.sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
+        return self.make_table(lambda s, r: (s.sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
+                                             s.ttl,
+                                             r.sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
 
     def get_trace(self):
         trace = {}

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1129,9 +1129,9 @@ class TracerouteResult(SndRcvList):
         self.nloc = None
 
     def show(self):
-        return self.make_table(lambda s_r: (s_r[0].sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
-                                            s_r[0].ttl,
-                                            s_r[1].sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
+        return self.make_table(lambda s,r: (s.sprintf("%IP.dst%:{TCP:tcp%ir,TCP.dport%}{UDP:udp%ir,UDP.dport%}{ICMP:ICMP}"),
+                                            s.ttl,
+                                            r.sprintf("%-15s,IP.src% {TCP:%TCP.flags%}{ICMP:%ir,ICMP.type%}")))
 
     def get_trace(self):
         trace = {}

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3441,9 +3441,9 @@ class TracerouteResult6(TracerouteResult):
     __slots__ = []
 
     def show(self):
-        return self.make_table(lambda s_r: (s_r[0].sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"),  # TODO: ICMPv6 !
-                                            s_r[0].hlim,
-                                            s_r[1].sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}" +
+        return self.make_table(lambda s, r: (s.sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"),  # TODO: ICMPv6 !
+                                             s.hlim,
+                                             r.sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}" +
                                                            "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}" +
                                                            "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}" +
                                                            "{ICMPv6EchoReply:%ir,type%}")))

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3444,9 +3444,9 @@ class TracerouteResult6(TracerouteResult):
         return self.make_table(lambda s, r: (s.sprintf("%-42s,IPv6.dst%:{TCP:tcp%TCP.dport%}{UDP:udp%UDP.dport%}{ICMPv6EchoRequest:IER}"),  # TODO: ICMPv6 !
                                              s.hlim,
                                              r.sprintf("%-42s,IPv6.src% {TCP:%TCP.flags%}" +
-                                                           "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}" +
-                                                           "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}" +
-                                                           "{ICMPv6EchoReply:%ir,type%}")))
+                                                       "{ICMPv6DestUnreach:%ir,type%}{ICMPv6PacketTooBig:%ir,type%}" +
+                                                       "{ICMPv6TimeExceeded:%ir,type%}{ICMPv6ParamProblem:%ir,type%}" +
+                                                       "{ICMPv6EchoReply:%ir,type%}")))
 
     def get_trace(self):
         trace = {}

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 from collections import defaultdict
 
+from scapy.compat import lambda_tuple_converter
 from scapy.config import conf
 from scapy.consts import WINDOWS
 from scapy.base_classes import BasePacket, BasePacketList
@@ -165,11 +166,15 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         lfilter: a truth function that decides whether a packet must be plotted
         """
 
+        # Python 2 backward compatibility
+        f = lambda_tuple_converter(f)
+        lfilter = lambda_tuple_converter(lfilter)
+
         # Get the list of packets
         if lfilter is None:
-            l = [f(e) for e in self.res]
+            l = [f(*e) for e in self.res]
         else:
-            l = [f(e) for e in self.res if lfilter(e)]
+            l = [f(*e) for e in self.res if lfilter(*e)]
 
         # Mimic the default gnuplot output
         if kargs == {}:
@@ -219,11 +224,15 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         A list of matplotlib.lines.Line2D is returned.
         """
 
+        # Python 2 backward compatibility
+        f = lambda_tuple_converter(f)
+        lfilter = lambda_tuple_converter(lfilter)
+
         # Get the list of packets
         if lfilter is None:
-            l = (f(e) for e in self.res)
+            l = (f(*e) for e in self.res)
         else:
-            l = (f(e) for e in self.res if lfilter(e))
+            l = (f(*e) for e in self.res if lfilter(*e))
 
         # Apply the function f to the packets
         d = {}

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1516,13 +1516,18 @@ def pretty_list(rtlst, header, sortBy=0):
 
 
 def __make_table(yfmtfunc, fmtfunc, endline, data, fxyz, sortx=None, sorty=None, seplinefunc=None):
+    """Core function of the make_table suite, which generates the table"""
     vx = {}
     vy = {}
     vz = {}
     vxf = {}
+
+    # Python 2 backward compatibility
+    fxyz = lambda_tuple_converter(fxyz)
+
     l = 0
     for e in data:
-        xx, yy, zz = [str(s) for s in fxyz(e)]
+        xx, yy, zz = [str(s) for s in fxyz(*e)]
         l = max(len(yy), l)
         vx[xx] = max(vx.get(xx, 0), len(xx), len(zz))
         vy[yy] = None

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1101,7 +1101,13 @@ old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
 ans,unans=sr(IP(dst="www.google.com/30")/TCP(dport=[80,443]),timeout=2)
 conf.debug_dissector = old_debug_dissector
-ans.make_table(lambda s_r: (s_r[0].dst, s_r[0].dport, s_r[1].sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))
+
+# Backward compatibility: Python 2 only
+if six.PY2:
+    exec("""ans.make_table(lambda (s, r): (s.dst, s.dport, r.sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))""")
+
+# New format: all Python versions
+ans.make_table(lambda s, r: (s.dst, s.dport, r.sprintf("{TCP:%TCP.flags%}{ICMP:%ICMP.code%}")))
 
 = Send & receive with retry
 ~ netaccess IP ICMP


### PR DESCRIPTION
This PR:
- updates the notebooks with the new lambda format `lambda x,y: ...` instead of `lambda (x,y): ...`
- updates ploting functions to support both formats on python 2 (on python 3, the first one isn't available)