### PR TITLE
Minor fixes and refactoring for UDS (automotive)

### DIFF
--- a/scapy/contrib/automotive/bmw/doip.py
+++ b/scapy/contrib/automotive/bmw/doip.py
@@ -11,7 +11,7 @@ from scapy.packet import Packet, bind_layers
 from scapy.fields import LenField, ShortEnumField, XByteField
 from scapy.layers.inet import TCP
 from scapy.supersocket import StreamSocket
-from scapy.contrib.uds import UDS
+from scapy.contrib.automotive.uds import UDS
 
 
 """
@@ -45,8 +45,7 @@ class DoIP(Packet):
         return s[:8], s[8:]
 
 
-bind_layers(TCP, DoIP, sport=6801)
-bind_layers(TCP, DoIP, dport=6801)
+bind_layers(TCP, DoIP, sport=6801, dport=6801)
 bind_layers(DoIP, UDS)
 
 

--- a/scapy/contrib/automotive/bmw/doip.py
+++ b/scapy/contrib/automotive/bmw/doip.py
@@ -7,7 +7,7 @@
 
 import struct
 import socket
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.fields import LenField, ShortEnumField, XByteField
 from scapy.layers.inet import TCP
 from scapy.supersocket import StreamSocket
@@ -45,6 +45,8 @@ class DoIP(Packet):
         return s[:8], s[8:]
 
 
+bind_bottom_up(TCP, DoIP, sport=6801)
+bind_bottom_up(TCP, DoIP, dport=6801)
 bind_layers(TCP, DoIP, sport=6801, dport=6801)
 bind_layers(DoIP, UDS)
 

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -77,7 +77,7 @@ class CANSocket(SuperSocket):
             return None
 
         # need to change the byteoder of the first four bytes,
-        # required by the underlaying Linux SocketCAN frame format
+        # required by the underlying Linux SocketCAN frame format
         pkt = struct.pack("<I12s", *struct.unpack(">I12s", pkt))
         len = pkt[4]
         canpkt = CAN(pkt[:len + 8])
@@ -93,7 +93,7 @@ class CANSocket(SuperSocket):
                 x.sent_time = time.time()
 
             # need to change the byteoder of the first four bytes,
-            # required by the underlaying Linux SocketCAN frame format
+            # required by the underlying Linux SocketCAN frame format
             bs = bytes(x)
             bs = bs + b'\x00' * (CAN_FRAME_SIZE - len(bs))
             bs = struct.pack("<I12s", *struct.unpack(">I12s", bs))


### PR DESCRIPTION
- fixed import path for UDS
UDS.py has been moved to `contrib/automotive` some time ago but one import hasn't been updated

- fixed binding between TCP and DoIP
Only one binding between two layers is possible. Thus only the last defined `bind_layers` call will have effect, as previous ones are overwritten.

- underlaying -> underlying



