### PR TITLE
Fixed MQTT module for payload length > 127 bytes

### DIFF
--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -22,7 +22,7 @@ class VariableFieldLenField(FieldLenField):
         while val:
             if val > 127:
                 data.append(val & 127)
-                val /= 127
+                val //= 128
             else:
                 data.append(val)
                 lastoffset = len(data) - 1

--- a/scapy/contrib/mqtt.uts
+++ b/scapy/contrib/mqtt.uts
@@ -108,3 +108,13 @@ assert(pc.msgid == 1)
 s = b'P\x02\x00\x01'
 pubrec = MQTT(s)
 assert(pubrec.msgid == 1)
+
+= MQTTPublish, long value
+p = MQTT()/MQTTPublish(topic='test1',value='a'*200)
+assert(str(p))
+assert(p.type == 3)
+assert(p.topic == b'test1')
+assert(p.value == b'a'*200)
+assert(p.len == None)
+assert(p.length == None)
+


### PR DESCRIPTION
Fixes generation of MQTT packets with a payload above 127 byte.

Previously the following error occurred:

```python
p = MQTT()/MQTTPublish(topic='test1',value='a'*200)
assert(str(p))

Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "/mnt/data/Documents/projects/scapy/scapy/packet.py", line 351, in __str__
    return str(self.build())
  File "/mnt/data/Documents/projects/scapy/scapy/packet.py", line 461, in build
    p = self.do_build()
  File "/mnt/data/Documents/projects/scapy/scapy/packet.py", line 443, in do_build
    pkt = self.self_build()
  File "/mnt/data/Documents/projects/scapy/scapy/packet.py", line 424, in self_build
    p = f.addfield(self, p, val)
  File "/mnt/data/Documents/projects/scapy/scapy/contrib/mqtt.py", line 30, in addfield
    for i, val in enumerate(data))
  File "/mnt/data/Documents/projects/scapy/scapy/contrib/mqtt.py", line 30, in <genexpr>
    for i, val in enumerate(data))
TypeError: unsupported operand type(s) for |: 'float' and 'int'
```