### PR TITLE
OBD: Negative responses with service >= 0x40 are detected now

### DIFF
--- a/scapy/contrib/automotive/obd/obd.py
+++ b/scapy/contrib/automotive/obd/obd.py
@@ -52,7 +52,7 @@ class OBD(Packet):
 
     def hashret(self):
         if self.service == 0x7f:
-            return struct.pack('B', self.request_service_id)
+            return struct.pack('B', self.request_service_id & ~0x40)
         return struct.pack('B', self.service & ~0x40)
 
     def answers(self, other):

--- a/scapy/contrib/automotive/obd/obd.uts
+++ b/scapy/contrib/automotive/obd/obd.uts
@@ -36,6 +36,20 @@ assert res.answers(req)
 assert req.hashret() == res.hashret()
 
 
+= Check hashret for Service 0x40
+
+req = OBD(b'\x40')
+res = OBD(b'\x7F\x40\x11')
+assert req.hashret() == res.hashret()
+
+
+= Check hashret for Service 0x51
+
+req = OBD(b'\x51')
+res = OBD(b'\x7F\x51\x11')
+assert req.hashret() == res.hashret()
+
+
 = Check dissecting a request for Service 01 PID 00
 
 p = OBD(b'\x01\x00')


### PR DESCRIPTION
A small, but important fix.

If I requested a service >= 0x40 and the ECU responds with "Negative response, serviceNotSupported", scapy did not detect this response, because the hashes did not match.