### PR TITLE
Minor UTscapy fixes

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -954,13 +954,16 @@ def main(argv):
     if FORMAT == Format.HTML:
         glob_output = pack_html_campaigns(runned_campaigns, glob_output, LOCAL, glob_title)
 
+    # Write the final output
+    # Note: on Python 2, we force-encode to ignore ascii errors
+    # on Python 3, we need to detect the type of stream
     if OUTPUTFILE == sys.stdout:
         OUTPUTFILE.write(glob_output.encode("utf8", "ignore")
-                         if 'b' in OUTPUTFILE.mode else glob_output)
+                         if 'b' in OUTPUTFILE.mode or six.PY2 else glob_output)
     else:
         with open(OUTPUTFILE, "wb") as f:
             f.write(glob_output.encode("utf8", "ignore")
-                    if 'b' in f.mode else glob_output)
+                    if 'b' in f.mode or six.PY2 else glob_output)
 
     # Delete scapy's test environment vars
     del os.environ['SCAPY_ROOT_DIR']

--- a/test/configs/linux.utsc
+++ b/test/configs/linux.utsc
@@ -18,8 +18,9 @@
   },
   "format": "text",
   "kw_ko": [
+    "osx",
+    "windows",
     "crypto_advanced",
-    "ipv6",
-    "osx"
+    "ipv6"
   ]
 }

--- a/test/configs/osx.utsc
+++ b/test/configs/osx.utsc
@@ -19,6 +19,7 @@
   "format": "text",
   "kw_ko": [
     "linux",
+    "windows",
     "crypto_advanced",
     "ipv6"
   ]

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -20,12 +20,12 @@
   },
   "format": "text",
   "kw_ko": [
+    "osx",
+    "linux",
     "crypto_advanced",
     "mock_read_routes_bsd",
     "require_gui",
     "open_ssl_client",
-    "ipv6",
-    "osx",
-    "linux"
+    "ipv6"
   ]
 }

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -20,11 +20,12 @@
   },
   "format": "html",
   "kw_ko": [
+    "osx",
+    "linux",
     "crypto_advanced",
     "mock_read_routes_bsd",
-    "open_ssl_client",
     "appveyor_only",
-    "osx",
-    "linux"
+    "open_ssl_client",
+    "ipv6"
   ]
 }


### PR DESCRIPTION
- A few minor UTscapy fixes for Python 2.7
- Re-ordering a few messy .utsc files (so that the keyword are OK + in the same order)