### PR TITLE
Fix for windows batches errors that causes the wrong python to be run.

### DIFF
--- a/bin/UTscapy.bat
+++ b/bin/UTscapy.bat
@@ -1,4 +1,4 @@
 @echo off
 REM Use Python to run the UTscapy script from the current directory, passing all parameters
 title UTscapy
-python "%~dp0\UTscapy" %*
+"%~dp0..\python" "%~dp0\UTscapy" %*

--- a/bin/scapy.bat
+++ b/bin/scapy.bat
@@ -1,4 +1,4 @@
 @echo off
 REM Use Python to run the Scapy script from the current directory, passing all parameters
 title scapy
-python "%~dp0\scapy" %*
+"%~dp0..\python" "%~dp0\scapy" %*

--- a/test/run_tests_py2.bat
+++ b/test/run_tests_py2.bat
@@ -1,6 +1,6 @@
 @echo off
 title UTscapy - All tests - PY2
-set MYDIR=%~dp0\..
+set MYDIR=%~dp0..
 set PYTHONPATH=%MYDIR%
 set PYTHONDONTWRITEBYTECODE=True
 if [%1]==[] (

--- a/test/run_tests_py3.bat
+++ b/test/run_tests_py3.bat
@@ -1,6 +1,6 @@
 @echo off
 title UTscapy - All tests - PY3
-set MYDIR=%~dp0\..
+set MYDIR=%~dp0..
 set PYTHONPATH=%MYDIR%
 set PYTHONDONTWRITEBYTECODE=True
 if [%1]==[] (


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-91
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Fix for windows batches errors that causes the wrong python to be run, when we have different versions of
 python installed, or not to be run at all, when python exe is not available directly (e.g.by the PATH).
Cosmetic in test batches.