### PR TITLE
Adds Wireshark pipes support, cleanup OSX tcpdump handling.

### DIFF
--- a/doc/scapy/conf.py
+++ b/doc/scapy/conf.py
@@ -106,6 +106,8 @@ html_sidebars = {
     ]
 }
 
+# Make :manpage directive work on HTML output.
+manpages_url = 'https://manpages.debian.org/{path}'
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1533,28 +1533,76 @@ Viewing packets with Wireshark
 Problem
 ^^^^^^^
 
-You have generated or sniffed some packets with Scapy and want to view them with `Wireshark <http://www.wireshark.org>`_, because of its advanced packet dissection abilities.
+You have generated or sniffed some packets with Scapy.
+
+Now you want to view them with `Wireshark <https://www.wireshark.org>`_, because
+of its advanced packet dissection capabilities.
 
 Solution
 ^^^^^^^^
 
-That's what the ``wireshark()`` function is for:
+That's what :py:func:`wireshark` is for!
 
-    >>> packets = Ether()/IP(dst=Net("google.com/30"))/ICMP()     # first generate some packets
-    >>> wireshark(packets)                                        # show them with Wireshark
+.. code-block:: python3
 
-Wireshark will start in the background and show your packets.
+    # First, generate some packets...
+    packets = IP(src="192.0.2.9", dst=Net("192.0.2.10/30"))/ICMP()
+
+    # Show them with Wireshark
+    wireshark(packets)
+
+Wireshark will start in the background, and show your packets.
  
 Discussion
 ^^^^^^^^^^
 
-The ``wireshark()`` function generates a temporary pcap-file containing your packets, starts Wireshark in the background and makes it read the file on startup.   
+.. py:function:: wireshark(pktlist, ...)
 
-Please remember that Wireshark works with Layer 2 packets (usually called "frames"). So we had to add an ``Ether()`` header to our ICMP packets. Passing just IP packets (layer 3) to Wireshark will give strange results.
+    With a :py:class:`Packet` or :py:class:`PacketList`, serialises your
+    packets, and streams this into Wireshark via ``stdin`` as if it were a
+    capture device.
 
-You can tell Scapy where to find the Wireshark executable by changing the ``conf.prog.wireshark`` configuration setting.
+    Because this uses ``pcap`` format to serialise the packets, there are some
+    limitations:
 
+    * Packets must be all of the same ``linktype``.
 
+      For example, you can't mix :py:class:`Ether` and :py:class:`IP` at the
+      top layer.
+
+    * Packets must have an assigned (and supported) ``DLT_*`` constant for the
+      ``linktype``.  An unsupported ``linktype`` is replaced with ``DLT_EN10MB``
+      (Ethernet), and will display incorrectly in Wireshark.
+
+      For example, can't pass a bare :py:class:`ICMP` packet, but you can send
+      it as a payload of an :py:class:`IP` or :py:class:`IPv6` packet.
+
+    With a filename (passed as a string), this loads the given file in
+    Wireshark. This needs to be in a format that Wireshark supports.
+
+    You can tell Scapy where to find the Wireshark executable by changing the
+    ``conf.prog.wireshark`` configuration setting.
+
+    This accepts the same extra parameters as :py:func:`tcpdump`.
+
+.. seealso::
+
+    :py:class:`WiresharkSink`
+        A :ref:`PipeTools sink <pipetools>` for live-streaming packets.
+
+    :manpage:`wireshark(1)`
+        Additional description of Wireshark's functionality, and its
+        command-line arguments.
+
+    `Wireshark's website`__
+        For up-to-date releases of Wireshark.
+
+    `Wireshark Protocol Reference`__
+        Contains detailed information about Wireshark's protocol dissectors, and
+        reference documentation for various network protocols.
+
+__ https://www.wireshark.org
+__ https://wiki.wireshark.org/ProtocolReference
 
 OS Fingerprinting
 -----------------

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -652,12 +652,11 @@ class QueueSink(Sink):
     def high_push(self, msg):
         self.q.put(msg)
 
-    def recv(self):
-        while True:
-            try:
-                return self.q.get(True, timeout=0.1)
-            except six.moves.queue.Empty:
-                pass
+    def recv(self, block=True, timeout=None):
+        try:
+            return self.q.get(block=block, timeout=timeout)
+        except six.moves.queue.Empty:
+            pass
 
 
 class TransformDrain(Drain):

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -5,34 +5,54 @@
 
 from __future__ import print_function
 import socket
+import subprocess
+
 from scapy.modules.six.moves.queue import Queue, Empty
 from scapy.pipetool import Source, Drain, Sink
 from scapy.config import conf
 from scapy.compat import raw
-from scapy.utils import PcapReader, PcapWriter
+from scapy.utils import ContextManagerSubprocess, PcapReader, PcapWriter
 from scapy.automaton import recv_error
 from scapy.consts import WINDOWS
 
 
 class SniffSource(Source):
     """Read packets from an interface and send them to low exit.
-     +-----------+
-  >>-|           |->>
-     |           |
-   >-|  [iface]--|->
-     +-----------+
-"""
 
-    def __init__(self, iface=None, filter=None, name=None):
+         +-----------+
+      >>-|           |->>
+         |           |
+       >-|  [iface]--|->
+         +-----------+
+
+    If neither of the ``iface`` or ``socket`` parameters are specified, then
+    Scapy will capture from the first network interface.
+
+    :param iface: A layer 2 interface to sniff packets from. Mutually
+                  exclusive with the ``socket`` parameter.
+    :param filter: Packet filter to use while capturing. See ``L2listen``.
+                   Not used with ``socket`` parameter.
+    :param socket: A ``SuperSocket`` to sniff packets from.
+    """
+
+    def __init__(self, iface=None, filter=None, socket=None, name=None):
         Source.__init__(self, name=name)
+
+        if (iface or filter) and socket:
+            raise ValueError("iface and filter options are mutually exclusive "
+                             "with socket")
+
+        self.s = socket
         self.iface = iface
         self.filter = filter
 
     def start(self):
-        self.s = conf.L2listen(iface=self.iface, filter=self.filter)
+        if not self.s:
+            self.s = conf.L2listen(iface=self.iface, filter=self.filter)
 
     def stop(self):
-        self.s.close()
+        if self.s:
+            self.s.close()
 
     def fileno(self):
         return self.s.fileno()
@@ -127,14 +147,48 @@ class WrpcapSink(Sink):
 
     def __init__(self, fname, name=None):
         Sink.__init__(self, name=name)
-        self.f = PcapWriter(fname)
+        self.fname = fname
+        self.f = None
+
+    def start(self):
+        self.f = PcapWriter(self.fname)
 
     def stop(self):
-        self.f.flush()
-        self.f.close()
+        if self.f:
+            self.f.flush()
+            self.f.close()
 
     def push(self, msg):
-        self.f.write(msg)
+        if msg:
+            self.f.write(msg)
+
+
+class WiresharkSink(WrpcapSink):
+    """Packets received on low input are pushed to Wireshark.
+
+         +----------+
+      >>-|          |->>
+         |          |
+       >-|--[pcap]  |->
+         +----------+
+    """
+
+    def __init__(self, name=None):
+        WrpcapSink.__init__(self, fname=None, name=name)
+
+    def start(self):
+        # Wireshark must be running first, because PcapWriter will block until
+        # data has been read!
+        with ContextManagerSubprocess("WiresharkSink", conf.prog.wireshark):
+            proc = subprocess.Popen(
+                [conf.prog.wireshark, "-ki", "-"],
+                stdin=subprocess.PIPE,
+                stdout=None,
+                stderr=None,
+            )
+
+        self.fname = proc.stdin
+        WrpcapSink.start(self)
 
 
 class UDPDrain(Drain):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -48,16 +48,41 @@ def issubtype(x, t):
     return isinstance(x, type) and issubclass(x, t)
 
 
-def get_temp_file(keep=False, autoext=""):
-    """Create a temporary file and return its name. When keep is False,
-    the file is deleted when scapy exits.
+def get_temp_file(keep=False, autoext="", fd=False):
+    """Creates a temporary file.
 
+    :param keep: If False, automatically delete the file when Scapy exits.
+    :param autoext: Suffix to add to the generated file name.
+    :param fd: If True, this returns a file-like object with the temporary
+               file opened. If False (default), this returns a file path.
     """
-    fname = tempfile.NamedTemporaryFile(prefix="scapy", suffix=autoext,
-                                        delete=False).name
+    f = tempfile.NamedTemporaryFile(prefix="scapy", suffix=autoext,
+                                    delete=False)
     if not keep:
-        conf.temp_files.append(fname)
-    return fname
+        conf.temp_files.append(f.name)
+
+    if fd:
+        return f
+    else:
+        # Close the file so something else can take it.
+        f.close()
+        return f.name
+
+
+def get_temp_dir(keep=False):
+    """Creates a temporary file, and returns its name.
+
+    :param keep: If False (default), the directory will be recursively
+                 deleted when Scapy exits.
+    :return: A full path to a temporary directory.
+    """
+
+    dname = tempfile.mkdtemp(prefix="scapy")
+
+    if not keep:
+        conf.temp_files.append(dname)
+
+    return dname
 
 
 def sane_color(x):
@@ -1365,12 +1390,9 @@ def import_hexcap():
 
 
 @conf.commands.register
-def wireshark(pktlist, **kwargs):
+def wireshark(pktlist):
     """Run wireshark on a list of packets"""
-    f = get_temp_file()
-    wrpcap(f, pktlist, **kwargs)
-    with ContextManagerSubprocess("wireshark()", conf.prog.wireshark):
-        subprocess.Popen([conf.prog.wireshark, "-r", f])
+    tcpdump(pktlist, prog=conf.prog.wireshark)
 
 
 @conf.commands.register
@@ -1381,8 +1403,27 @@ def tdecode(pktlist):
 
 @conf.commands.register
 def tcpdump(pktlist, dump=False, getfd=False, args=None,
-            prog=None, getproc=False, quiet=False):
-    """Run tcpdump or tshark on a list of packets
+            prog=None, getproc=False, quiet=False, use_tempfile=None,
+            read_stdin_opts=None):
+    """Run tcpdump or tshark on a list of packets.
+
+    When using ``tcpdump`` on OSX (``prog == conf.prog.tcpdump``), this uses a
+    temporary file to store the packets. This works around a bug in Apple's
+    version of ``tcpdump``: http://apple.stackexchange.com/questions/152682/
+
+    Otherwise, the packets are passed in stdin.
+
+    This function can be explicitly enabled or disabled with the
+    ``use_tempfile`` parameter.
+
+    When using ``wireshark``, it will be called with ``-ki -`` to start
+    immediately capturing packets from stdin.
+
+    Otherwise, the command will be run with ``-r -`` (which is correct for
+    ``tcpdump`` and ``tshark``).
+
+    This can be overridden with ``read_stdin_opts``. This has no effect when
+    ``use_tempfile=True``, or otherwise reading packets from a regular file.
 
 pktlist: a Packet instance, a PacketList instance or a list of Packet
          instances. Can also be a filename (as a string), an open
@@ -1397,6 +1438,12 @@ args:    arguments (as a list) to pass to tshark (example for tshark:
          args=["-T", "json"]).
 prog:    program to use (defaults to tcpdump, will work with tshark)
 quiet:   when set to True, the process stderr is discarded
+use_tempfile: When set to True, always use a temporary file to store packets.
+              When set to False, pipe packets through stdin.
+              When set to None (default), only use a temporary file with
+              ``tcpdump`` on OSX.
+read_stdin_opts: When set, a list of arguments needed to capture from stdin.
+                 Otherwise, attempts to guess.
 
 Examples:
 
@@ -1430,18 +1477,32 @@ To get a JSON representation of a tshark-parsed PacketList(), one can:
   u'_type': u'pcap_file'}]
 >>> json_data[0]['_source']['layers']['ip']['ip.ttl']
 u'64'
-
     """
     getfd = getfd or getproc
     if prog is None:
         prog = [conf.prog.tcpdump]
+        _prog_name = "windump()" if WINDOWS else "tcpdump()"
     elif isinstance(prog, six.string_types):
+        _prog_name = "{}()".format(prog)
         prog = [prog]
-    _prog_name = "windump()" if WINDOWS else "tcpdump()"
+
     # Build Popen arguments
     args = args if args is not None else []
     stdout = subprocess.PIPE if dump or getfd else None
     stderr = open(os.devnull) if quiet else None
+
+    if use_tempfile is None:
+        # Apple's tcpdump cannot read from stdin, see:
+        # http://apple.stackexchange.com/questions/152682/
+        use_tempfile = DARWIN and prog[0] == conf.prog.tcpdump
+
+    if read_stdin_opts is None:
+        if prog[0] == conf.prog.wireshark:
+            # Start capturing immediately (-k) from stdin (-i -)
+            read_stdin_opts = ["-ki", "-"]
+        else:
+            read_stdin_opts = ["-r", "-"]
+
     if pktlist is None:
         # sniff
         with ContextManagerSubprocess(_prog_name, prog[0]):
@@ -1458,10 +1519,8 @@ u'64'
                 stdout=stdout,
                 stderr=stderr,
             )
-    elif DARWIN:
-        # Tcpdump cannot read from stdin, see
-        # <http://apple.stackexchange.com/questions/152682/>
-        tmpfile = tempfile.NamedTemporaryFile(delete=False)
+    elif use_tempfile:
+        tmpfile = get_temp_file(autoext=".pcap", fd=True)
         try:
             tmpfile.writelines(iter(lambda: pktlist.read(1048576), b""))
         except AttributeError:
@@ -1474,12 +1533,11 @@ u'64'
                 stdout=stdout,
                 stderr=stderr,
             )
-        conf.temp_files.append(tmpfile.name)
     else:
         # pass the packet stream
         with ContextManagerSubprocess(_prog_name, prog[0]):
             proc = subprocess.Popen(
-                prog + ["-r", "-"] + args,
+                prog + read_stdin_opts + args,
                 stdin=subprocess.PIPE,
                 stdout=stdout,
                 stderr=stderr,

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -165,6 +165,7 @@ p.start()
 
 p.wait_and_stop()
 assert c.recv() == "hello"
+assert c.recv(block=False) is None
 
 = Test UpDrain
 
@@ -318,22 +319,76 @@ from io import BytesIO
 f = BytesIO()
 pkt = Ether()/IP()/ICMP()
 
-with mock.patch("subprocess.Popen", return_value=Bunch(stdin=f)):
+with mock.patch("subprocess.Popen", return_value=Bunch(stdin=f)) as popen:
     p = PipeEngine()
     src = CLIFeeder()
-    d = Drain()
     sink = WiresharkSink()
-    p.add(src > d > sink)
+    p.add(src > sink)
     p.start()
     src.send(pkt)
-    time.sleep(1)
-    # Prevent stop from closing us
-    sink.f = None
-    # Now stop
-    p.stop()
+    time.sleep(3)
+    # Prevent stop from closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        p.stop()
 
-print(bytes_hex(f.getvalue()))
+popen.assert_called_once_with(
+    [conf.prog.wireshark, '-ki', '-'], stdin=subprocess.PIPE, stdout=None,
+    stderr=None)
+bytes_hex(f.getvalue())
+bytes_hex(raw(pkt))
 assert raw(pkt) in f.getvalue()
+
+= Test WiresharkSink with linktype
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+linktype = scapy.data.DLT_EN3MB
+
+with mock.patch("subprocess.Popen", return_value=Bunch(stdin=f)) as popen:
+    p = PipeEngine()
+    src = CLIFeeder()
+    sink = WiresharkSink(linktype=linktype)
+    p.add(src > sink)
+    p.start()
+    src.send(pkt)
+    time.sleep(3)
+    # Prevent stop from closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        p.stop()
+
+popen.assert_called_once_with(
+    [conf.prog.wireshark, '-ki', '-'],
+    stdin=subprocess.PIPE, stdout=None, stderr=None)
+
+bytes_hex(f.getvalue())
+bytes_hex(raw(pkt))
+assert raw(pkt) in f.getvalue()
+
+# Check that the linktype was also correct
+f.seek(0) or None
+r = PcapReader(f)
+assert r.linktype == DLT_EN3MB
+
+= Test WiresharkSink with args
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+
+with mock.patch("subprocess.Popen", return_value=Bunch(stdin=f)) as popen:
+    p = PipeEngine()
+    src = CLIFeeder()
+    sink = WiresharkSink(args=['-c', '1'])
+    p.add(src > sink)
+    p.start()
+    src.send(pkt)
+    time.sleep(3)
+    # Prevent stop from closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        p.stop()
+
+popen.assert_called_once_with(
+    [conf.prog.wireshark, '-ki', '-', '-c', '1'],
+    stdin=subprocess.PIPE, stdout=None, stderr=None)
 
 = Test RdpcapSource and WrpcapSink
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -27,11 +27,6 @@ time.sleep(3)
 s.msg = []
 p.stop()
 
-try:
-    os.remove("test.png")
-except OSError:
-    pass
-
 = Test add_pipe
 
 s = AutoSource()
@@ -237,17 +232,60 @@ mocked_l2listen.start()
 try:
     p = PipeEngine()
     s = SniffSource()
+    assert s.s is None
     d1 = Drain(name="d1")
     c = QueueSink(name="c")
     s > d1 > c
     p.add(s)
     p.start()
     assert c.q.get(2)
+    assert s.s is not None
     p.stop()
 finally:
     mocked_l2listen.stop()
     os.close(r)
     os.close(w)
+
+= Test SniffSource with socket
+
+r, w = os.pipe()
+os.write(w, b"X")
+
+class FakeSocket(object):
+    def __init__(self):
+        self.times = 0
+    def recv(self, x=None):
+        if self.times > 2:
+            return
+        self.times += 1
+        return Raw(b'hello')
+    def fileno(self):
+        return r
+
+try:
+    p = PipeEngine()
+    s = SniffSource(socket=FakeSocket())
+    assert s.s is not None
+    d = Drain()
+    c = QueueSink()
+    p.add(s > d > c)
+    p.start()
+    msg = c.q.get(timeout=1)
+    p.stop()
+    assert raw(msg) == b'hello'
+finally:
+    os.close(r)
+    os.close(w)
+
+= Test SniffSource with invalid args
+
+try:
+    s = SniffSource(iface='eth0', socket='not a socket')
+except ValueError:
+    pass
+else:
+    # expected ValueError
+    assert False
 
 = Test exhausted AutoSource and SniffSource
 
@@ -273,31 +311,56 @@ try:
 except:
     pass
 
+= Test WiresharkSink
+
+from io import BytesIO
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+
+with mock.patch("subprocess.Popen", return_value=Bunch(stdin=f)):
+    p = PipeEngine()
+    src = CLIFeeder()
+    d = Drain()
+    sink = WiresharkSink()
+    p.add(src > d > sink)
+    p.start()
+    src.send(pkt)
+    time.sleep(1)
+    # Prevent stop from closing us
+    sink.f = None
+    # Now stop
+    p.stop()
+
+print(bytes_hex(f.getvalue()))
+assert raw(pkt) in f.getvalue()
+
 = Test RdpcapSource and WrpcapSink
-~ needs_root
+
+dname = get_temp_dir()
 
 req = Ether()/IP()/ICMP()
 rpy = Ether()/IP('E\x00\x00\x1c\x00\x00\x00\x004\x01\x1d\x04\xd8:\xd0\x83\xc0\xa8\x00w\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 
-wrpcap("t.pcap", [req, rpy])
+wrpcap(os.path.join(dname, "t.pcap"), [req, rpy])
 
 p = PipeEngine()
 
-s = RdpcapSource("t.pcap")
+s = RdpcapSource(os.path.join(dname, "t.pcap"))
 d1 = Drain(name="d1")
-c = WrpcapSink("t2.pcap", name="c")
+c = WrpcapSink(os.path.join(dname, "t2.pcap"), name="c")
 s > d1 > c
 p.add(s)
 p.start()
 p.wait_and_stop()
 
-results = rdpcap("t2.pcap")
+results = rdpcap(os.path.join(dname, "t2.pcap"))
 
 assert raw(results[0]) == raw(req)
 assert raw(results[1]) == raw(rpy)
 
-os.unlink("t.pcap")
-os.unlink("t2.pcap")
+os.unlink(os.path.join(dname, "t.pcap"))
+os.unlink(os.path.join(dname, "t2.pcap"))
 
 = Test InjectSink and Inject3Sink
 ~ needs_root

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6701,11 +6701,30 @@ assert b'IP 127.0.0.1.20 > 127.0.0.1.80:' in data[0]
 assert b'IP 127.0.0.1.53 > 127.0.0.1.53:' in data[1]
 assert b'IP 127.0.0.1 > 127.0.0.1:' in data[2]
 
+# Also check with use_tempfile=True (for non-OSX platforms)
+pcapfile.seek(0) or None
+tempfile_count = len(conf.temp_files)
+data = tcpdump(pcapfile, dump=True, args=['-nn'], use_tempfile=True).split(b'\n')
+print(data)
+assert b'IP 127.0.0.1.20 > 127.0.0.1.80:' in data[0]
+assert b'IP 127.0.0.1.53 > 127.0.0.1.53:' in data[1]
+assert b'IP 127.0.0.1 > 127.0.0.1:' in data[2]
+# We should have another tempfile tracked.
+assert len(conf.temp_files) > tempfile_count
+
+# Check with a simple packet
+data = tcpdump([Ether()/IP()/ICMP()], dump=True, args=['-nn']).split(b'\n')
+print(data)
+assert b'IP 127.0.0.1 > 127.0.0.1: ICMP' in data[0]
+
 = Check tcpdump() command with tshark
 ~ tshark
 pcapfile = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00e\x00\x00\x00\xcf\xc5\xacVo*\n\x00(\x00\x00\x00(\x00\x00\x00E\x00\x00(\x00\x01\x00\x00@\x06|\xcd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91|\x00\x00\xcf\xc5\xacV_-\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r\xcf\xc5\xacV\xf90\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x01|\xde\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\xf7\xff\x00\x00\x00\x00')
+# tshark doesn't need workarounds on OSX
+tempfile_count = len(conf.temp_files)
 values = [tuple(int(val) for val in line[:-1].split(b'\t')) for line in tcpdump(pcapfile, prog=conf.prog.tshark, getfd=True, args=['-T', 'fields', '-e', 'ip.ttl', '-e', 'ip.proto'])]
 assert values == [(64, 6), (64, 17), (64, 1)]
+assert len(conf.temp_files) == tempfile_count
 
 = Run scapy's tshark command
 ~ netaccess
@@ -11832,3 +11851,8 @@ os.remove(filename_css)
 #    assert(output == expected)
 #
 #test_snmpwalk("secdev.org")
+
+= test get_temp_dir
+
+dname = get_temp_dir()
+assert os.path.isdir(dname)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6691,6 +6691,41 @@ assert isinstance(pkt, Padding) and pkt.load == b'\xeay$\xf6'
 pkt = pkt.payload
 assert isinstance(pkt, NoPayload)
 
+= Check PcapWriter on null write
+
+f = BytesIO()
+w = PcapWriter(f)
+w.write([])
+assert len(f.getvalue()) == 0
+
+# Stop being closed for reals, but we still want to have the header written
+with mock.patch.object(f, 'close') as cf:
+    w.close()
+
+cf.assert_called_once_with()
+assert len(f.getvalue()) != 0
+
+= Check PcapWriter sets correct linktype after null write
+
+f = BytesIO()
+w = PcapWriter(f)
+w.write([])
+assert len(f.getvalue()) == 0
+w.write(Ether()/IP()/ICMP())
+assert len(f.getvalue()) != 0
+
+# Stop being closed for reals, but we still want to have the header written
+with mock.patch.object(f, 'close') as cf:
+    w.close()
+
+cf.assert_called_once_with()
+f.seek(0) or None
+assert len(f.getvalue()) != 0
+
+r = PcapReader(f)
+assert r.LLcls is Ether
+assert r.linktype == DLT_EN10MB
+
 = Check tcpdump()
 ~ tcpdump
 * No very specific tests because we do not want to depend on tcpdump output
@@ -6717,6 +6752,61 @@ data = tcpdump([Ether()/IP()/ICMP()], dump=True, args=['-nn']).split(b'\n')
 print(data)
 assert b'IP 127.0.0.1 > 127.0.0.1: ICMP' in data[0]
 
+= Check tcpdump() command with linktype
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+
+with mock.patch('subprocess.Popen', return_value=Bunch(
+        stdin=f, wait=lambda: None)) as popen:
+    # Prevent closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        tcpdump([pkt], linktype=scapy.data.DLT_EN3MB, use_tempfile=False)
+
+popen.assert_called_once_with(
+    [conf.prog.tcpdump, '-r', '-'],
+    stdin=subprocess.PIPE, stdout=None, stderr=None)
+
+print(bytes_hex(f.getvalue()))
+assert raw(pkt) in f.getvalue()
+f.close()
+del f, pkt
+
+= Check tcpdump() command with linktype and args
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+
+with mock.patch('subprocess.Popen', return_value=Bunch(
+        stdin=f, wait=lambda: None)) as popen:
+    # Prevent closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        tcpdump([pkt], linktype=scapy.data.DLT_EN3MB, use_tempfile=False,
+                args=['-y', 'DLT_EN10MB'])
+
+popen.assert_called_once_with(
+    [conf.prog.tcpdump, '-r', '-', '-y', 'DLT_EN10MB'],
+    stdin=subprocess.PIPE, stdout=None, stderr=None)
+
+print(bytes_hex(f.getvalue()))
+assert raw(pkt) in f.getvalue()
+f.close()
+del f, pkt
+
+= Check tcpdump() command rejects non-string input for prog
+
+pkt = Ether()/IP()/ICMP()
+
+try:
+    tcpdump([pkt], prog=+17607067425, args=['-nn'])
+except ValueError as e:
+    if hasattr(e, 'args'):
+        assert 'prog' in e.args[0]
+    else:
+        assert 'prog' in e.message
+else:
+    assert False, 'expected exception'
+
 = Check tcpdump() command with tshark
 ~ tshark
 pcapfile = BytesIO(b'\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00e\x00\x00\x00\xcf\xc5\xacVo*\n\x00(\x00\x00\x00(\x00\x00\x00E\x00\x00(\x00\x01\x00\x00@\x06|\xcd\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x91|\x00\x00\xcf\xc5\xacV_-\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r\xcf\xc5\xacV\xf90\n\x00\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x01|\xde\x7f\x00\x00\x01\x7f\x00\x00\x01\x08\x00\xf7\xff\x00\x00\x00\x00')
@@ -6726,9 +6816,73 @@ values = [tuple(int(val) for val in line[:-1].split(b'\t')) for line in tcpdump(
 assert values == [(64, 6), (64, 17), (64, 1)]
 assert len(conf.temp_files) == tempfile_count
 
+= Check tdecode command directly for tshark
+~ tshark
+
+pkts = [
+    Ether()/IP(src='192.0.2.1', dst='192.0.2.2')/ICMP(type='echo-request')/Raw(b'X'*100),
+    Ether()/IP(src='192.0.2.2', dst='192.0.2.1')/ICMP(type='echo-reply')/Raw(b'X'*100),
+]
+
+# tshark doesn't need workarounds on OSX
+tempfile_count = len(conf.temp_files)
+
+r = tdecode(pkts, dump=True)
+r
+assert b'Src: 192.0.2.1' in r
+assert b'Src: 192.0.2.2' in r
+assert b'Dst: 192.0.2.2' in r
+assert b'Dst: 192.0.2.1' in r
+assert b'Echo (ping) request' in r
+assert b'Echo (ping) reply' in r
+assert b'ICMP' in r
+assert len(conf.temp_files) == tempfile_count
+
+= Check tdecode with linktype
+~ tshark
+
+# These are the same as the ping packets above
+pkts = [
+  b'\xff\xff\xff\xff\xff\xff\xac"\x0b\xc5j\xdb\x08\x00E\x00\x00\x80\x00\x01\x00\x00@\x01\xf6x\xc0\x00\x02\x01\xc0\x00\x02\x02\x08\x00\xb6\xbe\x00\x00\x00\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  b'\xff\xff\xff\xff\xff\xff\xac"\x0b\xc5j\xdb\x08\x00E\x00\x00\x80\x00\x01\x00\x00@\x01\xf6x\xc0\x00\x02\x02\xc0\x00\x02\x01\x00\x00\xbe\xbe\x00\x00\x00\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+]
+
+# tshark doesn't need workarounds on OSX
+tempfile_count = len(conf.temp_files)
+
+r = tdecode(pkts, dump=True, linktype=DLT_EN10MB)
+assert b'Src: 192.0.2.1' in r
+assert b'Src: 192.0.2.2' in r
+assert b'Dst: 192.0.2.2' in r
+assert b'Dst: 192.0.2.1' in r
+assert b'Echo (ping) request' in r
+assert b'Echo (ping) reply' in r
+assert b'ICMP' in r
+assert len(conf.temp_files) == tempfile_count
+
+
 = Run scapy's tshark command
 ~ netaccess
 tshark(count=1, timeout=3)
+
+= Check wireshark()
+
+f = BytesIO()
+pkt = Ether()/IP()/ICMP()
+
+with mock.patch('subprocess.Popen', return_value=Bunch(stdin=f)) as popen:
+    # Prevent closing the BytesIO
+    with mock.patch.object(f, 'close'):
+        wireshark([pkt])
+
+popen.assert_called_once_with(
+    [conf.prog.wireshark, '-ki', '-'],
+    stdin=subprocess.PIPE, stdout=None, stderr=None)
+
+print(bytes_hex(f.getvalue()))
+assert raw(pkt) in f.getvalue()
+f.close()
+del f, pkt
 
 = Check Raw IP pcap files
 


### PR DESCRIPTION
New:

* `WiresharkSink`, a PipeTools Sink for streaming packets to Wireshark
* `utils.get_temp_dir`: creates a temporary directory

Extensions:

* `tcpdump()`: Adds `use_tempfile`, to explicitly control use of a tempfile for packets.
* `tcpdump()`: Adds `read_stdin_opts` parameter, which allows callers to control the options used for reading packets over `stdin` (previously hard-coded to `-r -`).  This auto-detects `wireshark` to use `-ki -` instead.
* `tcpdump()`, `WrpcapSink`: Adds `linktype` parameter.
* `get_temp_file()`: Adds `fd` parameter, which allows a temporary file to be used without closing and re-opening it.
* Expands `wireshark()`, `Source` and `Pipe` documentation.
* `tdecode()`: Add `args` parameter (defaults to `-V`, as before), pass kwargs to `tcpdump()`.
* `QueueSink.recv`: add `block` and `timeout` parameters.

Fixes:

* `tcpdump()` now only uses a temporary file by default for calling tcpdump on OSX (to work around Apple's broken version of `tcpdump`). `stdin` is now used with other tools which are not impacted by this bug (eg: `tshark`).
* `wireshark()` now uses a pipe rather than a temporary file. Wireshark itself has options to save this file to disk if desired.
* `SniffSource` now only opens a socket on calling `start`.
* `WrpcapSink` only opens a `PcapWriter` on calling `start`.
* `RawPcapWriter` no longer writes a header on `write` calls with no packets specified.
* `RawPcapWriter` writes a header on `close` if no header has been written.
* `QueueSink.recv()` no longer busy-loops.
* `PcapWriter`, `wrpcap()`: support packets as bytes
* PEP-8 fixups and docstring revisions to touched methods.

Documentation fixes:

* Documentation wordsmithing for `wireshark()` and `Pipes`
* Use `py:function` / `py:class` for Sinks and `wireshark()` to allow easy cross-referencing, and expand this documentation.
* `wireshark()`: Remove references to `google.com`, and use RFC 5737 IP addresses instead
* `wireshark()`: Set a source IP address (to avoid looking up host's IP address).
* `wireshark()`: Remove `Ether` layer, as Wireshark works fine with `DLT_RAW` for `IP` packets, which removes the need to lookup MAC addresses
* Add `manpages_url` to configuration, to support `:manpage:` directives. This is pointing at Debian's server, which should have a good spread of versions of tools, and Debian generally adds manpages for tools that don't have them.

Test fixes:

* Removes `os.remove("test.png")` (which seems to be unused).
* Uses a temporary directory for some pipetool tests.

Other changes:

* `{Raw,}PcapWriter._write_packet`: Remove unused support for `packet` as tuple, as `write` will always unroll iterators for us (and do it better).
* `{Raw,}PcapWriter._write_packet`: Always set the `usec` parameter if `sec` was unset.
* `{Raw,}PcapWriter._write_packet`: Set `usec=0` if `sec` was set, but `usec` was unset (instead of using the current time's usec value
