### PR TITLE
Use default CAN interface

### DIFF
--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -59,7 +59,7 @@ class CANSocket(SuperSocket):
                             socket.CAN_RAW_FILTER,
                             struct.pack(can_filter_fmt, *filter_data))
 
-        self.ins.bind((iface,))
+        self.ins.bind((self.iface,))
         self.outs = self.ins
 
     def recv(self, x=CAN_FRAME_SIZE):


### PR DESCRIPTION
allows usage without specifiying the CAN interface (using the default, can0)
`socket = CANSocket()`

The default CAN interface is set during initialization of the CANSocket object, but it binds to the one given to the constructor. This is inconsistent and doesn't allow to use the upper code, which shows the most common usage.