### PR TITLE
Add default path to Wireshark on OSX

### DIFF
--- a/scapy/data.py
+++ b/scapy/data.py
@@ -271,7 +271,8 @@ else:
     ETHER_TYPES = load_ethertypes("/etc/ethertypes")
     TCP_SERVICES, UDP_SERVICES = load_services("/etc/services")
     MANUFDB = None
-    for prefix in ['/usr', '/usr/local', '/opt', '/opt/wireshark']:
+    for prefix in ['/usr', '/usr/local', '/opt', '/opt/wireshark',
+                   '/Applications/Wireshark.app/Contents/Resources']:
         try:
             MANUFDB = load_manuf(os.path.join(prefix, "share", "wireshark",
                                               "manuf"))


### PR DESCRIPTION
This adds Wireshark's default installation path on OSX to the source path for `MANUFDB`.

This allows regression tests to pass on OSX 10.14.2 on Python 3.7, when Wireshark is installed.