### PR TITLE
Use tox to test with pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ matrix:
         - os: linux
           python: pypy
           env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=pypy-linux_non_root,codecov
 
         - os: linux
           python: pypy3
           env:
-            - SCAPY_COVERAGE=yes
+            - TOXENV=pypy3-linux_non_root,codecov
 
         - os: osx
           language: generic
@@ -55,6 +55,20 @@ matrix:
           python: 2.7
           env:
             - TOXENV=py27-linux_root,codecov
+
+        - os: linux
+          sudo: required
+          python: pypy
+          env:
+            - TOXENV=pypy-linux_root,codecov
+
+# Note: a bug in pypy3 <= 5.10.1 prevents from using Scapy to inject packets
+#       see https://bitbucket.org/pypy/pypy/issues/2787/pypy3-sockname-error
+#        - os: linux
+#          sudo: required
+#          python: pypy3
+#          env:
+#            - TOXENV=pypy3-linux_root,codecov
 
         - os: linux
           sudo: required

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -10,6 +10,12 @@ then
       # Linux non root
       UT_FLAGS+=" -K manufdb"
     fi
+    # pypy
+    if python --version 2>&1 | grep -q PyPy
+    then
+      # cryptography requires PyPy >= 2.6, Travis CI uses 2.5.0
+      UT_FLAGS+=" -K crypto -K not_pypy"
+    fi
   elif [ "$TRAVIS_OS_NAME" = "osx" ]
   then
     UT_FLAGS=" -K tcpdump"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 
 [tox]
-envlist = py{27,33,34,35,36}-{linux,osx}_{non_root,root}
+envlist = py{27,34,35,36,py,py3}-{linux,osx}_{non_root,root}
 skip_missing_interpreters = true
 minversion = 2.9
 
@@ -13,7 +13,7 @@ description = "Scapy unit tests"
 whitelist_externals = sudo
 setenv = SCAPY_ROOT_DIR={env:PWD}
 deps = mock
-       cryptography
+       {py27,py34,py35,py36}: cryptography
        coverage
 
 platform =
@@ -21,8 +21,8 @@ platform =
   osx_non_root,osx_root: darwin
 
 commands =
-  linux_non_root: coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K not_pypy -K random_weird_py3 -K netaccess -K needs_root {posargs}
-  linux_root: sudo -E {envpython} -m coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K not_pypy -K random_weird_py3 {posargs}
+  linux_non_root: coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K random_weird_py3 -K netaccess -K needs_root {posargs}
+  linux_root: sudo -E {envpython} -m coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K random_weird_py3 {posargs}
   osx_non_root: coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c test/configs/osx.utsc -K manufdb -K tshark -K random_weird_py3 -K netaccess -K needs_root {posargs}
   osx_root: sudo -E coverage run --rcfile=.coveragerc.tox -a -m scapy.tools.UTscapy -c test/configs/osx.utsc -K manufdb -K tshark -K random_weird_py3 {posargs}
   coverage combine


### PR DESCRIPTION
Migrate pypy tests to `tox`.

The previous Travis errors might be an issue with pypy3 see https://bitbucket.org/pypy/pypy/issues/2787/pypy3-sockname-error The pypy3 root tests are disabled in .travis.yml