### PR TITLE
Python 2 & 3 - use errno attribute to handle OSError and socket.error

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -523,7 +523,7 @@ class L2Socket(SuperSocket):
         try:
             return SuperSocket.send(self, x)
         except socket.error as msg:
-            if msg[0] == 22 and len(x) < conf.min_pkt_size:
+            if msg.errno == 22 and len(x) < conf.min_pkt_size:
                 padding = b"\x00" * (conf.min_pkt_size - len(x))
                 if isinstance(x, Packet):
                     return SuperSocket.send(self, x / Padding(load=padding))
@@ -565,9 +565,9 @@ class L3PacketSocket(L2Socket):
         try:
             self.outs.sendto(sx, sdto)
         except socket.error as msg:
-            if msg[0] == 22 and len(sx) < conf.min_pkt_size:
+            if msg.errno == 22 and len(sx) < conf.min_pkt_size:
                 self.outs.send(sx + b"\x00" * (conf.min_pkt_size - len(sx)))
-            elif conf.auto_fragment and msg[0] == 90:
+            elif conf.auto_fragment and msg.errno == 90:
                 for p in x.fragment():
                     self.outs.sendto(raw(ll(p)), sdto)
             else:

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -126,7 +126,8 @@ class AS_resolver_multi(AS_resolver):
             try:
                 res = ASres.resolve(*todo)
             except socket.error as e:
-                if e[0] in [errno.ECONNREFUSED, errno.ETIMEDOUT, errno.ECONNRESET]:  # noqa: E501
+                if e.errno in [errno.ECONNREFUSED, errno.ETIMEDOUT,
+                   errno.ECONNRESET]:
                     continue
             resolved = [ip for ip, asn, desc in res]
             todo = [ip for ip in todo if ip not in resolved]

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -330,3 +330,17 @@ def test_read_routes(mock_ioctl):
     read_routes()
 
 test_read_routes()
+
+
+= L3PacketSocket sendto exception
+~ linux needs_root
+
+if six.PY3:
+    import mock, six, socket
+    @mock.patch("scapy.arch.linux.socket.socket.sendto")
+    def test_L3PacketSocket_sendto_python3(mock_sendto):
+        mock_sendto.side_effect = OSError(22, 2807)
+        l3ps = L3PacketSocket()
+        l3ps.send(IP(dst="8.8.8.8")/ICMP())
+        return True
+    assert test_L3PacketSocket_sendto_python3()


### PR DESCRIPTION
This PR fixes #1683.