### PR TITLE
PY3 compatibility simplification and little improvement.  [Please add to TODO]

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -23,13 +23,6 @@ from scapy.consts import WINDOWS
 from scapy.compat import *
 import scapy.modules.six as six
 
-try:
-    import thread
-except ImportError:
-    THREAD_EXCEPTION = RuntimeError
-else:
-    THREAD_EXCEPTION = thread.error
-
 if WINDOWS:
     from scapy.error import Scapy_Exception
     recv_error = Scapy_Exception
@@ -107,7 +100,7 @@ class SelectableObject:
         self.was_ended = arborted
         try:
             self.trigger.release()
-        except (THREAD_EXCEPTION, AttributeError):
+        except (threading.ThreadError, AttributeError):
             pass
 
 class SelectableSelector(object):


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-79
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Exclamation.
In Py2 threading.ThreadError is just thread.error
In Py3 threading.ThreadError is just thread._error and is just RuntimeError

There is exist some subtle incompatibility in original master (and after my change).
In Py2:
```        except (threading.ThreadError, AttributeError):```
does not cover situation when unacquired lock has released, because  threading.ThreadError (=== thread.error) is not Runtime error (but RuntimeError("cannot release un-acquired lock") is raised)
In Py3 this situation is covered because threading.ThreadError === RuntimeError.
It is a subtle bug/inconsistence of Py2, so maybe will be better also cover such situation in Py2 by using:
```        except (threading.ThreadError, RuntimeError, AttributeError):```
?
I 'vote' for such change. It guarantees FC for PY2 and PY3. 