### PR TITLE
Missing import

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -9,6 +9,7 @@ Packet class. Binding mechanism. fuzz() method.
 
 from __future__ import absolute_import
 from __future__ import print_function
+import os
 import re
 import time
 import itertools


### PR DESCRIPTION
- import is missing for `os.startfile` In pdfdump