### PR TITLE
[Contribs] Big cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,10 @@ New protocols can go either in `scapy/layers` or to
 on common networks, while protocols in `scapy/contrib` should be
 uncommon or specific.
 
+To be precise, `scapy/layers` protocols should not be importing `scapy/contrib`
+protocols, whereas `scapy/contrib` protocols may import both `scapy/contrib` and
+`scapy/layers` protocols.
+
 ### Features
 
 Protocol-related features should be implemented within the same module

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -440,56 +440,39 @@ class ASN1_UTC_TIME(ASN1_STRING):
     tag = ASN1_Class_UNIVERSAL.UTC_TIME
 
     def __init__(self, val):
-        super(ASN1_UTC_TIME, self).__init__(val)
+        ASN1_STRING.__init__(self, val)
 
     def __setattr__(self, name, value):
         if isinstance(value, bytes):
             value = plain_str(value)
         if name == "val":
             pretty_time = None
+            if isinstance(self, ASN1_GENERALIZED_TIME):
+                _len = 15
+                _format = "%Y%m%d%H%M%S"
+            else:
+                _len = 13
+                _format = "%y%m%d%H%M%S"
+            _nam = self.tag._asn1_obj.__name__[4:].lower()
             if (isinstance(value, str) and
-                    len(value) == 13 and value[-1] == "Z"):
-                dt = datetime.strptime(value[:-1], "%y%m%d%H%M%S")
+                    len(value) == _len and value[-1] == "Z"):
+                dt = datetime.strptime(value[:-1], _format)
                 pretty_time = dt.strftime("%b %d %H:%M:%S %Y GMT")
             else:
-                pretty_time = "%s [invalid utc_time]" % value
-            super(ASN1_UTC_TIME, self).__setattr__("pretty_time", pretty_time)
-            super(ASN1_UTC_TIME, self).__setattr__(name, value)
+                pretty_time = "%s [invalid %s]" % (value, _nam)
+            ASN1_STRING.__setattr__(self, "pretty_time", pretty_time)
+            ASN1_STRING.__setattr__(self, name, value)
         elif name == "pretty_time":
             print("Invalid operation: pretty_time rewriting is not supported.")
         else:
-            super(ASN1_UTC_TIME, self).__setattr__(name, value)
+            ASN1_STRING.__setattr__(self, name, value)
 
     def __repr__(self):
         return "%s %s" % (self.pretty_time, ASN1_STRING.__repr__(self))
 
 
-class ASN1_GENERALIZED_TIME(ASN1_STRING):
+class ASN1_GENERALIZED_TIME(ASN1_UTC_TIME):
     tag = ASN1_Class_UNIVERSAL.GENERALIZED_TIME
-
-    def __init__(self, val):
-        super(ASN1_GENERALIZED_TIME, self).__init__(val)
-
-    def __setattr__(self, name, value):
-        if isinstance(value, bytes):
-            value = plain_str(value)
-        if name == "val":
-            pretty_time = None
-            if (isinstance(value, str) and
-                    len(value) == 15 and value[-1] == "Z"):
-                dt = datetime.strptime(value[:-1], "%Y%m%d%H%M%S")
-                pretty_time = dt.strftime("%b %d %H:%M:%S %Y GMT")
-            else:
-                pretty_time = "%s [invalid generalized_time]" % value
-            super(ASN1_GENERALIZED_TIME, self).__setattr__("pretty_time", pretty_time)  # noqa: E501
-            super(ASN1_GENERALIZED_TIME, self).__setattr__(name, value)
-        elif name == "pretty_time":
-            print("Invalid operation: pretty_time rewriting is not supported.")
-        else:
-            super(ASN1_GENERALIZED_TIME, self).__setattr__(name, value)
-
-    def __repr__(self):
-        return "%s %s" % (self.pretty_time, ASN1_STRING.__repr__(self))
 
 
 class ASN1_ISO646_STRING(ASN1_STRING):

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -17,6 +17,7 @@ import struct
 
 from scapy.compat import chb, orb, raw
 from scapy.config import conf
+from scapy.error import warning
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, FieldLenField, FlagsField, IntEnumField, IntField, IPField, LongField, MACField, PacketField, PacketListField, ShortEnumField, ShortField, StrFixedLenField, X3BytesField, XBitField, XByteField, XIntField, XShortField  # noqa: E501
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import TCP

--- a/scapy/contrib/openflow.uts
+++ b/scapy/contrib/openflow.uts
@@ -32,7 +32,7 @@ assert(ofm.buffer_id == 0xffffffff)
 assert(ofm.out_port == 0xfffd)
 ofm.flags == 6
 
-+ Complex OFv1.3 messages
++ Complex OFv1.0 messages
 
 = OFPTFlowMod(), complex flow_mod
 mtc = OFPMatch(dl_vlan=10, nw_src='192.168.42.0', nw_src_mask=8)

--- a/scapy/contrib/openflow.uts
+++ b/scapy/contrib/openflow.uts
@@ -1,5 +1,9 @@
 % Tests for OpenFlow v1.0 with Scapy
 
++ Preparation
+= Be sure we have loaded OpenFlow v1
+load_contrib("openflow")
+
 + Usual OFv1.0 messages
 
 = OFPTHello(), simple hello message
@@ -19,7 +23,7 @@ ofm.wildcards2 == 0xee
 = OpenFlow(), generic method test with OFPTEchoRequest()
 ofm = OFPTEchoRequest()
 s = raw(ofm)
-isinstance(OpenFlow(None,s)(s), OFPTEchoRequest)
+isinstance(OpenFlow(s), OFPTEchoRequest)
 
 = OFPTFlowMod(), check codes and defaults values
 ofm = OFPTFlowMod(cmd='OFPFC_DELETE', out_port='CONTROLLER', flags='CHECK_OVERLAP+EMERG')

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -4,11 +4,11 @@
 # This program is published under a GPLv2 license
 
 # Copyright (C) 2014 Maxence Tury <maxence.tury@ssi.gouv.fr>
-# OpenFlow3 is an open standard used in SDN deployments.
-# Based on OpenFlow3 v1.3.4
+# OpenFlow is an open standard used in SDN deployments.
+# Based on OpenFlow v1.3.4
 # Specifications can be retrieved from https://www.opennetworking.org/
 
-# scapy.contrib.description = OpenFlow3 v1.3
+# scapy.contrib.description = OpenFlow v1.3
 # scapy.contrib.status = loads
 
 from __future__ import absolute_import
@@ -22,16 +22,13 @@ from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     FieldLenField, FlagsField, IntEnumField, IntField, IPField, \
     LongField, MACField, PacketField, PacketListField, ShortEnumField, \
     ShortField, StrFixedLenField, X3BytesField, XBitField, XByteField, \
-    XIntField, XShortField
+    XIntField, XShortField, PacketLenField
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import TCP
 from scapy.packet import Packet, Padding, Raw
 
-from scapy.contrib.openflow import _ofp_header, ActionPacketListField, \
-    OFPacketField
-# We add this star import with its noqa to be sure every OpenFlow packet exist,
-# and will be overwritten by their pairs in OpenFlow3
-from scapy.contrib.openflow import *  # noqa: F401, F403
+from scapy.contrib.openflow import _ofp_header, _ofp_header_item, \
+    OFPacketField, OpenFlow, _UnknownOpenFlow
 
 #####################################################
 #                 Predefined values                 #
@@ -70,26 +67,29 @@ ofp_max_len = {0xffff: "NO_BUFFER"}
 #####################################################
 
 # The following structures will be used in different types
-# of OpenFlow3 messages: ports, matches/OXMs, actions,
+# of OpenFlow messages: ports, matches/OXMs, actions,
 # instructions, buckets, queues, meter bands.
 
 
 #                  Hello elements                   #
 
-class _ofp_hello_elem_header(Packet):
-    name = "Dummy OpenFlow3 Hello Elem Header"
-
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
-        return p + pay
-
 
 ofp_hello_elem_types = {1: "OFPHET_VERSIONBITMAP"}
 
 
-class OFPHETVersionBitmap(_ofp_hello_elem_header):
+class OFPHET(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_hello_elem_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPHETVersionBitmap(_ofp_header):
     name = "OFPHET_VERSIONBITMAP"
     fields_desc = [ShortEnumField("type", 1, ofp_hello_elem_types),
                    ShortField("len", 8),
@@ -103,29 +103,6 @@ class OFPHETVersionBitmap(_ofp_hello_elem_header):
 
 
 ofp_hello_elem_cls = {1: OFPHETVersionBitmap}
-
-
-class HelloElemPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_hello_elem_cls.get(t, Raw)(s)
-
-    @staticmethod
-    def _get_hello_elem_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = HelloElemPacketListField._get_hello_elem_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
 
 
 #                       Ports                       #
@@ -178,15 +155,13 @@ class OFPPort(Packet):
 
     def extract_padding(self, s):
         return b"", s
-    # extract_padding is overridden in order for s not to be considered
-    # as belonging to the same layer (s usually contains other OFPPorts)
 
 
 #                   Matches & OXMs                  #
 
 ofp_oxm_classes = {0: "OFPXMC_NXM_0",
                    1: "OFPXMC_NXM_1",
-                   0x8000: "OFPXMC_OpenFlow3_BASIC",
+                   0x8000: "OFPXMC_OPENFLOW_BASIC",
                    0xffff: "OFPXMC_EXPERIMENTER"}
 
 ofp_oxm_names = {0: "OFB_IN_PORT",
@@ -290,10 +265,10 @@ ofp_oxm_fields = {}
 
 
 def add_ofp_oxm_fields(i, org):
-    ofp_oxm_fields[i] = [ShortEnumField("class", "OFPXMC_OpenFlow3_BASIC", ofp_oxm_classes),  # noqa: E501
+    ofp_oxm_fields[i] = [ShortEnumField("class", "OFPXMC_OPENFLOW_BASIC", ofp_oxm_classes),  # noqa: E501
                          BitEnumField("field", i // 2, 7, ofp_oxm_names),
                          BitField("hasmask", i % 2, 1)]
-    ofp_oxm_fields[i].append(ByteField("length", org[2] + org[2] * (i % 2)))
+    ofp_oxm_fields[i].append(ByteField("len", org[2] + org[2] * (i % 2)))
     if i // 2 == 0:           # OFBInPort
         ofp_oxm_fields[i].append(IntEnumField(org[1], 0, ofp_port_no))
     elif i // 2 == 3 or i // 2 == 4:          # OFBEthSrc & OFBEthDst
@@ -320,12 +295,12 @@ ofp_oxm_cls = {}
 ofp_oxm_id_cls = {}
 
 
-def create_oxm_cls():
+def _create_oxm_cls():
     # static variable initialization
-    if not hasattr(create_oxm_cls, "i"):
-        create_oxm_cls.i = 0
+    if not hasattr(_create_oxm_cls, "i"):
+        _create_oxm_cls.i = 0
 
-    index = create_oxm_cls.i
+    index = _create_oxm_cls.i
     cls_name = ofp_oxm_constr[index // 4][0]
     # we create standard OXM then OXM ID then OXM with mask then OXM-hasmask ID
     if index % 4 == 2:
@@ -347,177 +322,178 @@ def create_oxm_cls():
     # self.fields_desc = [ ShortEnumField("class", 0x8000, ofp_oxm_classes),
     #                              BitEnumField("field", 0, 7, ofp_oxm_names),
     #                              BitField("hasmask", 0, 1),
-    #                              ByteField("length", 4),
+    #                              ByteField("len", 4),
     # IntEnumField("in_port", 0, ofp_port_no) ]
 
     if index % 2 == 0:
         ofp_oxm_cls[index // 2] = cls
     else:
         ofp_oxm_id_cls[index // 2] = cls
-    create_oxm_cls.i += 1
+    _create_oxm_cls.i += 1
+    cls.extract_padding = lambda self, s: (b"", s)
     return cls
 
 
-OFBInPort = create_oxm_cls()
-OFBInPortID = create_oxm_cls()
-OFBInPortHM = create_oxm_cls()
-OFBInPortHMID = create_oxm_cls()
-OFBInPhyPort = create_oxm_cls()
-OFBInPhyPortID = create_oxm_cls()
-OFBInPhyPortHM = create_oxm_cls()
-OFBInPhyPortHMID = create_oxm_cls()
-OFBMetadata = create_oxm_cls()
-OFBMetadataID = create_oxm_cls()
-OFBMetadataHM = create_oxm_cls()
-OFBMetadataHMID = create_oxm_cls()
-OFBEthDst = create_oxm_cls()
-OFBEthDstID = create_oxm_cls()
-OFBEthDstHM = create_oxm_cls()
-OFBEthDstHMID = create_oxm_cls()
-OFBEthSrc = create_oxm_cls()
-OFBEthSrcID = create_oxm_cls()
-OFBEthSrcHM = create_oxm_cls()
-OFBEthSrcHMID = create_oxm_cls()
-OFBEthType = create_oxm_cls()
-OFBEthTypeID = create_oxm_cls()
-OFBEthTypeHM = create_oxm_cls()
-OFBEthTypeHMID = create_oxm_cls()
-OFBVLANVID = create_oxm_cls()
-OFBVLANVIDID = create_oxm_cls()
-OFBVLANVIDHM = create_oxm_cls()
-OFBVLANVIDHMID = create_oxm_cls()
-OFBVLANPCP = create_oxm_cls()
-OFBVLANPCPID = create_oxm_cls()
-OFBVLANPCPHM = create_oxm_cls()
-OFBVLANPCPHMID = create_oxm_cls()
-OFBIPDSCP = create_oxm_cls()
-OFBIPDSCPID = create_oxm_cls()
-OFBIPDSCPHM = create_oxm_cls()
-OFBIPDSCPHMID = create_oxm_cls()
-OFBIPECN = create_oxm_cls()
-OFBIPECNID = create_oxm_cls()
-OFBIPECNHM = create_oxm_cls()
-OFBIPECNHMID = create_oxm_cls()
-OFBIPProto = create_oxm_cls()
-OFBIPProtoID = create_oxm_cls()
-OFBIPProtoHM = create_oxm_cls()
-OFBIPProtoHMID = create_oxm_cls()
-OFBIPv4Src = create_oxm_cls()
-OFBIPv4SrcID = create_oxm_cls()
-OFBIPv4SrcHM = create_oxm_cls()
-OFBIPv4SrcHMID = create_oxm_cls()
-OFBIPv4Dst = create_oxm_cls()
-OFBIPv4DstID = create_oxm_cls()
-OFBIPv4DstHM = create_oxm_cls()
-OFBIPv4DstHMID = create_oxm_cls()
-OFBTCPSrc = create_oxm_cls()
-OFBTCPSrcID = create_oxm_cls()
-OFBTCPSrcHM = create_oxm_cls()
-OFBTCPSrcHMID = create_oxm_cls()
-OFBTCPDst = create_oxm_cls()
-OFBTCPDstID = create_oxm_cls()
-OFBTCPDstHM = create_oxm_cls()
-OFBTCPDstHMID = create_oxm_cls()
-OFBUDPSrc = create_oxm_cls()
-OFBUDPSrcID = create_oxm_cls()
-OFBUDPSrcHM = create_oxm_cls()
-OFBUDPSrcHMID = create_oxm_cls()
-OFBUDPDst = create_oxm_cls()
-OFBUDPDstID = create_oxm_cls()
-OFBUDPDstHM = create_oxm_cls()
-OFBUDPDstHMID = create_oxm_cls()
-OFBSCTPSrc = create_oxm_cls()
-OFBSCTPSrcID = create_oxm_cls()
-OFBSCTPSrcHM = create_oxm_cls()
-OFBSCTPSrcHMID = create_oxm_cls()
-OFBSCTPDst = create_oxm_cls()
-OFBSCTPDstID = create_oxm_cls()
-OFBSCTPDstHM = create_oxm_cls()
-OFBSCTPDstHMID = create_oxm_cls()
-OFBICMPv4Type = create_oxm_cls()
-OFBICMPv4TypeID = create_oxm_cls()
-OFBICMPv4TypeHM = create_oxm_cls()
-OFBICMPv4TypeHMID = create_oxm_cls()
-OFBICMPv4Code = create_oxm_cls()
-OFBICMPv4CodeID = create_oxm_cls()
-OFBICMPv4CodeHM = create_oxm_cls()
-OFBICMPv4CodeHMID = create_oxm_cls()
-OFBARPOP = create_oxm_cls()
-OFBARPOPID = create_oxm_cls()
-OFBARPOPHM = create_oxm_cls()
-OFBARPOPHMID = create_oxm_cls()
-OFBARPSPA = create_oxm_cls()
-OFBARPSPAID = create_oxm_cls()
-OFBARPSPAHM = create_oxm_cls()
-OFBARPSPAHMID = create_oxm_cls()
-OFBARPTPA = create_oxm_cls()
-OFBARPTPAID = create_oxm_cls()
-OFBARPTPAHM = create_oxm_cls()
-OFBARPTPAHMID = create_oxm_cls()
-OFBARPSHA = create_oxm_cls()
-OFBARPSHAID = create_oxm_cls()
-OFBARPSHAHM = create_oxm_cls()
-OFBARPSHAHMID = create_oxm_cls()
-OFBARPTHA = create_oxm_cls()
-OFBARPTHAID = create_oxm_cls()
-OFBARPTHAHM = create_oxm_cls()
-OFBARPTHAHMID = create_oxm_cls()
-OFBIPv6Src = create_oxm_cls()
-OFBIPv6SrcID = create_oxm_cls()
-OFBIPv6SrcHM = create_oxm_cls()
-OFBIPv6SrcHMID = create_oxm_cls()
-OFBIPv6Dst = create_oxm_cls()
-OFBIPv6DstID = create_oxm_cls()
-OFBIPv6DstHM = create_oxm_cls()
-OFBIPv6DstHMID = create_oxm_cls()
-OFBIPv6FLabel = create_oxm_cls()
-OFBIPv6FLabelID = create_oxm_cls()
-OFBIPv6FLabelHM = create_oxm_cls()
-OFBIPv6FLabelHMID = create_oxm_cls()
-OFBICMPv6Type = create_oxm_cls()
-OFBICMPv6TypeID = create_oxm_cls()
-OFBICMPv6TypeHM = create_oxm_cls()
-OFBICMPv6TypeHMID = create_oxm_cls()
-OFBICMPv6Code = create_oxm_cls()
-OFBICMPv6CodeID = create_oxm_cls()
-OFBICMPv6CodeHM = create_oxm_cls()
-OFBICMPv6CodeHMID = create_oxm_cls()
-OFBIPv6NDTarget = create_oxm_cls()
-OFBIPv6NDTargetID = create_oxm_cls()
-OFBIPv6NDTargetHM = create_oxm_cls()
-OFBIPv6NDTargetHMID = create_oxm_cls()
-OFBIPv6NDSLL = create_oxm_cls()
-OFBIPv6NDSLLID = create_oxm_cls()
-OFBIPv6NDSLLHM = create_oxm_cls()
-OFBIPv6NDSLLHMID = create_oxm_cls()
-OFBIPv6NDTLL = create_oxm_cls()
-OFBIPv6NDTLLID = create_oxm_cls()
-OFBIPv6NDTLLHM = create_oxm_cls()
-OFBIPv6NDTLLHMID = create_oxm_cls()
-OFBMPLSLabel = create_oxm_cls()
-OFBMPLSLabelID = create_oxm_cls()
-OFBMPLSLabelHM = create_oxm_cls()
-OFBMPLSLabelHMID = create_oxm_cls()
-OFBMPLSTC = create_oxm_cls()
-OFBMPLSTCID = create_oxm_cls()
-OFBMPLSTCHM = create_oxm_cls()
-OFBMPLSTCHMID = create_oxm_cls()
-OFBMPLSBoS = create_oxm_cls()
-OFBMPLSBoSID = create_oxm_cls()
-OFBMPLSBoSHM = create_oxm_cls()
-OFBMPLSBoSHMID = create_oxm_cls()
-OFBPBBISID = create_oxm_cls()
-OFBPBBISIDID = create_oxm_cls()
-OFBPBBISIDHM = create_oxm_cls()
-OFBPBBISIDHMID = create_oxm_cls()
-OFBTunnelID = create_oxm_cls()
-OFBTunnelIDID = create_oxm_cls()
-OFBTunnelIDHM = create_oxm_cls()
-OFBTunnelIDHMID = create_oxm_cls()
-OFBIPv6ExtHdr = create_oxm_cls()
-OFBIPv6ExtHdrID = create_oxm_cls()
-OFBIPv6ExtHdrHM = create_oxm_cls()
-OFBIPv6ExtHdrHMID = create_oxm_cls()
+OFBInPort = _create_oxm_cls()
+OFBInPortID = _create_oxm_cls()
+OFBInPortHM = _create_oxm_cls()
+OFBInPortHMID = _create_oxm_cls()
+OFBInPhyPort = _create_oxm_cls()
+OFBInPhyPortID = _create_oxm_cls()
+OFBInPhyPortHM = _create_oxm_cls()
+OFBInPhyPortHMID = _create_oxm_cls()
+OFBMetadata = _create_oxm_cls()
+OFBMetadataID = _create_oxm_cls()
+OFBMetadataHM = _create_oxm_cls()
+OFBMetadataHMID = _create_oxm_cls()
+OFBEthDst = _create_oxm_cls()
+OFBEthDstID = _create_oxm_cls()
+OFBEthDstHM = _create_oxm_cls()
+OFBEthDstHMID = _create_oxm_cls()
+OFBEthSrc = _create_oxm_cls()
+OFBEthSrcID = _create_oxm_cls()
+OFBEthSrcHM = _create_oxm_cls()
+OFBEthSrcHMID = _create_oxm_cls()
+OFBEthType = _create_oxm_cls()
+OFBEthTypeID = _create_oxm_cls()
+OFBEthTypeHM = _create_oxm_cls()
+OFBEthTypeHMID = _create_oxm_cls()
+OFBVLANVID = _create_oxm_cls()
+OFBVLANVIDID = _create_oxm_cls()
+OFBVLANVIDHM = _create_oxm_cls()
+OFBVLANVIDHMID = _create_oxm_cls()
+OFBVLANPCP = _create_oxm_cls()
+OFBVLANPCPID = _create_oxm_cls()
+OFBVLANPCPHM = _create_oxm_cls()
+OFBVLANPCPHMID = _create_oxm_cls()
+OFBIPDSCP = _create_oxm_cls()
+OFBIPDSCPID = _create_oxm_cls()
+OFBIPDSCPHM = _create_oxm_cls()
+OFBIPDSCPHMID = _create_oxm_cls()
+OFBIPECN = _create_oxm_cls()
+OFBIPECNID = _create_oxm_cls()
+OFBIPECNHM = _create_oxm_cls()
+OFBIPECNHMID = _create_oxm_cls()
+OFBIPProto = _create_oxm_cls()
+OFBIPProtoID = _create_oxm_cls()
+OFBIPProtoHM = _create_oxm_cls()
+OFBIPProtoHMID = _create_oxm_cls()
+OFBIPv4Src = _create_oxm_cls()
+OFBIPv4SrcID = _create_oxm_cls()
+OFBIPv4SrcHM = _create_oxm_cls()
+OFBIPv4SrcHMID = _create_oxm_cls()
+OFBIPv4Dst = _create_oxm_cls()
+OFBIPv4DstID = _create_oxm_cls()
+OFBIPv4DstHM = _create_oxm_cls()
+OFBIPv4DstHMID = _create_oxm_cls()
+OFBTCPSrc = _create_oxm_cls()
+OFBTCPSrcID = _create_oxm_cls()
+OFBTCPSrcHM = _create_oxm_cls()
+OFBTCPSrcHMID = _create_oxm_cls()
+OFBTCPDst = _create_oxm_cls()
+OFBTCPDstID = _create_oxm_cls()
+OFBTCPDstHM = _create_oxm_cls()
+OFBTCPDstHMID = _create_oxm_cls()
+OFBUDPSrc = _create_oxm_cls()
+OFBUDPSrcID = _create_oxm_cls()
+OFBUDPSrcHM = _create_oxm_cls()
+OFBUDPSrcHMID = _create_oxm_cls()
+OFBUDPDst = _create_oxm_cls()
+OFBUDPDstID = _create_oxm_cls()
+OFBUDPDstHM = _create_oxm_cls()
+OFBUDPDstHMID = _create_oxm_cls()
+OFBSCTPSrc = _create_oxm_cls()
+OFBSCTPSrcID = _create_oxm_cls()
+OFBSCTPSrcHM = _create_oxm_cls()
+OFBSCTPSrcHMID = _create_oxm_cls()
+OFBSCTPDst = _create_oxm_cls()
+OFBSCTPDstID = _create_oxm_cls()
+OFBSCTPDstHM = _create_oxm_cls()
+OFBSCTPDstHMID = _create_oxm_cls()
+OFBICMPv4Type = _create_oxm_cls()
+OFBICMPv4TypeID = _create_oxm_cls()
+OFBICMPv4TypeHM = _create_oxm_cls()
+OFBICMPv4TypeHMID = _create_oxm_cls()
+OFBICMPv4Code = _create_oxm_cls()
+OFBICMPv4CodeID = _create_oxm_cls()
+OFBICMPv4CodeHM = _create_oxm_cls()
+OFBICMPv4CodeHMID = _create_oxm_cls()
+OFBARPOP = _create_oxm_cls()
+OFBARPOPID = _create_oxm_cls()
+OFBARPOPHM = _create_oxm_cls()
+OFBARPOPHMID = _create_oxm_cls()
+OFBARPSPA = _create_oxm_cls()
+OFBARPSPAID = _create_oxm_cls()
+OFBARPSPAHM = _create_oxm_cls()
+OFBARPSPAHMID = _create_oxm_cls()
+OFBARPTPA = _create_oxm_cls()
+OFBARPTPAID = _create_oxm_cls()
+OFBARPTPAHM = _create_oxm_cls()
+OFBARPTPAHMID = _create_oxm_cls()
+OFBARPSHA = _create_oxm_cls()
+OFBARPSHAID = _create_oxm_cls()
+OFBARPSHAHM = _create_oxm_cls()
+OFBARPSHAHMID = _create_oxm_cls()
+OFBARPTHA = _create_oxm_cls()
+OFBARPTHAID = _create_oxm_cls()
+OFBARPTHAHM = _create_oxm_cls()
+OFBARPTHAHMID = _create_oxm_cls()
+OFBIPv6Src = _create_oxm_cls()
+OFBIPv6SrcID = _create_oxm_cls()
+OFBIPv6SrcHM = _create_oxm_cls()
+OFBIPv6SrcHMID = _create_oxm_cls()
+OFBIPv6Dst = _create_oxm_cls()
+OFBIPv6DstID = _create_oxm_cls()
+OFBIPv6DstHM = _create_oxm_cls()
+OFBIPv6DstHMID = _create_oxm_cls()
+OFBIPv6FLabel = _create_oxm_cls()
+OFBIPv6FLabelID = _create_oxm_cls()
+OFBIPv6FLabelHM = _create_oxm_cls()
+OFBIPv6FLabelHMID = _create_oxm_cls()
+OFBICMPv6Type = _create_oxm_cls()
+OFBICMPv6TypeID = _create_oxm_cls()
+OFBICMPv6TypeHM = _create_oxm_cls()
+OFBICMPv6TypeHMID = _create_oxm_cls()
+OFBICMPv6Code = _create_oxm_cls()
+OFBICMPv6CodeID = _create_oxm_cls()
+OFBICMPv6CodeHM = _create_oxm_cls()
+OFBICMPv6CodeHMID = _create_oxm_cls()
+OFBIPv6NDTarget = _create_oxm_cls()
+OFBIPv6NDTargetID = _create_oxm_cls()
+OFBIPv6NDTargetHM = _create_oxm_cls()
+OFBIPv6NDTargetHMID = _create_oxm_cls()
+OFBIPv6NDSLL = _create_oxm_cls()
+OFBIPv6NDSLLID = _create_oxm_cls()
+OFBIPv6NDSLLHM = _create_oxm_cls()
+OFBIPv6NDSLLHMID = _create_oxm_cls()
+OFBIPv6NDTLL = _create_oxm_cls()
+OFBIPv6NDTLLID = _create_oxm_cls()
+OFBIPv6NDTLLHM = _create_oxm_cls()
+OFBIPv6NDTLLHMID = _create_oxm_cls()
+OFBMPLSLabel = _create_oxm_cls()
+OFBMPLSLabelID = _create_oxm_cls()
+OFBMPLSLabelHM = _create_oxm_cls()
+OFBMPLSLabelHMID = _create_oxm_cls()
+OFBMPLSTC = _create_oxm_cls()
+OFBMPLSTCID = _create_oxm_cls()
+OFBMPLSTCHM = _create_oxm_cls()
+OFBMPLSTCHMID = _create_oxm_cls()
+OFBMPLSBoS = _create_oxm_cls()
+OFBMPLSBoSID = _create_oxm_cls()
+OFBMPLSBoSHM = _create_oxm_cls()
+OFBMPLSBoSHMID = _create_oxm_cls()
+OFBPBBISID = _create_oxm_cls()
+OFBPBBISIDID = _create_oxm_cls()
+OFBPBBISIDHM = _create_oxm_cls()
+OFBPBBISIDHMID = _create_oxm_cls()
+OFBTunnelID = _create_oxm_cls()
+OFBTunnelIDID = _create_oxm_cls()
+OFBTunnelIDHM = _create_oxm_cls()
+OFBTunnelIDHMID = _create_oxm_cls()
+OFBIPv6ExtHdr = _create_oxm_cls()
+OFBIPv6ExtHdrID = _create_oxm_cls()
+OFBIPv6ExtHdrHM = _create_oxm_cls()
+OFBIPv6ExtHdrHMID = _create_oxm_cls()
 
 # need_prereq holds a list of prerequisites defined in 7.2.3.8 of the specifications  # noqa: E501
 # e.g. if you want to use an OFBTCPSrc instance (code 26)
@@ -641,37 +617,28 @@ class OXMPacketListField(PacketListField):
         return remain + ret, lst
 
 
-class OXMIDPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = orb(s[2])
-        return ofp_oxm_id_cls.get(t, Raw)(s)
+class OXMID(Packet):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = orb(_pkt[2])
+            return ofp_oxm_id_cls.get(t, Raw)
+        return Raw
 
-    def getfield(self, pkt, s):
-        lst = []
-        lim = self.length_from(pkt)
-        ret = s[lim:]
-        remain = s[:lim]
-
-        while remain and len(remain) >= 4:
-            # all OXM ID are 32-bit long (no experimenter OXM support here)
-            current = remain[:4]
-            remain = remain[4:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain + ret, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMatch(Packet):
     name = "OFP_MATCH"
     fields_desc = [ShortEnumField("type", 1, {0: "OFPMT_STANDARD",
                                               1: "OFPMT_OXM"}),
-                   ShortField("length", None),
+                   ShortField("len", None),
                    OXMPacketListField("oxm_fields", [], Packet,
-                                      length_from=lambda pkt:pkt.length - 4)]
+                                      length_from=lambda pkt:pkt.len - 4)]
 
     def post_build(self, p, pay):
-        tmp_len = self.length
+        tmp_len = self.len
         if tmp_len is None:
             tmp_len = len(p) + len(pay)
             p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
@@ -681,7 +648,7 @@ class OFPMatch(Packet):
         return p + pay
 
     def extract_padding(self, s):
-        tmp_len = self.length
+        tmp_len = self.len
         zero_bytes = (8 - tmp_len % 8) % 8
         return s[zero_bytes:], s[:zero_bytes]
 
@@ -714,14 +681,8 @@ class MatchField(PacketField):
 #                      Actions                      #
 
 
-class OpenFlow3(Packet):
-    name = "Dummy OpenFlow3 Action Header"
-
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
-        return p + pay
+class OpenFlow3(OpenFlow):
+    name = "OpenFlow v1.3 dissector"
 
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
@@ -748,7 +709,7 @@ class OpenFlow3(Packet):
                 return ofp_multipart_reply_cls[mp_type]
             else:
                 return ofpt_cls[of_type]
-        return OFPTHello
+        return _UnknownOpenFlow
 
 
 ofp_action_types = {0: "OFPAT_OUTPUT",
@@ -783,7 +744,19 @@ ofp_action_types = {0: "OFPAT_OUTPUT",
                     65535: "OFPAT_EXPERIMENTER"}
 
 
-class OFPATOutput(OpenFlow3):
+class OFPAT(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_action_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPATOutput(OFPAT):
     name = "OFPAT_OUTPUT"
     fields_desc = [ShortEnumField("type", 0, ofp_action_types),
                    ShortField("len", 16),
@@ -795,7 +768,7 @@ class OFPATOutput(OpenFlow3):
 # the following actions are not supported by OFv1.3
 
 
-class OFPATSetVLANVID(OpenFlow3):
+class OFPATSetVLANVID(OFPAT):
     name = "OFPAT_SET_VLAN_VID"
     fields_desc = [ShortEnumField("type", 1, ofp_action_types),
                    ShortField("len", 8),
@@ -803,7 +776,7 @@ class OFPATSetVLANVID(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATSetVLANPCP(OpenFlow3):
+class OFPATSetVLANPCP(OFPAT):
     name = "OFPAT_SET_VLAN_PCP"
     fields_desc = [ShortEnumField("type", 2, ofp_action_types),
                    ShortField("len", 8),
@@ -811,14 +784,14 @@ class OFPATSetVLANPCP(OpenFlow3):
                    X3BytesField("pad", 0)]
 
 
-class OFPATStripVLAN(OpenFlow3):
+class OFPATStripVLAN(OFPAT):
     name = "OFPAT_STRIP_VLAN"
     fields_desc = [ShortEnumField("type", 3, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATSetDlSrc(OpenFlow3):
+class OFPATSetDlSrc(OFPAT):
     name = "OFPAT_SET_DL_SRC"
     fields_desc = [ShortEnumField("type", 4, ofp_action_types),
                    ShortField("len", 16),
@@ -826,7 +799,7 @@ class OFPATSetDlSrc(OpenFlow3):
                    XBitField("pad", 0, 48)]
 
 
-class OFPATSetDlDst(OpenFlow3):
+class OFPATSetDlDst(OFPAT):
     name = "OFPAT_SET_DL_DST"
     fields_desc = [ShortEnumField("type", 5, ofp_action_types),
                    ShortField("len", 16),
@@ -834,21 +807,21 @@ class OFPATSetDlDst(OpenFlow3):
                    XBitField("pad", 0, 48)]
 
 
-class OFPATSetNwSrc(OpenFlow3):
+class OFPATSetNwSrc(OFPAT):
     name = "OFPAT_SET_NW_SRC"
     fields_desc = [ShortEnumField("type", 6, ofp_action_types),
                    ShortField("len", 8),
                    IPField("nw_addr", "0")]
 
 
-class OFPATSetNwDst(OpenFlow3):
+class OFPATSetNwDst(OFPAT):
     name = "OFPAT_SET_NW_DST"
     fields_desc = [ShortEnumField("type", 7, ofp_action_types),
                    ShortField("len", 8),
                    IPField("nw_addr", "0")]
 
 
-class OFPATSetNwToS(OpenFlow3):
+class OFPATSetNwToS(OFPAT):
     name = "OFPAT_SET_TP_TOS"
     fields_desc = [ShortEnumField("type", 8, ofp_action_types),
                    ShortField("len", 8),
@@ -856,7 +829,7 @@ class OFPATSetNwToS(OpenFlow3):
                    X3BytesField("pad", 0)]
 
 
-class OFPATSetTpSrc(OpenFlow3):
+class OFPATSetTpSrc(OFPAT):
     name = "OFPAT_SET_TP_SRC"
     fields_desc = [ShortEnumField("type", 9, ofp_action_types),
                    ShortField("len", 8),
@@ -864,14 +837,14 @@ class OFPATSetTpSrc(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATSetTpDst(OpenFlow3):
+class OFPATSetTpDst(OFPAT):
     name = "OFPAT_SET_TP_DST"
     fields_desc = [ShortEnumField("type", 10, ofp_action_types),
                    ShortField("len", 8),
                    ShortField("tp_port", 0),
                    XShortField("pad", 0)]
 
-# class OFPATEnqueue(OpenFlow3):
+# class OFPATEnqueue(OFPAT):
 #       name = "OFPAT_ENQUEUE"
 #       fields_desc = [ ShortEnumField("type", 11, ofp_action_types),
 #                       ShortField("len", 16),
@@ -880,14 +853,14 @@ class OFPATSetTpDst(OpenFlow3):
 #                       IntEnumField("queue_id", 0, ofp_queue) ]
 
 
-class OFPATSetMPLSLabel(OpenFlow3):
+class OFPATSetMPLSLabel(OFPAT):
     name = "OFPAT_SET_MPLS_LABEL"
     fields_desc = [ShortEnumField("type", 13, ofp_action_types),
                    ShortField("len", 8),
                    IntField("mpls_label", 0)]
 
 
-class OFPATSetMPLSTC(OpenFlow3):
+class OFPATSetMPLSTC(OFPAT):
     name = "OFPAT_SET_MPLS_TC"
     fields_desc = [ShortEnumField("type", 14, ofp_action_types),
                    ShortField("len", 8),
@@ -897,21 +870,21 @@ class OFPATSetMPLSTC(OpenFlow3):
 # end of unsupported actions
 
 
-class OFPATCopyTTLOut(OpenFlow3):
+class OFPATCopyTTLOut(OFPAT):
     name = "OFPAT_COPY_TTL_OUT"
     fields_desc = [ShortEnumField("type", 11, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATCopyTTLIn(OpenFlow3):
+class OFPATCopyTTLIn(OFPAT):
     name = "OFPAT_COPY_TTL_IN"
     fields_desc = [ShortEnumField("type", 12, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATSetMPLSTTL(OpenFlow3):
+class OFPATSetMPLSTTL(OFPAT):
     name = "OFPAT_SET_MPLS_TTL"
     fields_desc = [ShortEnumField("type", 15, ofp_action_types),
                    ShortField("len", 8),
@@ -919,14 +892,14 @@ class OFPATSetMPLSTTL(OpenFlow3):
                    X3BytesField("pad", 0)]
 
 
-class OFPATDecMPLSTTL(OpenFlow3):
+class OFPATDecMPLSTTL(OFPAT):
     name = "OFPAT_DEC_MPLS_TTL"
     fields_desc = [ShortEnumField("type", 16, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATPushVLAN(OpenFlow3):
+class OFPATPushVLAN(OFPAT):
     name = "OFPAT_PUSH_VLAN"
     fields_desc = [ShortEnumField("type", 17, ofp_action_types),
                    ShortField("len", 8),
@@ -934,14 +907,14 @@ class OFPATPushVLAN(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATPopVLAN(OpenFlow3):
+class OFPATPopVLAN(OFPAT):
     name = "OFPAT_POP_VLAN"
     fields_desc = [ShortEnumField("type", 18, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATPushMPLS(OpenFlow3):
+class OFPATPushMPLS(OFPAT):
     name = "OFPAT_PUSH_MPLS"
     fields_desc = [ShortEnumField("type", 19, ofp_action_types),
                    ShortField("len", 8),
@@ -949,7 +922,7 @@ class OFPATPushMPLS(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATPopMPLS(OpenFlow3):
+class OFPATPopMPLS(OFPAT):
     name = "OFPAT_POP_MPLS"
     fields_desc = [ShortEnumField("type", 20, ofp_action_types),
                    ShortField("len", 8),
@@ -957,21 +930,21 @@ class OFPATPopMPLS(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATSetQueue(OpenFlow3):
+class OFPATSetQueue(OFPAT):
     name = "OFPAT_SET_QUEUE"
     fields_desc = [ShortEnumField("type", 21, ofp_action_types),
                    ShortField("len", 8),
                    IntEnumField("queue_id", 0, ofp_queue)]
 
 
-class OFPATGroup(OpenFlow3):
+class OFPATGroup(OFPAT):
     name = "OFPAT_GROUP"
     fields_desc = [ShortEnumField("type", 22, ofp_action_types),
                    ShortField("len", 8),
                    IntEnumField("group_id", 0, ofp_group)]
 
 
-class OFPATSetNwTTL(OpenFlow3):
+class OFPATSetNwTTL(OFPAT):
     name = "OFPAT_SET_NW_TTL"
     fields_desc = [ShortEnumField("type", 23, ofp_action_types),
                    ShortField("len", 8),
@@ -979,14 +952,22 @@ class OFPATSetNwTTL(OpenFlow3):
                    X3BytesField("pad", 0)]
 
 
-class OFPATDecNwTTL(OpenFlow3):
+class OFPATDecNwTTL(OFPAT):
     name = "OFPAT_DEC_NW_TTL"
     fields_desc = [ShortEnumField("type", 24, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATSetField(OpenFlow3):
+class OFPATSetField(OFPAT):
+    name = "OFPAT_SET_FIELD"
+    fields_desc = [ShortEnumField("type", 25, ofp_action_types),
+                   ShortField("len", None),
+                   # there should not be more than one oxm tlv
+                   OXMPacketListField("field", [], Packet,
+                                      length_from=lambda pkt:pkt.len - 4,
+                                      # /!\ contains padding!
+                                      autocomplete=False)]
 
     def post_build(self, p, pay):
         tmp_len = self.len
@@ -1005,17 +986,8 @@ class OFPATSetField(OpenFlow3):
     def extract_padding(self, s):
         return b"", s
 
-    name = "OFPAT_SET_FIELD"
-    fields_desc = [ShortEnumField("type", 25, ofp_action_types),
-                   ShortField("len", None),
-                   # there should not be more than one oxm tlv
-                   OXMPacketListField("field", [], Packet,
-                                      length_from=lambda pkt:pkt.len - 4,
-                                      # /!\ contains padding!
-                                      autocomplete=False)]
 
-
-class OFPATPushPBB(OpenFlow3):
+class OFPATPushPBB(OFPAT):
     name = "OFPAT_PUSH_PBB"
     fields_desc = [ShortEnumField("type", 26, ofp_action_types),
                    ShortField("len", 8),
@@ -1023,14 +995,14 @@ class OFPATPushPBB(OpenFlow3):
                    XShortField("pad", 0)]
 
 
-class OFPATPopPBB(OpenFlow3):
+class OFPATPopPBB(OFPAT):
     name = "OFPAT_POP_PBB"
     fields_desc = [ShortEnumField("type", 27, ofp_action_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPATExperimenter(OpenFlow3):
+class OFPATExperimenter(OFPAT):
     name = "OFPAT_EXPERIMENTER"
     fields_desc = [ShortEnumField("type", 65535, ofp_action_types),
                    ShortField("len", 8),
@@ -1071,10 +1043,22 @@ ofp_action_cls = {0: OFPATOutput,
 
 #                     Action IDs                    #
 
-# length is computed as in instruction structures,
-# so we reuse _ofp_instruction_header
+class OFPATID(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_action_id_cls.get(t, Raw)
+        return Raw
 
-class OFPATOutputID(OpenFlow3):
+    def extract_padding(self, s):
+        return b"", s
+
+# length is computed as in instruction structures,
+# so we reuse _ofp_header
+
+
+class OFPATOutputID(OFPATID):
     name = "OFPAT_OUTPUT"
     fields_desc = [ShortEnumField("type", 0, ofp_action_types),
                    ShortField("len", 4)]
@@ -1082,78 +1066,78 @@ class OFPATOutputID(OpenFlow3):
 # the following actions are not supported by OFv1.3
 
 
-class OFPATSetVLANVIDID(OpenFlow3):
+class OFPATSetVLANVIDID(OFPATID):
     name = "OFPAT_SET_VLAN_VID"
     fields_desc = [ShortEnumField("type", 1, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetVLANPCPID(OpenFlow3):
+class OFPATSetVLANPCPID(OFPATID):
     name = "OFPAT_SET_VLAN_PCP"
     fields_desc = [ShortEnumField("type", 2, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATStripVLANID(OpenFlow3):
+class OFPATStripVLANID(OFPATID):
     name = "OFPAT_STRIP_VLAN"
     fields_desc = [ShortEnumField("type", 3, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetDlSrcID(OpenFlow3):
+class OFPATSetDlSrcID(OFPATID):
     name = "OFPAT_SET_DL_SRC"
     fields_desc = [ShortEnumField("type", 4, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetDlDstID(OpenFlow3):
+class OFPATSetDlDstID(OFPATID):
     name = "OFPAT_SET_DL_DST"
     fields_desc = [ShortEnumField("type", 5, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetNwSrcID(OpenFlow3):
+class OFPATSetNwSrcID(OFPATID):
     name = "OFPAT_SET_NW_SRC"
     fields_desc = [ShortEnumField("type", 6, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetNwDstID(OpenFlow3):
+class OFPATSetNwDstID(OFPATID):
     name = "OFPAT_SET_NW_DST"
     fields_desc = [ShortEnumField("type", 7, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetNwToSID(OpenFlow3):
+class OFPATSetNwToSID(OFPATID):
     name = "OFPAT_SET_TP_TOS"
     fields_desc = [ShortEnumField("type", 8, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetTpSrcID(OpenFlow3):
+class OFPATSetTpSrcID(OFPATID):
     name = "OFPAT_SET_TP_SRC"
     fields_desc = [ShortEnumField("type", 9, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetTpDstID(OpenFlow3):
+class OFPATSetTpDstID(OFPATID):
     name = "OFPAT_SET_TP_DST"
     fields_desc = [ShortEnumField("type", 10, ofp_action_types),
                    ShortField("len", 4)]
 
-# class OFPATEnqueueID(OpenFlow3):
+# class OFPATEnqueueID(OFPAT):
 #       name = "OFPAT_ENQUEUE"
 #       fields_desc = [ ShortEnumField("type", 11, ofp_action_types),
 #                       ShortField("len", 4) ]
 
 
-class OFPATSetMPLSLabelID(OpenFlow3):
+class OFPATSetMPLSLabelID(OFPATID):
     name = "OFPAT_SET_MPLS_LABEL"
     fields_desc = [ShortEnumField("type", 13, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetMPLSTCID(OpenFlow3):
+class OFPATSetMPLSTCID(OFPATID):
     name = "OFPAT_SET_MPLS_TC"
     fields_desc = [ShortEnumField("type", 14, ofp_action_types),
                    ShortField("len", 4)]
@@ -1161,97 +1145,97 @@ class OFPATSetMPLSTCID(OpenFlow3):
 # end of unsupported actions
 
 
-class OFPATCopyTTLOutID(OpenFlow3):
+class OFPATCopyTTLOutID(OFPATID):
     name = "OFPAT_COPY_TTL_OUT"
     fields_desc = [ShortEnumField("type", 11, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATCopyTTLInID(OpenFlow3):
+class OFPATCopyTTLInID(OFPATID):
     name = "OFPAT_COPY_TTL_IN"
     fields_desc = [ShortEnumField("type", 12, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetMPLSTTLID(OpenFlow3):
+class OFPATSetMPLSTTLID(OFPATID):
     name = "OFPAT_SET_MPLS_TTL"
     fields_desc = [ShortEnumField("type", 15, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATDecMPLSTTLID(OpenFlow3):
+class OFPATDecMPLSTTLID(OFPATID):
     name = "OFPAT_DEC_MPLS_TTL"
     fields_desc = [ShortEnumField("type", 16, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPushVLANID(OpenFlow3):
+class OFPATPushVLANID(OFPATID):
     name = "OFPAT_PUSH_VLAN"
     fields_desc = [ShortEnumField("type", 17, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPopVLANID(OpenFlow3):
+class OFPATPopVLANID(OFPATID):
     name = "OFPAT_POP_VLAN"
     fields_desc = [ShortEnumField("type", 18, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPushMPLSID(OpenFlow3):
+class OFPATPushMPLSID(OFPATID):
     name = "OFPAT_PUSH_MPLS"
     fields_desc = [ShortEnumField("type", 19, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPopMPLSID(OpenFlow3):
+class OFPATPopMPLSID(OFPATID):
     name = "OFPAT_POP_MPLS"
     fields_desc = [ShortEnumField("type", 20, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetQueueID(OpenFlow3):
+class OFPATSetQueueID(OFPATID):
     name = "OFPAT_SET_QUEUE"
     fields_desc = [ShortEnumField("type", 21, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATGroupID(OpenFlow3):
+class OFPATGroupID(OFPATID):
     name = "OFPAT_GROUP"
     fields_desc = [ShortEnumField("type", 22, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetNwTTLID(OpenFlow3):
+class OFPATSetNwTTLID(OFPATID):
     name = "OFPAT_SET_NW_TTL"
     fields_desc = [ShortEnumField("type", 23, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATDecNwTTLID(OpenFlow3):
+class OFPATDecNwTTLID(OFPATID):
     name = "OFPAT_DEC_NW_TTL"
     fields_desc = [ShortEnumField("type", 24, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATSetFieldID(OpenFlow3):
+class OFPATSetFieldID(OFPATID):
     name = "OFPAT_SET_FIELD"
     fields_desc = [ShortEnumField("type", 25, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPushPBBID(OpenFlow3):
+class OFPATPushPBBID(OFPATID):
     name = "OFPAT_PUSH_PBB"
     fields_desc = [ShortEnumField("type", 26, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATPopPBBID(OpenFlow3):
+class OFPATPopPBBID(OFPATID):
     name = "OFPAT_POP_PBB"
     fields_desc = [ShortEnumField("type", 27, ofp_action_types),
                    ShortField("len", 4)]
 
 
-class OFPATExperimenterID(OpenFlow3):
+class OFPATExperimenterID(OFPATID):
     name = "OFPAT_EXPERIMENTER"
     fields_desc = [ShortEnumField("type", 65535, ofp_action_types),
                    ShortField("len", None)]
@@ -1289,43 +1273,7 @@ ofp_action_id_cls = {0: OFPATOutputID,
                      65535: OFPATExperimenterID}
 
 
-class ActionIDPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_action_id_cls.get(t, Raw)(s)
-
-    @staticmethod
-    def _get_action_id_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain and len(remain) >= 4:
-            tmp_len = ActionIDPacketListField._get_action_id_length(remain)
-            if tmp_len < 4 or len(remain) < tmp_len:
-                # length is 4 (may be more for experimenter messages),
-                # and no incoherent length
-                break
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
 #                    Instructions                   #
-
-class _ofp_instruction_header(Packet):
-    name = "Dummy OpenFlow3 Instruction Header"
-
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
-        return p + pay
 
 
 ofp_instruction_types = {1: "OFPIT_GOTO_TABLE",
@@ -1337,7 +1285,19 @@ ofp_instruction_types = {1: "OFPIT_GOTO_TABLE",
                          65535: "OFPIT_EXPERIMENTER"}
 
 
-class OFPITGotoTable(_ofp_instruction_header):
+class OFPIT(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_instruction_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPITGotoTable(OFPIT):
     name = "OFPIT_GOTO_TABLE"
     fields_desc = [ShortEnumField("type", 1, ofp_instruction_types),
                    ShortField("len", 8),
@@ -1345,7 +1305,7 @@ class OFPITGotoTable(_ofp_instruction_header):
                    X3BytesField("pad", 0)]
 
 
-class OFPITWriteMetadata(_ofp_instruction_header):
+class OFPITWriteMetadata(OFPIT):
     name = "OFPIT_WRITE_METADATA"
     fields_desc = [ShortEnumField("type", 2, ofp_instruction_types),
                    ShortField("len", 24),
@@ -1354,41 +1314,39 @@ class OFPITWriteMetadata(_ofp_instruction_header):
                    LongField("metadata_mask", 0)]
 
 
-class OFPITWriteActions(_ofp_instruction_header):
+class OFPITWriteActions(OFPIT):
     name = "OFPIT_WRITE_ACTIONS"
     fields_desc = [ShortEnumField("type", 3, ofp_instruction_types),
                    ShortField("len", None),
                    XIntField("pad", 0),
-                   ActionPacketListField("actions", [], Packet,
-                                         ofp_action_cls,
-                                         length_from=lambda pkt:pkt.len - 8)]
+                   PacketListField("actions", [], OFPAT,
+                                   length_from=lambda pkt:pkt.len - 8)]
 
 
-class OFPITApplyActions(_ofp_instruction_header):
+class OFPITApplyActions(OFPIT):
     name = "OFPIT_APPLY_ACTIONS"
     fields_desc = [ShortEnumField("type", 4, ofp_instruction_types),
                    ShortField("len", None),
                    XIntField("pad", 0),
-                   ActionPacketListField("actions", [], Packet,
-                                         ofp_action_cls,
-                                         length_from=lambda pkt:pkt.len - 8)]
+                   PacketListField("actions", [], OFPAT,
+                                   length_from=lambda pkt:pkt.len - 8)]
 
 
-class OFPITClearActions(_ofp_instruction_header):
+class OFPITClearActions(OFPIT):
     name = "OFPIT_CLEAR_ACTIONS"
     fields_desc = [ShortEnumField("type", 5, ofp_instruction_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPITMeter(_ofp_instruction_header):
+class OFPITMeter(OFPIT):
     name = "OFPIT_METER"
     fields_desc = [ShortEnumField("type", 6, ofp_instruction_types),
                    ShortField("len", 8),
                    IntEnumField("meter_id", 1, ofp_meter)]
 
 
-class OFPITExperimenter(_ofp_instruction_header):
+class OFPITExperimenter(OFPIT):
     name = "OFPIT_EXPERIMENTER"
     fields_desc = [ShortEnumField("type", 65535, ofp_instruction_types),
                    ShortField("len", None),
@@ -1404,76 +1362,60 @@ ofp_instruction_cls = {1: OFPITGotoTable,
                        65535: OFPITExperimenter}
 
 
-class InstructionPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_instruction_cls.get(t, Raw)(s)
-
-    @staticmethod
-    def _get_instruction_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        _IPLF = InstructionPacketListField
-
-        while remain and len(remain) > 4:
-            tmp_len = _IPLF._get_instruction_length(remain)
-            if tmp_len < 8 or len(remain) < tmp_len:
-                # length should be at least 8 (non-zero, 64-bit aligned),
-                # and no incoherent length
-                break
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
 #                  Instruction IDs                  #
 
 # length is computed as in instruction structures,
-# so we reuse _ofp_instruction_header
+# so we reuse _ofp_header
 
-class OFPITGotoTableID(_ofp_instruction_header):
+class OFPITID(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_instruction_id_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPITGotoTableID(OFPITID):
     name = "OFPIT_GOTO_TABLE"
     fields_desc = [ShortEnumField("type", 1, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITWriteMetadataID(_ofp_instruction_header):
+class OFPITWriteMetadataID(OFPITID):
     name = "OFPIT_WRITE_METADATA"
     fields_desc = [ShortEnumField("type", 2, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITWriteActionsID(_ofp_instruction_header):
+class OFPITWriteActionsID(OFPITID):
     name = "OFPIT_WRITE_ACTIONS"
     fields_desc = [ShortEnumField("type", 3, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITApplyActionsID(_ofp_instruction_header):
+class OFPITApplyActionsID(OFPITID):
     name = "OFPIT_APPLY_ACTIONS"
     fields_desc = [ShortEnumField("type", 4, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITClearActionsID(_ofp_instruction_header):
+class OFPITClearActionsID(OFPITID):
     name = "OFPIT_CLEAR_ACTIONS"
     fields_desc = [ShortEnumField("type", 5, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITMeterID(_ofp_instruction_header):
+class OFPITMeterID(OFPITID):
     name = "OFPIT_METER"
     fields_desc = [ShortEnumField("type", 6, ofp_instruction_types),
                    ShortField("len", 4)]
 
 
-class OFPITExperimenterID(_ofp_instruction_header):
+class OFPITExperimenterID(OFPITID):
     name = "OFPIT_EXPERIMENTER"
     fields_desc = [ShortEnumField("type", 65535, ofp_instruction_types),
                    ShortField("len", None)]
@@ -1488,101 +1430,49 @@ ofp_instruction_id_cls = {1: OFPITGotoTableID,
                           65535: OFPITExperimenterID}
 
 
-class InstructionIDPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_instruction_cls.get(t, Raw)(s)
-
-    @staticmethod
-    def _get_instruction_id_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        _IIDPLF = InstructionIDPacketListField
-
-        while remain and len(remain) >= 4:
-            tmp_len = _IIDPLF._get_instruction_id_length(remain)
-            if tmp_len < 4 or len(remain) < tmp_len:
-                # length is 4 (may be more for experimenter messages),
-                # and no incoherent length
-                break
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
 #                      Buckets                      #
 
-class OFPBucket(Packet):
+class OFPBucket(_ofp_header_item):
     name = "OFP_BUCKET"
     fields_desc = [ShortField("len", None),
                    ShortField("weight", 0),
                    IntEnumField("watch_port", 0, ofp_port_no),
                    IntEnumField("watch_group", 0, ofp_group),
                    XIntField("pad", 0),
-                   ActionPacketListField("actions", [], Packet,
-                                         ofp_action_cls,
-                                         length_from=lambda pkt:pkt.len - 16)]
+                   PacketListField("actions", [], OFPAT,
+                                   length_from=lambda pkt:pkt.len - 16)]
 
     def extract_padding(self, s):
         return b"", s
 
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
-
-
-class BucketPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_bucket_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = BucketPacketListField._get_bucket_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPBucket(current)
-            lst.append(p)
-
-        return remain, lst
-
 
 #                       Queues                      #
-
-class _ofp_queue_property_header(Packet):
-    name = "Dummy OpenFlow3 Queue Property Header"
-
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
-        return p + pay
 
 
 ofp_queue_property_types = {0: "OFPQT_NONE",
                             1: "OFPQT_MIN_RATE"}
 
 
-class OFPQTNone(_ofp_queue_property_header):
+class OFPQT(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_queue_property_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPQTNone(OFPQT):
     name = "OFPQT_NONE"
     fields_desc = [ShortEnumField("type", 0, ofp_queue_property_types),
                    ShortField("len", 8),
                    XIntField("pad", 0)]
 
 
-class OFPQTMinRate(_ofp_queue_property_header):
+class OFPQTMinRate(OFPQT):
     name = "OFPQT_MIN_RATE"
     fields_desc = [ShortEnumField("type", 1, ofp_queue_property_types),
                    ShortField("len", 16),
@@ -1595,31 +1485,13 @@ ofp_queue_property_cls = {0: OFPQTNone,
                           1: OFPQTMinRate}
 
 
-class QueuePropertyPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_queue_property_cls.get(t, Raw)(s)
-
-    @staticmethod
-    def _get_queue_property_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        _QPFLF = QueuePropertyPacketListField
-
-        while remain:
-            tmp_len = _QPFLF._get_queue_property_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
 class OFPPacketQueue(Packet):
+    name = "OFP_PACKET_QUEUE"
+    fields_desc = [IntEnumField("queue_id", 0, ofp_queue),
+                   ShortField("len", None),
+                   XShortField("pad", 0),
+                   PacketListField("properties", [], OFPQT,
+                                   length_from=lambda pkt:pkt.len - 8)]  # noqa: E501
 
     def extract_padding(self, s):
         return b"", s
@@ -1632,33 +1504,6 @@ class OFPPacketQueue(Packet):
             p = p[:4] + struct.pack("!H", tmp_len) + p[6:]
         return p + pay
 
-    name = "OFP_PACKET_QUEUE"
-    fields_desc = [IntEnumField("queue_id", 0, ofp_queue),
-                   ShortField("len", None),
-                   XShortField("pad", 0),
-                   QueuePropertyPacketListField("properties", [], Packet,
-                                                length_from=lambda pkt:pkt.len - 8)]  # noqa: E501
-
-
-class QueuePacketListField(PacketListField):
-
-    @staticmethod
-    def _get_queue_length(s):
-        return struct.unpack("!H", s[4:6])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = QueuePacketListField._get_queue_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPPacketQueue(current)
-            lst.append(p)
-
-        return remain, lst
-
 
 #                    Meter bands                    #
 
@@ -1667,7 +1512,19 @@ ofp_meter_band_types = {0: "OFPMBT_DROP",
                         65535: "OFPMBT_EXPERIMENTER"}
 
 
-class OFPMBTDrop(Packet):
+class OFPMBT(_ofp_header):
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_meter_band_cls.get(t, Raw)
+        return Raw
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OFPMBTDrop(OFPMBT):
     name = "OFPMBT_DROP"
     fields_desc = [ShortEnumField("type", 0, ofp_queue_property_types),
                    ShortField("len", 16),
@@ -1676,7 +1533,7 @@ class OFPMBTDrop(Packet):
                    XIntField("pad", 0)]
 
 
-class OFPMBTDSCPRemark(Packet):
+class OFPMBTDSCPRemark(OFPMBT):
     name = "OFPMBT_DSCP_REMARK"
     fields_desc = [ShortEnumField("type", 1, ofp_queue_property_types),
                    ShortField("len", 16),
@@ -1686,7 +1543,7 @@ class OFPMBTDSCPRemark(Packet):
                    X3BytesField("pad", 0)]
 
 
-class OFPMBTExperimenter(Packet):
+class OFPMBTExperimenter(OFPMBT):
     name = "OFPMBT_EXPERIMENTER"
     fields_desc = [ShortEnumField("type", 65535, ofp_queue_property_types),
                    ShortField("len", 16),
@@ -1700,26 +1557,8 @@ ofp_meter_band_cls = {0: OFPMBTDrop,
                       2: OFPMBTExperimenter}
 
 
-class MeterBandPacketListField(PacketListField):
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_meter_band_cls.get(t, Raw)(s)
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            current = remain[:16]
-            remain = remain[16:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
 #####################################################
-#              OpenFlow3 1.3 Messages                #
+#              OpenFlow 1.3 Messages                #
 #####################################################
 
 ofp_version = {0x01: "OpenFlow 1.0",
@@ -1766,8 +1605,8 @@ class OFPTHello(_ofp_header):
                    ByteEnumField("type", 0, ofp_type),
                    ShortField("len", None),
                    IntField("xid", 0),
-                   HelloElemPacketListField("elements", [], Packet,
-                                            length_from=lambda pkt:pkt.len - 32)]  # noqa: E501
+                   PacketListField("elements", [], OFPHET,
+                                   length_from=lambda pkt: pkt.len - 8)]
     overload_fields = {TCP: {"sport": 6653}}
 
 #####################################################
@@ -2256,9 +2095,9 @@ class OFPTPacketOut(_ofp_header):
                    IntEnumField("in_port", "CONTROLLER", ofp_port_no),
                    FieldLenField("actions_len", None, fmt="H", length_of="actions"),  # noqa: E501
                    XBitField("pad", 0, 48),
-                   ActionPacketListField("actions", [], Packet,
-                                         ofp_action_cls,
-                                         length_from=lambda pkt:pkt.actions_len),  # noqa: E501
+                   PacketListField("actions", [], OFPAT,
+                                   OFPAT,
+                                   length_from=lambda pkt:pkt.actions_len),
                    PacketField("data", "", Ether)]
     overload_fields = {TCP: {"sport": 6653}}
 
@@ -2290,9 +2129,9 @@ class OFPTFlowMod(_ofp_header):
                                                "NO_BYT_COUNTS"]),
                    XShortField("pad", 0),
                    MatchField("match"),
-                   InstructionPacketListField("instructions", [], Packet,
-                                              length_from=lambda pkt:pkt.len - 48 - (pkt.match.length + (8 - pkt.match.length % 8) % 8))]  # noqa: E501
-    # include match padding to match.length
+                   PacketListField("instructions", [], OFPIT,
+                                              length_from=lambda pkt:pkt.len - 48 - (pkt.match.len + (8 - pkt.match.len % 8) % 8))]  # noqa: E501
+    # include match padding to match.len
     overload_fields = {TCP: {"sport": 6653}}
 
 
@@ -2311,8 +2150,8 @@ class OFPTGroupMod(_ofp_header):
                                                    3: "OFPGT_FF"}),
                    XByteField("pad", 0),
                    IntEnumField("group_id", 0, ofp_group),
-                   BucketPacketListField("buckets", [], Packet,
-                                         length_from=lambda pkt:pkt.len - 16)]
+                   PacketListField("buckets", [], OFPBucket,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"sport": 6653}}
 
 
@@ -2419,9 +2258,9 @@ class OFPMPRequestFlow(_ofp_header):
     overload_fields = {TCP: {"sport": 6653}}
 
 
-class OFPFlowStats(Packet):
+class OFPFlowStats(_ofp_header_item):
     name = "OFP_FLOW_STATS"
-    fields_desc = [ShortField("length", None),
+    fields_desc = [ShortField("len", None),
                    ByteEnumField("table_id", 0, ofp_table),
                    XByteField("pad1", 0),
                    IntField("duration_sec", 0),
@@ -2439,34 +2278,11 @@ class OFPFlowStats(Packet):
                    LongField("packet_count", 0),
                    LongField("byte_count", 0),
                    MatchField("match"),
-                   InstructionPacketListField("instructions", [], Packet,
-                                              length_from=lambda pkt:pkt.length - 56 - pkt.match.length)]  # noqa: E501
+                   PacketListField("instructions", [], OFPIT,
+                                   length_from=lambda pkt:pkt.len - 56 - pkt.match.len)]  # noqa: E501
 
-    def post_build(self, p, pay):
-        if self.length is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
-
-
-class FlowStatsPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_flow_stats_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = FlowStatsPacketListField._get_flow_stats_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPFlowStats(current)
-            lst.append(p)
-
-        return remain, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyFlow(_ofp_header):
@@ -2478,8 +2294,8 @@ class OFPMPReplyFlow(_ofp_header):
                    ShortEnumField("mp_type", 1, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   FlowStatsPacketListField("flow_stats", [], Packet,
-                                            length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("flow_stats", [], OFPFlowStats,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -2532,14 +2348,15 @@ class OFPMPRequestTable(_ofp_header):
 
 
 class OFPTableStats(Packet):
-    def extract_padding(self, s):
-        return b"", s
     name = "OFP_TABLE_STATS"
     fields_desc = [ByteEnumField("table_id", 0, ofp_table),
                    X3BytesField("pad1", 0),
                    IntField("active_count", 0),
                    LongField("lookup_count", 0),
                    LongField("matched_count", 0)]
+
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyTable(_ofp_header):
@@ -2621,8 +2438,6 @@ class OFPMPRequestQueue(_ofp_header):
 
 
 class OFPQueueStats(Packet):
-    def extract_padding(self, s):
-        return b"", s
     name = "OFP_QUEUE_STATS"
     fields_desc = [IntEnumField("port_no", 0, ofp_port_no),
                    IntEnumField("queue_id", 0, ofp_queue),
@@ -2631,6 +2446,9 @@ class OFPQueueStats(Packet):
                    LongField("tx_errors", 0),
                    IntField("duration_sec", 0),
                    IntField("duration_nsec", 0)]
+
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyQueue(_ofp_header):
@@ -2662,21 +2480,17 @@ class OFPMPRequestGroup(_ofp_header):
 
 
 class OFPBucketStats(Packet):
-    def extract_padding(self, s):
-        return b"", s
     name = "OFP_BUCKET_STATS"
     fields_desc = [LongField("packet_count", 0),
                    LongField("byte_count", 0)]
 
+    def extract_padding(self, s):
+        return b"", s
 
-class OFPGroupStats(Packet):
-    def post_build(self, p, pay):
-        if self.length is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
+
+class OFPGroupStats(_ofp_header_item):
     name = "OFP_GROUP_STATS"
-    fields_desc = [ShortField("length", None),
+    fields_desc = [ShortField("len", None),
                    XShortField("pad1", 0),
                    IntEnumField("group_id", 0, ofp_group),
                    IntField("ref_count", 0),
@@ -2686,27 +2500,10 @@ class OFPGroupStats(Packet):
                    IntField("duration_sec", 0),
                    IntField("duration_nsec", 0),
                    PacketListField("bucket_stats", None, OFPBucketStats,
-                                   length_from=lambda pkt:pkt.length - 40)]
+                                   length_from=lambda pkt:pkt.len - 40)]
 
-
-class GroupStatsPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_group_stats_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = GroupStatsPacketListField._get_group_stats_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPGroupStats(current)
-            lst.append(p)
-
-        return remain, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyGroup(_ofp_header):
@@ -2718,8 +2515,8 @@ class OFPMPReplyGroup(_ofp_header):
                    ShortEnumField("mp_type", 6, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   GroupStatsPacketListField("group_stats", [], Packet,
-                                             length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("group_stats", [], OFPGroupStats,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -2735,42 +2532,20 @@ class OFPMPRequestGroupDesc(_ofp_header):
     overload_fields = {TCP: {"sport": 6653}}
 
 
-class OFPGroupDesc(Packet):
-    def post_build(self, p, pay):
-        if self.length is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
+class OFPGroupDesc(_ofp_header_item):
     name = "OFP_GROUP_DESC"
-    fields_desc = [ShortField("length", None),
+    fields_desc = [ShortField("len", None),
                    ByteEnumField("type", 0, {0: "OFPGT_ALL",
                                              1: "OFPGT_SELECT",
                                              2: "OFPGT_INDIRECT",
                                              3: "OFPGT_FF"}),
                    XByteField("pad", 0),
                    IntEnumField("group_id", 0, ofp_group),
-                   BucketPacketListField("buckets", None, Packet,
-                                         length_from=lambda pkt: pkt.length - 8)]  # noqa: E501
+                   PacketListField("buckets", None, OFPBucket,
+                                   length_from=lambda pkt: pkt.len - 8)]
 
-
-class GroupDescPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_group_desc_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain:
-            tmp_len = GroupDescPacketListField._get_group_desc_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPGroupDesc(current)
-            lst.append(p)
-
-        return remain, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyGroupDesc(_ofp_header):
@@ -2782,8 +2557,8 @@ class OFPMPReplyGroupDesc(_ofp_header):
                    ShortEnumField("mp_type", 7, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   GroupDescPacketListField("group_descs", [], Packet,
-                                            length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("group_descs", [], OFPGroupDesc,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -2846,19 +2621,15 @@ class OFPMPRequestMeter(_ofp_header):
 
 
 class OFPMeterBandStats(Packet):
-    def extract_padding(self, s):
-        return b"", s
     name = "OFP_METER_BAND_STATS"
     fields_desc = [LongField("packet_band_count", 0),
                    LongField("byte_band_count", 0)]
 
+    def extract_padding(self, s):
+        return b"", s
+
 
 class OFPMeterStats(Packet):
-    def post_build(self, p, pay):
-        if self.len is None:
-            tmp_len = len(p) + len(pay)
-            p = p[:4] + struct.pack("!H", tmp_len) + p[6:]
-        return p + pay
     name = "OFP_GROUP_STATS"
     fields_desc = [IntEnumField("meter_id", 1, ofp_meter),
                    ShortField("len", None),
@@ -2871,27 +2642,14 @@ class OFPMeterStats(Packet):
                    PacketListField("band_stats", None, OFPMeterBandStats,
                                    length_from=lambda pkt:pkt.len - 40)]
 
+    def post_build(self, p, pay):
+        if self.len is None:
+            tmp_len = len(p) + len(pay)
+            p = p[:4] + struct.pack("!H", tmp_len) + p[6:]
+        return p + pay
 
-class MeterStatsPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_meter_stats_length(s):
-        return struct.unpack("!H", s[4:6])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        tmp_len = 0
-        ret = b""
-        remain = s
-
-        while remain:
-            tmp_len = MeterStatsPacketListField._get_meter_stats_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPMeterStats(current)
-            lst.append(p)
-
-        return remain + ret, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyMeter(_ofp_header):
@@ -2903,8 +2661,8 @@ class OFPMPReplyMeter(_ofp_header):
                    ShortEnumField("mp_type", 9, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   MeterStatsPacketListField("meter_stats", [], Packet,
-                                             length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("meter_stats", [], OFPMeterStats,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -2922,42 +2680,19 @@ class OFPMPRequestMeterConfig(_ofp_header):
     overload_fields = {TCP: {"sport": 6653}}
 
 
-class OFPMeterConfig(Packet):
-    def post_build(self, p, pay):
-        if self.length is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
+class OFPMeterConfig(_ofp_header_item):
     name = "OFP_METER_CONFIG"
-    fields_desc = [ShortField("length", None),
+    fields_desc = [ShortField("len", None),
                    FlagsField("flags", 0, 16, ["KBPS",
                                                "PKTPS",
                                                "BURST",
                                                "STATS"]),
                    IntEnumField("meter_id", 1, ofp_meter),
-                   MeterBandPacketListField("bands", [], Packet,
-                                            length_from=lambda pkt:pkt.len - 8)]  # noqa: E501
+                   PacketListField("bands", [], OFPMBT,
+                                   length_from=lambda pkt:pkt.len - 8)]
 
-
-class MeterConfigPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_meter_config_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        _MCPLF = MeterConfigPacketListField
-
-        while remain:
-            tmp_len = _MCPLF._get_meter_config_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPMeterConfig(current)
-            lst.append(p)
-
-        return remain, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPReplyMeterConfig(_ofp_header):
@@ -2969,8 +2704,8 @@ class OFPMPReplyMeterConfig(_ofp_header):
                    ShortEnumField("mp_type", 10, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   MeterConfigPacketListField("meter_configs", [], Packet,
-                                              length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("meter_configs", [], OFPMeterConfig,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -3011,11 +2746,18 @@ class OFPMPReplyMeterFeatures(_ofp_header):
 #       table features for multipart messages       #
 
 
-class _ofp_table_features_prop_header(Packet):
+class OFPTFPT(Packet):
     name = "Dummy OpenFlow3 Table Features Properties Header"
 
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            t = struct.unpack("!H", _pkt[:2])[0]
+            return ofp_table_features_prop_cls.get(t, Raw)
+        return Raw
+
     def post_build(self, p, pay):
-        tmp_len = self.length
+        tmp_len = self.len
         if tmp_len is None:
             tmp_len = len(p) + len(pay)
             p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
@@ -3046,141 +2788,144 @@ ofp_table_features_prop_types = {0: "OFPTFPT_INSTRUCTIONS",
                                  65535: "OFPTFPT_EXPERIMENTER_MISS"}
 
 
-class OFPTFPTInstructions(_ofp_table_features_prop_header):
+class OFPTFPTInstructions(OFPTFPT):
     name = "OFPTFPT_INSTRUCTIONS"
     fields_desc = [ShortField("type", 0),
-                   ShortField("length", None),
-                   InstructionIDPacketListField("instruction_ids", [], Packet,
-                                                length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("instruction_ids", [], OFPITID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTInstructionsMiss(_ofp_table_features_prop_header):
+class OFPTFPTInstructionsMiss(OFPTFPT):
     name = "OFPTFPT_INSTRUCTIONS_MISS"
     fields_desc = [ShortField("type", 1),
-                   ShortField("length", None),
-                   InstructionIDPacketListField("instruction_ids", [], Packet,
-                                                length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("instruction_ids", [], OFPITID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
 class OFPTableID(Packet):
-    def extract_padding(self, s):
-        return b"", s
     name = "OFP_TABLE_ID"
     fields_desc = [ByteEnumField("table_id", 0, ofp_table)]
 
+    def extract_padding(self, s):
+        return b"", s
 
-class OFPTFPTNextTables(_ofp_table_features_prop_header):
+
+class OFPTFPTNextTables(OFPTFPT):
     name = "OFPTFPT_NEXT_TABLES"
     fields_desc = [ShortField("type", 2),
-                   ShortField("length", None),
+                   ShortField("len", None),
                    PacketListField("next_table_ids", None, OFPTableID,
-                                   length_from=lambda pkt:pkt.length - 4)]
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTNextTablesMiss(_ofp_table_features_prop_header):
+class OFPTFPTNextTablesMiss(OFPTFPT):
     name = "OFPTFPT_NEXT_TABLES_MISS"
     fields_desc = [ShortField("type", 3),
-                   ShortField("length", None),
+                   ShortField("len", None),
                    PacketListField("next_table_ids", None, OFPTableID,
-                                   length_from=lambda pkt:pkt.length - 4)]
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTWriteActions(_ofp_table_features_prop_header):
+class OFPTFPTWriteActions(OFPTFPT):
     name = "OFPTFPT_WRITE_ACTIONS"
     fields_desc = [ShortField("type", 4),
-                   ShortField("length", None),
-                   ActionIDPacketListField("action_ids", [], Packet,
-                                           length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("action_ids", [], OFPATID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTWriteActionsMiss(_ofp_table_features_prop_header):
+class OFPTFPTWriteActionsMiss(OFPTFPT):
     name = "OFPTFPT_WRITE_ACTIONS_MISS"
     fields_desc = [ShortField("type", 5),
-                   ShortField("length", None),
-                   ActionIDPacketListField("action_ids", [], Packet,
-                                           length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("action_ids", [], OFPATID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTApplyActions(_ofp_table_features_prop_header):
+class OFPTFPTApplyActions(OFPTFPT):
     name = "OFPTFPT_APPLY_ACTIONS"
     fields_desc = [ShortField("type", 6),
-                   ShortField("length", None),
-                   ActionIDPacketListField("action_ids", [], Packet,
-                                           length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("action_ids", [], OFPATID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTApplyActionsMiss(_ofp_table_features_prop_header):
+class OFPTFPTApplyActionsMiss(OFPTFPT):
     name = "OFPTFPT_APPLY_ACTIONS_MISS"
     fields_desc = [ShortField("type", 7),
-                   ShortField("length", None),
-                   ActionIDPacketListField("action_ids", [], Packet,
-                                           length_from=lambda pkt:pkt.length - 4)]  # noqa: E501
+                   ShortField("len", None),
+                   PacketListField("action_ids", [], OFPATID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTMatch(_ofp_table_features_prop_header):
+class OFPTFPTMatch(OFPTFPT):
     name = "OFPTFPT_MATCH"
     fields_desc = [ShortField("type", 8),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTWildcards(_ofp_table_features_prop_header):
+class OFPTFPTWildcards(OFPTFPT):
     name = "OFPTFPT_WILDCARDS"
     fields_desc = [ShortField("type", 10),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTWriteSetField(_ofp_table_features_prop_header):
+class OFPTFPTWriteSetField(OFPTFPT):
     name = "OFPTFPT_WRITE_SETFIELD"
     fields_desc = [ShortField("type", 12),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTWriteSetFieldMiss(_ofp_table_features_prop_header):
+class OFPTFPTWriteSetFieldMiss(OFPTFPT):
     name = "OFPTFPT_WRITE_SETFIELD_MISS"
     fields_desc = [ShortField("type", 13),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTApplySetField(_ofp_table_features_prop_header):
+class OFPTFPTApplySetField(OFPTFPT):
     name = "OFPTFPT_APPLY_SETFIELD"
     fields_desc = [ShortField("type", 14),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTApplySetFieldMiss(_ofp_table_features_prop_header):
+class OFPTFPTApplySetFieldMiss(OFPTFPT):
     name = "OFPTFPT_APPLY_SETFIELD_MISS"
     fields_desc = [ShortField("type", 15),
-                   ShortField("length", None),
-                   OXMIDPacketListField("oxm_ids", [], Packet,
-                                        length_from=lambda pkt:pkt.length - 4)]
+                   ShortField("len", None),
+                   PacketListField("oxm_ids", [], OXMID,
+                                   length_from=lambda pkt:pkt.len - 4)]
 
 
-class OFPTFPTExperimenter(_ofp_table_features_prop_header):
+class OFPTFPTExperimenter(OFPTFPT):
     name = "OFPTFPT_EXPERIMENTER"
     fields_desc = [ShortField("type", 65534),
-                   ShortField("length", None),
+                   ShortField("len", None),
                    IntField("experimenter", 0),
                    IntField("exp_type", 0),
-                   PacketField("experimenter_data", None, Raw)]
+                   PacketLenField("experimenter_data", None, Raw,
+                                  length_from=lambda pkt: pkt.len - 12)]
 
 
-class OFPTFPTExperimenterMiss(_ofp_table_features_prop_header):
+class OFPTFPTExperimenterMiss(OFPTFPT):
     name = "OFPTFPT_EXPERIMENTER_MISS"
     fields_desc = [ShortField("type", 65535),
-                   ShortField("length", None),
+                   ShortField("len", None),
                    IntField("experimenter", 0),
                    IntField("exp_type", 0),
-                   PacketField("experimenter_data", None, Raw)]
+                   PacketLenField("experimenter_data", None, Raw,
+                                  length_from=lambda pkt: pkt.len - 12)]
 
 
 ofp_table_features_prop_cls = {0: OFPTFPTInstructions,
@@ -3201,43 +2946,9 @@ ofp_table_features_prop_cls = {0: OFPTFPTInstructions,
                                65535: OFPTFPTExperimenterMiss}
 
 
-class TableFeaturesPropPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_table_features_prop_length(s):
-        return struct.unpack("!H", s[2:4])[0]
-
-    def m2i(self, pkt, s):
-        t = struct.unpack("!H", s[:2])[0]
-        return ofp_table_features_prop_cls.get(t, Raw)(s)
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-
-        while remain and len(remain) >= 4:
-            tmp_len = TableFeaturesPropPacketListField._get_table_features_prop_length(remain)  # noqa: E501
-            # add padding !
-            lpad = tmp_len + (8 - tmp_len % 8) % 8
-            if tmp_len < 4 or len(remain) < lpad:
-                # no zero length nor incoherent length
-                break
-            current = remain[:lpad]
-            remain = remain[lpad:]
-            p = self.m2i(pkt, current)
-            lst.append(p)
-
-        return remain, lst
-
-
-class OFPTableFeatures(Packet):
-    def post_build(self, p, pay):
-        if self.length is None:
-            tmp_len = len(p) + len(pay)
-            p = struct.pack("!H", tmp_len) + p[2:]
-        return p + pay
+class OFPTableFeatures(_ofp_header_item):
     name = "OFP_TABLE_FEATURES"
-    fields_desc = [ShortField("length", None),
+    fields_desc = [ShortField("len", None),
                    ByteEnumField("table_id", 0, ofp_table),
                    XBitField("pad", 0, 40),
                    StrFixedLenField("table_name", "", 32),
@@ -3246,29 +2957,11 @@ class OFPTableFeatures(Packet):
                    IntEnumField("config", 0, {0: "OFPTC_NO_MASK",
                                               3: "OFPTC_DEPRECATED_MASK"}),
                    IntField("max_entries", 0),
-                   TableFeaturesPropPacketListField("properties", [], Packet,
-                                                    length_from=lambda pkt:pkt.length - 64)]  # noqa: E501
+                   PacketListField("properties", [], OFPTFPT,
+                                   length_from=lambda pkt:pkt.len - 64)]
 
-
-class TableFeaturesPacketListField(PacketListField):
-
-    @staticmethod
-    def _get_table_features_length(s):
-        return struct.unpack("!H", s[:2])[0]
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        _TFPLF = TableFeaturesPacketListField
-
-        while remain:
-            tmp_len = _TFPLF._get_table_features_length(remain)
-            current = remain[:tmp_len]
-            remain = remain[tmp_len:]
-            p = OFPTableFeatures(current)
-            lst.append(p)
-
-        return remain, lst
+    def extract_padding(self, s):
+        return b"", s
 
 
 class OFPMPRequestTableFeatures(_ofp_header):
@@ -3280,8 +2973,8 @@ class OFPMPRequestTableFeatures(_ofp_header):
                    ShortEnumField("mp_type", 12, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_request_flags),
                    XIntField("pad1", 0),
-                   TableFeaturesPacketListField("table_features", [], Packet,
-                                                length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("table_features", [], OFPTableFeatures,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"sport": 6653}}
 
 
@@ -3294,8 +2987,8 @@ class OFPMPReplyTableFeatures(_ofp_header):
                    ShortEnumField("mp_type", 12, ofp_multipart_types),
                    FlagsField("flags", 0, 16, ofpmp_reply_flags),
                    XIntField("pad1", 0),
-                   TableFeaturesPacketListField("table_features", [], Packet,
-                                                length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("table_features", [], OFPTableFeatures,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 #               end of table features               #
@@ -3431,8 +3124,8 @@ class OFPTQueueGetConfigReply(_ofp_header):
                    IntField("xid", 0),
                    IntEnumField("port", 0, ofp_port_no),
                    XIntField("pad", 0),
-                   QueuePacketListField("queues", [], Packet,
-                                        length_from=lambda pkt:pkt.len - 16)]
+                   PacketListField("queues", [], OFPPacketQueue,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"dport": 6653}}
 
 
@@ -3533,8 +3226,8 @@ class OFPTMeterMod(_ofp_header):
                                                "BURST",
                                                "STATS"]),
                    IntEnumField("meter_id", 1, ofp_meter),
-                   MeterBandPacketListField("bands", [], Packet,
-                                            length_from=lambda pkt:pkt.len - 16)]  # noqa: E501
+                   PacketListField("bands", [], OFPMBT,
+                                   length_from=lambda pkt:pkt.len - 16)]
     overload_fields = {TCP: {"sport": 6653}}
 
 

--- a/scapy/contrib/openflow3.uts
+++ b/scapy/contrib/openflow3.uts
@@ -4,14 +4,6 @@
 = Be sure we have loaded OpenFlow v3
 load_contrib("openflow3")
 
-+ Fields
-
-= GroupDescPacketListField(), check getfield
-remain, lst = GroupDescPacketListField(None, None, None).getfield(None, b'\x00\x10')
-not remain
-all([OFPGroupDesc in gd for gd in lst])
-lst[0].length == 0x0010
-
 + Usual OFv1.3 messages
 
 = OFPTHello(), hello without version bitmap
@@ -80,7 +72,6 @@ fpti = OFPTFPTInstructions(instruction_ids=[OFPITGotoTableID(), OFPITClearAction
 fpti = OFPTFPTInstructions(raw(fpti))
 assert len(fpti) == 16
 assert fpti.instruction_ids[0].type == 1
-assert fpti.instruction_ids[0].table_id == 0
 assert fpti.instruction_ids[1].type == 5
 
 = OFPTPacketIn() containing an Ethernet frame
@@ -171,7 +162,7 @@ e[OFPTFeaturesRequest].xid == 23
 pkt = TCP()/OFPMPRequestTableFeatures(table_features=[OFPTableFeatures(properties=[OFPTFPTMatch(oxm_ids=[OFBUDPSrcID()])])])
 assert raw(pkt) == b'\x19\xfd\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x00\x00\x00\x00\x04\x12\x00X\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x08\x80\x00\x1e\x02'
 pkt = TCP(raw(pkt))
-assert pkt.table_features[0].properties[0].oxm_ids[0].fields == {'class': 32768, 'field': 15, 'hasmask': 0, 'length': 2}
+assert pkt.table_features[0].properties[0].oxm_ids[0].fields == {'class': 32768, 'field': 15, 'hasmask': 0, 'len': 2}
 
 = Test OFBTCPSrc Autocompletion
 

--- a/scapy/contrib/openflow3.uts
+++ b/scapy/contrib/openflow3.uts
@@ -1,5 +1,9 @@
 % Tests for OpenFlow v1.3 with Scapy
 
++ Preparation
+= Be sure we have loaded OpenFlow v3
+load_contrib("openflow3")
+
 + Fields
 
 = GroupDescPacketListField(), check getfield
@@ -23,10 +27,10 @@ ofm = OFPMatch(oxm_fields=OFBEthType(eth_type=0x86dd))
 assert(len(raw(ofm))%8 == 0)
 raw(ofm) == b'\x00\x01\x00\x0a\x80\x00\x0a\x02\x86\xdd\x00\x00\x00\x00\x00\x00'
 
-= OpenFlow(), generic method test with OFPTEchoRequest()
+= OpenFlow3(), generic method test with OFPTEchoRequest()
 ofm = OFPTEchoRequest()
 s = raw(ofm)
-isinstance(OpenFlow(None,s)(s), OFPTEchoRequest)
+isinstance(OpenFlow3(s), OFPTEchoRequest)
 
 = OFPTFlowMod(), check codes and defaults values
 ofm = OFPTFlowMod(cmd='OFPFC_DELETE', out_group='ALL', flags='CHECK_OVERLAP+NO_PKT_COUNTS')

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -18,7 +18,9 @@ import time
 
 from scapy.config import conf
 from scapy.dadict import DADict
-from scapy.volatile import RandBin, RandByte, RandEnumKeys, RandInt, RandIP, RandIP6, RandLong, RandMAC, RandNum, RandShort, RandSInt, RandTermString, VolatileValue  # noqa: E501
+from scapy.volatile import RandBin, RandByte, RandEnumKeys, RandInt, \
+    RandIP, RandIP6, RandLong, RandMAC, RandNum, RandShort, RandSInt, \
+    RandSByte, RandTermString, VolatileValue
 from scapy.data import EPOCH
 from scapy.error import log_runtime, Scapy_Exception
 from scapy.compat import bytes_hex, chb, orb, plain_str, raw
@@ -664,6 +666,9 @@ class LEX3BytesField(LEThreeBytesField, XByteField):
 class SignedByteField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "b")
+
+    def randval(self):
+        return RandSByte()
 
 
 class FieldValueRangeException(Scapy_Exception):

--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -15,11 +15,10 @@ from scapy.packet import Packet, bind_layers
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     Field, FlagsField, LEIntField, LEShortEnumField, LEShortField, MACField, \
     PacketListField, X3BytesField, XBitField, XByteField, XIntField, \
-    XShortField
+    XShortField, XLEIntField, XLEShortField
 from scapy.layers.dot11 import _dbmField
 from scapy.layers.ppi import PPI, addPPIType, PPIGenericFldHdr
 
-from scapy.contrib.ppi_geotag import XLEIntField, XLEShortField
 from scapy.layers.bluetooth import EIR_Hdr, L2CAP_Hdr
 
 from scapy.modules.six.moves import range

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -178,10 +178,13 @@ def load_contrib(name, globals_dict=None, symb_list=None):
         importlib.import_module("scapy.contrib." + name)
         _load("scapy.contrib." + name,
               globals_dict=globals_dict, symb_list=symb_list)
-    except ImportError:
+    except ImportError as e:
         # if layer not found in contrib, try in layers
-        load_layer(name,
-                   globals_dict=globals_dict, symb_list=symb_list)
+        try:
+            load_layer(name,
+                       globals_dict=globals_dict, symb_list=symb_list)
+        except ImportError:
+            raise e  # Let's raise the original error to avoid confusion
 
 
 def list_contrib(name=None, ret=False):
@@ -327,7 +330,7 @@ def init_session(session_name, mydict=None):
     six.moves.builtins.__dict__.update(scapy_builtins)
     GLOBKEYS.extend(scapy_builtins)
     GLOBKEYS.append("scapy_session")
-    scapy_builtins = None  # XXX replace with "with" statement
+    scapy_builtins = None
 
     if session_name:
         try:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -248,7 +248,6 @@ scapy_delete_temp_files()
 assert(len(conf.temp_files) == 0)
 
 = Emulate interact()
-
 import mock, sys
 from scapy.main import interact
 # Detect IPython
@@ -257,7 +256,7 @@ try:
 except:
     code_interact_import = "scapy.main.code.interact"
 else:
-    code_interact_import = "IPython.terminal.embed.InteractiveShellEmbed"
+    code_interact_import = "IPython.start_ipython"
 
 @mock.patch(code_interact_import)
 def interact_emulator(code_int, extra_args=[]):
@@ -266,7 +265,6 @@ def interact_emulator(code_int, extra_args=[]):
         interact(argv=["-s scapy1"] + extra_args, mybanner="What a test")
         return True
     except:
-        raise
         return False
     finally:
         sys.ps1 = ">>> "
@@ -342,6 +340,16 @@ try:
     assert False  # The previous should have raised an exception
 except Scapy_Exception:
     pass
+
+= Test load_contrib overwrite
+load_contrib("gtp")
+assert GTPHeader.__module__ == "scapy.contrib.gtp"
+
+load_contrib("gtp_v2")
+assert GTPHeader.__module__ == "scapy.contrib.gtp_v2"
+
+load_contrib("gtp")
+assert GTPHeader.__module__ == "scapy.contrib.gtp"
 
 = Test sane function
 sane("A\x00\xFFB") == "A..B"
@@ -10773,7 +10781,7 @@ if PYX:
 = svgdump()
 
 print("PYX: %d" % PYX)
-if PYX:
+if PYX and not six.PY2:
     import tempfile
     import os
     filename = tempfile.mktemp(suffix=".svg")


### PR DESCRIPTION
This PR performs some various clean-ups around several modules, especially:
- by using `dispatch_hook` to simplify custom-made `PacketListField` (inet6)
- by merging the logic behind very similar functions (`defrag` and `defragment`)
- by creating a universal class for very similar class (`ppi_geotag` and `asn1`)
- removes the extremely ugly OpenFlow binding mechanism (`TCP.guess_payload_class = OpenFlow`)
- **general OpenFlow overhaul, removing hundreds of duplicated things (+a few breaking changes: length all renamed to len for consistency)**

This PR led to the discovery of several bugs:
- some IPv6 options could be wrongly decoded when they were more than 1 (Raw)
- the `load_*` will now reload a module if already loaded. This will allow modules that overwrite each other to be used in any importation order

I used `codeclimate` to locate the duplication issues.