### PR TITLE
fix __str__, __bytes__ for ASN1_BIT_STRING to return BER encoded values

### DIFF
--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -378,11 +378,12 @@ class ASN1_BIT_STRING(ASN1_Object):
             v = plain_str(self.val)
             return "<%s[%s] (%d unused bit%s)>" % (self.__dict__.get("name", self.__class__.__name__), v, self.unused_bits, "s" if self.unused_bits > 1 else "")  # noqa: E501
 
-    def __str__(self):
-        return self.val_readable
+# These need to be BER encoded values. Use inherited methods from ASN1_Object that does that.
+#   def __str__(self):
+#       return self.val_readable
 
-    def __bytes__(self):
-        return self.val_readable
+#   def __bytes__(self):
+#       return self.val_readable
 
 
 class ASN1_STRING(ASN1_Object):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1067,11 +1067,11 @@ assert raw(a) in [b'A\x02\x07q', b'C\x02\xfe\x92', b'\x1e\x023V']
 = ASN1 - ASN1_BIT_STRING
 a = ASN1_BIT_STRING("test", "value")
 a
-assert raw(a) == b'test'
+assert raw(a) == b'\x03\x05\x00' + b'test'
 
 a = ASN1_BIT_STRING(b"\xff"*16, "value")
 a
-assert raw(a) == b'\xff'*16
+assert raw(a) == b'\x03\x11\x00' + b'\xff'*16
 
 = ASN1 - ASN1_SEQUENCE
 a = ASN1_SEQUENCE([ASN1_Object(1), ASN1_Object(0)])


### PR DESCRIPTION
ASN1_BIT_STRING.\_\_bytes__() and ASN1_BIT_STRING.\_\_str__() should return BER encoded TLV, but returns self.val_readable instead.

fixes #1761
