### PR TITLE
"import scapy.contrib.lldp" shouldn't enable debug_dissector

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -38,7 +38,6 @@
           - multiplicity of TLVs (if given by the standard)
           - min sizes of strings used by the TLVs
         - conf.contribs['LLDP'].strict_mode_disable() -> disable strict mode
-        - strict mode = True => conf.debug_dissector = True
 
 """
 from scapy.config import conf
@@ -738,14 +737,12 @@ class LLDPConfiguration(object):
         enable strict mode and dissector debugging
         """
         self._strict_mode = True
-        conf.debug_dissector = True
 
     def strict_mode_disable(self):
         """
         disable strict mode and dissector debugging
         """
         self._strict_mode = False
-        conf.debug_dissector = False
 
     def strict_mode(self):
         """


### PR DESCRIPTION
conf.debug_dissector is being enabled as a side-effect of importing
scapy.contrib.lldp. This module doesn't "own" debug_dissector, it
should respect the value that the user configured and follow the
principle of least surprise.
