### PR TITLE
Fixed DHCP6OptClientLinkLayerAddr.optlen field adjustment

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -929,7 +929,7 @@ class DHCP6OptClientLinkLayerAddr(_DHCP6OptGuessPayload):  # RFC6939
     name = "DHCP6 Option - Client Link Layer address"
     fields_desc = [ShortEnumField("optcode", 79, dhcp6opts),
                    FieldLenField("optlen", None, length_of="clladdr",
-                                 adjust=lambda pkt, x: x + 1),
+                                 adjust=lambda pkt, x: x + 2),
                    ShortField("lltype", 1),  # ethernet
                    _LLAddrField("clladdr", ETHER_ANY)]
 


### PR DESCRIPTION
This is just a checklist to guide you. You can remove it safely.


**Checklist:**
- [ ] If you are new to Scapy: I have checked https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- [ ] I squashed commits belonging together
- [ ] I added unit tests or explained why they are not relevant
- [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)


< brief description what this PR will do, e.g. fixes broken dissection of XXX >

< if required - short explanation why you fixed something in a way that may look more complicated as it actually is >

< if required - outline impacts on other parts of the library >

fixes #< add issue number here if appropriate, else remove this line>
