### PR TITLE
Don't put the interface in promiscuous mode while getting the BPF filter

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -102,7 +102,8 @@ def attach_filter(fd, iface, bpf_filter_string):
     """Attach a BPF filter to the BPF file descriptor"""
 
     # Retrieve the BPF byte code in decimal
-    command = "%s -i %s -ddd -s 1600 '%s'" % (conf.prog.tcpdump, iface, bpf_filter_string)  # noqa: E501
+    cmd_fmt = "%s -p -i %s -ddd -s 1600 '%s'"
+    command = cmd_fmt % (conf.prog.tcpdump, iface, bpf_filter_string)
     try:
         f = os.popen(command)
     except OSError as msg:

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -149,7 +149,7 @@ def attach_filter(s, bpf_filter, iface):
     if not TCPDUMP:
         return
     try:
-        f = os.popen("%s -i %s -ddd -s %d '%s'" % (
+        f = os.popen("%s -p -i %s -ddd -s %d '%s'" % (
             conf.prog.tcpdump,
             conf.iface if iface is None else iface,
             MTU,


### PR DESCRIPTION
This PR fixes #1623.

I believe that there is not need for `tcpdump` do be run in promiscuous mode, so I decided to always use `-p`.