### PR TITLE
Linux: fix read_routes() when an interface has no IP address

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -269,10 +269,12 @@ def read_routes():
             ifreq = ioctl(s, SIOCGIFADDR, struct.pack("16s16x", iff.encode("utf8")))  # noqa: E501
         except IOError:  # interface is present in routing tables but does not have any assigned IP  # noqa: E501
             ifaddr = "0.0.0.0"
+            ifaddr_int = 0
         else:
             addrfamily = struct.unpack("h", ifreq[16:18])[0]
             if addrfamily == socket.AF_INET:
                 ifaddr = scapy.utils.inet_ntoa(ifreq[20:24])
+                ifaddr_int = struct.unpack("!I", ifreq[20:24])[0]
             else:
                 warning("Interface %s: unknown address family (%i)", iff, addrfamily)  # noqa: E501
                 continue
@@ -280,7 +282,6 @@ def read_routes():
         # Attempt to detect an interface alias based on addresses inconsistencies  # noqa: E501
         dst_int = socket.htonl(int(dst, 16)) & 0xffffffff
         msk_int = socket.htonl(int(msk, 16)) & 0xffffffff
-        ifaddr_int = struct.unpack("!I", ifreq[20:24])[0]
         gw_str = scapy.utils.inet_ntoa(struct.pack("I", int(gw, 16)))
         metric = int(metric)
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -313,3 +313,20 @@ except subprocess.CalledProcessError:
     assert False
 except Exception:
     assert False
+
+
+= Routing table, interface with no names
+~ linux
+
+from mock import patch
+
+@patch("scapy.arch.linux.ioctl")
+def test_read_routes(mock_ioctl):
+    def raise_ioerror(*args, **kwargs):
+        if args[1] == 0x8912:
+            return args[2]
+        raise IOError
+    mock_ioctl.side_effect = raise_ioerror
+    read_routes()
+
+test_read_routes()


### PR DESCRIPTION
Fixes #1567.