### PR TITLE
add hint for conf.debug_dissector=1 to test section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,10 @@ Please consider adding tests for your new features or that trigger the
 bug you are fixing. This will prevent a regression from being
 unnoticed. Do not use the variable `_`  in your tests, as it could break them.
 
+If you find yourself in a situation where your tests locally succeed  but 
+fail if executed on the CI, try to enable the debuging option for the 
+dissector by setting `conf.debug_dissector = 1`.
+
 ### New protocols
 
 New protocols can go either in `scapy/layers` or to


### PR DESCRIPTION
Based on a hint of @gpotter2, setting `conf.debug_dissector=1` 
helped a lot to fix a bug that only popped up on CI.
