### PR TITLE
Add receive socket poll rate configurability

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -435,6 +435,7 @@ AS_resolver: choose the AS resolver class to use
 extensions_paths: path or list of paths where extensions are to be looked for
 contribs : a dict which can be used by contrib layers to store local configuration  # noqa: E501
 debug_tls:When 1, print some TLS session secrets when they are computed.
+recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
 """
     version = VERSION
     session = ""
@@ -518,6 +519,7 @@ debug_tls:When 1, print some TLS session secrets when they are computed.
     crypto_valid_advanced = crypto_valid_recent and isCryptographyAdvanced()
     fancy_prompt = True
     auto_crop_tables = True
+    recv_poll_rate = 0.05
 
 
 if not Conf.ipv6_enabled:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -123,12 +123,12 @@ def _sndrcv_rcv(pks, hsent, stopevent, nbrecv, notans, verbose, chainCC,
         def _get_pkt():
             res = pks.nonblock_recv()
             if res is None:
-                time.sleep(0.05)
+                time.sleep(conf.recv_poll_rate)
             return res
     else:
         def _get_pkt():
             try:
-                inp, _, _ = select([pks], [], [], 0.05)
+                inp, _, _ = select([pks], [], [], conf.recv_poll_rate)
             except (IOError, select_error) as exc:
                 # select.error has no .errno attribute
                 if exc.args[0] != errno.EINTR:


### PR DESCRIPTION
Adds conf.recv_poll_rate, which is used in the _get_pkt function in sendrecv.py, allowing the user to configure the socket poll rate. 

Using scapy on Ubuntu 18.04 with default settings, I see a ~50ms delay before sr(..., timeout=0.001) returns when no response packet is sent. This seems to be caused by the slow socket poll rate. 

Some folks may care about the additional CPU usage, so making it runtime tunable seems a better approach here.

A better approach here may be to pass the exact timeout through to the select(), but I wasn't sure how to implement that.

`cd tests &&  ./run_tests_py3`
Before patch: `PASSED=1151 FAILED=64`
After patch: `PASSED=1151 FAILED=64`