### PR TITLE
bluetooth4LE: fix typo "Energie" -> "Energy"

### DIFF
--- a/test/bluetooth4LE.uts
+++ b/test/bluetooth4LE.uts
@@ -1,8 +1,8 @@
 % Regression tests for the bluetooth4LE layer
 
-###################################
-#### Bluetooth 4.0 Low Energie ####
-###################################
+##################################
+#### Bluetooth 4.0 Low Energy ####
+##################################
 
 + BTLE tests
 


### PR DESCRIPTION
This change only impacts comments in a test, and should have no impact on the outcome of the test.
