### PR TITLE
Set time of defragmented ip packet to time of last fragment

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1050,6 +1050,8 @@ def _defrag_logic(plist, complete=False):
             if conf.padding_layer in q:
                 del(q[conf.padding_layer].underlayer.payload)
             txt.add_payload(q[IP].payload.copy())
+            if q.time > p.time:
+                p.time = q.time
         else:
             ip.flags &= ~1  # !MF
             del(ip.chksum)
@@ -1061,6 +1063,7 @@ def _defrag_logic(plist, complete=False):
     for p in defrag:
         q = p.__class__(raw(p))
         q._defrag_pos = p._defrag_pos
+        q.time = p.time
         defrag2.append(q)
     if complete:
         final.extend(defrag2)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6425,6 +6425,21 @@ assert len(defrags) == 1
 * which should be the same as pkt reconstructed
 assert defrags[0] == IP(raw(pkt))
 
+= defragment() uses timestamp of last fragment
+payloadlen, fragsize = 100, 8
+assert fragsize % 8 == 0
+packet = Ether()/IP()/("X" * payloadlen)
+frags = fragment(packet, fragsize)
+for i,fragment in enumerate(frags):
+    fragment.time -= 100 + i
+
+last_time = max(frag.time for frag in frags)
+defrags = defragment(frags)
+assert defrags[0].time == last_time
+nonfrag, defrags, badfrag = defrag(frags)
+assert defrags[0].time == last_time
+
+
 = defrag() / defragment() - Real DNS packets
 
 import base64


### PR DESCRIPTION
This fixes the Problem that reassembled ip packets were always timestamped with the time of reassembly.
After applying this PR the reassembled packet will have the timestamp of the last received fragment