### PR TITLE
Python 3.7 Support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ The project aims to provide code that works both on Python 2 and Python 3. There
 - use scapy.modules.six.itervalues(dict) instead of dict.values() or dict.itervalues()
 - use scapy.modules.six.string_types instead of basestring
 - `__bool__ = __nonzero__` must be used when declaring `__nonzero__` methods
+- `__next__ = next` must be used when declaring `next` methods in iterators
+- `StopIteration` must NOT be used in generators (but it can still be used in iterators)
 - `io.BytesIO` must be used instead of `StringIO` when using bytes
 - `__cmp__` must not be used.
 - UserDict should be imported via `six.UserDict`

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -802,7 +802,8 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                             self.cmdout.send(c)
                             break
             except StopIteration as e:
-                c = Message(type=_ATMT_Command.END, result=e.args[0])
+                c = Message(type=_ATMT_Command.END,
+                            result=self.final_state_output)
                 self.cmdout.send(c)
             except Exception as e:
                 exc_info = sys.exc_info()
@@ -828,7 +829,8 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                     raise self.ErrorState("Reached %s: [%r]" % (self.state.state, state_output),  # noqa: E501
                                           result=state_output, state=self.state.state)  # noqa: E501
                 if self.state.final:
-                    raise StopIteration(state_output)
+                    self.final_state_output = state_output
+                    return
 
                 if state_output is None:
                     state_output = ()

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -164,7 +164,7 @@ class OID(Gen):
             i = 0
             while True:
                 if i >= len(ii):
-                    raise StopIteration
+                    return
                 if ii[i] < self.cmpt[i][1]:
                     ii[i] += 1
                     break

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -667,7 +667,7 @@ def sndrcvflood(pks, pkt, inter=0, verbose=None, chainCC=False, store_unanswered
         while True:
             for p in tobesent:
                 if stopevent.is_set():
-                    raise StopIteration()
+                    return
                 count_packets.put(0)
                 yield p
 

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -975,8 +975,6 @@ if __name__ == "__main__":
             warnings.resetwarnings()
             # Let's discover the garbage waste
             warnings.simplefilter('error')
-            # TODO fix this: Scapy has too many StopIteration (deprecated)
-            warnings.filterwarnings('ignore', message=r'.*generator.*', category=DeprecationWarning)
             print("### Warning mode enabled ###")
             res = main(sys.argv[1:])
             if cw:


### PR DESCRIPTION
Only Python 3.7 fixes (separated from the Travis tests, which don’t work properly for now)

This PR adds Python 3.7 support in scapy:
- fixes StopIteration in generators. They can't be used in generators anymore, but must in iterators

Tests in https://github.com/secdev/scapy/pull/1571