### PR TITLE
Update manuf test (fix AppVeyor fails)

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1274,7 +1274,7 @@ else:
 = check _resolve_MAC
 
 if conf.manufdb:
-    assert conf.manufdb._resolve_MAC("00:00:63") == "HP"
+    assert conf.manufdb._resolve_MAC("00:00:17") == "Oracle"
 else:
     True
 


### PR DESCRIPTION
Wireshark has been updated today, and the chocolatey package too.
In the latest version, some MACS have been updated. The one we used is now wrong:

```
>>> conf.manufdb._resolve_MAC("00:00:63")
'BarcoCon'
```

Let's use the Oracle one, which has remained stable, so that the tests pass on previous and following wireshark versions