### PR TITLE
Add binding for MPLS in IP as per RFC 4023

### DIFF
--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -64,7 +64,7 @@ class MPLS(Packet):
 
 bind_layers(Ether, MPLS, type=0x8847)
 bind_layers(IP, MPLS, proto=137)
-bind_layers(IPv6, MPLS, proto=137)
+bind_layers(IPv6, MPLS, nh=137)
 bind_layers(UDP, MPLS, dport=6635)
 bind_layers(GRE, MPLS, proto=0x8847)
 bind_layers(MPLS, MPLS, s=0)

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -64,6 +64,7 @@ class MPLS(Packet):
 
 bind_layers(Ether, MPLS, type=0x8847)
 bind_layers(IP, MPLS, proto=137)
+bind_layers(IPv6, MPLS, proto=137)
 bind_layers(UDP, MPLS, dport=6635)
 bind_layers(GRE, MPLS, proto=0x8847)
 bind_layers(MPLS, MPLS, s=0)

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -63,6 +63,7 @@ class MPLS(Packet):
 
 
 bind_layers(Ether, MPLS, type=0x8847)
+bind_layers(IP, MPLS, proto=137)
 bind_layers(UDP, MPLS, dport=6635)
 bind_layers(GRE, MPLS, proto=0x8847)
 bind_layers(MPLS, MPLS, s=0)

--- a/scapy/contrib/mpls.uts
+++ b/scapy/contrib/mpls.uts
@@ -22,3 +22,12 @@ assert(s == b'\xff\xff\xff\xff\xff\xff\x00\x01\x02\x04\x05\x00\x88G\x00\x000\x00
 
 p = Ether(s)
 assert(IPv6 in p and isinstance(p[MPLS].payload, MPLS))
+
+= Association on IP and IPv6
+p = IP()/MPLS()
+p = IP(raw(p))
+assert p[IP].proto == 137
+
+p2 = IPv6()/MPLS()
+p2 = IPv6(raw(p2))
+assert p2[IPv6].nh == 137


### PR DESCRIPTION
IANA IP protocol assignments agrees.

This is just a checklist to guide you. You can remove it safely.


**Checklist:**
- [ ] If you are new to Scapy: I have checked https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- [ ] I squashed commits belonging together
- [ ] I added unit tests or explained why they are not relevant
- [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)


This PR adds bindings for MPLS on top of IP / IPv6