### PR TITLE
UUID cleanup

### DIFF
--- a/scapy/contrib/dce_rpc.py
+++ b/scapy/contrib/dce_rpc.py
@@ -23,13 +23,10 @@ Isn't reliable for all packets and for building
 """
 
 # TODO: namespace locally used fields
-import re
-import struct
 from scapy.packet import Packet, Raw, bind_layers
-from scapy.fields import Field, BitEnumField, ByteEnumField, ByteField, \
-    FlagsField, IntField, LenField, ShortField, XByteField, XShortField
-from scapy.volatile import RandField, RandNum, RandInt, RandShort, RandByte
-import scapy.modules.six
+from scapy.fields import BitEnumField, ByteEnumField, ByteField, \
+    FlagsField, IntField, LenField, ShortField, UUIDField, XByteField, \
+    XShortField
 
 
 # Fields
@@ -45,8 +42,13 @@ class EndiannessField(object):
         """Add the endianness to the format"""
         end = self.endianess_from(pkt)
         if isinstance(end, str) and len(end) > 0:
-            # fld.fmt should always start with a order specifier, cf field init
-            self.fld.fmt = end[0] + self.fld.fmt[1:]
+            if isinstance(self.fld, UUIDField):
+                self.fld.uuid_fmt = (UUIDField.FORMAT_LE if end == '<'
+                                     else UUIDField.FORMAT_BE)
+            else:
+                # fld.fmt should always start with a order specifier, cf field
+                # init
+                self.fld.fmt = end[0] + self.fld.fmt[1:]
 
     def getfield(self, pkt, buf):
         """retrieve the field with endianness"""
@@ -60,88 +62,6 @@ class EndiannessField(object):
 
     def __getattr__(self, attr):
         return getattr(self.fld, attr)
-
-
-class UUIDField(Field):
-    """UUID Field"""
-    __slots__ = ["reg"]
-
-    def __init__(self, name, default):
-        # create and compile the regex used to extract the uuid values from str
-        reg = r"^\s*{0}-{1}-{1}-{2}{2}-{2}{2}{2}{2}{2}{2}\s*$".format(
-            "([0-9a-f]{8})", "([0-9a-f]{4})", "([0-9a-f]{2})"
-        )
-        self.reg = re.compile(reg, re.I)
-
-        Field.__init__(self, name, default, fmt="I2H8B")
-
-    def i2m(self, pkt, val):
-        if val is None:
-            return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
-        if isinstance(val, bytearray) or isinstance(val, str):  # py3 concern
-            # use the regex to extract the values
-            match = self.reg.match(val)
-            if match:
-                # we return a tuple of values after parsing them to integer
-                return tuple([int(i, 16) for i in match.groups()])
-            else:
-                return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        else:
-            return val
-
-    def m2i(self, pkt, val):
-        return ("%08x-%04x-%04x-%02x%02x-" + "%02x" * 6) % val
-
-    def any2i(self, pkt, val):
-        if isinstance(val, bytearray) and len(val) == 16:
-            return self.getfield(pkt, val)[1]
-        elif isinstance(val, bytearray):
-            return val.lower()
-        return val
-
-    def addfield(self, pkt, s, val):
-        return s + struct.pack(self.fmt, *self.i2m(pkt, val))
-
-    def getfield(self, pkt, s):
-        return s[16:], self.m2i(pkt, struct.unpack(self.fmt, s[:16]))
-
-    @staticmethod
-    def randval():
-        return RandUUID()
-
-
-class RandUUID(RandField):
-    """generate a random UUID"""
-    def __init__(self, template="*-*-*-**-******"):
-        base = "([0-9a-f]{{{0}}}|\\*|[0-9a-f]{{{0}}}:[0-9a-f]{{{0}}})"
-        reg = re.compile(
-            r"^\s*{0}-{1}-{1}-{2}{2}-{2}{2}{2}{2}{2}{2}\s*$".format(
-                base.format(8), base.format(4), base.format(2)
-            ),
-            re.I
-        )
-
-        tmp = reg.match(template)
-        if tmp:
-            template = tmp.groups()
-        else:
-            template = ["*"] * 11
-
-        rnd_f = [RandInt] + [RandShort] * 2 + [RandByte] * 8
-        self.uuid = ()
-        for i in scapy.modules.six.moves.range(11):
-            if template[i] == "*":
-                val = rnd_f[i]()
-            elif ":" in template[i]:
-                mini, maxi = template[i].split(":")
-                val = RandNum(int(mini, 16), int(maxi, 16))
-            else:
-                val = int(template[i], 16)
-            self.uuid += (val,)
-
-    def _fix(self):
-        return ("%08x-%04x-%04x-%02x%02x-" + "%02x" * 6) % self.uuid
 
 
 # DCE/RPC Packet

--- a/scapy/contrib/dce_rpc.py
+++ b/scapy/contrib/dce_rpc.py
@@ -41,7 +41,7 @@ class EndiannessField(object):
     def set_endianess(self, pkt):
         """Add the endianness to the format"""
         end = self.endianess_from(pkt)
-        if isinstance(end, str) and len(end) > 0:
+        if isinstance(end, str) and end:
             if isinstance(self.fld, UUIDField):
                 self.fld.uuid_fmt = (UUIDField.FORMAT_LE if end == '<'
                                      else UUIDField.FORMAT_BE)

--- a/scapy/contrib/dce_rpc.uts
+++ b/scapy/contrib/dce_rpc.uts
@@ -4,6 +4,7 @@
 = Import the DCE/RPC layer
 import re
 from scapy.contrib.dce_rpc import *
+from uuid import UUID
 
 
 + Check EndiannessField
@@ -40,46 +41,24 @@ f.getfield(None, '0102030405') == (b'', '0102030405')
 f = EndiannessField(StrField('f', 0), lambda p: '>')
 f.addfield(None, b'01', '02030405') == b'0102030405'
 
+= Little Endian UUIDField getfield
+* The endianness of a UUIDField should be apply by block on each block in
+* parenthesis '(01234567)-(89ab)-(cdef)-(01)(23)-(45)(67)(89)(ab)(cd)(ef)'
 
+f = EndiannessField(UUIDField('f', None), lambda p: '<')
+f.getfield(None, hex_bytes('0123456789abcdef0123456789abcdef')) == (b'', UUID('67452301-ab89-efcd-0123-456789abcdef'))
 
-+ Check UUIDField
-
-= Parsing a human-readable UUID
-f = UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef')
-f.addfield(None, b'', f.default) == bytearray.fromhex('0123456789abcdef0123456789abcdef')
-
-= Parsing a machine-encoded UUID
-f = UUIDField('f', bytearray.fromhex('0123456789abcdef0123456789abcdef'))
-f.addfield(None, b'', f.default) == bytearray.fromhex('0123456789abcdef0123456789abcdef')
-
-= Parsing a tuple of values
-f = UUIDField('f', (0x01234567, 0x89ab, 0xcdef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef))
-f.addfield(None, b'', f.default) == bytearray.fromhex('0123456789abcdef0123456789abcdef')
-
-= Handle None values
-f = UUIDField('f', None)
-f.addfield(None, b'', f.default) == bytearray.fromhex('00000000000000000000000000000000')
-
-= Get a UUID for dissection
-f = UUIDField('f', None)
-f.getfield(None, bytearray.fromhex('0123456789abcdef0123456789abcdef01')) == (b'\x01', '01234567-89ab-cdef-0123-456789abcdef')
-
-= Verify little endianness of UUIDField
-* The endianness of a UUIDField should be apply by block on each block in parenthesis '(01234567)-(89ab)-(cdef)-(01)(23)-(45)(67)(89)(ab)(cd)(ef)'
+= Little Endian UUIDField addfield
 f = EndiannessField(UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef'), lambda p: '<')
-f.addfield(None, b'', f.default) == bytearray.fromhex('67452301ab89efcd0123456789abcdef')
+f.addfield(None, b'', f.default) == hex_bytes('67452301ab89efcd0123456789abcdef')
 
-= Verify RandUUID
-re.match(r'[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}', str(RandUUID()), re.I) is not None
+= Big Endian UUIDField getfield
+f = EndiannessField(UUIDField('f', None), lambda p: '>')
+f.getfield(None, hex_bytes('0123456789abcdef0123456789abcdef')) == (b'', UUID('01234567-89ab-cdef-0123456789abcdef'))
 
-= Verify RandUUID with a static part
-* RandUUID template can contain static part such a 01234567-89ab-*-01*-*****ef
-re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{10}ef', str(RandUUID('01234567-89ab-*-01*-*****ef')), re.I) is not None
-
-= Verify RandUUID with a range part
-* RandUUID template can contain a part with a range of values such a 01234567-89ab-*-01*-****c0:c9ef
-re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{8}c[0-9]ef', str(RandUUID('01234567-89ab-*-01*-****c0:c9ef')), re.I) is not None
-
+= Big Endian UUIDField addfield
+f = EndiannessField(UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef'), lambda p: '>')
+f.addfield(None, b'', f.default) == hex_bytes('0123456789abcdef0123456789abcdef')
 
 
 + Check DCE/RPC layer

--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -22,16 +22,18 @@ PNIO RPC endpoints
 """
 
 import struct
+from uuid import UUID
+
 from scapy.packet import Packet, bind_layers
 from scapy.config import conf
-from scapy.fields import BitField, ByteField, BitEnumField, \
+from scapy.fields import BitField, ByteField, BitEnumField, ConditionalField, \
     FieldLenField, FieldListField, IntField, IntEnumField, \
     LenField, MACField, PadField, PacketField, PacketListField, \
     ShortEnumField, ShortField, StrFixedLenField, StrLenField, \
-    XByteField, XIntField, XShortEnumField, XShortField, ConditionalField
-from scapy.contrib.dce_rpc import DceRpc, EndiannessField, DceRpcPayload, \
-    UUIDField, RandUUID
+    UUIDField, XByteField, XIntField, XShortEnumField, XShortField
+from scapy.contrib.dce_rpc import DceRpc, EndiannessField, DceRpcPayload
 from scapy.compat import bytes_hex
+from scapy.volatile import RandUUID
 
 # Block Packet
 BLOCK_TYPES_ENUM = {
@@ -275,14 +277,19 @@ IOCR_BLOCK_REQ_IOCR_PROPERTIES = {
 }
 
 
-# List of all valid activity uuid for the DceRpc
-# layer with PROFINET RPC endpoint
+# List of all valid activity UUIDs for the DceRpc layer with PROFINET RPC
+# endpoint.
+#
+# Because these are used in overloaded_fields, it must be a ``UUID``, not a
+# string.
 RPC_INTERFACE_UUID = {
-    "UUID_IO_DeviceInterface": "dea00001-6c97-11d1-8271-00a02442df7d",
-    "UUID_IO_ControllerInterface": "dea00002-6c97-11d1-8271-00a02442df7d",
-    "UUID_IO_SupervisorInterface": "dea00003-6c97-11d1-8271-00a02442df7d",
+    "UUID_IO_DeviceInterface": UUID("dea00001-6c97-11d1-8271-00a02442df7d"),
+    "UUID_IO_ControllerInterface":
+        UUID("dea00002-6c97-11d1-8271-00a02442df7d"),
+    "UUID_IO_SupervisorInterface":
+        UUID("dea00003-6c97-11d1-8271-00a02442df7d"),
     "UUID_IO_ParameterServerInterface":
-        "dea00004-6c97-11d1-8271-00a02442df7d",
+        UUID("dea00004-6c97-11d1-8271-00a02442df7d"),
 }
 
 
@@ -963,7 +970,7 @@ class PNIOServiceReqPDU(Packet):
         """heuristical guess_payload_class"""
         # type = 0 => request
         if rpc.getfieldval("type") == 0 and \
-                rpc.object_uuid.startswith("dea00000-6c97-11d1-8271-"):
+                str(rpc.object_uuid).startswith("dea00000-6c97-11d1-8271-"):
             return True
         return False
 
@@ -995,7 +1002,7 @@ class PNIOServiceResPDU(Packet):
         """heuristical guess_payload_class"""
         # type = 2 => response
         if rpc.getfieldval("type") == 2 and \
-                rpc.object_uuid.startswith("dea00000-6c97-11d1-8271-"):
+                str(rpc.object_uuid).startswith("dea00000-6c97-11d1-8271-"):
             return True
         return False
 

--- a/scapy/contrib/pnio_rpc.uts
+++ b/scapy/contrib/pnio_rpc.uts
@@ -4,10 +4,11 @@
 = Import the PNIO RPC layer
 from scapy.contrib.dce_rpc import *
 from scapy.contrib.pnio_rpc import *
+from scapy.modules.six import itervalues
 
 = Check that we have UUIDs
 
-for v in RPC_INTERFACE_UUID.values():
+for v in itervalues(RPC_INTERFACE_UUID):
     assert(isinstance(v, UUID))
 
 + Check Block

--- a/scapy/contrib/pnio_rpc.uts
+++ b/scapy/contrib/pnio_rpc.uts
@@ -5,6 +5,10 @@
 from scapy.contrib.dce_rpc import *
 from scapy.contrib.pnio_rpc import *
 
+= Check that we have UUIDs
+
+for v in RPC_INTERFACE_UUID.values():
+    assert(isinstance(v, UUID))
 
 + Check Block
 

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -25,7 +25,7 @@ from scapy.fields import BitField, ByteEnumField, ByteField, FieldLenField, \
     FlagsField, IntEnumField, IntField, MACField, PacketField, \
     PacketListField, ShortEnumField, ShortField, StrField, StrFixedLenField, \
     StrLenField, UTCTimeField, X3BytesField, XIntField, XShortEnumField, \
-    PacketLenField
+    PacketLenField, UUIDField
 from scapy.layers.inet import UDP
 from scapy.layers.inet6 import DomainNameListField, IP6Field, IP6ListField, \
     IPv6
@@ -285,7 +285,7 @@ class DUID_LL(Packet):  # sect 9.4 RFC 3315
 class DUID_UUID(Packet):  # RFC 6355
     name = "DUID - Based on UUID"
     fields_desc = [ShortEnumField("type", 4, duidtypes),
-                   StrFixedLenField("uuid", "", 16)]
+                   UUIDField("uuid", None, uuid_fmt=UUIDField.FORMAT_BE)]
 
 
 duid_cls = {1: "DUID_LLT",

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -1,6 +1,8 @@
 # This file is part of Scapy
 # See http://www.secdev.org/projects/scapy for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
+# Copyright (C) Michael Farrell <micolous+git@gmail.com>
+# Copyright (C) Gauthier Sebaux
 # This program is published under a GPLv2 license
 
 """
@@ -11,6 +13,9 @@ from __future__ import absolute_import
 import random
 import time
 import math
+import re
+import uuid
+
 from scapy.base_classes import Net
 from scapy.compat import bytes_encode, chb, plain_str
 from scapy.utils import corrupt_bits, corrupt_bytes
@@ -782,6 +787,130 @@ class RandPool(RandField):
     def _fix(self):
         r = random.choice(self._pool)
         return r._fix()
+
+
+class RandUUID(RandField):
+    """Generates a random UUID.
+
+    By default, this generates a RFC 4122 version 4 UUID (totally random).
+
+    See Python's ``uuid`` module documentation for more information.
+
+    Args:
+        template (optional): A template to build the UUID from. Not valid with
+                             any other option.
+        node (optional): A 48-bit Host ID. Only valid for version 1 (where it
+                         is optional).
+        clock_seq (optional): An integer of up to 14-bits for the sequence
+                              number. Only valid for version 1 (where it is
+                              optional).
+        namespace: A namespace identifier, which is also a UUID. Required for
+                   versions 3 and 5, must be omitted otherwise.
+        name: string, required for versions 3 and 5, must be omitted otherwise.
+        version: Version of UUID to use (1, 3, 4 or 5). If omitted, attempts to
+                 guess which version to generate, defaulting to version 4
+                 (totally random).
+
+    Raises:
+        ValueError: on invalid constructor arguments
+    """
+    # This was originally scapy.contrib.dce_rpc.RandUUID.
+
+    _BASE = "([0-9a-f]{{{0}}}|\\*|[0-9a-f]{{{0}}}:[0-9a-f]{{{0}}})"
+    _REG = re.compile(
+        r"^{0}-?{1}-?{1}-?{2}{2}-?{2}{2}{2}{2}{2}{2}$".format(
+            _BASE.format(8), _BASE.format(4), _BASE.format(2)
+        ),
+        re.I
+    )
+    VERSIONS = (1, 3, 4, 5)
+
+    def __init__(self, template=None, node=None, clock_seq=None,
+                 namespace=None, name=None, version=None):
+        self.uuid_template = None
+        self.node = None
+        self.clock_seq = None
+        self.namespace = None
+        self.node = None
+        self.version = None
+
+        if template:
+            if node or clock_seq or namespace or name or version:
+                raise ValueError("UUID template must be the only parameter, "
+                                 "if specified")
+            tmp = RandUUID._REG.match(template)
+            if tmp:
+                template = tmp.groups()
+            else:
+                # Invalid template
+                raise ValueError("UUID template is invalid")
+
+            rnd_f = [RandInt] + [RandShort] * 2 + [RandByte] * 8
+            uuid_template = []
+            for i, t in enumerate(template):
+                if t == "*":
+                    val = rnd_f[i]()
+                elif ":" in t:
+                    mini, maxi = t.split(":")
+                    val = RandNum(int(mini, 16), int(maxi, 16))
+                else:
+                    val = int(t, 16)
+                uuid_template.append(val)
+
+            self.uuid_template = tuple(uuid_template)
+        else:
+            if version:
+                if version not in RandUUID.VERSIONS:
+                    raise ValueError("version is not supported")
+                else:
+                    self.version = version
+            else:
+                # No version specified, try to guess...
+                # This could be wrong, and cause an error later!
+                if node or clock_seq:
+                    self.version = 1
+                elif namespace and name:
+                    self.version = 5
+                else:
+                    # Don't know, random!
+                    self.version = 4
+
+            # We have a version, now do things...
+            if self.version == 1:
+                if namespace or name:
+                    raise ValueError("namespace and name may not be used with "
+                                     "version 1")
+                self.node = node
+                self.clock_seq = clock_seq
+            elif self.version in (3, 5):
+                if node or clock_seq:
+                    raise ValueError("node and clock_seq may not be used with "
+                                     "version {}".format(self.version))
+
+                self.namespace = namespace
+                self.name = name
+            elif self.version == 4:
+                if namespace or name or node or clock_seq:
+                    raise ValueError("node, clock_seq, node and clock_seq may "
+                                     "not be used with version 4. If you "
+                                     "did not specify version, you need to "
+                                     "specify it explicitly.")
+
+    def _fix(self):
+        if self.uuid_template:
+            return uuid.UUID(("%08x%04x%04x" + ("%02x" * 8))
+                             % self.uuid_template)
+        elif self.version == 1:
+            return uuid.uuid1(self.node, self.clock_seq)
+        elif self.version == 3:
+            return uuid.uuid3(self.namespace, self.name)
+        elif self.version == 4:
+            return uuid.uuid4()
+        elif self.version == 5:
+            return uuid.uuid5(self.namespace, self.name)
+        else:
+            raise ValueError("Unhandled version")
+
 
 # Automatic timestamp
 

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -823,7 +823,7 @@ class RandUUID(RandField):
         ),
         re.I
     )
-    VERSIONS = (1, 3, 4, 5)
+    VERSIONS = [1, 3, 4, 5]
 
     def __init__(self, template=None, node=None, clock_seq=None,
                  namespace=None, name=None, version=None):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6,6 +6,14 @@
 ############
 + Information on Scapy
 
+= Setup
+def expect_exception(e, c):
+    try:
+        c()
+        return False
+    except e:
+        return True
+
 = Get conf
 ~ conf command
 * Dump the current configuration
@@ -4374,6 +4382,29 @@ a.type == 3 and a.hwtype == 1 and a.lladdr == "00:00:00:00:00:00"
 = DUID_LL with specific values 
 a=DUID_LL(b'\x00\x03\x00\x01\xff\xff\xff\xff\xff\xff')
 a.hwtype == 1 and a.lladdr == "ff:ff:ff:ff:ff:ff"
+
+
+############
+############
++ Test DHCP6 DUID_UUID
+
+= DUID_UUID basic instantiation
+a=DUID_UUID() 
+
+= DUID_UUID basic build
+raw(DUID_UUID()) == b"\0\x04\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+
+= DUID_UUID build with specific values
+raw(DUID_UUID(uuid="272adcca-138c-4e8d-b3f4-634e953128cf")) == \
+   b"\x00\x04'*\xdc\xca\x13\x8cN\x8d\xb3\xf4cN\x951(\xcf"
+
+= DUID_UUID basic dissection
+a=DUID_UUID(raw(DUID_UUID()))
+a.type == 4 and str(a.uuid) == "00000000-0000-0000-0000-000000000000"
+
+= DUID_UUID with specific values 
+a=DUID_UUID(b"\x00\x04'*\xdc\xca\x13\x8cN\x8d\xb3\xf4cN\x951(\xcf")
+a.type == 4 and str(a.uuid) == "272adcca-138c-4e8d-b3f4-634e953128cf"
 
 
 ############
@@ -9937,8 +9968,8 @@ len(r4.routes) == len_r4
 
 = RandomEnumeration
 
-re = RandomEnumeration(0, 7, seed=0x2807, forever=False)
-[x for x in re] == ([3, 4, 2, 5, 1, 6, 0, 7] if six.PY2 else [5, 0, 2, 7, 6, 3, 1, 4])
+ren = RandomEnumeration(0, 7, seed=0x2807, forever=False)
+[x for x in ren] == ([3, 4, 2, 5, 1, 6, 0, 7] if six.PY2 else [5, 0, 2, 7, 6, 3, 1, 4])
 
 = RandIP6
 
@@ -9979,8 +10010,8 @@ assert(ro == ("1.2.3.11" if six.PY2 else "1.2.3.12"))
 = RandRegExp
 
 random.seed(0x2807)
-re = RandRegExp("[g-v]* @? [0-9]{3} . (g|v)")
-bytes(re) == ('vmuvr @ 906 \x9e g' if six.PY2 else b'irrtv @ 517 \xc2\xb8 v')
+rex = RandRegExp("[g-v]* @? [0-9]{3} . (g|v)")
+bytes(rex) == ('vmuvr @ 906 \x9e g' if six.PY2 else b'irrtv @ 517 \xc2\xb8 v')
 
 = Corrupted(Bytes|Bits)
 
@@ -11010,6 +11041,166 @@ assert p.inner.f_name == b"scapy"
 
 p = TestPacket()
 assert p.inner.f_name == b"test"
+
++ UUIDField
+
+= Parsing a human-readable UUID
+f = UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef')
+f.addfield(None, b'', f.default) == hex_bytes('0123456789abcdef0123456789abcdef')
+
+= Parsing a machine-encoded UUID
+f = UUIDField('f', bytearray.fromhex('0123456789abcdef0123456789abcdef'))
+f.addfield(None, b'', f.default) == hex_bytes('0123456789abcdef0123456789abcdef')
+
+= Parsing a tuple of values
+f = UUIDField('f', (0x01234567, 0x89ab, 0xcdef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef))
+f.addfield(None, b'', f.default) == hex_bytes('0123456789abcdef0123456789abcdef')
+
+= Handle None values
+f = UUIDField('f', None)
+f.addfield(None, b'', f.default) == hex_bytes('00000000000000000000000000000000')
+
+= Get a UUID for dissection
+from uuid import UUID
+f = UUIDField('f', None)
+f.getfield(None, bytearray.fromhex('0123456789abcdef0123456789abcdef01')) == (b'\x01', UUID('01234567-89ab-cdef-0123-456789abcdef'))
+
+= Verify little endian UUIDField
+* The endianness of a UUIDField should be apply by block on each block in parenthesis '(01234567)-(89ab)-(cdef)-(01)(23)-(45)(67)(89)(ab)(cd)(ef)'
+f = UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef', uuid_fmt=UUIDField.FORMAT_LE)
+f.addfield(None, b'', f.default) == hex_bytes('67452301ab89efcd0123456789abcdef')
+
+= Verify reversed UUIDField
+* This should reverse the entire value as 128-bits
+f = UUIDField('f', '01234567-89ab-cdef-0123-456789abcdef', uuid_fmt=UUIDField.FORMAT_REV)
+f.addfield(None, b'', f.default) == hex_bytes('efcdab8967452301efcdab8967452301')
+
++ RandUUID
+
+= RandUUID setup
+
+RANDUUID_TEMPLATE = '01234567-89ab-*-01*-*****ef'
+RANDUUID_FIXED = uuid.uuid4()
+
+= RandUUID default behaviour
+
+u = RandUUID()._fix()
+u.version == 4
+
+= RandUUID incorrect implicit args
+
+expect_exception(ValueError, lambda: RandUUID(node=0x1234, name="scapy"))
+expect_exception(ValueError, lambda: RandUUID(node=0x1234, namespace=uuid.uuid4()))
+expect_exception(ValueError, lambda: RandUUID(clock_seq=0x1234, name="scapy"))
+expect_exception(ValueError, lambda: RandUUID(clock_seq=0x1234, namespace=uuid.uuid4()))
+expect_exception(ValueError, lambda: RandUUID(name="scapy"))
+expect_exception(ValueError, lambda: RandUUID(namespace=uuid.uuid4()))
+
+= RandUUID v4 UUID (correct args)
+
+u = RandUUID(version=4)._fix()
+u.version == 4
+
+u2 = RandUUID(version=4)._fix()
+u2.version == 4
+
+str(u) != str(u2)
+
+= RandUUID v4 UUID (incorrect args)
+
+expect_exception(ValueError, lambda: RandUUID(version=4, template=RANDUUID_TEMPLATE))
+expect_exception(ValueError, lambda: RandUUID(version=4, node=0x1234))
+expect_exception(ValueError, lambda: RandUUID(version=4, clock_seq=0x1234))
+expect_exception(ValueError, lambda: RandUUID(version=4, namespace=uuid.uuid4()))
+expect_exception(ValueError, lambda: RandUUID(version=4, name="scapy"))
+
+= RandUUID v1 UUID
+
+u = RandUUID(version=1)._fix()
+u.version == 1
+
+u = RandUUID(version=1, node=0x1234)._fix()
+u.version == 1
+u.node == 0x1234
+
+u = RandUUID(version=1, clock_seq=0x1234)._fix()
+u.version == 1
+u.clock_seq == 0x1234
+
+u = RandUUID(version=1, node=0x1234, clock_seq=0x1bcd)._fix()
+u.version == 1
+u.node == 0x1234
+u.clock_seq == 0x1bcd
+
+= RandUUID v1 UUID (implicit version)
+
+u = RandUUID(node=0x1234)._fix()
+u.version == 1
+u.node == 0x1234
+
+u = RandUUID(clock_seq=0x1234)._fix()
+u.version == 1
+u.clock_seq == 0x1234
+
+u = RandUUID(node=0x1234, clock_seq=0x1bcd)._fix()
+u.version == 1
+u.node == 0x1234
+u.clock_seq == 0x1bcd
+
+= RandUUID v1 UUID (incorrect args)
+
+expect_exception(ValueError, lambda: RandUUID(version=1, template=RANDUUID_TEMPLATE))
+expect_exception(ValueError, lambda: RandUUID(version=1, namespace=uuid.uuid4()))
+expect_exception(ValueError, lambda: RandUUID(version=1, name="scapy"))
+
+= RandUUID v5 UUID
+
+u = RandUUID(version=5, namespace=RANDUUID_FIXED, name="scapy")._fix()
+u.version == 5
+
+u2 = RandUUID(version=5, namespace=RANDUUID_FIXED, name="scapy")._fix()
+u2.version == 5
+u.bytes == u2.bytes
+
+# implicit v5
+u2 = RandUUID(namespace=RANDUUID_FIXED, name="scapy")._fix()
+u.bytes == u2.bytes
+
+= RandUUID v5 UUID (incorrect args)
+
+expect_exception(ValueError, lambda: RandUUID(version=5, template=RANDUUID_TEMPLATE))
+expect_exception(ValueError, lambda: RandUUID(version=5, node=0x1234))
+expect_exception(ValueError, lambda: RandUUID(version=5, clock_seq=0x1234))
+
+= RandUUID v3 UUID
+
+u = RandUUID(version=3, namespace=RANDUUID_FIXED, name="scapy")._fix()
+u.version == 3
+
+u2 = RandUUID(version=3, namespace=RANDUUID_FIXED, name="scapy")._fix()
+u2.version == 3
+u.bytes == u2.bytes
+
+# implicit v5
+u2 = RandUUID(namespace=RANDUUID_FIXED, name="scapy")._fix()
+u.bytes != u2.bytes
+
+= RandUUID v3 UUID (incorrect args)
+
+expect_exception(ValueError, lambda: RandUUID(version=5, template=RANDUUID_TEMPLATE))
+expect_exception(ValueError, lambda: RandUUID(version=5, node=0x1234))
+expect_exception(ValueError, lambda: RandUUID(version=5, clock_seq=0x1234))
+
+= RandUUID looks like a UUID with str
+re.match(r'[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}', str(RandUUID()), re.I) is not None
+
+= RandUUID with a static part
+* RandUUID template can contain static part such a 01234567-89ab-*-01*-*****ef
+re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{10}ef', str(RandUUID('01234567-89ab-*-01*-*****ef')), re.I) is not None
+
+= RandUUID with a range part
+* RandUUID template can contain a part with a range of values such a 01234567-89ab-*-01*-****c0:c9ef
+re.match(r'01234567-89ab-[0-9a-f]{4}-01[0-9a-f]{2}-[0-9a-f]{8}c[0-9]ef', str(RandUUID('01234567-89ab-*-01*-****c0:c9ef')), re.I) is not None
 
 ############
 ############


### PR DESCRIPTION
There are multiple implementations of a UUID-like field, and some places where we don't use this at all (but could!).  This pull request merges them, and brings it into a new `scapy.field.UUIDField`.

This impacts `s.l.bluetooth`, `s.l.dhcp6`, `s.c.dce_rpc`, `s.c.opc_da` and `s.c.pnio_rpc`.

The new `UUIDField` always uses Python's `uuid.UUID` class as an internal representation (not all modules did this).

- Merge functionality of `s.l.bluetooth.BTUUIDField` and `s.c.dce_rpc.UUIDField` into `s.fields.UUIDField`
- Moves `s.c.dce_rpc.RandUUID` to `s.volatile`
- Adds support for RFC 4122 "versioned" UUIDs to `RandUUID`, and adds tests
- Moves `UUIDField` tests that don't use `EndiannessField` from `s/c/dce_rpc.uts` to `t/regression.uts`
- `dhcp6`: Migrates `DUID_UUID.uuid` to `UUIDField`, and adds tests (tested only with regression tests, based on my reading of the RFC)
- `opc_da`: Migrate from `PUUID` to `UUIDField`, removes `PUUID` (tested only with regression tests)
- `pnio_rpc`: Fix regressions from `dce_rpc` changes (tested only with regression tests)
- Fix `re` module stomping in `t/regression.uts`

Tests still pass on py2.7 and 3.7 (skipping root/netaccess tests)