### PR TITLE
New field type: LSB Extended Field

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -1047,6 +1047,16 @@ Special
            # Add bytes after the proxified field so that it ends at
            # the specified alignment from its beginning
 
+    BitExtendedField(extension_bit)
+           # Field with a variable number of bytes. Each byte is made of:
+           # - 7 bits of data
+           # - 1 extension bit:
+           #    * 0 means that it is the last byte of the field ("stopping bit")
+           #    * 1 means that there is another byte after this one ("forwarding bit")
+           # extension_bit is the bit number [0-7] of the extension bit in the byte
+
+    MSBExtendedField, LSBExtendedField      # Special cases of BitExtendedField
+
 TCP/IP
 ------
 
@@ -1149,3 +1159,4 @@ Scapy provides an ``explore()`` function, to search through the available layer/
     # scapy.contrib.status = skip 
 
 - A **layer** module must have a docstring, in which the first line shortly describes the module.
+

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1565,3 +1565,122 @@ x = DebugPacket()
 r = x.fields_desc[0].randval()
 assert r.min == -5
 assert r.max == 20
+
+
+############
+############
++ BitExtendedField
+
+= BitExtendedField: simple test
+
+class DebugPacket(Packet):
+    fields_desc = [
+        BitExtendedField("val", None, extension_bit=0)
+    ]
+
+a = DebugPacket(val=1234)
+assert(a.val == 1234)
+
+= BitExtendedField i2m: corner values
+* 7 bits of data = 0
+import codecs
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.i2m(None, 0)
+    r = int(codecs.encode(r, 'hex'), 16)
+    assert(r == 0)
+
+* 7 bits of data = 1
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.i2m(None, 0b1111111)
+    r = int(codecs.encode(r, 'hex'), 16)
+    assert(r == 0xff - 2**i)
+
+= BitExtendedField i2m: field expansion
+* If there is 8 bits of data, we need to add a byte
+m = BitExtendedField("foo", None, extension_bit=0)
+r = m.i2m(None, 0b10000000)
+r = int(codecs.encode(r, 'hex'), 16)
+assert(r == 0x0300)
+
+= BitExtendedField i2m: test all FX bit positions
+* Data is 0b10000001 (129) and all str values are precomputed
+data_129 = {
+    "extended": 129,
+    "int_with_fx": [770, 769, 1281, 2305, 4353, 8449, 16641, 33025],
+    "str_with_fx" : []
+}
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.i2m(None, data_129["extended"])
+    data_129["str_with_fx"].append(r)
+    r = int(codecs.encode(r, 'hex'), 16)
+    assert(r == data_129["int_with_fx"][i])
+
+= BitExtendedField m2i: test all FX bit positions
+* Data is 0b10000001 (129) and all str values are precomputed
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.m2i(None, data_129["str_with_fx"][i])
+    assert(r == data_129["extended"])
+
+= BitExtendedField m2i: stop at FX zero
+* 1 byte of zeroes (FX stop) then 1 byte of ones : ignore 2nd byte
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.m2i(None, b'\x00\xff')
+    assert(r == 0)
+
+= BitExtendedField m2i: multiple bytes
+* 0b00000011 0b11111110 --> 0xff
+data_254 = {
+    "extended": 0xff,
+    "str_with_fx" : [b'\x03\xfe', b'\x03\xfd', b'\x05\xfb', b'\x09\xf7', b'\x11\xef', b'\x21\xdf', b'\x41\xbf', b'\x81\x7f']
+}
+for i in range(len(data_254['str_with_fx'])):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.m2i(None, data_254["str_with_fx"][i])
+    assert(r == data_254['extended'])
+
+= BitExtendedField m2i: invalid field with no stopping bit
+* 1 byte of one (no FX stop) shall return an error
+for i in range(8):
+    m = BitExtendedField("foo", None, extension_bit=i)
+    r = m.m2i(None, b'\xff')
+    assert(r == None)
+
+=LSBExtendedField
+* Test i2m and m2i
+data_129 = {
+    "extended": 129,
+    "int_with_fx": 770,
+    "str_with_fx" : None
+}
+m = LSBExtendedField("foo", None)
+r = m.i2m(None, data_129["extended"])
+data_129["str_with_fx"] = r
+r = int(codecs.encode(r, 'hex'), 16)
+assert(r == data_129["int_with_fx"])
+
+m = LSBExtendedField("foo", None)
+r = m.m2i(None, data_129["str_with_fx"])
+assert(r == data_129["extended"])
+
+=MSBExtendedField
+* Test i2m and m2i
+data_129 = {
+    "extended": 129,
+    "int_with_fx": 33025,
+    "str_with_fx" : None
+}
+m = MSBExtendedField("foo", None)
+r = m.i2m(None, data_129["extended"])
+data_129["str_with_fx"] = r
+r = int(codecs.encode(r, 'hex'), 16)
+assert(r == data_129["int_with_fx"])
+
+m = MSBExtendedField("foo", None)
+r = m.m2i(None, data_129["str_with_fx"])
+assert(r == data_129["extended"])
+


### PR DESCRIPTION
**Description:**

This PR adds a new type of field that I add to implement to dissect a custom protocol. It is not very often seen in protocols but as it is generic, maybe it worth including in the main scapy distribution.

Up to you to decide.

**Details:**

This type of field has a variable number of bytes. Size is not taken from another field. Each byte is defined as follows:
- The 7 MSB bits are data
- The LSB is an extension bit
  - 0 means it is last byte of the field ("stopping bit")
  - 1 means there is another byte after this one ("forwarding bit")

To get the actual data, it is necessary to hop the binary data from byte to byte until LSB is 0.

**Tests:**

I tested with success both on Python 2 and Python 3. I did not write unit tests as to be fair I don't really know how to do it. However, I am not sure that it is very important as the field does not rely on anything special from Scapy.

*Note:*
*I noticed while writing this PR description that my VSCode automatically removed the trailing spaces from the modified files. It is always better for the code itself but it clutters a little the diff. Sorry for that.*