### PR TITLE
PCAPDNET tests re-enabled on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,11 +115,10 @@ matrix:
           env:
             - TOXENV=py27-bsd_root,codecov
 
-        # FIXME - Networking with pcapdnet seem to be failing on OSX at the moment
-        #- os: osx
-        #  language: generic
-        #  env:
-        #    - SCAPY_SUDO=sudo SCAPY_USE_PCAPDNET=yes TOXENV=py27-pcapdnet_root,codecov
+        - os: osx
+          language: generic
+          env:
+            - SCAPY_SUDO=sudo SCAPY_USE_PCAPDNET=yes TOXENV=py27-pcapdnet_root,codecov
 
         - os: osx
           language: generic


### PR DESCRIPTION
Fix for #1642.