### PR TITLE
Export-subst util: change format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 dist/
 build/
 MANIFEST
+VERSION
 *.egg-info/
-scapy/VERSION
 test/*.html
 .tox
 doc/scapy/_build

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -78,7 +78,7 @@ def _version():
         except:
             # Rely on git archive "export-subst" git attribute.
             # See 'man gitattributes' for more details.
-            git_archive_id = '$Format:%h %d$'
+            git_archive_id = '$Format:%h$'
             sha1 = git_archive_id.strip().split()[0]
             match = re.search('tag:(\\S+)', git_archive_id)
             if match:

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -61,7 +61,7 @@ def _version_from_git_describe():
 
 
 def _version():
-    version_file = os.path.join(_SCAPY_PKG_DIR, 'VERSION')
+    version_file = os.path.join(_SCAPY_PKG_DIR, os.path.pardir, 'VERSION')
     try:
         tag = _version_from_git_describe()
         # successfully read the tag from git, write it in VERSION for

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10460,7 +10460,7 @@ assert(pl[1][Ether].dst == '00:22:33:44:55:66')
 = _version()
 
 import os
-version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
+version_filename = os.path.join(scapy._SCAPY_PKG_DIR, os.path.pardir, "VERSION")
 
 version = scapy._version()
 assert(os.path.exists(version_filename))
@@ -10470,7 +10470,7 @@ with mock.patch("scapy._version_from_git_describe") as version_mocked:
   version_mocked.side_effect = Exception()
   assert(scapy._version() == version)
   os.unlink(version_filename)
-  assert(scapy._version() == "git-archive.dev$Format:%h")
+  assert(scapy._version() == "git-archive.dev$Format:%h$")
 
 
 ############


### PR DESCRIPTION
This PR:
- moves VERSION from `scapy/scapy/` to `scapy/` which sounds more logical
- replaces `'$Format:%h %d$'` (exported as `c32159d45 (HEAD -> master)`) by `'$Format:%h$'` (exported as `c32159d45`), so that we only depend on the commit state

fixes https://github.com/secdev/scapy/issues/1520