### PR TITLE
Fixes Scapy.1

### DIFF
--- a/doc/scapy.1
+++ b/doc/scapy.1
@@ -63,17 +63,19 @@ do not run startup file
 Only the vital commands to begin are listed here for the moment.
 .TP
 \fBls()\fR
-lists supported protocol layers. If a protocol layer is given as parameter, lists its fields and types of fields.
+lists supported protocol layers.
+If a protocol layer is given as parameter, lists its fields and types of fields.
+If a string is given as parameter, it is used to filter the layers.
 .TP
 \fBlsc()\fR
-lists some user commands. If a command is given as parameter, its documentation is displayed.
+lists scapy's main user commands.
 .TP
 \fBconf\fR
 this object contains the configuration. 
 
 .SH FILES
 \fB$HOME/.scapy_prestart.py\fR
-This file is run before Scapy core is loaded. Only the \fb\conf\fP object 
+This file is run before Scapy core is loaded. Only the \fBconf\fP object
 is available. This file can be used to manipulate \fBconf.load_layers\fP 
 list to choose which layers will be loaded:
 
@@ -87,20 +89,20 @@ This file is run after Scapy is loaded. It can be used to configure
 some of the Scapy behaviors:
 
 .nf
-conf.prog.pdfreader="xpdf"
+conf.prog.pdfreader = "xpdf"
 split_layers(UDP,DNS)
 .fi
 
 .SH EXAMPLES
 
 More verbose examples are available at
-http://www.secdev.org/projects/scapy/demo.html
+https://scapy.net/demo/
 Just run \fBscapy\fP and try the following commands in the interpreter.
 
 .LP
 Test the robustness of a network stack with invalid packets:
 .nf
-sr(IP(dst="172.16.1.1", ihl=2, options="\verb$\x02$", version=3)/ICMP())
+sr(IP(dst="172.16.1.1", ihl=2, options="\everb$\ex02$", version=3)/ICMP())
 .fi
 
 .LP
@@ -175,15 +177,15 @@ report_ports("192.168.2.34", (20,30))
 .SH SEE ALSO
 
 .nf
-https://scapy.net/
-https://github.com/secdev/scapy/
-https://scapy.readthedocs.io/en/latest/
+The official website: \fIhttps://scapy.net/\fP
+The GitHub Development repository: \fIhttps://github.com/secdev/scapy/\fP
+The official documentation: \fIhttps://scapy.readthedocs.io/en/latest/\fP
 .fi
 
 .SH BUGS
 Does not give the right source IP for routes that use interface aliases.
 
-May miss packets under heavy load.
+May miss packets under heavy load. This is a restriction from python itself
 
 Session saving is limited by Python ability to marshal objects. As a 
 consequence, lambda functions and generators can't be saved, which seriously

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -442,6 +442,9 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=20):
         log_loading.error(msg)
         sys.exit(1)
 
+    # Reset sys.argv, otherwise IPython thinks it is for him
+    sys.argv = sys.argv[:1]
+
     init_session(session_name, mydict)
 
     if STARTUP_FILE:

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1555,8 +1555,10 @@ def ls(obj=None, case_sensitive=False, verbose=False):
         else:
             pattern = re.compile(obj, 0 if case_sensitive else re.I)
             all_layers = sorted((layer for layer in conf.layers
-                                 if (pattern.search(layer.__name__ or '')
-                                     or pattern.search(layer.name or ''))),
+                                 if (isinstance(layer.name, str) and
+                                     pattern.search(layer.__name__))
+                                 or (isinstance(layer.name, str) and
+                                     pattern.search(layer.name))),
                                 key=lambda x: x.__name__)
         for layer in all_layers:
             print("%-10s : %s" % (layer.__name__, layer._name))

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -18,11 +18,22 @@ scapy.consts.LOOPBACK_INTERFACE
 ~ conf command
 ls()
 
+= List layers - advanced
+~ conf command
+
+with ContextManagerCaptureOutput() as cmco:
+    ls("IP")
+    result_ls = cmco.get_output().split("\n")
+
+assert all("IP" in x for x in result_ls if x.strip())
+assert len(result_ls) >= 3
+
 = List commands
 ~ conf command
 lsc()
 
 = List contribs
+~ command
 def test_list_contrib():
     with ContextManagerCaptureOutput() as cmco:
         list_contrib()


### PR DESCRIPTION
This PR:
- fixes the issues mentioned in https://github.com/secdev/scapy/issues/1476
- Updates the doc of `ls()` and  `lsc()` to their current behavior
- fixes that some scapy arguments (as specified in the scapy.1) cannot be used at the same time as IPython
- fixes `ls()` behavior & add a test

All those fixes are discovered thanks to the edit of scapy.1 and are small... I could create several PRs but I am a bit lazy for that....

fixes https://github.com/secdev/scapy/issues/1476