### PR TITLE
Add packet.svgdump()

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -431,6 +431,7 @@ class WinProgPath(ConfClass):
     def _reload(self):
         self.pdfreader = None
         self.psreader = None
+        self.svgreader = None
         # We try some magic to find the appropriate executables
         self.dot = win_find_exe("dot")
         self.tcpdump = win_find_exe("windump")

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -73,6 +73,7 @@ class Interceptor(object):
 class ProgPath(ConfClass):
     pdfreader = "open" if DARWIN else "xdg-open"
     psreader = "open" if DARWIN else "xdg-open"
+    svgreader = "open" if DARWIN else "xdg-open"
     dot = "dot"
     display = "display"
     tcpdump = "tcpdump"

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -555,6 +555,28 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             canvas.writePDFfile(filename)
         print()
 
+    def svgdump(self, filename=None, **kargs):
+        """
+        psdump(filename=None, layer_shift=0, rebuild=1)
+
+        Creates an SVG file describing a packet. If filename is not provided a
+        temporary file is created and gs is called.
+
+        :param filename: the file's filename
+        """
+        canvas = self.canvas_dump(**kargs)
+        if filename is None:
+            fname = get_temp_file(autoext=".svg")
+            canvas.writeSVGfile(fname)
+            if WINDOWS and conf.prog.svgreader is None:
+                os.startfile(fname)
+            else:
+                with ContextManagerSubprocess("svgdump()", conf.prog.svgreader):
+                    subprocess.Popen([conf.prog.svgreader, fname])
+        else:
+            canvas.writeSVGfile(filename)
+        print()
+
     def canvas_dump(self, layer_shift=0, rebuild=1):
         if PYX == 0:
             raise ImportError("PyX and its dependencies must be installed")


### PR DESCRIPTION
Right now we're able to create EPS and PDF files from Packet objects using `psdump()` and `pdfdump()`. I wanted to make SVG files - and PyX supports that out of the box with `writeSVGfile()`.

This PR adds `packet.svgdump()` which does exactly the same as `pdfdump()`, but makes an SVG file instead.

Tested on Windows 10 - I presume the Linux / OSX open handler will work:
```svgreader = "open" if DARWIN else "xdg-open"```