### PR TITLE
Fix guess_payload_class() method in RadioTap.

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -206,10 +206,12 @@ class RadioTap(Packet):
                    StrLenField('notdecoded', "", length_from=lambda pkt: pkt.len - pkt._tmp_dissect_pos)]  # noqa: E501
 
     def guess_payload_class(self, payload):
-        if self.Flags.FCS:
-            return Dot11FCS
-        else:
-            return Dot11
+        if self.present and self.present.Flags:
+            if self.Flags.FCS:
+                return Dot11FCS
+            else:
+                return Dot11
+        return Dot11
 
     def post_build(self, p, pay):
         if self.len is None:

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -206,11 +206,8 @@ class RadioTap(Packet):
                    StrLenField('notdecoded', "", length_from=lambda pkt: pkt.len - pkt._tmp_dissect_pos)]  # noqa: E501
 
     def guess_payload_class(self, payload):
-        if self.present and self.present.Flags:
-            if self.Flags.FCS:
-                return Dot11FCS
-            else:
-                return Dot11
+        if self.present and self.present.Flags and self.Flags.FCS:
+            return Dot11FCS
         return Dot11
 
     def post_build(self, p, pay):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -795,6 +795,15 @@ r = RadioTap(data)
 r.show()
 assert r.present == 18479
 
+= RadioTap - Dissection - guess_payload_class() test
+data = b'\x00\x00\r\x00\x04\x80\x02\x00\x02\x00\x00\x00\x00@\x00\x00\x00\xff\xff\xff\xff\xff\xff\xe8\x94\xf6\x1c\xdf\x8b\xff\xff\xff\xff\xff\xff\xa0\x01\x00\x10ciscosb-wpa2-eap\x01\x08\x02\x04\x0b\x16\x0c\x12\x18$2\x040H`l\x03\x01\x01-\x1an\x11\x1b\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+radiotap = RadioTap(data)
+assert radiotap.present.Rate
+assert radiotap.present.b16
+assert radiotap.present.b18
+assert radiotap.present == 163844
+assert radiotap.guess_payload_class("")
+
 = fuzz() calls for Dot11Elt()
 for i in range(10):
     assert isinstance(raw(fuzz(Dot11Elt())), bytes)


### PR DESCRIPTION
This PR fixes the `guess_payload_class()` method in RadioTap (`scapy/layers/dot11.py`).

`Flags` is a `ConditionalField`, it is necessary to test if it is present.
