### PR TITLE
Fix recursion error in packet list #1374

### DIFF
--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -85,6 +85,19 @@ class PacketList(BasePacketList):
                                s,
                                ct.punct(">"))
 
+    def __getstate__(self):
+        state = {
+            'res': self.res,
+            'stats': self.stats,
+            'listname': self.listname
+        }
+        return state
+
+    def __setstate__(self, state):
+        self.res = state['res']
+        self.stats = state['stats']
+        self.listname = state['listname']
+
     def __getattr__(self, attr):
         return getattr(self.res, attr)
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -86,6 +86,10 @@ class PacketList(BasePacketList):
                                ct.punct(">"))
 
     def __getstate__(self):
+        """
+        create a basic representation of the instance, used in conjunction with __setstate__() e.g. by pickle
+        :return: dict representing this instance
+        """
         state = {
             'res': self.res,
             'stats': self.stats,
@@ -94,6 +98,10 @@ class PacketList(BasePacketList):
         return state
 
     def __setstate__(self, state):
+        """
+        set instance attributes to values given by state, used in conjunction with __getstate__() e.g. by pickle
+        :param state: dict representing this instance
+        """
         self.res = state['res']
         self.stats = state['stats']
         self.listname = state['listname']

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10160,6 +10160,17 @@ if PYX:
     assert(os.path.exists(filename))
     os.unlink(filename)
 
+= __getstate__ / __setstate__ (used by pickle)
+
+import pickle
+
+frm = Ether(src='00:11:22:33:44:55', dst='00:11:22:33:44:55')/Raw()
+pl = PacketList(res=[frm, frm])
+pickled = pickle.dumps(pl)
+pl = pickle.loads(pickled)
+assert(len(pl) == 2)
+
+
 ############
 ############
 + Scapy version

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10164,11 +10164,14 @@ if PYX:
 
 import pickle
 
-frm = Ether(src='00:11:22:33:44:55', dst='00:11:22:33:44:55')/Raw()
-pl = PacketList(res=[frm, frm])
+frm = Ether(src='00:11:22:33:44:55', dst='00:22:33:44:55:66')/Raw()
+pl = PacketList(res=[frm, frm], name='WhatAGreatName')
 pickled = pickle.dumps(pl)
 pl = pickle.loads(pickled)
+assert(pl.listname == "WhatAGreatName")
 assert(len(pl) == 2)
+assert(pl[0][Ether].src == '00:11:22:33:44:55')
+assert(pl[1][Ether].dst == '00:22:33:44:55:66')
 
 
 ############


### PR DESCRIPTION
Allows pickling and unpickling of PacketList so it can be used with other containers like multiprocessing.SimpleQueue() that utilizes pickle to handle that queued data...

fixes #1374 
