### PR TITLE
Better Npcap detection

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -392,8 +392,10 @@ And if you are on an x64 machine:
 
 To use npcap instead. Those files are not removed by the Winpcap un-installer.
 
-2. If you get the message 'The installed Windump version does not work with Npcap' it means that you have installed an old version of Windump.
+2. If you get the message 'The installed Windump version does not work with Npcap' it surely means that you have installed an old version of Windump.
 Download the correct one on https://github.com/hsluoyz/WinDump/releases
+
+In some cases, it could also mean that you had installed Npcap and Winpcap, and that Windump is using Winpcap. Fully delete Winpcap using the above method to solve the problem.
 
 Build the documentation offline
 ===============================


### PR DESCRIPTION
I managed to find a way to workaround the issue we had with `SetDllDirectory`, by loading also loading `Packet.dll` even if unused.

This makes scapy able to use Npcap, when winpcap and npcap are both installed. This might not work properly under windows XP, in which case it will follow the previous behavior