### PR TITLE
Add forgotten parenthesis

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -847,11 +847,12 @@ class NetBIOSNameField(StrFixedLenField):
 
     def i2m(self, pkt, x):
         l = self.length_from(pkt) // 2
+        x = raw(x)
         if x is None:
             x = b""
         x += b" " * (l)
         x = x[:l]
-        x = b"".join(chb(0x41 + orb(b) >> 4) + chb(0x41 + orb(b) & 0xf) for b in x)
+        x = b"".join(chb(0x41 + (orb(b) >> 4)) + chb(0x41 + (orb(b) & 0xf)) for b in x)
         x = b" " + x
         return x
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8575,6 +8575,21 @@ for binfrm in ["\x00" * 15, b"\x00" * 17]:
 
 ############
 ############
++ Netbios tests
+
+= NBNSQueryRequest - build
+
+z = NBNSQueryRequest(SUFFIX="file server service", QUESTION_NAME='TEST1', QUESTION_TYPE='NB')
+
+assert raw(z) == b'\x00\x00\x01\x10\x00\x01\x00\x00\x00\x00\x00\x00 FEEFFDFEDBCACACACACACACACACACACA\x00\x00 \x00\x01'
+
+pkt = IP(dst='192.168.0.255')/UDP(sport=137, dport='netbios_ns')/z
+pkt = IP(raw(pkt))
+assert pkt.QUESTION_NAME == b'TEST1          '
+
+
+############
+############
 + VRRP tests
 
 = VRRP - build


### PR DESCRIPTION
fixes https://github.com/secdev/scapy/issues/1391
some parenthesis had been forgotten while building a correct netbios format