### PR TITLE
Adds Packet conversion semantics.

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1473,7 +1473,7 @@ hashable.
         if "_internal" not in kwargs:
             return other_cls.convert_packet(self, _internal=True, **kwargs)
 
-        raise TypeError("Cannot convert {} to {}".format(self, other_cls))
+        raise TypeError("Cannot convert {} to {}".format(type(self), other_cls))
 
     @classmethod
     def convert_packet(cls, pkt, **kwargs):
@@ -1493,7 +1493,7 @@ hashable.
         if "_internal" not in kwargs:
             return pkt.convert_to(cls, _internal=True, **kwargs)
 
-        raise TypeError("Cannot convert {} to {}".format(pkt, cls))
+        raise TypeError("Cannot convert {} to {}".format(type(pkt), cls))
 
     @classmethod
     def convert_packets(cls, pkts, **kwargs):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1456,8 +1456,10 @@ hashable.
         By default, this only implements conversion to ``Raw``.
 
         :param other_cls: Reference to a Packet class to convert to.
-        :returns: Converted form of the packet, or None if no conversion is
-                  available.
+        :type other_cls: Type[Packet]
+        :returns: Converted form of the packet.
+        :rtype: other_cls
+        :raises TypeError: When conversion is not possible
         """
         if not issubtype(other_cls, Packet):
             raise TypeError("{} must implement Packet".format(other_cls))
@@ -1471,6 +1473,8 @@ hashable.
         if "_internal" not in kwargs:
             return other_cls.convert_packet(self, _internal=True, **kwargs)
 
+        raise TypeError("Cannot convert {} to {}".format(self, other_cls))
+
     @classmethod
     def convert_packet(cls, pkt, **kwargs):
         """Converts another packet to be this type.
@@ -1478,14 +1482,18 @@ hashable.
         This is not guaranteed to be a lossless process.
 
         :param pkt: The packet to convert.
-        :returns: Converted form of the packet, or None if no conversion is
-                  available.
+        :type pkt: Packet
+        :returns: Converted form of the packet.
+        :rtype: cls
+        :raises TypeError: When conversion is not possible
         """
         if not isinstance(pkt, Packet):
             raise TypeError("Can only convert Packets")
 
         if "_internal" not in kwargs:
             return pkt.convert_to(cls, _internal=True, **kwargs)
+
+        raise TypeError("Cannot convert {} to {}".format(pkt, cls))
 
     @classmethod
     def convert_packets(cls, pkts, **kwargs):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1470,7 +1470,8 @@ hashable.
         if "_internal" not in kwargs:
             return other_cls.convert_packet(self, _internal=True, **kwargs)
 
-        raise TypeError("Cannot convert {} to {}".format(type(self), other_cls))
+        raise TypeError("Cannot convert {} to {}".format(
+            type(self).__name__, other_cls.__name__))
 
     @classmethod
     def convert_packet(cls, pkt, **kwargs):
@@ -1490,7 +1491,8 @@ hashable.
         if "_internal" not in kwargs:
             return pkt.convert_to(cls, _internal=True, **kwargs)
 
-        raise TypeError("Cannot convert {} to {}".format(type(pkt), cls))
+        raise TypeError("Cannot convert {} to {}".format(
+            type(pkt).__name__, cls.__name__))
 
     @classmethod
     def convert_packets(cls, pkts, **kwargs):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1467,9 +1467,6 @@ hashable.
         if other_cls is Raw:
             return Raw(raw(self))
 
-        if self.haslayer(other_cls):
-            return self.getlayer(other_cls)
-
         if "_internal" not in kwargs:
             return other_cls.convert_packet(self, _internal=True, **kwargs)
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -565,6 +565,74 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
             x.append(p)
         return x
 
+    def getlayer(self, cls, nb=None, flt=None, name=None, stats=None):
+        """Returns the packet list from a given layer.
+
+        See ``Packet.getlayer`` for more info.
+
+        :param cls: search for a layer that is an instance of ``cls``
+        :type cls: Type[Packet]
+
+        :param nb: return the nb^th layer that is an instance of ``cls``
+        :type nb: Optional[int]
+
+        :param flt: filter parameters for ``Packet.getlayer``
+        :type flt: Optional[Dict[str, Any]]
+
+        :param name: optional name for the new PacketList
+        :type name: Optional[str]
+
+        :param stats: optional list of protocols to give stats on; if not
+                      specified, inherits from this PacketList.
+        :type stats: Optional[List[Type[Packet]]]
+        :rtype: PacketList
+        """
+        if name is None:
+            name = "{} layer {}".format(self.listname, cls.__name__)
+        if stats is None:
+            stats = self.stats
+
+        getlayer_arg = {}
+        if flt is not None:
+            getlayer_arg.update(flt)
+        getlayer_arg['cls'] = cls
+        if nb is not None:
+            getlayer_arg['nb'] = nb
+
+        # Only return non-None getlayer results
+        return PacketList([
+            pc for pc in (p.getlayer(**getlayer_arg) for p in self.res)
+            if pc is not None],
+            name, stats
+        )
+
+    def convert_to(self, other_cls, name=None, stats=None):
+        """Converts all packets to another type.
+
+        See ``Packet.convert_to`` for more info.
+
+        :param other_cls: reference to a Packet class to convert to
+        :type other_cls: Type[Packet]
+
+        :param name: optional name for the new PacketList
+        :type name: Optional[str]
+
+        :param stats: optional list of protocols to give stats on;
+                      if not specified, inherits from this PacketList.
+        :type stats: Optional[List[Type[Packet]]]
+
+        :rtype: PacketList
+        """
+        if name is None:
+            name = "{} converted to {}".format(self.listname, other_cls.__name__)
+        if stats is None:
+            stats = self.stats
+
+        return PacketList(
+            [p.convert_to(other_cls) for p in self.res],
+            name, stats
+        )
+
 
 class SndRcvList(PacketList):
     __slots__ = []

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -624,7 +624,8 @@ lfilter: truth function to apply to each packet to decide whether it will be dis
         :rtype: PacketList
         """
         if name is None:
-            name = "{} converted to {}".format(self.listname, other_cls.__name__)
+            name = "{} converted to {}".format(
+                self.listname, other_cls.__name__)
         if stats is None:
             stats = self.stats
 

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -472,3 +472,30 @@ class TriggeredSwitch(Drain):
     def on_trigger(self, msg):
         self.low ^= True
         self._trigger(msg)
+
+
+class ConvertPipe(Drain):
+    """Packets sent on entry are converted to another type of packet.
+
+         +-------------+
+      >>-|--[convert]--|->>
+         |             |
+       >-|--[convert]--|->
+         +-------------+
+
+    See ``Packet.convert_packet``.
+    """
+    def __init__(self, low_type=None, high_type=None, name=None):
+        Drain.__init__(self, name=name)
+        self.low_type = low_type
+        self.high_type = high_type
+
+    def push(self, msg):
+        if self.low_type:
+            msg = self.low_type.convert_packet(msg)
+        self._send(msg)
+
+    def high_push(self, msg):
+        if self.high_type:
+            msg = self.high_type.convert_packet(msg)
+        self._high_send(msg)

--- a/test/packet.uts
+++ b/test/packet.uts
@@ -1,0 +1,223 @@
+% Regression tests for Scapy packets
+
++ Test packet conversion (convert_to/convert_packet)
+
+= Setup packet conversion
+
+# PacketA declares no conversions, but will have conversions declared by
+# PacketB.
+class PacketA(Packet):
+    fields_desc = [LEShortField('foo', None)]
+
+# PacketB declares conversions for PacketA
+class PacketB(Packet):
+    fields_desc = [ShortField('bar', None)]
+    def convert_to(self, other_cls, **kwargs):
+        if other_cls is PacketA:
+            return PacketA(foo=self.bar)
+        return Packet.convert_to(self, other_cls, **kwargs)
+    @classmethod
+    def convert_packet(cls, pkt, **kwargs):
+        if isinstance(pkt, PacketA):
+            return cls(bar=pkt.foo)
+        return Packet.convert_packet(pkt, **kwargs)
+
+# PacketC has no defined conversions, either way.
+# Converting to or from it should fail.
+class PacketC(Packet):
+    fields_desc = [IntField('x', None),]
+
+# Packet D stacks Packet C under it. This should be convertible to PacketC only.
+class PacketD(Packet):
+    fields_desc = [ShortField('version', 12),]
+
+bind_layers(PacketD, PacketC)
+
+= Check formatting is expected.
+
+# This isn't strictly relevant for the test, but it ensures that we have the
+# environment we expected.
+
+p = PacketA(b'\xd2\x04')
+assert p.foo == 1234
+
+p = PacketB(b'\x04\xd2')
+assert p.bar == 1234
+
+p = PacketC(b'\0\0\x04\xd2')
+assert p.x == 1234
+
+p = PacketD(b'\0\x0c\0\0\x04\xd2')
+assert p.version == 12
+assert p.haslayer(PacketC)
+assert p.x == 1234
+
+p = PacketA(foo=1234)
+assert raw(p) == b'\xd2\x04'
+
+p = PacketB(raw(p))
+assert p.bar == 53764
+
+p = PacketB(bar=1234)
+assert raw(p) == b'\x04\xd2'
+
+p = PacketA(raw(p))
+assert p.foo == 53764
+
+p = PacketC(x=1234)
+assert raw(p) == b'\0\0\x04\xd2'
+
+p = PacketD()/PacketC(x=1234)
+assert raw(p) == b'\0\x0c\0\0\x04\xd2'
+
+= convert_to A -> B
+
+p1 = PacketA(foo=1234)
+p2 = p1.convert_to(PacketB)
+
+assert p1.foo == 1234
+assert p2.bar == 1234
+
+= convert_to A -> C (fails)
+
+p1 = PacketA(foo=1234)
+p2 = p1.convert_to(PacketC)
+
+assert p1.foo == 1234
+assert p2 is None
+
+= convert_to A -> Raw
+
+p1 = PacketA(foo=1234)
+p2 = p1.convert_to(Raw)
+
+assert p1.foo == 1234
+assert isinstance(p2, Raw)
+assert p2.load == b'\xd2\x04'
+
+= convert_to B -> A
+
+p1 = PacketB(bar=1234)
+p2 = p1.convert_to(PacketA)
+
+assert p1.bar == 1234
+assert p2.foo == 1234
+
+= convert_to B -> C (fails)
+
+p1 = PacketB(bar=1234)
+p2 = p1.convert_to(PacketC)
+
+assert p1.bar == 1234
+assert p2 is None
+
+= convert_to B -> Raw
+
+p1 = PacketB(bar=1234)
+p2 = p1.convert_to(Raw)
+
+assert p1.bar == 1234
+assert isinstance(p2, Raw)
+assert p2.load == b'\x04\xd2'
+
+= convert_to D -> C
+
+p1 = PacketD()/PacketC(x=1234)
+p2 = p1.convert_to(PacketC)
+
+assert p1.x == 1234
+assert p2.x == 1234
+
+= convert_to invalid type
+
+try:
+    PacketA().convert_to(3)
+except TypeError:
+    pass
+else:
+    assert False
+
+= convert_packet A -> B
+
+p1 = PacketA(foo=1234)
+p2 = PacketB.convert_packet(p1)
+
+assert p1.foo == 1234
+assert p2.bar == 1234
+
+= convert_packet A -> C (fails)
+
+p1 = PacketA(foo=1234)
+p2 = PacketC.convert_packet(p1)
+
+assert p1.foo == 1234
+assert p2 is None
+
+= convert_packet A -> Raw
+
+p1 = PacketA(foo=1234)
+p2 = Raw.convert_packet(p1)
+
+assert p1.foo == 1234
+assert isinstance(p2, Raw)
+assert p2.load == b'\xd2\x04'
+
+= convert_packet B -> A
+
+p1 = PacketB(bar=1234)
+p2 = PacketA.convert_packet(p1)
+
+assert p1.bar == 1234
+assert p2.foo == 1234
+
+= convert_packet B -> C (fails)
+
+p1 = PacketB(bar=1234)
+p2 = PacketC.convert_packet(p1)
+
+assert p1.bar == 1234
+assert p2 is None
+
+= convert_packet B -> Raw
+
+p1 = PacketB(bar=1234)
+p2 = Raw.convert_packet(p1)
+
+assert p1.bar == 1234
+assert isinstance(p2, Raw)
+assert p2.load == b'\x04\xd2'
+
+= convert_packet D -> C
+
+p1 = PacketD()/PacketC(x=1234)
+p2 = PacketC.convert_packet(p1)
+
+assert p1.x == 1234
+assert p2.x == 1234
+
+= convert_packets A -> B
+
+p1 = [PacketA(foo=x) for x in range(100)]
+p2 = list(PacketB.convert_packets(p1))
+
+for x in range(100):
+    assert p1[x].foo == x
+    assert p2[x].bar == x
+
+= convert_packets B -> A
+
+p1 = [PacketB(bar=x) for x in range(100)]
+p2 = list(PacketA.convert_packets(p1))
+
+for x in range(100):
+    assert p1[x].bar == x
+    assert p2[x].foo == x
+
+= convert_packet invalid type
+
+try:
+    PacketA.convert_packet(3)
+except TypeError:
+    pass
+else:
+    assert False

--- a/test/packet.uts
+++ b/test/packet.uts
@@ -11,13 +11,23 @@ def expect_exception(e, c):
     except e:
         return True
 
+def no_theme(c):
+    old_theme = conf.color_theme
+    conf.color_theme = NoTheme()
+    try:
+        return c()
+    finally:
+        conf.color_theme = old_theme
+
 # PacketA declares no conversions, but will have conversions declared by
 # PacketB.
 class PacketA(Packet):
+    name = 'PacketA'
     fields_desc = [LEShortField('foo', None)]
 
 # PacketB declares conversions for PacketA
 class PacketB(Packet):
+    name = 'PacketB'
     fields_desc = [ShortField('bar', None)]
     def convert_to(self, other_cls, **kwargs):
         if other_cls is PacketA:
@@ -32,10 +42,12 @@ class PacketB(Packet):
 # PacketC has no defined conversions, either way.
 # Converting to or from it should fail.
 class PacketC(Packet):
+    name = 'PacketC'
     fields_desc = [IntField('x', None),]
 
 # Packet D stacks Packet C under it.
 class PacketD(Packet):
+    name = 'PacketD'
     fields_desc = [ShortField('version', 12),]
 
 bind_layers(PacketD, PacketC)
@@ -222,3 +234,66 @@ except TypeError:
     pass
 else:
     assert False
+
+= PacketList.convert_to A -> B
+
+pl1 = PacketList([PacketA(foo=x) for x in range(10)])
+pl2 = pl1.convert_to(PacketB)
+
+for i, p2 in enumerate(pl2):
+    assert p2.bar == i
+
+assert 'PacketB' in pl2.listname
+
+= PacketList.convert_to custom name / stats
+
+pl1 = PacketList(
+    [PacketA(foo=x) for x in range(10)], name='my old list', stats=[PacketA])
+assert pl1.listname == 'my old list'
+
+pl2 = pl1.convert_to(PacketB, name='my new list', stats=[PacketB, PacketC])
+
+for i, p2 in enumerate(pl2):
+    assert p2.bar == i
+
+assert pl2.listname == 'my new list'
+
+assert no_theme(lambda: 'PacketA' not in str(pl2))
+assert no_theme(lambda: 'PacketB:10' in str(pl2))
+
+= PacketList.getlayer
+
+pl1 = PacketList([PacketC(x=x)/PacketD(version=x*2) for x in range(10)])
+pl2 = pl1.getlayer(PacketD)
+
+for i, p2 in enumerate(pl2):
+    assert p2.version == i * 2
+
+assert 'PacketD' in pl2.listname
+
+= PacketList.getlayer custom name / stats
+
+pl1 = PacketList(
+    [PacketC(x=x)/PacketD(version=x*2) for x in range(10)],
+    name='old list', stats=[PacketC])
+pl2 = pl1.getlayer(PacketD, name='new list', stats=[PacketD])
+
+for i, p2 in enumerate(pl2):
+    assert p2.version == i * 2
+
+assert pl2.listname == 'new list'
+assert no_theme(lambda: 'PacketC' not in str(pl2))
+assert no_theme(lambda: 'PacketD:10' in str(pl2))
+
+= PacketList.getlayer filtering
+
+pl1 = PacketList([PacketC(x=x)/PacketD(version=x*2) for x in range(10)])
+pl2 = pl1.getlayer(PacketD, nb=1, flt={'version': 6})
+
+assert len(pl2) == 1
+assert pl2[0].version == 6
+
+= PacketList.getlayer filtering with 0 results
+
+pl2 = pl1.getlayer(PacketD, nb=1, flt={'version': 1})
+assert len(pl2) == 0

--- a/test/packet.uts
+++ b/test/packet.uts
@@ -4,6 +4,13 @@
 
 = Setup packet conversion
 
+def expect_exception(e, c):
+    try:
+        c()
+        return False
+    except e:
+        return True
+
 # PacketA declares no conversions, but will have conversions declared by
 # PacketB.
 class PacketA(Packet):
@@ -81,10 +88,9 @@ assert p2.bar == 1234
 = convert_to A -> C (fails)
 
 p1 = PacketA(foo=1234)
-p2 = p1.convert_to(PacketC)
+expect_exception(TypeError, lambda: p1.convert_to(PacketC))
 
 assert p1.foo == 1234
-assert p2 is None
 
 = convert_to A -> Raw
 
@@ -106,10 +112,9 @@ assert p2.foo == 1234
 = convert_to B -> C (fails)
 
 p1 = PacketB(bar=1234)
-p2 = p1.convert_to(PacketC)
+expect_exception(TypeError, lambda: p1.convert_to(PacketC))
 
 assert p1.bar == 1234
-assert p2 is None
 
 = convert_to B -> Raw
 
@@ -148,10 +153,9 @@ assert p2.bar == 1234
 = convert_packet A -> C (fails)
 
 p1 = PacketA(foo=1234)
-p2 = PacketC.convert_packet(p1)
+expect_exception(TypeError, lambda: PacketC.convert_packet(p1))
 
 assert p1.foo == 1234
-assert p2 is None
 
 = convert_packet A -> Raw
 
@@ -173,10 +177,9 @@ assert p2.foo == 1234
 = convert_packet B -> C (fails)
 
 p1 = PacketB(bar=1234)
-p2 = PacketC.convert_packet(p1)
+expect_exception(TypeError, lambda: PacketC.convert_packet(p1))
 
 assert p1.bar == 1234
-assert p2 is None
 
 = convert_packet B -> Raw
 

--- a/test/packet.uts
+++ b/test/packet.uts
@@ -34,7 +34,7 @@ class PacketB(Packet):
 class PacketC(Packet):
     fields_desc = [IntField('x', None),]
 
-# Packet D stacks Packet C under it. This should be convertible to PacketC only.
+# Packet D stacks Packet C under it.
 class PacketD(Packet):
     fields_desc = [ShortField('version', 12),]
 
@@ -125,13 +125,12 @@ assert p1.bar == 1234
 assert isinstance(p2, Raw)
 assert p2.load == b'\x04\xd2'
 
-= convert_to D -> C
+= convert_to D -> C (fails)
 
 p1 = PacketD()/PacketC(x=1234)
-p2 = p1.convert_to(PacketC)
+expect_exception(TypeError, lambda: p1.convert_to(PacketC))
 
 assert p1.x == 1234
-assert p2.x == 1234
 
 = convert_to invalid type
 
@@ -190,13 +189,12 @@ assert p1.bar == 1234
 assert isinstance(p2, Raw)
 assert p2.load == b'\x04\xd2'
 
-= convert_packet D -> C
+= convert_packet D -> C (fails)
 
 p1 = PacketD()/PacketC(x=1234)
-p2 = PacketC.convert_packet(p1)
+expect_exception(TypeError, lambda: PacketC.convert_packet(p1))
 
 assert p1.x == 1234
-assert p2.x == 1234
 
 = convert_packets A -> B
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -709,3 +709,67 @@ result = c.q.get(timeout=10)
 p.stop()
 
 assert result.startswith(b"HTTP/1.1 200 OK")
+
+= Packet conversion (ConvertPipe)
+
+class PacketA(Packet):
+    fields_desc = [LEShortField('foo', None)]
+
+class PacketB(Packet):
+    fields_desc = [ShortField('bar', None)]
+    def convert_to(self, other_cls, **kwargs):
+        if other_cls is PacketA:
+            return PacketA(foo=self.bar)
+        return Packet.convert_to(self, other_cls, **kwargs)
+    @classmethod
+    def convert_packet(cls, pkt, **kwargs):
+        if isinstance(pkt, PacketA):
+            return cls(bar=pkt.foo)
+        return Packet.convert_packet(pkt, **kwargs)
+
+p = PipeEngine()
+s = CLIFeeder()
+sh = CLIHighFeeder()
+c = ConvertPipe(low_type=PacketA)
+d = QueueSink()
+
+s > c > d
+sh >> c >> d
+
+p.add(s)
+p.start()
+
+# QueueSink puts all packets in the same queue, and this can race on Windows
+s.send(PacketB(bar=1234))
+r0 = d.q.get(timeout=5)
+
+sh.send(PacketB(bar=1234))
+r1 = d.q.get(timeout=5)
+p.stop()
+
+# Debug info
+r0, raw(r0)
+r1, raw(r1)
+
+assert raw(r0) == b'\xd2\x04'
+assert raw(r1) == b'\x04\xd2'
+assert isinstance(r0, PacketA)
+assert isinstance(r1, PacketB)
+
+# Try converting on high
+c.high_type = PacketB
+c.low_type = None
+
+p.start()
+s.send(PacketA(foo=1234))
+r0 = d.q.get(timeout=5)
+sh.send(PacketA(foo=1234))
+r1 = d.q.get(timeout=5)
+p.stop()
+
+r0, raw(r0)
+r1, raw(r1)
+assert raw(r0) == b'\xd2\x04'
+assert raw(r1) == b'\x04\xd2'
+assert isinstance(r0, PacketA)
+assert isinstance(r1, PacketB)


### PR DESCRIPTION
This pull requests adds Packet conversion semantics:

* `Packet.convert_to` (method) allows a Packet to declare how it can be   converted into another Packet type.
* `Packet.convert_packet` (classmethod) allows a Packet to declare how it convert other Packet instances into itself.
* Both methods will fall back to ~getting child layers, or~ using the other method.  In the absence of available conversions, it ~returns `None`~ raises `TypeError`.
* `ConvertPipe` uses these conversion semantics with Pipes.
* Add `PacketList.convert_to` (which calls `Packet.convert_to`) and `PacketList.getlayer` (which calls `Packet.getlayer`).

All of these conversions are **not** guaranteed to be lossless, nor are they guaranteed to be bidirectional.  It is intended to convert between two functionally similar packet types.

This is used by the Nordic BLE protocol handling branch I'm working on (nrf5sniff), to convert between the protocol used by the device and the protocol declared by `DLT_NORDIC_BLE` (and a couple of other variants). As that's a much larger patch, I've sharded it up to make it easier to review.

Adds unit tests for all of this, which also serve as examples as to how this could be used.