### PR TITLE
Unit tests fixes

### DIFF
--- a/doc/scapy/development.rst
+++ b/doc/scapy/development.rst
@@ -242,3 +242,14 @@ To see an example that is targeted to Scapy, go to http://www.secdev.org/project
 ./test/run_tests -t demo_campaign.txt -f html -o demo_campaign.html -F -l
 
 Examine the output generated in file ``demo_campaign.html``.
+
+Using tox to test Scapy
+-----------------------
+
+The ``tox`` command simplifies testing Scapy. It will automatically create
+virtual environments and install the mandatory Python modules.
+
+For example, on a fresh Debian installation, the following command will start
+all Scapy unit tests automatically without any external dependency::
+
+ tox -- -K vcan_socket -K tcpdump -K tshark -K nmap -K manufdb -K crypto

--- a/test/edns0.uts
+++ b/test/edns0.uts
@@ -62,6 +62,7 @@ raw(tlv) == b'\x00\x02\x00\x00'
 
 = NSID - Live test
 ~ netaccess
+
 from scapy.tools.UTscapy import retry_test
 def _test():
     old_debug_dissector = conf.debug_dissector

--- a/test/nmap.uts
+++ b/test/nmap.uts
@@ -18,6 +18,8 @@ d = nmap_tcppacket_sig(IP()/TCP())
 assert len(d) == 5
 
 = Fetch database
+~ netaccess
+
 from __future__ import print_function
 try:
     from urllib.request import urlopen
@@ -34,6 +36,8 @@ for i in range(10):
 conf.nmap_base = 'nmap-os-fingerprints'
 
 = Database loading
+~ netaccess
+
 assert len(nmap_kdb.get_base()) > 100
 
 = fingerprint test: www.secdev.org

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -11,6 +11,8 @@
 load_module('p0f')
 
 = Fetch database
+~ netaccess
+
 from __future__ import print_function
 try:
     from urllib.request import urlopen
@@ -42,12 +44,14 @@ p0f_load_knowledgebases()
 + Default tests
 
 = Test p0f
+~ netaccess
 
 pkt = Ether(b'\x14\x0cv\x8f\xfe(\xd0P\x99V\xdd\xf9\x08\x00E\x00\x0045+@\x00\x80\x06\x00\x00\xc0\xa8\x00w(M\xe2\xf9\xda\xcb\x01\xbbcc\xdd\x1e\x00\x00\x00\x00\x80\x02\xfa\xf0\xcc\x8c\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
 
 assert p0f(pkt) == [('@Windows', 'XP/2000 (RFC1323+, w+, tstamp-)', 0)]
 
 = Test prnp0f
+~ netaccess
 
 with ContextManagerCaptureOutput() as cmco:
     prnp0f(pkt)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1490,12 +1490,9 @@ def _test():
 retry_test(_test)
 
 = Traceroute function
-~ netaccess
+~ netaccess tcpdump
 * Let's test traceroute
 ans, unans = traceroute("www.slashdot.org")
-
-= Result manipulation
-~ netaccess
 ans.nsummary()
 s,r=ans[0]
 s.show()
@@ -1520,7 +1517,7 @@ assert(DNS in IP(raw(dns_ans2)))
 assert raw(DNSRR(type='A', rdata='1.2.3.4')) == b'\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x04\x01\x02\x03\x04'
 
 = Arping
-~ netaccess
+~ netaccess tcpdump
 * This test assumes the local network is a /24. This is bad.
 def _test():
     ip_address = conf.route.route("0.0.0.0")[2]
@@ -1530,7 +1527,7 @@ def _test():
 retry_test(_test)
 
 = send() and sniff()
-~ netaccess
+~ netaccess tcpdump
 import time
 import os
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -524,6 +524,8 @@ save_object(fname, 2807)
 assert(load_object(fname) == 2807)
 
 = Test whois function
+~ netaccess
+
 if not WINDOWS:
     result = whois("193.0.6.139")
     assert(b"inetnum" in result and b"Amsterdam" in result)
@@ -837,6 +839,9 @@ assert all(p.hashret() == p2.hashret() for p in px)
 assert not any(p.answers(p2) for p in px)
 assert all(p2.answers(p) for p in px)
 conf.checkIPinIP = conf_back
+
+= answers - Net
+~ netaccess
 
 a1, a2 = Net("www.google.com"), Net("www.secdev.org")
 prt1, prt2 = 12345, 54321
@@ -9717,6 +9722,7 @@ assert n3.__iterlen__() == 5
 (n3 in n2) == True
 
 = Net using web address
+~ netaccess
 
 ip = IP(dst="www.google.com")
 n1 = ip.dst
@@ -10896,6 +10902,7 @@ new_pl = pl.replace(IP.src, "192.168.0.254", "192.168.0.42")
 assert("192.168.0.254" not in [p[IP].src for p in new_pl])
 
 = IPv4 - reporting
+~ netaccess
 
 @mock.patch("scapy.layers.inet.sr")
 def test_report_ports(mock_sr):

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -226,7 +226,7 @@ with VEthPair('a_0', 'a_1') as veth_0:
 ############
 + Test arpleak() using a tap socket
 
-~ tap linux
+~ tap linux tcpdump
 
 = Create two tap interfaces
 


### PR DESCRIPTION
This PR does several things:
- allows tests to be run without any network connectivity
- removes as useless test
- flags more tests using `tcpdump`
- documents using `tox` on a fresh Linux installation (that fixes #1887)