### PR TITLE
Use OEM version of Npcap (encrypted using AppVeyor secure)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,9 @@
 environment:
-
+  # This key is encrypted using secdev's appveyor private key,
+  # dissected only on master builds (not PRs) and is used during
+  # npcap OEM installation
+  npcap_oem_key:
+    secure: d120KTZBsVnzZ+pFPLPEOTOkyJxTVRjhbDJn9L+RYnM=
   # Python versions that will be tested
   # Note: it defines variables that can be used later
   matrix:

--- a/.appveyor/InstallNpcap.ps1
+++ b/.appveyor/InstallNpcap.ps1
@@ -1,19 +1,48 @@
-# Config
-$urlPath = "https://nmap.org/npcap/dist/npcap-0.90.exe"
-$checksum = "0477a42a9c54f31a7799fb3ee0537826041730f462abfc066fe36d81c50721a7"
+# Install Npcap on the machine.
 
-############
-############
-# Download the file
-wget $urlPath -UseBasicParsing -OutFile $PSScriptRoot"\npcap.exe"
-# Now let's check its checksum
-$_chksum = $(CertUtil -hashfile $PSScriptRoot"\npcap.exe" SHA256)[1] -replace " ",""
-if ($_chksum -ne $checksum){
-    echo "Checksums does NOT match !"
-    exit
-} else {
-    echo "Checksums matches !"
+# Config:
+$npcap_oem_file = "npcap-0.99-r3-oem.exe"
+
+# Note: because we need the /S option (silent), this script has two cases:
+#  - The script is runned from a master build, then use the secure variable 'npcap_oem_key' which will be available
+#    to decode the very recent npcap install oem file and use it
+#  - The script is runned from a PR, then use the provided archived 0.96 version, which is the last public one to
+#    provide support for the /S option
+
+Try
+{
+    # Check that the key is defined (build mode)
+    $user, $pass = (Get-ChildItem Env:npcap_oem_key).Value.replace("`"", "").split(",")
+    if(!$user -Or !$pass){
+        Throw (New-Object System.Exception)
+    }
+    $file = $PSScriptRoot+"\"+$npcap_oem_file
+    # Download oem file using (super) secret credentials
+    $pair = "${user}:${pass}"
+    $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+    $basicAuthValue = "Basic $encodedCreds"
+    $headers = @{ Authorization = $basicAuthValue }
+    $secpasswd = ConvertTo-SecureString $pass -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential($user, $secpasswd)
+    Invoke-WebRequest -uri (-join("https://nmap.org/npcap/oem/dist/",$npcap_oem_file)) -OutFile $file -Headers $headers -Credential $credential
 }
+Catch
+{
+    $file = $PSScriptRoot+"\npcap-0.96.exe"
+    # Download the 0.96 file from nmap servers
+    wget "https://nmap.org/npcap/dist/npcap-0.96.exe" -UseBasicParsing -OutFile $file
+    # Now let's check its checksum
+    $_chksum = $(CertUtil -hashfile $file SHA256)[1] -replace " ",""
+    if ($_chksum -ne "83667e1306fdcf7f9967c10277b36b87e50ee8812e1ee2bb9443bdd065dc04a1"){
+        echo "Checksums does NOT match !"
+        exit
+    } else {
+        echo "Checksums matches !"
+    }
+}
+echo "Installing:"
+echo $file
+
 # Run installer
-Start-Process $PSScriptRoot"\npcap.exe" -ArgumentList "/loopback_support=yes /S" -wait
+Start-Process $file -ArgumentList "/loopback_support=yes /S" -wait
 echo "Npcap installation completed"


### PR DESCRIPTION
This allows us to use the OEM versions of Npcap, without making it public.

AppVeyor hides the secure variables from the "PR builds" for obvious reasons. The script has 2 options depending on the case

@guedou

Disclaimer: As this PR is a PR, the "master case" won't be tested in this PR.
Here's an example showing that it also works:
https://ci.appveyor.com/project/gpotter2/scapy/build/1.0.1587/job/whemnjrudyloc6i8?fullLog=true