### PR TITLE
inet: fix incorrect parsing of IP payload as padding

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -427,6 +427,8 @@ class IP(Packet, IPTools):
 
     def extract_padding(self, s):
         l = self.len - (self.ihl << 2)
+        if l < 0:
+            return s, b""
         return s[:l], s[l:]
 
     def route(self):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6387,6 +6387,14 @@ pkt = IP(len=42, ihl=6, options=[IPOption_RR()]) / UDP() / ("A" * 10)
 bpkt = IP(raw(pkt))
 assert bpkt.chksum == 0x70bd and bpkt.payload.chksum == 0xbb17
 
+= TCP payload with IP Total Length 0
+data = b'1234567890abcdef123456789ABCDEF'
+pkt = IP()/TCP()/data
+pkt2 = IP(raw(pkt))
+pkt2.len = 0
+pkt3 = IP(raw(pkt2))
+assert pkt3.load == data
+
 = DNS
 
 * DNS over UDP


### PR DESCRIPTION
While processing an existing capture, I noticed that the last 20 bytes
of a TCP segment were missing in `pkt[TCP].load`. It turns out that
there were wrongly parsed as padding.

The IP Total Length header can be zero in case TSO is applied. Assume
that Total Lengths which cannot fit the IP header to have no padding.
___
Testing note: the new regression test case failed before this patch and passes after the patch.

The full test suite is failing though for unrelated reasons:
```
Traceback (most recent call last):
  File "./../scapy/tools/UTscapy.py", line 976, in <module>
    sys.exit(main(sys.argv[1:]))
  File "./../scapy/tools/UTscapy.py", line 958, in main
    glob_output = pack_html_campaigns(runned_campaigns, glob_output, LOCAL, glob_title)
  File "./../scapy/tools/UTscapy.py", line 632, in pack_html_campaigns
    External_Files.UTscapy_js.write(os.path.dirname(test_campaign.output_file.name))  # noqa: E501
AttributeError: 'str' object has no attribute 'name'
```