### PR TITLE
Fix branch 1668

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1284,6 +1284,12 @@ class FieldListField(Field):
         ret = b""
         if len_pkt is not None:
             s, ret = s[:len_pkt], s[len_pkt:]
+            if len_pkt > len(s):  # len_pkt is bigger than s, so we truncate
+                return b'' + ret, [b'Error/Malformed: Vector length '
+                                   + str(len_pkt).encode()
+                                   + b' is too large, truncating it to '
+                                   + str(len(s)).encode()
+                                   + b'original is : "' + s + b'"']
 
         while s:
             if c is not None:

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1285,11 +1285,11 @@ class FieldListField(Field):
         if len_pkt is not None:
             s, ret = s[:len_pkt], s[len_pkt:]
             if len_pkt > len(s):  # len_pkt is bigger than s, so we truncate
-                return b'' + ret, [b'Error/Malformed: Vector length '
+                return b'' + ret, [b"Error/Malformed: Vector length "
                                    + str(len_pkt).encode()
-                                   + b' is too large, truncating it to '
+                                   + b" is too large, truncating it to "
                                    + str(len(s)).encode()
-                                   + b'original is : "' + s + b'"']
+                                   + b" original is : \"" + s + b"\""]
 
         while s:
             if c is not None:


### PR DESCRIPTION
The problem was an extension of the handshake protocole "Server Hello" inside the TLS packet, named "supported_versions".

The length of the versions was supposed to be 3, but the real size was 1, so scapy was trying to parse more than it could, and because of that it was returning the raw data.

The fix is adding a test to know if the size is less than what it should be, and it also does like wireshark, which writes that there is an error/malformation, give the supposed length and the real one. But scapy will also show the raw data.

The result for the code in the issue will be : 

`###[ TLS ]### `
`    type= handshake`
`    version= TLS 1.2`
`    len= 122`
`    iv= b''`
`    \msg\`
`     |###[ TLS Handshake - Server Hello ]###` 
`     |    msgtype= server_hello`
`     |    msglen= 118`
`     |    version= TLS 1.2`
`     |    gmt_unix_time= Mon, 09 Feb 2015 08:41:13 +0000 (1423471273)`
`     |    random_bytes= 60290781a55827539ab607abe2ba8db77a212053ad7e98c92598ba46`
`     |    sidlen= 32`
`     |    sid= '3\xd5b\xb3\x93T\x0cu @X3\xf0n\x8c\x84\xd0\xdf\xb0\xe8\xe0\x9f.\xa9\xd4\xe7\xb8T\x81\xb9\x89\xac'`
`     |    cipher= TLS_AES_128_GCM_SHA256`
`     |    comp= null`
`     |    extlen= 46`
`     |    \ext\`
`     |     |###[ TLS Extension - Scapy Unknown ]###` 
`     |     |    type= 51`
`     |     |    len= 36`
`     |     |    val= '\x00\x1d\x00 \x10\x0bro\xd7z\x0f\xd0\xe6\xa0\x02(W\x9d^d\x9fA\x05\x1a\x9b+Y\xf5\xaf\xb0\x9f\xe7/y4\x10'`
`     |     |###[ TLS Extension - Supported Versions ]###` 
`     |     |    type= supported_versions`
`     |     |    len= 2`
`     |     |    versionslen= 3`
`     |     |    versions= [b'Error/Malformed: Vector length 3 is too large, truncating it to 1 original is : "\x04"']`
`  mac= b''`
`  pad= b''`
`  padlen= None`

fixes #1668

