### PR TITLE
PyPy: cryptography tests

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -10,8 +10,7 @@ then
   # pypy
   if python --version 2>&1 | grep -q PyPy
   then
-    # cryptography requires PyPy >= 2.6, Travis CI uses 2.5.0
-    UT_FLAGS+=" -K crypto -K not_pypy"
+    UT_FLAGS+=" -K not_pypy"
   fi
 elif [ "$TRAVIS_OS_NAME" = "osx" ]
 then

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -342,20 +342,23 @@ def isCryptographyValid():
     return LooseVersion(cryptography.__version__) >= LooseVersion("1.7")
 
 
-def isCryptographyAdvanced():
+def isCryptographyRecent():
     """
-    Check if the cryptography library is present, and if it supports X25519,
-    ChaCha20Poly1305 and such (v2.0 or later).
+    Check if the cryptography library is recent (2.0 and later)
     """
     try:
         import cryptography
     except ImportError:
         return False
     from distutils.version import LooseVersion
-    lib_valid = LooseVersion(cryptography.__version__) >= LooseVersion("2.0")
-    if not lib_valid:
-        return False
+    return LooseVersion(cryptography.__version__) >= LooseVersion("2.0")
 
+
+def isCryptographyAdvanced():
+    """
+    Check if the cryptography library is present, and if it supports X25519,
+    ChaCha20Poly1305 and such (v2.0 or later).
+    """
     try:
         from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey  # noqa: E501
         X25519PrivateKey.generate()
@@ -494,7 +497,8 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
                    'tftp', 'vrrp', 'vxlan', 'x509']
     contribs = dict()
     crypto_valid = isCryptographyValid()
-    crypto_valid_advanced = isCryptographyAdvanced()
+    crypto_valid_recent = isCryptographyRecent()
+    crypto_valid_advanced = crypto_valid_recent and isCryptographyAdvanced()
     fancy_prompt = True
     auto_crop_tables = True
 

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -37,7 +37,7 @@ if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
-if conf.crypto_valid_advanced:
+if conf.crypto_valid_recent:
     from cryptography.hazmat.backends.openssl.ec import InvalidSignature
 
 from scapy.error import warning
@@ -330,7 +330,7 @@ class PubKeyECDSA(PubKey):
     @crypto_validator
     def verify(self, msg, sig, h="sha256", **kwargs):
         # 'sig' should be a DER-encoded signature, as per RFC 3279
-        if conf.crypto_valid_advanced:
+        if conf.crypto_valid_recent:
             try:
                 self.pubkey.verify(sig, msg, ec.ECDSA(_get_hash(h)))
                 return True
@@ -531,7 +531,7 @@ class PrivKeyECDSA(PrivKey):
     @crypto_validator
     def verify(self, msg, sig, h="sha256", **kwargs):
         # 'sig' should be a DER-encoded signature, as per RFC 3279
-        if conf.crypto_valid_advanced:
+        if conf.crypto_valid_recent:
             try:
                 self.pubkey.verify(sig, msg, ec.ECDSA(_get_hash(h)))
                 return True
@@ -544,7 +544,7 @@ class PrivKeyECDSA(PrivKey):
 
     @crypto_validator
     def sign(self, data, h="sha256", **kwargs):
-        if conf.crypto_valid_advanced:
+        if conf.crypto_valid_recent:
             return self.key.sign(data, ec.ECDSA(_get_hash(h)))
         else:
             signer = self.key.signer(ec.ECDSA(_get_hash(h)))

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ description = "Scapy unit tests"
 whitelist_externals = sudo
 setenv = SCAPY_ROOT_DIR={env:PWD}
 deps = mock
-       {py27,py34,py35,py36}: cryptography
+       cryptography
        coverage
        python-can
 


### PR DESCRIPTION
This PR tries to make cryptography based tests run on all platforms, (even PyPy). Currently, they are skipped when run on PyPy, because cryptography used not to support PyPy.

This *should* not be the case anymore in recent versions

fixes https://github.com/secdev/scapy/issues/1307 ?