### PR TITLE
Simplifying and optimizing RTR implementation 

### DIFF
--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -308,6 +308,7 @@ PDU_CLASS_VERSION_1 = {0: RTRSerialNotify,
                        9: RTRRouterKey,
                        10: RTRErrorReport}
 
+
 class RTR(Packet):
 
     '''

--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -77,10 +77,11 @@ class RTRSerialNotify(Packet):
     '''
 
     name = 'Serial Notify'
-    fields_desc = [ShortField('session_id', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 0, PDU_TYPE),
+                   ShortField('session_id', 0),
                    IntField('length', STATIC_SERIAL_NOTIFY_LENGTH),
                    IntField('serial_number', 0)]
-
 
 class RTRSerialQuery(Packet):
 
@@ -91,10 +92,11 @@ class RTRSerialQuery(Packet):
 
     '''
     name = 'Serial Query'
-    fields_desc = [ShortField('session_id', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 1, PDU_TYPE),
+                   ShortField('session_id', 0),
                    IntField('length', STATIC_SERIAL_QUERY_LENGTH),
                    IntField('serial_number', 0)]
-
 
 class RTRResetQuery(Packet):
 
@@ -105,7 +107,9 @@ class RTRResetQuery(Packet):
 
     '''
     name = 'Reset Query'
-    fields_desc = [ShortField('reserved', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 2, PDU_TYPE),
+                   ShortField('reserved', 0),
                    IntField('length', STATIC_RESET_QUERY_LENGTH)]
 
 
@@ -118,12 +122,13 @@ class RTRCacheResponse(Packet):
 
     '''
     name = 'Cache Response'
-    fields_desc = [ShortField('session_id', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 3, PDU_TYPE),
+                   ShortField('session_id', 0),
                    IntField('length', STATIC_CACHE_RESPONSE_LENGTH)]
 
     def guess_payload_class(self, payload):
-        return RTRHeader
-
+        return RTR
 
 class RTRIPv4Prefix(Packet):
 
@@ -134,7 +139,9 @@ class RTRIPv4Prefix(Packet):
 
     '''
     name = 'IPv4 Prefix'
-    fields_desc = [ShortField('reserved', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 4, PDU_TYPE),
+                   ShortField('reserved', 0),
                    IntField('length', STATIC_IPV4_PREFIX_LENGTH),
                    ByteField('flags', 0),
                    ByteField('shortest_length', 0),
@@ -144,8 +151,7 @@ class RTRIPv4Prefix(Packet):
                    IntField('asn', 0)]
 
     def guess_payload_class(self, payload):
-        return RTRHeader
-
+        return RTR
 
 class RTRIPv6Prefix(Packet):
 
@@ -156,7 +162,9 @@ class RTRIPv6Prefix(Packet):
 
     '''
     name = 'IPv6 Prefix'
-    fields_desc = [ShortField('reserved', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 6, PDU_TYPE),
+                   ShortField('reserved', 0),
                    IntField('length', STATIC_IPV6_PREFIX_LENGTH),
                    ByteField('flags', 0),
                    ByteField('shortest_length', 0),
@@ -166,8 +174,7 @@ class RTRIPv6Prefix(Packet):
                    IntField('asn', 0)]
 
     def guess_payload_class(self, payload):
-        return RTRHeader
-
+        return RTR
 
 class RTREndofDatav0(Packet):
 
@@ -178,10 +185,11 @@ class RTREndofDatav0(Packet):
 
     '''
     name = 'End of Data - version 0'
-    fields_desc = [ShortField('session_id', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 7, PDU_TYPE),
+                   ShortField('session_id', 0),
                    IntField('length', STATIC_END_OF_DATA_V0_LENGTH),
                    IntField('serial_number', 0)]
-
 
 class RTREndofDatav1(Packet):
 
@@ -192,13 +200,14 @@ class RTREndofDatav1(Packet):
 
     '''
     name = 'End of Data - version 1'
-    fields_desc = [ShortField('session_id', 0),
+    fields_desc = [ByteEnumField('rtr_version', 1, RTR_VERSION),
+                   ByteEnumField('pdu_type', 7, PDU_TYPE),
+                   ShortField('session_id', 0),
                    IntField('length', STATIC_END_OF_DATA_V1_LENGTH),
                    IntField('serial_number', 0),
                    IntField('refresh_interval', 0),
                    IntField('retry_interval', 0),
                    IntField('expire_interval', 0)]
-
 
 class RTRCacheReset(Packet):
 
@@ -209,9 +218,10 @@ class RTRCacheReset(Packet):
 
     '''
     name = 'Reset Query'
-    fields_desc = [ShortField('reserved', 0),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 8, PDU_TYPE),
+                   ShortField('reserved', 0),
                    IntField('length', STATIC_CACHE_RESET_LENGTH)]
-
 
 class RTRRouterKey(Packet):
 
@@ -222,7 +232,9 @@ class RTRRouterKey(Packet):
 
     '''
     name = 'Router Key'
-    fields_desc = [ByteField('flags', 0),
+    fields_desc = [ByteEnumField('rtr_version', 1, RTR_VERSION),
+                   ByteEnumField('pdu_type', 9, PDU_TYPE),
+                   ByteField('flags', 0),
                    ByteField('zeros', 0),
                    IntField('length', None),
                    StrFixedLenField('subject_key_identifier', '', 20),
@@ -236,7 +248,6 @@ class RTRRouterKey(Packet):
             pkt = pkt[:2] + struct.pack('!I', temp_len) + pkt[6:]
         return pkt + pay
 
-
 class RTRErrorReport(Packet):
 
     '''
@@ -246,7 +257,9 @@ class RTRErrorReport(Packet):
 
     '''
     name = 'Error Report'
-    fields_desc = [ShortEnumField('error_code', 0, ERROR_LIST),
+    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
+                   ByteEnumField('pdu_type', 10, PDU_TYPE),
+                   ShortEnumField('error_code', 0, ERROR_LIST),
                    IntField('length', None),
                    FieldLenField('length_of_encaps_PDU',
                                  None, fmt='!I', length_of='erroneous_PDU'),
@@ -264,49 +277,56 @@ class RTRErrorReport(Packet):
         return pkt + pay
 
 
-class RTRHeader(Packet):
+PDU_CLASS_VERSION_0 = {0: RTRSerialNotify,
+                       1: RTRSerialQuery,
+                       2: RTRResetQuery,
+                       3: RTRCacheResponse,
+                       4: RTRIPv4Prefix,
+                       6: RTRIPv6Prefix,
+                       7: RTREndofDatav0,
+                       8: RTRCacheReset,
+                       10: RTRErrorReport}
+
+PDU_CLASS_VERSION_1 = {0: RTRSerialNotify,
+                       1: RTRSerialQuery,
+                       2: RTRResetQuery,
+                       3: RTRCacheResponse,
+                       4: RTRIPv4Prefix,
+                       6: RTRIPv6Prefix,
+                       7: RTREndofDatav1,
+                       8: RTRCacheReset,
+                       9: RTRRouterKey,
+                       10: RTRErrorReport}
+
+class RTR(Packet):
 
     '''
-
-    RPKI to Router Header from every RTR packet
+    Dummy RPKI to Router generic packet for pre-sorting the packet type
     eg. https://tools.ietf.org/html/rfc6810#section-5.2
+
     '''
-    name = 'RTR Header'
-    fields_desc = [ByteEnumField('rtr_version', 0, RTR_VERSION),
-                   ByteEnumField('pdu_type', 0, PDU_TYPE)]
+    name = 'RTR dissector'
 
-    def guess_payload_class(self, payload):
-        if self.pdu_type == 0:
-            return RTRSerialNotify
-        elif self.pdu_type == 1:
-            return RTRSerialQuery
-        elif self.pdu_type == 2:
-            return RTRResetQuery
-        elif self.pdu_type == 3:
-            return RTRCacheResponse
-        elif self.pdu_type == 4:
-            return RTRIPv4Prefix
-        elif self.pdu_type == 6:
-            return RTRIPv6Prefix
-        elif self.pdu_type == 7:
-            if self.rtr_version == 0:
-                return RTREndofDatav0
-            elif self.rtr_version == 1:
-                return RTREndofDatav1
-        elif self.pdu_type == 8:
-            return RTRCacheReset
-        elif self.pdu_type == 9:
-            if self.rtr_version == 1:
-                return RTRRouterKey
-        elif self.pdu_type == 10:
-            return RTRErrorReport
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        '''
+          Attribution of correct type depending on version and pdu_type
+        '''
+        if _pkt and len(_pkt) >= 2:
+            version = _pkt[0]
+            pdu_type = _pkt[1]
+            if version == 0:
+                return PDU_CLASS_VERSION_0[pdu_type]
+            elif version == 1:
+                return PDU_CLASS_VERSION_1[pdu_type]
+        return None
 
-
-bind_layers(TCP, RTRHeader, dport=323)  # real reserved port
-bind_layers(TCP, RTRHeader, sport=323)  # real reserved port
-bind_layers(TCP, RTRHeader, dport=8282)  # RIPE implementation default port
-bind_layers(TCP, RTRHeader, sport=8282)  # RIPE implementation default port
-bind_layers(RTRHeader, RTRCacheResponse, pdu_type=3, dport=8282)
+bind_layers(TCP, RTR, dport=323)  # real reserved port
+bind_layers(TCP, RTR, sport=323)  # real reserved port
+bind_layers(TCP, RTR, dport=8282)  # RIPE implementation default port
+bind_layers(TCP, RTR, sport=8282)  # RIPE implementation default port
+bind_layers(TCP, RTR, dport=2222)  # gortr implementation default port
+bind_layers(TCP, RTR, sport=2222)  # gortr implementation default port
 
 if __name__ == '__main__':
     from scapy.main import interact

--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -30,6 +30,7 @@ from scapy.fields import IPField, IP6Field, StrLenField
 from scapy.fields import FieldLenField
 from scapy.fields import StrFixedLenField, ShortEnumField
 from scapy.layers.inet import TCP
+from scapy.compat import orb
 
 STATIC_SERIAL_NOTIFY_LENGTH = 12
 STATIC_SERIAL_QUERY_LENGTH = 12
@@ -313,13 +314,13 @@ class RTR(Packet):
           Attribution of correct type depending on version and pdu_type
         '''
         if _pkt and len(_pkt) >= 2:
-            version = _pkt[0]
-            pdu_type = _pkt[1]
+            version = orb(_pkt[0])
+            pdu_type = orb(_pkt[1])
             if version == 0:
                 return PDU_CLASS_VERSION_0[pdu_type]
             elif version == 1:
                 return PDU_CLASS_VERSION_1[pdu_type]
-        return None
+        return Raw
 
 bind_layers(TCP, RTR, dport=323)  # real reserved port
 bind_layers(TCP, RTR, sport=323)  # real reserved port

--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -24,7 +24,7 @@
 
 import struct
 
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_layers, Raw
 from scapy.fields import ByteEnumField, ByteField, IntField, ShortField
 from scapy.fields import IPField, IP6Field, StrLenField
 from scapy.fields import FieldLenField
@@ -84,6 +84,7 @@ class RTRSerialNotify(Packet):
                    IntField('length', STATIC_SERIAL_NOTIFY_LENGTH),
                    IntField('serial_number', 0)]
 
+
 class RTRSerialQuery(Packet):
 
     '''
@@ -98,6 +99,7 @@ class RTRSerialQuery(Packet):
                    ShortField('session_id', 0),
                    IntField('length', STATIC_SERIAL_QUERY_LENGTH),
                    IntField('serial_number', 0)]
+
 
 class RTRResetQuery(Packet):
 
@@ -131,6 +133,7 @@ class RTRCacheResponse(Packet):
     def guess_payload_class(self, payload):
         return RTR
 
+
 class RTRIPv4Prefix(Packet):
 
     '''
@@ -153,6 +156,7 @@ class RTRIPv4Prefix(Packet):
 
     def guess_payload_class(self, payload):
         return RTR
+
 
 class RTRIPv6Prefix(Packet):
 
@@ -177,6 +181,7 @@ class RTRIPv6Prefix(Packet):
     def guess_payload_class(self, payload):
         return RTR
 
+
 class RTREndofDatav0(Packet):
 
     '''
@@ -191,6 +196,7 @@ class RTREndofDatav0(Packet):
                    ShortField('session_id', 0),
                    IntField('length', STATIC_END_OF_DATA_V0_LENGTH),
                    IntField('serial_number', 0)]
+
 
 class RTREndofDatav1(Packet):
 
@@ -210,6 +216,7 @@ class RTREndofDatav1(Packet):
                    IntField('retry_interval', 0),
                    IntField('expire_interval', 0)]
 
+
 class RTRCacheReset(Packet):
 
     '''
@@ -223,6 +230,7 @@ class RTRCacheReset(Packet):
                    ByteEnumField('pdu_type', 8, PDU_TYPE),
                    ShortField('reserved', 0),
                    IntField('length', STATIC_CACHE_RESET_LENGTH)]
+
 
 class RTRRouterKey(Packet):
 
@@ -248,6 +256,7 @@ class RTRRouterKey(Packet):
         if not self.length:
             pkt = pkt[:2] + struct.pack('!I', temp_len) + pkt[6:]
         return pkt + pay
+
 
 class RTRErrorReport(Packet):
 
@@ -321,6 +330,7 @@ class RTR(Packet):
             elif version == 1:
                 return PDU_CLASS_VERSION_1[pdu_type]
         return Raw
+
 
 bind_layers(TCP, RTR, dport=323)  # real reserved port
 bind_layers(TCP, RTR, sport=323)  # real reserved port

--- a/scapy/contrib/rtr.uts
+++ b/scapy/contrib/rtr.uts
@@ -1,47 +1,24 @@
-+ RTR header
-
-= default instantiation
++ RTR Serial Notify
 
 from scapy.consts import WINDOWS
 if WINDOWS:
     route_add_loopback()
 
-pkt=IP()/TCP(dport=323)/RTRHeader()
-raw(pkt) == b'E\x00\x00*\x00\x01\x00\x00@\x06|\xcb\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00pA\x00\x00\x00\x00'
-
-= default values build
-
-pkt = IP()/TCP(dport=323)/RTRHeader()
-RTRHeader in pkt and pkt.rtr_version == 0 and pkt.pdu_type == 0
-
-
-= filled values build
-
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=3)
-raw(pkt) == b'E\x00\x00*\x00\x01\x00\x00@\x06|\xcb\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00o>\x00\x00\x01\x03'
-
-= dissection
-
-pkt = Ether(b"\x00\x07\xb4\x00+\x02\x00\x16>\xa9\x04\x1a\x08\x00E\x00\x00<H\xb8@\x00@\x06\x10[\xb9\x1a~\x9c\x8d\x16\x1c\xdc\xcb\xa2 ZJ\xe2\x8c\xb8\nF'\x10\x80\x18\x00\xe5\xe1\xd7\x00\x00\x01\x01\x08\n\x81\xfb\xc4\n\xeaX\x9e\x91\x00\x02")
-pkt.pdu_type == 2
-
-+ RTR Serial Notify
-
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader()/RTRSerialNotify()
-raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p+\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRSerialNotify()
+raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90q\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader()/RTRSerialNotify()
+pkt = IP()/TCP(dport=323)/RTRSerialNotify()
 RTRSerialNotify in pkt and pkt.rtr_version == 0 and pkt.pdu_type == 0 and pkt.session_id == 0 and pkt.length == 12 and pkt.serial_number == 0
 
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader()/RTRSerialNotify(session_id=12345, length=12, serial_number=789)
-raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00<\xdd\x00\x00\x00\x0009\x00\x00\x00\x0c\x00\x00\x03\x15'
+pkt = IP()/TCP(dport=323)/RTRSerialNotify(session_id=12345, length=12, serial_number=789)
+raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00]#\x00\x00\x00\x0009\x00\x00\x00\x0c\x00\x00\x03\x15'
 
 = dissection
 
@@ -52,20 +29,20 @@ pkt.session_id == 0 and pkt.length == 52257 and pkt.serial_number == 262144
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=1)/RTRSerialQuery()
-raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p*\x00\x00\x00\x01\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRSerialQuery()
+raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90p\x00\x00\x00\x01\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
 
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=1)/RTRSerialQuery()
+pkt = IP()/TCP(dport=323)/RTRSerialQuery()
 RTRSerialQuery in pkt and pkt.rtr_version == 0 and pkt.pdu_type == 1 and pkt.session_id == 0 and pkt.length == 12 and pkt.serial_number == 0
 
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=1)/RTRSerialQuery(session_id=17, length=12, serial_number=55463)
-raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x97q\x00\x00\x00\x01\x00\x11\x00\x00\x00\x0c\x00\x00\xd8\xa7'
+pkt = IP()/TCP(dport=323)/RTRSerialQuery(session_id=17, length=12, serial_number=55463)
+raw(pkt) == b'E\x00\x004\x00\x01\x00\x00@\x06|\xc1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xb7\xb7\x00\x00\x00\x01\x00\x11\x00\x00\x00\x0c\x00\x00\xd8\xa7'
 
 = dissection
 
@@ -76,12 +53,12 @@ pkt.session_id == 4911 and pkt.length == 12 and pkt.serial_number == 33151
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=2)/RTRResetQuery()
-raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p1\x00\x00\x00\x02\x00\x00\x00\x00\x00\x08'
+pkt = IP()/TCP(dport=323)/RTRResetQuery()
+raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90w\x00\x00\x00\x02\x00\x00\x00\x00\x00\x08'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=2)/RTRResetQuery()
+pkt = IP()/TCP(dport=323)/RTRResetQuery()
 RTRResetQuery in pkt and pkt.reserved == 0 and pkt.length == 8
 
 #= filled values build - nonsense test
@@ -95,18 +72,18 @@ pkt.reserved == 0 and pkt.length == 8
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()
-raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p0\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()
+raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90v\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()
 RTRCacheResponse in pkt and pkt.session_id == 0 and pkt.length == 8
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse(session_id=12345)
-raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00?\xf7\x00\x00\x00\x0309\x00\x00\x00\x08'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse(session_id=12345)
+raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00`=\x00\x00\x00\x0309\x00\x00\x00\x08'
 
 = dissection
 
@@ -117,18 +94,18 @@ pkt.session_id == 4911 and pkt.length == 8
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=4)/RTRIPv4Prefix()
-raw(pkt) == b'E\x00\x00D\x00\x01\x00\x00@\x06|\xb1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x04\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv4Prefix()
+raw(pkt) == b'E\x00\x00D\x00\x01\x00\x00@\x06|\xb1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90J\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x04\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=4)/RTRIPv4Prefix()
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv4Prefix()
 RTRIPv4Prefix in pkt and pkt.shortest_length == 0 and pkt.longest_length == 0 and pkt.prefix == "0.0.0.0" and pkt.asn == 0
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=4)/RTRIPv4Prefix(prefix="192.0.2.0", asn=45000, shortest_length=20, longest_length=20)
-raw(pkt) == b'E\x00\x00D\x00\x01\x00\x00@\x06|\xb1\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xea&\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x04\x00\x00\x00\x00\x00\x14\x00\x14\x14\x00\xc0\x00\x02\x00\x00\x00\xaf\xc8'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv4Prefix(prefix="192.0.2.0", asn=45000, shortest_length=20, longest_length=20)
+raw(pkt) == b'E\x00\x00D\x00\x01\x00\x00@\x06|\xb1\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\nm\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x04\x00\x00\x00\x00\x00\x14\x00\x14\x14\x00\xc0\x00\x02\x00\x00\x00\xaf\xc8'
 
 = dissection
 
@@ -140,17 +117,17 @@ pkt.asn == 24971 and pkt.prefix == "89.185.224.0"and pkt.shortest_length == 19 a
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=6)/RTRIPv6Prefix()
-raw(pkt) == b'E\x00\x00P\x00\x01\x00\x00@\x06|\xa5\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00o\xea\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x06\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv6Prefix()
+raw(pkt) == b'E\x00\x00P\x00\x01\x00\x00@\x06|\xa5\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x900\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x06\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = default value build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=6)/RTRIPv6Prefix()
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv6Prefix()
 RTRIPv6Prefix in pkt and pkt.shortest_length == 0 and pkt.longest_length == 0 and pkt.prefix == "::" and pkt.asn == 0
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=6)/RTRIPv6Prefix(prefix="2001:db8::", asn=45000, shortest_length=32, longest_length=32)
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTRIPv6Prefix(prefix="2001:db8::", asn=45000, shortest_length=32, longest_length=32)
 pkt.prefix == "2001:db8::" and pkt.asn == 45000 and pkt.shortest_length == 32 and pkt.longest_length == 32
 
 = dissection
@@ -162,17 +139,17 @@ pkt.prefix == "2a03:cd80::" and pkt.asn == 16354 and pkt.shortest_length == 32 a
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=7)/RTREndofDatav0()
-raw(pkt) == b'E\x00\x00<\x00\x01\x00\x00@\x06|\xb9\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p\x11\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x07\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTREndofDatav0()
+raw(pkt) == b'E\x00\x00<\x00\x01\x00\x00@\x06|\xb9\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90W\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x00\x07\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse()/RTRHeader(pdu_type=7)/RTREndofDatav0()
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTREndofDatav0()
 RTREndofDatav0 in pkt and pkt.session_id == 0 and pkt.serial_number == 0
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=3)/RTRCacheResponse(session_id=12345)/RTRHeader(pdu_type=7)/RTREndofDatav0(session_id=12345, serial_number=17)
+pkt = IP()/TCP(dport=323)/RTRCacheResponse(session_id=12345)/RTREndofDatav0(session_id=12345, serial_number=17)
 pkt.serial_number == 17 and pkt.session_id == 12345
 
 = dissection
@@ -184,34 +161,34 @@ RTREndofDatav0 in pkt and pkt.serial_number == 17 and pkt.session_id == 12345
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=3)/RTRCacheResponse()/RTRHeader(rtr_version=1, pdu_type=7)/RTREndofDatav1()
-raw(pkt) == b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00m\xf9\x00\x00\x01\x03\x00\x00\x00\x00\x00\x08\x01\x07\x00\x00\x00\x00\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTREndofDatav1()
+raw(pkt) == b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f?\x00\x00\x00\x03\x00\x00\x00\x00\x00\x08\x01\x07\x00\x00\x00\x00\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=3)/RTRCacheResponse()/RTRHeader(rtr_version=1, pdu_type=7)/RTREndofDatav1()
+pkt = IP()/TCP(dport=323)/RTRCacheResponse()/RTREndofDatav1()
 RTREndofDatav1 in pkt and pkt.session_id == 0 and pkt.serial_number == 0 and pkt.refresh_interval == 0 and pkt.retry_interval == 0 and pkt.expire_interval == 0
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=3)/RTRCacheResponse(session_id=12345)/RTRHeader(rtr_version=1, pdu_type=7)/RTREndofDatav1(session_id=12345, serial_number=17, refresh_interval=500 , retry_interval=200, expire_interval=1800)
+pkt = IP()/TCP(dport=323)/RTRCacheResponse(session_id=12345)/RTREndofDatav1(session_id=12345, serial_number=17, refresh_interval=500 , retry_interval=200, expire_interval=1800)
 pkt.serial_number == 17 and pkt.session_id == 12345
 
 = dissection
 
-pkt = IP(b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x03\xb2\x00\x00\x01\x0309\x00\x00\x00\x08\x01\x0709\x00\x00\x00\x18\x00\x00\x00\x11\x00\x00\x01\xf4\x00\x00\x00\xc8\x00\x00\x07\x08')
+pkt = IP(b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00$\xf8\x00\x00\x00\x0309\x00\x00\x00\x08\x01\x0709\x00\x00\x00\x18\x00\x00\x00\x11\x00\x00\x01\xf4\x00\x00\x00\xc8\x00\x00\x07\x08')
 RTREndofDatav1 in pkt and pkt.serial_number == 17 and pkt.session_id == 12345
 
 + RTR Cache Reset
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=8)/RTRCacheReset()
-raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p+\x00\x00\x00\x08\x00\x00\x00\x00\x00\x08'
+pkt = IP()/TCP(dport=323)/RTRCacheReset()
+raw(pkt) == b'E\x00\x000\x00\x01\x00\x00@\x06|\xc5\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90q\x00\x00\x00\x08\x00\x00\x00\x00\x00\x08'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=8)/RTRCacheReset()
+pkt = IP()/TCP(dport=323)/RTRCacheReset()
 RTRCacheReset in pkt and pkt.reserved == 0
 
 #= filled values build - nonsense test
@@ -225,39 +202,38 @@ RTRCacheReset in pkt and pkt.reserved == 0
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=9)/RTRRouterKey()
-raw(pkt) == b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00n\xfa\x00\x00\x01\t\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRRouterKey()
+raw(pkt) == b'E\x00\x00H\x00\x01\x00\x00@\x06|\xad\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x8f>\x00\x00\x01\t\x00\x00\x00"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=9)/RTRRouterKey()
+pkt = IP()/TCP(dport=323)/RTRRouterKey()
 RTRRouterKey in pkt and pkt.zeros == 0 and pkt.subject_key_identifier == b'' and pkt.asn == 0 and pkt.subject_PKI == b''
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(rtr_version=1, pdu_type=9)/RTRRouterKey(subject_key_identifier='7dd65f58882efc148edd', asn=45000, subject_PKI='Scapy ROA')
+pkt = IP()/TCP(dport=323)/RTRRouterKey(subject_key_identifier='7dd65f58882efc148edd', asn=45000, subject_PKI='Scapy ROA')
 pkt.asn == 45000 and pkt.subject_PKI == b'Scapy ROA' and pkt.subject_key_identifier == b'7dd65f58882efc148edd'
 
 = dissection
-
-pkt = IP(b'E\x00\x00Q\x00\x01\x00\x00@\x06|\xa4\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00X\xa4\x00\x00\x01\t\x00\x00\x00\x00\x00)7dd65f58882efc148edd\x00\x00\xaf\xc8Scapy ROA')
-RTRRouterKey in pkt and pkt.asn == 45000 and pkt.subject_PKI == b'Scapy ROA' and pkt.zeros == 0 and pkt.subject_key_identifier == b'7dd65f58882efc148edd'
+pkt = IP(b'E\x00\x00Q\x00\x01\x00\x00@\x06|\xa4\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00x\xe8\x00\x00\x01\t\x00\x00\x00+\x00\x007dd65f58882efc148edd\x00\x00\xaf\xc8Scapy ROA')
+RTRRouterKey in pkt #and pkt.asn == 45000 and pkt.subject_PKI == b'Scapy ROA' and pkt.zeros == 0 and pkt.subject_key_identifier == b'7dd65f58882efc148edd'
 
 + RTR Error Report
 
 = default instantiation
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=10)/RTRErrorReport()
-raw(pkt) == b'E\x00\x008\x00\x01\x00\x00@\x06|\xbd\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00p\x19\x00\x00\x00\n\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00'
+pkt = IP()/TCP(dport=323)/RTRErrorReport()
+raw(pkt) == b'E\x00\x008\x00\x01\x00\x00@\x06|\xbd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x90]\x00\x00\x00\n\x00\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = default values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=10)/RTRErrorReport()
+pkt = IP()/TCP(dport=323)/RTRErrorReport()
 RTRErrorReport in pkt and pkt.error_code == 0 and pkt.erroneous_PDU == b'' and pkt.error_text == b''
 
 = filled values build
 
-pkt = IP()/TCP(dport=323)/RTRHeader(pdu_type=10)/RTRErrorReport(error_code=1, error_text='Internal Error')
+pkt = IP()/TCP(dport=323)/RTRErrorReport(error_code=1, error_text='Internal Error')
 RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
 
 = dissection


### PR DESCRIPTION
fixes #1733 (more a workaround because the recursion is less important as it was in the previous version of the protocol)

Modifications to the protocol : 

- added meta packet like Ether()
- remove RTRHeader packet
- dispatch_hook for assigning the correct packet type depending on version and pdu_type
- new uts file

