### PR TITLE
UTScapy detects Python version and export python3_only

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -821,6 +821,10 @@ def main(argv):
             elif opt == "-K":
                 KW_KO.append(optarg.split(","))
 
+        # Discard Python3 tests when using Python2
+        if six.PY2:
+            KW_KO.append(["python3_only"])
+
         if VERB > 2:
             print("### Booting scapy...", file=sys.stderr)
         try:

--- a/test/cansocket_native.uts
+++ b/test/cansocket_native.uts
@@ -1,4 +1,5 @@
 % Regression tests for nativecansocket
+~ python3_only
 
 # More informations at http://www.secdev.org/projects/UTscapy/
 
@@ -10,12 +11,9 @@
 = Load module
 ~ conf command needs_root linux
 
-import scapy.modules.six as six
-
-if six.PY3:
-    load_layer("can")
-    conf.contribs['CANSocket'] = {'use-python-can': False}
-    from scapy.contrib.cansocket_native import *
+load_layer("can")
+conf.contribs['CANSocket'] = {'use-python-can': False}
+from scapy.contrib.cansocket_native import *
 
 = Setup string for vcan
 ~ conf command
@@ -31,280 +29,226 @@ from time import sleep
 = Setup vcan0
 ~ conf command needs_root linux
 
-if six.PY3:
-    0 == os.system(bashCommand)
+0 == os.system(bashCommand)
 
 + Basic Packet Tests()
 = CAN Packet init
 ~ needs_root linux
 
-if six.PY3:
-    canframe = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-    bytes(canframe) == b'\x00\x00\x07\xff\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08'
+canframe = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+bytes(canframe) == b'\x00\x00\x07\xff\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08'
 
 + Basic Socket Tests()
 = CAN Socket Init
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface="vcan0")
+sock1 = CANSocket(iface="vcan0")
 
 = CAN Socket send recv small packet
 ~ needs_root linux
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x7ff,length=1,data=b'\x01'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x7ff,length=1,data=b'\x01'))
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    rx = sock1.recv()
-    rx == CAN(identifier=0x7ff,length=1,data=b'\x01')
+thread = threading.Thread(target=sender)
+thread.start()
+rx = sock1.recv()
+rx == CAN(identifier=0x7ff,length=1,data=b'\x01')
 
 = CAN Socket send recv
 ~ needs_root linux
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    rx = sock1.recv()
-    rx == CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread = threading.Thread(target=sender)
+thread.start()
+rx = sock1.recv()
+rx == CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 
 + Advanced Socket Tests()
 = CAN Socket sr1
 ~ needs_root linux
 
-if six.PY3:
-    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 
 = CAN Socket sr1 init time
 ~ needs_root linux
 
-if six.PY3:
-    tx.sent_time == None
+tx.sent_time == None
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(tx)
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(tx)
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    rx = None
-    rx = sock1.sr1(tx)
-    rx == tx
+thread = threading.Thread(target=sender)
+thread.start()
+rx = None
+rx = sock1.sr1(tx)
+rx == tx
 
 = CAN Socket sr1 time check
 ~ needs_root linux
 
-if six.PY3:
-    tx.sent_time < rx.time and rx.time > 0
+tx.sent_time < rx.time and rx.time > 0
 
 = srcan
 ~ needs_root linux
 
-if six.PY3:
-    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 
 = srcan check init time
 ~ needs_root linux
 
-if six.PY3:
-    tx.sent_time == None
+tx.sent_time == None
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(tx)
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(tx)
 
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    rx = None
-    rx = srcan(tx, "vcan0", timeout=1)
-    rx = rx[0][0][1]
-    tx == rx
+thread = threading.Thread(target=sender)
+thread.start()
+rx = None
+rx = srcan(tx, "vcan0", timeout=1)
+rx = rx[0][0][1]
+tx == rx
 
 = srcan check rx and tx
 ~ needs_root linux
 
-if six.PY3:
-    tx.sent_time > 0 and rx.time > 0 and tx.sent_time < rx.time
+tx.sent_time > 0 and rx.time > 0 and tx.sent_time < rx.time
 
 = sniff with filtermask 0x7ff
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 3
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 3
 
 = sniff with filtermask 0x700
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x700}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x700}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x212, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x2ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x2aa, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x212, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x2ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x2aa, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 4
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
 
 = sniff with filtermask 0x0ff
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x0ff}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x0ff}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x301, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x301, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x1ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 4
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
 
 = sniff with multiple filters
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}, {'can_id': 0x400, 'can_mask': 0x7ff}, {'can_id': 0x600, 'can_mask': 0x7ff},  {'can_id': 0x7ff, 'can_mask': 0x7ff}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200, 'can_mask': 0x7ff}, {'can_id': 0x400, 'can_mask': 0x7ff}, {'can_id': 0x600, 'can_mask': 0x7ff},  {'can_id': 0x7ff, 'can_mask': 0x7ff}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x400, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x500, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x600, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x7ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x400, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x500, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x600, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x700, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x7ff, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 4
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 4
 
 = sniff with filtermask 0x7ff and inverse filter
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200 | CAN_INV_FILTER, 'can_mask': 0x7ff}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x200 | CAN_INV_FILTER, 'can_mask': 0x7ff}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x100, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 2
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 2
 
 = sniff with filtermask 0x1FFFFFFF
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000, 'can_mask': 0x1fffffff}])
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000, 'can_mask': 0x1fffffff}])
 
-if six.PY3:
-    def sender():
-        sleep(0.1)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+def sender():
+    sleep(0.1)
+    sock2 = CANSocket(iface="vcan0")
+    sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
+    sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
 
-
-if six.PY3:
-    thread = threading.Thread(target=sender)
-    thread.start()
-    packets = sock1.sniff(timeout=0.3)
-    len(packets) == 2
+thread = threading.Thread(target=sender)
+thread.start()
+packets = sock1.sniff(timeout=0.3)
+len(packets) == 2
 
 = sniff with filtermask 0x1FFFFFFF and inverse filter
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000 | CAN_INV_FILTER, 'can_mask': 0x1fffffff}])
-
-if six.PY3:
-    def sender():
-        sleep(0.2)
-        sock2 = CANSocket(iface="vcan0")
-        sock2.send(CAN(flags='extended', identifier=0x10010000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10020000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10030000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10040000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-        sock2.send(CAN(flags='extended', identifier=0x10000000, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08'))
-
+sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000 | CAN_INV_FILTER, 'can_mask': 0x1fffffff}])
 
 if six.PY3:
     thread = threading.Thread(target=sender)
@@ -315,19 +259,17 @@ if six.PY3:
 = CAN Socket sr1 with receive own messages
 ~ needs_root linux
 
-if six.PY3:
-    sock1 = CANSocket(iface="vcan0", receive_own_messages=True)
-    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-    rx = None
-    rx = sock1.sr1(tx)
-    tx == rx
-    tx.sent_time < rx.time and tx == rx and rx.time > 0
+sock1 = CANSocket(iface="vcan0", receive_own_messages=True)
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+rx = None
+rx = sock1.sr1(tx)
+tx == rx
+tx.sent_time < rx.time and tx == rx and rx.time > 0
 
 = srcan
 ~ needs_root linux
 
-if six.PY3:
-    tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-    rx = None
-    rx = srcan(tx, iface="vcan0", receive_own_messages=True, timeout=1)
-    tx == rx[0][0][1]
+tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+rx = None
+rx = srcan(tx, iface="vcan0", receive_own_messages=True, timeout=1)
+tx == rx[0][0][1]


### PR DESCRIPTION
This PR will ease writing Python3 only unit tests. The `python3_only` is automatically set by UTScapy when launched from Python2.