### PR TITLE
Correctly display GeneralizedTime in X.509 certificates

### DIFF
--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -445,14 +445,14 @@ class ASN1_UTC_TIME(ASN1_STRING):
             pretty_time = None
             if isinstance(self, ASN1_GENERALIZED_TIME):
                 _len = 15
-                _format = "%Y%m%d%H%M%S"
+                self._format = "%Y%m%d%H%M%S"
             else:
                 _len = 13
-                _format = "%y%m%d%H%M%S"
+                self._format = "%y%m%d%H%M%S"
             _nam = self.tag._asn1_obj.__name__[4:].lower()
             if (isinstance(value, str) and
                     len(value) == _len and value[-1] == "Z"):
-                dt = datetime.strptime(value[:-1], _format)
+                dt = datetime.strptime(value[:-1], self._format)
                 pretty_time = dt.strftime("%b %d %H:%M:%S %Y GMT")
             else:
                 pretty_time = "%s [invalid %s]" % (value, _nam)

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -611,7 +611,8 @@ class Cert(six.with_metaclass(_CertMaker, object)):
         if notBefore[-1] == "Z":
             notBefore = notBefore[:-1]
         try:
-            self.notBefore = time.strptime(notBefore, "%y%m%d%H%M%S")
+            _format = tbsCert.validity.not_before._format
+            self.notBefore = time.strptime(notBefore, _format)
         except Exception:
             raise Exception(error_msg)
         self.notBefore_str_simple = time.strftime("%x", self.notBefore)
@@ -621,7 +622,8 @@ class Cert(six.with_metaclass(_CertMaker, object)):
         if notAfter[-1] == "Z":
             notAfter = notAfter[:-1]
         try:
-            self.notAfter = time.strptime(notAfter, "%y%m%d%H%M%S")
+            _format = tbsCert.validity.not_after._format
+            self.notAfter = time.strptime(notAfter, _format)
         except Exception:
             raise Exception(error_msg)
         self.notAfter_str_simple = time.strftime("%x", self.notAfter)

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -634,3 +634,16 @@ except:
 
 repr_str = Chain([], c0).__repr__()
 assert repr_str == '__ /OU=Domain Control Validated/CN=*.tools.ietf.org [Not Self Signed]\n'
+
+= Test GeneralizedTime
+
+data = b"MHAwXAIBADANBgkqhkiG9w0BAQ0FADAAMCIYDzIwMTExMDA2MDgzOTU2WhgPMjA0NjEwMDYwODM5NTZaMAAwHDANBgkqhkiG9w0BAQEFAAMLADAIAgEAAgMBAAGjAjAAMA0GCSqGSIb3DQEBDQUAAwEA"
+import tempfile, os
+_, filename = tempfile.mkstemp()
+fd = open(filename, "wb")
+fd.write(b"-----BEGIN CERTIFICATE-----\n")
+fd.write(data)
+fd.write(b"-----END CERTIFICATE-----\n")
+fd.close()
+cert = Cert(filename)
+assert "2011" in cert.notBefore_str and "2046" in cert.notAfter_str


### PR DESCRIPTION
This PR fixes #1662.

Once again writing a test was more time consuming than fixing the issue =)