### PR TITLE
Add arpleak() to test ARP leak flaws

### DIFF
--- a/scapy/contrib/ethercat.py
+++ b/scapy/contrib/ethercat.py
@@ -43,14 +43,18 @@
         - padding for minimum frame size is added automatically
 
 """
+
+
+import struct
+
+
 from scapy.compat import raw
-from scapy.error import Scapy_Exception
+from scapy.error import log_runtime, Scapy_Exception
 from scapy.fields import BitField, ByteField, LEShortField, FieldListField, LEIntField, FieldLenField, _EnumField, \
     EnumField
-from scapy.layers.dot11 import Packet
-from scapy.layers.l2 import Ether, Dot1Q, Padding, bind_layers, \
-    log_runtime, struct
+from scapy.layers.l2 import Ether, Dot1Q
 from scapy.modules import six
+from scapy.packet import bind_layers, Packet, Padding
 
 '''
 EtherCat uses some little endian bitfields without alignment to any common boundaries.
@@ -104,7 +108,7 @@ class LEBitField(BitField):
 
         """
         if type(s) is tuple and len(s) == 4:
-            s, bitsdone, data, lower_field_type = s
+            s, bitsdone, data, _ = s
             self._check_field_type(pkt, -1)
         else:
             # this is the first bit field in the set
@@ -611,9 +615,8 @@ class EtherCat(Packet):
 
             return raw(_EtherCatLengthCalc(length=self.length,
                                            type=self.type)) + pay + raw(pad)
-        else:
-            return raw(_EtherCatLengthCalc(length=self.length,
-                                           type=self.type)) + pay
+        return raw(_EtherCatLengthCalc(length=self.length,
+                                       type=self.type)) + pay
 
     def guess_payload_class(self, payload):
         try:

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -322,6 +322,9 @@ the value to set is also known) of ._find_fld_pkt() instead.
     def i2h(self, pkt, val):
         return self._find_fld_pkt_val(pkt, val).i2h(pkt, val)
 
+    def i2m(self, pkt, val):
+        return self._find_fld_pkt_val(pkt, val).i2m(pkt, val)
+
     def i2len(self, pkt, val):
         return self._find_fld_pkt_val(pkt, val).i2len(pkt, val)
 

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -130,7 +130,10 @@ class Route:
         if dest is None:
             dest = "0.0.0.0"
         elif isinstance(dest, bytes):
-            dest = plain_str(dest)
+            try:
+                dest = plain_str(dest)
+            except UnicodeDecodeError:
+                dest = "0.0.0.0"
         if dest in self.cache:
             return self.cache[dest]
         if verbose is None:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -455,16 +455,22 @@ def atol(x):
 
 
 def valid_ip(addr):
-    addr = plain_str(addr)
+    try:
+        addr = plain_str(addr)
+    except UnicodeDecodeError:
+        return False
     try:
         atol(addr)
-    except (OSError, socket.error):
+    except (OSError, ValueError, socket.error):
         return False
     return True
 
 
 def valid_net(addr):
-    addr = plain_str(addr)
+    try:
+        addr = plain_str(addr)
+    except UnicodeDecodeError:
+        return False
     if '/' in addr:
         ip, mask = addr.split('/', 1)
         return valid_ip(ip) and mask.isdigit() and 0 <= int(mask) <= 32
@@ -472,7 +478,10 @@ def valid_net(addr):
 
 
 def valid_ip6(addr):
-    addr = plain_str(addr)
+    try:
+        addr = plain_str(addr)
+    except UnicodeDecodeError:
+        return False
     try:
         inet_pton(socket.AF_INET6, addr)
     except socket.error:
@@ -484,7 +493,10 @@ def valid_ip6(addr):
 
 
 def valid_net6(addr):
-    addr = plain_str(addr)
+    try:
+        addr = plain_str(addr)
+    except UnicodeDecodeError:
+        return False
     if '/' in addr:
         ip, mask = addr.split('/', 1)
         return valid_ip6(ip) and mask.isdigit() and 0 <= int(mask) <= 128

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -168,6 +168,7 @@ t_sniff.join()
 = Delete the tun interfaces
 del tun0, tun1
 
+
 ############
 ############
 + Test bridge_and_sniff() using veth pairs
@@ -209,3 +210,84 @@ with VEthPair('a_0', 'a_1') as veth_0:
         # now test of the socket used in bridge_and_sniff() was alive all the time
         assert (xfrm_count['a_0'] == 2)
         assert (xfrm_count['b_0'] == 2)
+
+
+############
+############
++ Test arpleak() using a tap socket
+
+~ tap linux
+
+= Create two tap interfaces
+
+import mock
+import struct
+import subprocess
+from threading import Thread
+import time
+
+tap0 = TunTapInterface("tap0")
+
+if LINUX:
+    assert subprocess.check_call(["ip", "link", "set", "tap0", "up"]) == 0
+else:
+    assert subprocess.check_call(["ifconfig", "tap0", "up"]) == 0
+
+def answer_arp_leak(pkt):
+    mymac = b"\x00\x01\x02\x03\x04\x06"
+    myip = b"\x01\x02\x03\x02"
+    if not ARP in pkt:
+        return
+    e_src = pkt.src
+    pkt = raw(pkt[ARP])
+    if pkt[:4] != b'\x00\x01\x08\x00':
+        print("Invalid ARP")
+        return
+    hwlen, plen, op = struct.unpack('>BBH', pkt[4:8])
+    if op != 1:
+        print("Invalid ARP op")
+        return
+    fmt = ('%ds%ds' % (hwlen, plen)) * 2
+    hwsrc, psrc, hwdst, pdst = struct.unpack(fmt,
+                                             pkt[8:8 + (plen + hwlen) * 2])
+    if pdst[:4] != myip[:plen]:
+        print("Invalid ARP pdst %r" % pdst)
+        return
+    ans = Ether(dst=e_src, src=mymac, type=0x0806)
+    ans /= (b'\x00\x01\x08\x00' +
+            struct.pack('>BBH' + fmt,
+                        hwlen, plen, 2, mymac, myip, hwsrc, psrc))
+    tap0.send(ans)
+    print('Answered!')
+
+t_answer = Thread(
+    target=sniff,
+    kwargs={"prn": answer_arp_leak, "timeout": 10, "store": False,
+            "opened_socket": tap0}
+)
+
+t_answer.start()
+
+@mock.patch("scapy.layers.l2.get_if_addr")
+@mock.patch("scapy.layers.l2.get_if_hwaddr")
+def test_arpleak(mock_get_if_hwaddr, mock_get_if_addr, hwlen=255, plen=255):
+    conf.route.ifadd("tap0", "1.2.3.0/24")
+    mock_get_if_addr.side_effect = lambda _: "1.2.3.1"
+    mock_get_if_hwaddr.side_effect = lambda _: "00:01:02:03:04:05"
+    return arpleak("1.2.3.2/31", timeout=2, hwlen=hwlen, plen=plen)
+
+time.sleep(2)
+
+ans, unans = test_arpleak()
+assert len(ans) == 1
+assert len(unans) == 1
+ans, unans = test_arpleak(hwlen=6)
+assert len(ans) == 1
+assert len(unans) == 1
+ans, unans = test_arpleak(plen=4)
+assert len(ans) == 1
+assert len(unans) == 1
+
+t_answer.join()
+
+del tap0

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -81,7 +81,12 @@ t_bridge.join()
 t_sniff.join()
 
 = Delete the tap interfaces
-del tap0, tap1
+if conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    tap0.close()
+    tap1.close()
+else:
+    del tap0, tap1
 
 
 ############
@@ -166,7 +171,12 @@ t_bridge.join()
 t_sniff.join()
 
 = Delete the tun interfaces
-del tun0, tun1
+if conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    tun0.close()
+    tun1.close()
+else:
+    del tun0, tun1
 
 
 ############
@@ -290,4 +300,8 @@ assert len(unans) == 1
 
 t_answer.join()
 
-del tap0
+if conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    tap0.close()
+else:
+    del tap0


### PR DESCRIPTION
This PR also cleans `ARP.answers()`, and uses `ARP.hashret()` to improve the performances.

The tests for `arpleak()` are mocked, using a basic `struct`-based implementation of the ARP protocol, independent from the `ARP` class.

`arpleak()` has been successfully tested with a VM running the NetBSD 7.0.2 installation ISO.

Again, some imports had to be fixed...