### PR TITLE
Fixup Dot11EltRSN elements order

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -608,12 +608,12 @@ class Dot11EltRSN(Dot11Elt):
             AKMSuite,
             count_from=lambda p: p.nb_akm_suites
         ),
-        BitField("pre_auth", 0, 1),
-        BitField("no_pairwise", 0, 1),
-        BitField("ptksa_replay_counter", 0, 2),
-        BitField("gtksa_replay_counter", 0, 2),
-        BitField("mfp_required", 0, 1),
         BitField("mfp_capable", 0, 1),
+        BitField("mfp_required", 0, 1),
+        BitField("gtksa_replay_counter", 0, 2),
+        BitField("ptksa_replay_counter", 0, 2),
+        BitField("no_pairwise", 0, 1),
+        BitField("pre_auth", 0, 1),
         BitField("reserved", 0, 8),
         ConditionalField(
             PacketField("pmkids", None, PMKIDListPacket),

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10473,7 +10473,7 @@ assert rsn_ie.nb_pairwise_cipher_suites == 0x01
 assert rsn_ie.pairwise_cipher_suites[0].cipher == 0x04
 assert rsn_ie.nb_akm_suites == 0x01
 assert rsn_ie.akm_suites[0].suite == 0x01
-assert rsn_ie.mfp_capable
+assert rsn_ie.pre_auth
 assert Dot11Elt in rsn_ie
 
 = Dot11EltMicrosoftWPA


### PR DESCRIPTION
- fixes https://github.com/secdev/scapy/issues/1826

(They are LE => in reversed order)