### PR TITLE
Stabilize windows tests

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -839,6 +839,10 @@ def main(argv):
             except ImportError as e:
                 raise getopt.GetoptError("cannot import [%s]: %s" % (m, e))
 
+        if WINDOWS:
+            from scapy.arch.windows import route_add_loopback
+            route_add_loopback()
+
     except getopt.GetoptError as msg:
         print("ERROR:", msg, file=sys.stderr)
         raise SystemExit

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -46,9 +46,6 @@ conf.route.delt(net="1.2.3.4/32")
 = IPField class
 ~ core field
 
-if WINDOWS:
-    route_add_loopback()
-
 i = IPField("foo", None)
 r = i.i2m(None, "1.2.3.4")
 r

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -368,18 +368,20 @@ assert status[0] in ["npcap", "npf"]
 assert status[2] == True
 
 = test pcap_service_stop
+~ appveyor_only
 
 pcap_service_stop()
 assert pcap_service_status()[2] == False
 
 = test pcap_service_start
+~ appveyor_only
 
 pcap_service_start()
 assert pcap_service_status()[2] == True
 
 = Test auto-pcap start UI
 
-old_ifaces = IFACES.data
+old_ifaces = IFACES.data.copy()
 
 @mock.patch("scapy.arch.windows.get_if_list")
 def _test_autostart_ui(mocked_getiflist):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -42,9 +42,6 @@ conf.debug_dissector = True
 = UTscapy route check
 * Check that UTscapy has correctly replaced the routes. Many tests won't work otherwise
 
-if WINDOWS:
-    route_add_loopback()
-
 p = IP().src
 p
 assert p == "127.0.0.1"
@@ -54,6 +51,8 @@ assert p == "127.0.0.1"
 + Scapy functions tests
 
 = Interface related functions
+
+conf.iface
 
 get_if_raw_hwaddr(conf.iface)
 
@@ -1126,7 +1125,7 @@ len(ans) == 1 and len(unans) == 1
 ~ netaccess IP ICMP
 old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
-ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), process=lambda x, y: (x[IP].dst, y[IP].src))
+ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), process=lambda x, y: (x[IP].dst, y[IP].src), timeout=2)
 conf.debug_dissector = old_debug_dissector
 assert all(x == y for x, y in ans)
 assert isinstance(unans, list)
@@ -1135,7 +1134,7 @@ assert isinstance(unans, list)
 ~ netaccess IP ICMP
 old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
-ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), store_unanswered=False)
+ans, unans = sr(IP(dst=["www.google.fr", "www.google.com", "www.google.co.uk"])/ICMP(), store_unanswered=False, timeout=2)
 conf.debug_dissector = old_debug_dissector
 assert isinstance(ans, PacketList)
 assert unans == None
@@ -10076,17 +10075,6 @@ else:
 assert(ret)
 
 p[IP]
-
-+ Restore normal routes & Ifaces
-
-= Windows
-
-if WINDOWS:
-    IFACES.reload()
-    conf.route.resync()
-    conf.route6.resync()
-
-True
 
 
 ############


### PR DESCRIPTION
- A few `timeout` parameters were missing (new fast send/recv things), making sometimes the tests stuck forever.
- Make tests pass way easier locally on Windows (restrict the `pcap_[start/stop]` to Appveyor, as they start a UAC when ran locally)
- Fixes `IFACES` not beeing properly restored (added a `.copy()` call, otherwise the `old_ifaces` followed the change). This allow us to only use `route_add_loopback()` once and for all, so we don't need anymore to call it every where