### PR TITLE
Detect the location of p0f fingerprint libraries.

### DIFF
--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -29,10 +29,34 @@ if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route  # noqa: F401
 
-conf.p0f_base = "/etc/p0f/p0f.fp"
-conf.p0fa_base = "/etc/p0f/p0fa.fp"
-conf.p0fr_base = "/etc/p0f/p0fr.fp"
-conf.p0fo_base = "/etc/p0f/p0fo.fp"
+if os.path.exists("/opt/local/share/p0f/p0f.fp"):
+	conf.p0f_base = "/opt/local/share/p0f/p0f.fp"
+elif os.path.exists("/usr/share/p0f/p0f.fp"):
+	conf.p0f_base = "/usr/share/p0f/p0f.fp"
+else:
+	conf.p0f_base = "/etc/p0f/p0f.fp"
+
+if os.path.exists("/opt/local/share/p0f/p0f.fp"):
+	conf.p0fa_base = "/opt/local/share/p0f/p0fa.fp"
+elif os.path.exists("/usr/share/p0f/p0f.fp"):
+	conf.p0fa_base = "/usr/share/p0f/p0fa.fp"
+else:
+	conf.p0fa_base = "/etc/p0f/p0fa.fp"
+
+
+if os.path.exists("/opt/local/share/p0f/p0fr.fp"):
+	conf.p0fr_base = "/opt/local/share/p0f/p0fr.fp"
+elif os.path.exists("/usr/share/p0f/p0fr.fp"):
+	conf.p0fr_base = "/usr/share/p0f/p0fr.fp"
+else:
+	conf.p0fr_base = "/etc/p0f/p0fr.fp"
+
+if os.path.exists("/opt/local/share/p0f/p0fo.fp"):
+	conf.p0fo_base = "/opt/local/share/p0f/p0fo.fp"
+elif os.path.exists("/usr/share/p0f/p0fo.fp"):
+	conf.p0fo_base = "/usr/share/p0f/p0fo.fp"
+else:
+	conf.p0fo_base = "/etc/p0f/p0fo.fp"
 
 
 ###############

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -30,33 +30,33 @@ if conf.route is None:
     import scapy.route  # noqa: F401
 
 if os.path.exists("/opt/local/share/p0f/p0f.fp"):
-	conf.p0f_base = "/opt/local/share/p0f/p0f.fp"
+    conf.p0f_base = "/opt/local/share/p0f/p0f.fp"
 elif os.path.exists("/usr/share/p0f/p0f.fp"):
-	conf.p0f_base = "/usr/share/p0f/p0f.fp"
+    conf.p0f_base = "/usr/share/p0f/p0f.fp"
 else:
-	conf.p0f_base = "/etc/p0f/p0f.fp"
+    conf.p0f_base = "/etc/p0f/p0f.fp"
 
 if os.path.exists("/opt/local/share/p0f/p0f.fp"):
-	conf.p0fa_base = "/opt/local/share/p0f/p0fa.fp"
+    conf.p0fa_base = "/opt/local/share/p0f/p0fa.fp"
 elif os.path.exists("/usr/share/p0f/p0f.fp"):
-	conf.p0fa_base = "/usr/share/p0f/p0fa.fp"
+    conf.p0fa_base = "/usr/share/p0f/p0fa.fp"
 else:
-	conf.p0fa_base = "/etc/p0f/p0fa.fp"
+    conf.p0fa_base = "/etc/p0f/p0fa.fp"
 
 
 if os.path.exists("/opt/local/share/p0f/p0fr.fp"):
-	conf.p0fr_base = "/opt/local/share/p0f/p0fr.fp"
+    conf.p0fr_base = "/opt/local/share/p0f/p0fr.fp"
 elif os.path.exists("/usr/share/p0f/p0fr.fp"):
-	conf.p0fr_base = "/usr/share/p0f/p0fr.fp"
+    conf.p0fr_base = "/usr/share/p0f/p0fr.fp"
 else:
-	conf.p0fr_base = "/etc/p0f/p0fr.fp"
+    conf.p0fr_base = "/etc/p0f/p0fr.fp"
 
 if os.path.exists("/opt/local/share/p0f/p0fo.fp"):
-	conf.p0fo_base = "/opt/local/share/p0f/p0fo.fp"
+    conf.p0fo_base = "/opt/local/share/p0f/p0fo.fp"
 elif os.path.exists("/usr/share/p0f/p0fo.fp"):
-	conf.p0fo_base = "/usr/share/p0f/p0fo.fp"
+    conf.p0fo_base = "/usr/share/p0f/p0fo.fp"
 else:
-	conf.p0fo_base = "/etc/p0f/p0fo.fp"
+    conf.p0fo_base = "/etc/p0f/p0fo.fp"
 
 
 ###############


### PR DESCRIPTION
This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [X] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [X] I squashed commits belonging together
-   [X] I added unit tests or explained why they are not relevant
-   [X] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
    I don't believe the unit tests would apply for this type of fix - I'd have to rename or move files around on the user's system to do so.
    A number of the tests fail on my Mac OS, but the failures do not seem to be related to the patch.

> brief description what this PR will do, e.g. fixes broken dissection of XXX
Finds the p0f fingerprint files the 2 common alternate locations, falling back on /etc/p0f as a default.

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library


