### PR TITLE
Force Python 2 for run_scapy_py2.bat, use Python 3 first in run_scapy.bat

### DIFF
--- a/run_scapy.bat
+++ b/run_scapy.bat
@@ -1,7 +1,7 @@
 @echo off
-call run_scapy_py2.bat --nopause
+call run_scapy_py3.bat --nopause
 if errorlevel 1 (
-   call run_scapy_py3.bat --nopause
+   call run_scapy_py2.bat --nopause
 )
 if errorlevel 1 (
    PAUSE

--- a/run_scapy_py2.bat
+++ b/run_scapy_py2.bat
@@ -3,10 +3,10 @@ set PYTHONPATH=%~dp0
 set PYTHONDONTWRITEBYTECODE=True
 if "%1"=="--nopause" (
   set nopause="True"
-  python -m scapy
+  python2 -m scapy
 ) else (
   set nopause="False"
-  python -m scapy %*
+  python2 -m scapy %*
 )
 if %errorlevel%==1 if NOT "%nopause%"=="True" (
    PAUSE


### PR DESCRIPTION
Fixes #1763.