### PR TITLE
Fixed an ISOTPSoftSocket padding issue

### DIFF
--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -996,6 +996,7 @@ class ISOTPSocketImplementation:
 
         if self.rx_idx >= self.rx_len:
             # we are done
+            self.rx_buf = self.rx_buf[0:self.rx_len]
             self.rx_state = ISOTP_IDLE
             self.rx_messages.append(self.rx_buf)
             if self.rx_callback:

--- a/scapy/contrib/isotp.uts
+++ b/scapy/contrib/isotp.uts
@@ -457,6 +457,18 @@ assert(msg == dhex("05 01 02 03 04 05"))
 assert(len(sent) == 0)
 
 
+= Two frame receive
+
+sent = []
+impl = ISOTPSocketImplementation(sent.append)
+impl.on_recv(CAN(identifier=0x241, data=dhex("10 09 01 02 03 04 05 06")))
+assert(sent[0] == dhex("30 00 00"))
+impl.on_recv(CAN(identifier=0x241, data=dhex("21 07 08 09 00 00 00 00")))
+msg = impl.rx_messages.pop()
+assert(msg == dhex("01 02 03 04 05 06 07 08 09"))
+assert(len(sent) == 1)
+
+
 = 20000 bytes receive
 
 data = dhex("01 02 03 04 05")*4000


### PR DESCRIPTION
ISOTPSoftSocket: Fixed a bug that included the passing of the last CAN frame in the ISOTP message