### PR TITLE
Do not check IP source addresses when conf.checkIPsrc is False

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -853,13 +853,21 @@ class IPerror(IP):
     def answers(self, other):
         if not isinstance(other, IP):
             return 0
-        if not (((conf.checkIPsrc == 0) or (self.dst == other.dst)) and
-                (self.src == other.src) and
-                (((conf.checkIPID == 0) or
-                  (self.id == other.id) or
-                  (conf.checkIPID == 1 and self.id == socket.htons(other.id)))) and  # noqa: E501
-                (self.proto == other.proto)):
+
+        # Check if IP addresses match
+        test_IPsrc = not conf.checkIPsrc or self.src == other.src
+        test_IPdst = self.dst == other.dst
+
+        # Check if IP ids match
+        test_IPid = not conf.checkIPID or self.id == other.id
+        test_IPid |= conf.checkIPID and self.id == socket.htons(other.id)
+
+        # Check if IP protocols match
+        test_IPproto = self.proto == other.proto
+
+        if not (test_IPsrc and test_IPdst and test_IPid and test_IPproto):
             return 0
+
         return self.payload.answers(other.payload)
 
     def mysummary(self):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -869,6 +869,15 @@ p1 = IP(src=a1, dst=a2)/TCP(flags='A', seq=s1+9, ack=s2+10, sport=prt1, dport=pr
 assert not p2.answers(p1)
 assert not p1.answers(p2)
 
+= conf.checkIPsrc
+
+conf_checkIPsrc = conf.checkIPsrc
+conf.checkIPsrc = 0
+query = IP(id=42676, src='10.128.0.7', dst='192.168.0.1')/ICMP(id=26)
+answer = IP(src='192.168.48.19', dst='10.128.0.7')/ICMP(type=11)/IPerror(id=42676, src='192.168.51.23', dst='192.168.0.1')/ICMPerror(id=26)
+assert answer.answers(query)
+conf.checkIPsrc = conf_checkIPsrc
+
 
 ############
 ############


### PR DESCRIPTION
This PR fixes #1894.

I rewrote the whole test as it was quite difficult to understand.