### PR TITLE
Introduce match_subclass Packet parameter

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -355,6 +355,7 @@ class Dot11(Packet):
 
 class Dot11FCS(Dot11):
     name = "802.11-FCS"
+    match_subclass = True
     fields_desc = Dot11.fields_desc + [XLEIntField("fcs", None)]  # Automatically moved to the end of the packet  # noqa: E501
 
     def compute_fcs(self, s):

--- a/scapy/layers/dot15d4.py
+++ b/scapy/layers/dot15d4.py
@@ -145,6 +145,7 @@ class Dot15d4FCS(Dot15d4):
     that will validate the FCS/CRC in firmware, and add it automatically when transmitting.  # noqa: E501
     '''
     name = "802.15.4 - FCS"
+    match_subclass = True
     fields_desc = Dot15d4.fields_desc + [XLEShortField("fcs", None)]  # Automatically moved to the end of the packet  # noqa: E501
 
     def compute_fcs(self, data):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -74,6 +74,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
     payload_guess = []
     show_indent = 1
     show_summary = True
+    match_subclass = False
     class_dont_cache = dict()
     class_packetfields = dict()
     class_default_fields = dict()
@@ -1012,10 +1013,12 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
                         return ret
         return self.payload.haslayer(cls)
 
-    def getlayer(self, cls, nb=1, _track=None, _subclass=False, **flt):
+    def getlayer(self, cls, nb=1, _track=None, _subclass=None, **flt):
         """Return the nb^th layer that is an instance of cls, matching flt
 values.
         """
+        if _subclass is None:
+            _subclass = self.match_subclass or None
         if _subclass:
             match = lambda cls1, cls2: issubclass(cls1, cls2)
         else:

--- a/test/dot15d4.uts
+++ b/test/dot15d4.uts
@@ -23,6 +23,11 @@ assert Dot15d4CmdGTSReq in pkt.layers()
 assert Dot15d4Data in pkt.layers()
 assert Dot15d4FCS in pkt.layers()
 
+= Dot15d4FCS parent matching
+
+pkt = Ether()/IP()/Dot15d4FCS()
+assert pkt[Dot15d4]
+
 ###################
 #### SixLoWPAN ####
 ###################

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -976,6 +976,10 @@ assert(len(y[TFTP_Options].options) == 2 and y[TFTP_Option].oname == b"blksize")
 ############
 + Dot11 tests
 
+= Dot11FCS parent matching
+
+pkt = Ether()/IP()/Dot11FCS()
+assert pkt[Dot11]
 
 = WEP tests
 ~ wifi crypto Dot11 LLC SNAP IP TCP


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10530980/47531393-d3411600-d8ad-11e8-830b-723c22ec72ad.png)


I don't know how clean this is. It's actually pretty handy.
I'm not a big fan of the name `_PacketAllowSubclass`. any suggestions ?

- fixes https://github.com/secdev/scapy/issues/1590
- fixes https://github.com/secdev/scapy/issues/1828