### PR TITLE
Consistency between OSX and Windows monitor APIs

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -135,7 +135,7 @@ if conf.use_winpcapy:
   class _PcapWrapper_pypcap:
       """Wrapper for the WinPcap calls"""
 
-      def __init__(self, device, snaplen, promisc, to_ms, monitor=False):
+      def __init__(self, device, snaplen, promisc, to_ms, monitor=None):
           self.errbuf = create_string_buffer(PCAP_ERRBUF_SIZE)
           self.iface = create_string_buffer(device.encode("utf8"))
           if monitor:
@@ -198,7 +198,7 @@ if conf.use_winpcapy:
   class L2pcapListenSocket(SuperSocket, SelectableObject):
       desc = "read packets at layer 2 using libpcap"
 
-      def __init__(self, iface=None, type=ETH_P_ALL, promisc=None, filter=None, monitor=False):
+      def __init__(self, iface=None, type=ETH_P_ALL, promisc=None, filter=None, monitor=None):
           self.type = type
           self.outs = None
           self.iface = iface
@@ -262,7 +262,7 @@ if conf.use_winpcapy:
       desc = "read/write packets at layer 2 using only libpcap"
 
       def __init__(self, iface=None, type=ETH_P_ALL, promisc=None, filter=None, nofilter=0,
-                   monitor=False):
+                   monitor=None):
           if iface is None:
               iface = conf.iface
           self.iface = iface

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -959,11 +959,22 @@ _orig_open_pcap = pcapdnet.open_pcap
 
 
 def open_pcap(iface, *args, **kargs):
+    """open_pcap: Windows routine for creating a pcap from an interface.
+    This function is also responsible for detecting monitor mode.
+    """
     iface_pcap_name = pcapname(iface)
     if not isinstance(iface, NetworkInterface) and iface_pcap_name is not None:
         iface = IFACES.dev_from_name(iface)
-    if conf.use_npcap and isinstance(iface, NetworkInterface) and iface.ismonitor():
-        kargs["monitor"] = True
+    if conf.use_npcap and isinstance(iface, NetworkInterface):
+        monitored = iface.ismonitor()
+        kw_monitor = kargs.get("monitor", None)
+        if kw_monitor is None:
+            # The monitor param is not specified. Matching it to current state
+            kargs["monitor"] = monitored
+        elif kw_monitor is not monitored:
+            # The monitor param is specified, and not matching the current
+            # interface state
+            iface.setmonitor(kw_monitor)
     return _orig_open_pcap(iface_pcap_name, *args, **kargs)
 
 

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -642,65 +642,45 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
           L2socket=None, timeout=None, opened_socket=None,
           stop_filter=None, iface=None, *arg, **karg):
     """
+    Sniff packets and return a list of packets.
 
-Sniff packets and return a list of packets.
+    Args:
+        count: number of packets to capture. 0 means infinity.
+        store: whether to store sniffed packets or discard them
+        prn: function to apply to each packet. If something is returned, it
+             is displayed.
+             --Ex: prn = lambda x: x.summary()
+        filter: BPF filter to apply.
+        lfilter: Python function applied to each packet to determine if
+                 further action may be done.
+                 --Ex: lfilter = lambda x: x.haslayer(Padding)
+        offline: PCAP file (or list of PCAP files) to read packets from,
+                 instead of sniffing them
+        timeout: stop sniffing after a given time (default: None).
+        L2socket: use the provided L2socket (default: use conf.L2listen).
+        opened_socket: provide an object (or a list of objects) ready to use
+                      .recv() on.
+        stop_filter: Python function applied to each packet to determine if
+                     we have to stop the capture after this packet.
+                     --Ex: stop_filter = lambda x: x.haslayer(TCP)
+        iface: interface or list of interfaces (default: None for sniffing
+               on all interfaces).
+        monitor: use monitor mode. May not be available on all OS
 
-Arguments:
+    The iface, offline and opened_socket parameters can be either an
+    element, a list of elements, or a dict object mapping an element to a
+    label (see examples below).
 
-  count: number of packets to capture. 0 means infinity.
-
-  store: whether to store sniffed packets or discard them
-
-  prn: function to apply to each packet. If something is returned, it
-      is displayed.
-
-      Ex: prn = lambda x: x.summary()
-
-  filter: BPF filter to apply.
-
-  lfilter: Python function applied to each packet to determine if
-      further action may be done.
-
-      Ex: lfilter = lambda x: x.haslayer(Padding)
-
-  offline: PCAP file (or list of PCAP files) to read packets from,
-      instead of sniffing them
-
-  timeout: stop sniffing after a given time (default: None).
-
-  L2socket: use the provided L2socket (default: use conf.L2listen).
-
-  opened_socket: provide an object (or a list of objects) ready to use
-      .recv() on.
-
-  stop_filter: Python function applied to each packet to determine if
-      we have to stop the capture after this packet.
-
-      Ex: stop_filter = lambda x: x.haslayer(TCP)
-
-  iface: interface or list of interfaces (default: None for sniffing
-      on all interfaces).
-
-The iface, offline and opened_socket parameters can be either an
-element, a list of elements, or a dict object mapping an element to a
-label (see examples below).
-
-Examples:
-
-  >>> sniff(filter="arp")
-
-  >>> sniff(lfilter=lambda pkt: ARP in pkt)
-
-  >>> sniff(iface="eth0", prn=Packet.summary)
-
-  >>> sniff(iface=["eth0", "mon0"],
-  ...       prn=lambda pkt: "%s: %s" % (pkt.sniffed_on,
-  ...                                   pkt.summary()))
-
-  >>> sniff(iface={"eth0": "Ethernet", "mon0": "Wifi"},
-  ...       prn=lambda pkt: "%s: %s" % (pkt.sniffed_on,
-  ...                                   pkt.summary()))
-
+    Examples:
+      >>> sniff(filter="arp")
+      >>> sniff(lfilter=lambda pkt: ARP in pkt)
+      >>> sniff(iface="eth0", prn=Packet.summary)
+      >>> sniff(iface=["eth0", "mon0"],
+      ...       prn=lambda pkt: "%s: %s" % (pkt.sniffed_on,
+      ...                                   pkt.summary()))
+      >>> sniff(iface={"eth0": "Ethernet", "mon0": "Wifi"},
+      ...       prn=lambda pkt: "%s: %s" % (pkt.sniffed_on,
+      ...                                   pkt.summary()))
     """
     c = 0
     sniff_sockets = {}  # socket: label dict


### PR DESCRIPTION
This PR:
- now correctly handles the `monitor` parameter: 
  - if passed, turn the interface into it (such as on OSX) if the interface is not already in it. (no explicit call to `conf.iface.setmonitor` needed)
  - if not passed, detect the state of the interface and adapt to it
- reformat sniff() doc to add the monitor parameter. Sorry to whoever wrote it, but I found it too over indented (\n every where)