### PR TITLE
Pcapfix

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -22,6 +22,10 @@ def str2mac(s):
     return ("%02x:" * 6)[:-1] % tuple(orb(x) for x in s)
 
 
+class ScapyInvalidPlatformException(Scapy_Exception):
+    pass
+
+
 if not WINDOWS:
     if not scapy.config.conf.use_pcap and not scapy.config.conf.use_dnet:
         from scapy.arch.bpf.core import get_if_raw_addr
@@ -53,20 +57,13 @@ def get_if_hwaddr(iff):
 
 if LINUX:
     from scapy.arch.linux import *  # noqa F403
-    if scapy.config.conf.use_pcap or scapy.config.conf.use_dnet:
-        from scapy.arch.pcapdnet import *  # noqa F403
 elif BSD:
     from scapy.arch.unix import read_routes, read_routes6, in6_getifaddr  # noqa: F401, E501
 
-    if scapy.config.conf.use_pcap or scapy.config.conf.use_dnet:
-        from scapy.arch.pcapdnet import *  # noqa F403
-    else:
+    if not scapy.config.conf.use_pcap or scapy.config.conf.use_dnet:
         from scapy.arch.bpf.supersocket import L2bpfListenSocket, L2bpfSocket, L3bpfSocket  # noqa: E501
         from scapy.arch.bpf.core import *  # noqa F403
         scapy.config.conf.use_bpf = True
-        scapy.config.conf.L2listen = L2bpfListenSocket
-        scapy.config.conf.L2socket = L2bpfSocket
-        scapy.config.conf.L3socket = L3bpfSocket
 elif SOLARIS:
     from scapy.arch.solaris import *  # noqa F403
 elif WINDOWS:
@@ -75,6 +72,51 @@ elif WINDOWS:
 if scapy.config.conf.iface is None:
     scapy.config.conf.iface = scapy.consts.LOOPBACK_INTERFACE
 
+
+def _set_conf_sockets():
+    """Populate the conf.L2Socket and conf.L3Socket
+    according to the various use_* parameters
+    """
+    # Caution: Use setattr on conf.use_* to avoid circular calls
+    if conf.use_pcap or conf.use_dnet or conf.use_winpcapy:
+        if conf.use_winpcapy and not WINDOWS:
+            setattr(conf, "use_winpcapy", False)
+            raise ScapyInvalidPlatformException
+        import scapy.arch.pcapdnet
+        try:
+            from scapy.arch.pcapdnet import L2pcapListenSocket, L2pcapSocket, \
+                    L3pcapSocket
+        except ImportError:
+            warning("No pcap provider available ! pcap wont be used")
+            setattr(conf, "use_pcap", False)
+            setattr(conf, "use_winpcapy", False)
+        else:
+            conf.L2listen = L2pcapListenSocket
+            conf.L2socket = L2pcapSocket
+            conf.L3socket = L3pcapSocket
+            return
+    if conf.use_bpf:
+        if not DARWIN:
+            setattr(conf, "use_bpf", False)
+            raise ScapyInvalidPlatformException
+        conf.L2listen = L2bpfListenSocket
+        conf.L2socket = L2bpfSocket
+        conf.L3socket = L3bpfSocket
+        return
+    if LINUX:
+        conf.L3socket = L3PacketSocket
+        conf.L2socket = L2Socket
+        conf.L2listen = L2ListenSocket
+        return
+    if WINDOWS:  # Should have been conf.use_winpcapy
+        from scapy.arch.windows import _NotAvailableSocket
+        conf.L2socket = _NotAvailableSocket
+        conf.L2listen = _NotAvailableSocket
+        conf.L3socket = _NotAvailableSocket
+        return
+
+
+_set_conf_sockets()  # Apply config
 
 def get_if_addr6(iff):
     """

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -114,6 +114,8 @@ def _set_conf_sockets():
         conf.L2listen = _NotAvailableSocket
         conf.L3socket = _NotAvailableSocket
         return
+    from scapy.supersocket import L3RawSocket
+    conf.L3socket = L3RawSocket
 
 
 _set_conf_sockets()  # Apply config

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -574,15 +574,6 @@ class L3PacketSocket(L2Socket):
                 raise
 
 
-conf.L3socket = L3PacketSocket
-conf.L2socket = L2Socket
-conf.L2listen = L2ListenSocket
-
-
-class ScapyInvalidPlatformException(Scapy_Exception):
-    pass
-
-
 class VEthPair(object):
     """
     encapsulates a virtual Ethernet interface pair
@@ -592,7 +583,8 @@ class VEthPair(object):
 
         if not LINUX:
             # ToDo: do we need a kernel version check here?
-            raise ScapyInvalidPlatformException('virtual Ethernet interface pair only available on Linux')  # noqa: E501
+            raise scapy.arch.ScapyInvalidPlatformException('virtual Ethernet'
+            'interface pair only available on Linux')
 
         self.ifaces = [iface_name, peer_name]
 

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -29,8 +29,8 @@ from scapy.packet import Packet, Padding
 from scapy.config import conf
 from scapy.data import MTU, ETH_P_ALL
 from scapy.supersocket import SuperSocket
-import scapy.arch
-from scapy.error import warning, Scapy_Exception, log_interactive, log_loading
+from scapy.error import warning, Scapy_Exception, log_interactive, \
+    log_loading, ScapyInvalidPlatformException
 from scapy.arch.common import get_if, get_bpf_pointer
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
@@ -583,8 +583,9 @@ class VEthPair(object):
 
         if not LINUX:
             # ToDo: do we need a kernel version check here?
-            raise scapy.arch.ScapyInvalidPlatformException('virtual Ethernet'
-            'interface pair only available on Linux')
+            raise ScapyInvalidPlatformException(
+                'Virtual Ethernet interface pair only available on Linux'
+            )
 
         self.ifaces = [iface_name, peer_name]
 

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -171,7 +171,7 @@ if conf.use_winpcapy:
         elif b"npcap" in version.lower():
             conf.use_npcap = True
             LOOPBACK_NAME = scapy.consts.LOOPBACK_NAME = "Npcap Loopback Adapter"  # noqa: E501
-    except OSError as e:
+    except OSError:
         conf.use_winpcapy = False
         if conf.interactive:
             log_loading.warning("wpcap.dll is not installed. You won't be able to send/receive packets. Visit the scapy's doc to install it")  # noqa: E501
@@ -286,11 +286,11 @@ if conf.use_pcap:
             _PCAP_MODE = "pypcap"
         except ImportError as e2:
             try:
-                # This is our last chance, but we dont really
+                # This is our last chance, but we don't really
                 # recommand it as very little tested
                 import libpcap as pcap  # python-libpcap
                 _PCAP_MODE = "libpcap"
-            except ImportError as e3:
+            except ImportError:
                 if conf.interactive:
                     log_loading.error(
                         "Unable to import any of the pcap "
@@ -303,7 +303,7 @@ if conf.use_pcap:
         if _PCAP_MODE == "pypcap":  # python-pypcap
             class _PcapWrapper_pypcap:  # noqa: F811
                 def __init__(self, device, snaplen, promisc,
-                        to_ms, monitor=False):
+                             to_ms, monitor=False):
                     try:
                         self.pcap = pcap.pcap(device, snaplen, promisc, immediate=1, timeout_ms=to_ms, rfmon=monitor)  # noqa: E501
                     except TypeError:
@@ -474,7 +474,6 @@ if conf.use_pcap or conf.use_winpcapy:
 
         def send(self, x):
             raise Scapy_Exception("Can't send anything with L2pcapListenSocket")  # noqa: E501
-
 
     class L2pcapSocket(_L2pcapdnetSocket):
         desc = "read/write packets at layer 2 using only libpcap"

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -472,7 +472,6 @@ if conf.use_pcap or conf.use_winpcapy:
         def send(self, x):
             raise Scapy_Exception("Can't send anything with L2pcapListenSocket")  # noqa: E501
 
-    conf.L2listen = L2pcapListenSocket
 
     class L2pcapSocket(_L2pcapdnetSocket):
         desc = "read/write packets at layer 2 using only libpcap"
@@ -552,8 +551,7 @@ if conf.use_pcap or conf.use_winpcapy:
             if hasattr(x, "sent_time"):
                 x.sent_time = time.time()
             return self.ins.send(sx)
-    conf.L2socket = L2pcapSocket
-    conf.L3socket = L3pcapSocket
+
 
 ##########
 #  DNET  #

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -47,9 +47,9 @@ _winapi_SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
 _winapi_SetHandleInformation.restype = wintypes.BOOL
 _winapi_SetHandleInformation.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD]  # noqa: E501
 
-setattr(conf, "use_winpcapy", True)
-setattr(conf, "use_pcap", False)
-setattr(conf, "use_dnet", False)
+conf.use_winpcapy = True
+conf.use_pcap = False
+conf.use_dnet = False
 
 # These import must appear after setting conf.use_* variables
 from scapy.arch import pcapdnet  # noqa: E402
@@ -1351,4 +1351,3 @@ class _NotAvailableSocket(SuperSocket):
     def __init__(self, *args, **kargs):
         raise RuntimeError("Sniffing and sending packets is not available: "  # noqa: E501
                            "winpcap is not installed")
-

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -47,7 +47,9 @@ _winapi_SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
 _winapi_SetHandleInformation.restype = wintypes.BOOL
 _winapi_SetHandleInformation.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD]  # noqa: E501
 
-conf.use_winpcapy = True
+setattr(conf, "use_winpcapy", True)
+setattr(conf, "use_pcap", False)
+setattr(conf, "use_dnet", False)
 
 # These import must appear after setting conf.use_* variables
 from scapy.arch import pcapdnet  # noqa: E402

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -47,8 +47,6 @@ _winapi_SetHandleInformation = ctypes.windll.kernel32.SetHandleInformation
 _winapi_SetHandleInformation.restype = wintypes.BOOL
 _winapi_SetHandleInformation.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD]  # noqa: E501
 
-conf.use_pcap = False
-conf.use_dnet = False
 conf.use_winpcapy = True
 
 # These import must appear after setting conf.use_* variables
@@ -1345,15 +1343,10 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
             routes.append(loopback_route)
 
 
-if not conf.use_winpcapy:
+class _NotAvailableSocket(SuperSocket):
+    desc = "wpcap.dll missing"
 
-    class NotAvailableSocket(SuperSocket):
-        desc = "wpcap.dll missing"
+    def __init__(self, *args, **kargs):
+        raise RuntimeError("Sniffing and sending packets is not available: "  # noqa: E501
+                           "winpcap is not installed")
 
-        def __init__(self, *args, **kargs):
-            raise RuntimeError("Sniffing and sending packets is not available: "  # noqa: E501
-                               "winpcap is not installed")
-
-    conf.L2socket = NotAvailableSocket
-    conf.L2listen = NotAvailableSocket
-    conf.L3socket = NotAvailableSocket

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -801,7 +801,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                             c = Message(type=_ATMT_Command.SINGLESTEP, state=state)  # noqa: E501
                             self.cmdout.send(c)
                             break
-            except (StopIteration, RuntimeError) as e:
+            except (StopIteration, RuntimeError):
                 c = Message(type=_ATMT_Command.END,
                             result=self.final_state_output)
                 self.cmdout.send(c)

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -16,10 +16,10 @@ import socket
 import sys
 
 from scapy import VERSION, base_classes
-from scapy.consts import DARWIN
+from scapy.consts import DARWIN, WINDOWS, LINUX
 from scapy.data import ETHER_TYPES, IP_PROTOS, TCP_SERVICES, UDP_SERVICES, \
     MANUFDB
-from scapy.error import log_scapy
+from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
 from scapy.modules import six
 from scapy.themes import NoTheme, apply_ipython_style
 
@@ -59,6 +59,7 @@ class Interceptor(object):
         self.hook = hook
         self.args = args if args is not None else []
         self.kargs = kargs if kargs is not None else {}
+        self.locked = False
 
     def __get__(self, obj, typ=None):
         if not hasattr(obj, self.intname):
@@ -67,7 +68,11 @@ class Interceptor(object):
 
     def __set__(self, obj, val):
         setattr(obj, self.intname, val)
-        self.hook(self.name, val, *self.args, **self.kargs)
+        if not self.locked:
+            # We allow the hook to edit the field
+            self.locked = True
+            self.hook(self.name, val, *self.args, **self.kargs)
+            self.locked = False
 
 
 class ProgPath(ConfClass):
@@ -422,18 +427,63 @@ def _prompt_changer(attr, val):
         pass
 
 
+def _set_conf_sockets():
+    """Populate the conf.L2Socket and conf.L3Socket
+    according to the various use_* parameters
+    """
+    if conf.use_pcap or conf.use_dnet or conf.use_winpcapy:
+        if conf.use_winpcapy and not WINDOWS:
+            conf.use_winpcapy = False
+            raise ScapyInvalidPlatformException
+        try:
+            from scapy.arch.pcapdnet import L2pcapListenSocket, L2pcapSocket, \
+                L3pcapSocket
+        except ImportError:
+            warning("No pcap provider available ! pcap won't be used")
+            conf.use_pcap = False
+            conf.use_winpcapy = False
+        else:
+            conf.L2listen = L2pcapListenSocket
+            conf.L2socket = L2pcapSocket
+            conf.L3socket = L3pcapSocket
+            return
+    if conf.use_bpf:
+        if not DARWIN:
+            conf.use_bpf = False
+            raise ScapyInvalidPlatformException
+        from scapy.arch.bpf.supersocket import L2bpfListenSocket, \
+            L2bpfSocket, L3bpfSocket
+        conf.L2listen = L2bpfListenSocket
+        conf.L2socket = L2bpfSocket
+        conf.L3socket = L3bpfSocket
+        return
+    if LINUX:
+        from scapy.arch.linux import L3PacketSocket, L2Socket, L2ListenSocket
+        conf.L3socket = L3PacketSocket
+        conf.L2socket = L2Socket
+        conf.L2listen = L2ListenSocket
+        return
+    if WINDOWS:  # Should have been conf.use_winpcapy
+        from scapy.arch.windows import _NotAvailableSocket
+        conf.L2socket = _NotAvailableSocket
+        conf.L2listen = _NotAvailableSocket
+        conf.L3socket = _NotAvailableSocket
+        return
+    from scapy.supersocket import L3RawSocket
+    conf.L3socket = L3RawSocket
+
+
 def _socket_changer(attr, val):
     if not isinstance(val, bool):
         raise TypeError("This argument should be a boolean")
     if val:  # Only if True
-        depedencies = {
+        dependencies = {
             "use_pcap": ["use_bpf", "use_winpcapy"],
             "use_bpf": ["use_pcap"],
             "use_winpcapy": ["use_pcap", "use_dnet"],
         }
-        for param in depedencies[attr]:
+        for param in dependencies[attr]:
             setattr(conf, param, False)
-    from scapy.arch import _set_conf_sockets
     _set_conf_sockets()
 
 
@@ -523,9 +573,11 @@ recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
     noenum = Resolve()
     emph = Emphasize()
     use_pypy = isPyPy()
-    use_pcap = Interceptor("use_pcap",
-            os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y"),
-            _socket_changer)
+    use_pcap = Interceptor(
+        "use_pcap",
+        os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y"),
+        _socket_changer
+    )
     # XXX use_dnet is deprecated
     use_dnet = os.getenv("SCAPY_USE_PCAPDNET", "").lower().startswith("y")
     use_bpf = Interceptor("use_bpf", False, _socket_changer)

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -21,6 +21,10 @@ class Scapy_Exception(Exception):
     pass
 
 
+class ScapyInvalidPlatformException(Scapy_Exception):
+    pass
+
+
 class ScapyFreqFilter(logging.Filter):
     def __init__(self):
         logging.Filter.__init__(self)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -88,7 +88,7 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True
         if interactive:
             raise
         log_loading.warning("Cannot read config file [%s] [%s]", cf, e)
-    except Exception as e:
+    except Exception:
         if interactive:
             raise
         log_loading.exception("Error during evaluation of config file [%s]", cf)  # noqa: E501

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -300,15 +300,6 @@ class TunTapInterface(SuperSocket):
         self.closed = True
         self.open()
 
-    def __enter__(self):
-        return self
-
-    def __del__(self):
-        self.close()
-
-    def __exit__(self, *_):
-        self.close()
-
     def open(self):
         """Open the TUN or TAP device."""
         if not self.closed:
@@ -364,6 +355,3 @@ conf.L2listen, conf.L2socket or conf.L3socket.
         except socket.error:
             log_runtime.error("%s send", self.__class__.__name__, exc_info=True)  # noqa: E501
 
-
-if conf.L3socket is None:
-    conf.L3socket = L3RawSocket

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -354,4 +354,3 @@ conf.L2listen, conf.L2socket or conf.L3socket.
             os.write(self.outs.fileno(), sx)
         except socket.error:
             log_runtime.error("%s send", self.__class__.__name__, exc_info=True)  # noqa: E501
-

--- a/scapy/tools/check_asdis.py
+++ b/scapy/tools/check_asdis.py
@@ -71,7 +71,7 @@ def main(argv):
         except KeyboardInterrupt:
             raise
         except Exception as e:
-            print("Dissection error on packet %i" % i)
+            print("Dissection error on packet %i: %s" % (i, e))
             failed += 1
         else:
             if p1 == p2:


### PR DESCRIPTION
This PR contains various improvements about the libpcap provider’s handling:
- Dynamically set / update `conf.L{2,3}*` according to the value of `conf.use_*`. This fixes the « the module was loaded before » issue we already had previously
- few minor improvements (renames, prioritize pcapy and pypcap rather then python-libpcap)
- fixes « Segmentation Fault », caused by the duplicate call of `close()` on the pcap objects: the first one being from the socket’s `close()` and the second one from `__del__` by replacing the `__del__` by `close`

fixes https://github.com/secdev/scapy/issues/1731