### PR TITLE
Use scapy.net images rather than img.shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Travis Build Status](https://travis-ci.org/secdev/scapy.svg?branch=master)](https://travis-ci.org/secdev/scapy)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/secdev/scapy?svg=true)](https://ci.appveyor.com/project/secdev/scapy)
 [![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy)
-[![PyPI Version](https://img.shields.io/pypi/v/scapy.svg)](https://pypi.python.org/pypi/scapy/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/scapy.svg)](https://pypi.python.org/pypi/scapy/)
-[![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
+[![PyPI Version](https://scapy.net/images/badges/pyversions.svg)](https://pypi.python.org/pypi/scapy/)
+[![Python Versions](https://scapy.net/images/badges/scapyversion.svg)](https://pypi.python.org/pypi/scapy/)
+[![License: GPL v2](https://scapy.net/images/badges/gplv2.svg)](LICENSE)
 [![Join the chat at https://gitter.im/secdev/scapy](https://badges.gitter.im/secdev/scapy.svg)](https://gitter.im/secdev/scapy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
`img.shields.io` is very unstable, and overused compared to its server capacity.

![image](https://user-images.githubusercontent.com/10530980/38810103-0b2f251c-4186-11e8-9ed0-4e92d3ac60ac.png)

Let's use the svg images that we host on scapy.net (as they are svg, they are easily editable).
**This also allows us to remove Python 3.3 from the icon**