### PR TITLE
E731 - do not assign a lambda expression, use a def

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,5 +83,6 @@ commands = flake8 scapy/
 select = E1,E2,E30,E401,E5,E70,E71,
          F402,F8,
          W2,W3
+ignore = E731
 exclude = scapy/modules/six.py,
           scapy/modules/winpcapy.py


### PR DESCRIPTION
Following discussions on #1277 this PR explicitly accept ignores E731.