### PR TITLE
mock_read_routes6_bsd renamed to mock_read_routes_bsd

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ test_script:
   - if not x%PYTHON:3=%==x%PYTHON% set ARGS=%ARGS% -K FIXME_py3
   
   # Main unit tests
-  - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes6_bsd -K ipv6 || exit /b 42"
+  - "%PYTHON%\\python -m coverage run --parallel-mode bin\\UTscapy -f text -t test\\regression.uts -F -K mock_read_routes_bsd -K ipv6 || exit /b 42"
   - 'del test\regression.uts'
 
   # Secondary and contrib unit tests

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -13,7 +13,7 @@
   "format": "html",
   "kw_ko": [
     "crypto_advanced",
-    "mock_read_routes6_bsd",
+    "mock_read_routes_bsd",
     "appveyor_only",
     "linux"
   ]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6357,7 +6357,7 @@ assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)
 + Mocked read_routes() calls
 
 = Truncated netstat -rn output on OS X
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 import mock
 from io import StringIO
@@ -6413,7 +6413,7 @@ test_osx_netstat_truncated()
 
 
 = OpenBSD 6.3
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 import mock
 from io import StringIO
@@ -6475,7 +6475,7 @@ test_openbsd_6_3()
 + Mocked read_routes6() calls
 
 = Preliminary definitions
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 import mock
 from io import StringIO
@@ -6505,7 +6505,7 @@ def check_mandatory_ipv6_routes(routes6):
 
 
 = Mac OS X 10.9.5
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -6546,7 +6546,7 @@ test_osx_10_9_5()
 
 
 = Mac OS X 10.9.5 with global IPv6 connectivity
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
 def test_osx_10_9_5_global(mock_os, mock_in6_getifaddr):
@@ -6595,7 +6595,7 @@ test_osx_10_9_5_global()
 
 
 = Mac OS X 10.10.4
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -6635,7 +6635,7 @@ test_osx_10_10_4()
 
 
 = FreeBSD 10.2
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 @mock.patch("scapy.arch.unix.in6_getifaddr")
 @mock.patch("scapy.arch.unix.os")
@@ -6674,7 +6674,7 @@ test_freebsd_10_2()
 
 
 = OpenBSD 5.5
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 @mock.patch("scapy.arch.unix.OPENBSD")
 @mock.patch("scapy.arch.unix.in6_getifaddr")
@@ -6732,7 +6732,7 @@ test_openbsd_5_5()
 
 
 = NetBSD 7.0
-~ mock_read_routes6_bsd
+~ mock_read_routes_bsd
 
 @mock.patch("scapy.arch.unix.NETBSD")
 @mock.patch("scapy.arch.unix.in6_getifaddr")


### PR DESCRIPTION
This renames a UT keyword introduces after #1233.