### PR TITLE
Corrected pip download command

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 1.  Please check that you are using the latest scapy version, e.g. installed via:
 
-    `pip install https://github.com/secdev/scapy`
+    `pip install --upgrade git+git://github.com/secdev/scapy`
 
 2.  If you are here to ask a question - please check previous issues and online resources, and consider using gitter instead: <https://gitter.im/secdev/scapy>
 


### PR DESCRIPTION
This fixes the pip download command in the issue template.

The current pip download command (`pip install https://github.com/secdev/scapy`) produces the following output:
```
The directory '/home/george/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/george/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting https://github.com/secdev/scapy
  Downloading https://github.com/secdev/scapy
     / 204kB 3.6MB/s
  Cannot unpack file /tmp/pip-HsBjcU-unpack/scapy (downloaded from /tmp/pip-chxNw2-build, content-type: text/html; charset=utf-8); cannot detect archive format
Cannot determine archive format of /tmp/pip-chxNw2-build
```

Changing the command to use the `git+git://` prefix (`pip install --upgrade git+git://github.com/secdev/scapy`) fixes this.
