### PR TITLE
Adds Extended Master Secret to TLS (RFC 7627)

### DIFF
--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -207,18 +207,25 @@ class PRF(object):
             warning("Unknown TLS version")
 
     def compute_master_secret(self, pre_master_secret,
-                              client_random, server_random):
+                              client_random, server_random, extms=False, handshake_hash=None):
         """
         Return the 48-byte master_secret, computed from pre_master_secret,
         client_random and server_random. See RFC 5246, section 6.3.
+        Supports Extended Master Secret Derivation, see RFC 7627
         """
         seed = client_random + server_random
+        label = b'master secret'
+
+        if extms is True and handshake_hash is not None:
+            seed = handshake_hash
+            label = b'extended master secret'
+
         if self.tls_version < 0x0300:
             return None
         elif self.tls_version == 0x0300:
             return self.prf(pre_master_secret, seed, 48)
         else:
-            return self.prf(pre_master_secret, b"master secret", seed, 48)
+            return self.prf(pre_master_secret, label, seed, 48)
 
     def derive_key_block(self, master_secret, server_random,
                          client_random, req_len):

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -526,7 +526,8 @@ class tlsSession(object):
             warning("Missing client_random while computing master_secret!")
         if self.server_random is None:
             warning("Missing server_random while computing master_secret!")
-
+        if self.extms and self.session_hash is None:
+            warning("Missing session hash while computing master secret!")
 
         ms = self.pwcs.prf.compute_master_secret(self.pre_master_secret,
                                                  self.client_random,

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -449,6 +449,10 @@ class tlsSession(object):
         self.handshake_messages = []
         self.handshake_messages_parsed = []
 
+        # Flag, whether we derive the secret as Extended MS or not
+        self.extms = False
+        self.session_hash = None
+
         # All exchanged TLS packets.
         # XXX no support for now
         # self.exchanged_pkts = []
@@ -523,9 +527,12 @@ class tlsSession(object):
         if self.server_random is None:
             warning("Missing server_random while computing master_secret!")
 
+
         ms = self.pwcs.prf.compute_master_secret(self.pre_master_secret,
                                                  self.client_random,
-                                                 self.server_random)
+                                                 self.server_random,
+                                                 self.extms,
+                                                 self.session_hash)
         self.master_secret = ms
         if conf.debug_tls:
             log_runtime.debug("TLS: master secret: %s", repr_hex(ms))


### PR DESCRIPTION
extms snads for Extended Master Secret, see RFC 7627. 

I just needed to do this for myself, so created PR by the way. If it does not comply to the rules or is screwed in any way, I'm probably not spending more time on this...

Did not created unit test, however tested it on few real handshakes. It works. My assumptions:

- The ClientHello offers using this extension via extension field. But whether it is actually going to be used is decided by the server, in a similar field inside the Server Hello record.
- Scapy is already gathering the handshake messages, so they can be used easily.

Based on this, I did the following adjustments:

- `tls_session_update` on `TLSServerHello` record looks for the extension and notes its usage into the session object
- `tls_session_update` on `ClientKeyExchange` gathers all handshake messages into one binary string and computes the hash on it. By that time, all should be available.
- Then, the master secret is computed with the updated `compute_master_secret` method.

