### PR TITLE
Implement select() per-socket custom method

### DIFF
--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -214,6 +214,14 @@ class _L2bpfSocket(SuperSocket):
         """Dummy recv method"""
         raise Exception("Can't recv anything with %s" % self.__name__)
 
+    @staticmethod
+    def select(sockets, remain=None):
+        """This function is called during sendrecv() routine to select
+        the available sockets.
+        """
+        # sockets, None (means use the socket's recv() )
+        return bpf_select(sockets, remain), None
+
 
 class L2bpfListenSocket(_L2bpfSocket):
     """"Scapy L2 BPF Listen Super Socket"""

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -106,13 +106,6 @@ class CANSocket(SuperSocket):
     def close(self):
         self.ins.close()
 
-    @staticmethod
-    def is_python_can_socket():
-        """Function used to determine if a socket is a python-can CANSocket.
-        This is used from sendrecv, to determine if a non standard _get_pkt()
-        and _select() function needs to be used."""
-        return False
-
 
 @conf.commands.register
 def srcan(pkt, iface=None, receive_own_messages=False,

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -28,6 +28,7 @@ class CANSocketTimeoutElapsed(Scapy_Exception):
 
 
 class CANSocket(SuperSocket):
+    read_allowed_exceptions = (CANSocketTimeoutElapsed,)
     desc = "read/write packets at a given CAN interface " \
            "using a python-can bus object"
 
@@ -71,11 +72,13 @@ class CANSocket(SuperSocket):
             raise ex
 
     @staticmethod
-    def is_python_can_socket():
-        """Function used to determine if a socket is a python-can CANSocket.
-        This is used from sendrecv, to determine if a non standard _get_pkt()
-        and _select() function needs to be used."""
-        return True
+    def select(sockets, remain=None):
+        """This function is called during sendrecv() routine to select
+        the available sockets.
+        """
+        # pcap sockets aren't selectable, so we return all of them
+        # sockets, None (means use the socket's recv() )
+        return sockets, None
 
 
 @conf.commands.register

--- a/scapy/contrib/isotp.uts
+++ b/scapy/contrib/isotp.uts
@@ -89,7 +89,7 @@ else:
     from scapy.contrib.cansocket_python_can import *
 
 
-if CANSocket.is_python_can_socket():
+if "python_can" in CANSocket.__module__:
     import can as python_can
     new_can_socket = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface, bitrate=250000))
 else:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -87,13 +87,12 @@ def _sndrcv_rcv(pks, hsent, stopevent, nbrecv, notans, verbose, chainCC,
         _storage_policy = lambda x, y: (x, y)
     ans = []
 
-    selected, read_func = pks.select([pks])
-    read_func = read_func or pks.__class__.recv
-
     def _get_pkt():
         # SuperSocket.select() returns, according to each socket type,
         # the selected sockets + the function to recv() the packets (or None)
         # (when sockets aren't selectable, should be nonblock_recv)
+        selected, read_func = pks.select([pks])
+        read_func = read_func or pks.__class__.recv
         if selected:
             return read_func(selected[0])
 
@@ -849,7 +848,7 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
         warning("Warning: inconsistent socket types ! The used select function"
                 "will be the one of the first socket")
     # Now let's build the select function, used later on
-    _select = lambda sockets: select_func(sockets)[0]
+    _select = lambda sockets, remain: select_func(sockets, remain)[0]
 
     try:
         if started_callback:
@@ -859,8 +858,7 @@ def sniff(count=0, store=True, offline=None, prn=None, lfilter=None,
                 remain = stoptime - time.time()
                 if remain <= 0:
                     break
-            ins = _select(sniff_sockets)
-            for s in ins:
+            for s in _select(sniff_sockets, remain):
                 try:
                     p = s.recv()
                 except socket.error as ex:

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -243,6 +243,7 @@ if LINUX:
 else:
     assert subprocess.check_call(["ifconfig", "tap0", "up"]) == 0
 
+
 def answer_arp_leak(pkt):
     mymac = b"\x00\x01\x02\x03\x04\x06"
     myip = b"\x01\x02\x03\x02"
@@ -298,7 +299,10 @@ ans, unans = test_arpleak(plen=4)
 assert len(ans) == 1
 assert len(unans) == 1
 
-t_answer.join()
+t_answer.join(15)
+
+if t_answer.isAlive():
+    raise Exception("Test timed out")
 
 if conf.use_pypy:
     # See https://pypy.readthedocs.io/en/latest/cpython_differences.html


### PR DESCRIPTION
This PR implement a dynamic `select()` handling:
- during sniffing methods / sendrecv methods, sockets class are called with `.select(sockets)` and asked to return the selected sockets. This avoids having case-by-case all over sniffing methods, but rather inside their respective SuperSocket subclasses
- read_allowed_exceptions are now extracted from the SuperSocket classes
- a few random comments added