### PR TITLE
"import scapy.contrib.isis" shouldn't enable debug_dissector

### DIFF
--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -80,8 +80,6 @@ from scapy.compat import orb, hex_bytes
 
 EXT_VERSION = "v0.0.2"
 
-conf.debug_dissector = True
-
 
 #######################################################################
 #   ISIS Utilities + Fields                                           #


### PR DESCRIPTION
conf.debug_dissector was being enabled as a side-effect of importing
scapy.contrib.isis.

---

Sorry for not catching this when I spotted LLDP enabling debug_dissector last week.
I've now grep'd the source, and no other module is doing this in an obvious way.
