### PR TITLE
fix issue #1887

### DIFF
--- a/scapy/contrib/isotp.uts
+++ b/scapy/contrib/isotp.uts
@@ -70,6 +70,16 @@ def exit_if_no_isotp_module():
         exit(0)
 
 
+# function to exit when can is not available
+CAN_SOCKETS_AVAILABLE = False
+def exit_if_no_can_sockets():
+    if not CAN_SOCKETS_AVAILABLE:
+        err = "TEST SKIPPED: CANSockets not available"
+        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        warning("Can't test because no CANSockets are available")
+        exit(0)
+
+
 = Initialize a virtual CAN interface
 ~ needs_root linux conf
 if 0 != call("cansend %s 000#" % iface0, shell=True):
@@ -95,25 +105,30 @@ if 0 != call("cansend %s 000#" % iface1, shell=True):
 
 if 0 != call("cansend %s 000#" % iface1, shell=True):
     raise Exception("cansend doesn't work")
-
-print("CAN should work now")
-
-
-if six.PY3:
-    from scapy.contrib.cansocket_native import *
 else:
-    from scapy.contrib.cansocket_python_can import *
+    print("CAN should work now")
+    CAN_SOCKETS_AVAILABLE = True
 
+= Initialize new_can_socket helper functions
+~ linux conf
 
-if "python_can" in CANSocket.__module__:
-    import can as python_can
-    new_can_socket = lambda iface: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface, bitrate=250000))
-    new_can_socket0 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface0, bitrate=250000), timeout=0.01)
-    new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface1, bitrate=250000), timeout=0.01)
-else:
-    new_can_socket = lambda iface: CANSocket(iface)
-    new_can_socket0 = lambda: CANSocket(iface0)
-    new_can_socket1 = lambda: CANSocket(iface1)
+try:
+    if six.PY3:
+        from scapy.contrib.cansocket_native import *
+    else:
+        from scapy.contrib.cansocket_python_can import *
+    if "python_can" in CANSocket.__module__:
+        import can as python_can
+        new_can_socket = lambda iface: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface, bitrate=250000))
+        new_can_socket0 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface0, bitrate=250000), timeout=0.01)
+        new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface1, bitrate=250000), timeout=0.01)
+    else:
+        new_can_socket = lambda iface: CANSocket(iface)
+        new_can_socket0 = lambda: CANSocket(iface0)
+        new_can_socket1 = lambda: CANSocket(iface1)
+except ImportError:
+    CAN_SOCKETS_AVAILABLE = False
+    print("Import Error. python-can isn't installed, probably.")
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
@@ -123,11 +138,15 @@ def drain_bus(iface=iface0, assert_empty=True):
         assert len(pkts) == 0
     s.close()
 
-print("CAN sockets should work now")
+if CAN_SOCKETS_AVAILABLE:
+    print("CAN sockets should work now")
+else:
+    print("CAN socket tests will be skipped")
 
 
 # Verify that a CAN socket can be created and closed
 ~ conf linux needs_root
+exit_if_no_can_sockets()
 s = new_can_socket(iface0)
 s.close()
 
@@ -622,7 +641,7 @@ assert(msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 1
 + Test sniffer
 = Test sniffer with multiple frames
 ~ linux needs_root
-
+exit_if_no_can_sockets()
 
 test_frames = [
     (0x241, "EA 10 28 01 02 03 04 05"),
@@ -652,8 +671,6 @@ assert(succ)
 
 
 + ISOTPSocket tests
-
-
 = Single-frame receive
 
 cans = MockCANSocket()
@@ -842,6 +859,7 @@ with ISOTPSocket(cans, sid=0x641, did=0x241) as s:
 
 = Verify that packets are not lost if they arrive before the sniff() is called
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 ss = new_can_socket(iface0)
 sr = new_can_socket(iface0)
@@ -860,6 +878,8 @@ del sr
 
 = Send single frame ISOTP message, using begin_send
 ~ linux needs_root
+exit_if_no_can_sockets()
+
 cans = new_can_socket(iface0)
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     s.begin_send(ISOTP(data=dhex("01 02 03 04 05")))
@@ -870,6 +890,8 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Send many single frame ISOTP messages, using begin_send
 ~ linux needs_root
+exit_if_no_can_sockets()
+
 cans = new_can_socket(iface0)
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     for i in range(100):
@@ -884,6 +906,8 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Send two-frame ISOTP message, using begin_send
 ~ linux needs_root
+exit_if_no_can_sockets()
+
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     s.begin_send(ISOTP(data=dhex("01 02 03 04 05 06 07 08")))
@@ -898,6 +922,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Send single frame ISOTP message
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 cans = new_can_socket(iface0)
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
@@ -909,6 +934,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Send two-frame ISOTP message
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 cans = new_can_socket(iface0)
 acker_ready = threading.Event()
@@ -935,6 +961,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Receive a single frame ISOTP message
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
@@ -949,6 +976,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Receive a single frame ISOTP message, with extended addressing
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241, extended_addr=0xc0, extended_rx_addr=0xea) as s:
     cans = new_can_socket(iface0)
@@ -963,6 +991,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241, extended_addr=0xc
 
 = Receive a two-frame ISOTP message
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
@@ -974,6 +1003,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = Check what happens when a CAN frame with wrong identifier gets received
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
@@ -983,9 +1013,9 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 + Testing ISOTPSocket timeouts
 
-
 = Check if not sending the last CF will make the socket timeout
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
@@ -999,6 +1029,7 @@ assert(len(isotp) == 0)
 
 = Check if not sending the first CF will make the socket timeout
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
@@ -1010,6 +1041,7 @@ assert(len(isotp) == 0)
 
 = Check if not sending the first FC will make the socket timeout
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 exception = None
 isotp = ISOTP(data=dhex("01 02 03 04 05 06 07 08 09 0A"))
@@ -1027,6 +1059,7 @@ assert(str(exception) == "TX state was reset due to timeout")
 
 = Check if not sending the second FC will make the socket timeout
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 exception = None
 isotp = ISOTP(data=b"\xa5" * 120)
@@ -1058,6 +1091,7 @@ assert(str(exception) == "TX state was reset due to timeout")
 
 = Check if reception of an overflow FC will make a send fail
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 exception = None
 isotp = ISOTP(data=b"\xa5" * 120)
@@ -1089,6 +1123,7 @@ assert(str(exception) == "Overflow happened at the receiver side")
 
 = Close the Socket
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     s.close()
@@ -1097,6 +1132,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 
 = ISOTPSoftSocket sr1
 ~ needs_root linux
+exit_if_no_can_sockets()
 
 evt = threading.Event()
 msg = ISOTP(b'\x11\x22\x33\x11\x22\x33\x11\x22\x33\x11\x22\x33')
@@ -1126,6 +1162,7 @@ assert(rx2 == msg)
 
 = ISOTPSoftSocket sr1 and ISOTP test vice versa
 ~ needs_root linux
+exit_if_no_can_sockets()
 
 rx2 = None
 sent = False
@@ -1154,6 +1191,7 @@ assert(sent)
 
 = ISOTPSoftSocket sniff
 ~ needs_root linux
+exit_if_no_can_sockets()
 
 evt = threading.Event()
 succ = False
@@ -1200,6 +1238,7 @@ assert(succ)
 
 = bridge and sniff with isotp soft sockets set up vcan0 and vcan1 for package forwarding vcan1
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 drain_bus(iface0)
 drain_bus(iface1)
@@ -1237,6 +1276,7 @@ drain_bus(iface1)
 
 = bridge and sniff with isotp soft sockets and multiple long packets
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 drain_bus(iface0)
 drain_bus(iface1)
@@ -1281,7 +1321,7 @@ drain_bus(iface1)
 
 = bridge and sniff with isotp soft sockets set up vcan0 and vcan1 for package change vcan1
 ~ linux needs_root
-
+exit_if_no_can_sockets()
 
 drain_bus(iface0)
 drain_bus(iface1)
@@ -1314,9 +1354,9 @@ assert succ
 drain_bus(iface0)
 drain_bus(iface1)
 
-
 = Two ISOTPSockets at the same time, sending and receiving
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
      ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641) as s2:
@@ -1333,6 +1373,7 @@ assert(result.data == isotp.data)
 
 = Two ISOTPSockets at the same time, multiple sends/receives
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
      ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641) as s2:
@@ -1349,6 +1390,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
 
 = Send a single frame ISOTP message with padding
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
@@ -1359,6 +1401,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
 
 = Send a two-frame ISOTP message with padding
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 cans = new_can_socket(iface0)
 acker_ready = threading.Event()
@@ -1386,6 +1429,7 @@ assert(can.data == dhex("21 07 08 00 00 00 00 00"))
 
 = Receive a padded single frame ISOTP message with padding disabled
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
     cans = new_can_socket(iface0)
@@ -1396,6 +1440,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
 
 = Receive a padded single frame ISOTP message with padding enabled
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
@@ -1406,6 +1451,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
 
 = Receive a non-padded single frame ISOTP message with padding enabled
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
@@ -1416,6 +1462,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
 
 = Receive a padded two-frame ISOTP message with padding enabled
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
@@ -1427,6 +1474,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
 
 = Receive a padded two-frame ISOTP message with padding disabled
 ~ linux needs_root
+exit_if_no_can_sockets()
 
 with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
     cans = new_can_socket(iface0)
@@ -1444,6 +1492,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
 
 = Compatibility with isotpsend
 exit_if_no_isotp_module()
+exit_if_no_can_sockets()
 
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
@@ -1459,6 +1508,8 @@ with ISOTPSocket(new_can_socket0(), sid=0x642, did=0x242) as s:
 
 = Compatibility with isotpsend - extended addresses
 exit_if_no_isotp_module()
+exit_if_no_can_sockets()
+
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
 with ISOTPSocket(new_can_socket0(), sid=0x644, did=0x244, extended_addr=0xaa, extended_rx_addr=0xee) as s:
@@ -1473,6 +1524,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x644, did=0x244, extended_addr=0xaa, ex
 
 = Compatibility with isotprecv
 exit_if_no_isotp_module()
+exit_if_no_can_sockets()
 
 isotp = ISOTP(data=bytearray(range(1,20)))
 cmd = "isotprecv -s 243 -d 643 -b 3 %s" % iface0
@@ -1502,6 +1554,8 @@ assert(result_data == isotp.data)
 
 = Compatibility with isotprecv - extended addresses
 exit_if_no_isotp_module()
+exit_if_no_can_sockets()
+
 isotp = ISOTP(data=bytearray(range(1,20)))
 cmd = "isotprecv -s 245 -d 645 -b 3 %s -x ee:aa" % iface0
 print(cmd)


### PR DESCRIPTION
Issue #1887 occurs, if python-can is not installed. The following changes to the unit-test will verify if python-can is available. If it is not available, all test which require python-can will be skipped. 