### PR TITLE
Add StrLenField.max_length attribute to prevent crashes

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -637,15 +637,9 @@ class BGPCapGeneric(BGPCapability):
     name = "BGP Capability"
     fields_desc = [
         ByteEnumField("code", 0, _capabilities),
-        ByteField("length", 0),
-        ConditionalField(
-            StrLenField(
-                "cap_data",
-                '',
-                length_from=lambda p: p.length
-            ),
-            lambda p: p.length > 0
-        )
+        FieldLenField("length", None, fmt="B", length_of="cap_data"),
+        StrLenField("cap_data", '',
+                    length_from=lambda p: p.length, max_length=255),
     ]
 
 

--- a/scapy/contrib/bgp.uts
+++ b/scapy/contrib/bgp.uts
@@ -731,3 +731,10 @@ assert(m.orf_data[0].entries[1].action == 0)
 assert(m.orf_data[0].entries[1].match == 0)
 assert(m.orf_data[0].entries[1].prefix.prefix == "0.0.0.0/0")
 
+
+########## BGPCapGeneric fuzz() ###################################
++ BGPCapGeneric fuzz()
+
+= BGPCapGeneric fuzz()
+for i in range(10):
+    assert isinstance(raw(fuzz(BGPCapGeneric())), bytes)

--- a/scapy/contrib/bp.py
+++ b/scapy/contrib/bp.py
@@ -116,7 +116,9 @@ class BPBLOCK(Packet):
     fields_desc = [ByteEnumField('Type', 1, {1: "Bundle payload block"}),
                    SDNV2('ProcFlags', 0),
                    SDNV2FieldLenField('BlockLen', None, length_of="load"),
-                   StrLenField("load", "", length_from=lambda pkt: pkt.BlockLen)
+                   StrLenField("load", "",
+                               length_from=lambda pkt: pkt.BlockLen,
+                               max_length=65535)
                    ]
 
     def mysummary(self):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -862,15 +862,19 @@ class NetBIOSNameField(StrFixedLenField):
 
 
 class StrLenField(StrField):
-    __slots__ = ["length_from"]
+    __slots__ = ["length_from", "max_length"]
 
-    def __init__(self, name, default, fld=None, length_from=None):
+    def __init__(self, name, default, fld=None, length_from=None, max_length=None):
         StrField.__init__(self, name, default)
         self.length_from = length_from
+        self.max_length = max_length
 
     def getfield(self, pkt, s):
         l = self.length_from(pkt)
         return s[l:], self.m2i(pkt, s[:l])
+
+    def randval(self):
+        return RandBin(RandNum(0, self.max_length or 1200))
 
 
 class XStrField(StrField):

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -229,7 +229,8 @@ class Dot11Elt(Packet):
     fields_desc = [ByteEnumField("ID", 0, {0: "SSID", 1: "Rates", 2: "FHset", 3: "DSset", 4: "CFset", 5: "TIM", 6: "IBSSset", 16: "challenge",
                                            42: "ERPinfo", 46: "QoS Capability", 47: "ERPinfo", 48: "RSNinfo", 50: "ESRates", 221: "vendor", 68: "reserved"}),
                    FieldLenField("len", None, "info", "B"),
-                   StrLenField("info", "", length_from=lambda x: x.len)]
+                   StrLenField("info", "", length_from=lambda x: x.len,
+                               max_length=255)]
 
     def mysummary(self):
         if self.ID == 0:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -774,6 +774,10 @@ r = RadioTap(data)
 r.show()
 assert r.present == 18479
 
+= fuzz() calls for Dot11Elt()
+for i in range(10):
+    assert isinstance(raw(fuzz(Dot11Elt())), bytes)
+
 
 ############
 ############


### PR DESCRIPTION
This attribute is used for random values maximum length.

`.max_length` will be set on other `StrLenField()` (and subclasses) uses. This can be done in other PRs.

Fixes #1398.