### PR TITLE
Support x86 while loading Npcap

### DIFF
--- a/scapy/modules/winpcapy.py
+++ b/scapy/modules/winpcapy.py
@@ -33,8 +33,8 @@ if WINDOWS:
         # Set DLL directory priority
         windll.kernel32.SetDllDirectoryW(npcap_folder)
         # Packet.dll is unused, but needs to overwrite the winpcap one if it exists
-        windll.LoadLibrary(npcap_folder + "\\Packet.dll")
-        _lib = windll.LoadLibrary(npcap_folder + "\\wpcap.dll")
+        cdll.LoadLibrary(npcap_folder + "\\Packet.dll")
+        _lib = cdll.LoadLibrary(npcap_folder + "\\wpcap.dll")
     else:
         _lib=WinDLL("wpcap.dll")
     del npcap_folder


### PR DESCRIPTION
Small mistake: we need to use `cdll` with the `LoadLibrary` function so that is supports both x64 and x86 (`windll.LoadLibrary` will fail on x86).

However, with `SetDllDirectoryW`, we need to use `windll` as `cdll` won't support x64, and `windll` has compatibility for x86