### PR TITLE
Make ARP() great again!

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -12,16 +12,21 @@
 # scapy.contrib.status = loads
 
 from __future__ import absolute_import
-import time
-import logging
+import struct
 
-from scapy.packet import *
-from scapy.fields import *
+
+from scapy.compat import chb, orb
+from scapy.error import warning
+from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
+    ConditionalField, FieldLenField, FieldListField, FlagsField, IntField, \
+    IPField, PacketListField, ShortField, StrFixedLenField, StrLenField, \
+    XBitField, XByteField, XIntField
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IP6Field
-from scapy.error import warning
 from scapy.modules.six.moves import range
-from scapy.compat import chb, orb, plain_str
+from scapy.packet import bind_layers, Packet, Raw
+from scapy.volatile import RandInt, RandIP, RandNum, RandString
+
 
 # GTP Data types
 
@@ -34,7 +39,7 @@ RATType = {
 }
 
 GTPmessageType = {1: "echo_request",
-                     2: "echo_response",
+                  2: "echo_response",
                   16: "create_pdp_context_req",
                   17: "create_pdp_context_res",
                   18: "update_pdp_context_req",
@@ -907,7 +912,3 @@ bind_layers(UDP, GTP_U_Header, dport=2152)
 bind_layers(UDP, GTP_U_Header, sport=2152)
 bind_layers(GTP_U_Header, GTPErrorIndication, gtp_type=26, S=1)
 bind_layers(GTP_U_Header, IP, gtp_type=255)
-
-if __name__ == "__main__":
-    from scapy.all import *
-    interact(mydict=globals(), mybanner="GTPv1 add-on")

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -20,16 +20,24 @@
 # scapy.contrib.description = GTPv2
 # scapy.contrib.status = loads
 
-import time
 import logging
+import struct
+import time
 
-from scapy.packet import *
-from scapy.fields import *
+
+from scapy.compat import orb
+from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
+    ConditionalField, IntField, IPField, LongField, PacketField, \
+    PacketListField, ShortEnumField, ShortField, StrFixedLenField, \
+    StrLenField, ThreeBytesField, XBitField, XIntField, XShortField
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IP6Field
-from scapy.compat import orb
+from scapy.packet import bind_layers, Packet, Raw
+from scapy.volatile import RandIP, RandShort
 
-import scapy.contrib.gtp as gtp
+
+from scapy.contrib import gtp
+
 
 RATType = {
     6: "EUTRAN",

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -18,12 +18,13 @@
 # scapy.contrib.status = loads
 
 from __future__ import print_function
-from scapy.packet import *
-from scapy.fields import *
-from scapy.layers.inet import *
-from scapy.layers.l2 import DestMACField, getmacbyip
-from scapy.error import warning
 from scapy.compat import chb, orb
+from scapy.error import warning
+from scapy.fields import ByteEnumField, ByteField, IPField, XShortField
+from scapy.layers.inet import IP, IPOption_Router_Alert
+from scapy.layers.l2 import Ether, getmacbyip
+from scapy.packet import bind_layers, Packet
+from scapy.utils import atol, checksum
 
 
 def isValidMCAddr(ip):

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -13,10 +13,16 @@
 
 from __future__ import absolute_import
 import struct
-from scapy.fields import *
-from scapy.layers.l2 import *
-from scapy.layers.inet import *
-from scapy.compat import orb, raw
+
+
+from scapy.compat import chb, orb, raw
+from scapy.config import conf
+from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, FieldLenField, FlagsField, IntEnumField, IntField, IPField, LongField, MACField, PacketField, PacketListField, ShortEnumField, ShortField, StrFixedLenField, X3BytesField, XBitField, XByteField, XIntField, XShortField
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import TCP
+from scapy.packet import Packet, Raw
+from scapy.utils import binrepr
+
 
 # If prereq_autocomplete is True then match prerequisites will be
 # automatically handled. See OFPMatch class.

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -12,11 +12,17 @@
 # scapy.contrib.status = loads
 
 from __future__ import absolute_import
+import copy
 import struct
-from scapy.fields import *
-from scapy.layers.l2 import *
-from scapy.layers.inet import *
-from scapy.compat import *
+
+
+from scapy.compat import orb, raw
+from scapy.config import conf
+from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, FieldLenField, FlagsField, IntEnumField, IntField, IPField, LongField, MACField, PacketField, PacketListField, ShortEnumField, ShortField, StrFixedLenField, X3BytesField, XBitField, XByteField, XIntField, XShortField
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import TCP
+from scapy.packet import Packet, Padding, Raw
+
 
 # If prereq_autocomplete is True then match prerequisites will be
 # automatically handled. See OFPMatch class.

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -432,7 +432,9 @@ class IPField(Field):
         return x
 
     def i2m(self, pkt, x):
-        return inet_aton(x)
+        if x is None:
+            return b'\x00\x00\x00\x00'
+        return inet_aton(plain_str(x))
 
     def m2i(self, pkt, x):
         return inet_ntoa(x)
@@ -460,7 +462,7 @@ class SourceIPField(IPField):
             # unused import, only to initialize conf.route
             import scapy.route
         dst = ("0.0.0.0" if self.dstname is None
-               else getattr(pkt, self.dstname))
+               else getattr(pkt, self.dstname) or "0.0.0.0")
         if isinstance(dst, (Gen, list)):
             r = {conf.route.route(str(daddr)) for daddr in dst}
             if len(r) > 1:

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1344,9 +1344,9 @@ class _EnumField(Field):
             self.i2s_cb = None
             self.s2i_cb = None
             if isinstance(enum, list):
-                keys = range(len(enum))
+                keys = list(range(len(enum)))
             elif isinstance(enum, DADict):
-                keys = enum.iterkeys()
+                keys = enum.keys()
             else:
                 keys = list(enum)
             if any(isinstance(x, str) for x in keys):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -725,7 +725,7 @@ class StrField(Field):
         return len(i)
 
     def any2i(self, pkt, x):
-        if isinstance(x, str if six.PY3 else unicode):
+        if isinstance(x, six.text_type):
             x = raw(x)
         return super(StrField, self).any2i(pkt, x)
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -10,17 +10,19 @@ DHCP (Dynamic Host Configuration Protocol) and BOOTP
 from __future__ import absolute_import
 from __future__ import print_function
 from collections import Iterable
+import random
 import struct
 
-from scapy.packet import *
-from scapy.fields import *
-from scapy.ansmachine import *
-from scapy.data import *
-from scapy.compat import *
+from scapy.ansmachine import AnsweringMachine
+from scapy.base_classes import Net
+from scapy.data import chb, orb, raw
+from scapy.fields import ByteEnumField, ByteField, Field, FieldListField, \
+    FlagsField, IntField, IPField, ShortField, StrField
 from scapy.layers.inet import UDP, IP
 from scapy.layers.l2 import Ether
-from scapy.base_classes import Net
-from scapy.volatile import RandField
+from scapy.packet import bind_layers, bind_bottom_up
+from scapy.utils import atol, itom, ltoa, sane
+from scapy.volatile import RandBin, RandField, RandNum, RandNumExpo
 
 from scapy.arch import get_if_raw_hwaddr
 from scapy.sendrecv import *

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -18,7 +18,8 @@ import types
 from select import select
 from collections import defaultdict
 
-from scapy.utils import checksum, inet_aton, inet_ntoa
+from scapy.utils import checksum, do_graph, incremental_label, inet_aton, \
+    inet_ntoa, linehexdump, strxor
 from scapy.base_classes import Gen
 from scapy.data import *
 from scapy.layers.l2 import *

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -12,14 +12,20 @@ mechanisms which are addressed with keyexchange.py.
 
 from __future__ import absolute_import
 import math
+import struct
 
 from scapy.error import log_runtime, warning
-from scapy.fields import *
-from scapy.compat import *
+from scapy.fields import ByteEnumField, ByteField, EnumField, Field, \
+    FieldLenField, IntField, PacketField, PacketListField, ShortField, \
+    StrFixedLenField, StrLenField, ThreeBytesField, UTCTimeField
+
+from scapy.compat import bytes_hex, orb, raw
+from scapy.config import conf
+from scapy.modules import six
 from scapy.packet import Packet, Raw, Padding
-from scapy.utils import repr_hex
+from scapy.utils import randstring, repr_hex
 from scapy.layers.x509 import OCSP_Response
-from scapy.layers.tls.cert import Cert, PrivKey, PubKey
+from scapy.layers.tls.cert import Cert
 from scapy.layers.tls.basefields import (_tls_version, _TLSVersionField,
                                          _TLSClientVersionField)
 from scapy.layers.tls.extensions import (_ExtensionsLenField, _ExtensionsField,
@@ -28,7 +34,6 @@ from scapy.layers.tls.keyexchange import (_TLSSignature, _TLSServerParamsField,
                                           _TLSSignatureField, ServerRSAParams,
                                           SigAndHashAlgsField, _tls_hash_sig,
                                           SigAndHashAlgsLenField)
-from scapy.layers.tls.keyexchange_tls13 import TicketField
 from scapy.layers.tls.session import (_GenericTLSSessionInheritance,
                                       readConnState, writeConnState)
 from scapy.layers.tls.crypto.compression import (_tls_compression_algs,

--- a/scapy/layers/tls/handshake_sslv2.py
+++ b/scapy/layers/tls/handshake_sslv2.py
@@ -6,12 +6,16 @@
 SSLv2 handshake fields & logic.
 """
 
-import math
+import struct
 
+from scapy.compat import chb
 from scapy.error import log_runtime, warning
-from scapy.fields import *
-from scapy.packet import Packet, Raw, Padding
-from scapy.layers.tls.cert import Cert, PrivKey, PubKey
+from scapy.utils import randstring
+from scapy.fields import ByteEnumField, ByteField, EnumField, FieldLenField, \
+    ShortEnumField, StrLenField, XStrField, XStrLenField
+
+from scapy.packet import Padding
+from scapy.layers.tls.cert import Cert
 from scapy.layers.tls.basefields import _tls_version, _TLSVersionField
 from scapy.layers.tls.handshake import _CipherSuitesField
 from scapy.layers.tls.keyexchange import _TLSSignatureField, _TLSSignature
@@ -19,8 +23,6 @@ from scapy.layers.tls.session import (_GenericTLSSessionInheritance,
                                       readConnState, writeConnState)
 from scapy.layers.tls.crypto.suites import (_tls_cipher_suites,
                                             _tls_cipher_suites_cls,
-                                            _GenericCipherSuite,
-                                            _GenericCipherSuiteMetaclass,
                                             get_usable_ciphersuites,
                                             SSL_CK_DES_192_EDE3_CBC_WITH_MD5)
 

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -15,7 +15,7 @@ import scapy.consts
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.modules import six
-from scapy.utils import atol, ltoa, itom, pretty_list
+from scapy.utils import atol, ltoa, itom, plain_str, pretty_list
 
 
 ##############################
@@ -127,6 +127,10 @@ class Route:
         self.routes.append((the_net, the_msk, '0.0.0.0', iff, the_addr, 1))
 
     def route(self, dest, verbose=None):
+        if dest is None:
+            dest = "0.0.0.0"
+        elif isinstance(dest, bytes):
+            dest = plain_str(dest)
         if dest in self.cache:
             return self.cache[dest]
         if verbose is None:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -386,6 +386,14 @@ def mac2str(mac):
     return b"".join(chb(int(x, 16)) for x in plain_str(mac).split(':'))
 
 
+def valid_mac(mac):
+    try:
+        return len(mac2str(mac)) == 6
+    except ValueError:
+        pass
+    return False
+
+
 def str2mac(s):
     if isinstance(s, str):
         return ("%02x:" * 6)[:-1] % tuple(map(ord, s))
@@ -444,6 +452,43 @@ def atol(x):
     except socket.error:
         ip = inet_aton(socket.gethostbyname(x))
     return struct.unpack("!I", ip)[0]
+
+
+def valid_ip(addr):
+    addr = plain_str(addr)
+    try:
+        atol(addr)
+    except (OSError, socket.error):
+        return False
+    return True
+
+
+def valid_net(addr):
+    addr = plain_str(addr)
+    if '/' in addr:
+        ip, mask = addr.split('/', 1)
+        return valid_ip(ip) and mask.isdigit() and 0 <= int(mask) <= 32
+    return valid_ip(addr)
+
+
+def valid_ip6(addr):
+    addr = plain_str(addr)
+    try:
+        inet_pton(socket.AF_INET6, addr)
+    except socket.error:
+        try:
+            socket.getaddrinfo(addr, None, socket.AF_INET6)[0][4][0]
+        except socket.error:
+            return False
+    return True
+
+
+def valid_net6(addr):
+    addr = plain_str(addr)
+    if '/' in addr:
+        ip, mask = addr.split('/', 1)
+        return valid_ip6(ip) and mask.isdigit() and 0 <= int(mask) <= 128
+    return valid_ip6(addr)
 
 
 def ltoa(x):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -9993,6 +9993,42 @@ test_IPID_count()
 
 ############
 ############
++ ARP
+
+= ARP for IPv4
+
+p = raw(ARP())
+assert p == raw(ARP(ptype=0x0800))
+p = ARP(p)
+assert p.ptype == 0x0800
+assert valid_ip(p.pdst)
+assert valid_ip(p.psrc)
+assert isinstance(p.payload, NoPayload)
+
+= ARP for IPv6
+
+p = ARP(raw(ARP(ptype=0x86dd)))
+assert p.ptype == 0x86dd
+assert valid_ip6(p.pdst)
+assert valid_ip6(p.psrc)
+assert isinstance(p.payload, NoPayload)
+
+= Dummy ARP
+
+p = ARP(raw(ARP(plen=2, hwlen=1, hwdst="x", hwsrc="y", pdst="aa", psrc="bb")))
+assert p.hwdst == b"x"
+assert p.hwsrc == b"y"
+assert p.pdst == b"aa"
+assert p.psrc == b"bb"
+assert isinstance(p.payload, NoPayload)
+
+p = ARP(raw(ARP(plen=1, hwlen=1)))
+assert p.hwdst == p.hwsrc == p.pdst == p.psrc == b"\x00"
+assert isinstance(p.payload, NoPayload)
+
+
+############
+############
 + Fields
 
 = FieldLenField with BitField


### PR DESCRIPTION
This PR introduces `MultipleTypeField()` pseudo Field type, and uses it to enhance `ARP()`. It also fixes a bug and clean some imports (see detailed commit log for more -- please do **not** stash this PR).

In `ARP()`, `MultipleTypeField()` are now used for `{hw,p}{dst,src}` fields, to achieve two goals:
- Make `ARP()` usable with other `{hw,p}types` than Ether and IP.
- Keep `ARP()` as simple as possible to use.

With this patch:
- `raw(ARP())` returns the same result as before.
- `ARP(pytpe="IPv4")` works and `raw(ARP(pytpe="IPv4")) == raw(ARP())`
- `ARP(ptype="IPv6")` now works, `plen` is then set to 16 and `psrc` & `pdst` fields are IPv6 addresses: `ARP(raw(ARP(ptype="IPv6"))).pdst == "::"`

As always, when fixing imports in some important parts of Scapy shows that some modules imports are still a mess. I had to fix some of them, using this opportunity to remove some wildcard imports.