### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
             - TOXENV=py36-linux_non_root,codecov
 
         - os: linux
+          dist: xenial
+          python: 3.7
+          env:
+            - TOXENV=py37-linux_non_root,codecov
+
+        - os: linux
           python: pypy
           env:
             - TOXENV=pypy-linux_non_root,codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,14 @@ matrix:
           env:
             - TOXENV=py36-linux_root,codecov
 
+        # Temporary Python 3.7 trick https://github.com/travis-ci/travis-ci/issues/9815
+        - os: linux
+          sudo: required
+          dist: xenial
+          python: 3.7
+          env:
+            - TOXENV=py37-linux_root,codecov
+
         - os: linux
           sudo: required
           python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,7 @@ matrix:
           env:
             - TOXENV=py36-linux_root,codecov
 
-        # Temporary Python 3.7 trick https://github.com/travis-ci/travis-ci/issues/9815
-        - os: linux
+        - language: python
           sudo: required
           dist: xenial
           python: 3.7

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -25,6 +25,12 @@ then
   UT_FLAGS+=" -K FIXME_py3"
 fi
 
+if [[ ${TRAVIS_DIST:=trusty} == xenial ]]
+then
+  # The vcan module is currently unavailable on Travis-CI xenial builds
+  UT_FLAGS+=" -K vcan_socket"
+fi
+
 # Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
 set
 

--- a/scapy/contrib/cansocket_native.uts
+++ b/scapy/contrib/cansocket_native.uts
@@ -1,5 +1,5 @@
 % Regression tests for nativecansocket
-~ python3_only
+~ python3_only vcan_socket
 
 # More information at http://www.secdev.org/projects/UTscapy/
 

--- a/scapy/contrib/cansocket_python_can.uts
+++ b/scapy/contrib/cansocket_python_can.uts
@@ -1,4 +1,5 @@
 % Regression tests for the CANSocket
+~ vcan_socket
 
 # More information at http://www.secdev.org/projects/UTscapy/
 

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -29,11 +29,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 import abc
 import re
+import sys
 from io import BytesIO
 import struct
 import scapy.modules.six as six
 from scapy.compat import raw, plain_str, bytes_hex, orb, chb
-from scapy.modules.six.moves import range
 
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".
@@ -632,8 +632,17 @@ class FieldUVarLenField(AbstractUVarIntField):
 #                                                HPACK String Fields          #
 ###############################################################################
 
+# Welcome the magic of Python inconsistencies !
+# https://stackoverflow.com/a/41622155
 
-class HPackStringsInterface(six.with_metaclass(abc.ABCMeta, Sized)):
+
+if sys.version_info >= (3, 4):
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta('ABC', (), {})
+
+
+class HPackStringsInterface(ABC, Sized):
     @abc.abstractmethod
     def __str__(self):
         pass

--- a/scapy/contrib/isotp.uts
+++ b/scapy/contrib/isotp.uts
@@ -1,4 +1,5 @@
 % ISOTP Tests
+~ vcan_socket
 * Tests for ISOTP
 
 

--- a/scapy/contrib/ppi_geotag.uts
+++ b/scapy/contrib/ppi_geotag.uts
@@ -31,10 +31,7 @@ assert GPSTime_Field("GPSTime", None).delta == 0.0
 = Define local_to_utc
 
 def local_to_utc(local_time):
-    # BUG workaround: on some Python 2 systems, summer time is ignored while converting time to UTC.
-    # This function converts it properly. That was fixed on Python 3
-    if six.PY3:
-        return local_time
+    # Let's handle all cases, even with summer time not matching UTC...
     utc_time_clock = time.gmtime(time.mktime(local_time))
     utc_time_clock = list(utc_time_clock.__reduce__()[1][0])
     if local_time.tm_isdst:
@@ -51,7 +48,11 @@ strft_time = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_time)
 strft_time_sum = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_to_utc(local_time))
 
 # Backup: also test summer time bug
-assert utc_time.i2repr(None, None) in [(strft_time + " (" + str(int(utc_time.delta)) + ")"), (strft_time_sum + " (" + str(int(utc_time.delta)) + ")")]
+expected = [(strft_time + " (" + str(int(utc_time.delta)) + ")"), (strft_time_sum + " (" + str(int(utc_time.delta)) + ")")]
+result = utc_time.i2repr(None, None)
+result
+expected
+assert result in expected
 
 = Test LETimeField with time values
 
@@ -63,4 +64,8 @@ strft_time = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_time)
 strft_time_sum = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_to_utc(local_time))
 
 # Backup: also test summer time bug
-assert lme_time.i2repr(None, None) in [(strft_time + " (" + str(int(lme_time.delta)) + ")"), (strft_time_sum + " (" + str(int(lme_time.delta)) + ")")]
+expected = [(strft_time + " (" + str(int(lme_time.delta)) + ")"), (strft_time_sum + " (" + str(int(lme_time.delta)) + ")")]
+result = lme_time.i2repr(None, None)
+result
+expected
+assert result in expected

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -319,6 +319,8 @@ assert(x_pubNum.n == 19231328316532061413420367242571475005688288081144416166988
 x_pubNum.e == 0x10001
 
 = Cert class : Checking extensions
+x.show()
+x.tbsCertificate.show()
 assert(x.cA)
 assert(x.authorityKeyID == b'\xf3\xd8N\xde\x90\xf7\xe6]\xd2\xce3\xcd\\V\x8co\x97\x141K')
 not hasattr(x, "keyUsage")

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -26,6 +26,9 @@
     "mock_read_routes_bsd",
     "appveyor_only",
     "open_ssl_client",
-    "ipv6"
+    "ipv6",
+    "manufdb",
+    "tcpdump",
+    "tshark"
   ]
 }

--- a/test/mock_windows.uts
+++ b/test/mock_windows.uts
@@ -296,6 +296,10 @@ ps_ip
 assert get_ip_from_name(conf.iface.name) == ps_ip
 
 = Test get_windows_if_list with VBS
+~ appveyor_only
+
+# This test is slightly unstable locally, especially on Windows 7
+
 ps_if_list
 
 def is_in_if_list(i, list):
@@ -331,7 +335,7 @@ def is_in_route_list(i, list):
     return False
 
 vbs_read_routes = read_routes()
-vbs_if_list
+vbs_read_routes
 _correct = True
 for i in vbs_read_routes:
     if not is_in_route_list(i, ps_read_routes):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1389,9 +1389,9 @@ def send_and_sniff(pkt, timeout=2, flt=None, opened_socket=None):
         while not results.empty():
             assert results.get()
 
-send_and_sniff(IP(dst="secdev.org")/ICMP())
-send_and_sniff(IP(dst="secdev.org")/ICMP(), flt="icmp")
-send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP())
+retry_test(lambda: send_and_sniff(IP(dst="secdev.org")/ICMP()))
+retry_test(lambda: send_and_sniff(IP(dst="secdev.org")/ICMP(), flt="icmp"))
+retry_test(lambda: send_and_sniff(Ether()/IP(dst="secdev.org")/ICMP()))
 
 = Test L2ListenTcpdump socket
 ~ netaccess FIXME_py3

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 
 [tox]
-envlist = py{27,34,35,36,py,py3}-{linux,osx}_{non_root,root}, py{27,36}-windows-linux_garbage
+envlist = py{27,34,35,36,37,py,py3}-{linux,osx}_{non_root,root}, py{27,36}-windows-linux_garbage
 skip_missing_interpreters = true
 minversion = 2.9
 


### PR DESCRIPTION
This PR:
- adds Travis tests (because Python 3.7 is not available by default in Travis yet, it is specifying the distro)
- fixes windows on 3.7
- fixes http2 on 3.7
- stabilize some tests (networking + ppi_geotag)

Watching https://github.com/travis-ci/travis-ci/issues/9815

fixes https://github.com/secdev/scapy/issues/1570
fixes https://github.com/secdev/scapy/issues/1649