### PR TITLE
Fix documentation: VarLenQField example triggers AttributeError

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -213,6 +213,7 @@ associated string, but used that encoding format::
 
     class VarLenQField(Field):
         """ variable length quantities """
+        __slots__ = ["fld"]
     
         def __init__(self, name, default, fld):
             Field.__init__(self, name, default)


### PR DESCRIPTION
This PR addresses issue #1301 with a one-line fix suggested by Guillaume Valadon.  For convenience, this is the issue:

At [http://scapy.readthedocs.io/en/latest/build_dissect.html#example-variable-length-quantities](http://scapy.readthedocs.io/en/latest/build_dissect.html#example-variable-length-quantities), class `VarLenQField` is defined as a subclass of `Field`.

Any attempt to instantiate VarLenQField results in:
`AttributeError: 'VarLenQField' object has no attribute 'fld'`

The offending line is:
`self.fld = fld`

Somehow, inheriting from `Field` is causing the problem. The error happens whether in the scapy iPython environment or executing a python script.