### PR TITLE
Fixes for jupyter notebooks. [Please add to TODO] 

### DIFF
--- a/doc/notebooks/HTTP_2_Tuto.ipynb
+++ b/doc/notebooks/HTTP_2_Tuto.ipynb
@@ -54,7 +54,8 @@
       "\n",
       "s = socket.socket(l[0][0], l[0][1], l[0][2])\n",
       "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n",
-      "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)\n",
+      "if hasattr(socket, 'SO_REUSEPORT'):\n",
+      "    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)\n",
       "ip_and_port = l[0][4]"
      ],
      "language": "python",

--- a/doc/notebooks/Scapy in 15 minutes.ipynb
+++ b/doc/notebooks/Scapy in 15 minutes.ipynb
@@ -82,7 +82,7 @@
    ],
    "source": [
     "ans = sr([IP(dst=\"8.8.8.8\", ttl=(1, 8), options=IPOption_RR())/ICMP(seq=RandShort()), IP(dst=\"8.8.8.8\", ttl=(1, 8), options=IPOption_Traceroute())/ICMP(seq=RandShort()), IP(dst=\"8.8.8.8\", ttl=(1, 8))/ICMP(seq=RandShort())], verbose=False, timeout=3)[0]\n",
-    "ans.make_table(lambda (x, y): (\", \".join(z.summary() for z in x[IP].options) or '-', x[IP].ttl, y.sprintf(\"%IP.src% %ICMP.type%\")))"
+    "ans.make_table(lambda x_y: (\", \".join(z.summary() for z in x_y[0][IP].options) or '-', x_y[0][IP].ttl, x_y[1].sprintf(\"%IP.src% %ICMP.type%\")))"
    ]
   },
   {
@@ -259,11 +259,11 @@
     }
    ],
    "source": [
-    "print p.dst  # first layer that has an src field, here Ether\n",
-    "print p[IP].src  # explicitly access the src field of the IP layer\n",
+    "print(p.dst)  # first layer that has an src field, here Ether\n",
+    "print(p[IP].src)  # explicitly access the src field of the IP layer\n",
     "\n",
     "# sprintf() is a useful method to display fields\n",
-    "print p.sprintf(\"%Ether.src% > %Ether.dst%\\n%IP.src% > %IP.dst%\")"
+    "print(p.sprintf(\"%Ether.src% > %Ether.dst%\\n%IP.src% > %IP.dst%\"))"
    ]
   },
   {
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "print p.sprintf(\"%TCP.flags% %TCP.dport%\")"
+    "print(p.sprintf(\"%TCP.flags% %TCP.dport%\"))"
    ]
   },
   {
@@ -444,8 +444,8 @@
    ],
    "source": [
     "# Access the first tuple\n",
-    "print r[0][0].summary()  # the packet sent\n",
-    "print r[0][1].summary()  # the answer received\n",
+    "print(r[0][0].summary())  # the packet sent\n",
+    "print(r[0][1].summary())  # the answer received\n",
     "\n",
     "# Access the ICMP layer. Scapy received a time-exceeded error message\n",
     "r[0][1][ICMP]"
@@ -658,7 +658,7 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "ans.multiplot(lambda (x, y): (y[IP].src, (y.time, y[IP].id)), plot_xy=True)"
+    "ans.multiplot(lambda x_y: (x_y[1][IP].src, (x_y[1].time, x_y[1][IP].id)), plot_xy=True)"
    ]
   },
   {
@@ -683,7 +683,7 @@
    ],
    "source": [
     "pkt = IP() / UDP() / DNS(qd=DNSQR())\n",
-    "print repr(raw(pkt))"
+    "print(repr(raw(pkt)))"
    ]
   },
   {
@@ -708,7 +708,7 @@
     }
    ],
    "source": [
-    "print pkt.summary()"
+    "print(pkt.summary())"
    ]
   },
   {
@@ -944,7 +944,7 @@
    "source": [
     "ans = sr(IP(dst=[\"scanme.nmap.org\", \"nmap.org\"])/TCP(dport=[22, 80, 443, 31337]), timeout=3, verbose=False)[0]\n",
     "ans.extend(sr(IP(dst=[\"scanme.nmap.org\", \"nmap.org\"])/UDP(dport=53)/DNS(qd=DNSQR()), timeout=3, verbose=False)[0])\n",
-    "ans.make_table(lambda (x, y): (x[IP].dst, x.sprintf('%IP.proto%/{TCP:%r,TCP.dport%}{UDP:%r,UDP.dport%}'), y.sprintf('{TCP:%TCP.flags%}{ICMP:%ICMP.type%}')))"
+    "ans.make_table(lambda x_y: (x_y[0][IP].dst, x_y[0].sprintf('%IP.proto%/{TCP:%r,TCP.dport%}{UDP:%r,UDP.dport%}'), x_y[1].sprintf('{TCP:%TCP.flags%}{ICMP:%ICMP.type%}')))"
    ]
   },
   {
@@ -1082,7 +1082,7 @@
     "    parser.add_argument(\"ipv6_address\", help=\"An IPv6 address\")\n",
     "    args = parser.parse_args()\n",
     "\n",
-    "    print sr1(IPv6(dst=args.ipv6_address)/ICMPv6EchoRequest(), verbose=0).summary()"
+    "    print(sr1(IPv6(dst=args.ipv6_address)/ICMPv6EchoRequest(), verbose=0).summary())"
    ]
   },
   {
@@ -1244,21 +1244,21 @@
     "\n",
     "    @ATMT.state()\n",
     "    def SYN(self):\n",
-    "        print \"-> SYN\"\n",
+    "        print(\"-> SYN\")\n",
     "\n",
     "    @ATMT.state()\n",
     "    def SYN_ACK(self):\n",
-    "        print \"<- SYN/ACK\"\n",
+    "        print(\"<- SYN/ACK\")\n",
     "        raise self.END()\n",
     "\n",
     "    @ATMT.state()\n",
     "    def RST(self):\n",
-    "        print \"<- RST\"\n",
+    "        print(\"<- RST\")\n",
     "        raise self.END()\n",
     "\n",
     "    @ATMT.state()\n",
     "    def ERROR(self):\n",
-    "        print \"!! ERROR\"\n",
+    "        print(\"!! ERROR\")\n",
     "        raise self.END()\n",
     "    @ATMT.state(final=1)\n",
     "    def END(self):\n",

--- a/doc/notebooks/graphs-ipids.ipynb
+++ b/doc/notebooks/graphs-ipids.ipynb
@@ -550,7 +550,7 @@
      "collapsed": false,
      "input": [
       "%matplotlib inline\n",
-      "ans.multiplot(lambda (p, q): (q[IP].src, (q.time, q[IP].id)), plot_xy=True)"
+      "ans.multiplot(lambda p_q: (p_q[1][IP].src, (p_q[1].time, p_q[1][IP].id)), plot_xy=True)"
      ],
      "language": "python",
      "metadata": {},
@@ -579,7 +579,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "ans.multiplot(lambda (p, q): (q[IP].src, q[IP].id))"
+      "ans.multiplot(lambda p_q: (p_q[1][IP].src, p_q[1][IP].id))"
      ],
      "language": "python",
      "metadata": {},

--- a/doc/notebooks/tls/notebook1_x509.ipynb
+++ b/doc/notebooks/tls/notebook1_x509.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "# Use Shift+Enter to run the current cell\n",
-    "print 'Hello!'"
+    "print('Hello!')"
    ]
   },
   {
@@ -36,7 +36,7 @@
    "source": [
     "# You may also use Alt+Enter to run the current cell, then create a new cell right below\n",
     "from datetime import datetime\n",
-    "print 'This is the time right now: %s' % datetime.now()"
+    "print('This is the time right now: %s' % datetime.now())"
    ]
   },
   {
@@ -50,7 +50,7 @@
     "# If needed, pause the cell edition with Ctrl-M.\n",
     "# Then you can delete the current cell with D+D. You can also undo cell deletion with Z.\n",
     "# Finally, should Jupyter become stuck in execution, use Kernel/Interrupt from the menu bar.\n",
-    "print 'Got it!'"
+    "print('Got it!')"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "keystr = open('raw_data/pki/ca_key.der', 'rb').read()\n",
-    "print repr(keystr)\n",
+    "print(repr(keystr))\n",
     "# (btw, you can hide the output of a cell by double-clicking on the left of the output)"
    ]
   },
@@ -106,8 +106,8 @@
    "outputs": [],
    "source": [
     "v = privkey.version\n",
-    "print 'The \\'version\\' stripped from any ASN.1 encoding is 0x%02x.' % v.val\n",
-    "print 'The \\'version\\' field corresponds to bytes  %r.' % raw(v)"
+    "print('The \\'version\\' stripped from any ASN.1 encoding is 0x%02x.' % v.val)\n",
+    "print('The \\'version\\' field corresponds to bytes  %r.' % raw(v))"
    ]
   },
   {
@@ -131,10 +131,10 @@
    },
    "outputs": [],
    "source": [
-    "print 'Original data: %r...' % keystr[:13]\n",
-    "print 'New version bytes:          %r' % raw(privkey.version)\n",
-    "print 'New modulus bytes:                      %r...' % raw(privkey.modulus)[:6]\n",
-    "print 'Rebuilt data:  %r...' % raw(privkey)[:13]"
+    "print('Original data: %r...' % keystr[:13])\n",
+    "print('New version bytes:          %r' % raw(privkey.version))\n",
+    "print('New modulus bytes:                      %r...' % raw(privkey.modulus)[:6])\n",
+    "print('Rebuilt data:  %r...' % raw(privkey)[:13])"
    ]
   },
   {
@@ -244,8 +244,8 @@
    },
    "outputs": [],
    "source": [
-    "print privkey.key\n",
-    "print privkey.pubkey"
+    "print(privkey.key)\n",
+    "print(privkey.pubkey)"
    ]
   },
   {

--- a/doc/notebooks/tls/notebook2_tls_protected.ipynb
+++ b/doc/notebooks/tls/notebook2_tls_protected.ipynb
@@ -19,7 +19,8 @@
    "outputs": [],
    "source": [
     "# We're going to parse several successive records from the passive listening of a standard TLS handshake\n",
-    "from scapy.all import *"
+    "from scapy.all import *\n",
+    "load_layer('tls')"
    ]
   },
   {
@@ -37,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "record1 = TLS(open('raw_data/tls_session_protected/01_cli.raw').read())\n",
+    "record1 = TLS(open('raw_data/tls_session_protected/01_cli.raw', 'rb').read())\n",
     "record1.show()"
    ]
   },
@@ -50,7 +51,7 @@
    "outputs": [],
    "source": [
     "for extension in record1.msg[0].ext:\n",
-    "    print ''\n",
+    "    print('')\n",
     "    extension.show()"
    ]
   },
@@ -69,7 +70,7 @@
    },
    "outputs": [],
    "source": [
-    "record2 = TLS(open('raw_data/tls_session_protected/02_srv.raw').read())\n",
+    "record2 = TLS(open('raw_data/tls_session_protected/02_srv.raw', 'rb').read())\n",
     "record2.show()"
    ]
   },
@@ -88,7 +89,7 @@
    },
    "outputs": [],
    "source": [
-    "record3 = TLS(open('raw_data/tls_session_protected/03_srv.raw').read())\n",
+    "record3 = TLS(open('raw_data/tls_session_protected/03_srv.raw', 'rb').read())\n",
     "record3.show()"
    ]
   },
@@ -102,9 +103,9 @@
    "source": [
     "# The Certificate message actually contains a *chain* of certificates\n",
     "for cert in record3.msg[0].certs:\n",
-    "    print type(cert[1])\n",
+    "    print(type(cert[1]))\n",
     "    cert[1].show()\n",
-    "    print ''"
+    "    print('')"
    ]
   },
   {
@@ -120,7 +121,7 @@
     "\n",
     "# Indeed the certificate may be used with other domains than its CN 'www.github.com'\n",
     "x509c = record3.msg[0].certs[0][1].x509Cert\n",
-    "print type(x509c)\n",
+    "print(type(x509c))\n",
     "x509c.tbsCertificate.extensions[2].show()"
    ]
   },
@@ -140,7 +141,7 @@
    "outputs": [],
    "source": [
     "# Here the server sent three TLS records in the same TCP segment\n",
-    "record4 = TLS(open('raw_data/tls_session_protected/04_srv.raw').read())\n",
+    "record4 = TLS(open('raw_data/tls_session_protected/04_srv.raw', 'rb').read())\n",
     "record4.show()"
    ]
   },
@@ -156,7 +157,7 @@
     "# First, we need to assemble the whole data being signed\n",
     "cli_random = pkcs_i2osp(record1.msg[0].gmt_unix_time, 4) + record1.msg[0].random_bytes\n",
     "srv_random = pkcs_i2osp(record2.msg[0].gmt_unix_time, 4) + record2.msg[0].random_bytes\n",
-    "ecdh_params = str(record4[TLSServerKeyExchange].params)\n",
+    "ecdh_params = bytes(record4[TLSServerKeyExchange].params)\n",
     "\n",
     "# Then we retrieve the server's Cert and verify the signature\n",
     "cert_srv = record3.msg[0].certs[0][1]\n",
@@ -180,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "record5_str = open('raw_data/tls_session_protected/05_cli.raw').read()\n",
+    "record5_str = open('raw_data/tls_session_protected/05_cli.raw', 'rb').read()\n",
     "record5 = TLS(record5_str)\n",
     "record5.show()"
    ]
@@ -213,7 +214,7 @@
    },
    "outputs": [],
    "source": [
-    "record6_str = open('raw_data/tls_session_protected/06_srv.raw').read()\n",
+    "record6_str = open('raw_data/tls_session_protected/06_srv.raw', 'rb').read()\n",
     "record6 = TLS(record6_str, tls_session=record5.tls_session.mirror())\n",
     "record6.show()"
    ]
@@ -233,7 +234,7 @@
    },
    "outputs": [],
    "source": [
-    "record7_str = open('raw_data/tls_session_protected/07_cli.raw').read()\n",
+    "record7_str = open('raw_data/tls_session_protected/07_cli.raw', 'rb').read()\n",
     "record7 = TLS(record7_str, tls_session=record6.tls_session.mirror())\n",
     "record7.show()"
    ]

--- a/doc/notebooks/tls/notebook3_tls_compromised.ipynb
+++ b/doc/notebooks/tls/notebook3_tls_compromised.ipynb
@@ -15,7 +15,8 @@
    },
    "outputs": [],
    "source": [
-    "from scapy.all import *"
+    "from scapy.all import *\n",
+    "load_layer('tls')"
    ]
   },
   {
@@ -26,7 +27,7 @@
    },
    "outputs": [],
    "source": [
-    "record1_str = open('raw_data/tls_session_compromised/01_cli.raw').read()\n",
+    "record1_str = open('raw_data/tls_session_compromised/01_cli.raw', 'rb').read()\n",
     "record1 = TLS(record1_str)\n",
     "record1.msg[0].show()"
    ]
@@ -40,7 +41,7 @@
    },
    "outputs": [],
    "source": [
-    "record2_str = open('raw_data/tls_session_compromised/02_srv.raw').read()\n",
+    "record2_str = open('raw_data/tls_session_compromised/02_srv.raw', 'rb').read()\n",
     "record2 = TLS(record2_str, tls_session=record1.tls_session.mirror())\n",
     "record2.msg[0].show()"
    ]
@@ -67,7 +68,7 @@
    },
    "outputs": [],
    "source": [
-    "record3_str = open('raw_data/tls_session_compromised/03_cli.raw').read()\n",
+    "record3_str = open('raw_data/tls_session_compromised/03_cli.raw', 'rb').read()\n",
     "record3 = TLS(record3_str, tls_session=record2.tls_session.mirror())\n",
     "record3.show()"
    ]
@@ -80,7 +81,7 @@
    },
    "outputs": [],
    "source": [
-    "record4_str = open('raw_data/tls_session_compromised/04_srv.raw').read()\n",
+    "record4_str = open('raw_data/tls_session_compromised/04_srv.raw', 'rb').read()\n",
     "record4 = TLS(record4_str, tls_session=record3.tls_session.mirror())\n",
     "record4.show()"
    ]
@@ -93,7 +94,7 @@
    },
    "outputs": [],
    "source": [
-    "record5_str = open('raw_data/tls_session_compromised/05_cli.raw').read()\n",
+    "record5_str = open('raw_data/tls_session_compromised/05_cli.raw', 'rb').read()\n",
     "record5 = TLS(record5_str, tls_session=record4.tls_session.mirror())\n",
     "record5.show()"
    ]

--- a/doc/notebooks/tls/notebook4_tls13.ipynb
+++ b/doc/notebooks/tls/notebook4_tls13.ipynb
@@ -18,7 +18,8 @@
    },
    "outputs": [],
    "source": [
-    "from scapy.all import *"
+    "from scapy.all import *\n",
+    "load_layer('tls')"
    ]
   },
   {
@@ -27,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record1_str = open('raw_data/tls_session_13/01_cli.raw').read()\n",
+    "record1_str = open('raw_data/tls_session_13/01_cli.raw', 'rb').read()\n",
     "record1 = TLS(record1_str)\n",
     "sess = record1.tls_session\n",
     "record1.show()"
@@ -39,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record2_str = open('raw_data/tls_session_13/02_srv.raw').read()\n",
+    "record2_str = open('raw_data/tls_session_13/02_srv.raw', 'rb').read()\n",
     "record2 = TLS(record2_str, tls_session=sess.mirror())\n",
     "record2.show()"
    ]
@@ -50,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record3_str = open('raw_data/tls_session_13/03_cli.raw').read()\n",
+    "record3_str = open('raw_data/tls_session_13/03_cli.raw', 'rb').read()\n",
     "record3 = TLS(record3_str, tls_session=sess.mirror())\n",
     "record3.show()"
    ]
@@ -66,7 +67,7 @@
     "# The PFS relies on the ECDH secret below being kept from observers, and deleted right after the key exchange\n",
     "#from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateNumbers\n",
     "#from cryptography.hazmat.backends import default_backend\n",
-    "#secp256r1_client_privkey = open('raw_data/tls_session_13/cli_key.raw').read()\n",
+    "#secp256r1_client_privkey = open('raw_data/tls_session_13/cli_key.raw', 'rb').read()\n",
     "#pubnum = sess.tls13_client_pubshares[\"secp256r1\"].public_numbers()\n",
     "#privnum = EllipticCurvePrivateNumbers(pkcs_os2ip(secp256r1_client_privkey), pubnum)\n",
     "#privkey = privnum.private_key(default_backend())\n",
@@ -81,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "record4_str = open('raw_data/tls_session_13/04_srv.raw').read()\n",
+    "record4_str = open('raw_data/tls_session_13/04_srv.raw', 'rb').read()\n",
     "record4 = TLS(record4_str, tls_session=sess.mirror())\n",
     "record4.show()"
    ]
@@ -92,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record5_str = open('raw_data/tls_session_13/05_srv.raw').read()\n",
+    "record5_str = open('raw_data/tls_session_13/05_srv.raw', 'rb').read()\n",
     "record5 = TLS(record5_str, tls_session=sess)\n",
     "record5.show()"
    ]
@@ -103,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "record6_str = open('raw_data/tls_session_13/06_cli.raw').read()\n",
+    "record6_str = open('raw_data/tls_session_13/06_cli.raw', 'rb').read()\n",
     "record6 = TLS(record6_str, tls_session=sess.mirror())\n",
     "record6.show()"
    ]


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-79
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Fix for #1280
All notebooks has been ported to Python3.
All notebooks in tls/*.ipynb works now as expected, graphs-ipids.ipynb also
but HTTP_2_Tuto.ipynb and 'Scapy in 15 minutes.ipynb' works much better than previously.