### PR TITLE
catch `RuntimeError`s from 3.7 generator fns

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -607,7 +607,7 @@ if conf.use_dnet:
 
             try:
                 intf = next(if_iter)
-            except StopIteration:
+            except StopIteration or RuntimeError:
                 return scapy.consts.LOOPBACK_NAME
 
             return intf.get("name", scapy.consts.LOOPBACK_NAME)

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -607,7 +607,7 @@ if conf.use_dnet:
 
             try:
                 intf = next(if_iter)
-            except StopIteration or RuntimeError:
+            except (StopIteration, RuntimeError):
                 return scapy.consts.LOOPBACK_NAME
 
             return intf.get("name", scapy.consts.LOOPBACK_NAME)

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -402,7 +402,7 @@ def _where(filename, dirs=None, env="PATH"):
                     for path in paths
                     for match in glob(os.path.join(path, filename))
                     if match)
-    except StopIteration or RuntimeError:
+    except (StopIteration, RuntimeError):
         raise IOError("File not found: %s" % filename)
 
 
@@ -872,7 +872,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.name == name)
-        except StopIteration or RuntimeError:
+        except (StopIteration, RuntimeError):
             raise ValueError("Unknown network interface %r" % name)
 
     def dev_from_pcapname(self, pcap_name):
@@ -880,7 +880,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.pcap_name == pcap_name)
-        except StopIteration or RuntimeError:
+        except (StopIteration, RuntimeError):
             raise ValueError("Unknown pypcap network interface %r" % pcap_name)
 
     def dev_from_index(self, if_index):
@@ -888,7 +888,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.win_index == str(if_index))
-        except StopIteration or RuntimeError:
+        except (StopIteration, RuntimeError):
             if str(if_index) == "1":
                 # Test if the loopback interface is set up
                 if isinstance(scapy.consts.LOOPBACK_INTERFACE, NetworkInterface):  # noqa: E501

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -402,7 +402,7 @@ def _where(filename, dirs=None, env="PATH"):
                     for path in paths
                     for match in glob(os.path.join(path, filename))
                     if match)
-    except StopIteration:
+    except StopIteration or RuntimeError:
         raise IOError("File not found: %s" % filename)
 
 
@@ -872,7 +872,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.name == name)
-        except StopIteration:
+        except StopIteration or RuntimeError:
             raise ValueError("Unknown network interface %r" % name)
 
     def dev_from_pcapname(self, pcap_name):
@@ -880,7 +880,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.pcap_name == pcap_name)
-        except StopIteration:
+        except StopIteration or RuntimeError:
             raise ValueError("Unknown pypcap network interface %r" % pcap_name)
 
     def dev_from_index(self, if_index):
@@ -888,7 +888,7 @@ class NetworkInterfaceDict(UserDict):
         try:
             return next(iface for iface in six.itervalues(self)
                         if iface.win_index == str(if_index))
-        except StopIteration:
+        except StopIteration or RuntimeError:
             if str(if_index) == "1":
                 # Test if the loopback interface is set up
                 if isinstance(scapy.consts.LOOPBACK_INTERFACE, NetworkInterface):  # noqa: E501

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -801,7 +801,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                             c = Message(type=_ATMT_Command.SINGLESTEP, state=state)  # noqa: E501
                             self.cmdout.send(c)
                             break
-            except StopIteration or RuntimeError as e:
+            except (StopIteration, RuntimeError) as e:
                 c = Message(type=_ATMT_Command.END,
                             result=self.final_state_output)
                 self.cmdout.send(c)

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -801,7 +801,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                             c = Message(type=_ATMT_Command.SINGLESTEP, state=state)  # noqa: E501
                             self.cmdout.send(c)
                             break
-            except StopIteration as e:
+            except StopIteration or RuntimeError as e:
                 c = Message(type=_ATMT_Command.END,
                             result=self.final_state_output)
                 self.cmdout.send(c)

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1446,7 +1446,7 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
         # Find the source address we will use
         try:
             addr = next(x for x in in6_getifaddr() if x[2] == iface and in6_islladdr(x[0]))  # noqa: E501
-        except StopIteration:
+        except StopIteration or RuntimeError:
             warning("Unable to get a Link-Local address")
             return
         else:

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1446,7 +1446,7 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
         # Find the source address we will use
         try:
             addr = next(x for x in in6_getifaddr() if x[2] == iface and in6_islladdr(x[0]))  # noqa: E501
-        except StopIteration or RuntimeError:
+        except (StopIteration, RuntimeError):
             warning("Unable to get a Link-Local address")
             return
         else:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1249,7 +1249,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             if not self.header_present:
                 try:
                     p = next(pkt)
-                except StopIteration:
+                except StopIteration or RuntimeError:
                     self._write_header(None)
                     return
                 self._write_header(p)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1249,7 +1249,7 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             if not self.header_present:
                 try:
                     p = next(pkt)
-                except StopIteration or RuntimeError:
+                except (StopIteration, RuntimeError):
                     self._write_header(None)
                     return
                 self._write_header(p)

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -891,7 +891,7 @@ class Net6(Gen):  # syntax ex. fec0::/126
     def __str__(self):
         try:
             return next(self.__iter__())
-        except StopIteration or RuntimeError:
+        except (StopIteration, RuntimeError):
             return None
 
     def __eq__(self, other):

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -891,7 +891,7 @@ class Net6(Gen):  # syntax ex. fec0::/126
     def __str__(self):
         try:
             return next(self.__iter__())
-        except StopIteration:
+        except StopIteration or RuntimeError:
             return None
 
     def __eq__(self, other):


### PR DESCRIPTION
should fix #1570 
`except StopIteration:` is changed to `except StopIterator or RuntimeError`
all occurrences of `raise StopIteration` are in Iterator classes, not generator functions, so they should be able to be left as is.
`run_tests_py3` on py3.7.0 has 1188 passed and 44 failed before and after the commit