### PR TITLE
New explore() function with prompt_toolkit 2.0 integration

### DIFF
--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -4,6 +4,8 @@
 # This program is published under a GPLv2 license
 
 """
+ASN.1 Packet
+
 Packet holding data in Abstract Syntax Notation (ASN.1).
 """
 

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -229,8 +229,9 @@ class Packet_metaclass(type):
         for f in newcls.fields_desc:
             if hasattr(f, "register_owner"):
                 f.register_owner(newcls)
-        from scapy import config
-        config.conf.layers.register(newcls)
+        if newcls.__name__[0] != "_":
+            from scapy import config
+            config.conf.layers.register(newcls)
         return newcls
 
     def __getattr__(self, attr):

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -177,7 +177,7 @@ class LayersList(list):
 
     def register(self, layer):
         self.append(layer)
-        if not layer.__module__ in self.ldict:
+        if layer.__module__ not in self.ldict:
             self.ldict[layer.__module__] = []
         self.ldict[layer.__module__].append(layer)
 

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -184,6 +184,8 @@ class LayersList(list):
     def layers(self):
         layers = self.ldict.keys()
         result = []
+        # This import may feel useless, but it is required for the eval below
+        import scapy  # noqa: F401
         for lay in layers:
             doc = eval(lay).__doc__
             result.append((lay, doc.strip().split("\n")[0] if doc else lay))

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -168,11 +168,26 @@ class Num2Layer:
 
 class LayersList(list):
 
+    def __init__(self):
+        list.__init__(self)
+        self.ldict = {}
+
     def __repr__(self):
         return "\n".join("%-20s: %s" % (l.__name__, l.name) for l in self)
 
     def register(self, layer):
         self.append(layer)
+        if not layer.__module__ in self.ldict:
+            self.ldict[layer.__module__] = []
+        self.ldict[layer.__module__].append(layer)
+
+    def layers(self):
+        layers = self.ldict.keys()
+        result = []
+        for lay in layers:
+            doc = eval(lay).__doc__
+            result.append((lay, doc.strip().split("\n")[0] if doc else lay))
+        return result
 
 
 class CommandsList(list):

--- a/scapy/contrib/bier.py
+++ b/scapy/contrib/bier.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = BIER
+# scapy.contrib.description = Bit Index Explicit Replication (BIER)
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/cansocket.py
+++ b/scapy/contrib/cansocket.py
@@ -3,6 +3,8 @@
 # Copyright (C) Nils Weiss <nils@we155.de>
 # This program is published under a GPLv2 license
 
+# scapy.contrib.description = CANSocket Utils
+# scapy.contrib.status = loads
 
 """
 CANSocket.

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -3,6 +3,8 @@
 # Copyright (C) Nils Weiss <nils@we155.de>
 # This program is published under a GPLv2 license
 
+# scapy.contrib.description = Native CANSocket
+# scapy.contrib.status = loads
 
 """
 Native CANSocket.

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -3,6 +3,8 @@
 # Copyright (C) Nils Weiss <nils@we155.de>
 # This program is published under a GPLv2 license
 
+# scapy.contrib.description = Python-Can CANSocket
+# scapy.contrib.status = loads
 
 """
 Python-CAN CANSocket Wrapper.

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = CARP
+# scapy.contrib.description = Common Address Redundancy Protocol (CARP)
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# scapy.contrib.description = Cisco Discovery Protocol
+# scapy.contrib.description = Cisco Discovery Protocol (CDP)
 # scapy.contrib.status = loads
 
 #############################################################################

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = DTP
+# scapy.contrib.description = Dynamic Trunking Protocol (DTP)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = EIGRP
+# scapy.contrib.description = Enhanced Interior Gateway Routing Protocol (EIGRP)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
+# flake8: noqa: E501
+
 # scapy.contrib.description = Enhanced Interior Gateway Routing Protocol (EIGRP)
 # scapy.contrib.status = loads
 
@@ -38,7 +40,7 @@
 
     :Thanks:
 
-    - TLV code derived from the CDP implementation of scapy. (Thanks to Nicolas Bareil and Arnaud Ebalard)  # noqa: E501
+    - TLV code derived from the CDP implementation of scapy. (Thanks to Nicolas Bareil and Arnaud Ebalard)
         http://trac.secdev.org/scapy/ticket/18
     - IOS / EIGRP Version Representation FIX by Dirk Loss
 """
@@ -63,10 +65,10 @@ from scapy.volatile import RandShort, RandString
 
 class EigrpIPField(StrField, IPField):
     """
-    This is a special field type for handling ip addresses of destination networks in internal and  # noqa: E501
+    This is a special field type for handling ip addresses of destination networks in internal and
     external route updates.
 
-    EIGRP removes zeros from the host portion of the ip address if the netmask is 8, 16 or 24 bits.  # noqa: E501
+    EIGRP removes zeros from the host portion of the ip address if the netmask is 8, 16 or 24 bits.
     """
 
     __slots__ = ["length_from"]
@@ -133,7 +135,7 @@ class EigrpIPField(StrField, IPField):
 
 class EigrpIP6Field(StrField, IP6Field):
     """
-    This is a special field type for handling ip addresses of destination networks in internal and  # noqa: E501
+    This is a special field type for handling ip addresses of destination networks in internal and
     external route updates.
 
     """
@@ -281,7 +283,7 @@ class ShortVersionField(ShortField):
 
     def h2i(self, pkt, x):
         """The field accepts string values like v12.1, v1.1 or integer values.
-           String values have to start with a "v" folled by a floating point number.  # noqa: E501
+           String values have to start with a "v" folled by a floating point number.
            Valid numbers are between 0 and 255.
         """
 

--- a/scapy/contrib/geneve.py
+++ b/scapy/contrib/geneve.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = GENEVE
+# scapy.contrib.description = Generic Network Virtualization Encapsulation (GENEVE)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/geneve.py
+++ b/scapy/contrib/geneve.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
+# flake8: noqa: E501
+
 # scapy.contrib.description = Generic Network Virtualization Encapsulation (GENEVE)
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -8,7 +8,7 @@
 ##
 # This program is published under a GPLv2 license
 
-# scapy.contrib.description = GTP
+# scapy.contrib.description = GPRS Tunneling Protocol (GTP)
 # scapy.contrib.status = loads
 
 from __future__ import absolute_import

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = GTPv2
+# scapy.contrib.description = GPRS Tunneling Protocol v2 (GTPv2)
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
+# flake8: noqa: E501
+
 # scapy.contrib.description = Internet Group Management Protocol v1/v2 (IGMP/IGMPv2)
 # scapy.contrib.status = loads
 
@@ -67,7 +69,7 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
                    IPField("gaddr", "0.0.0.0")]
 
     def post_build(self, p, pay):
-        """Called implicitly before a packet is sent to compute and place IGMP checksum.  # noqa: E501
+        """Called implicitly before a packet is sent to compute and place IGMP checksum.
 
         Parameters:
           self    The instantiation of an IGMP class
@@ -95,14 +97,14 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
 
         The rules are:
         General:
-            1.  the Max Response time is meaningful only in Membership Queries and should be zero  # noqa: E501
+            1.  the Max Response time is meaningful only in Membership Queries and should be zero
         IP:
             1. Send General Group Query to 224.0.0.1 (all systems)
             2. Send Leave Group to 224.0.0.2 (all routers)
             3a.Otherwise send the packet to the group address
             3b.Send reports/joins to the group address
             4. ttl = 1 (RFC 2236, section 2)
-            5. send the packet with the router alert IP option (RFC 2236, section 2)  # noqa: E501
+            5. send the packet with the router alert IP option (RFC 2236, section 2)
         Ether:
             1. Recalculate destination
 
@@ -113,8 +115,8 @@ IGMPv2 message format   http://www.faqs.org/rfcs/rfc2236.html
                     were adjusted.
 
         The function will examine the IGMP message to assure proper format.
-        Corrections will be attempted if possible. The IP header is then properly  # noqa: E501
-        adjusted to ensure correct formatting and assignment. The Ethernet header  # noqa: E501
+        Corrections will be attempted if possible. The IP header is then properly
+        adjusted to ensure correct formatting and assignment. The Ethernet header
         is then adjusted to the proper IGMP packet format.
         """
         gaddr = self.gaddr if hasattr(self, "gaddr") and self.gaddr else "0.0.0.0"  # noqa: E501

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = IGMP/IGMPv2
+# scapy.contrib.description = Internet Group Management Protocol v1/v2 (IGMP/IGMPv2)
 # scapy.contrib.status = loads
 
 from __future__ import print_function

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = IGMPv3
+# scapy.contrib.description = Internet Group Management Protocol v3 (IGMPv3)
 # scapy.contrib.status = loads
 
 from __future__ import print_function

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = IKEv2
+# scapy.contrib.description = Internet Key Exchange v2 (IKEv2)
 # scapy.contrib.status = loads
 
 import logging

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = ISIS
+# scapy.contrib.description = Intermediate System to Intermediate System (ISIS)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -6,6 +6,14 @@
 # Copyright (C) Enrico Pozzobon <enricopozzobon@gmail.com>
 # This program is published under a GPLv2 license
 
+# scapy.contrib.description = ISO-TP (ISO 15765-2)
+# scapy.contrib.status = loads
+
+"""
+ISOTPSocket.
+"""
+
+
 import ctypes
 from ctypes.util import find_library
 import struct
@@ -886,7 +894,7 @@ class ISOTPSocketImplementation:
                     load = self.ea_hdr
                     load += struct.pack("B", N_PCI_CF + self.tx_sn)
                     load += self.tx_buf[self.tx_idx:self.tx_idx + max_bytes]
-                    assert (len(load) <= 8)
+	assert (len(load) <= 8)
                     self.sendfunc(load)
 
                     self.tx_sn = (self.tx_sn + 1) % 16

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -894,7 +894,7 @@ class ISOTPSocketImplementation:
                     load = self.ea_hdr
                     load += struct.pack("B", N_PCI_CF + self.tx_sn)
                     load += self.tx_buf[self.tx_idx:self.tx_idx + max_bytes]
-	assert (len(load) <= 8)
+                    assert (len(load) <= 8)
                     self.sendfunc(load)
 
                     self.tx_sn = (self.tx_sn + 1) % 16

--- a/scapy/contrib/lacp.py
+++ b/scapy/contrib/lacp.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = LACP
+# scapy.contrib.description = Link Aggregation Control Protocol (LACP)
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# scapy.contrib.description = LLDP
+# scapy.contrib.description = Link Layer Discovery Protocol (LLDP)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/macsec.py
+++ b/scapy/contrib/macsec.py
@@ -3,6 +3,9 @@
 # Copyright (C) Sabrina Dubroca <sd@queasysnail.net>
 # This program is published under a GPLv2 license
 
+# scapy.contrib.description = 802.1AE - IEEE MAC Security standard (MACsec)
+# scapy.contrib.status = loads
+
 """
 Classes and functions for MACsec.
 """

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = MPLS
+# scapy.contrib.description = Multiprotocol Label Switching (MPLS)
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers, Padding

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -3,6 +3,8 @@
 # Copyright (C) Santiago Hernandez Ramos <shramos@protonmail.com>
 # This program is published under GPLv2 license
 
+# scapy.contrib.description = Message Queuing Telemetry Transport (MQTT)
+# scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers
 from scapy.fields import FieldLenField, BitEnumField, StrLenField, \

--- a/scapy/contrib/nsh.py
+++ b/scapy/contrib/nsh.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = NSH Protocol
+# scapy.contrib.description = Network Services Headers (NSH)
 # scapy.contrib.status = loads
 
 from scapy.all import bind_layers

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# scapy.contrib.description = OSPF
+# scapy.contrib.description = Open Shortest Path First (OSPF)
 # scapy.contrib.status = loads
 
 # This file is part of Scapy

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -14,7 +14,7 @@
 
 # author: <jellch@harris.com>
 
-# scapy.contrib.description = Parallel Peripheral Interface CACE Fields (PPI CACE)
+# scapy.contrib.description = Parallel Peripheral Interface CACE (PPI CACE)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -14,7 +14,7 @@
 
 # author: <jellch@harris.com>
 
-# scapy.contrib.description = PPI CACE
+# scapy.contrib.description = Parallel Peripheral Interface CACE Fields (PPI CACE)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -14,7 +14,7 @@
 
 # author: <jellch@harris.com>
 
-# scapy.contrib.description = PPI GEOLOCATION
+# scapy.contrib.description = Parallel Peripheral Interface Geolocation Fields (PPI GEOLOCATION)
 # scapy.contrib.status = loads
 
 

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -14,7 +14,7 @@
 
 # author: <jellch@harris.com>
 
-# scapy.contrib.description = Parallel Peripheral Interface Geolocation Fields (PPI GEOLOCATION)
+# scapy.contrib.description = Parallel Peripheral Interface (PPI) Geolocation
 # scapy.contrib.status = loads
 
 

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = RIPng
+# scapy.contrib.description = Routing Information Protocol next generation (RIPng)
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = Routing Information Protocol next generation (RIPng)
+# scapy.contrib.description = Routing Information Protocol next gen (RIPng)
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = RSVP
+# scapy.contrib.description = Resource Reservation Protocol (RSVP)
 # scapy.contrib.status = loads
 
 from scapy.compat import chb

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -17,7 +17,7 @@
 # https://en.wikipedia.org/wiki/IEEE_802.1aq
 # Modeled after the scapy VXLAN contribution
 
-# scapy.contrib.description = SBPM
+# scapy.contrib.description = Shorest Path Bridging Mac-in-mac (SBPM)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/tacacs.py
+++ b/scapy/contrib/tacacs.py
@@ -16,7 +16,7 @@
 
 # Based on tacacs+ v6 draft https://tools.ietf.org/html/draft-ietf-opsawg-tacacs-06  # noqa: E501
 
-# scapy.contrib.description = TACACS+ Protocol
+# scapy.contrib.description = Terminal Access Controller Access-Control System + (TACACS+)
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/tacacs.py
+++ b/scapy/contrib/tacacs.py
@@ -16,7 +16,7 @@
 
 # Based on tacacs+ v6 draft https://tools.ietf.org/html/draft-ietf-opsawg-tacacs-06  # noqa: E501
 
-# scapy.contrib.description = Terminal Access Controller Access-Control System + (TACACS+)
+# scapy.contrib.description = Terminal Access Controller Access-Control System+
 # scapy.contrib.status = loads
 
 import struct

--- a/scapy/contrib/tzsp.py
+++ b/scapy/contrib/tzsp.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-# scapy.contrib.description = TZSP
+# scapy.contrib.description = TaZmen Sniffer Protocol (TZSP)
 # scapy.contrib.status = loads
 
 """

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
-# scapy.contrib.description = WPA EAPOL dissector
+# scapy.contrib.description = WPA EAPOL-KEY
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -4,7 +4,7 @@
 # This program is published under a GPLv2 license
 
 """
-Classes related to the EAP protocol.
+Extensible Authentication Protocol (EAP)
 """
 
 from __future__ import absolute_import

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -1,3 +1,8 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more informations
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
 """
 LLMNR (Link Local Multicast Node Resolution).
 
@@ -18,6 +23,11 @@ from scapy.layers.dns import DNSQRField, DNSRRField, DNSRRCountField
 #############################################################################
 # LLMNR is based on the DNS packet format (RFC1035 Section 4)
 # RFC also envisions LLMNR over TCP. Like vista, we don't support it -- arno
+
+from scapy.fields import *
+from scapy.packet import *
+from scapy.layers.inet import UDP
+from scapy.layers.dns import DNSQRField, DNSRRField, DNSRRCountField
 
 _LLMNR_IPv6_mcast_Addr = "FF02:0:0:0:0:0:1:3"
 _LLMNR_IPv4_mcast_addr = "224.0.0.252"

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -1,5 +1,5 @@
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more informations
+# See http://www.secdev.org/projects/scapy for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # This program is published under a GPLv2 license
 
@@ -7,6 +7,9 @@
 LLMNR (Link Local Multicast Node Resolution).
 
 [RFC 4795]
+
+LLMNR is based on the DNS packet format (RFC1035 Section 4)
+RFC also envisions LLMNR over TCP. Like vista, we don't support it -- arno
 """
 
 import struct
@@ -17,17 +20,6 @@ from scapy.compat import orb
 from scapy.layers.inet import UDP
 from scapy.layers.dns import DNSQRField, DNSRRField, DNSRRCountField
 
-
-#############################################################################
-#                             LLMNR (RFC4795)                               #
-#############################################################################
-# LLMNR is based on the DNS packet format (RFC1035 Section 4)
-# RFC also envisions LLMNR over TCP. Like vista, we don't support it -- arno
-
-from scapy.fields import *
-from scapy.packet import *
-from scapy.layers.inet import UDP
-from scapy.layers.dns import DNSQRField, DNSRRField, DNSRRCountField
 
 _LLMNR_IPv6_mcast_Addr = "FF02:0:0:0:0:0:1:3"
 _LLMNR_IPv4_mcast_addr = "224.0.0.252"

--- a/scapy/layers/ppi.py
+++ b/scapy/layers/ppi.py
@@ -15,6 +15,10 @@
 
 # Original PPI author: <jellch@harris.com>
 
+# scapy.contrib.description = Parallel Peripheral Interface (PPI)
+# scapy.contrib.status = loads
+
+
 """
 Per-Packet Information (PPI) Protocol
 """

--- a/scapy/layers/sixlowpan.py
+++ b/scapy/layers/sixlowpan.py
@@ -5,15 +5,14 @@
 # Intern at INRIA Grand Nancy Est
 # This program is published under a GPLv2 license
 """
+6LoWPAN Protocol Stack
+======================
 
 This implementation follows the next documents:
     * Transmission of IPv6 Packets over IEEE 802.15.4 Networks
     * Compression Format for IPv6 Datagrams in Low Power and Lossy
       networks (6LoWPAN): draft-ietf-6lowpan-hc-15
     * RFC 4291
-
-6LoWPAN Protocol Stack
-======================
 
                             |-----------------------|
 Application                 | Application Protocols |

--- a/scapy/layers/skinny.py
+++ b/scapy/layers/skinny.py
@@ -4,7 +4,7 @@
 # This program is published under a GPLv2 license
 
 """
-Cisco Skinny protocol.
+Skinny Call Control Protocol (SCCP)
 """
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -1,5 +1,5 @@
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more informations
+# See http://www.secdev.org/projects/scapy for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # This program is published under a GPLv2 license
 

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -1,11 +1,19 @@
-#! /usr/bin/env python
-# RFC 7348 - Virtual eXtensible Local Area Network (VXLAN):
-# A Framework for Overlaying Virtualized Layer 2 Networks over Layer 3 Networks
-# http://tools.ietf.org/html/rfc7348
-# https://www.ietf.org/id/draft-ietf-nvo3-vxlan-gpe-02.txt
-#
-# VXLAN Group Policy Option:
-# http://tools.ietf.org/html/draft-smith-vxlan-group-policy-00
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more informations
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+"""
+Virtual eXtensible Local Area Network (VXLAN)
+- RFC 7348 -
+
+A Framework for Overlaying Virtualized Layer 2 Networks over Layer 3 Networks
+http://tools.ietf.org/html/rfc7348
+https://www.ietf.org/id/draft-ietf-nvo3-vxlan-gpe-02.txt
+
+VXLAN Group Policy Option:
+http://tools.ietf.org/html/draft-smith-vxlan-group-policy-00
+"""
 
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import Ether

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -188,7 +188,7 @@ def list_contrib(name=None, ret=False):
     """Show the list of all existing contribs.
     Params:
      - name: filter to search the contribs
-     - ret: whether or not the function should return a dict instead of printing
+     - ret: whether the function should return a dict instead of printing it
     """
     if name is None:
         name = "*.py"

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -188,7 +188,7 @@ def list_contrib(name=None, ret=False):
     """Show the list of all existing contribs.
     Params:
      - name: filter to search the contribs
-     - ret: wether or not the function should return a dict instead of printing
+     - ret: whether or not the function should return a dict instead of printing
     """
     if name is None:
         name = "*.py"

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -184,12 +184,18 @@ def load_contrib(name, globals_dict=None, symb_list=None):
                    globals_dict=globals_dict, symb_list=symb_list)
 
 
-def list_contrib(name=None):
+def list_contrib(name=None, ret=False):
+    """Show the list of all existing contribs.
+    Params:
+     - name: filter to search the contribs
+     - ret: wether or not the function should return a dict instead of printing
+    """
     if name is None:
         name = "*.py"
     elif "*" not in name and "?" not in name and not name.endswith(".py"):
         name += ".py"
     name = os.path.join(os.path.dirname(__file__), "contrib", name)
+    results = []
     for f in sorted(glob.glob(name)):
         mod = os.path.basename(f)
         if mod.startswith("__"):
@@ -205,7 +211,12 @@ def list_contrib(name=None):
                 key = l[p:q].strip()
                 value = l[q + 1:].strip()
                 desc[key] = value
-        print("%(name)-20s: %(description)-40s status=%(status)s" % desc)
+        results.append(desc)
+    if ret:
+        return results
+    else:
+        for desc in results:
+            print("%(name)-20s: %(description)-40s status=%(status)s" % desc)
 
 
 ##############################
@@ -552,7 +563,7 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=20):
                 cfg.TerminalInteractiveShell.confirm_exit = False
                 cfg.TerminalInteractiveShell.separate_in = u''
             if int(IPython.__version__[0]) >= 6:
-                cfg.TerminalInteractiveShell.term_title_format = "Scapy v" + conf.version  # noqa: E501
+                cfg.TerminalInteractiveShell.term_title_format = "Scapy v%s" % conf.version  # noqa: E501
             else:
                 cfg.TerminalInteractiveShell.term_title = False
             cfg.HistoryAccessor.hist_file = conf.histfile

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -15,6 +15,7 @@ import time
 import itertools
 import copy
 import subprocess
+import types
 
 from scapy.fields import StrField, ConditionalField, Emph, PacketListField, \
     BitField, MultiEnumField, EnumField, FlagsField
@@ -1603,76 +1604,107 @@ def split_layers(lower, upper, __fval=None, **fval):
 
 
 @conf.commands.register
-def explore():
-    """Pretty GUI function used to discover the Scapy layers and protocols.
+def explore(layer=None):
+    """Function used to discover the Scapy layers and protocols.
     It helps to see which packets exists in contrib or layer files.
+
+    params:
+     - layer: If specified, the function will explore the layer. If not,
+              the GUI mode will be activated, to browse the available layers
     """
-    if not conf.interactive:
-        raise OSError("explore() cannot be run in interactive mode")
+    if layer is None:  # GUI MODE
+        if not conf.interactive:
+            raise Scapy_Exception("explore() GUI-mode cannot be run in interactive mode. "
+                          "Please provide a 'layer' parameter !")
+        # 0 - Imports
+        try:
+            import prompt_toolkit
+        except ImportError:
+            raise ImportError("prompt_toolkit is not installed ! "
+                              "You may install IPython, which contains it, via"
+                              " `pip install ipython`")
+        if not _version_checker(prompt_toolkit, (2, 0)):
+            raise ImportError("prompt_toolkit >= 2.0.0 is required !")
+        # Only available with prompt_toolkit > 2.0, not released on PyPi yet
+        from prompt_toolkit.shortcuts.dialogs import radiolist_dialog, \
+            yes_no_dialog
+        from prompt_toolkit.formatted_text import HTML
+        # 1 - Ask for layer or contrib
+        is_layer = yes_no_dialog(
+            title="Scapy v%s" % conf.version,
+            text=HTML(
+                six.text_type(
+                    '<style bg="white" fg="red">Chose the type of packets'
+                    ' you want to explore:</style>'
+                )
+            ),
+            yes_text=six.text_type("Layers"),
+            no_text=six.text_type("Contribs"))
+        # 2 - Retrieve list of Packets
+        if is_layer is True:
+            # Get all loaded layers
+            _radio_values = conf.layers.layers()
+            # Restrict to layers-only (not contribs) + packet.py and asn1*.py
+            _radio_values = [x for x in _radio_values if ("layers" in x[0] or
+                                                          "packet" in x[0] or
+                                                          "asn1" in x[0])]
+        elif is_layer is False:
+            # Get all existing contribs
+            from scapy.main import list_contrib
+            _radio_values = list_contrib(ret=True)
+            _radio_values = [(x['name'], x['description']) for x in _radio_values]
+            # Remove very specific modules
+            _radio_values = [x for x in _radio_values if not ("can" in x[0])]
+        else:
+            # Escape was pressed
+            return
+        # Python 2 compat
+        if six.PY2:
+            _radio_values = [(six.text_type(x), six.text_type(y))
+                             for x, y in _radio_values]
+        # 3 - Ask for the layer/contrib module to explore
+        result = radiolist_dialog(
+            values=_radio_values,
+            title="Scapy v%s" % conf.version,
+            text=HTML(
+                six.text_type(
+                    '<style bg="white" fg="red">Please select a layer among'
+                    ' the following, to see all packets contained in it:</style>'
+                )
+            ))
+        if result is None:
+            return  # User pressed "Cancel"
+        # 4 - (Contrib only): load contrib
+        if not is_layer:
+            from scapy.main import load_contrib
+            load_contrib(result)
+            result = "scapy.contrib." + result
+    else:  # NON-GUI MODE
+        # We handle layer as a short layer name, full layer name or the module itself
+        if isinstance(layer, types.ModuleType):
+            layer = layer.__name__
+        if isinstance(layer, str):
+            if layer.startswith("scapy.layers."):
+                result = layer
+            else:
+                if layer.startswith("scapy.contrib."):
+                    layer = layer.replace("scapy.contrib.", "")
+                from scapy.main import load_contrib
+                load_contrib(layer)
+                result_layer, result_contrib = (("scapy.layers.%s" % layer),
+                                                ("scapy.contrib.%s" % layer))
+                if result_layer in conf.layers.ldict:
+                    result = result_layer
+                elif result_contrib in conf.layers.ldict:
+                    result = result_contrib
+                else:
+                    raise Scapy_Exception("Unknown scapy module '%s'" % layer)
+    # COMMON PART
+    # Get the list of all Packets contained in that module
     try:
-        import prompt_toolkit
-    except ImportError:
-        raise ImportError("prompt_toolkit is not installed ! "
-                          "You may install IPython, which contains it, via"
-                          " `pip install ipython`")
-    if not _version_checker(prompt_toolkit, (2, 0)):
-        raise ImportError("prompt_toolkit >= 2.0.0 is required !")
-    # Only available with prompt_toolkit > 2.0, not released on PyPi yet
-    from prompt_toolkit.shortcuts.dialogs import radiolist_dialog, \
-        yes_no_dialog
-    from prompt_toolkit.formatted_text import HTML
-    # 1 - Ask for layer or contrib
-    is_layer = yes_no_dialog(
-        title="Scapy v%s" % conf.version,
-        text=HTML(
-            six.text_type(
-                '<style bg="white" fg="red">Chose the type of packets'
-                ' you want to explore:</style>'
-            )
-        ),
-        yes_text=six.text_type("Layers"),
-        no_text=six.text_type("Contribs"))
-    # 2 - Retrieve list of Packets
-    if is_layer is True:
-        # Get all loaded layers
-        _radio_values = conf.layers.layers()
-        # Restrict to layers-only (not contribs) + packet.py and asn1*.py
-        _radio_values = [x for x in _radio_values if ("layers" in x[0] or
-                                                      "packet" in x[0] or
-                                                      "asn1" in x[0])]
-    elif is_layer is False:
-        # Get all existing contribs
-        from scapy.main import list_contrib
-        _radio_values = list_contrib(ret=True)
-        _radio_values = [(x['name'], x['description']) for x in _radio_values]
-        # Remove very specific modules
-        _radio_values = [x for x in _radio_values if not ("can" in x[0])]
-    else:
-        # Escape was pressed
-        return
-    # Python 2 compat
-    if six.PY2:
-        _radio_values = [(six.text_type(x), six.text_type(y))
-                         for x, y in _radio_values]
-    # 3 - Ask for the layer/contrib module to explore
-    result = radiolist_dialog(
-        values=_radio_values,
-        title="Scapy v%s" % conf.version,
-        text=HTML(
-            six.text_type(
-                '<style bg="white" fg="red">Please select a layer among'
-                ' the following, to see all packets contained in it:</style>'
-            )
-        ))
-    if result is None:
-        return  # User pressed "Cancel"
-    # 4 - (Contrib only): load contrib
-    if not is_layer:
-        from scapy.main import load_contrib
-        load_contrib(result)
-        result = "scapy.contrib." + result
-    # 5 - Get the list of all Packets contained in that module
-    all_layers = conf.layers.ldict[result]
+        all_layers = conf.layers.ldict[result]
+    except KeyError:
+        raise Scapy_Exception("Unknown scapy module '%s'" % layer)
     # Print
     print(conf.color_theme.layer_name("Packets contained in %s:" % result))
     rtlst = [(layer.__name__ or "", layer._name or "") for layer in all_layers]

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1665,6 +1665,7 @@ def explore():
         return  # User pressed "Cancel"
     # 4 - (Contrib only): load contrib
     if not is_layer:
+        from scapy.main import load_contrib
         load_contrib(result)
         result = "scapy.contrib." + result
     # 5 - Get the list of all Packets contained in that module
@@ -1692,19 +1693,25 @@ def ls(obj=None, case_sensitive=False, verbose=False):
             all_layers = sorted(conf.layers, key=lambda x: x.__name__)
         else:
             pattern = re.compile(obj, 0 if case_sensitive else re.I)
+            # We first order by accuracy, then length
+            if case_sensitive:
+                sorter = lambda x: (x.__name__.index(obj), len(x.__name__))
+            else:
+                obj = obj.lower()
+                sorter = lambda x: (x.__name__.lower().index(obj),
+                                    len(x.__name__))
             all_layers = sorted((layer for layer in conf.layers
                                  if (isinstance(layer.__name__, str) and
                                      pattern.search(layer.__name__)) or
                                  (isinstance(layer.name, str) and
                                      pattern.search(layer.name))),
-                                key=lambda x: x.__name__)
+                                key=sorter)
         for layer in all_layers:
             print("%-10s : %s" % (layer.__name__, layer._name))
         if tip and conf.interactive:
             print()
-            print("TIP: having troubles reading this text ? "
-                  "Discover the new `explore()` function, with a fancy and"
-                  " clear GUI !")
+            print("TIP: You may use `explore()` to navigate through all "
+                  "layers using a clear GUI")
 
     else:
         is_pkt = isinstance(obj, Packet)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -18,7 +18,7 @@ import subprocess
 
 from scapy.fields import StrField, ConditionalField, Emph, PacketListField, \
     BitField, MultiEnumField, EnumField, FlagsField
-from scapy.config import conf
+from scapy.config import conf, _version_checker
 from scapy.consts import WINDOWS
 from scapy.compat import raw, orb
 from scapy.base_classes import BasePacket, Gen, SetGen, Packet_metaclass
@@ -1604,7 +1604,7 @@ def split_layers(lower, upper, __fval=None, **fval):
 
 @conf.commands.register
 def explore():
-    """Pretty GUI function used to discover the scapy layers and protocols.
+    """Pretty GUI function used to discover the Scapy layers and protocols.
     It helps to see which packets exists in contrib or layer files.
     """
     if not conf.interactive:
@@ -1615,8 +1615,8 @@ def explore():
         raise ImportError("prompt_toolkit is not installed ! "
                           "You may install IPython, which contains it, via"
                           " `pip install ipython`")
-    if not int(prompt_toolkit.__version__.split(".")[0]) >= 2:
-            raise ImportError("prompt_toolkit >= 2.0.0 is required !")
+    if not _version_checker(prompt_toolkit, (2, 0)):
+        raise ImportError("prompt_toolkit >= 2.0.0 is required !")
     # Only available with prompt_toolkit > 2.0, not released on PyPi yet
     from prompt_toolkit.shortcuts.dialogs import radiolist_dialog, \
         yes_no_dialog
@@ -1633,20 +1633,23 @@ def explore():
         yes_text=six.text_type("Layers"),
         no_text=six.text_type("Contribs"))
     # 2 - Retrieve list of Packets
-    if is_layer:
+    if is_layer is True:
         # Get all loaded layers
         _radio_values = conf.layers.layers()
         # Restrict to layers-only (not contribs) + packet.py and asn1*.py
         _radio_values = [x for x in _radio_values if ("layers" in x[0] or
                                                       "packet" in x[0] or
                                                       "asn1" in x[0])]
-    else:
+    elif is_layer is False:
         # Get all existing contribs
         from scapy.main import list_contrib
         _radio_values = list_contrib(ret=True)
         _radio_values = [(x['name'], x['description']) for x in _radio_values]
         # Remove very specific modules
         _radio_values = [x for x in _radio_values if not ("can" in x[0])]
+    else:
+        # Escape was pressed
+        return
     # Python 2 compat
     if six.PY2:
         _radio_values = [(six.text_type(x), six.text_type(y))
@@ -1710,7 +1713,7 @@ def ls(obj=None, case_sensitive=False, verbose=False):
             print("%-10s : %s" % (layer.__name__, layer._name))
         if tip and conf.interactive:
             print()
-            print("TIP: You may use `explore()` to navigate through all "
+            print("TIP: You may use explore() to navigate through all "
                   "layers using a clear GUI")
 
     else:

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1614,8 +1614,9 @@ def explore(layer=None):
     """
     if layer is None:  # GUI MODE
         if not conf.interactive:
-            raise Scapy_Exception("explore() GUI-mode cannot be run in interactive mode. "
-                          "Please provide a 'layer' parameter !")
+            raise Scapy_Exception("explore() GUI-mode cannot be run in "
+                                  "interactive mode. Please provide a "
+                                  "'layer' parameter !")
         # 0 - Imports
         try:
             import prompt_toolkit
@@ -1652,7 +1653,8 @@ def explore(layer=None):
             # Get all existing contribs
             from scapy.main import list_contrib
             _radio_values = list_contrib(ret=True)
-            _radio_values = [(x['name'], x['description']) for x in _radio_values]
+            _radio_values = [(x['name'], x['description'])
+                             for x in _radio_values]
             # Remove very specific modules
             _radio_values = [x for x in _radio_values if not ("can" in x[0])]
         else:
@@ -1669,7 +1671,8 @@ def explore(layer=None):
             text=HTML(
                 six.text_type(
                     '<style bg="white" fg="red">Please select a layer among'
-                    ' the following, to see all packets contained in it:</style>'
+                    ' the following, to see all packets contained in'
+                    ' it:</style>'
                 )
             ))
         if result is None:
@@ -1680,7 +1683,8 @@ def explore(layer=None):
             load_contrib(result)
             result = "scapy.contrib." + result
     else:  # NON-GUI MODE
-        # We handle layer as a short layer name, full layer name or the module itself
+        # We handle layer as a short layer name, full layer name
+        # or the module itself
         if isinstance(layer, types.ModuleType):
             layer = layer.__name__
         if isinstance(layer, str):
@@ -1707,7 +1711,7 @@ def explore(layer=None):
         raise Scapy_Exception("Unknown scapy module '%s'" % layer)
     # Print
     print(conf.color_theme.layer_name("Packets contained in %s:" % result))
-    rtlst = [(layer.__name__ or "", layer._name or "") for layer in all_layers]
+    rtlst = [(lay.__name__ or "", lay._name or "") for lay in all_layers]
     print(pretty_list(rtlst, [("Class", "Name")], borders=True))
 
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1603,66 +1603,77 @@ def split_layers(lower, upper, __fval=None, **fval):
 
 
 @conf.commands.register
-def ls(obj=None, case_sensitive=False, verbose=False, fancy_mode=None):
+def explore():
+    """Pretty GUI function used to discover the scapy layers and protocols.
+    It helps to see which packets exists in contrib or layer files.
+    """
+    if not conf.interactive:
+        raise OSError("explore() cannot be run in interactive mode")
+    try:
+        import prompt_toolkit
+    except ImportError:
+        raise ImportError("prompt_toolkit is not installed ! "
+                          "You may install IPython, which contains it, via"
+                          " `pip install ipython`")
+    if not int(prompt_toolkit.__version__.split(".")[0]) >= 2:
+            raise ImportError("prompt_toolkit >= 2.0.0 is required !")
+    # Only available with prompt_toolkit > 2.0, not released on PyPi yet
+    from prompt_toolkit.shortcuts.dialogs import radiolist_dialog, yes_no_dialog
+    from prompt_toolkit.formatted_text import HTML
+    # 1 - Ask for layer or contrib
+    is_layer = yes_no_dialog(
+        title="Scapy v%s" % conf.version,
+        text=HTML(six.text_type('<style bg="white" fg="red">Chose the type of packets you want to explore:</style>')),
+        yes_text=six.text_type("Layers"),
+        no_text=six.text_type("Contribs"))
+    # 2 - Retrieve list of Packets
+    if is_layer:
+        # Get all loaded layers
+        _radio_values = conf.layers.layers()
+        # Restrict to layers-only (not contribs) + packet.py and asn1*.py
+        _radio_values = [x for x in _radio_values if ("layers" in x[0] or
+                                                      "packet" in x[0] or
+                                                      "asn1" in x[0])]
+    else:
+        # Get all existing contribs
+        from scapy.main import list_contrib
+        _radio_values = list_contrib(ret=True)
+        _radio_values = [(x['name'], x['description']) for x in _radio_values]
+        # Remove very specific modules
+        _radio_values = [x for x in _radio_values if not ("can" in x[0])]
+    # Python 2 compat
+    if six.PY2:
+        _radio_values = [(six.text_type(x),six.text_type(y)) for x,y in _radio_values]
+    # 3 - Ask for the layer/contrib module to explore
+    result = radiolist_dialog(
+        values=_radio_values,
+        title="Scapy v%s" % conf.version,
+        text=HTML(six.text_type('<style bg="white" fg="red">Please select a layer among the following, to see all packets contained in it:</style>')))
+    if result is None:
+        return  # User pressed "Cancel"
+    # 4 - (Contrib only): load contrib
+    if not is_layer:
+        load_contrib(result)
+        result = "scapy.contrib." + result
+    # 5 - Get the list of all Packets contained in that module
+    all_layers = conf.layers.ldict[result]
+    # Print
+    for layer in all_layers:
+        print("%-10s : %s" % (layer.__name__, layer._name))
+
+
+@conf.commands.register
+def ls(obj=None, case_sensitive=False, verbose=False):
     """List  available layers, or infos on a given layer class or name.
     params:
      - obj: Packet / packet name to use
      - case_sensitive: if obj is a string, is it case sensitive?
      - verbose
-     - fancy_mode: should fancy mode mode be used ? (default: None = automatic when interactive)
     """
     is_string = isinstance(obj, six.string_types)
-    fancy_mode = conf.interactive if fancy_mode is None else fancy_mode
-    if fancy_mode:
-        try:
-            import prompt_toolkit
-            fancy_mode = int(prompt_toolkit.__version__[0]) >= 2
-        except ImportError:
-            fancy_mode = False
 
     if obj is None or is_string:
-        if obj is None and fancy_mode:
-            # Only available with prompt_toolkit > 2.0, not released on PyPi yet
-            from prompt_toolkit.shortcuts.dialogs import radiolist_dialog, yes_no_dialog
-            from prompt_toolkit.formatted_text import HTML
-            # 1 - Ask for layer or contrib
-            is_layer = yes_no_dialog(
-                title="Scapy v%s" % conf.version,
-                text=HTML(six.text_type('<style bg="white" fg="red">Chose the type of packets you want to explore:</style>')),
-                yes_text=six.text_type("Layers"),
-                no_text=six.text_type("Contribs"))
-            # 2 - Retrieve list of Packets
-            if is_layer:
-                # Get all loaded layers
-                _radio_values = conf.layers.layers()
-                # Restrict to layers-only (not contribs) + packet.py and asn1*.py
-                _radio_values = [x for x in _radio_values if ("layers" in x[0] or
-                                                              "packet" in x[0] or
-                                                              "asn1" in x[0])]
-            else:
-                # Get all existing contribs
-                from scapy.main import list_contrib
-                _radio_values = list_contrib(ret=True)
-                _radio_values = [(x['name'], x['description']) for x in _radio_values]
-                # Remove very specific modules
-                _radio_values = [x for x in _radio_values if not ("can" in x[0])]
-            # Python 2 compat
-            if six.PY2:
-                _radio_values = [(six.text_type(x),six.text_type(y)) for x,y in _radio_values]
-            # 3 - Ask for the layer/contrib module to explore
-            result = radiolist_dialog(
-                values=_radio_values,
-                title="Scapy v%s" % conf.version,
-                text=HTML(six.text_type('<style bg="white" fg="red">Please select a layer among the following, to see all packets contained in it:</style>')))
-            if result is None:
-                return  # User pressed "Cancel"
-            # 4 - (Contrib only): load contrib
-            if not is_layer:
-                load_contrib(result)
-                result = "scapy.contrib." + result
-            # 5 - Get the list of all Packets contained in that module
-            all_layers = conf.layers.ldict[result]
-        elif obj is None:
+        if obj is None:
             all_layers = sorted(conf.layers, key=lambda x: x.__name__)
         else:
             pattern = re.compile(obj, 0 if case_sensitive else re.I)
@@ -1674,6 +1685,11 @@ def ls(obj=None, case_sensitive=False, verbose=False, fancy_mode=None):
                                 key=lambda x: x.__name__)
         for layer in all_layers:
             print("%-10s : %s" % (layer.__name__, layer._name))
+        if conf.interactive:
+            print()
+            print("TIP: having troubles reading this text ?"
+                  "Discover the new `explore()` function, with a fancy and"
+                  " clear GUI !")
 
     else:
         is_pkt = isinstance(obj, Packet)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1522,9 +1522,12 @@ def get_terminal_width():
             return None
 
 
-def pretty_list(rtlst, header, sortBy=0):
+def pretty_list(rtlst, header, sortBy=0, borders=False):
     """Pretty list to fit the terminal, and add header"""
-    _space = "  "
+    if borders:
+        _space = "|"
+    else:
+        _space = "  "
     # Windows has a fat terminal border
     _spacelen = len(_space) * (len(header) - 1) + (10 if WINDOWS else 0)
     _croped = False
@@ -1558,6 +1561,9 @@ def pretty_list(rtlst, header, sortBy=0):
         log_runtime.info("Table cropped to fit the terminal (conf.auto_crop_tables==True)")  # noqa: E501
     # Generate padding scheme
     fmt = _space.join(["%%-%ds" % x for x in colwidth])
+    # Append separation line if needed
+    if borders:
+        rtlst.insert(1, tuple("-" * x for x in colwidth))
     # Compile
     rt = "\n".join(((fmt % x).strip() for x in rtlst))
     return rt

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -39,7 +39,7 @@ ls()
 ~ conf command
 
 with ContextManagerCaptureOutput() as cmco:
-    ls("IP")
+    ls("IP", case_sensitive=True)
     result_ls = cmco.get_output().split("\n")
 
 assert all("IP" in x for x in result_ls if x.strip())

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -292,7 +292,6 @@ def test_explore_gui(is_layer, layer):
                                        formatted_text=Bunch(HTML=lambda x: x),
                                        __version__="2.0.0"
                                    )
-
     # a mock.patch isn't enough to mock a module. Let's roll sys.modules
     modules_patched = {
         "prompt_toolkit": prompt_toolkit_mocked_module,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -275,6 +275,75 @@ assert interact_emulator()  # Default
 assert not interact_emulator(extra_args=["-?"])  # Failing
 assert interact_emulator(extra_args=["-d"])  # Extended
 
+= Test explore() with GUI mode
+~ command
+
+import mock
+from scapy.tools.UTscapy import Bunch
+
+def test_explore_gui(is_layer, layer):
+    prompt_toolkit_mocked_module = Bunch(
+                                       shortcuts=Bunch(
+                                           dialogs=Bunch(
+                                               radiolist_dialog=(lambda *args, **kargs: layer),
+                                               yes_no_dialog=(lambda *args, **kargs: is_layer)
+                                           )
+                                       ),
+                                       formatted_text=Bunch(HTML=lambda x: x),
+                                       __version__="2.0.0"
+                                   )
+
+    # a mock.patch isn't enough to mock a module. Let's roll sys.modules
+    modules_patched = {
+        "prompt_toolkit": prompt_toolkit_mocked_module,
+        "prompt_toolkit.shortcuts": prompt_toolkit_mocked_module.shortcuts,
+        "prompt_toolkit.shortcuts.dialogs": prompt_toolkit_mocked_module.shortcuts.dialogs,
+        "prompt_toolkit.formatted_text": prompt_toolkit_mocked_module.formatted_text,
+    }
+    with mock.patch.dict("sys.modules", modules_patched):
+        with ContextManagerCaptureOutput() as cmco:
+            explore()
+            result_explore = cmco.get_output()
+        return result_explore
+
+explore_dns = test_explore_gui(True, "scapy.layers.dns")
+assert "DNS" in explore_dns
+assert "DNS Question Record" in explore_dns
+assert "DNSRRNSEC3" in explore_dns
+assert "DNS TSIG Resource Record" in explore_dns
+
+explore_avs = test_explore_gui(False, "avs")
+assert "AVSWLANHeader" in explore_avs
+assert "AVS WLAN Monitor Header" in explore_avs
+
+= Test explore() with non-GUI mode
+~ command
+
+def test_explore_non_gui(layer):
+    with ContextManagerCaptureOutput() as cmco:
+        explore(layer)
+        result_explore = cmco.get_output()
+    return result_explore
+
+explore_dns = test_explore_non_gui("scapy.layers.dns")
+assert "DNS" in explore_dns
+assert "DNS Question Record" in explore_dns
+assert "DNSRRNSEC3" in explore_dns
+assert "DNS TSIG Resource Record" in explore_dns
+
+explore_avs = test_explore_non_gui("avs")
+assert "AVSWLANHeader" in explore_avs
+assert "AVS WLAN Monitor Header" in explore_avs
+
+assert test_explore_non_gui("scapy.layers.dns") == test_explore_non_gui("dns")
+assert test_explore_non_gui("scapy.contrib.avs") == test_explore_non_gui("avs")
+
+try:
+    explore("unknown_module")
+    assert False  # The previous should have raised an exception
+except Scapy_Exception:
+    pass
+
 = Test sane function
 sane("A\x00\xFFB") == "A..B"
 


### PR DESCRIPTION
Current ls() function has different features:
- explore a layer e.g. `ls(IP)`
- search for a packet e.g. `ls("IP")`
- list all packets: `ls()`

The last function, `ls()` is currently un-readable and very useless, for several reasons:
- There are two many layers in scapy
- There are not ordered
- There are hidden layers (starting with `_`)

This PR adds a fancy system to discover packets (last case only), when launched in interactive mode, by using the funcionalities of `prompt_toolkit` (module included in IPython)

## Screenshots

### Layers

![image](https://user-images.githubusercontent.com/10530980/39969151-39a8b8b0-56d8-11e8-91a0-7d8cc9c9547d.png)
![image](https://user-images.githubusercontent.com/10530980/39969152-3e5e937a-56d8-11e8-865b-4507fc8b6f4b.png)
![image](https://user-images.githubusercontent.com/10530980/42733715-a24ef908-8836-11e8-964f-68a6372f0193.png)


### Contribs

![image](https://user-images.githubusercontent.com/10530980/39969163-5b1b692a-56d8-11e8-94be-eb984ea2e585.png)
![image](https://user-images.githubusercontent.com/10530980/42733718-b5f38eba-8836-11e8-839b-407114ae104a.png)


## Important notes

~This PR requires `prompt_toolkit>=2.0.0`, the new prompt_toolkit version. It is currently unavailable on PyPi, but according to https://github.com/ipython/ipython/pull/10964, both `prompt_toolkit>=2.0.0` and `ipython` supporting it should be released very soon (matter of days).~

Both prompt_toolkit 2.0 and IPython 7 have now been released. The PR is now mergeable