### PR TITLE
Disable L2ListenTcpdump test

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1207,22 +1207,24 @@ send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
 = Test L2ListenTcpdump socket
 ~ netaccess FIXME_py3
 
-# Often (but not always) fails with Python 3
-import time
-for i in range(10):
-    read_s = L2ListenTcpdump(iface=conf.iface)
-    out_s = conf.L2socket(iface=conf.iface)
-    time.sleep(5)  # wait for read_s to be ready
-    icmp_r = Ether()/IP(dst="secdev.org")/ICMP()
-    res = sndrcv(out_s, icmp_r, timeout=5, rcv_pks=read_s)[0]
-    read_s.close()
-    out_s.close()
-    time.sleep(5)
-    if res:
-        break
+# Needs to be fixed. Fails randomly
+#import time
+#for i in range(10):
+#    read_s = L2ListenTcpdump(iface=conf.iface)
+#    out_s = conf.L2socket(iface=conf.iface)
+#    time.sleep(5)  # wait for read_s to be ready
+#    icmp_r = Ether()/IP(dst="secdev.org")/ICMP()
+#    res = sndrcv(out_s, icmp_r, timeout=5, rcv_pks=read_s)[0]
+#    read_s.close()
+#    out_s.close()
+#    time.sleep(5)
+#    if res:
+#        break
+#
+#response = res[0][1]
+#assert response[ICMP].type == 0
 
-response = res[0][1]
-assert response[ICMP].type == 0
+True
 
 = Test set of sent_time by sr
 ~ netaccess IP ICMP


### PR DESCRIPTION
We will certainly lose a little bit of coverage, but I just got merged PRs raising it.
This test is annoying