### PR TITLE
Fix get_trace() in TracerouteResult and TracerouteResult6

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1144,7 +1144,7 @@ class TracerouteResult(SndRcvList):
             trace[d][s[IP].ttl] = r[IP].src, ICMP not in r
         for k in six.itervalues(trace):
             try:
-                m = min(x for x, y in six.itervalues(k) if y)
+                m = min(x for x, y in six.iteritems(k) if y[1])
             except ValueError:
                 continue
             for l in list(k):  # use list(): k is modified in the loop

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3467,7 +3467,7 @@ class TracerouteResult6(TracerouteResult):
 
         for k in six.itervalues(trace):
             try:
-                m = min(x for x, y in six.itervalues(k) if y)
+                m = min(x for x, y in six.iteritems(k) if y[1])
             except ValueError:
                 continue
             for l in list(k):  # use list(): k is modified in the loop


### PR DESCRIPTION
The iteration is not compliant with the produced data structure which holds the traceroute results.
The expected value for comparison is the key of the dictionary entry but 'x' holds the IP address (as str).

This solves the produced TypeError: unorderable types: int() > str() which occurs because 'x' does not hold the dictionary key but the IP address.