### PR TITLE
Speedup winpcapy loading

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -461,6 +461,7 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     wepkey = ""
     cache_iflist = {}
     cache_ipaddrs = {}
+    cache_in6_getifaddr = []
     route = None  # Filed by route.py
     route6 = None  # Filed by route6.py
     auto_fragment = 1


### PR DESCRIPTION
This PR:
- unifies all winpcapy loading functions into one: current way (old code imported ported from scapy3k) loads 3 times all interfaces, I fixed it
- smooth ~2-3 seconds boost while loading on windows 