### PR TITLE
Restore ARP attributes removed in 3dd7b912cfa24c331b32d666df2d4367822…

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -384,6 +384,8 @@ class ARP(Packet):
             StrFixedLenField("pdst", None, length_from=lambda pkt: pkt.plen),
         ),
     ]
+    who_has = 1
+    is_at = 2
 
     def hashret(self):
         return struct.pack(">HHH", self.hwtype, self.ptype,


### PR DESCRIPTION
3dd7b912cfa24c331b32d666df2d4367822dcb96.

    who_has = 1
    is_at = 2

