### PR TITLE
Calculate BIOCSETF ioctl constant for 32 bit architectures.

### DIFF
--- a/scapy/arch/bpf/consts.py
+++ b/scapy/arch/bpf/consts.py
@@ -4,8 +4,9 @@
 Scapy *BSD native support - constants
 """
 
-from ctypes import Structure, c_uint, c_void_p, sizeof
+from ctypes import sizeof
 
+from scapy.arch.common import bpf_program
 from scapy.data import MTU
 
 
@@ -13,12 +14,6 @@ SIOCGIFFLAGS = 0xc0206911
 BPF_BUFFER_LENGTH = MTU
 
 # From net/bpf.h
-
-
-class bpf_program(Structure):
-    _fields_ = [("bf_len", c_uint), ("bf_insns", c_void_p)]
-
-
 BIOCIMMEDIATE = 0x80044270
 BIOCGSTATS = 0x4008426f
 BIOCPROMISC = 0x20004269

--- a/scapy/arch/bpf/consts.py
+++ b/scapy/arch/bpf/consts.py
@@ -4,6 +4,7 @@
 Scapy *BSD native support - constants
 """
 
+from ctypes import Structure, c_uint, c_void_p, sizeof
 
 from scapy.data import MTU
 
@@ -12,13 +13,19 @@ SIOCGIFFLAGS = 0xc0206911
 BPF_BUFFER_LENGTH = MTU
 
 # From net/bpf.h
+
+
+class bpf_program(Structure):
+    _fields_ = [("bf_len", c_uint), ("bf_insns", c_void_p)]
+
+
 BIOCIMMEDIATE = 0x80044270
 BIOCGSTATS = 0x4008426f
 BIOCPROMISC = 0x20004269
 BIOCSETIF = 0x8020426c
 BIOCSBLEN = 0xc0044266
 BIOCGBLEN = 0x40044266
-BIOCSETF = 0x80104267
+BIOCSETF = 0x80004267 | ((sizeof(bpf_program) & 0x1fff) << 16)
 BIOCSDLT = 0x80044278
 BIOCSHDRCMPLT = 0x80044275
 BIOCGDLT = 0x4004426a


### PR DESCRIPTION
The size of the ioctl(2) argument is embeded in the constant.  Struct
bpf_program is 16 bytes on 64 bit architectures but only 8 bytes
on 32 bit architectures.  Use ctypes to calculate the size dynamically
in Python and adjust BIOCSETF.  Fixes sniff(filter="ip") on
OpenBSD/i386.
