### PR TITLE
Use UTScapy flags according to  value

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -21,7 +21,7 @@ then
     UT_FLAGS=" -K tcpdump"
   fi
 
-  if python --version 2>&1 | grep -q '^Python 3\.'
+  if [[ $TOXENV == py3* ]]
   then
     # Some Python 3 tests currently fail. They should be tracked and
     # fixed.


### PR DESCRIPTION
I think that this is the correct fix for the failing L2ListenTcpdump tests. Related to PR #1351