### PR TITLE
Scapy.commands improvement + doc

### DIFF
--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -310,6 +310,7 @@ bind_layers(BOOTP, DHCP, options=b'c\x82Sc')
 
 @conf.commands.register
 def dhcp_request(iface=None, **kargs):
+    """Send a DHCP discover request and return the answer"""
     if conf.checkIPaddr != 0:
         warning("conf.checkIPaddr is not 0, I may not be able to match the answer")  # noqa: E501
     if iface is None:

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -84,7 +84,10 @@ conf.netcache.new_cache("in6_neighbor", 120)
 
 @conf.commands.register
 def neighsol(addr, src, iface, timeout=1, chainCC=0):
-    """Sends an ICMPv6 Neighbor Solicitation message to get the MAC address of the neighbor with specified IPv6 address addr  # noqa: E501
+    """Sends and receive an ICMPv6 Neighbor Solicitation message
+
+    This function sends an ICMPv6 Neighbor Solicitation message
+    to get the MAC address of the neighbor with specified IPv6 address address.
 
     'src' address is used as source of the message. Message is sent on iface.
     By default, timeout waiting for an answer is 1 second.

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -865,12 +865,12 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
                   if isinstance(val, VolatileValue)] + list(self.fields.keys())
         length = 1
         for field in fields:
-            val = self.getfieldval(field)
+            fld, val = self.getfield_and_val(field)
             if hasattr(val, "__iterlen__"):
                 length *= val.__iterlen__()
             elif isinstance(val, tuple) and len(val) == 2 and all(hasattr(z, "__int__") for z in val):  # noqa: E501
                 length *= (val[1] - val[0])
-            elif isinstance(val, list):
+            elif isinstance(val, list) and not fld.islist:
                 len2 = 0
                 for x in val:
                     if hasattr(x, "__iterlen__"):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -794,8 +794,7 @@ iface:    listen answers only on the given interface"""
 def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
           L2socket=None, timeout=None, opened_socket=None,
           stop_filter=None, iface=None, started_callback=None, *arg, **karg):
-    """
-    Sniff packets and return a list of packets.
+    """Sniff packets and return a list of packets.
 
     Args:
         count: number of packets to capture. 0 means infinity.

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -148,7 +148,7 @@ def linehexdump(x, onlyasc=0, onlyhex=0, dump=False):
     :returns: a String only when dump=True
     """
     s = ""
-    s = hexstr(raw(x), onlyasc=onlyasc, onlyhex=onlyhex, color=dump)
+    s = hexstr(raw(x), onlyasc=onlyasc, onlyhex=onlyhex, color=not dump)
     if dump:
         return s
     else:
@@ -181,7 +181,7 @@ def hexstr(x, onlyasc=0, onlyhex=0, color=False):
     _sane_func = sane_color if color else sane
     s = []
     if not onlyasc:
-        s.append(" ".join("%02x" % orb(b) for b in x))
+        s.append(" ".join("%02X" % orb(b) for b in x))
     if not onlyhex:
         s.append(_sane_func(x))
     return "  ".join(s)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10347,6 +10347,25 @@ def test_hexdump():
 
 test_hexdump()
 
+= import_hexcap()
+
+@mock.patch("%s.input" % six.moves.builtins.__name__)
+def test_import_hexcap(mock_input):
+    data = """
+0000  FF FF FF FF FF FF AA AA AA AA AA AA 08 00 45 00  ..............E.
+0010  00 1C 00 01 00 00 40 01 7C DE 7F 00 00 01 7F 00  ......@.|.......
+0020  00 01 08 00 F7 FF 00 00 00 00                    ..........
+"""[1:].split("\n")
+    lines = iter(data)
+    mock_input.side_effect = lambda: next(lines)
+    return import_hexcap()
+
+pkt = test_import_hexcap()
+pkt = Ether(pkt)
+assert pkt[Ether].dst == "ff:ff:ff:ff:ff:ff"
+assert pkt[IP].dst == "127.0.0.1"
+assert ICMP in pkt
+
 = padding()
 
 def test_padding():

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -277,7 +277,7 @@ finally:
 = Test linehexdump function
 conf_color_theme = conf.color_theme
 conf.color_theme = BlackAndWhite()
-assert(linehexdump(Ether(src="00:01:02:03:04:05"), dump=True) == "FFFFFFFFFFFF0001020304059000 ..............")
+assert linehexdump(Ether(src="00:01:02:03:04:05"), dump=True) == 'FF FF FF FF FF FF 00 01 02 03 04 05 90 00  ..............'
 conf.color_theme = conf_color_theme
 
 = Test chexdump function
@@ -287,7 +287,7 @@ chexdump(Ether(src="00:01:02:02:04:05"), dump=True) == "0xff, 0xff, 0xff, 0xff, 
 repr_hex("scapy") == "7363617079"
 
 = Test hexstr function
-hexstr(b"A\x00\xFFB") == "41 00 ff 42  A..B"
+hexstr(b"A\x00\xFFB") == "41 00 FF 42  A..B"
 
 = Test fletcher16 functions
 assert(fletcher16_checksum(b"\x28\x07") == 22319)
@@ -10319,7 +10319,7 @@ def test_rawhexdump():
         p.rawhexdump()
         result_pl_rawhexdump = cmco.get_output()
     assert(len(result_pl_rawhexdump.split('\n')) == 7)
-    assert(result_pl_rawhexdump.startswith("0000  45000028"))
+    assert(result_pl_rawhexdump.startswith("0000  45 00 00 28"))
 
 test_rawhexdump()
 
@@ -10343,7 +10343,7 @@ def test_hexdump():
         p.hexdump()
         result_pl_hexdump = cmco.get_output()
     assert(len(result_pl_hexdump.split('\n')) == 7)
-    assert("0010  7F00000131" in result_pl_hexdump)
+    assert("0010  7F 00 00 01 31" in result_pl_hexdump)
 
 test_hexdump()
 
@@ -10386,7 +10386,7 @@ def test_nzpadding():
         p.nzpadding()
         result_pl_nzpadding = cmco.get_output()
     assert(len(result_pl_nzpadding.split('\n')) == 5)
-    assert("0000  4130" in result_pl_nzpadding)
+    assert("0000  41 30" in result_pl_nzpadding)
 
 test_nzpadding()
 


### PR DESCRIPTION
This PR:
- fixes `lsc()` printing by adding extra docs to the commands listed
- improves a few of those commands / remove duplicated code
- fixes a small bug in `__iterlen__` that could result on some layers (e.g. DHCP) to the `sr()` suite never ending

fixes https://github.com/secdev/scapy/issues/1478