### PR TITLE
Fix deprecated import

### DIFF
--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -9,7 +9,7 @@ DHCP (Dynamic Host Configuration Protocol) and BOOTP
 
 from __future__ import absolute_import
 from __future__ import print_function
-from collections import Iterable
+from collections.abc import Iterable
 import random
 import struct
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -9,7 +9,11 @@ DHCP (Dynamic Host Configuration Protocol) and BOOTP
 
 from __future__ import absolute_import
 from __future__ import print_function
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # For backwards compatibility.  This was removed in Python 3.8
+    from collections import Iterable
 import random
 import struct
 


### PR DESCRIPTION
`from collections import Iterable` was removed in Python 3.8
