### PR TITLE
adds mysummary()s to RAs, and to RA options MTU, route info, RDNSS, …

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1946,7 +1946,7 @@ class ICMPv6NDOptRDNSS(_ICMPv6NDGuessPayload, Packet):  # RFC 5006
                                 length_from=lambda pkt: 8 * (pkt.len - 1))]
 
     def mysummary(self):
-        return self.sprintf("%name% %dns%")
+        return self.sprintf("%name% " + ", ".join(self.dns))
 
 
 class ICMPv6NDOptEFA(_ICMPv6NDGuessPayload, Packet):  # RFC 5175 (prev. 5075)
@@ -2023,7 +2023,7 @@ class ICMPv6NDOptDNSSL(_ICMPv6NDGuessPayload, Packet):  # RFC 6106
                    ]
 
     def mysummary(self):
-        return self.sprintf("%name% %searchlist%")
+        return self.sprintf("%name% " + ", ".join(self.searchlist))
 
 # End of ICMPv6 Neighbor Discovery Options.
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1676,6 +1676,7 @@ icmp6ndraprefs = {0: "Medium (default)",
                   2: "Reserved",
                   3: "Low"}  # RFC 4191
 
+
 class _ICMPv6NDGuessPayload:
     name = "Dummy ND class that implements guess_payload_class()"
 
@@ -1728,7 +1729,9 @@ class ICMPv6NDOptPrefixInfo(_ICMPv6NDGuessPayload, Packet):
                    IP6Field("prefix", "::")]
 
     def mysummary(self):
-        return self.sprintf("%name% %prefix%/%prefixlen% On-link %L% Autonomous Address %A% Router Address %R%")
+        return self.sprintf("%name% %prefix%/%prefixlen% "
+                            "On-link %L% Autonomous Address %A% "
+                            "Router Address %R%")
 
 # TODO: We should also limit the size of included packet to something
 # like (initiallen - 40 - 2)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1671,6 +1671,10 @@ icmp6ndoptscls = {1: "ICMPv6NDOptSrcLLAddr",
                   31: "ICMPv6NDOptDNSSL"
                   }
 
+icmp6ndraprefs = {0: "Medium (default)",
+                  1: "High",
+                  2: "Reserved",
+                  3: "Low"}  # RFC 4191
 
 class _ICMPv6NDGuessPayload:
     name = "Dummy ND class that implements guess_payload_class()"
@@ -1724,7 +1728,7 @@ class ICMPv6NDOptPrefixInfo(_ICMPv6NDGuessPayload, Packet):
                    IP6Field("prefix", "::")]
 
     def mysummary(self):
-        return self.sprintf("%name% %prefix%")
+        return self.sprintf("%name% %prefix%/%prefixlen% On-link %L% Autonomous Address %A% Router Address %R%")
 
 # TODO: We should also limit the size of included packet to something
 # like (initiallen - 40 - 2)
@@ -1780,6 +1784,9 @@ class ICMPv6NDOptMTU(_ICMPv6NDGuessPayload, Packet):
                    ByteField("len", 1),
                    XShortField("res", 0),
                    IntField("mtu", 1280)]
+
+    def mysummary(self):
+        return self.sprintf("%name% %mtu%")
 
 
 class ICMPv6NDOptShortcutLimit(_ICMPv6NDGuessPayload, Packet):  # RFC 2491
@@ -1916,10 +1923,13 @@ class ICMPv6NDOptRouteInfo(_ICMPv6NDGuessPayload, Packet):  # RFC 4191
                                  adjust=lambda pkt, x: x // 8 + 1),
                    ByteField("plen", None),
                    BitField("res1", 0, 3),
-                   BitField("prf", 0, 2),
+                   BitEnumField("prf", 0, 2, icmp6ndraprefs),
                    BitField("res2", 0, 3),
                    IntField("rtlifetime", 0xffffffff),
                    _IP6PrefixField("prefix", None)]
+
+    def mysummary(self):
+        return self.sprintf("%name% %prefix%/%plen% Preference %prf%")
 
 
 class ICMPv6NDOptRDNSS(_ICMPv6NDGuessPayload, Packet):  # RFC 5006
@@ -1931,6 +1941,9 @@ class ICMPv6NDOptRDNSS(_ICMPv6NDGuessPayload, Packet):  # RFC 5006
                    IntField("lifetime", 0xffffffff),
                    IP6ListField("dns", [],
                                 length_from=lambda pkt: 8 * (pkt.len - 1))]
+
+    def mysummary(self):
+        return self.sprintf("%name% %dns%")
 
 
 class ICMPv6NDOptEFA(_ICMPv6NDGuessPayload, Packet):  # RFC 5175 (prev. 5075)
@@ -2006,6 +2019,9 @@ class ICMPv6NDOptDNSSL(_ICMPv6NDGuessPayload, Packet):  # RFC 6106
                                        padded=True)
                    ]
 
+    def mysummary(self):
+        return self.sprintf("%name% %searchlist%")
+
 # End of ICMPv6 Neighbor Discovery Options.
 
 
@@ -2027,10 +2043,7 @@ class ICMPv6ND_RA(_ICMPv6NDGuessPayload, _ICMPv6):
                    BitField("M", 0, 1),
                    BitField("O", 0, 1),
                    BitField("H", 0, 1),
-                   BitEnumField("prf", 1, 2, {0: "Medium (default)",
-                                              1: "High",
-                                              2: "Reserved",
-                                              3: "Low"}),  # RFC 4191
+                   BitEnumField("prf", 1, 2, icmp6ndraprefs),  # RFC 4191
                    BitField("P", 0, 1),
                    BitField("res", 0, 2),
                    ShortField("routerlifetime", 1800),
@@ -2040,6 +2053,11 @@ class ICMPv6ND_RA(_ICMPv6NDGuessPayload, _ICMPv6):
 
     def answers(self, other):
         return isinstance(other, ICMPv6ND_RS)
+
+    def mysummary(self):
+        return self.sprintf("%name% Lifetime %routerlifetime% "
+                            "Hop Limit %chlim% Preference %prf% "
+                            "Managed %M% Other %O% Home %H%")
 
 
 class ICMPv6ND_NS(_ICMPv6NDGuessPayload, _ICMPv6, Packet):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2567,6 +2567,9 @@ a=IPv6(b'`\x00\x00\x00\x00\x10:\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x
 b = IPv6(b"`\x00\x00\x00\x00\x10:\xff\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x85\x00M\xff\x00\x00\x00\x00")
 assert a.answers(b)
 
+= ICMPv6ND_RA - Summary Output
+ICMPv6ND_RA(chlim=42, M=0, O=1, H=0, prf=1, P=0, routerlifetime=300).mysummary() == "ICMPv6 Neighbor Discovery - Router Advertisement Lifetime 300 Hop Limit 42 Preference High Managed 0 Other 1 Home 0"
+
 ############
 ############
 + ICMPv6ND_NS Class Test
@@ -2762,6 +2765,9 @@ a.type == 5 and a.len == 1 and a.res == 0 and a.mtu == 1280
 = ICMPv6NDOptMTU - Dissection with specific values
 a=ICMPv6NDOptMTU(b'\x05\x02\x11\x11\x00\x00\x05\xdc')
 a.type == 5 and a.len == 2 and a.res == 0x1111 and a.mtu == 1500
+
+= ICMPv6NDOptMTU - Summary Output
+ICMPv6NDOptMTU(b'\x05\x02\x11\x11\x00\x00\x05\xdc').mysummary() == "ICMPv6 Neighbor Discovery Option - MTU 1500"
 
 
 ############
@@ -2967,6 +2973,9 @@ a.type == 24 and a.len == 3 and a.plen == 0 and a.res1 == 0 and a.prf == 0 and a
 a=ICMPv6NDOptRouteInfo(b'\x18\x04\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01')
 a.plen == 0x11 and a.res1 == 1 and a.prf == 3 and a.res2 == 1 and a.rtlifetime == 0x22222222 and a.prefix == "2001:db8::1" 
 
+= ICMPv6NDOptRouteInfo - Summary Output
+ICMPv6NDOptRouteInfo(b'\x18\x04\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01').mysummary == "ICMPv6 Neighbor Discovery Option - Route Information Option 2001:db8::1/17 Preference Low"
+
 
 ############
 ############
@@ -3015,6 +3024,10 @@ a.type==25 and a.len==3 and a.res ==0 and len(a.dns) == 1 and a.dns[0] == "2001:
 a=ICMPv6NDOptRDNSS(b'\x19\x05\xaa\xee\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
 a.type==25 and a.len==5 and a.res == 0xaaee and len(a.dns) == 2 and a.dns[0] == "2001:db8::1" and a.dns[1] == "2001:db8::2"
 
+= ICMPv6NDOptRDNSS - Summary Output
+a=ICMPv6NDOptRDNSS(b'\x19\x05\xaa\xee\xff\xff\xff\xff \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
+a.mysummary() == "ICMPv6 Neighbor Discovery Option - Recursive DNS Server Option 2001:db8::1, 2001:db8::2"
+
 
 ############
 ############
@@ -3039,6 +3052,9 @@ p.type == 31 and p.len == 1 and p.res == 0 and p.searchlist == []
 = ICMPv6NDOptDNSSL - Basic Dissection with specific values
 p = ICMPv6NDOptDNSSL(b'\x1f\x02\x00\x00\x00\x00\x00<\x04home\x00\x00\x00')
 p.type == 31 and p.len == 2 and p.res == 0 and p.lifetime == 60 and p.searchlist == ["home."]
+
+= ICMPv6NDOptDNSSL - Summary Output
+ICMPv6NDOptDNSSL(searchlist=["home.", "office."]).mysummary() == "ICMPv6 Neighbor Discovery Option - DNS Search List Option home., office."
 
 
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2974,7 +2974,7 @@ a=ICMPv6NDOptRouteInfo(b'\x18\x04\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x0
 a.plen == 0x11 and a.res1 == 1 and a.prf == 3 and a.res2 == 1 and a.rtlifetime == 0x22222222 and a.prefix == "2001:db8::1" 
 
 = ICMPv6NDOptRouteInfo - Summary Output
-ICMPv6NDOptRouteInfo(b'\x18\x04\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01').mysummary == "ICMPv6 Neighbor Discovery Option - Route Information Option 2001:db8::1/17 Preference Low"
+ICMPv6NDOptRouteInfo(b'\x18\x04\x119"""" \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01').mysummary() == "ICMPv6 Neighbor Discovery Option - Route Information Option 2001:db8::1/17 Preference Low"
 
 
 ############


### PR DESCRIPTION
…DNSSL

This PR:
- adds `mysummary()`s to the classes `ICMPv6ND_RA`, `ICMPv6NDOptRouteInfo`, `ICMPv6NDOptRDNSS`, `ICMPv6NDOptDNSSL`, and `ICMPv6NDOptMTU`.
- extends the `mysummary()` of `ICMPv6NDOptPrefixInfo`.
- adds `icmp6ndraprefs` RFC 4191 route(r) preference enumeration values to common use in `ICMPv6ND_RA` and `ICMPv6NDOptRouteInfo`.

I manually run the regression tests and they passed for the classes mentioned above (python3 test output); in addition this PR is subject to your normal test suite:
```
passed 988340A1 ICMPv6ND_RA - Basic Instantiation
passed EAB9F5B1 ICMPv6ND_RA - Basic instantiation with empty dst in IPv6 underlayer
passed 854A2794 ICMPv6ND_RA - Basic dissection
passed 10B9F0CB ICMPv6ND_RA - Basic instantiation with empty dst in IPv6 underlayer
passed 5F315605 ICMPv6ND_RA - Answers
passed 12DB2C22 ICMPv6NDOptMTU - Basic Instantiation
passed 65770798 ICMPv6NDOptMTU - Instantiation with specific values
passed 83B871C6 ICMPv6NDOptMTU - Basic dissection
passed 17C89A45 ICMPv6NDOptMTU - Dissection with specific values
passed F594DA97 ICMPv6NDOptPrefixInfo - Basic Instantiation
passed 48915433 ICMPv6NDOptPrefixInfo - Instantiation with specific values
passed ACF9B9CF ICMPv6NDOptPrefixInfo - Basic Dissection
passed 5CFA5B35 ICMPv6NDOptPrefixInfo - Instantiation with specific values
passed 8C3E3751 ICMPv6NDOptRouteInfo - Basic Instantiation
passed 44A42CE7 ICMPv6NDOptRouteInfo - Instantiation with forced prefix but no length
passed D30C6789 ICMPv6NDOptRouteInfo - Instantiation with forced length values (1/4)
passed 03213D9B ICMPv6NDOptRouteInfo - Instantiation with forced length values (2/4)
passed D2034B7A ICMPv6NDOptRouteInfo - Instantiation with forced length values (3/4)
passed 9B323128 ICMPv6NDOptRouteInfo - Instantiation with forced length values (4/4)
passed 0E899A78 ICMPv6NDOptRouteInfo - Instantiation with specific values
passed A9702412 ICMPv6NDOptRouteInfo - Basic dissection
passed BA32308F ICMPv6NDOptRouteInfo - Dissection with specific values
passed 4F509225 ICMPv6NDOptRDNSS - Basic Instantiation
passed 9CD0A8FB ICMPv6NDOptRDNSS - Basic instantiation with 1 DNS address
passed C58A2B38 ICMPv6NDOptRDNSS - Basic instantiation with 2 DNS addresses
passed 43D6D077 ICMPv6NDOptRDNSS - Instantiation with specific values
passed DC2BFF23 ICMPv6NDOptRDNSS - Basic Dissection
passed 37BF7067 ICMPv6NDOptRDNSS - Dissection (with 1 DNS address)
passed 9D964AF3 ICMPv6NDOptRDNSS - Dissection (with 2 DNS addresses)
passed 043EECBA ICMPv6NDOptDNSSL - Basic Instantiation
passed F6B0842F ICMPv6NDOptDNSSL - Instantiation with 1 search domain, as seen in the wild
passed E914C420 ICMPv6NDOptDNSSL - Basic instantiation with 2 search domains
passed ECC9DE2E ICMPv6NDOptDNSSL - Basic instantiation with 3 search domains
passed B1DC63A2 ICMPv6NDOptDNSSL - Basic Dissection
passed B96216D1 ICMPv6NDOptDNSSL - Basic Dissection with specific values
```
