### PR TITLE
PPI cleanups

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -615,7 +615,7 @@ recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
                    'dot11', 'dot15d4', 'eap', 'gprs', 'hsrp', 'inet',
                    'inet6', 'ipsec', 'ir', 'isakmp', 'l2', 'l2tp',
                    'llmnr', 'lltd', 'mgcp', 'mobileip', 'netbios',
-                   'netflow', 'ntp', 'ppp', 'pptp', 'radius', 'rip',
+                   'netflow', 'ntp', 'ppi', 'ppp', 'pptp', 'radius', 'rip',
                    'rtp', 'sctp', 'sixlowpan', 'skinny', 'smb', 'snmp',
                    'tftp', 'vrrp', 'vxlan', 'x509', 'zigbee']
     contribs = dict()

--- a/scapy/contrib/ppi_cace.uts
+++ b/scapy/contrib/ppi_cace.uts
@@ -8,132 +8,135 @@
 from scapy.contrib.ppi_cace import *
 from scapy.contrib.ppi_geotag import *
 
+
+
 def Pkt_10_1():
     """GPS Only"""
-    pkt = PPI(PPIFieldHeaders=GPS(Latitude=40.787743, Longitude=-73.971210))/\
-            Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:01")/\
-            Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.1")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(Latitude=40.787743,Longitude=-73.971210)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:01")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.1")
     return PPI(raw(pkt))
 
 def Pkt_10_2():
     """GPS + VECTOR + ANTENNA + RADIOTAP""" #No radiotap support yet...
-    pkt = PPI(PPIFieldHeaders=[
-            GPS(Latitude=40.787743, Longitude=-73.971210),
-            Vector(VectorFlags=0x02, VectorChars="Antenna", Pitch=90.0, Roll=0.0, Heading=0.0, DescString="Antenna-1 orientation"),
-            Antenna(AntennaFlags=0x02,Gain=8,HorizBw=360.0,ModelName="8dBi-MagMountOmni"),
-            Dot11Common(Antsignal=-80,Antnoise=-110,Ch_Freq=2437)])/\
-            Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:02")/\
-            Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.2")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(Latitude=40.787743, Longitude=-73.971210),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars="Antenna", Pitch=90.0, Roll=0.0, Heading=0.0, DescString="Antenna-1 orientation"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x02,Gain=8,HorizBw=360.0,ModelName="8dBi-MagMountOmni"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-80,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:02")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.2")
     return PPI(raw(pkt))
 
 def Pkt_10_3():
     """Direction of travel + one directional antenna, with Pitch in ForwardFrame"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
-                Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=10.0,  Heading=22.5, DescString="VehicleVec"),
-                Sensor(SensorType="Velocity", Val_T=20.0),
-                Vector(                  VectorChars=0x01,              Heading=90.0, DescString="AntennaVec"),
-                Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9"),
-                Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:03")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.3")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=10.0,  Heading=22.5, DescString="VehicleVec"),
+            PPI_Hdr()/PPI_Geotag_Sensor(SensorType="Velocity", Val_T=20.0),
+            PPI_Hdr()/PPI_Geotag_Vector(                  VectorChars=0x01,              Heading=90.0, DescString="AntennaVec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:03")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.3")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_4():
     """Two static directional antennas with offsets"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210, Altitude_g=2.00),
-                Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=10.0, Heading=22.5),
-                Sensor(SensorType="Velocity", Val_T=8.5),
-                Sensor(SensorType="Acceleration", Val_T=0.5),
-                Vector(VectorFlags=0x00, VectorChars=0x01, Heading=90.0, Off_X=0.75, Off_Y=0.6, Off_Z=-0.2, DescString="Antenna1Vec"),
-                Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9",DescString="RightAntenna"),
-                Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437),
-                Vector(VectorFlags=0x00, VectorChars=0x01, Heading=270.0, Off_X=-0.75, Off_Y=0.6, Off_Z=-0.2, DescString="Antenna2Vec"),
-                Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9",DescString="LeftAntenna"),
-                Dot11Common(Antsignal=-95,Antnoise=-110,Ch_Freq=2437)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:04")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.4")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210, Altitude_g=2.00),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=10.0, Heading=22.5),
+            PPI_Hdr()/PPI_Geotag_Sensor(SensorType="Velocity", Val_T=8.5),
+            PPI_Hdr()/PPI_Geotag_Sensor(SensorType="Acceleration", Val_T=0.5),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x01, Heading=90.0, Off_X=0.75, Off_Y=0.6, Off_Z=-0.2, DescString="Antenna1Vec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9",DescString="RightAntenna"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x01, Heading=270.0, Off_X=-0.75, Off_Y=0.6, Off_Z=-0.2, DescString="Antenna2Vec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9",DescString="LeftAntenna"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-95,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:04")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.4")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_5():
     """Similar to 10_3, but with a electronically steerable antenna"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
-                Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=00.0, Heading=22.5, DescString="VehicleVec"),
-                Vector(                  VectorChars=0x01,             Heading=120.0, DescString="AntennaVec"),
-                Antenna(AntennaFlags=0x010002,Gain=12,HorizBw=60,BeamID=0xF1A1, ModelName="ElectronicallySteerableExAntenna", AppId=0x04030201),
-                Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:05")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.5")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x06, Pitch=00.0, Heading=22.5, DescString="VehicleVec"),
+            PPI_Hdr()/PPI_Geotag_Vector(                  VectorChars=0x01,             Heading=120.0, DescString="AntennaVec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x010002,Gain=12,HorizBw=60,BeamID=0xF1A1, ModelName="ElectronicallySteerableExAntenna", AppId=0x04030201),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-75,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:05")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.5")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_6():
     """Mechanically steerable antenna. Non-intuitive forward"""
-    pkt = PPI(PPIFieldHeaders=[
-               GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
-                Vector(VectorFlags=0x02, VectorChars=0x06,  Heading=22.5, DescString="VehicleVec"),
-                Vector(VectorFlags=0x03, VectorChars=0x00,  Heading=202.5, DescString="ForwardVec"),
-                Vector(VectorFlags=0x00, VectorChars=0x01,  Heading=75.0, DescString="AntennaVec"),
-                Antenna(AntennaFlags=0x020002,Gain=12,HorizBw=60,ModelName="MechanicallySteerableAnt"),
-                Dot11Common(Antsignal=-77,Antnoise=-110,Ch_Freq=2437)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:06")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.6")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags=0x02, Latitude=40.787743, Longitude=-73.971210),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x06,  Heading=22.5, DescString="VehicleVec"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x00,  Heading=202.5, DescString="ForwardVec"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x01,  Heading=75.0, DescString="AntennaVec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x020002,Gain=12,HorizBw=60,ModelName="MechanicallySteerableAnt"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-77,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:06")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.6")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_7():
     """Drifting boat."""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags=0x02, Latitude= 41.876154,  Longitude=-87.608602),
-                Vector(VectorFlags=0x03, VectorChars=0x04,  Heading=50.0, DescString="VehicleVec"),
-                Vector(VectorFlags=0x00, VectorChars=0x02,  Heading=230.0, DescString="DOT-Vec"),
-                Vector(VectorFlags=0x00, VectorChars=0x01,  Heading=90.0, DescString="AntennaVec"),
-                Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9"),
-                Dot11Common(Antsignal=-77,Antnoise=-110,Ch_Freq=2437)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:07")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.7")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags=0x02, Latitude= 41.876154,  Longitude=-87.608602),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x04,  Heading=50.0, DescString="VehicleVec"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x02,  Heading=230.0, DescString="DOT-Vec"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x01,  Heading=90.0, DescString="AntennaVec"),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x02,Gain=9,HorizBw=120,ModelName="SA24-120-9"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-77,Antnoise=-110,Ch_Freq=2437)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:07")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.7")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_8():
     """Time of arrival analysis"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags="Manual Input", Latitude=41.861885, Longitude=-87.616926, GPSTime=1288720719, FractionalTime=0.20),
-                Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-1 orientation"),
-                Sensor(SensorType="TDOA_Clock", ScaleFactor=-9, Val_T=60.8754, AppId=0x04030201),
-                Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 1"),
-                Dot11Common(Antsignal=-60),
-                GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
-                Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
-                Sensor(SensorType="TDOA_Clock", ScaleFactor=-9, Val_T=178.124, AppId=0x04030201),
-                Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
-                Dot11Common(Antsignal=-80)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:08")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.8")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags="Manual Input", Latitude=41.861885, Longitude=-87.616926, GPSTime=1288720719, FractionalTime=0.20),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-1 orientation"),
+            PPI_Hdr()/PPI_Geotag_Sensor(SensorType="TDOA_Clock", ScaleFactor=-9, Val_T=60.8754, AppId=0x04030201),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 1"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-60),
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
+            PPI_Hdr()/PPI_Geotag_Sensor(SensorType="TDOA_Clock", ScaleFactor=-9, Val_T=178.124, AppId=0x04030201),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-80)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:08")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.8")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_9():
     """Time of arrival analysis(AOA)"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
-                Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
-                Vector(VectorFlags=0x02, VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
-                Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
-                Dot11Common(Antsignal=-80)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:098")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.9")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-80)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:098")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.9")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def Pkt_10_10():
     """Transmitter Position/AOA example"""
-    pkt = PPI(PPIFieldHeaders=[
-                GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
-                Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
-                Vector(VectorFlags=0x03, VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
-                Vector(VectorFlags=0x00, VectorChars=0x10, Off_Y=40, Err_Off=2.0, DescString="Transmitter Position", AppId=0x4030201),
-                Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
-                Dot11Common(Antsignal=-80)])/\
-                Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:0A")/\
-                Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.10")
+    pkt = PPI(headers=[
+            PPI_Hdr()/PPI_Geotag_GPS(GPSFlags="Manual Input", Latitude=41.861904, Longitude=-87.616365, GPSTime=1288720719, FractionalTime=0.20),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x02, VectorChars=0x01, Pitch=90.0, DescString="Antenna-2 orientation"),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x03, VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
+            PPI_Hdr()/PPI_Geotag_Vector(VectorFlags=0x00, VectorChars=0x10, Off_Y=40, Err_Off=2.0, DescString="Transmitter Position", AppId=0x4030201),
+            PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
+            PPI_Hdr()/PPI_Dot11Common(Antsignal=-80)])/\
+        Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:0A")/\
+        Dot11Beacon()/Dot11Elt(ID=0,info="Test-10.10")
     return PPI(raw(pkt)) #Cause the fields to be built
 
 def TestPackets():
@@ -152,9 +155,10 @@ def TestPackets():
 
 = Pkt_10_1
 a = Pkt_10_1()
+raw(a)
 assert raw(a) == b'\x00\x00\x1c\x00i\x00\x00\x002u\x10\x00\x02\x00\x10\x00\x06\x00\x00\x006\x89\x99\x83\x9c\xb52?\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\tTest-10.1'
-assert a.PPIFieldHeaders[0].present == 6
-assert a.PPIFieldHeaders[0].Latitude == 40.7877430
+assert a.headers[0].present == 6
+assert a.headers[0].Latitude == 40.7877430
 assert a[Dot11Beacon].beacon_interval == 100
 assert a[Dot11Elt].info == b'Test-10.1'
 
@@ -162,13 +166,13 @@ assert a[Dot11Elt].info == b'Test-10.1'
 a = Pkt_10_2()
 a.show()
 assert raw(a) == b'\x00\x00\xa9\x00i\x00\x00\x002u\x10\x00\x02\x00\x10\x00\x06\x00\x00\x006\x89\x99\x83\x9c\xb52?3u<\x00\x02\x00<\x00\x1f\x00\x00\x10\x02\x00\x00\x00\x01\x00\x00\x00\x80J]\x05\x00\x00\x00\x00\x00\x00\x00\x00Antenna-1 orientation\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x005u1\x00\x02\x001\x00\x07\x00\x00\x08\x02\x00\x00\x00\x08\x00*u\x158dBi-MagMountOmni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x85\t\x00\x00\x00\x00\xb0\x92\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\tTest-10.2'
-assert isinstance(a.PPIFieldHeaders[0], GPS)
-assert a.PPIFieldHeaders[0].present == 6
-assert isinstance(a.PPIFieldHeaders[1], Vector)
-assert a.PPIFieldHeaders[2].present == 134217735
-assert isinstance(a.PPIFieldHeaders[2], Antenna)
-assert a.PPIFieldHeaders[2].HorizBw == 360.0
-assert isinstance(a.PPIFieldHeaders[3], Dot11Common)
+assert isinstance(a.headers[0].payload, PPI_Geotag_GPS)
+assert a.headers[0].present == 6
+assert isinstance(a.headers[1].payload, PPI_Geotag_Vector)
+assert a.headers[2].present == 134217735
+assert isinstance(a.headers[2].payload, PPI_Geotag_Antenna)
+assert a.headers[2].HorizBw == 360.0
+assert isinstance(a.headers[3].payload, PPI_Dot11Common)
 
 = Pkt_10_3
 a = Pkt_10_3()
@@ -191,61 +195,61 @@ assert raw(a) == b'\x00\x00\x15\x01i\x00\x00\x002u\x14\x00\x02\x00\x14\x00\x07\x
 = Pkt_10_7
 a = Pkt_10_7()
 assert raw(a) == b"\x00\x00\x15\x01i\x00\x00\x002u\x14\x00\x02\x00\x14\x00\x07\x00\x00\x00\x02\x00\x00\x00D\x9d?\x84\xfc\xce\x1173u4\x00\x02\x004\x00\x13\x00\x00\x10\x03\x00\x00\x00\x04\x00\x00\x00\x80\xf0\xfa\x02VehicleVec\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x003u4\x00\x02\x004\x00\x13\x00\x00\x10\x00\x00\x00\x00\x02\x00\x00\x00\x80\x85\xb5\rDOT-Vec\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x003u4\x00\x02\x004\x00\x13\x00\x00\x10\x00\x00\x00\x00\x01\x00\x00\x00\x80J]\x05AntennaVec\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x005u1\x00\x02\x001\x00\x07\x00\x00\x08\x02\x00\x00\x00\t\x00\x0e'\x07SA24-120-9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x85\t\x00\x00\x00\x00\xb3\x92\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\tTest-10.7"
-assert a.PPIFieldHeaders[5].Antnoise == -110
+assert a.headers[5].Antnoise == -110
 assert isinstance(a[Dot11].payload, Dot11Beacon)
 
 = Pkt_10_8
 a = Pkt_10_8()
 a.show()
 assert raw(a) == b'\x00\x00\xc0\x01i\x00\x00\x002u\x1c\x00\x02\x00\x1c\x00g\x00\x00\x00\x80\x00\x00\x00\xe2o=\x84\xd4\x89\x107L\xd0QO\x00\xc2\xeb\x0b3u4\x00\x02\x004\x00\x07\x00\x00\x10\x02\x00\x00\x00\x01\x00\x00\x00\x80J]\x05Antenna-1 orientation\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x004u\x13\x00\x02\x00\x13\x00#\x00\x00 \xd0\x07\xf7\xf2\x1bSk\x01\x02\x03\x045uQ\x00\x02\x00Q\x00\x07\x00\x00\x18\x01\x00\x00\x00\x05\x00*u\x158dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00Signal 1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xc4\x802u\x1c\x00\x02\x00\x1c\x00g\x00\x00\x00\x80\x00\x00\x00\xa0p=\x84\xbe\x9f\x107L\xd0QO\x00\xc2\xeb\x0b3u4\x00\x02\x004\x00\x07\x00\x00\x10\x02\x00\x00\x00\x01\x00\x00\x00\x80J]\x05Antenna-2 orientation\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x004u\x13\x00\x02\x00\x13\x00#\x00\x00 \xd0\x07\xf7\xf8\xffdk\x01\x02\x03\x045uQ\x00\x02\x00Q\x00\x07\x00\x00\x18\x01\x00\x00\x00\x05\x00*u\x158dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00Signal 2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xb0\x80\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\tTest-10.8'
-assert isinstance(a.PPIFieldHeaders[7], Sensor)
-assert a.PPIFieldHeaders[7].ScaleFactor == -9
-assert a.PPIFieldHeaders[7].pfh_length == 19
+assert isinstance(a.headers[7].payload, PPI_Geotag_Sensor)
+assert a.headers[7].ScaleFactor == -9
+assert a.headers[7].pfh_length == 19
 
 = Pkt_10_9
 a = Pkt_10_9()
 assert raw(a) == b'\x00\x00\r\x01i\x00\x00\x002u\x1c\x00\x02\x00\x1c\x00g\x00\x00\x00\x80\x00\x00\x00\xa0p=\x84\xbe\x9f\x107L\xd0QO\x00\xc2\xeb\x0b3u4\x00\x02\x004\x00\x07\x00\x00\x10\x02\x00\x00\x00\x01\x00\x00\x00\x80J]\x05Antenna-2 orientation\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x003u<\x00\x02\x00<\x00\x13\x00\x010\x02\x00\x00\x00\x08\x00\x00\x00@\xb1F\x13\x80\x96\x98\x00AOA at Antenna-2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x045uQ\x00\x02\x00Q\x00\x07\x00\x00\x18\x01\x00\x00\x00\x05\x00*u\x158dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00Signal 2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xb0\x80\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\x98\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\tTest-10.9'
-assert a.PPIFieldHeaders[2].DescString == b'AOA at Antenna-2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+assert a.headers[2].DescString == b'AOA at Antenna-2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = Pkt_10_10
 a = Pkt_10_10()
 assert raw(a) == b'\x00\x00M\x01i\x00\x00\x002u\x1c\x00\x02\x00\x1c\x00g\x00\x00\x00\x80\x00\x00\x00\xa0p=\x84\xbe\x9f\x107L\xd0QO\x00\xc2\xeb\x0b3u4\x00\x02\x004\x00\x07\x00\x00\x10\x02\x00\x00\x00\x01\x00\x00\x00\x80J]\x05Antenna-2 orientation\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x003u<\x00\x02\x00<\x00\x13\x00\x010\x03\x00\x00\x00\x08\x00\x00\x00@\xb1F\x13\x80\x96\x98\x00AOA at Antenna-2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x043u<\x00\x02\x00<\x00C\x00\x020\x00\x00\x00\x00\x10\x00\x00\x00\x80\xecOk  JkTransmitter Position\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x045uQ\x00\x02\x00Q\x00\x07\x00\x00\x18\x01\x00\x00\x00\x05\x00*u\x158dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00Signal 2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xb0\x80\x80\x00\x00\x00\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x00\x01\x02\t\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00d\x00\x00\x00\x00\nTest-10.10'
-assert a.PPIFieldHeaders[0].GPSTime == 1288720719
-assert a.PPIFieldHeaders[4].ModelName == b'8dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-assert isinstance(a.PPIFieldHeaders[3], Vector)
-assert a.PPIFieldHeaders[3].pfh_type == 30003
-assert a.PPIFieldHeaders[3].Off_Y == 40.0
-assert a.PPIFieldHeaders[3].Err_Off == 2.0
+assert a.headers[0].GPSTime == 1288720719
+assert a.headers[4].ModelName == b'8dBi-Omni\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+assert isinstance(a.headers[3].payload, PPI_Geotag_Vector)
+assert a.headers[3].pfh_type == 30003
+assert a.headers[3].Off_Y == 40.0
+assert a.headers[3].Err_Off == 2.0
 
 = All-in-one packet
 # Extracted from PPI_GEOLOCATION_SDK.zip\PPI_GEOLOCATION_SDK\pcaps\reference-pcaps\all-ppi-geo-fields.py
 a = hex_bytes(b'00008a02690000003275900002029000ff03007002000000368999839cb5323fa0584b6b406e4a6b4f51d04cffffffff40420f0080841e00005ed0b2416c6c4669656c64734750535061636b6574000000000000000000000000000004030201414243442e2e2e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003375900002029000ff000370ff0000000800000080969800002d3101e09da30110f9496b20204a6b0055496b80c3c90128604d6b46756c6c7946696c6c65644f7574566563746f720000000000000000000000000403020141424344000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034757f0002027f007f0000700100ff4014596b8056686bc098776b00db866b50954a6b4d616465557056656c6f63697479730000000000000000000000000000000000010203044142434400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003575bb000102bb003f00007c0200000009000e2707002d310160f59000b2a13030303030310000000000000000000000000000000000000000000000000000534132342d3132302d39000000000000000000000000000000000000000000004c656674416e74656e6e610000000000000000000000000000000000000000000102030441424344000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002001400000000000000000000000000850900000000a19280000000ffffffffffff0001020304050001020901040000000000000000000064000000000b546573742d53656e736f72')
 pkt = PPI(a)
-assert isinstance(pkt.PPIFieldHeaders[0], GPS)
-assert pkt.PPIFieldHeaders[0].present == 1879049215
-assert isinstance(pkt.PPIFieldHeaders[1], Vector)
-assert pkt.PPIFieldHeaders[1].present == 1879245055
-assert isinstance(pkt.PPIFieldHeaders[3], Antenna)
-assert repr(pkt.PPIFieldHeaders[3].present) == "<Flag 2080374847 (AntennaFlags+Gain+HorizBw+VertBw+PrecisionGain+BeamID+SerialNumber+ModelName+DescString+AppId+AppData)>"
-assert isinstance(pkt.PPIFieldHeaders[4], Dot11Common)
+assert isinstance(pkt.headers[0].payload, PPI_Geotag_GPS)
+assert pkt.headers[0].present == 1879049215
+assert isinstance(pkt.headers[1].payload, PPI_Geotag_Vector)
+assert pkt.headers[1].present == 1879245055
+assert isinstance(pkt.headers[3].payload, PPI_Geotag_Antenna)
+assert repr(pkt.headers[3].present) == "<Flag 2080374847 (AntennaFlags+Gain+HorizBw+VertBw+PrecisionGain+BeamID+SerialNumber+ModelName+DescString+AppId+AppData)>"
+assert isinstance(pkt.headers[4].payload, PPI_Dot11Common)
 assert isinstance(pkt[Dot11][Dot11Beacon].payload, Dot11Elt)
 assert pkt[Dot11Elt].info == b'Test-Sensor'
 assert pkt[Dot11Elt].ID == 0
 
 = All-wrong-data packet
-pkt = PPI(PPIFieldHeaders=[
-            GPS(GPSFlags="Manual Input", Latitude=-181, Longitude=181, GPSTime=1288720719, FractionalTime=-1, ept=100, eph=-1, epv=1000, Altitude=-999999, Altitude_g=999999),
-            Vector(VectorFlags="DefinesForward+RelativeToEarth", VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
-            Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
-            Dot11Common(Antsignal=-80)])/\
-            Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:0A")/\
-            Dot11Beacon()/Dot11Elt(ID=0,info="Test-allwrong")
+pkt = PPI(headers=[
+        PPI_Hdr()/PPI_Geotag_GPS(GPSFlags="Manual Input", Latitude=-181, Longitude=181, GPSTime=1288720719, FractionalTime=-1, ept=100, eph=-1, epv=1000, Altitude=-999999, Altitude_g=999999),
+        PPI_Hdr()/PPI_Geotag_Vector(VectorFlags="DefinesForward+RelativeToEarth", VectorChars=0x08, Heading=323.4, Err_Rot=10.0, DescString="AOA at Antenna-2", AppId=0x04030201),
+        PPI_Hdr()/PPI_Geotag_Antenna(AntennaFlags=0x01,Gain=5,HorizBw=360.0,ModelName="8dBi-Omni", DescString="Signal 2"),
+        PPI_Hdr()/PPI_Dot11Common(Antsignal=-80)])/\
+    Dot11(addr1="FF:FF:FF:FF:FF:FF",addr2="00:01:02:03:04:05",addr3="00:01:02:09:01:0A")/\
+    Dot11Beacon()/Dot11Elt(ID=0,info="Test-allwrong")
 pkt = PPI(raw(pkt))
 pkt.show()
-assert pkt.PPIFieldHeaders[0].Latitude == -180.0
-assert pkt.PPIFieldHeaders[0].Longitude == 180.0
-assert pkt.PPIFieldHeaders[0].Altitude == -180000.0
-assert pkt.PPIFieldHeaders[0].Altitude_g == 180000.0
-assert pkt.PPIFieldHeaders[0].epv < 1000
-assert pkt.PPIFieldHeaders[0].ept < 5
-assert pkt.PPIFieldHeaders[0].FractionalTime == 0.0
+assert pkt.headers[0].Latitude == -180.0
+assert pkt.headers[0].Longitude == 180.0
+assert pkt.headers[0].Altitude == -180000.0
+assert pkt.headers[0].Altitude_g == 180000.0
+assert pkt.headers[0].epv < 1000
+assert pkt.headers[0].ept < 5
+assert pkt.headers[0].FractionalTime == 0.0

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -14,7 +14,7 @@
 
 # author: <jellch@harris.com>
 
-# scapy.contrib.description = Parallel Peripheral Interface (PPI) Geolocation
+# scapy.contrib.description = CACE Per-Packet Information (PPI) Geolocation
 # scapy.contrib.status = loads
 
 
@@ -23,23 +23,22 @@ PPI-GEOLOCATION tags
 """
 
 from __future__ import absolute_import
+import functools
 import struct
 
-from scapy.packet import Packet
-from scapy.fields import ByteField, ConditionalField, FlagsField, \
+from scapy.base_classes import Packet_metaclass
+from scapy.data import PPI_GPS, PPI_VECTOR, PPI_SENSOR, PPI_ANTENNA
+from scapy.packet import bind_layers
+from scapy.fields import ByteField, ConditionalField, Field, FlagsField, \
     LEIntField, LEShortEnumField, LEShortField, StrFixedLenField, \
     UTCTimeField, XLEIntField, SignedByteField, XLEShortField
-from scapy.layers.ppi import addPPIType
+from scapy.layers.ppi import PPI_Hdr, PPI_Element
 from scapy.error import warning
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
 
 CURR_GEOTAG_VER = 2  # Major revision of specification
 
-PPI_GPS = 30002
-PPI_VECTOR = 30003
-PPI_SENSOR = 30004
-PPI_ANTENNA = 30005
 
 # The FixedX_Y Fields are used to store fixed point numbers in a variety of
 # fields in the GEOLOCATION-TAGS specification
@@ -137,7 +136,8 @@ class Fixed6_4Field(_RMMLEIntField):
                                 lambda x: int(round((x + 180000.0) * 1e4)),
                                 "6.4f")
 
-# The GPS timestamps fractional time counter is stored in a 32-bit unsigned ns counter.  # noqa: E501
+# The GPS timestamps fractional time counter is stored in a 32-bit unsigned ns
+# counter.
 # The ept field is as well,
 
 
@@ -157,14 +157,16 @@ class NSCounter_Field(_RMMLEIntField):
 class LETimeField(UTCTimeField, LEIntField):
     __slots__ = ["epoch", "delta", "strf"]
 
-    def __init__(self, name, default, epoch=None, strf="%a, %d %b %Y %H:%M:%S +0000"):  # noqa: E501
+    def __init__(self, name, default, epoch=None,
+                 strf="%a, %d %b %Y %H:%M:%S %z"):
         LEIntField.__init__(self, name, default)
         UTCTimeField.__init__(self, name, default, epoch=epoch, strf=strf)
 
 
 class GPSTime_Field(LETimeField):
     def __init__(self, name, default):
-        return LETimeField.__init__(self, name, default, strf="%a, %d %b %Y %H:%M:%S UTC")  # noqa: E501
+        LETimeField.__init__(self, name, default,
+                             strf="%a, %d %b %Y %H:%M:%S UTC")
 
 
 class VectorFlags_Field(XLEIntField):
@@ -172,7 +174,12 @@ class VectorFlags_Field(XLEIntField):
     _fwdstr = "DefinesForward"
     _resmask = 0xfffffff8
     _relmask = 0x6
-    _relnames = ["RelativeToForward", "RelativeToEarth", "RelativeToCurrent", "RelativeToReserved"]  # noqa: E501
+    _relnames = [
+        "RelativeToForward",
+        "RelativeToEarth",
+        "RelativeToCurrent",
+        "RelativeToReserved",
+    ]
     _relvals = [0x00, 0x02, 0x04, 0x06]
 
     def i2repr(self, pkt, x):
@@ -201,7 +208,7 @@ class VectorFlags_Field(XLEIntField):
                     y &= (~self._relmask)
                     y |= self._relvals[i]
                 else:
-                    # logging.warning("Unknown VectorFlags Argument: %s",  value)  # noqa: E501
+                    # logging.warning("Unknown VectorFlags Arg: %s", value)
                     pass
         else:
             y = x
@@ -210,10 +217,12 @@ class VectorFlags_Field(XLEIntField):
 
 
 class HCSIFlagsField(FlagsField):
-    """ A FlagsField where each bit/flag turns a conditional field on or off.
+    """A FlagsField where each bit/flag turns a conditional field on or off.
+
     If the value is None when building a packet, i2m() will check the value of
-    every field in self.names.  If the field's value is not None, the corresponding  # noqa: E501
-    flag will be set. """
+    every field in self.names.  If the field's value is not None, the
+    corresponding flag will be set.
+    """
 
     def i2m(self, pkt, val):
         if val is None:
@@ -226,19 +235,32 @@ class HCSIFlagsField(FlagsField):
         return val
 
 
-class HCSINullField(StrFixedLenField):
-    def __init__(self, name, default):
-        return StrFixedLenField.__init__(self, name, default, length=0)
+class HCSINullField(Field):
+    def __init__(self, name):
+        Field.__init__(self, name, None, '!')
+
+
+def _hcsi_null_range(*args, **kwargs):
+    """Builds a list of _HCSINullField with numbered "Reserved" names.
+
+    Takes the same arguments as the ``range`` built-in.
+
+    :returns: list[HCSINullField]
+    """
+    return [
+        HCSINullField('Reserved{:02d}'.format(x))
+        for x in range(*args, **kwargs)
+    ]
 
 
 class HCSIDescField(StrFixedLenField):
     def __init__(self, name, default):
-        return StrFixedLenField.__init__(self, name, default, length=32)
+        StrFixedLenField.__init__(self, name, default, length=32)
 
 
 class HCSIAppField(StrFixedLenField):
     def __init__(self, name, default):
-        return StrFixedLenField.__init__(self, name, default, length=60)
+        StrFixedLenField.__init__(self, name, default, length=60)
 
 
 def _FlagsList(myfields):
@@ -249,211 +271,197 @@ def _FlagsList(myfields):
 
 
 # Define all geolocation-tag flags lists
-_hcsi_gps_flags = _FlagsList({0: "No Fix Available", 1: "GPS", 2: "Differential GPS",  # noqa: E501
-                              3: "Pulse Per Second", 4: "Real Time Kinematic",
-                              5: "Float Real Time Kinematic", 6: "Estimated (Dead Reckoning)",  # noqa: E501
-                              7: "Manual Input", 8: "Simulation"})
+_hcsi_gps_flags = _FlagsList({
+    0: "No Fix Available",
+    1: "GPS",
+    2: "Differential GPS",
+    3: "Pulse Per Second",
+    4: "Real Time Kinematic",
+    5: "Float Real Time Kinematic",
+    6: "Estimated (Dead Reckoning)",
+    7: "Manual Input",
+    8: "Simulation",
+})
 
-# _hcsi_vector_flags = _FlagsList({0:"ForwardFrame", 1:"RotationsAbsoluteXYZ", 5:"OffsetFromGPS_XYZ"})  # noqa: E501
-# This has been replaced with the VectorFlags_Field class, in order to handle the RelativeTo:subfield  # noqa: E501
+_hcsi_vector_char_flags = _FlagsList({
+    0: "Antenna",
+    1: "Direction of Travel",
+    2: "Front of Vehicle",
+    3: "Angle of Arrival",
+    4: "Transmitter Position",
+    8: "GPS Derived",
+    9: "INS Derived",
+    10: "Compass Derived",
+    11: "Acclerometer Derived",
+    12: "Human Derived",
+})
 
-_hcsi_vector_char_flags = _FlagsList({0: "Antenna", 1: "Direction of Travel",
-                                      2: "Front of Vehicle", 3: "Angle of Arrival", 4: "Transmitter Position",  # noqa: E501
-                                      8: "GPS Derived", 9: "INS Derived", 10: "Compass Derived",  # noqa: E501
-                                      11: "Acclerometer Derived", 12: "Human Derived"})  # noqa: E501
+_hcsi_antenna_flags = _FlagsList({
+    1: "Horizontal Polarization",
+    2: "Vertical Polarization",
+    3: "Circular Polarization Left",
+    4: "Circular Polarization Right",
+    16: "Electronically Steerable",
+    17: "Mechanically Steerable",
+})
 
-_hcsi_antenna_flags = _FlagsList({1: "Horizontal Polarization", 2: "Vertical Polarization",  # noqa: E501
-                                  3: "Circular Polarization Left", 4: "Circular Polarization Right",  # noqa: E501
-                                  16: "Electronically Steerable", 17: "Mechanically Steerable"})  # noqa: E501
+# HCSI PPI Fields are similar to RadioTap.  A mask field called "present"
+# specifies if each field is present.  All other fields are conditional.  When
+# dissecting a packet, each field is present if "present" has the corresponding
+# bit set.
+#
+# When building a packet, if "present" is None, the mask is set to include
+# every field that does not have a value of None.  Otherwise, if the mask field
+# is not None, only the fields specified by "present" will be added to the
+# packet.
+#
+# To build each Packet type, build a list of the fields normally, excluding
+# the present bitmask field.  The code will then construct conditional
+# versions of each field and add the present field.
+#
+# See GPS_Fields as an example.
 
-""" HCSI PPI Fields are similar to RadioTap.  A mask field called "present" specifies if each field  # noqa: E501
-is present.  All other fields are conditional.  When dissecting a packet, each field is present if  # noqa: E501
-"present" has the corresponding bit set.  When building a packet, if "present" is None, the mask is  # noqa: E501
-set to include every field that does not have a value of None.  Otherwise, if the mask field is  # noqa: E501
-not None, only the fields specified by "present" will be added to the packet.
+_COMMON_GEOTAG_HEADERS = [
+    ByteField('geotag_ver', CURR_GEOTAG_VER),
+    ByteField('geotag_pad', 0),
+    LEShortField('geotag_len', None),
+]
 
-To build each Packet type, build a list of the fields normally, excluding the present bitmask field.  # noqa: E501
-The code will then construct conditional versions of each field and add the present field.  # noqa: E501
-See GPS_Fields as an example. """
+_COMMON_GEOTAG_FOOTER = [
+    HCSIDescField("DescString", None),
+    XLEIntField("AppId", None),
+    HCSIAppField("AppData", None),
+    HCSINullField("Extended"),
+]
+
 
 # Conditional test for all HCSI Fields
-
-
-def _HCSITest(pkt, ibit, name):
+def _HCSITest(fname, fbit, pkt):
     if pkt.present is None:
-        return (pkt.getfieldval(name) is not None)
-    return pkt.present & ibit
-
-# Wrap optional fields in ConditionalField, add HCSIFlagsField
+        return pkt.getfieldval(fname) is not None
+    return pkt.present & fbit
 
 
-def _HCSIBuildFields(fields):
-    names = [f.name for f in fields]
-    cond_fields = [HCSIFlagsField('present', None, -len(names), names)]
-    for i, name in enumerate(names):
-        ibit = 1 << i
-        seval = "lambda pkt:_HCSITest(pkt,%s,'%s')" % (ibit, name)
-        test = eval(seval)
-        cond_fields.append(ConditionalField(fields[i], test))
-    return cond_fields
+class _Geotag_metaclass(Packet_metaclass):
+    def __new__(cls, name, bases, dct):
+        hcsi_fields = dct.get('hcsi_fields', [])
+
+        if len(hcsi_fields) != 0:
+            hcsi_fields += _COMMON_GEOTAG_FOOTER
+            if len(hcsi_fields) not in (8, 16, 32):
+                raise TypeError(
+                    'hcsi_fields in {} was {} elements long, expected 8, 16 '
+                    'or 32'.format(name, len(hcsi_fields)))
+
+            names = [f.name for f in hcsi_fields]
+
+            # Add the base fields
+            fields_desc = _COMMON_GEOTAG_HEADERS + [
+                HCSIFlagsField('present', None, -len(names), names),
+            ]
+
+            # Add conditional fields
+            for i, field in enumerate(hcsi_fields):
+                fields_desc.append(ConditionalField(
+                    field, functools.partial(
+                        _HCSITest, field.name, 1 << i)))
+
+            dct['fields_desc'] = fields_desc
+
+        x = super(_Geotag_metaclass, cls).__new__(cls, name, bases, dct)
+        return x
 
 
-class HCSIPacket(Packet):
-    name = "PPI HCSI"
-    fields_desc = [LEShortField('pfh_type', None),
-                   LEShortField('pfh_length', None),
-                   ByteField('geotag_ver', CURR_GEOTAG_VER),
-                   ByteField('geotag_pad', 0),
-                   LEShortField('geotag_len', None)]
-
+class HCSIPacket(six.with_metaclass(_Geotag_metaclass, PPI_Element)):
     def post_build(self, p, pay):
-        if self.pfh_length is None:
-            tmp_len = len(p) - 4
-            sl = struct.pack('<H', tmp_len)
-            p = p[:2] + sl + p[4:]
         if self.geotag_len is None:
-            l_g = len(p) - 4
-            sl_g = struct.pack('<H', l_g)
-            p = p[:6] + sl_g + p[8:]
+            sl_g = struct.pack('<H', len(p))
+            p = p[:2] + sl_g + p[4:]
         p += pay
         return p
 
-    def extract_padding(self, p):
-        return b"", p
-
 
 # GPS Fields
-GPS_Fields = [FlagsField("GPSFlags", None, -32, _hcsi_gps_flags),
-              Fixed3_7Field("Latitude", None),
-              Fixed3_7Field("Longitude", None), Fixed6_4Field("Altitude", None),  # noqa: E501
-              Fixed6_4Field("Altitude_g", None), GPSTime_Field("GPSTime", None),  # noqa: E501
-              NSCounter_Field("FractionalTime", None), Fixed3_6Field("eph", None),  # noqa: E501
-              Fixed3_6Field("epv", None), NSCounter_Field("ept", None),
-              HCSINullField("Reserved10", None), HCSINullField("Reserved11", None),  # noqa: E501
-              HCSINullField("Reserved12", None), HCSINullField("Reserved13", None),  # noqa: E501
-              HCSINullField("Reserved14", None), HCSINullField("Reserved15", None),  # noqa: E501
-              HCSINullField("Reserved16", None), HCSINullField("Reserved17", None),  # noqa: E501
-              HCSINullField("Reserved18", None), HCSINullField("Reserved19", None),  # noqa: E501
-              HCSINullField("Reserved20", None), HCSINullField("Reserved21", None),  # noqa: E501
-              HCSINullField("Reserved22", None), HCSINullField("Reserved23", None),  # noqa: E501
-              HCSINullField("Reserved24", None), HCSINullField("Reserved25", None),  # noqa: E501
-              HCSINullField("Reserved26", None), HCSINullField("Reserved27", None),  # noqa: E501
-              HCSIDescField("DescString", None), XLEIntField("AppId", None),
-              HCSIAppField("AppData", None), HCSINullField("Extended", None)]
-
-
-class GPS(HCSIPacket):
+class PPI_Geotag_GPS(HCSIPacket):
     name = "PPI GPS"
-    fields_desc = [LEShortField('pfh_type', PPI_GPS),  # pfh_type
-                   LEShortField('pfh_length', None),  # pfh_len
-                   ByteField('geotag_ver', CURR_GEOTAG_VER),  # base_geotag_header.ver  # noqa: E501
-                   ByteField('geotag_pad', 0),  # base_geotag_header.pad
-                   LEShortField('geotag_len', None)] + _HCSIBuildFields(GPS_Fields)  # noqa: E501
+    hcsi_fields = [
+        FlagsField("GPSFlags", None, -32, _hcsi_gps_flags),
+        Fixed3_7Field("Latitude", None),
+        Fixed3_7Field("Longitude", None),
+        Fixed6_4Field("Altitude", None),
+        Fixed6_4Field("Altitude_g", None),
+        GPSTime_Field("GPSTime", None),
+        NSCounter_Field("FractionalTime", None),
+        Fixed3_6Field("eph", None),
+        Fixed3_6Field("epv", None),
+        NSCounter_Field("ept", None),
+    ] + _hcsi_null_range(10, 28)
 
 
-# Vector Fields
-VEC_Fields = [VectorFlags_Field("VectorFlags", None),
-              FlagsField("VectorChars", None, -32, _hcsi_vector_char_flags),
-              Fixed3_6Field("Pitch", None), Fixed3_6Field("Roll", None),
-              Fixed3_6Field("Heading", None), Fixed6_4Field("Off_X", None),
-              Fixed6_4Field("Off_Y", None), Fixed6_4Field("Off_Z", None),
-              HCSINullField("Reserved08", None), HCSINullField("Reserved09", None),  # noqa: E501
-              HCSINullField("Reserved10", None), HCSINullField("Reserved11", None),  # noqa: E501
-              HCSINullField("Reserved12", None), HCSINullField("Reserved13", None),  # noqa: E501
-              HCSINullField("Reserved14", None), HCSINullField("Reserved15", None),  # noqa: E501
-              Fixed3_6Field("Err_Rot", None), Fixed6_4Field("Err_Off", None),
-              HCSINullField("Reserved18", None), HCSINullField("Reserved19", None),  # noqa: E501
-              HCSINullField("Reserved20", None), HCSINullField("Reserved21", None),  # noqa: E501
-              HCSINullField("Reserved22", None), HCSINullField("Reserved23", None),  # noqa: E501
-              HCSINullField("Reserved24", None), HCSINullField("Reserved25", None),  # noqa: E501
-              HCSINullField("Reserved26", None), HCSINullField("Reserved27", None),  # noqa: E501
-              HCSIDescField("DescString", None), XLEIntField("AppId", None),
-              HCSIAppField("AppData", None), HCSINullField("Extended", None)]
-
-
-class Vector(HCSIPacket):
+# Vector fields
+class PPI_Geotag_Vector(HCSIPacket):
     name = "PPI Vector"
-    fields_desc = [LEShortField('pfh_type', PPI_VECTOR),  # pfh_type
-                   LEShortField('pfh_length', None),  # pfh_len
-                   ByteField('geotag_ver', CURR_GEOTAG_VER),  # base_geotag_header.ver  # noqa: E501
-                   ByteField('geotag_pad', 0),  # base_geotag_header.pad
-                   LEShortField('geotag_len', None)] + _HCSIBuildFields(VEC_Fields)  # noqa: E501
+    hcsi_fields = [
+        VectorFlags_Field("VectorFlags", None),
+        FlagsField("VectorChars", None, -32, _hcsi_vector_char_flags),
+        Fixed3_6Field("Pitch", None),
+        Fixed3_6Field("Roll", None),
+        Fixed3_6Field("Heading", None),
+        Fixed6_4Field("Off_X", None),
+        Fixed6_4Field("Off_Y", None),
+        Fixed6_4Field("Off_Z", None),
+    ] + _hcsi_null_range(8, 16) + [
+        Fixed3_6Field("Err_Rot", None),
+        Fixed6_4Field("Err_Off", None),
+    ] + _hcsi_null_range(18, 28)
 
 
 # Sensor Fields
 # http://www.iana.org/assignments/icmp-parameters
-sensor_types = {1: "Velocity",
-                2: "Acceleration",
-                3: "Jerk",
-                100: "Rotation",
-                101: "Magnetic",
-                1000: "Temperature",
-                1001: "Barometer",
-                1002: "Humidity",
-                2000: "TDOA_Clock",
-                2001: "Phase"
-                }
-SENS_Fields = [LEShortEnumField('SensorType', None, sensor_types),
-               SignedByteField('ScaleFactor', None),
-               Fixed6_4Field('Val_X', None),
-               Fixed6_4Field('Val_Y', None),
-               Fixed6_4Field('Val_Z', None),
-               Fixed6_4Field('Val_T', None),
-               Fixed6_4Field('Val_E', None),
-               HCSINullField("Reserved07", None), HCSINullField("Reserved08", None),  # noqa: E501
-               HCSINullField("Reserved09", None), HCSINullField("Reserved10", None),  # noqa: E501
-               HCSINullField("Reserved11", None), HCSINullField("Reserved12", None),  # noqa: E501
-               HCSINullField("Reserved13", None), HCSINullField("Reserved14", None),  # noqa: E501
-               HCSINullField("Reserved15", None), HCSINullField("Reserved16", None),  # noqa: E501
-               HCSINullField("Reserved17", None), HCSINullField("Reserved18", None),  # noqa: E501
-               HCSINullField("Reserved19", None), HCSINullField("Reserved20", None),  # noqa: E501
-               HCSINullField("Reserved21", None), HCSINullField("Reserved22", None),  # noqa: E501
-               HCSINullField("Reserved23", None), HCSINullField("Reserved24", None),  # noqa: E501
-               HCSINullField("Reserved25", None), HCSINullField("Reserved26", None),  # noqa: E501
-               HCSINullField("Reserved27", None),
-               HCSIDescField("DescString", None), XLEIntField("AppId", None),
-               HCSIAppField("AppData", None), HCSINullField("Extended", None)]
+sensor_types = {
+    1: "Velocity",
+    2: "Acceleration",
+    3: "Jerk",
+    100: "Rotation",
+    101: "Magnetic",
+    1000: "Temperature",
+    1001: "Barometer",
+    1002: "Humidity",
+    2000: "TDOA_Clock",
+    2001: "Phase"
+}
 
 
-class Sensor(HCSIPacket):
+class PPI_Geotag_Sensor(HCSIPacket):
     name = "PPI Sensor"
-    fields_desc = [LEShortField('pfh_type', PPI_SENSOR),  # pfh_type
-                   LEShortField('pfh_length', None),  # pfh_len
-                   ByteField('geotag_ver', CURR_GEOTAG_VER),  # base_geotag_header.ver  # noqa: E501
-                   ByteField('geotag_pad', 0),  # base_geotag_header.pad
-                   LEShortField('geotag_len', None)] + _HCSIBuildFields(SENS_Fields)  # noqa: E501
+    hcsi_fields = [
+        LEShortEnumField('SensorType', None, sensor_types),
+        SignedByteField('ScaleFactor', None),
+        Fixed6_4Field('Val_X', None),
+        Fixed6_4Field('Val_Y', None),
+        Fixed6_4Field('Val_Z', None),
+        Fixed6_4Field('Val_T', None),
+        Fixed6_4Field('Val_E', None),
+    ] + _hcsi_null_range(7, 28)
 
 
 # HCSIAntenna Fields
-ANT_Fields = [FlagsField("AntennaFlags", None, -32, _hcsi_antenna_flags),
-              ByteField("Gain", None),
-              Fixed3_6Field("HorizBw", None), Fixed3_6Field("VertBw", None),
-              Fixed3_6Field("PrecisionGain", None), XLEShortField("BeamID", None),  # noqa: E501
-              HCSINullField("Reserved06", None), HCSINullField("Reserved07", None),  # noqa: E501
-              HCSINullField("Reserved08", None), HCSINullField("Reserved09", None),  # noqa: E501
-              HCSINullField("Reserved10", None), HCSINullField("Reserved11", None),  # noqa: E501
-              HCSINullField("Reserved12", None), HCSINullField("Reserved13", None),  # noqa: E501
-              HCSINullField("Reserved14", None), HCSINullField("Reserved15", None),  # noqa: E501
-              HCSINullField("Reserved16", None), HCSINullField("Reserved17", None),  # noqa: E501
-              HCSINullField("Reserved18", None), HCSINullField("Reserved19", None),  # noqa: E501
-              HCSINullField("Reserved20", None), HCSINullField("Reserved21", None),  # noqa: E501
-              HCSINullField("Reserved22", None), HCSINullField("Reserved23", None),  # noqa: E501
-              HCSINullField("Reserved24", None), HCSINullField("Reserved25", None),  # noqa: E501
-              HCSIDescField("SerialNumber", None), HCSIDescField("ModelName", None),  # noqa: E501
-              HCSIDescField("DescString", None), XLEIntField("AppId", None),
-              HCSIAppField("AppData", None), HCSINullField("Extended", None)]
-
-
-class Antenna(HCSIPacket):
+class PPI_Geotag_Antenna(HCSIPacket):
     name = "PPI Antenna"
-    fields_desc = [LEShortField('pfh_type', PPI_ANTENNA),  # pfh_type
-                   LEShortField('pfh_length', None),  # pfh_len
-                   ByteField('geotag_ver', CURR_GEOTAG_VER),  # base_geotag_header.ver  # noqa: E501
-                   ByteField('geotag_pad', 0),  # base_geotag_header.pad
-                   LEShortField('geotag_len', None)] + _HCSIBuildFields(ANT_Fields)  # noqa: E501
+    hcsi_fields = [
+        FlagsField("AntennaFlags", None, -32, _hcsi_antenna_flags),
+        ByteField("Gain", None),
+        Fixed3_6Field("HorizBw", None),
+        Fixed3_6Field("VertBw", None),
+        Fixed3_6Field("PrecisionGain", None),
+        XLEShortField("BeamID", None),
+    ] + _hcsi_null_range(6, 26) + [
+        HCSIDescField("SerialNumber", None),
+        HCSIDescField("ModelName", None),
+    ]
 
 
-addPPIType(PPI_GPS, GPS)
-addPPIType(PPI_VECTOR, Vector)
-addPPIType(PPI_SENSOR, Sensor)
-addPPIType(PPI_ANTENNA, Antenna)
+bind_layers(PPI_Hdr, PPI_Geotag_GPS, pfh_type=PPI_GPS)
+bind_layers(PPI_Hdr, PPI_Geotag_Vector, pfh_type=PPI_VECTOR)
+bind_layers(PPI_Hdr, PPI_Geotag_Sensor, pfh_type=PPI_SENSOR)
+bind_layers(PPI_Hdr, PPI_Geotag_Antenna, pfh_type=PPI_ANTENNA)

--- a/scapy/contrib/ppi_geotag.uts
+++ b/scapy/contrib/ppi_geotag.uts
@@ -10,62 +10,53 @@ from scapy.contrib.ppi_geotag import *
 
 = Test GPS dissection
 
-assert raw(GPS()) == b'2u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
+assert raw(PPI_Hdr()/PPI_Geotag_GPS()) == b'2u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
 
 = Test Vector dissection
 
-assert raw(Vector()) == b'3u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
+assert raw(PPI_Hdr()/PPI_Geotag_Vector()) == b'3u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
 
 = Test Sensor dissection
 
-assert raw(Sensor()) == b'4u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
+assert raw(PPI_Hdr()/PPI_Geotag_Sensor()) == b'4u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
 
 = Test Antenna dissection
 
-assert raw(Antenna()) == b'5u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
+assert raw(PPI_Hdr()/PPI_Geotag_Antenna()) == b'5u\x08\x00\x02\x00\x08\x00\x00\x00\x00\x00'
 
 = Test GPSTime_Field time handling
 
 assert GPSTime_Field("GPSTime", None).delta == 0.0
 
-= Define local_to_utc
-
-def local_to_utc(local_time):
-    # Let's handle all cases, even with summer time not matching UTC...
-    utc_time_clock = time.gmtime(time.mktime(local_time))
-    utc_time_clock = list(utc_time_clock.__reduce__()[1][0])
-    if local_time.tm_isdst:
-        utc_time_clock[3] = (utc_time_clock[3]+1)%24
-    return time.struct_time(tuple(utc_time_clock))
-
 = Test UTCTimeField with time values
 
-local_time = time.localtime()
+# Always use ``time.gmtime`` and ``calendar.timegm``, not ``time.localtime``
+# and ``time.mktime``.
+
+local_time = time.gmtime()
 utc_time = UTCTimeField("Test", None, epoch=local_time)
-assert time.localtime(utc_time.epoch) == local_time
-assert time.mktime(time.gmtime(utc_time.delta)) == time.mktime(local_time)
-strft_time = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_time)
-strft_time_sum = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_to_utc(local_time))
+assert time.gmtime(utc_time.epoch) == local_time
+assert calendar.timegm(time.gmtime(utc_time.delta)) == calendar.timegm(local_time)
+strft_time = time.strftime("%a, %d %b %Y %H:%M:%S %z", local_time)
 
 # Backup: also test summer time bug
-expected = [(strft_time + " (" + str(int(utc_time.delta)) + ")"), (strft_time_sum + " (" + str(int(utc_time.delta)) + ")")]
+expected = "{} ({:d})".format(strft_time, utc_time.delta)
 result = utc_time.i2repr(None, None)
 result
 expected
-assert result in expected
+assert result == expected
 
 = Test LETimeField with time values
 
-local_time = time.localtime()
+local_time = time.gmtime()
 lme_time = LETimeField("Test", None, epoch=local_time)
-assert time.localtime(lme_time.epoch) == local_time
-assert time.mktime(time.gmtime(lme_time.delta)) == time.mktime(local_time)
-strft_time = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_time)
-strft_time_sum = time.strftime("%a, %d %b %Y %H:%M:%S +0000", local_to_utc(local_time))
+assert time.gmtime(lme_time.epoch) == local_time
+assert calendar.timegm(time.gmtime(lme_time.delta)) == calendar.timegm(local_time)
+strft_time = time.strftime("%a, %d %b %Y %H:%M:%S %z", local_time)
 
 # Backup: also test summer time bug
-expected = [(strft_time + " (" + str(int(lme_time.delta)) + ")"), (strft_time_sum + " (" + str(int(lme_time.delta)) + ")")]
+expected = "{} ({:d})".format(strft_time, lme_time.delta)
 result = lme_time.i2repr(None, None)
 result
 expected
-assert result in expected
+assert result == expected

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -7,10 +7,9 @@
 Global variables and functions for handling external data sets.
 """
 
-
+import calendar
 import os
 import re
-import time
 
 
 from scapy.dadict import DADict
@@ -116,9 +115,41 @@ IPV6_ADDR_SCOPE_MASK = 0xF0
 IPV6_ADDR_6TO4 = 0x0100   # Added to have more specific info (should be 0x0101 ?)  # noqa: E501
 IPV6_ADDR_UNSPECIFIED = 0x10000
 
+# Constants for PPI header types.
+PPI_DOT11COMMON = 2
+PPI_DOT11NMAC = 3
+PPI_DOT11NMACPHY = 4
+PPI_SPECTRUM_MAP = 5
+PPI_PROCESS_INFO = 6
+PPI_CAPTURE_INFO = 7
+PPI_AGGREGATION = 8
+PPI_DOT3 = 9
+PPI_GPS = 30002
+PPI_VECTOR = 30003
+PPI_SENSOR = 30004
+PPI_ANTENNA = 30005
+PPI_BTLE = 30006
+
+# Human-readable type names for PPI header types.
+PPI_TYPES = {
+    PPI_DOT11COMMON: 'dot11-common',
+    PPI_DOT11NMAC: 'dot11-nmac',
+    PPI_DOT11NMACPHY: 'dot11-nmacphy',
+    PPI_SPECTRUM_MAP: 'spectrum-map',
+    PPI_PROCESS_INFO: 'process-info',
+    PPI_CAPTURE_INFO: 'capture-info',
+    PPI_AGGREGATION: 'aggregation',
+    PPI_DOT3: 'dot3',
+    PPI_GPS: 'gps',
+    PPI_VECTOR: 'vector',
+    PPI_SENSOR: 'sensor',
+    PPI_ANTENNA: 'antenna',
+    PPI_BTLE: 'btle',
+}
+
 
 # On windows, epoch is 01/02/1970 at 00:00
-EPOCH = time.mktime((1970, 1, 2, 0, 0, 0, 3, 1, 0)) - 86400
+EPOCH = calendar.timegm((1970, 1, 2, 0, 0, 0, 3, 1, 0)) - 86400
 
 MTU = 0xffff  # a.k.a give me all you have
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -8,6 +8,7 @@ Fields: basic data structures that make up parts of packets.
 """
 
 from __future__ import absolute_import
+import calendar
 import collections
 import copy
 import inspect
@@ -2153,9 +2154,10 @@ class IP6PrefixField(_IPPrefixFieldBase):
 class UTCTimeField(IntField):
     __slots__ = ["epoch", "delta", "strf", "use_nano"]
 
-    def __init__(self, name, default, epoch=None, use_nano=False, strf="%a, %d %b %Y %H:%M:%S +0000"):  # noqa: E501
+    def __init__(self, name, default, epoch=None, use_nano=False,
+                 strf="%a, %d %b %Y %H:%M:%S %z"):
         IntField.__init__(self, name, default)
-        mk_epoch = EPOCH if epoch is None else time.mktime(epoch)
+        mk_epoch = EPOCH if epoch is None else calendar.timegm(epoch)
         self.epoch = mk_epoch
         self.delta = mk_epoch - EPOCH
         self.strf = strf

--- a/test/bluetooth4LE.uts
+++ b/test/bluetooth4LE.uts
@@ -82,13 +82,24 @@ assert a[BTLE_SCAN_REQ].ScanA == "aa:aa:aa:aa:aa:aa"
 
 + Specific tests after issue GH#1673
 
-= With PPI
+= DLT_USER0 with PPI
 
 pkt = PPI(b'\x00\x00\x18\x00\x93\x00\x00\x006u\x0c\x00\x00b\t\x00\xe1\xcf\x01\x00\xf1\xe3\x92\x00\xd6\xbe\x89\x8e@\x14M\x95P\x16\xfev\x02\x01\x1a\n\xffL\x00\x10\x05\x0b\x1c\x0e\xa86Z\xf0\x04')
-assert BTLE_PPI in pkt.PPIFieldHeaders[0]
+assert BTLE_PPI in pkt.headers[0].payload
+
+# We MUST NOT detect the BLTE link-layer at this point. This is intentionally
+# counter to issue 1673 -- Ubertooth One emits incorrect PCAP files.
+assert BTLE not in pkt
+
+= DLT_BLUETOOTH_LE_LL with PPI
+
+pkt = PPI(b'\x00\x00\x18\x00\xfb\x00\x00\x006u\x0c\x00\x00b\t\x00\xe1\xcf\x01\x00\xf1\xe3\x92\x00\xd6\xbe\x89\x8e@\x14M\x95P\x16\xfev\x02\x01\x1a\n\xffL\x00\x10\x05\x0b\x1c\x0e\xa86Z\xf0\x04')
+assert BTLE_PPI in pkt.headers[0].payload
+
+# Only now must we detect BTLE.
 assert BTLE in pkt
 
-= Without PPI
+= DLT_BLUETOOTH_LE_LL without PPI
 
 pkt = BTLE_RF(b'\x00\xc6\x80\x00\xd6\xbe\x89\x8e7\x00\xd6\xbe\x89\x8e@\x14\x03g\xa6+\xcbi\x00\x01\x1a\n\xffL\x00\x12E\x03\x18y\x9e\x96\x07\xfa%')
 assert BTLE_RF in pkt


### PR DESCRIPTION
PPI cleanups:

* _API change:_ PPI types are now stacked with `PPI_Hdr`, which works similarly to `EIR_Hdr`. Refactored existing uses (`ppi_cace`, `ppi_geotag` and `bt4LE`) and updated tests.
* _API change:_ `PPI` field `PPIFieldHeaders` is now `headers`.
* `addPPIType` has been removed (use `bind_layers` instead).
* _Behaviour change:_ Unknown PPI headers are now `Raw` layers. `PPIGenericFldHdr` removed.
* Removes `pfh_type` and `pfh_datalen` from every PPI header type (this is now part of `PPI_Hdr`).
* Fixes large amounts of PEP8 violations in `ppi`, `ppi_cace` and `ppi_geotag`. There are still some left, 
* Fixes PPI module labelling to say "CACE Per-Packet Information" (was "Parallel Peripheral Interface")
* _API change:_ PPI constants are now in `scapy.data`.
* `scapy.layers.ppi` is now loaded by default (it is used by `scapy.layers.bluetooth4LE`)

`scapy.contrib.ppi_cace`:

* _API change:_ Renames `Dot11Common` to `PPI_Dot11Common` to avoid collisions with other modules.

`scapy.contrib.ppi_geotag`

* _API change:_ Renames `GPS`, `Vector`, `Sensor` and `Antenna` to have `PPI_Geotag` prefixes, to avoid collisions with other modules.
* Internal `HCSINullField` no longer takes a `default` argument, as it is always `None`.
* Added `_hcsi_null_range` for adding large numbers of `HCSINullField` without repetition.
* `HCSIPacket` has been redesigned to use metaclasses so that it is easier to define these fields. It no longer uses `eval`.
* `_HCSIBuildFields` has been removed.
* Updated `ppi_geotag.uts` test for `UTCTimeField` and `LETimeField` so that they always use UTC internally. Removed broken `local_to_utc` function that would not work in timezones with non-whole-hour DST changes (eg: `Australia/Lord_Howe`).

`scapy.layers.bluetooth4LE`:

* Add documentation references for `BTLE_PPI` and `BTLE_RF`.
* Make `BTLE_PPI.rssi_*` values `SignedByteField` (cleanup; no net change)
* Change `BTLE_RF.signal` and `BTLE_RF.noise` to `sint8` (per specification).
* Unbind `BTLE` from `PPI.dlt=147` (`DLT_USER0`).  This will trigger the issue in #1673 again, as the tests use `DLT_USER0`.  There are patches for [ubertooth](https://github.com/greatscottgadgets/ubertooth/pull/359) and [libbtbb](https://github.com/greatscottgadgets/libbtbb/pull/55) to fix that going forward.

Other cleanups:

* `scapy.data.epoch` now declared using `calendar.timegm` (which calculates in UTC) rather than `time.mktime` (which calculates in localtime). This fixes the `ppi_geotag` tests.

These changes pass regression tests.