### PR TITLE
Remove useless _RADIUSAttrPacketListField class

### DIFF
--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -16,7 +16,7 @@ from scapy.fields import BitField, ByteField, XByteField, ByteEnumField,\
     ShortField, IntField, XIntField, ByteEnumField, StrLenField, XStrField,\
     XStrLenField, XStrFixedLenField, LenField, FieldLenField, PacketField,\
     PacketListField, ConditionalField, PadField
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, Padding, bind_layers
 from scapy.layers.l2 import SourceMACField, Ether, CookedLinux, GRE, SNAP
 from scapy.utils import issubtype
 from scapy.config import conf
@@ -278,6 +278,9 @@ class EAP(Packet):
             l = len(p) + len(pay)
             p = p[:2] + chb((l >> 8) & 0xff) + chb(l & 0xff) + p[4:]
         return p + pay
+
+    def guess_payload_class(self, _):
+        return Padding
 
 
 class EAP_MD5(EAP):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -8877,6 +8877,10 @@ l = PacketList(p)
 s = l.sessions()  # Crashed on commit: e42ecdc54556c4852ca06b1a6da6c1ccbf3f522e
 assert len(s) == 1
 
+= Issue GH#1407
+s = b"Z\xa5\xaaUZ\xa5\xaaU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe9\xc5\x00\x00\x14'\x02\x00\x00\x001\x9a\xe44\xea4"
+isinstance(Radius(s), Radius)
+
 
 ############
 ############


### PR DESCRIPTION
This class was useless since PacketListField does the job, moreover it
was buggy and could cause Scapy to go in a infinite loop. Test case
added.

Fixes #1407.