### PR TITLE
Reverse MIB storage format

### DIFF
--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -29,6 +29,9 @@ _mib_re_comments = re.compile(r'--.*(\r|\n)')
 
 
 class MIBDict(DADict):
+    def fixname(self, val):
+        return val
+
     def _findroot(self, x):
         if x.startswith("."):
             x = x[1:]
@@ -36,15 +39,17 @@ class MIBDict(DADict):
             x += "."
         max = 0
         root = "."
+        root_key = ""
         for k in six.iterkeys(self):
-            if x.startswith(self[k] + "."):
-                if max < len(self[k]):
-                    max = len(self[k])
-                    root = k
-        return root, x[max:-1]
+            if x.startswith(k + "."):
+                if max < len(k):
+                    max = len(k)
+                    root = self[k]
+                    root_key = k
+        return root, root_key, x[max:-1]
 
     def _oidname(self, x):
-        root, remainder = self._findroot(x)
+        root, _, remainder = self._findroot(x)
         return root + remainder
 
     def _oid(self, x):
@@ -52,16 +57,16 @@ class MIBDict(DADict):
         p = len(xl) - 1
         while p >= 0 and _mib_re_integer.match(xl[p]):
             p -= 1
-        if p != 0 or xl[p] not in self:
+        if p != 0 or xl[p] not in self.__dict__.values():
             return x
-        xl[p] = self[xl[p]]
+        xl[p] = next(k for k, v in six.iteritems(self.__dict__) if v == xl[p])
         return ".".join(xl[p:])
 
     def _make_graph(self, other_keys=None, **kargs):
         if other_keys is None:
             other_keys = []
-        nodes = [(k, self[k]) for k in six.iterkeys(self)]
-        oids = [self[k] for k in six.iterkeys(self)]
+        nodes = [(self[k], k) for k in six.iterkeys(self)]
+        oids = self.keys()
         for k in other_keys:
             if k not in oids:
                 nodes.append(self.oidname(k), k)
@@ -70,10 +75,10 @@ class MIBDict(DADict):
             s += '\t"%s" [ label="%s"  ];\n' % (o, k)
         s += "\n"
         for k, o in nodes:
-            parent, remainder = self._findroot(o[:-1])
+            parent, parent_key, remainder = self._findroot(o[:-1])
             remainder = remainder[1:] + o[-1]
             if parent != ".":
-                parent = self[parent]
+                parent = parent_key
             s += '\t"%s" -> "%s" [label="%s"];\n' % (parent, o, remainder)
         s += "}\n"
         do_graph(s, **kargs)
@@ -122,7 +127,7 @@ def load_mib(filenames):
     the_mib = {'iso': ['1']}
     unresolved = {}
     for k in six.iterkeys(conf.mib):
-        mib_register(k, conf.mib[k].split("."), the_mib, unresolved)
+        mib_register(conf.mib[k], k.split("."), the_mib, unresolved)
 
     if isinstance(filenames, (str, bytes)):
         filenames = [filenames]
@@ -143,10 +148,10 @@ def load_mib(filenames):
                 mib_register(ident, oid, the_mib, unresolved)
 
     newmib = MIBDict(_name="MIB")
-    for k, o in six.iteritems(the_mib):
-        newmib[k] = ".".join(o)
-    for k, o in six.iteritems(unresolved):
-        newmib[k] = ".".join(o)
+    for oid, key in six.iteritems(the_mib):
+        newmib[".".join(key)] = oid
+    for oid, key in six.iteritems(unresolved):
+        newmib[".".join(key)] = oid
 
     conf.mib = newmib
 
@@ -158,351 +163,351 @@ def load_mib(filenames):
 #      pkcs1       #
 
 pkcs1_oids = {
-    "rsaEncryption": "1.2.840.113549.1.1.1",
-    "md2WithRSAEncryption": "1.2.840.113549.1.1.2",
-    "md4WithRSAEncryption": "1.2.840.113549.1.1.3",
-    "md5WithRSAEncryption": "1.2.840.113549.1.1.4",
-    "sha1-with-rsa-signature": "1.2.840.113549.1.1.5",
-    "rsaOAEPEncryptionSET": "1.2.840.113549.1.1.6",
-    "id-RSAES-OAEP": "1.2.840.113549.1.1.7",
-    "id-mgf1": "1.2.840.113549.1.1.8",
-    "id-pSpecified": "1.2.840.113549.1.1.9",
-    "rsassa-pss": "1.2.840.113549.1.1.10",
-    "sha256WithRSAEncryption": "1.2.840.113549.1.1.11",
-    "sha384WithRSAEncryption": "1.2.840.113549.1.1.12",
-    "sha512WithRSAEncryption": "1.2.840.113549.1.1.13",
-    "sha224WithRSAEncryption": "1.2.840.113549.1.1.14"
+    "1.2.840.113549.1.1.1": "rsaEncryption",
+    "1.2.840.113549.1.1.2": "md2WithRSAEncryption",
+    "1.2.840.113549.1.1.3": "md4WithRSAEncryption",
+    "1.2.840.113549.1.1.4": "md5WithRSAEncryption",
+    "1.2.840.113549.1.1.5": "sha1-with-rsa-signature",
+    "1.2.840.113549.1.1.6": "rsaOAEPEncryptionSET",
+    "1.2.840.113549.1.1.7": "id-RSAES-OAEP",
+    "1.2.840.113549.1.1.8": "id-mgf1",
+    "1.2.840.113549.1.1.9": "id-pSpecified",
+    "1.2.840.113549.1.1.10": "rsassa-pss",
+    "1.2.840.113549.1.1.11": "sha256WithRSAEncryption",
+    "1.2.840.113549.1.1.12": "sha384WithRSAEncryption",
+    "1.2.840.113549.1.1.13": "sha512WithRSAEncryption",
+    "1.2.840.113549.1.1.14": "sha224WithRSAEncryption"
 }
 
 #       secsig oiw       #
 
 secsig_oids = {
-    "sha1": "1.3.14.3.2.26"
+    "1.3.14.3.2.26": "sha1"
 }
 
 #       pkcs9       #
 
 pkcs9_oids = {
-    "modules": "1.2.840.113549.1.9.0",
-    "emailAddress": "1.2.840.113549.1.9.1",
-    "unstructuredName": "1.2.840.113549.1.9.2",
-    "contentType": "1.2.840.113549.1.9.3",
-    "messageDigest": "1.2.840.113549.1.9.4",
-    "signing-time": "1.2.840.113549.1.9.5",
-    "countersignature": "1.2.840.113549.1.9.6",
-    "challengePassword": "1.2.840.113549.1.9.7",
-    "unstructuredAddress": "1.2.840.113549.1.9.8",
-    "extendedCertificateAttributes": "1.2.840.113549.1.9.9",
-    "signingDescription": "1.2.840.113549.1.9.13",
-    "extensionRequest": "1.2.840.113549.1.9.14",
-    "smimeCapabilities": "1.2.840.113549.1.9.15",
-    "smime": "1.2.840.113549.1.9.16",
-    "pgpKeyID": "1.2.840.113549.1.9.17",
-    "friendlyName": "1.2.840.113549.1.9.20",
-    "localKeyID": "1.2.840.113549.1.9.21",
-    "certTypes": "1.2.840.113549.1.9.22",
-    "crlTypes": "1.2.840.113549.1.9.23",
-    "pkcs-9-oc": "1.2.840.113549.1.9.24",
-    "pkcs-9-at": "1.2.840.113549.1.9.25",
-    "pkcs-9-sx": "1.2.840.113549.1.9.26",
-    "pkcs-9-mr": "1.2.840.113549.1.9.27",
-    "id-aa-CMSAlgorithmProtection": "1.2.840.113549.1.9.52"
+    "1.2.840.113549.1.9.0": "modules",
+    "1.2.840.113549.1.9.1": "emailAddress",
+    "1.2.840.113549.1.9.2": "unstructuredName",
+    "1.2.840.113549.1.9.3": "contentType",
+    "1.2.840.113549.1.9.4": "messageDigest",
+    "1.2.840.113549.1.9.5": "signing-time",
+    "1.2.840.113549.1.9.6": "countersignature",
+    "1.2.840.113549.1.9.7": "challengePassword",
+    "1.2.840.113549.1.9.8": "unstructuredAddress",
+    "1.2.840.113549.1.9.9": "extendedCertificateAttributes",
+    "1.2.840.113549.1.9.13": "signingDescription",
+    "1.2.840.113549.1.9.14": "extensionRequest",
+    "1.2.840.113549.1.9.15": "smimeCapabilities",
+    "1.2.840.113549.1.9.16": "smime",
+    "1.2.840.113549.1.9.17": "pgpKeyID",
+    "1.2.840.113549.1.9.20": "friendlyName",
+    "1.2.840.113549.1.9.21": "localKeyID",
+    "1.2.840.113549.1.9.22": "certTypes",
+    "1.2.840.113549.1.9.23": "crlTypes",
+    "1.2.840.113549.1.9.24": "pkcs-9-oc",
+    "1.2.840.113549.1.9.25": "pkcs-9-at",
+    "1.2.840.113549.1.9.26": "pkcs-9-sx",
+    "1.2.840.113549.1.9.27": "pkcs-9-mr",
+    "1.2.840.113549.1.9.52": "id-aa-CMSAlgorithmProtection"
 }
 
 #       x509       #
 
 attributeType_oids = {
-    "objectClass": "2.5.4.0",
-    "aliasedEntryName": "2.5.4.1",
-    "knowledgeInformation": "2.5.4.2",
-    "commonName": "2.5.4.3",
-    "surname": "2.5.4.4",
-    "serialNumber": "2.5.4.5",
-    "countryName": "2.5.4.6",
-    "localityName": "2.5.4.7",
-    "stateOrProvinceName": "2.5.4.8",
-    "streetAddress": "2.5.4.9",
-    "organizationName": "2.5.4.10",
-    "organizationUnitName": "2.5.4.11",
-    "title": "2.5.4.12",
-    "description": "2.5.4.13",
-    "searchGuide": "2.5.4.14",
-    "businessCategory": "2.5.4.15",
-    "postalAddress": "2.5.4.16",
-    "postalCode": "2.5.4.17",
-    "postOfficeBox": "2.5.4.18",
-    "physicalDeliveryOfficeName": "2.5.4.19",
-    "telephoneNumber": "2.5.4.20",
-    "telexNumber": "2.5.4.21",
-    "teletexTerminalIdentifier": "2.5.4.22",
-    "facsimileTelephoneNumber": "2.5.4.23",
-    "x121Address": "2.5.4.24",
-    "internationalISDNNumber": "2.5.4.25",
-    "registeredAddress": "2.5.4.26",
-    "destinationIndicator": "2.5.4.27",
-    "preferredDeliveryMethod": "2.5.4.28",
-    "presentationAddress": "2.5.4.29",
-    "supportedApplicationContext": "2.5.4.30",
-    "member": "2.5.4.31",
-    "owner": "2.5.4.32",
-    "roleOccupant": "2.5.4.33",
-    "seeAlso": "2.5.4.34",
-    "userPassword": "2.5.4.35",
-    "userCertificate": "2.5.4.36",
-    "cACertificate": "2.5.4.37",
-    "authorityRevocationList": "2.5.4.38",
-    "certificateRevocationList": "2.5.4.39",
-    "crossCertificatePair": "2.5.4.40",
-    "name": "2.5.4.41",
-    "givenName": "2.5.4.42",
-    "initials": "2.5.4.43",
-    "generationQualifier": "2.5.4.44",
-    "uniqueIdentifier": "2.5.4.45",
-    "dnQualifier": "2.5.4.46",
-    "enhancedSearchGuide": "2.5.4.47",
-    "protocolInformation": "2.5.4.48",
-    "distinguishedName": "2.5.4.49",
-    "uniqueMember": "2.5.4.50",
-    "houseIdentifier": "2.5.4.51",
-    "supportedAlgorithms": "2.5.4.52",
-    "deltaRevocationList": "2.5.4.53",
-    "dmdName": "2.5.4.54",
-    "clearance": "2.5.4.55",
-    "defaultDirQop": "2.5.4.56",
-    "attributeIntegrityInfo": "2.5.4.57",
-    "attributeCertificate": "2.5.4.58",
-    "attributeCertificateRevocationList": "2.5.4.59",
-    "confKeyInfo": "2.5.4.60",
-    "aACertificate": "2.5.4.61",
-    "attributeDescriptorCertificate": "2.5.4.62",
-    "attributeAuthorityRevocationList": "2.5.4.63",
-    "family-information": "2.5.4.64",
-    "pseudonym": "2.5.4.65",
-    "communicationsService": "2.5.4.66",
-    "communicationsNetwork": "2.5.4.67",
-    "certificationPracticeStmt": "2.5.4.68",
-    "certificatePolicy": "2.5.4.69",
-    "pkiPath": "2.5.4.70",
-    "privPolicy": "2.5.4.71",
-    "role": "2.5.4.72",
-    "delegationPath": "2.5.4.73",
-    "protPrivPolicy": "2.5.4.74",
-    "xMLPrivilegeInfo": "2.5.4.75",
-    "xmlPrivPolicy": "2.5.4.76",
-    "uuidpair": "2.5.4.77",
-    "tagOid": "2.5.4.78",
-    "uiiFormat": "2.5.4.79",
-    "uiiInUrh": "2.5.4.80",
-    "contentUrl": "2.5.4.81",
-    "permission": "2.5.4.82",
-    "uri": "2.5.4.83",
-    "pwdAttribute": "2.5.4.84",
-    "userPwd": "2.5.4.85",
-    "urn": "2.5.4.86",
-    "url": "2.5.4.87",
-    "utmCoordinates": "2.5.4.88",
-    "urnC": "2.5.4.89",
-    "uii": "2.5.4.90",
-    "epc": "2.5.4.91",
-    "tagAfi": "2.5.4.92",
-    "epcFormat": "2.5.4.93",
-    "epcInUrn": "2.5.4.94",
-    "ldapUrl": "2.5.4.95",
-    "ldapUrl": "2.5.4.96",
-    "organizationIdentifier": "2.5.4.97"
+    "2.5.4.0": "objectClass",
+    "2.5.4.1": "aliasedEntryName",
+    "2.5.4.2": "knowledgeInformation",
+    "2.5.4.3": "commonName",
+    "2.5.4.4": "surname",
+    "2.5.4.5": "serialNumber",
+    "2.5.4.6": "countryName",
+    "2.5.4.7": "localityName",
+    "2.5.4.8": "stateOrProvinceName",
+    "2.5.4.9": "streetAddress",
+    "2.5.4.10": "organizationName",
+    "2.5.4.11": "organizationUnitName",
+    "2.5.4.12": "title",
+    "2.5.4.13": "description",
+    "2.5.4.14": "searchGuide",
+    "2.5.4.15": "businessCategory",
+    "2.5.4.16": "postalAddress",
+    "2.5.4.17": "postalCode",
+    "2.5.4.18": "postOfficeBox",
+    "2.5.4.19": "physicalDeliveryOfficeName",
+    "2.5.4.20": "telephoneNumber",
+    "2.5.4.21": "telexNumber",
+    "2.5.4.22": "teletexTerminalIdentifier",
+    "2.5.4.23": "facsimileTelephoneNumber",
+    "2.5.4.24": "x121Address",
+    "2.5.4.25": "internationalISDNNumber",
+    "2.5.4.26": "registeredAddress",
+    "2.5.4.27": "destinationIndicator",
+    "2.5.4.28": "preferredDeliveryMethod",
+    "2.5.4.29": "presentationAddress",
+    "2.5.4.30": "supportedApplicationContext",
+    "2.5.4.31": "member",
+    "2.5.4.32": "owner",
+    "2.5.4.33": "roleOccupant",
+    "2.5.4.34": "seeAlso",
+    "2.5.4.35": "userPassword",
+    "2.5.4.36": "userCertificate",
+    "2.5.4.37": "cACertificate",
+    "2.5.4.38": "authorityRevocationList",
+    "2.5.4.39": "certificateRevocationList",
+    "2.5.4.40": "crossCertificatePair",
+    "2.5.4.41": "name",
+    "2.5.4.42": "givenName",
+    "2.5.4.43": "initials",
+    "2.5.4.44": "generationQualifier",
+    "2.5.4.45": "uniqueIdentifier",
+    "2.5.4.46": "dnQualifier",
+    "2.5.4.47": "enhancedSearchGuide",
+    "2.5.4.48": "protocolInformation",
+    "2.5.4.49": "distinguishedName",
+    "2.5.4.50": "uniqueMember",
+    "2.5.4.51": "houseIdentifier",
+    "2.5.4.52": "supportedAlgorithms",
+    "2.5.4.53": "deltaRevocationList",
+    "2.5.4.54": "dmdName",
+    "2.5.4.55": "clearance",
+    "2.5.4.56": "defaultDirQop",
+    "2.5.4.57": "attributeIntegrityInfo",
+    "2.5.4.58": "attributeCertificate",
+    "2.5.4.59": "attributeCertificateRevocationList",
+    "2.5.4.60": "confKeyInfo",
+    "2.5.4.61": "aACertificate",
+    "2.5.4.62": "attributeDescriptorCertificate",
+    "2.5.4.63": "attributeAuthorityRevocationList",
+    "2.5.4.64": "family-information",
+    "2.5.4.65": "pseudonym",
+    "2.5.4.66": "communicationsService",
+    "2.5.4.67": "communicationsNetwork",
+    "2.5.4.68": "certificationPracticeStmt",
+    "2.5.4.69": "certificatePolicy",
+    "2.5.4.70": "pkiPath",
+    "2.5.4.71": "privPolicy",
+    "2.5.4.72": "role",
+    "2.5.4.73": "delegationPath",
+    "2.5.4.74": "protPrivPolicy",
+    "2.5.4.75": "xMLPrivilegeInfo",
+    "2.5.4.76": "xmlPrivPolicy",
+    "2.5.4.77": "uuidpair",
+    "2.5.4.78": "tagOid",
+    "2.5.4.79": "uiiFormat",
+    "2.5.4.80": "uiiInUrh",
+    "2.5.4.81": "contentUrl",
+    "2.5.4.82": "permission",
+    "2.5.4.83": "uri",
+    "2.5.4.84": "pwdAttribute",
+    "2.5.4.85": "userPwd",
+    "2.5.4.86": "urn",
+    "2.5.4.87": "url",
+    "2.5.4.88": "utmCoordinates",
+    "2.5.4.89": "urnC",
+    "2.5.4.90": "uii",
+    "2.5.4.91": "epc",
+    "2.5.4.92": "tagAfi",
+    "2.5.4.93": "epcFormat",
+    "2.5.4.94": "epcInUrn",
+    "2.5.4.95": "ldapUrl",
+    "2.5.4.96": "ldapUrl",
+    "2.5.4.97": "organizationIdentifier"
 }
 
 certificateExtension_oids = {
-    "authorityKeyIdentifier": "2.5.29.1",
-    "keyAttributes": "2.5.29.2",
-    "certificatePolicies": "2.5.29.3",
-    "keyUsageRestriction": "2.5.29.4",
-    "policyMapping": "2.5.29.5",
-    "subtreesConstraint": "2.5.29.6",
-    "subjectAltName": "2.5.29.7",
-    "issuerAltName": "2.5.29.8",
-    "subjectDirectoryAttributes": "2.5.29.9",
-    "basicConstraints": "2.5.29.10",
-    "subjectKeyIdentifier": "2.5.29.14",
-    "keyUsage": "2.5.29.15",
-    "privateKeyUsagePeriod": "2.5.29.16",
-    "subjectAltName": "2.5.29.17",
-    "issuerAltName": "2.5.29.18",
-    "basicConstraints": "2.5.29.19",
-    "cRLNumber": "2.5.29.20",
-    "reasonCode": "2.5.29.21",
-    "expirationDate": "2.5.29.22",
-    "instructionCode": "2.5.29.23",
-    "invalidityDate": "2.5.29.24",
-    "cRLDistributionPoints": "2.5.29.25",
-    "issuingDistributionPoint": "2.5.29.26",
-    "deltaCRLIndicator": "2.5.29.27",
-    "issuingDistributionPoint": "2.5.29.28",
-    "certificateIssuer": "2.5.29.29",
-    "nameConstraints": "2.5.29.30",
-    "cRLDistributionPoints": "2.5.29.31",
-    "certificatePolicies": "2.5.29.32",
-    "policyMappings": "2.5.29.33",
-    "policyConstraints": "2.5.29.34",
-    "authorityKeyIdentifier": "2.5.29.35",
-    "policyConstraints": "2.5.29.36",
-    "extKeyUsage": "2.5.29.37",
-    "authorityAttributeIdentifier": "2.5.29.38",
-    "roleSpecCertIdentifier": "2.5.29.39",
-    "cRLStreamIdentifier": "2.5.29.40",
-    "basicAttConstraints": "2.5.29.41",
-    "delegatedNameConstraints": "2.5.29.42",
-    "timeSpecification": "2.5.29.43",
-    "cRLScope": "2.5.29.44",
-    "statusReferrals": "2.5.29.45",
-    "freshestCRL": "2.5.29.46",
-    "orderedList": "2.5.29.47",
-    "attributeDescriptor": "2.5.29.48",
-    "userNotice": "2.5.29.49",
-    "sOAIdentifier": "2.5.29.50",
-    "baseUpdateTime": "2.5.29.51",
-    "acceptableCertPolicies": "2.5.29.52",
-    "deltaInfo": "2.5.29.53",
-    "inhibitAnyPolicy": "2.5.29.54",
-    "targetInformation": "2.5.29.55",
-    "noRevAvail": "2.5.29.56",
-    "acceptablePrivilegePolicies": "2.5.29.57",
-    "id-ce-toBeRevoked": "2.5.29.58",
-    "id-ce-RevokedGroups": "2.5.29.59",
-    "id-ce-expiredCertsOnCRL": "2.5.29.60",
-    "indirectIssuer": "2.5.29.61",
-    "id-ce-noAssertion": "2.5.29.62",
-    "id-ce-aAissuingDistributionPoint": "2.5.29.63",
-    "id-ce-issuedOnBehaIFOF": "2.5.29.64",
-    "id-ce-singleUse": "2.5.29.65",
-    "id-ce-groupAC": "2.5.29.66",
-    "id-ce-allowedAttAss": "2.5.29.67",
-    "id-ce-attributeMappings": "2.5.29.68",
-    "id-ce-holderNameConstraints": "2.5.29.69"
+    "2.5.29.1": "authorityKeyIdentifier",
+    "2.5.29.2": "keyAttributes",
+    "2.5.29.3": "certificatePolicies",
+    "2.5.29.4": "keyUsageRestriction",
+    "2.5.29.5": "policyMapping",
+    "2.5.29.6": "subtreesConstraint",
+    "2.5.29.7": "subjectAltName",
+    "2.5.29.8": "issuerAltName",
+    "2.5.29.9": "subjectDirectoryAttributes",
+    "2.5.29.10": "basicConstraints",
+    "2.5.29.14": "subjectKeyIdentifier",
+    "2.5.29.15": "keyUsage",
+    "2.5.29.16": "privateKeyUsagePeriod",
+    "2.5.29.17": "subjectAltName",
+    "2.5.29.18": "issuerAltName",
+    "2.5.29.19": "basicConstraints",
+    "2.5.29.20": "cRLNumber",
+    "2.5.29.21": "reasonCode",
+    "2.5.29.22": "expirationDate",
+    "2.5.29.23": "instructionCode",
+    "2.5.29.24": "invalidityDate",
+    "2.5.29.25": "cRLDistributionPoints",
+    "2.5.29.26": "issuingDistributionPoint",
+    "2.5.29.27": "deltaCRLIndicator",
+    "2.5.29.28": "issuingDistributionPoint",
+    "2.5.29.29": "certificateIssuer",
+    "2.5.29.30": "nameConstraints",
+    "2.5.29.31": "cRLDistributionPoints",
+    "2.5.29.32": "certificatePolicies",
+    "2.5.29.33": "policyMappings",
+    "2.5.29.34": "policyConstraints",
+    "2.5.29.35": "authorityKeyIdentifier",
+    "2.5.29.36": "policyConstraints",
+    "2.5.29.37": "extKeyUsage",
+    "2.5.29.38": "authorityAttributeIdentifier",
+    "2.5.29.39": "roleSpecCertIdentifier",
+    "2.5.29.40": "cRLStreamIdentifier",
+    "2.5.29.41": "basicAttConstraints",
+    "2.5.29.42": "delegatedNameConstraints",
+    "2.5.29.43": "timeSpecification",
+    "2.5.29.44": "cRLScope",
+    "2.5.29.45": "statusReferrals",
+    "2.5.29.46": "freshestCRL",
+    "2.5.29.47": "orderedList",
+    "2.5.29.48": "attributeDescriptor",
+    "2.5.29.49": "userNotice",
+    "2.5.29.50": "sOAIdentifier",
+    "2.5.29.51": "baseUpdateTime",
+    "2.5.29.52": "acceptableCertPolicies",
+    "2.5.29.53": "deltaInfo",
+    "2.5.29.54": "inhibitAnyPolicy",
+    "2.5.29.55": "targetInformation",
+    "2.5.29.56": "noRevAvail",
+    "2.5.29.57": "acceptablePrivilegePolicies",
+    "2.5.29.58": "id-ce-toBeRevoked",
+    "2.5.29.59": "id-ce-RevokedGroups",
+    "2.5.29.60": "id-ce-expiredCertsOnCRL",
+    "2.5.29.61": "indirectIssuer",
+    "2.5.29.62": "id-ce-noAssertion",
+    "2.5.29.63": "id-ce-aAissuingDistributionPoint",
+    "2.5.29.64": "id-ce-issuedOnBehaIFOF",
+    "2.5.29.65": "id-ce-singleUse",
+    "2.5.29.66": "id-ce-groupAC",
+    "2.5.29.67": "id-ce-allowedAttAss",
+    "2.5.29.68": "id-ce-attributeMappings",
+    "2.5.29.69": "id-ce-holderNameConstraints"
 }
 
 certExt_oids = {
-    "cert-type": "2.16.840.1.113730.1.1",
-    "base-url": "2.16.840.1.113730.1.2",
-    "revocation-url": "2.16.840.1.113730.1.3",
-    "ca-revocation-url": "2.16.840.1.113730.1.4",
-    "ca-crl-url": "2.16.840.1.113730.1.5",
-    "ca-cert-url": "2.16.840.1.113730.1.6",
-    "renewal-url": "2.16.840.1.113730.1.7",
-    "ca-policy-url": "2.16.840.1.113730.1.8",
-    "homepage-url": "2.16.840.1.113730.1.9",
-    "entity-logo": "2.16.840.1.113730.1.10",
-    "user-picture": "2.16.840.1.113730.1.11",
-    "ssl-server-name": "2.16.840.1.113730.1.12",
-    "comment": "2.16.840.1.113730.1.13",
-    "lost-password-url": "2.16.840.1.113730.1.14",
-    "cert-renewal-time": "2.16.840.1.113730.1.15",
-    "aia": "2.16.840.1.113730.1.16",
-    "cert-scope-of-use": "2.16.840.1.113730.1.17",
+    "2.16.840.1.113730.1.1": "cert-type",
+    "2.16.840.1.113730.1.2": "base-url",
+    "2.16.840.1.113730.1.3": "revocation-url",
+    "2.16.840.1.113730.1.4": "ca-revocation-url",
+    "2.16.840.1.113730.1.5": "ca-crl-url",
+    "2.16.840.1.113730.1.6": "ca-cert-url",
+    "2.16.840.1.113730.1.7": "renewal-url",
+    "2.16.840.1.113730.1.8": "ca-policy-url",
+    "2.16.840.1.113730.1.9": "homepage-url",
+    "2.16.840.1.113730.1.10": "entity-logo",
+    "2.16.840.1.113730.1.11": "user-picture",
+    "2.16.840.1.113730.1.12": "ssl-server-name",
+    "2.16.840.1.113730.1.13": "comment",
+    "2.16.840.1.113730.1.14": "lost-password-url",
+    "2.16.840.1.113730.1.15": "cert-renewal-time",
+    "2.16.840.1.113730.1.16": "aia",
+    "2.16.840.1.113730.1.17": "cert-scope-of-use",
 }
 
 certPkixPe_oids = {
-    "authorityInfoAccess": "1.3.6.1.5.5.7.1.1",
-    "biometricInfo": "1.3.6.1.5.5.7.1.2",
-    "qcStatements": "1.3.6.1.5.5.7.1.3",
-    "auditIdentity": "1.3.6.1.5.5.7.1.4",
-    "aaControls": "1.3.6.1.5.5.7.1.6",
-    "proxying": "1.3.6.1.5.5.7.1.10",
-    "subjectInfoAccess": "1.3.6.1.5.5.7.1.11"
+    "1.3.6.1.5.5.7.1.1": "authorityInfoAccess",
+    "1.3.6.1.5.5.7.1.2": "biometricInfo",
+    "1.3.6.1.5.5.7.1.3": "qcStatements",
+    "1.3.6.1.5.5.7.1.4": "auditIdentity",
+    "1.3.6.1.5.5.7.1.6": "aaControls",
+    "1.3.6.1.5.5.7.1.10": "proxying",
+    "1.3.6.1.5.5.7.1.11": "subjectInfoAccess"
 }
 
 certPkixQt_oids = {
-    "cps": "1.3.6.1.5.5.7.2.1",
-    "unotice": "1.3.6.1.5.5.7.2.2"
+    "1.3.6.1.5.5.7.2.1": "cps",
+    "1.3.6.1.5.5.7.2.2": "unotice"
 }
 
 certPkixKp_oids = {
-    "serverAuth": "1.3.6.1.5.5.7.3.1",
-    "clientAuth": "1.3.6.1.5.5.7.3.2",
-    "codeSigning": "1.3.6.1.5.5.7.3.3",
-    "emailProtection": "1.3.6.1.5.5.7.3.4",
-    "ipsecEndSystem": "1.3.6.1.5.5.7.3.5",
-    "ipsecTunnel": "1.3.6.1.5.5.7.3.6",
-    "ipsecUser": "1.3.6.1.5.5.7.3.7",
-    "timeStamping": "1.3.6.1.5.5.7.3.8",
-    "ocspSigning": "1.3.6.1.5.5.7.3.9",
-    "dvcs": "1.3.6.1.5.5.7.3.10",
-    "secureShellClient": "1.3.6.1.5.5.7.3.21",
-    "secureShellServer": "1.3.6.1.5.5.7.3.22"
+    "1.3.6.1.5.5.7.3.1": "serverAuth",
+    "1.3.6.1.5.5.7.3.2": "clientAuth",
+    "1.3.6.1.5.5.7.3.3": "codeSigning",
+    "1.3.6.1.5.5.7.3.4": "emailProtection",
+    "1.3.6.1.5.5.7.3.5": "ipsecEndSystem",
+    "1.3.6.1.5.5.7.3.6": "ipsecTunnel",
+    "1.3.6.1.5.5.7.3.7": "ipsecUser",
+    "1.3.6.1.5.5.7.3.8": "timeStamping",
+    "1.3.6.1.5.5.7.3.9": "ocspSigning",
+    "1.3.6.1.5.5.7.3.10": "dvcs",
+    "1.3.6.1.5.5.7.3.21": "secureShellClient",
+    "1.3.6.1.5.5.7.3.22": "secureShellServer"
 }
 
 certPkixAd_oids = {
-    "ocsp": "1.3.6.1.5.5.7.48.1",
-    "caIssuers": "1.3.6.1.5.5.7.48.2",
-    "timestamping": "1.3.6.1.5.5.7.48.3",
-    "id-ad-dvcs": "1.3.6.1.5.5.7.48.4",
-    "id-ad-caRepository": "1.3.6.1.5.5.7.48.5",
-    "id-pkix-ocsp-archive-cutoff": "1.3.6.1.5.5.7.48.6",
-    "id-pkix-ocsp-service-locator": "1.3.6.1.5.5.7.48.7",
-    "id-ad-cmc": "1.3.6.1.5.5.7.48.12",
-    "basic-response": "1.3.6.1.5.5.7.48.1.1"
+    "1.3.6.1.5.5.7.48.1": "ocsp",
+    "1.3.6.1.5.5.7.48.2": "caIssuers",
+    "1.3.6.1.5.5.7.48.3": "timestamping",
+    "1.3.6.1.5.5.7.48.4": "id-ad-dvcs",
+    "1.3.6.1.5.5.7.48.5": "id-ad-caRepository",
+    "1.3.6.1.5.5.7.48.6": "id-pkix-ocsp-archive-cutoff",
+    "1.3.6.1.5.5.7.48.7": "id-pkix-ocsp-service-locator",
+    "1.3.6.1.5.5.7.48.12": "id-ad-cmc",
+    "1.3.6.1.5.5.7.48.1.1": "basic-response"
 }
 
 #       ansi-x962       #
 
 x962KeyType_oids = {
-    "prime-field": "1.2.840.10045.1.1",
-    "characteristic-two-field": "1.2.840.10045.1.2",
-    "ecPublicKey": "1.2.840.10045.2.1",
+    "1.2.840.10045.1.1": "prime-field",
+    "1.2.840.10045.1.2": "characteristic-two-field",
+    "1.2.840.10045.2.1": "ecPublicKey",
 }
 
 x962Signature_oids = {
-    "ecdsa-with-SHA1": "1.2.840.10045.4.1",
-    "ecdsa-with-Recommended": "1.2.840.10045.4.2",
-    "ecdsa-with-SHA224": "1.2.840.10045.4.3.1",
-    "ecdsa-with-SHA256": "1.2.840.10045.4.3.2",
-    "ecdsa-with-SHA384": "1.2.840.10045.4.3.3",
-    "ecdsa-with-SHA512": "1.2.840.10045.4.3.4"
+    "1.2.840.10045.4.1": "ecdsa-with-SHA1",
+    "1.2.840.10045.4.2": "ecdsa-with-Recommended",
+    "1.2.840.10045.4.3.1": "ecdsa-with-SHA224",
+    "1.2.840.10045.4.3.2": "ecdsa-with-SHA256",
+    "1.2.840.10045.4.3.3": "ecdsa-with-SHA384",
+    "1.2.840.10045.4.3.4": "ecdsa-with-SHA512"
 }
 
 #       elliptic curves       #
 
 ansiX962Curve_oids = {
-    "prime192v1": "1.2.840.10045.3.1.1",
-    "prime192v2": "1.2.840.10045.3.1.2",
-    "prime192v3": "1.2.840.10045.3.1.3",
-    "prime239v1": "1.2.840.10045.3.1.4",
-    "prime239v2": "1.2.840.10045.3.1.5",
-    "prime239v3": "1.2.840.10045.3.1.6",
-    "prime256v1": "1.2.840.10045.3.1.7"
+    "1.2.840.10045.3.1.1": "prime192v1",
+    "1.2.840.10045.3.1.2": "prime192v2",
+    "1.2.840.10045.3.1.3": "prime192v3",
+    "1.2.840.10045.3.1.4": "prime239v1",
+    "1.2.840.10045.3.1.5": "prime239v2",
+    "1.2.840.10045.3.1.6": "prime239v3",
+    "1.2.840.10045.3.1.7": "prime256v1"
 }
 
 certicomCurve_oids = {
-    "ansit163k1": "1.3.132.0.1",
-    "ansit163r1": "1.3.132.0.2",
-    "ansit239k1": "1.3.132.0.3",
-    "sect113r1": "1.3.132.0.4",
-    "sect113r2": "1.3.132.0.5",
-    "secp112r1": "1.3.132.0.6",
-    "secp112r2": "1.3.132.0.7",
-    "ansip160r1": "1.3.132.0.8",
-    "ansip160k1": "1.3.132.0.9",
-    "ansip256k1": "1.3.132.0.10",
-    "ansit163r2": "1.3.132.0.15",
-    "ansit283k1": "1.3.132.0.16",
-    "ansit283r1": "1.3.132.0.17",
-    "sect131r1": "1.3.132.0.22",
-    "ansit193r1": "1.3.132.0.24",
-    "ansit193r2": "1.3.132.0.25",
-    "ansit233k1": "1.3.132.0.26",
-    "ansit233r1": "1.3.132.0.27",
-    "secp128r1": "1.3.132.0.28",
-    "secp128r2": "1.3.132.0.29",
-    "ansip160r2": "1.3.132.0.30",
-    "ansip192k1": "1.3.132.0.31",
-    "ansip224k1": "1.3.132.0.32",
-    "ansip224r1": "1.3.132.0.33",
-    "ansip384r1": "1.3.132.0.34",
-    "ansip521r1": "1.3.132.0.35",
-    "ansit409k1": "1.3.132.0.36",
-    "ansit409r1": "1.3.132.0.37",
-    "ansit571k1": "1.3.132.0.38",
-    "ansit571r1": "1.3.132.0.39"
+    "1.3.132.0.1": "ansit163k1",
+    "1.3.132.0.2": "ansit163r1",
+    "1.3.132.0.3": "ansit239k1",
+    "1.3.132.0.4": "sect113r1",
+    "1.3.132.0.5": "sect113r2",
+    "1.3.132.0.6": "secp112r1",
+    "1.3.132.0.7": "secp112r2",
+    "1.3.132.0.8": "ansip160r1",
+    "1.3.132.0.9": "ansip160k1",
+    "1.3.132.0.10": "ansip256k1",
+    "1.3.132.0.15": "ansit163r2",
+    "1.3.132.0.16": "ansit283k1",
+    "1.3.132.0.17": "ansit283r1",
+    "1.3.132.0.22": "sect131r1",
+    "1.3.132.0.24": "ansit193r1",
+    "1.3.132.0.25": "ansit193r2",
+    "1.3.132.0.26": "ansit233k1",
+    "1.3.132.0.27": "ansit233r1",
+    "1.3.132.0.28": "secp128r1",
+    "1.3.132.0.29": "secp128r2",
+    "1.3.132.0.30": "ansip160r2",
+    "1.3.132.0.31": "ansip192k1",
+    "1.3.132.0.32": "ansip224k1",
+    "1.3.132.0.33": "ansip224r1",
+    "1.3.132.0.34": "ansip384r1",
+    "1.3.132.0.35": "ansip521r1",
+    "1.3.132.0.36": "ansit409k1",
+    "1.3.132.0.37": "ansit409r1",
+    "1.3.132.0.38": "ansit571k1",
+    "1.3.132.0.39": "ansit571r1"
 }
 
 #       policies       #
@@ -513,56 +518,51 @@ certPolicy_oids = {
 
 # from Chromium source code (ev_root_ca_metadata.cc)
 evPolicy_oids = {
-    "EV AC Camerfirma S.A. Chambers of Commerce Root - 2008": "1.3.6.1.4.1.17326.10.14.2.1.2",  # noqa: E501
-    "EV AC Camerfirma S.A. Chambers of Commerce Root - 2008": "1.3.6.1.4.1.17326.10.14.2.2.2",  # noqa: E501
-    "EV AC Camerfirma S.A. Global Chambersign Root - 2008": "1.3.6.1.4.1.17326.10.8.12.1.2",  # noqa: E501
-    "EV AC Camerfirma S.A. Global Chambersign Root - 2008": "1.3.6.1.4.1.17326.10.8.12.2.2",  # noqa: E501
-    "EV AddTrust/Comodo/USERTrust": "1.3.6.1.4.1.6449.1.2.1.5.1",
-    "EV AddTrust External CA Root": "1.3.6.1.4.1.782.1.2.1.8.1",
-    "EV Actualis Authentication Root CA": "1.3.159.1.17.1",
-    "EV AffirmTrust Commercial": "1.3.6.1.4.1.34697.2.1",
-    "EV AffirmTrust Networking": "1.3.6.1.4.1.34697.2.2",
-    "EV AffirmTrust Premium": "1.3.6.1.4.1.34697.2.3",
-    "EV AffirmTrust Premium ECC": "1.3.6.1.4.1.34697.2.4",
-    "EV Autoridad de Certificacion Firmaprofesional CIF A62634068": "1.3.6.1.4.1.13177.10.1.3.10",  # noqa: E501
-    "EV Baltimore CyberTrust Root": "1.3.6.1.4.1.6334.1.100.1",
-    "EV Buypass Class 3": "2.16.578.1.26.1.3.3",
-    "EV Certificate Authority of WoSign": "1.3.6.1.4.1.36305.2",
-    "EV CertPlus Class 2 Primary CA (KEYNECTIS)": "1.3.6.1.4.1.22234.2.5.2.3.1",  # noqa: E501
-    "EV Certum Trusted Network CA": "1.2.616.1.113527.2.5.1.1",
-    "EV China Internet Network Information Center EV Certificates Root": "1.3.6.1.4.1.29836.1.10",  # noqa: E501
-    "EV Cybertrust Global Root": "1.3.6.1.4.1.6334.1.100.1",
-    "EV DigiCert High Assurance EV Root CA": "2.16.840.1.114412.2.1",
-    "EV D-TRUST Root Class 3 CA 2 EV 2009": "1.3.6.1.4.1.4788.2.202.1",
-    "EV Entrust Certification Authority": "2.16.840.1.114028.10.1.2",
-    "EV Equifax Secure Certificate Authority (GeoTrust)": "1.3.6.1.4.1.14370.1.6",  # noqa: E501
-    "EV E-Tugra Certification Authority": "2.16.792.3.0.4.1.1.4",
-    "EV GeoTrust Primary Certification Authority": "1.3.6.1.4.1.14370.1.6",
-    "EV GlobalSign Root CAs": "1.3.6.1.4.1.4146.1.1",
-    "EV Go Daddy Certification Authority": "2.16.840.1.114413.1.7.23.3",
-    "EV Izenpe.com roots Business": "1.3.6.1.4.1.14777.6.1.1",
-    "EV Izenpe.com roots Government": "1.3.6.1.4.1.14777.6.1.2",
-    "EV Network Solutions Certificate Authority": "1.3.6.1.4.1.781.1.2.1.8.1",
-    "EV QuoVadis Roots": "1.3.6.1.4.1.8024.0.2.100.1.2",
-    "EV SecureTrust Corporation Roots": "2.16.840.1.114404.1.1.2.4.1",
-    "EV Security Communication RootCA1": "1.2.392.200091.100.721.1",
-    "EV Staat der Nederlanden EV Root CA": "2.16.528.1.1003.1.2.7",
-    "EV StartCom Certification Authority": "1.3.6.1.4.1.23223.1.1.1",
-    "EV Starfield Certificate Authority": "2.16.840.1.114414.1.7.23.3",
-    "EV Starfield Service Certificate Authority": "2.16.840.1.114414.1.7.24.3",
-    "EV SwissSign Gold CA - G2": "2.16.756.1.89.1.2.1.1",
-    "EV Swisscom Root EV CA 2": "2.16.756.1.83.21.0",
-    "EV thawte CAs": "2.16.840.1.113733.1.7.48.1",
-    "EV TWCA Roots": "1.3.6.1.4.1.40869.1.1.22.3",
-    "EV T-Telessec GlobalRoot Class 3": "1.3.6.1.4.1.7879.13.24.1",
-    "EV USERTrust Certification Authorities": "1.3.6.1.4.1.6449.1.2.1.5.1",
-    "EV ValiCert Class 2 Policy Validation Authority": "2.16.840.1.114413.1.7.23.3",  # noqa: E501
-    "EV VeriSign Certification Authorities": "2.16.840.1.113733.1.7.23.6",
-    "EV Wells Fargo WellsSecure Public Root Certification Authority": "2.16.840.1.114171.500.9",  # noqa: E501
-    "EV XRamp Global Certification Authority": "2.16.840.1.114404.1.1.2.4.1",
-    "jurisdictionOfIncorporationLocalityName": "1.3.6.1.4.1.311.60.2.1.1",
-    "jurisdictionOfIncorporationStateOrProvinceName": "1.3.6.1.4.1.311.60.2.1.2",  # noqa: E501
-    "jurisdictionOfIncorporationCountryName": "1.3.6.1.4.1.311.60.2.1.3"
+    '1.2.392.200091.100.721.1': 'EV Security Communication RootCA1',
+    '1.2.616.1.113527.2.5.1.1': 'EV Certum Trusted Network CA',
+    '1.3.159.1.17.1': 'EV Actualis Authentication Root CA',
+    '1.3.6.1.4.1.13177.10.1.3.10': 'EV Autoridad de Certificacion Firmaprofesional CIF A62634068',  # noqa: E501
+    '1.3.6.1.4.1.14370.1.6': 'EV GeoTrust Primary Certification Authority',
+    '1.3.6.1.4.1.14777.6.1.1': 'EV Izenpe.com roots Business',
+    '1.3.6.1.4.1.14777.6.1.2': 'EV Izenpe.com roots Government',
+    '1.3.6.1.4.1.17326.10.14.2.1.2': 'EV AC Camerfirma S.A. Chambers of Commerce Root - 2008',  # noqa: E501
+    '1.3.6.1.4.1.17326.10.14.2.2.2': 'EV AC Camerfirma S.A. Chambers of Commerce Root - 2008',  # noqa: E501
+    '1.3.6.1.4.1.17326.10.8.12.1.2': 'EV AC Camerfirma S.A. Global Chambersign Root - 2008',  # noqa: E501
+    '1.3.6.1.4.1.17326.10.8.12.2.2': 'EV AC Camerfirma S.A. Global Chambersign Root - 2008',  # noqa: E501
+    '1.3.6.1.4.1.22234.2.5.2.3.1': 'EV CertPlus Class 2 Primary CA (KEYNECTIS)',  # noqa: E501
+    '1.3.6.1.4.1.23223.1.1.1': 'EV StartCom Certification Authority',
+    '1.3.6.1.4.1.29836.1.10': 'EV China Internet Network Information Center EV Certificates Root',  # noqa: E501
+    '1.3.6.1.4.1.311.60.2.1.1': 'jurisdictionOfIncorporationLocalityName',
+    '1.3.6.1.4.1.311.60.2.1.2': 'jurisdictionOfIncorporationStateOrProvinceName',  # noqa: E501
+    '1.3.6.1.4.1.311.60.2.1.3': 'jurisdictionOfIncorporationCountryName',
+    '1.3.6.1.4.1.34697.2.1': 'EV AffirmTrust Commercial',
+    '1.3.6.1.4.1.34697.2.2': 'EV AffirmTrust Networking',
+    '1.3.6.1.4.1.34697.2.3': 'EV AffirmTrust Premium',
+    '1.3.6.1.4.1.34697.2.4': 'EV AffirmTrust Premium ECC',
+    '1.3.6.1.4.1.36305.2': 'EV Certificate Authority of WoSign',
+    '1.3.6.1.4.1.40869.1.1.22.3': 'EV TWCA Roots',
+    '1.3.6.1.4.1.4146.1.1': 'EV GlobalSign Root CAs',
+    '1.3.6.1.4.1.4788.2.202.1': 'EV D-TRUST Root Class 3 CA 2 EV 2009',
+    '1.3.6.1.4.1.6334.1.100.1': 'EV Cybertrust Global Root',
+    '1.3.6.1.4.1.6449.1.2.1.5.1': 'EV USERTrust Certification Authorities',
+    '1.3.6.1.4.1.781.1.2.1.8.1': 'EV Network Solutions Certificate Authority',
+    '1.3.6.1.4.1.782.1.2.1.8.1': 'EV AddTrust External CA Root',
+    '1.3.6.1.4.1.7879.13.24.1': 'EV T-Telessec GlobalRoot Class 3',
+    '1.3.6.1.4.1.8024.0.2.100.1.2': 'EV QuoVadis Roots',
+    '2.16.528.1.1003.1.2.7': 'EV Staat der Nederlanden EV Root CA',
+    '2.16.578.1.26.1.3.3': 'EV Buypass Class 3',
+    '2.16.756.1.83.21.0': 'EV Swisscom Root EV CA 2',
+    '2.16.756.1.89.1.2.1.1': 'EV SwissSign Gold CA - G2',
+    '2.16.792.3.0.4.1.1.4': 'EV E-Tugra Certification Authority',
+    '2.16.840.1.113733.1.7.23.6': 'EV VeriSign Certification Authorities',
+    '2.16.840.1.113733.1.7.48.1': 'EV thawte CAs',
+    '2.16.840.1.114028.10.1.2': 'EV Entrust Certification Authority',
+    '2.16.840.1.114171.500.9': 'EV Wells Fargo WellsSecure Public Root Certification Authority',  # noqa: E501
+    '2.16.840.1.114404.1.1.2.4.1': 'EV XRamp Global Certification Authority',
+    '2.16.840.1.114412.2.1': 'EV DigiCert High Assurance EV Root CA',
+    '2.16.840.1.114413.1.7.23.3': 'EV ValiCert Class 2 Policy Validation Authority',  # noqa: E501
+    '2.16.840.1.114414.1.7.23.3': 'EV Starfield Certificate Authority',
+    '2.16.840.1.114414.1.7.24.3': 'EV Starfield Service Certificate Authority'  # noqa: E501
 }
 
 

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -292,7 +292,7 @@ x.version == 3
 x.serial == 0xB45E7043E7090B71
 
 = Cert class : Checking signature algorithm
-x.sigAlg == 'sha1_with_rsa_signature'
+x.sigAlg == 'sha1-with-rsa-signature'
 
 = Cert class : Checking issuer extraction in basic format (/C=FR ...)
 x.issuer_str == '/C=FR/ST=Paris/L=Paris/O=Mushroom Corp./OU=Mushroom VPN Services/CN=IKEv2 X.509 Test certificate/emailAddress=ikev2-test@mushroom.corp'
@@ -413,7 +413,7 @@ assert cx.isRevoked([x])
 = CRL class : Test show
 awaited = """
 Version: 1
-sigAlg: sha1_with_rsa_signature
+sigAlg: sha1-with-rsa-signature
 Issuer: /C=US/O=VeriSign, Inc./OU=Class 1 Public Primary Certification Authority
 lastUpdate: Nov 02 00:00:00 2006 GMT
 nextUpdate: Feb 17 23:59:59 2007 GMT

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -292,7 +292,7 @@ x.version == 3
 x.serial == 0xB45E7043E7090B71
 
 = Cert class : Checking signature algorithm
-x.sigAlg == 'sha1_with_rsa_signature' 
+x.sigAlg == 'sha1_with_rsa_signature'
 
 = Cert class : Checking issuer extraction in basic format (/C=FR ...)
 x.issuer_str == '/C=FR/ST=Paris/L=Paris/O=Mushroom Corp./OU=Mushroom VPN Services/CN=IKEv2 X.509 Test certificate/emailAddress=ikev2-test@mushroom.corp'

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10056,6 +10056,7 @@ assert a.src == '00:00:00:00:00:00'
 + ASN.1
 
 = MIB
+~ mib
 
 import tempfile
 fd, fname = tempfile.mkstemp()
@@ -10063,7 +10064,7 @@ os.write(fd, b"-- MIB test\nscapy       OBJECT IDENTIFIER ::= {test 2807}\n")
 os.close(fd)
 
 load_mib(fname)
-assert(len([k for k in conf.mib.iterkeys() if "scapy" in k]) == 1)
+assert(len([k for k in conf.mib.__dict__.values() if "scapy" in k]) == 1)
 
 assert(len([oid for oid in conf.mib]) > 100)
 
@@ -10074,6 +10075,9 @@ assert(len(conf.mib._find("MIB", "keyUsage")))
 assert(len(conf.mib._recurs_find_all((), "MIB", "keyUsage")))
 
 = MIB - graph
+~ mib
+
+import mock
 
 @mock.patch("scapy.asn1.mib.do_graph")
 def get_mib_graph(do_graph):

--- a/test/x509.uts
+++ b/test/x509.uts
@@ -65,7 +65,7 @@ tbs.serialNumber == ASN1_INTEGER(0xb45e7043e7090b71)
 
 = Cert class : Signature algorithm (as advertised by TBSCertificate)
 assert(type(tbs.signature) is X509_AlgorithmIdentifier)
-tbs.signature.algorithm == ASN1_OID("sha1_with_rsa_signature")
+tbs.signature.algorithm == ASN1_OID("sha1-with-rsa-signature")
 
 = Cert class : Issuer structure
 assert(type(tbs.issuer) is list)
@@ -121,7 +121,7 @@ ext[0].extnValue.keyIdentifier == ASN1_STRING(b'\xf3\xd8N\xde\x90\xf7\xe6]\xd2\x
 
 = Cert class : Signature algorithm
 assert(type(x.signatureAlgorithm) is X509_AlgorithmIdentifier)
-x.signatureAlgorithm.algorithm == ASN1_OID("sha1_with_rsa_signature")
+x.signatureAlgorithm.algorithm == ASN1_OID("sha1-with-rsa-signature")
 
 = Cert class : Signature value
 x.signatureValue == ASN1_BIT_STRING(b"6\xce\xdd\x01\xbdz\x1f\x89[\xc71i_\xb5\x90\xac\xb5\x06\x9a\xc1\xe8\xf5Jlk\x01\xf0\xc1\xe0\xd5\x0c\xdb\x83l\x1b\xe5\x19#\xcf\x17\x03\x95\xcc\xe9\n%\x99\xfc\x8a\x9c\xda\xe8\x98\xc2\xc2\xd7\xee\x82h\\c\xabx\xc2\xfe\xa7R\xee'\xda\x94R\xd0V\x8e\xe2\x93\xfb^\xd3>\x8e\x96\x8d\x11\x90\x13`\xc9\xa8\x16=}\x8bG\x99\x07{\xd4oH;\xa8<\x8b\x1bHs&$\x0f|\x01\x9c\x1a\xb5\xbb\xc4\x86l\xcc \xd2MR\x81\xd5\xce\x13\xde\x1d\x99\xc8h\x18\x14\x06\r6]B\xe4\xfcIbt\xeeuE\xfd\xe0\x87\xc7Q\xfeH\x05A$\x13\xeb\xce\xef\xb3\\}M`\xf4\xd3=\x10\xd9\xbb6P]\xceo\x7f\x8dbA\x06\x12\x8eE\xf5\x17\x8fBm&c\xde\x02Oll\xe9jG\xa3N\xb4\x16\x8e\xdfV\x90\x05\x92\xd3\x16\xc7[\xe9\xbb\xec,\x11\xb4\x00\x86\x01\xaaWG\xc2Gd0(2\x1bN\xb3\xd6\xfe\x9fG&\xd2CaX\xd8t\x01q\xaf{;W\xbe\xf2", readable=True)
@@ -153,7 +153,7 @@ tbs.version == None
 
 = CRL class : Signature algorithm (as advertised by TBSCertList)
 assert(type(tbs.signature) is X509_AlgorithmIdentifier)
-tbs.signature.algorithm == ASN1_OID("sha1_with_rsa_signature")
+tbs.signature.algorithm == ASN1_OID("sha1-with-rsa-signature")
 
 = CRL class : Issuer structure
 assert(type(tbs.issuer) is list)
@@ -187,7 +187,7 @@ tbs.crlExtensions == None
 
 = CRL class : Signature algorithm
 assert(type(x.signatureAlgorithm) is X509_AlgorithmIdentifier)
-x.signatureAlgorithm.algorithm == ASN1_OID("sha1_with_rsa_signature")
+x.signatureAlgorithm.algorithm == ASN1_OID("sha1-with-rsa-signature")
 
 = CRL class : Signature value
 x.signatureValue == ASN1_BIT_STRING(b'"\xc9\xf6\xbb\x1d\xa1\xa5=$\xc7\xff\xb0"\x11\xb3p\x06[\xc5U\xdd3v\xa0\x98"\x08cDi\xcfOG%w\x99\x12\x84\xd2\x19\xae \x94\xca,T\x9ak\x81\xd2\x038\xa6Z\x95\x8d*\xe2a\xce\xdb\x19\xcdu\'Y&|V\xe1\xe4\x80q\x1aI\xb2\xaa\xcdI[\xda\x0f\xa8\xff\xce<\n\xfc\xc9\xad\xc6\xde\xc8@d\x0c&\t#\x90\xb7\x9c\xb9P\x03\x8fK\x18\x9f\xb0\xe0e\x0f`\x1c\x1ag\xe5\x85\xc4%\xf5\x0b\xc93\x82R\xe6', readable=True)
@@ -222,7 +222,7 @@ response = OCSP_Response(s)
 assert(response.responseStatus.val == 0)
 assert(isinstance(response.responseBytes, OCSP_ResponseBytes))
 responseBytes = response.responseBytes
-assert(responseBytes.responseType == ASN1_OID("basic_response"))
+assert(responseBytes.responseType == ASN1_OID("basic-response"))
 assert(responseBytes.signatureAlgorithm.algorithm == ASN1_OID("sha256WithRSAEncryption"))
 assert(responseBytes.signatureAlgorithm.parameters == ASN1_NULL(0))
 assert(responseBytes.signature.val_readable[:3] == b"\x90\xef\xf9" and responseBytes.signature.val_readable[-3:] == b"\x8bb\xfc")


### PR DESCRIPTION
See https://github.com/secdev/scapy/pull/1441

This PR reverse the way MIB data is stored in scapy: it makes more sense to use the unique OID as key in the storage dictionaries, rather than its value, that can be a duplicate

I'm pretty sure this even improve speed, as we use `self[key]` less often.

Warning: This PR has 2 breaking changes

- The format of the data dictionaries (raw) has changed, so direct usages of the dictionaries will fail (unlikely to be used as so: people should use `conf.mib`)
- The real values are now being used, rather than the formatted ones (as the values were stored as keys). This means that `-` which was previously converted to `_` (I.e `sha1-...`) will not be replaced anymore. This is the wanted usage, but not the one there used to be. (I’m open to a compatibility “- to _” function if necessary, but I’d rather move away from it)