### PR TITLE
Manage received_frames per bpf socket.

### DIFF
--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -226,7 +226,9 @@ class _L2bpfSocket(SuperSocket):
 class L2bpfListenSocket(_L2bpfSocket):
     """"Scapy L2 BPF Listen Super Socket"""
 
-    received_frames = []
+    def __init__(self, *args, **kwargs):
+        self.received_frames = []
+        super(L2bpfListenSocket, self).__init__(*args, **kwargs)
 
     def buffered_frames(self):
         """Return the number of frames in the buffer"""


### PR DESCRIPTION
When using sniff() and sndrcv() in multiple threads with different
bpf sockets, the global received_frames cache is disturbing.  Filters
or interfaces are not applied from the current sniff() invocation
as obsolete packets with different parameters may be already in the
received_frames array.  I would expect that the cache is part of
each bpf socket.  So it should be initialized in the constructor.