### PR TITLE
Add missing import of ASN.1 conf to x509 module

### DIFF
--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -8,6 +8,7 @@
 X.509 certificates.
 """
 
+from scapy.asn1.mib import conf
 from scapy.asn1.asn1 import ASN1_Codecs, ASN1_OID, \
     ASN1_IA5_STRING, ASN1_NULL, ASN1_PRINTABLE_STRING, \
     ASN1_UTC_TIME, ASN1_UTF8_STRING


### PR DESCRIPTION
This fixes the issue #1948

This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [x] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
