### PR TITLE
Vpython update

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -136,8 +136,10 @@ Here are the topics involved and some examples that you can use to try if your i
      >>> p=readpcap("myfile.pcap")
      >>> p.conversations(type="jpg", target="> test.jpg")
  
-* 3D graphics. ``trace3D()`` needs `VPython <http://www.vpython.org/>`_.
- 
+* 3D graphics. ``trace3D()`` needs `VPython-Jupyter <https://github.com/BruceSherwood/vpython-jupyter/>`_.
+
+    Jupyter-IPython is installable via `pip install vpython`
+
   .. code-block:: python
 
      >>> a,u=traceroute(["www.python.org", "google.com","slashdot.org"])

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -517,15 +517,13 @@ In this example, we used the `traceroute_map()` function to print the graphic. T
 It could have been done differently:
 
     >>> conf.geoip_city = "path/to/GeoLite2-City.mmdb"
-    >>> a = traceroute("www.google.co.uk", verbose=0)[0]
-    >>> b = traceroute("www.secdev.org", verbose=0)[0]
-    >>> a.res += b.res
+    >>> a = traceroute(["www.google.co.uk", "www.secdev.org"], verbose=0)
     >>> a.world_trace()
 
 or such as above:
 
     >>> conf.geoip_city = "path/to/GeoLite2-City.mmdb"
-    >>> traceroute_map("www.google.co.uk", "www.secdev.org")
+    >>> traceroute_map(["www.google.co.uk", "www.secdev.org"])
 
 To use those functions, it is required to have installed the `geoip2 <https://pypi.python.org/pypi/geoip2>`_ module, `its database <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ (`direct download <https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz>`_)
 but also the `cartopy <http://scitools.org.uk/cartopy/docs/latest/installing.html>`_ module.

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1161,7 +1161,8 @@ class TracerouteResult(SndRcvList):
         shift-left button: move the scene
         left button on a ball: toggle IP displaying
         double-click button on a ball: scan ports 21,22,23,25,80 and 443 and display the result"""  # noqa: E501
-        # When not ran from a notebook, vpython pooly closes itself once finished.
+        # When not ran from a notebook, vpython pooly closes itself
+        # using os._exit once finished. We pack it into a Process
         import multiprocessing
         p = multiprocessing.Process(target=self.trace3D_notebook)
         p.start()
@@ -1225,7 +1226,7 @@ class TracerouteResult(SndRcvList):
                     self.unfull()
 
         vpython.scene = vpython.canvas()
-        vpython.scene.title = "<center><u><b>%s</b></u></center>" % self.listname
+        vpython.scene.title = "<center><u><b>%s</b></u></center>" % self.listname  # noqa: E501
         vpython.scene.append_to_caption(
             re.sub(
                 r'\%(.*)\%',
@@ -1234,7 +1235,7 @@ class TracerouteResult(SndRcvList):
                     r'\`(.*)\`',
                     r'<span style="color: #3399ff">\1</span>',
                     """<u><b>Commands:</b></u>
-%Click% to toggle informations about a node.
+%Click% to toggle information about a node.
 %Double click% to perform a quick web scan on this node.
 <u><b>Camera usage:</b></u>
 `Right button drag or Ctrl-drag` to rotate "camera" to view scene.
@@ -1294,12 +1295,12 @@ Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
         # Keys handling
         # TODO: there is currently no way of closing vpython correctly
         # https://github.com/BruceSherwood/vpython-jupyter/issues/36
-        #def keyboard_press(ev):
-        #    k = ev.key
-        #    if k == "esc" or k == "q":
-        #        pass  # TODO: close
+        # def keyboard_press(ev):
+        #     k = ev.key
+        #     if k == "esc" or k == "q":
+        #         pass  # TODO: close
         #
-        #vpython.scene.bind('keydown', keyboard_press)
+        # vpython.scene.bind('keydown', keyboard_press)
 
         # Mouse handling
         def mouse_click(ev):

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1154,21 +1154,50 @@ class TracerouteResult(SndRcvList):
                     del k[l]
         return trace
 
-    def trace3D(self):
+    def trace3D(self, join=True):
         """Give a 3D representation of the traceroute.
         right button: rotate the scene
         middle button: zoom
-        left button: move the scene
+        shift-left button: move the scene
         left button on a ball: toggle IP displaying
-        ctrl-left button on a ball: scan ports 21,22,23,25,80 and 443 and display the result"""  # noqa: E501
-        trace = self.get_trace()
-        import visual
+        double-click button on a ball: scan ports 21,22,23,25,80 and 443 and display the result"""  # noqa: E501
+        # When not ran from a notebook, vpython pooly closes itself once finished.
+        import multiprocessing
+        p = multiprocessing.Process(target=self.trace3D_notebook)
+        p.start()
+        if join:
+            p.join()
 
-        class IPsphere(visual.sphere):
+    def trace3D_notebook(self):
+        """Same than trace3D, used when ran from Jupyther notebooks"""
+        trace = self.get_trace()
+        import vpython
+
+        class IPsphere(vpython.sphere):
             def __init__(self, ip, **kargs):
-                visual.sphere.__init__(self, **kargs)
+                vpython.sphere.__init__(self, **kargs)
                 self.ip = ip
                 self.label = None
+                self.setlabel(self.ip)
+                self.last_clicked = None
+                self.full = False
+                self.savcolor = vpython.vec(*self.color.value)
+
+            def fullinfos(self):
+                self.full = True
+                self.color = vpython.vec(1, 0, 0)
+                a, b = sr(IP(dst=self.ip) / TCP(dport=[21, 22, 23, 25, 80, 443], flags="S"), timeout=2, verbose=0)  # noqa: E501
+                if len(a) == 0:
+                    txt = "%s:\nno results" % self.ip
+                else:
+                    txt = "%s:\n" % self.ip
+                    for s, r in a:
+                        txt += r.sprintf("{TCP:%IP.src%:%TCP.sport% %TCP.flags%}{TCPerror:%IPerror.dst%:%TCPerror.dport% %IP.src% %ir,ICMP.type%}\n")  # noqa: E501
+                self.setlabel(txt, visible=1)
+
+            def unfull(self):
+                self.color = self.savcolor
+                self.full = False
                 self.setlabel(self.ip)
 
             def setlabel(self, txt, visible=None):
@@ -1178,14 +1207,46 @@ class TracerouteResult(SndRcvList):
                     self.label.visible = 0
                 elif visible is None:
                     visible = 0
-                self.label = visual.label(text=txt, pos=self.pos, space=self.radius, xoffset=10, yoffset=20, visible=visible)  # noqa: E501
+                self.label = vpython.label(text=txt, pos=self.pos, space=self.radius, xoffset=10, yoffset=20, visible=visible)  # noqa: E501
+
+            def check_double_click(self):
+                try:
+                    if self.full or not self.label.visible:
+                        return False
+                    if self.last_clicked is not None:
+                        return (time.time() - self.last_clicked) < 0.5
+                    return False
+                finally:
+                    self.last_clicked = time.time()
 
             def action(self):
                 self.label.visible ^= 1
+                if self.full:
+                    self.unfull()
 
-        visual.scene = visual.display()
-        visual.scene.exit = True
-        start = visual.box()
+        vpython.scene = vpython.canvas()
+        vpython.scene.title = "<center><u><b>%s</b></u></center>" % self.listname
+        vpython.scene.append_to_caption(
+            re.sub(
+                r'\%(.*)\%',
+                r'<span style="color: red">\1</span>',
+                re.sub(
+                    r'\`(.*)\`',
+                    r'<span style="color: #3399ff">\1</span>',
+                    """<u><b>Commands:</b></u>
+%Click% to toggle informations about a node.
+%Double click% to perform a quick web scan on this node.
+<u><b>Camera usage:</b></u>
+`Right button drag or Ctrl-drag` to rotate "camera" to view scene.
+`Shift-drag` to move the object around.
+`Middle button or Alt-drag` to drag up or down to zoom in or out.
+  On a two-button mouse, `middle is wheel or left + right`.
+Touch screen: pinch/extend to zoom, swipe or two-finger rotate."""
+                )
+            )
+        )
+        vpython.scene.exit = True
+        start = vpython.box()
         rings = {}
         tr3d = {}
         for i in trace:
@@ -1201,18 +1262,19 @@ class TracerouteResult(SndRcvList):
                 else:
                     rings[t].append(("unk", -1))
                     tr3d[i].append(len(rings[t]) - 1)
+
         for t in rings:
             r = rings[t]
             l = len(r)
             for i in range(l):
                 if r[i][1] == -1:
-                    col = (0.75, 0.75, 0.75)
+                    col = vpython.vec(0.75, 0.75, 0.75)
                 elif r[i][1]:
-                    col = visual.color.green
+                    col = vpython.color.green
                 else:
-                    col = visual.color.blue
+                    col = vpython.color.blue
 
-                s = IPsphere(pos=((l - 1) * visual.cos(2 * i * visual.pi / l), (l - 1) * visual.sin(2 * i * visual.pi / l), 2 * t),  # noqa: E501
+                s = IPsphere(pos=vpython.vec((l - 1) * vpython.cos(2 * i * vpython.pi / l), (l - 1) * vpython.sin(2 * i * vpython.pi / l), 2 * t),  # noqa: E501
                              ip=r[i][0],
                              color=col)
                 for trlst in six.itervalues(tr3d):
@@ -1221,48 +1283,37 @@ class TracerouteResult(SndRcvList):
                             trlst[t - 1] = s
         forecol = colgen(0.625, 0.4375, 0.25, 0.125)
         for trlst in six.itervalues(tr3d):
-            col = next(forecol)
-            start = (0, 0, 0)
+            col = vpython.vec(*next(forecol))
+            start = vpython.vec(0, 0, 0)
             for ip in trlst:
-                visual.cylinder(pos=start, axis=ip.pos - start, color=col, radius=0.2)  # noqa: E501
+                vpython.cylinder(pos=start, axis=ip.pos - start, color=col, radius=0.2)  # noqa: E501
                 start = ip.pos
 
-        movcenter = None
-        while True:
-            visual.rate(50)
-            if visual.scene.kb.keys:
-                k = visual.scene.kb.getkey()
-                if k == "esc" or k == "q":
-                    break
-            if visual.scene.mouse.events:
-                ev = visual.scene.mouse.getevent()
-                if ev.press == "left":
-                    o = ev.pick
-                    if o:
-                        if ev.ctrl:
-                            if o.ip == "unk":
-                                continue
-                            savcolor = o.color
-                            o.color = (1, 0, 0)
-                            a, b = sr(IP(dst=o.ip) / TCP(dport=[21, 22, 23, 25, 80, 443]), timeout=2)  # noqa: E501
-                            o.color = savcolor
-                            if len(a) == 0:
-                                txt = "%s:\nno results" % o.ip
-                            else:
-                                txt = "%s:\n" % o.ip
-                                for s, r in a:
-                                    txt += r.sprintf("{TCP:%IP.src%:%TCP.sport% %TCP.flags%}{TCPerror:%IPerror.dst%:%TCPerror.dport% %IP.src% %ir,ICMP.type%}\n")  # noqa: E501
-                            o.setlabel(txt, visible=1)
-                        else:
-                            if hasattr(o, "action"):
-                                o.action()
-                elif ev.drag == "left":
-                    movcenter = ev.pos
-                elif ev.drop == "left":
-                    movcenter = None
-            if movcenter:
-                visual.scene.center -= visual.scene.mouse.pos - movcenter
-                movcenter = visual.scene.mouse.pos
+        vpython.rate(50)
+
+        # Keys handling
+        # TODO: there is currently no way of closing vpython correctly
+        # https://github.com/BruceSherwood/vpython-jupyter/issues/36
+        #def keyboard_press(ev):
+        #    k = ev.key
+        #    if k == "esc" or k == "q":
+        #        pass  # TODO: close
+        #
+        #vpython.scene.bind('keydown', keyboard_press)
+
+        # Mouse handling
+        def mouse_click(ev):
+            if ev.press == "left":
+                o = vpython.scene.mouse.pick
+                if o and isinstance(o, IPsphere):
+                    if o.check_double_click():
+                        if o.ip == "unk":
+                            return
+                        o.fullinfos()
+                    else:
+                        o.action()
+
+        vpython.scene.bind('mousedown', mouse_click)
 
     def world_trace(self):
         """Display traceroute results on a world map."""
@@ -1570,16 +1621,14 @@ traceroute(target, [maxttl=30,] [dport=80,] [sport=80,] [verbose=conf.verb]) -> 
 
 
 @conf.commands.register
-def traceroute_map(*args, **kargs):
+def traceroute_map(ips, **kargs):
     """Util function to call traceroute on multiple targets, then
     show the different paths on a map.
     params:
-     - *args: IPs on which traceroute will be called"""
+     - ips: a list of IPs on which traceroute will be called
+     - optional: kwargs, passed to traceroute"""
     kargs.setdefault("verbose", 0)
-    res = []
-    for target in args:
-        res += traceroute(target, **kargs)[0].res
-    return TracerouteResult(res).world_trace()
+    return traceroute(ips)[0].world_trace()
 
 #############################
 #  Simple TCP client stack  #


### PR DESCRIPTION
As stated [here](http://vpython.org/contents/announcements/evolution.html), the "builtin VPython" is deprecated and has stopped being developed.

> After extended discussions we have decided that these two environments, GlowScript VPython and VPython 7, will be the VPython implementations to be further supported and developed.  The older “Classic” VPython, which required the separate installation of Python 2.7 and visual (as well as Tcl on the Macintosh), will continue to exist in its current form, but will no longer receive updates or bug fixes, though Matt Craig has offered to continue to build an Anaconda conda package until the official end-of-life of Python 2.7 in 2020, as long as building the package does not require substantial modification to the Classic VPython codebase.

 This PR migrates `trace3d()` to Vpython 7 (aka Vpython-Jupyter)

```
Classic VPython:    version is ['X.Y', 'release']
GlowScript VPython: version is ['X.Y', 'glowscript']
VPython 7:          version is ['X.Y.Z', 'jupyter']
and in VPython 7, the version of the GlowScript
graphics library is given by
                  GSversion is ['X.Y', 'glowscript']
```

Notes:
- Previous `trace3d()` function had integrated a way to move the object while dragging the background. This behavior is now implemented by default using shift-drag.
- Previous `trace3d()` function would detect shift+click and execute a sr scan. This is no more possible due to the last point, so migrated shift+click to double-click.

![image](https://user-images.githubusercontent.com/10530980/41281462-bc3f03c2-6e31-11e8-8759-1f11619456e7.png)
![image](https://user-images.githubusercontent.com/10530980/41281527-ea020b74-6e31-11e8-9c50-29a4f1cfe7ad.png)
