### PR TITLE
Add bits to canvas_dump()

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -651,7 +651,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             bkcol = next(backcolor)
             proto, fields = t.pop()
             y += 0.5
-            pt = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % proto.name, [pyx.text.size.Large])  # noqa: E501
+            pt = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(proto.name), [pyx.text.size.Large])  # noqa: E501
             y += 1
             ptbb = pt.bbox()
             ptbb.enlarge(pyx.unit.u_pt * 2)
@@ -659,17 +659,20 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             canvas.insert(pt)
             for field, fval, fdump in fields:
                 col = next(forecolor)
+                ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(field.name))  # noqa: E501
                 if isinstance(field, BitField):
-                    bits = int(field.i2len(None, 0) * 8)
-                    ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s \scriptsize{%sb}}" % (tex_escape(field.name), bits))  # noqa: E501
+                    fsize = '%sb' % field.size
                 else:
-                    ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(field.name))  # noqa: E501
+                    fsize = '%sB' % len(fdump)
+                if 'LE' in field.__class__.__name__[:3]:
+                    fsize = r'$\scriptstyle\langle$' + fsize
+                st = pyx.text.text(XSTART + 3.4, (YTXT - y) * YMUL, r"\font\cmbxfont=cmssbx10 scaled 600\cmbxfont{%s}" % fsize, [pyx.text.halign.boxright])  # noqa: E501
                 if isinstance(fval, str):
                     if len(fval) > 18:
                         fval = fval[:18] + "[...]"
                 else:
                     fval = ""
-                vt = pyx.text.text(XSTART + 3, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(fval))  # noqa: E501
+                vt = pyx.text.text(XSTART + 3.5, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(fval))  # noqa: E501
                 y += 1.0
                 if fdump:
                     dt, target, last_shift, last_y = make_dump(fdump, last_shift, last_y, col, bkcol)  # noqa: E501
@@ -693,6 +696,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
                     canvas.insert(dt)
 
                 canvas.insert(ft)
+                canvas.insert(st)
                 canvas.insert(vt)
             last_y += layer_shift
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -657,9 +657,13 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
             ptbb.enlarge(pyx.unit.u_pt * 2)
             canvas.stroke(ptbb.path(), [pyx.color.rgb.black, pyx.deco.filled([bkcol])])  # noqa: E501
             canvas.insert(pt)
-            for fname, fval, fdump in fields:
+            for field, fval, fdump in fields:
                 col = next(forecolor)
-                ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(fname.name))  # noqa: E501
+                if isinstance(field, BitField):
+                    bits = int(field.i2len(None, 0) * 8)
+                    ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s \scriptsize{%sb}}" % (tex_escape(field.name), bits))  # noqa: E501
+                else:
+                    ft = pyx.text.text(XSTART, (YTXT - y) * YMUL, r"\font\cmssfont=cmss10\cmssfont{%s}" % tex_escape(field.name))  # noqa: E501
                 if isinstance(fval, str):
                     if len(fval) > 18:
                         fval = fval[:18] + "[...]"

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -664,7 +664,9 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket)):
                     fsize = '%sb' % field.size
                 else:
                     fsize = '%sB' % len(fdump)
-                if 'LE' in field.__class__.__name__[:3]:
+                if (hasattr(field, 'field') and
+                        'LE' in field.field.__class__.__name__[:3] or
+                        'LE' in field.__class__.__name__[:3]):
                     fsize = r'$\scriptstyle\langle$' + fsize
                 st = pyx.text.text(XSTART + 3.4, (YTXT - y) * YMUL, r"\font\cmbxfont=cmssbx10 scaled 600\cmbxfont{%s}" % fsize, [pyx.text.halign.boxright])  # noqa: E501
                 if isinstance(fval, str):


### PR DESCRIPTION
Adds smaller text with the number of bits next to each BitField in a packet:
![image](https://user-images.githubusercontent.com/8326175/44153141-bd4c74b6-a0ea-11e8-92a6-2cfd12202aa8.png)

I think `\scriptsize` is about right visually

Will still go wider than the space set aside for it, if the field name is very long (try it with a field named `arbitrarily-long-field-name`). I don't think that's a big issue.

I also changed `fname` to `field`, as that's what it actually is. To print the field name, we were calling `fname.name` which doesn't make sense.