### PR TITLE
MQTT VariableFieldLenField

### DIFF
--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -10,10 +10,10 @@ from scapy.fields import FieldLenField, BitEnumField, StrLenField, \
 from scapy.layers.inet import TCP
 from scapy.error import Scapy_Exception
 from scapy.compat import orb, chb
+from scapy.volatile import RandNum
 
 
 # CUSTOM FIELDS
-
 # source: http://stackoverflow.com/a/43717630
 class VariableFieldLenField(FieldLenField):
     def addfield(self, pkt, s, val):
@@ -32,6 +32,8 @@ class VariableFieldLenField(FieldLenField):
             if len(data) > 3:
                 raise Scapy_Exception("%s: malformed length field" %
                                       self.__class__.__name__)
+        # If val is None / 0
+        return s + b"\x00"
 
     def getfield(self, pkt, s):
         value = 0
@@ -44,9 +46,16 @@ class VariableFieldLenField(FieldLenField):
                 raise Scapy_Exception("%s: malformed length field" %
                                       self.__class__.__name__)
 
+    def randval(self):
+        return RandVariableFieldLen()
+
+
+class RandVariableFieldLen(RandNum):
+    def __init__(self):
+        RandNum.__init__(self, 0, 268435455)
+
 
 # LAYERS
-
 CONTROL_PACKET_TYPE = {1: 'CONNECT',
                        2: 'CONNACK',
                        3: 'PUBLISH',

--- a/scapy/contrib/mqtt.uts
+++ b/scapy/contrib/mqtt.uts
@@ -118,3 +118,11 @@ assert(p.value == b'a'*200)
 assert(p.len == None)
 assert(p.length == None)
 
+= MQTT without payload
+p = MQTT()
+assert(bytes(p) == b'\x10\x00')
+
+= MQTT RandVariableFieldLen
+assert(type(MQTT().fieldtype['len'].randval()) == RandVariableFieldLen)
+assert(type(MQTT().fieldtype['len'].randval() + 0) == int)
+


### PR DESCRIPTION
**Checklist:**
- [x] If you are new to Scapy: I have checked https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- [x] I squashed commits belonging together
- [x] I added unit tests or explained why they are not relevant
- [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)

The added test case demonstrates the bug:
```
-- Run Thu Jul  5 22:06:04 2018 from [scapy/contrib/mqtt.uts] by UTscapy

Passed=14
Failed=1


######
## MQTT protocol test
######


###(014)=[failed] MQTT without payload

>>> p = MQTT()
>>> assert(bytes(p) == b'\x10\x00')
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "scapy/packet.py", line 354, in __str__
    return str(self.build())
  File "scapy/packet.py", line 464, in build
    p = self.do_build()
  File "scapy/packet.py", line 451, in do_build
    return self.post_build(pkt, pay)
  File "scapy/packet.py", line 477, in post_build
    return pkt + pay
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
If an MQTT packet has no payload and the length is therefore 0, the method addfield did return None.

The PR fixes the method addfield to return `s + b"\x00`, when the length is 0.

The PR additionally changes the VariableFieldLenField to return a randval() according to MQTT [specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718023).