### PR TITLE
Support __version__

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -90,7 +90,7 @@ def _version():
                 return 'unknown.version'
 
 
-VERSION = _version()
+VERSION = __version__ = _version()
 
 if __name__ == "__main__":
     from scapy.main import interact

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -36,6 +36,8 @@ assert not _version_checker(FakeModule2, (5, 143, 4))
 
 assert _version_checker(FakeModule3, (2, 4, 2))
 
+assert _version_checker(scapy, (2, 4, 2))
+
 = List layers
 ~ conf command
 ls()


### PR DESCRIPTION
- support for `scapy.__version__` which is the standard (https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names)