### PR TITLE
Handle socket exceptions

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -926,7 +926,8 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                 try:
                     p = s.recv()
                 except socket.error as ex:
-                    log_runtime.warning("Socket %s failed with '%s' and thus will be ignored" % (s, ex))
+                    log_runtime.warning("Socket %s failed with '%s' and thus"
+                                        " will be ignored" % (s, ex))
                     del sniff_sockets[s]
                     continue
                 except read_allowed_exceptions:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -13,10 +13,11 @@ import itertools
 import threading
 import os
 from select import select, error as select_error
+import socket
 import subprocess
 import time
 import types
-import socket
+
 from scapy.consts import DARWIN, FREEBSD, OPENBSD, WINDOWS
 from scapy.compat import plain_str
 from scapy.data import ETH_P_ALL, MTU
@@ -924,9 +925,10 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
             for s in ins:
                 try:
                     p = s.recv()
-                except socket.error:
+                except socket.error as ex:
+                    log_runtime.warning("Socket %s failed with '%s' and thus will be ignored" % (s, ex))
                     del sniff_sockets[s]
-                    break
+                    continue
                 except read_allowed_exceptions:
                     continue
                 if p is None:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -16,7 +16,7 @@ from select import select, error as select_error
 import subprocess
 import time
 import types
-
+import socket
 from scapy.consts import DARWIN, FREEBSD, OPENBSD, WINDOWS
 from scapy.compat import plain_str
 from scapy.data import ETH_P_ALL, MTU
@@ -924,6 +924,9 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
             for s in ins:
                 try:
                     p = s.recv()
+                except socket.error:
+                    del sniff_sockets[s]
+                    break
                 except read_allowed_exceptions:
                     continue
                 if p is None:


### PR DESCRIPTION
Implementing https://blog.skyplabs.net/2018/03/01/python-sniffing-inside-a-thread-with-scapy/ (using an external socket) I came to a case where the socket was closed, throwing an exception that I think should be handled.