### PR TITLE
Add auth method output(PSK or 802.1X) in network_stats() crypto

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -655,7 +655,7 @@ class _Dot11NetStats(Packet):
                         p.info.startswith(b'\x00P\xf2\x01\x01\x00'):
                     if p.akm_suites:
                         auth = akmsuite_types.get(p.akm_suites[0].suite)
-                        crypto.add("WPA/%s" % (auth))
+                        crypto.add("WPA/%s" % auth)
                     else:
                         crypto.add("WPA")
             p = p.payload

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -647,7 +647,7 @@ class _Dot11NetStats(Packet):
             elif isinstance(p, Dot11EltRSN):
                 if p.akm_suites:
                     auth = akmsuite_types.get(p.akm_suites[0].suite)
-                    crypto.add("WPA2/%s" % (auth))
+                    crypto.add("WPA2/%s" % auth)
                 else:
                     crypto.add("WPA2")
             elif p.ID == 221:

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -622,6 +622,11 @@ class _Dot11NetStats(Packet):
         """
         summary = {}
         crypto = set()
+        akmsuite_types = {
+            0x00: "Reserved",
+            0x01: "802.1X",
+            0x02: "PSK"
+        }
         p = self.payload
         while isinstance(p, Dot11Elt):
             if p.ID == 0:
@@ -640,11 +645,19 @@ class _Dot11NetStats(Packet):
             elif isinstance(p, Dot11EltRates):
                 summary["rates"] = p.rates
             elif isinstance(p, Dot11EltRSN):
-                crypto.add("WPA2")
+                if p.akm_suites:
+                    auth = akmsuite_types.get(p.akm_suites[0].suite)
+                    crypto.add("WPA2/%s" % (auth))
+                else:
+                    crypto.add("WPA2")
             elif p.ID == 221:
                 if isinstance(p, Dot11EltMicrosoftWPA) or \
                         p.info.startswith(b'\x00P\xf2\x01\x01\x00'):
-                    crypto.add("WPA")
+                    if p.akm_suites:
+                        auth = akmsuite_types.get(p.akm_suites[0].suite)
+                        crypto.add("WPA/%s" % (auth))
+                    else:
+                        crypto.add("WPA")
             p = p.payload
         if not crypto:
             if self.cap.privacy:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10576,7 +10576,7 @@ nstats = pkt[Dot11Beacon].network_stats()
 nstats
 assert nstats == {
    'channel': 8,
-   'crypto': {'WPA2'},
+   'crypto': {'WPA2/PSK'},
    'rates': [130, 132, 12, 18, 24, 36, 48, 72, 96, 108],
    'ssid': 'SSID76',
    'country': 'US',


### PR DESCRIPTION
It's necessary to show an AP is authorized by 802.1X or PSK, outputs like this:

```
t = sniff(iface="wlan0",  filter="subtype probe-resp or subtype beacon", timeout=0.5)
for i in range(len(t)):
  p = t[i]
  if p.subtype == 8: #Beacon
    print( p[Dot11Beacon].network_stats()["crypto"])
  if p.subtype == 5: #ProbeResp
    print( p[Dot11ProbeResp].network_stats()["crypto"])

{'WPA2/PSK'}
{'WPA2/PSK'}
{'WEP'}
{'OPN'}
{'WPA2/802.1X'}
{'OPN'}
{'WPA2/802.1X'}
{'OPN'}
{'WPA2/PSK'}
{'WEP'}
{'WPA/PSK', 'WPA2/PSK'}
{'WPA2/802.1X'}
{'WPA2/PSK'}
{'WPA2/802.1X'}
{'WPA2/PSK'}
{'WPA2/PSK'}
{'WPA/PSK', 'WPA2/PSK'}
{'WPA/PSK', 'WPA2/PSK'}
{'WPA2/PSK'}
{'WPA2/802.1X'}
```