### PR TITLE
Fix PYX detection

### DIFF
--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -43,7 +43,7 @@ def _test_pyx():
         with open(os.devnull, 'wb') as devnull:
             r = subprocess.check_call(["pdflatex", "--version"],
                                       stdout=devnull, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         return False
     else:
         return r == 0


### PR DESCRIPTION
fixes https://github.com/secdev/scapy/issues/1801

FTR tho only happens when:
- pyx is installed without its dependencies (it I unusable)