### PR TITLE
Implementation of lower layer ISOTP frames [ready to merge]

### DIFF
--- a/scapy/contrib/isotp.uts
+++ b/scapy/contrib/isotp.uts
@@ -122,7 +122,7 @@ if p.wait() == 0:
 = Import isotp
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': False}
 load_contrib("isotp")
-from scapy.contrib.isotp import ISOTP
+
 
 + ISOTP packet check
 
@@ -137,6 +137,192 @@ p = ISOTP(b"eee", src=0x241)
 assert(p.src == 0x241)
 assert(p.data == b"eee")
 assert(bytes(p) == b"eee")
+
++ ISOTPFrame related checks
+
+= Build a packet with extended addressing
+
+pkt = CAN(identifier=0x123, data=b'\x42\x10\xff\xde\xea\xdd\xaa\xaa')
+isotpex = ISOTPHeaderEA(bytes(pkt))
+assert(isotpex.type == 1)
+assert(isotpex.message_size == 0xff)
+assert(isotpex.extended_address == 0x42)
+assert(isotpex.identifier == 0x123)
+assert(isotpex.length == 8)
+
+
+= Build a packet with normal addressing
+
+pkt = CAN(identifier=0x123, data=b'\x10\xff\xde\xea\xdd\xaa\xaa')
+isotpno = ISOTPHeader(bytes(pkt))
+assert(isotpno.type == 1)
+assert(isotpno.message_size == 0xff)
+assert(isotpno.identifier == 0x123)
+assert(isotpno.length == 7)
+
+
+= Compare both isotp payloads
+
+assert(isotpno.data == isotpex.data)
+assert(isotpno.message_size == isotpex.message_size)
+
+
+= Dissect multiple packets
+
+frames = \
+    [b'\x00\x00\x00\x00\x08\x00\x00\x00\x10(\xde\xad\xbe\xef\xde\xad',
+    b'\x00\x00\x00\x00\x08\x00\x00\x00!\xbe\xef\xde\xad\xbe\xef\xde',
+    b'\x00\x00\x00\x00\x08\x00\x00\x00"\xad\xbe\xef\xde\xad\xbe\xef',
+    b'\x00\x00\x00\x00\x08\x00\x00\x00#\xde\xad\xbe\xef\xde\xad\xbe',
+    b'\x00\x00\x00\x00\x08\x00\x00\x00$\xef\xde\xad\xbe\xef\xde\xad',
+    b'\x00\x00\x00\x00\x07\x00\x00\x00%\xbe\xef\xde\xad\xbe\xef']
+
+isotpframes = [ISOTPHeader(x) for x in frames]
+
+assert(isotpframes[0].type == 1)
+assert(isotpframes[0].message_size == 40)
+assert(isotpframes[0].length == 8)
+assert(isotpframes[1].type == 2)
+assert(isotpframes[1].index == 1)
+assert(isotpframes[1].length == 8)
+assert(isotpframes[2].type == 2)
+assert(isotpframes[2].index == 2)
+assert(isotpframes[2].length == 8)
+assert(isotpframes[3].type == 2)
+assert(isotpframes[3].index == 3)
+assert(isotpframes[3].length == 8)
+assert(isotpframes[4].type == 2)
+assert(isotpframes[4].index == 4)
+assert(isotpframes[4].length == 8)
+assert(isotpframes[5].type == 2)
+assert(isotpframes[5].index == 5)
+assert(isotpframes[5].length == 7)
+
+= Build SF frame with constructor, check for correct length assignments
+
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_SF(data=b'\xad\xbe\xad\xff')))
+assert(p.length == 5)
+assert(p.message_size == 4)
+assert(len(p.data) == 4)
+assert(p.data == b'\xad\xbe\xad\xff')
+assert(p.type == 0)
+assert(p.identifier == 0)
+
+= Build SF frame EA with constructor, check for correct length assignments
+
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_SF(data=b'\xad\xbe\xad\xff')))
+assert(p.extended_address == 0)
+assert(p.length == 6)
+assert(p.message_size == 4)
+assert(len(p.data) == 4)
+assert(p.data == b'\xad\xbe\xad\xff')
+assert(p.type == 0)
+assert(p.identifier == 0)
+
+= Build FF frame with constructor, check for correct length assignments
+
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_FF(message_size=10, data=b'\xad\xbe\xad\xff')))
+assert(p.length == 6)
+assert(p.message_size == 10)
+assert(len(p.data) == 4)
+assert(p.data == b'\xad\xbe\xad\xff')
+assert(p.type == 1)
+assert(p.identifier == 0)
+
+= Build FF frame EA with constructor, check for correct length assignments
+
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_FF(message_size=10, data=b'\xad\xbe\xad\xff')))
+assert(p.extended_address == 0)
+assert(p.length == 7)
+assert(p.message_size == 10)
+assert(len(p.data) == 4)
+assert(p.data == b'\xad\xbe\xad\xff')
+assert(p.type == 1)
+assert(p.identifier == 0)
+
+= Build FF frame EA, extended size, with constructor, check for correct length assignments
+
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_FF(message_size=0,
+                                                 extended_message_size=2000,
+                                                 data=b'\xad')))
+assert(p.extended_address == 0)
+assert(p.length == 8)
+assert(p.message_size == 0)
+assert(p.extended_message_size == 2000)
+assert(len(p.data) == 1)
+assert(p.data == b'\xad')
+assert(p.type == 1)
+assert(p.identifier == 0)
+
+= Build FF frame, extended size, with constructor, check for correct length assignments
+
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_FF(message_size=0,
+                                             extended_message_size=2000,
+                                             data=b'\xad')))
+assert(p.length == 7)
+assert(p.message_size == 0)
+assert(p.extended_message_size == 2000)
+assert(len(p.data) == 1)
+assert(p.data == b'\xad')
+assert(p.type == 1)
+assert(p.identifier == 0)
+
+= Build CF frame with constructor, check for correct length assignments
+
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_CF(data=b'\xad')))
+assert(p.length == 2)
+assert(p.index == 0)
+assert(len(p.data) == 1)
+assert(p.data == b'\xad')
+assert(p.type == 2)
+assert(p.identifier == 0)
+
+= Build CF frame EA with constructor, check for correct length assignments
+
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_CF(data=b'\xad')))
+assert(p.length == 3)
+assert(p.index == 0)
+assert(len(p.data) == 1)
+assert(p.data == b'\xad')
+assert(p.type == 2)
+assert(p.identifier == 0)
+
+= Build FC frame EA with constructor, check for correct length assignments
+
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_FC()))
+assert(p.length == 4)
+assert(p.block_size == 0)
+assert(p.separation_time == 0)
+assert(p.type == 3)
+assert(p.identifier == 0)
+
+= Build FC frame with constructor, check for correct length assignments
+
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_FC()))
+assert(p.length == 3)
+assert(p.block_size == 0)
+assert(p.separation_time == 0)
+assert(p.type == 3)
+assert(p.identifier == 0)
+
+= Construct some single frames
+
+p = ISOTPHeader(identifier=0x123, length=5)/ISOTP_SF(message_size=4, data=b'abcd')
+assert(p.length == 5)
+assert(p.identifier == 0x123)
+assert(p.type == 0)
+assert(p.message_size == 4)
+assert(p.data == b'abcd')
+
+= Construct some single frames EA
+
+p = ISOTPHeaderEA(identifier=0x123, length=6, extended_address=42)/ISOTP_SF(message_size=4, data=b'abcd')
+assert(p.length == 6)
+assert(p.extended_address == 42)
+assert(p.identifier == 0x123)
+assert(p.type == 0)
+assert(p.message_size == 4)
+assert(p.data == b'abcd')
 
 
 + ISOTP fragment and defragment checks


### PR DESCRIPTION
Hi maintainers, 
this PR is not ready to merge, yet. I need this PR to discuss the implementation of ISOTP frames.
I would need your help here. 

Some background information:
```
  CAN Frame

+-------------------+-+-+-+--------+---------------------------------------------------------------------+
|                   | | | | Length |                                                                     |
| Identifier 29 Bit | | | |        |        Data: 0 to 8 Byte                                            |
|                   | | | | 8 Bit  |                                                                     |
+-------------------+-+-+-+--------+---------------------------------------------------------------------+
                     Flags



                              +----------------+
                              |                |
  ISOTP Header                |                |
                              |                |
+-------------------+-+-+-+---+----+-----------v---------------------------------------------------------+
|                   | | | | Length |                                                                     |
| Identifier 29 Bit | | | |        |        Payload 0 to 8 Byte                                          |
|                   | | | | 8 Bit  |                                                                     |
+-------------------+-+-+-+--------+---------------------------------------------------------------------+
                     Flags




  ISOTP Header  Extended Addressing

+-------------------+-+-+-+--------+--------+------------------------------------------------------------+
|                   | | | | Length |  ext.  |                                                            |
| Identifier 29 Bit | | | |        |address |  Payload 0 to 7 Byte                                       |
|                   | | | | 8 Bit  | 1 Byte |                                                            |
+-------------------+-+-+-+---+----+---^----+-----^------------------------------------------------------+
                     Flags    |        |          |
                              |        |          |
                              +--------+----------+

ISOTP Payload: Single Frame


+--------+--------+-----------------------------------------------------------------------------------+
| type   |  msg.  |                                                                                   |
| SF = 0 |  size  |  Data: 0 to 6 byte if extended addressing, else 7 byte                            |
| 4 Bit  |  4 Bit |                                                                                   |
+--------+---+----+-----^-----------------------------------------------------------------------------+
             |          |
             |          |
             +----------+

ISOTP Payload: First Frame

+--------+---------------+------------------------+---------------------------------------------------+
| type   |  msg. size    |  optional extended msg | Data: 6 byte without ext. addressing              |
| FF = 1 |  12 Bit of    |  size, if msg. size    | 5 byte with ext. addressing                       |
| 4 Bit  |  defrag. msg  |  == 0: 32 Bit          | 2 byte without EA and ext. msg. size, with EA 1 B |
+--------+---------------+------------------------+---------------------------------------------------+


 ISOTP Payload: Consecutive Frame

+--------+-------+------------------------------------------------------------------------------------+
| type   | index |                                                                                    |
| CF = 2 | 4 Bit |  Data: 0 to 6 byte if EA, else 0 to 7 byte                                         |
| 4 Bit  |       |                                                                                    |
+--------+-------+------------------------------------------------------------------------------------+



 ISOTP Payload: Flow Control



+--------+-------+-------------------+--------------------+
| type   | flags |  Block Size       |   Separation Time  |
| FC = 3 | 4 Bit |  1 Byte           |   1 Byte           |
| 4 Bit  |       |                   |                    |
+--------+-------+-------------------+--------------------+

```

This is, how ISOTP is built. Every ISOTP Frame is supposed to be send over CAN. Therefore, the ISOTPHeader is identical with the CAN header. 

message_size in the FirstFrame is the length of the full defragmented isotp message. 
message_size in the SingleFrame corresponds to the length of data

The length of the ISOTPHeader is the length of the ISOTP Frame + optional the extended address.

My goal is, to design the implementation of these frames in a way, that Scapy can determine as most length or size fields as possible, when doing a build of the packet. 

The current implementation works, but I'm wondering, if some of my overwritten Packet functions can be refactored. 

Could you please tell me your thoughts on this implementation? 