### PR TITLE
improved tracing error in sending thread

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -74,7 +74,7 @@ def _sndrcv_snd(pks, timeout, inter, verbose, tobesent, hsent, timessent, stopev
     except KeyboardInterrupt:
         pass
     except Exception:
-        log_runtime.info("--- Error sending packets", exc_info=True)
+        log_runtime.exception("--- Error sending packets")
     if timeout is not None:
         stopevent.wait(timeout)
         stopevent.set()


### PR DESCRIPTION
An error condition is currently traced on info level.
By default tracing is set to level higher than info so this error is not visible.
I would like to change it from info to exception (which is error + tracing exception stack).