### PR TITLE
Cleaned up UDS and ISO-TP implementation

### DIFF
--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -9,7 +9,7 @@ import struct
 from scapy.fields import ByteEnumField, StrField, ConditionalField, \
     BitEnumField, BitField, XByteField, FieldListField, \
     XShortField, X3BytesField, XIntField, ByteField, \
-    ShortField, ObservableDict, XShortEnumField, XByteEnumField
+    ShortField, XShortEnumField, XByteEnumField
 from scapy.packet import Packet, bind_layers
 
 """
@@ -18,58 +18,58 @@ UDS
 
 
 class UDS(Packet):
-    services = ObservableDict(
-        {0x10: 'DiagnosticSessionControl',
-         0x11: 'ECUReset',
-         0x14: 'ClearDiagnosticInformation',
-         0x19: 'ReadDTCInformation',
-         0x22: 'ReadDataByIdentifier',
-         0x23: 'ReadMemoryByAddress',
-         0x24: 'ReadScalingDataByIdentifier',
-         0x27: 'SecurityAccess',
-         0x28: 'CommunicationControl',
-         0x2A: 'ReadDataPeriodicIdentifier',
-         0x2C: 'DynamicallyDefineDataIdentifier',
-         0x2E: 'WriteDataByIdentifier',
-         0x2F: 'InputOutputControlByIdentifier',
-         0x31: 'RoutineControl',
-         0x34: 'RequestDownload',
-         0x35: 'RequestUpload',
-         0x36: 'TransferData',
-         0x37: 'RequestTransferExit',
-         0x3D: 'WriteMemoryByAddress',
-         0x3E: 'TesterPresent',
-         0x50: 'DiagnosticSessionControlPositiveResponse',
-         0x51: 'ECUResetPositiveResponse',
-         0x54: 'ClearDiagnosticInformationPositiveResponse',
-         0x59: 'ReadDTCInformationPositiveResponse',
-         0x62: 'ReadDataByIdentifierPositiveResponse',
-         0x63: 'ReadMemoryByAddressPositiveResponse',
-         0x64: 'ReadScalingDataByIdentifierPositiveResponse',
-         0x67: 'SecurityAccessPositiveResponse',
-         0x68: 'CommunicationControlPositiveResponse',
-         0x6A: 'ReadDataPeriodicIdentifierPositiveResponse',
-         0x6C: 'DynamicallyDefineDataIdentifierPositiveResponse',
-         0x6E: 'WriteDataByIdentifierPositiveResponse',
-         0x6F: 'InputOutputControlByIdentifierPositiveResponse',
-         0x71: 'RoutineControlPositiveResponse',
-         0x74: 'RequestDownloadPositiveResponse',
-         0x75: 'RequestUploadPositiveResponse',
-         0x76: 'TransferDataPositiveResponse',
-         0x77: 'RequestTransferExitPositiveResponse',
-         0x7D: 'WriteMemoryByAddressPositiveResponse',
-         0x7E: 'TesterPresentPositiveResponse',
-         0x83: 'AccessTimingParameter',
-         0x84: 'SecuredDataTransmission',
-         0x85: 'ControlDTCSetting',
-         0x86: 'ResponseOnEvent',
-         0x87: 'LinkControl',
-         0xC3: 'AccessTimingParameterPositiveResponse',
-         0xC4: 'SecuredDataTransmissionPositiveResponse',
-         0xC5: 'ControlDTCSettingPositiveResponse',
-         0xC6: 'ResponseOnEventPositiveResponse',
-         0xC7: 'LinkControlPositiveResponse',
-         0x7f: 'NegativeResponse'})
+    services = {
+        0x10: 'DiagnosticSessionControl',
+        0x11: 'ECUReset',
+        0x14: 'ClearDiagnosticInformation',
+        0x19: 'ReadDTCInformation',
+        0x22: 'ReadDataByIdentifier',
+        0x23: 'ReadMemoryByAddress',
+        0x24: 'ReadScalingDataByIdentifier',
+        0x27: 'SecurityAccess',
+        0x28: 'CommunicationControl',
+        0x2A: 'ReadDataPeriodicIdentifier',
+        0x2C: 'DynamicallyDefineDataIdentifier',
+        0x2E: 'WriteDataByIdentifier',
+        0x2F: 'InputOutputControlByIdentifier',
+        0x31: 'RoutineControl',
+        0x34: 'RequestDownload',
+        0x35: 'RequestUpload',
+        0x36: 'TransferData',
+        0x37: 'RequestTransferExit',
+        0x3D: 'WriteMemoryByAddress',
+        0x3E: 'TesterPresent',
+        0x50: 'DiagnosticSessionControlPositiveResponse',
+        0x51: 'ECUResetPositiveResponse',
+        0x54: 'ClearDiagnosticInformationPositiveResponse',
+        0x59: 'ReadDTCInformationPositiveResponse',
+        0x62: 'ReadDataByIdentifierPositiveResponse',
+        0x63: 'ReadMemoryByAddressPositiveResponse',
+        0x64: 'ReadScalingDataByIdentifierPositiveResponse',
+        0x67: 'SecurityAccessPositiveResponse',
+        0x68: 'CommunicationControlPositiveResponse',
+        0x6A: 'ReadDataPeriodicIdentifierPositiveResponse',
+        0x6C: 'DynamicallyDefineDataIdentifierPositiveResponse',
+        0x6E: 'WriteDataByIdentifierPositiveResponse',
+        0x6F: 'InputOutputControlByIdentifierPositiveResponse',
+        0x71: 'RoutineControlPositiveResponse',
+        0x74: 'RequestDownloadPositiveResponse',
+        0x75: 'RequestUploadPositiveResponse',
+        0x76: 'TransferDataPositiveResponse',
+        0x77: 'RequestTransferExitPositiveResponse',
+        0x7D: 'WriteMemoryByAddressPositiveResponse',
+        0x7E: 'TesterPresentPositiveResponse',
+        0x83: 'AccessTimingParameter',
+        0x84: 'SecuredDataTransmission',
+        0x85: 'ControlDTCSetting',
+        0x86: 'ResponseOnEvent',
+        0x87: 'LinkControl',
+        0xC3: 'AccessTimingParameterPositiveResponse',
+        0xC4: 'SecuredDataTransmissionPositiveResponse',
+        0xC5: 'ControlDTCSettingPositiveResponse',
+        0xC6: 'ResponseOnEventPositiveResponse',
+        0xC7: 'LinkControlPositiveResponse',
+        0x7f: 'NegativeResponse'}
     name = 'UDS'
     fields_desc = [
         XByteEnumField('service', 0, services)
@@ -399,7 +399,7 @@ bind_layers(UDS, UDS_LCPR, service=0xC7)
 
 # #########################RDBI###################################
 class UDS_RDBI(Packet):
-    dataIdentifiers = ObservableDict()
+    dataIdentifiers = {}
     name = 'ReadDataByIdentifier'
     fields_desc = [
         FieldListField("identifiers", [],

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -14,14 +14,13 @@ import ctypes
 from ctypes.util import find_library
 import struct
 import socket
-import time
 
 import scapy.modules.six as six
 from scapy.error import Scapy_Exception, warning
 from scapy.packet import Packet
 from scapy.fields import StrField
 from scapy.supersocket import SuperSocket
-from scapy.sendrecv import sndrcv, sniff
+from scapy.sendrecv import sndrcv
 from scapy.arch.linux import get_last_packet_timestamp, SIOCGIFINDEX
 from scapy.config import conf
 from scapy.consts import WINDOWS
@@ -48,14 +47,6 @@ class ISOTP(Packet):
     fields_desc = [
         StrField('data', B"")
     ]
-
-    def hashret(self):
-        return self.payload.hashret()
-
-    def answers(self, other):
-        if other.__class__ == self.__class__:
-            return self.payload.answers(other.payload)
-        return 0
 
 
 CAN_MTU = 16
@@ -328,18 +319,7 @@ class ISOTPSocket(SuperSocket):
         ts = get_last_packet_timestamp(self.ins)
         return self.basecls, pkt, ts
 
-    def send(self, x):
-        if hasattr(x, "sent_time"):
-            x.sent_time = time.time()
-        return self.outs.send(bytes(x))
-
-    def sr(self, *args, **kargs):
-        return sndrcv(self, *args, **kargs)
-
     def sr1(self, *args, **kargs):
         data = sndrcv(self, *args, **kargs)
         if data:
             return data[0][0][1]
-
-    def sniff(self, *args, **kargs):
-        return sniff(opened_socket=self, *args, **kargs)


### PR DESCRIPTION
Usual cleaning work.

The ISO-TP class overrode several methods and implemented them in the same way.

The UDS class contained unused Observable Dictionaries, while usual Dictionaries are enough

