### PR TITLE
Add LEX3BytesField

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -869,8 +869,8 @@ Legend:
     XShortField
     
     X3BytesField        # three bytes as hex
-    LEX3BytesField      # three bytes as decimal
-    ThreeBytesField     # little endian three bytes as hex
+    LEX3BytesField      # little endian three bytes as hex
+    ThreeBytesField     # three bytes as decimal
     LEThreeBytesField   # little endian three bytes as decimal
     
     IntField

--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -868,7 +868,10 @@ Legend:
     LEShortField
     XShortField
     
-    X3BytesField        # three bytes (in hexad 
+    X3BytesField        # three bytes as hex
+    LEX3BytesField      # three bytes as decimal
+    ThreeBytesField     # little endian three bytes as hex
+    LEThreeBytesField   # little endian three bytes as decimal
     
     IntField
     SignedIntField

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -630,6 +630,22 @@ class ThreeBytesField(X3BytesField, ByteField):
         return ByteField.i2repr(self, pkt, x)
 
 
+class LEX3BytesField(XByteField):
+    def __init__(self, name, default):
+        Field.__init__(self, name, default, "<I")
+
+    def addfield(self, pkt, s, val):
+        return s + struct.pack(self.fmt, self.i2m(pkt, val))[:3]
+
+    def getfield(self, pkt, s):
+        return s[3:], self.m2i(pkt, struct.unpack(self.fmt, s[:3] + b"\x00")[0])  # noqa: E501
+
+
+class LEThreeBytesField(LEX3BytesField, ByteField):
+    def i2repr(self, pkt, x):
+        return ByteField.i2repr(self, pkt, x)
+
+
 class SignedByteField(Field):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "b")

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -614,7 +614,7 @@ class OByteField(ByteField):
         return "%03o" % self.i2h(pkt, x)
 
 
-class X3BytesField(XByteField):
+class ThreeBytesField(ByteField):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "!I")
 
@@ -625,12 +625,12 @@ class X3BytesField(XByteField):
         return s[3:], self.m2i(pkt, struct.unpack(self.fmt, b"\x00" + s[:3])[0])  # noqa: E501
 
 
-class ThreeBytesField(X3BytesField, ByteField):
+class X3BytesField(ThreeBytesField, XByteField):
     def i2repr(self, pkt, x):
-        return ByteField.i2repr(self, pkt, x)
+        return XByteField.i2repr(self, pkt, x)
 
 
-class LEX3BytesField(XByteField):
+class LEThreeBytesField(ByteField):
     def __init__(self, name, default):
         Field.__init__(self, name, default, "<I")
 
@@ -641,9 +641,9 @@ class LEX3BytesField(XByteField):
         return s[3:], self.m2i(pkt, struct.unpack(self.fmt, s[:3] + b"\x00")[0])  # noqa: E501
 
 
-class LEThreeBytesField(LEX3BytesField, ByteField):
+class LEX3BytesField(LEThreeBytesField, XByteField):
     def i2repr(self, pkt, x):
-        return ByteField.i2repr(self, pkt, x)
+        return XByteField.i2repr(self, pkt, x)
 
 
 class SignedByteField(Field):

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -83,6 +83,21 @@ assert IP(raw(IP(dst="0.0.0.0/31"))).src == defaddr
 #b.i2m("
 #b.getfield
 
+= ThreeBytesField
+~ field threebytesfield
+
+class TestThreeBytesField(Packet):
+    fields_desc = [ 
+        X3BytesField('test1', None),
+        ThreeBytesField('test2', None),
+        LEX3BytesField('test3', None),
+        LEThreeBytesField('test4', None),
+    ]
+
+p = TestThreeBytesField(test1=0x123456, test2=123456, test3=0xfedbca, test4=567890)
+assert(raw(p) == b'\x12\x34\x56\x01\xe2\x40\xca\xdb\xfe\x52\xaa\x08')
+print(p.sprintf('%test1% %test2% %test3% %test4%'))
+assert(p.sprintf('%test1% %test2% %test3% %test4%') == '0x123456 123456 0xfedbca 567890')
 
 ############
 ############


### PR DESCRIPTION
This pull request adds little endian versions of the existing X3BytesField and ThreeBytesField - LEX3BytesField and LEThreeBytesField. I had an obscure device using this format.

Also updated documentation to include both of the new fields, and also list the existing ThreeBytesField.

Have tested, and I think the byte fiddling in `addfield()` and `getfield()` is correct.