### PR TITLE
Fixed out of range exception for randval in ScalingField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2230,3 +2230,15 @@ class ScalingField(Field):
 
     def i2repr(self, pkt, x):
         return "%s %s" % (self.i2h(pkt, x), self.unit)
+
+    def randval(self):
+        value = super(ScalingField, self).randval()
+        if value is not None:
+            barrier1 = self.m2i(None, value.max)
+            barrier2 = self.m2i(None, value.min)
+
+            from math import ceil
+            min_value = ceil(min(barrier1, barrier2))
+            max_value = int(max(barrier1, barrier2))
+
+            return RandNum(min_value, max_value)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1552,3 +1552,16 @@ x.data = b'\x01'
 print(x.__repr__())
 assert x.data == 0.12346
 assert ScalingField.i2repr(x.fields_desc[0],x, x.data) == '0.12346 V'
+
+= ScalingField randval
+
+class DebugPacket(Packet):
+    fields_desc = [
+        ScalingField('data', 0, scaling=0.1, offset=-5)
+    ]
+
+x = DebugPacket()
+
+r = x.fields_desc[0].randval()
+assert r.min == -5
+assert r.max == 20


### PR DESCRIPTION
The `randval()` method did not ensure valid ranges for the generated value in `ScalingField`