### PR TITLE
Making scapy runnable module.

### DIFF
--- a/run_scapy
+++ b/run_scapy
@@ -2,4 +2,4 @@
 DIR=$(dirname $0)
 PYTHONDONTWRITEBYTECODE=True
 PYTHON=${PYTHON:-python}
-PYTHONPATH=$DIR exec $PYTHON -m scapy.__init__ $@
+PYTHONPATH=$DIR exec $PYTHON -m scapy $@

--- a/run_scapy_py2.bat
+++ b/run_scapy_py2.bat
@@ -3,10 +3,10 @@ set PYTHONPATH=%~dp0
 set PYTHONDONTWRITEBYTECODE=True
 if "%1"=="--nopause" (
   set nopause="True"
-  python -m scapy.__init__
+  python -m scapy
 ) else (
   set nopause="False"
-  python -m scapy.__init__ %*
+  python -m scapy %*
 )
 if %errorlevel%==1 if NOT "%nopause%"=="True" (
    PAUSE

--- a/run_scapy_py3.bat
+++ b/run_scapy_py3.bat
@@ -3,10 +3,10 @@ set PYTHONPATH=%~dp0
 set PYTHONDONTWRITEBYTECODE=True
 if "%1"=="--nopause" (
   set nopause="True"
-  python3 -m scapy.__init__
+  python3 -m scapy
 ) else (
   set nopause="False"
-  python3 -m scapy.__init__ %*
+  python3 -m scapy %*
 )
 if %errorlevel%==1 if NOT "%nopause%"=="True" (
    PAUSE

--- a/scapy/__main__.py
+++ b/scapy/__main__.py
@@ -1,0 +1,15 @@
+## This file is part of Scapy
+## See http://www.secdev.org/projects/scapy for more informations
+## Copyright (C) Philippe Biondi <phil@secdev.org>
+## This program is published under a GPLv2 license
+
+"""
+Scapy: create, send, sniff, dissect and manipulate network packets.
+
+Usable either from an interactive console or as a Python library.
+http://www.secdev.org/projects/scapy
+"""
+
+from scapy.main import interact
+
+interact()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import os
 
 
 EZIP_HEADER = """#! /bin/sh
-PYTHONPATH=$0/%s exec python -m scapy.__init__
+PYTHONPATH=$0/%s exec python -m scapy
 """
 
 


### PR DESCRIPTION
Scapy Version: 2.4.0rc5-79
System: Windows7/Windows10
Python Version: 2.7.14/3.4.4/3.6.4

Add scapy/\_\_main\_\_.py
This makes scapy a normal runnable module (by the standard/convenience way).