### PR TITLE
Change name of contrib layer from bmw.doip to bmw.enet.

### DIFF
--- a/scapy/contrib/automotive/bmw/enet.py
+++ b/scapy/contrib/automotive/bmw/enet.py
@@ -15,14 +15,14 @@ from scapy.contrib.automotive.uds import UDS
 
 
 """
-BMW specific diagnostic over IP protocol implementation
+BMW specific diagnostic over IP protocol implementation ENET
 """
 
 # #########################DoIP###################################
 
 
-class DoIP(Packet):
-    name = 'DoIP'
+class ENET(Packet):
+    name = 'ENET'
     fields_desc = [
         LenField('length', None, fmt='I', adjust=lambda x: x + 2),
         ShortEnumField('type', 1, {0x01: "message",
@@ -45,10 +45,10 @@ class DoIP(Packet):
         return s[:8], s[8:]
 
 
-bind_bottom_up(TCP, DoIP, sport=6801)
-bind_bottom_up(TCP, DoIP, dport=6801)
-bind_layers(TCP, DoIP, sport=6801, dport=6801)
-bind_layers(DoIP, UDS)
+bind_bottom_up(TCP, ENET, sport=6801)
+bind_bottom_up(TCP, ENET, dport=6801)
+bind_layers(TCP, ENET, sport=6801, dport=6801)
+bind_layers(ENET, UDS)
 
 
 # ########################DoIPSocket###################################
@@ -57,4 +57,4 @@ class DoIPSocket(StreamSocket):
     def __init__(self, ip='127.0.0.1', port=6801):
         s = socket.socket()
         s.connect((ip, port))
-        StreamSocket.__init__(self, s, DoIP)
+        StreamSocket.__init__(self, s, ENET)

--- a/scapy/contrib/automotive/bmw/enet.uts
+++ b/scapy/contrib/automotive/bmw/enet.uts
@@ -1,22 +1,22 @@
-+ DoIP Contrib tests
++ ENET Contrib tests
 
 = Load Contrib Layer
 
-load_contrib("automotive.bmw.doip")
+load_contrib("automotive.bmw.enet")
 
 = Basic Test 1
 
-pkt = DoIP(type=1, src=0xf4, dst=0x10)/Raw(b'\x11\x22\x33')
+pkt = ENET(type=1, src=0xf4, dst=0x10)/Raw(b'\x11\x22\x33')
 assert bytes(pkt) == b'\x00\x00\x00\x05\x00\x01\xf4\x10\x11"3'
 
 = Basic Test 2
 
-pkt = DoIP(type=1, src=0xf4, dst=0x10)/Raw(b'\x11\x22\x33\x11\x11\x11\x11\x11')
+pkt = ENET(type=1, src=0xf4, dst=0x10)/Raw(b'\x11\x22\x33\x11\x11\x11\x11\x11')
 assert bytes(pkt) == b'\x00\x00\x00\x0a\x00\x01\xf4\x10\x11"3\x11\x11\x11\x11\x11'
 
 = Basic Dissect Test
 
-pkt = DoIP(b'\x00\x00\x00\x0a\x00\x01\xf4\x10\x11"3\x11\x11\x11\x11\x11')
+pkt = ENET(b'\x00\x00\x00\x0a\x00\x01\xf4\x10\x11"3\x11\x11\x11\x11\x11')
 assert pkt.length == 10
 assert pkt.src == 0xf4
 assert pkt.dst == 0x10


### PR DESCRIPTION
This should prevent confusion between AUTOSAR DoIP and the BMW properitary ENET protocol.
