### PR TITLE
Pcapdnet: monitor mode + full support without dnet + cleanup

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -450,6 +450,7 @@ class L3PacketSocket(SuperSocket):
         SuperSocket.close(self)
 
     def recv_raw(self, x=MTU):
+        """Receives a packet, then returns a tuple containing (cls, pkt_data, time)"""
         pkt, sa_ll = self.ins.recvfrom(x)
         if sa_ll[2] == socket.PACKET_OUTGOING:
             return None, None, None
@@ -539,6 +540,7 @@ class L2Socket(SuperSocket):
         SuperSocket.close(self)
 
     def recv_raw(self, x=MTU):
+        """Receives a packet, then returns a tuple containing (cls, pkt_data, time)"""
         pkt, sa_ll = self.ins.recvfrom(x)
         if sa_ll[2] == socket.PACKET_OUTGOING:
             return None, None, None
@@ -598,6 +600,7 @@ class L2ListenSocket(SuperSocket):
         SuperSocket.close(self)
 
     def recv_raw(self, x=MTU):
+        """Receives a packet, then returns a tuple containing (cls, pkt_data, time)"""
         pkt, sa_ll = self.ins.recvfrom(x)
         if sa_ll[3] in conf.l2types:
             cls = conf.l2types[sa_ll[3]]

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -610,13 +610,14 @@ class L2ListenSocket(SuperSocket):
                     cls.name)
 
         ts = get_last_packet_timestamp(self.ins)
-        #direction = sa_ll[2]
-        return cls, pkt, ts#, direction
+        # direction = sa_ll[2]
+        return cls, pkt, ts  # , direction
 
     def recv(self, x=MTU):
-        #cls, pkt, ts, direction = self.recv_raw()
+        # cls, pkt, ts, direction = self.recv_raw()
+        # [Dissection stuff]
         pkt = SuperSocket.recv(self, x)
-        #pkt.direction = direction
+        # pkt.direction = direction
         return pkt
 
     def send(self, x):

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -28,11 +28,13 @@ if not scapy.consts.WINDOWS:
     from fcntl import ioctl
 
 ############
-## COMMON ##
+#  COMMON  #
 ############
+
 
 class PcapTimeoutElapsed(Scapy_Exception):
     pass
+
 
 class _L2pcapdnetSocket(SuperSocket, SelectableObject):
     def check_recv(self):
@@ -64,9 +66,11 @@ class _L2pcapdnetSocket(SuperSocket, SelectableObject):
         self.ins.setnonblock(0)
         return p
 
+
 ###################
-## WINPCAP/NPCAP ##
+#  WINPCAP/NPCAP  #
 ###################
+
 
 if conf.use_winpcapy:
     NPCAP_PATH = os.environ["WINDIR"] + "\\System32\\Npcap"
@@ -357,8 +361,9 @@ if conf.use_winpcapy:
     conf.L3socket = L3pcapSocket
 
 ################
-## PCAP/PCAPY ##
+#  PCAP/PCAPY  #
 ################
+
 
 if conf.use_pcap:
     try:
@@ -496,7 +501,7 @@ if conf.use_pcap:
         conf.L2listen = L2pcapListenSocket
 
 ##########
-## DNET ##
+#  DNET  #
 ##########
 
 if conf.use_dnet:
@@ -579,7 +584,7 @@ if conf.use_dnet:
             return intf.get("name", scapy.consts.LOOPBACK_NAME)
 
 #################
-## DNET & PCAP ##
+#  DNET & PCAP  #
 #################
 
 if conf.use_pcap and conf.use_dnet:

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -526,7 +526,7 @@ if conf.use_pcap or conf.use_winpcapy:
 # DEPRECATED
 
 if conf.use_dnet:
-    warning("Dnet usage with scapy is deprecated, and will be removed in a future version.")
+    warning("dnet usage with scapy is deprecated, and will be removed in a future version.")
     try:
         try:
             # First try to import dnet

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -41,13 +41,14 @@ class _L2pcapdnetSocket(SuperSocket, SelectableObject):
         return True
 
     def recv_raw(self, x=MTU):
-        """Returns a tuple containing (cls, pkt_data, time)"""
+        """Receives a packet, then returns a tuple containing (cls, pkt_data, time)"""
         ll = self.ins.datalink()
         if ll in conf.l2types:
             cls = conf.l2types[ll]
         else:
             cls = conf.default_l2
-            warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s", self.iface, ll, cls.name)
+            warning("Unable to guess datalink type (interface=%s linktype=%i). Using %s",
+                    self.iface, ll, cls.name)
 
         pkt = None
         while pkt is None:
@@ -61,6 +62,8 @@ class _L2pcapdnetSocket(SuperSocket, SelectableObject):
         return cls, pkt, ts
 
     def nonblock_recv(self):
+        """Receives and dissect a packet in non-blocking mode.
+        Note: on Windows, this won't do anything."""
         self.ins.setnonblock(1)
         p = self.recv(MTU)
         self.ins.setnonblock(0)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -92,7 +92,11 @@ def _sndrcv_rcv(pks, tobesent, stopevent, nbrecv, notans, verbose, chainCC,
 
     if WINDOWS and not is_python_can_socket():
         def _get_pkt():
-            return pks.recv(MTU)
+            from scapy.arch.pcapdnet import PcapTimeoutElapsed
+            try:
+                return pks.recv(MTU)
+            except PcapTimeoutElapsed:
+                return None
     elif conf.use_bpf:
         from scapy.arch.bpf.supersocket import bpf_select
 
@@ -800,10 +804,7 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
         read_allowed_exceptions = (PcapTimeoutElapsed,)
 
         def _select(sockets):
-            try:
-                return sockets
-            except PcapTimeoutElapsed:
-                return []
+            return sockets
     elif is_python_can_socket():
         from scapy.contrib.cansocket_python_can import CANSocketTimeoutElapsed
         read_allowed_exceptions = (CANSocketTimeoutElapsed,)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -435,8 +435,6 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface"""
-    if "timeout" not in kargs:
-        kargs["timeout"] = -1
     s = conf.L3socket(promisc=promisc, filter=filter, iface=iface, nofilter=nofilter)
     result = sndrcv(s, x, *args, **kargs)
     s.close()
@@ -454,8 +452,6 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    listen answers only on the given interface"""
-    if "timeout" not in kargs:
-        kargs["timeout"] = -1
     s = conf.L3socket(promisc=promisc, filter=filter, nofilter=nofilter, iface=iface)
     ans, _ = sndrcv(s, x, *args, **kargs)
     s.close()
@@ -476,8 +472,6 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface"""
-    if "timeout" not in kargs:
-        kargs["timeout"] = -1
     if iface is None and iface_hint is not None:
         iface = conf.route.route(iface_hint)[0]
     s = conf.L2socket(promisc=promisc, iface=iface, filter=filter, nofilter=nofilter, type=type)
@@ -497,8 +491,6 @@ verbose:  set verbosity level
 multi:    whether to accept multiple answers for the same stimulus
 filter:   provide a BPF filter
 iface:    work only on the given interface"""
-    if "timeout" not in kargs:
-        kargs["timeout"] = -1
     ans, _ = srp(*args, **kargs)
     if len(ans) > 0:
         return ans[0][1]

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -47,8 +47,24 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
             x.sent_time = time.time()
         return self.outs.send(sx)
 
+    def recv_raw(self, x=MTU):
+        """Returns a tuple containing (cls, pkt_data, time)"""
+        return conf.raw_layer, self.ins.recv(x), None
+
     def recv(self, x=MTU):
-        return conf.raw_layer(self.ins.recv(x))
+        cls, val, ts = self.recv_raw(x)
+        if not val or not cls:
+            return
+        try:
+            pkt = cls(val)
+        except KeyboardInterrupt:
+            raise
+        except:
+            if conf.debug_dissector:
+                raise
+            pkt = conf.raw_layer(val)
+        pkt.time = ts
+        return pkt
 
     def fileno(self):
         return self.ins.fileno()


### PR DESCRIPTION
This PR:
- Removes tons of duplicated code, which is used while receiving packets. To do so, we introduce a `recv_raw` function, which receives the packet, calculates its TimeStamp and returns the info required to build it. It will then be built in the `recv` function, which is now common to all SuperSockets.
- Updates API calls for pypcap, libpcap & pcapy
- Adds monitor mode support on pypcap and libpcap
- Makes `conf.use_pcap` useable without `conf.use_dnet`
- Because the pcap handlers can now send packet, remove the now useless "PCAP with DNET" mode. DNET is deprecated, but can still be used as a way to get system data