### PR TITLE
Add support for PPPoE tags

### DIFF
--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -41,15 +41,58 @@ class PPPoE(Packet):
         return p
 
 
+# PPPoE Active Discovery Code fields (RFC2516, RFC5578)
 class PPPoED(PPPoE):
     name = "PPP over Ethernet Discovery"
+
+    code_list = {0x00: "PPP Session Stage",
+                 0x09: "PPPoE Active Discovery Initiation (PADI)",
+                 0x07: "PPPoE Active Discovery Offer (PADO)",
+                 0x0a: "PPPoE Active Discovery Session-Grant (PADG)",
+                 0x0b: "PPPoE Active Discovery Session-Credit Response (PADC)", 
+                 0x0c: "PPPoE Active Discovery Quality (PADQ)", 
+                 0x19: "PPPoE Active Discovery Request (PADR)",
+                 0x65: "PPPoE Active Discovery Session-confirmation (PADS)",
+                 0xa7: "PPPoE Active Discovery Terminate (PADT)"}
+
     fields_desc = [BitField("version", 1, 4),
                    BitField("type", 1, 4),
-                   ByteEnumField("code", 0x09, {0x09: "PADI", 0x07: "PADO",
-                                                0x19: "PADR", 0x65: "PADS",
-                                                0xa7: "PADT"}),
+                   ByteEnumField("code", 0x09, code_list),
                    XShortField("sessionid", 0x0),
                    ShortField("len", None)]
+
+
+# PPPoE Tag types (RFC2516, RFC4638, RFC5578)
+class PPPoETag(Packet):
+    name = "PPPoE Tag"
+
+    tag_list = {0x0000: 'End-Of-List',
+                0x0101: 'Service-Name',
+                0x0102: 'AC-Name',
+                0x0103: 'Host-Uniq',
+                0x0104: 'AC-Cookie',
+                0x0105: 'Vendor-Specific',
+                0x0106: 'Credits',
+                0x0107: 'Metrics',
+                0x0108: 'Sequence Number',
+                0x0109: 'Credit Scale Factor',
+                0x0110: 'Relay-Session-Id',
+                0x0120: 'PPP-Max-Payload',
+                0x0201: 'Service-Name-Error',
+                0x0202: 'AC-System-Error',
+                0x0203: 'Generic-Error'}
+
+    fields_desc = [ ShortEnumField('tag_type', None, tag_list),
+                    FieldLenField('tag_len', None, length_of='tag_value', fmt='H'),
+                    StrLenField('tag_value', '', length_from=lambda pkt:pkt.tag_len)]
+
+    def extract_padding(self, s):
+        return '', s
+
+
+class PPPoED_Tags(Packet):
+    name = "PPPoE Tag List"
+    fields_desc = [ PacketListField('tag_list', None, PPPoETag) ]
 
 
 _PPP_PROTOCOLS = {
@@ -823,7 +866,7 @@ class PPP_CHAP_ChallengeResponse(PPP_CHAP):
         else:
             return super(PPP_CHAP_ChallengeResponse, self).mysummary()
 
-
+bind_layers(PPPoED, PPPoED_Tags, type=1)
 bind_layers(Ether, PPPoED, type=0x8863)
 bind_layers(Ether, PPPoE, type=0x8864)
 bind_layers(CookedLinux, PPPoED, proto=0x8863)

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -49,8 +49,8 @@ class PPPoED(PPPoE):
                  0x09: "PPPoE Active Discovery Initiation (PADI)",
                  0x07: "PPPoE Active Discovery Offer (PADO)",
                  0x0a: "PPPoE Active Discovery Session-Grant (PADG)",
-                 0x0b: "PPPoE Active Discovery Session-Credit Response (PADC)", 
-                 0x0c: "PPPoE Active Discovery Quality (PADQ)", 
+                 0x0b: "PPPoE Active Discovery Session-Credit Response (PADC)",
+                 0x0c: "PPPoE Active Discovery Quality (PADQ)",
                  0x19: "PPPoE Active Discovery Request (PADR)",
                  0x65: "PPPoE Active Discovery Session-confirmation (PADS)",
                  0xa7: "PPPoE Active Discovery Terminate (PADT)"}
@@ -82,9 +82,11 @@ class PPPoETag(Packet):
                 0x0202: 'AC-System-Error',
                 0x0203: 'Generic-Error'}
 
-    fields_desc = [ ShortEnumField('tag_type', None, tag_list),
-                    FieldLenField('tag_len', None, length_of='tag_value', fmt='H'),
-                    StrLenField('tag_value', '', length_from=lambda pkt:pkt.tag_len)]
+    fields_desc = [
+        ShortEnumField('tag_type', None, tag_list),
+        FieldLenField('tag_len', None, length_of='tag_value', fmt='H'),
+        StrLenField('tag_value', '', length_from=lambda pkt:pkt.tag_len)
+    ]
 
     def extract_padding(self, s):
         return '', s
@@ -92,7 +94,7 @@ class PPPoETag(Packet):
 
 class PPPoED_Tags(Packet):
     name = "PPPoE Tag List"
-    fields_desc = [ PacketListField('tag_list', None, PPPoETag) ]
+    fields_desc = [PacketListField('tag_list', None, PPPoETag)]
 
 
 _PPP_PROTOCOLS = {
@@ -865,6 +867,7 @@ class PPP_CHAP_ChallengeResponse(PPP_CHAP):
             )
         else:
             return super(PPP_CHAP_ChallengeResponse, self).mysummary()
+
 
 bind_layers(PPPoED, PPPoED_Tags, type=1)
 bind_layers(Ether, PPPoED, type=0x8863)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1887,6 +1887,26 @@ assert(q[TCP].flags == 2)
 ############
 + Test PPP
 
+= PPPoE
+~ ppp pppoe
+p=Ether(b'\xff\xff\xff\xff\xff\xff\x08\x00\x27\xf3<5\x88c\x11\x09\x00\x00\x00\x0c\x01\x01\x00\x00\x01\x03\x00\x04\x01\x02\x03\x04\x00\x00\x00\x00')
+p
+assert(p[Ether].type==0x8863)
+assert(PPPoED in p)
+assert(p[PPPoED].version==1)
+assert(p[PPPoED].type==1)
+assert(p[PPPoED].code==0x09)
+assert(PPPoED_Tags in p)
+q=p[PPPoED_Tags]
+assert(q.tag_list is not None)
+r=q.tag_list
+assert(r[0].tag_type==0x0101)
+assert(r[1].tag_type==0x0103)
+assert(r[1].tag_len==4)
+assert(r[1].tag_value==b'\x01\x02\x03\x04')
+assert(r[2].tag_type==0x0000)
+
+
 = PPP/HDLC
 ~ ppp hdlc
 p = HDLC()/PPP()/PPP_IPCP()


### PR DESCRIPTION
Added PPPoE tags and discovery codes following [RFC2516](https://tools.ietf.org/html/rfc2516), [RFC4638](https://tools.ietf.org/html/rfc4638) and [RFC5578](https://tools.ietf.org/html/rfc5578).

Now instead of displaying it as raw data, it displays the list of PPPoE tags as requested in issue #1496

This is my first contribution, feel free to comment, edit or request modifications!

