### PR TITLE
Fix F821 with Python3

### DIFF
--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -172,8 +172,8 @@ class _EncryptAndVerifyRSA(object):
         s = pkcs_os2ip(S)
         n = self._modulus
         if isinstance(s, int) and six.PY2:
-            s = long(s)
-        if (six.PY2 and not isinstance(s, long)) or s > n - 1:
+            s = long(s)  # noqa: F821
+        if (six.PY2 and not isinstance(s, long)) or s > n - 1:  # noqa: F821
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
         m = pow(s, self._pubExp, n)
@@ -217,8 +217,8 @@ class _DecryptAndSignRSA(object):
         m = pkcs_os2ip(EM)
         n = self._modulus
         if isinstance(m, int) and six.PY2:
-            m = long(m)
-        if (six.PY2 and not isinstance(m, long)) or m > n - 1:
+            m = long(m)  # noqa: F821
+        if (six.PY2 and not isinstance(m, long)) or m > n - 1:  # noqa: F821
             warning("Key._rsaep() expects a long between 0 and n-1")
             return None
         privExp = self.key.private_numbers().d


### PR DESCRIPTION
When flake8 is launched using Python3, it complains about `long`.