### PR TITLE
Backward compatibility: Add Deprecated fields

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -244,21 +244,6 @@ class ConditionalField(object):
         return getattr(self.fld, attr)
 
 
-class AliasField(Field):
-    __slots__ = ["pointer", "deprecated"]
-
-    def __init__(self, name, pointer, deprecated=False):
-        Field.__init__(self, name, 0, fmt="!")
-        self.pointer = pointer
-        self.deprecated = deprecated
-
-    def getfield(self, pkt, s):
-        return s, None
-
-    def addfield(self, pkt, s, val):
-        return s
-
-
 class MultipleTypeField(object):
     """MultipleTypeField are used for fields that can be implemented by
 various Field subclasses, depending on conditions on the packet.

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -244,6 +244,21 @@ class ConditionalField(object):
         return getattr(self.fld, attr)
 
 
+class AliasField(Field):
+    __slots__ = ["pointer", "deprecated"]
+
+    def __init__(self, name, pointer, deprecated=False):
+        Field.__init__(self, name, 0, fmt="!")
+        self.pointer = pointer
+        self.deprecated = deprecated
+
+    def getfield(self, pkt, s):
+        return s, None
+
+    def addfield(self, pkt, s, val):
+        return s
+
+
 class MultipleTypeField(object):
     """MultipleTypeField are used for fields that can be implemented by
 various Field subclasses, depending on conditions on the packet.

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -248,9 +248,9 @@ _rt_hemuother_per_user_known = {
 class RadioTap(Packet):
     name = "RadioTap dummy"
     deprecated_fields = {
-        "Channel": "ChannelFrequency",  # 2.4.3
-        "ChannelFlags2": "ChannelPlusFlags",  # 2.4.3
-        "ChannelNumber": "ChannelPlusNumber"  # 2.4.3
+        "Channel": ("ChannelFrequency", "2.4.3"),
+        "ChannelFlags2": ("ChannelPlusFlags", "2.4.3"),
+        "ChannelNumber": ("ChannelPlusNumber", "2.4.3"),
     }
     fields_desc = [
         ByteField('version', 0),

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -247,6 +247,11 @@ _rt_hemuother_per_user_known = {
 
 class RadioTap(Packet):
     name = "RadioTap dummy"
+    deprecated_fields = {
+        "Channel": "ChannelFrequency",  # 2.4.3
+        "ChannelFlags2": "ChannelPlusFlags",  # 2.4.3
+        "ChannelNumber": "ChannelPlusNumber"  # 2.4.3
+    }
     fields_desc = [
         ByteField('version', 0),
         ByteField('pad', 0),
@@ -278,7 +283,7 @@ class RadioTap(Packet):
         # Channel
         ConditionalField(
             _RadiotapReversePadField(
-                LEShortField("Channel", 0)
+                LEShortField("ChannelFrequency", 0)
              ),
             lambda pkt: pkt.present and pkt.present.Channel),
         ConditionalField(
@@ -323,14 +328,14 @@ class RadioTap(Packet):
         # ChannelPlus
         ConditionalField(
             _RadiotapReversePadField(
-                FlagsField("ChannelFlags2", None, -32, _rt_channelflags2)
+                FlagsField("ChannelPlusFlags", None, -32, _rt_channelflags2)
             ),
             lambda pkt: pkt.present and pkt.present.ChannelPlus),
         ConditionalField(
-            LEShortField("ChannelFrequency", 0),
+            LEShortField("ChannelPlusFrequency", 0),
             lambda pkt: pkt.present and pkt.present.ChannelPlus),
         ConditionalField(
-            ByteField("ChannelNumber", 0),
+            ByteField("ChannelPlusNumber", 0),
             lambda pkt: pkt.present and pkt.present.ChannelPlus),
         # MCS
         ConditionalField(

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -17,10 +17,11 @@ import code
 import gzip
 import glob
 import importlib
-import logging
-from random import choice
-import types
 import io
+import logging
+import types
+import warnings
+from random import choice
 
 # Never add any global import, in main.py, that would trigger a warning message  # noqa: E501
 # before the console handlers gets added in interact()
@@ -83,7 +84,11 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(), interactive=True
     """
     log_loading.debug("Loading config file [%s]", cf)
     try:
-        exec(compile(open(cf).read(), cf, 'exec'), _globals, _locals)
+        with open(cf) as cfgf:
+            exec(
+                compile(cfgf.read(), cf, 'exec'),
+                _globals, _locals
+            )
     except IOError as e:
         if interactive:
             raise
@@ -472,6 +477,9 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
             )
         )
     log_scapy.addHandler(console_handler)
+
+    # We're in interactive mode, let's throw the DeprecationWarnings
+    warnings.simplefilter("always")
 
     from scapy.config import conf
     conf.interactive = True

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -14,9 +14,11 @@ import time
 import itertools
 import copy
 import types
+import warnings
 
 from scapy.fields import StrField, ConditionalField, Emph, PacketListField, \
-    BitField, MultiEnumField, EnumField, FlagsField, MultipleTypeField
+    BitField, MultiEnumField, EnumField, FlagsField, MultipleTypeField, \
+    AliasField
 from scapy.config import conf, _version_checker
 from scapy.compat import raw, orb, bytes_encode
 from scapy.base_classes import BasePacket, Gen, SetGen, Packet_metaclass, \
@@ -51,9 +53,10 @@ class RawVal:
 class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
                                 _CanvasDumpExtended)):
     __slots__ = [
-        "time", "sent_time", "name", "default_fields",
-        "overload_fields", "overloaded_fields", "fields", "fieldtype",
-        "packetfields",
+        "time", "sent_time", "name",
+        "default_fields", "fields", "fieldtype",
+        "overload_fields", "overloaded_fields",
+        "packetfields", "alias_fields",
         "original", "explicit", "raw_packet_cache",
         "raw_packet_cache_fields", "_pkt", "post_transforms",
         # then payload and underlayer
@@ -80,6 +83,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
     class_default_fields = dict()
     class_default_fields_ref = dict()
     class_fieldtype = dict()
+    class_alias_fields = dict()
 
     @classmethod
     def from_hexcap(cls):
@@ -131,6 +135,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         self.overloaded_fields = {}
         self.fields = {}
         self.fieldtype = {}
+        self.alias_fields = {}
         self.packetfields = []
         self.payload = NoPayload()
         self.init_fields()
@@ -153,6 +158,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
                 value = fields.pop(fname)
             except KeyError:
                 continue
+            if fname in self.alias_fields:
+                fname = self._resolve_alias(fname)
             self.fields[fname] = self.get_field(fname).any2i(self, value)
         # The remaining fields are unknown
         for fname, _ in fields:
@@ -179,6 +186,9 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         Initialize each fields of the fields_desc dict
         """
         for f in flist:
+            if isinstance(f, AliasField):
+                self.alias_fields[f.name] = (f.pointer, f.deprecated)
+                continue
             self.default_fields[f.name] = copy.deepcopy(f.default)
             self.fieldtype[f.name] = f
             if f.holds_packets:
@@ -201,6 +211,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
             self.default_fields = Packet.class_default_fields[cls_name]
             self.fieldtype = Packet.class_fieldtype[cls_name]
             self.packetfields = Packet.class_packetfields[cls_name]
+            self.alias_fields = Packet.class_alias_fields[cls_name]
 
             # Deepcopy default references
             for fname in Packet.class_default_fields_ref[cls_name]:
@@ -223,6 +234,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
             Packet.class_default_fields[cls_name] = dict()
             Packet.class_default_fields_ref[cls_name] = list()
             Packet.class_fieldtype[cls_name] = dict()
+            Packet.class_alias_fields[cls_name] = dict()
             Packet.class_packetfields[cls_name] = list()
 
         # Fields initialization
@@ -235,6 +247,12 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
                 self.class_dont_cache[cls_name] = True
                 self.do_init_fields(self.fields_desc)
                 break
+
+            if isinstance(f, AliasField):
+                self.class_alias_fields[cls_name][f.name] = (
+                    f.pointer, f.deprecated
+                )
+                continue
 
             tmp_copy = copy.deepcopy(f.default)
             Packet.class_default_fields[cls_name][f.name] = tmp_copy
@@ -307,7 +325,18 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         clone.time = self.time
         return clone
 
+    def _resolve_alias(self, attr):
+        new_attr, dpr = self.alias_fields[attr]
+        if dpr:
+            warnings.warn(
+                "%s has been deprecated in favor of %s" % (attr, new_attr),
+                DeprecationWarning
+            )
+        return new_attr
+
     def getfieldval(self, attr):
+        if attr in self.alias_fields:
+            attr = self._resolve_alias(attr)
         if attr in self.fields:
             return self.fields[attr]
         if attr in self.overloaded_fields:
@@ -317,6 +346,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return self.payload.getfieldval(attr)
 
     def getfield_and_val(self, attr):
+        if attr in self.alias_fields:
+            attr = self._resolve_alias(attr)
         if attr in self.fields:
             return self.get_field(attr), self.fields[attr]
         if attr in self.overloaded_fields:
@@ -334,6 +365,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return v
 
     def setfieldval(self, attr, val):
+        if attr in self.alias_fields:
+            attr = self._resolve_alias(attr)
         if attr in self.default_fields:
             fld = self.get_field(attr)
             if fld is None:
@@ -1171,6 +1204,8 @@ values.
                                ct.punct("]###"))
         for f in self.fields_desc:
             if isinstance(f, ConditionalField) and not f._evalcond(self):
+                continue
+            if isinstance(f, AliasField):
                 continue
             if isinstance(f, Emph) or f in conf.emph:
                 ncol = ct.emph_field_name

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -317,10 +317,11 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return clone
 
     def _resolve_alias(self, attr):
-        new_attr = self.deprecated_fields[attr]
+        new_attr, version = self.deprecated_fields[attr]
         warnings.warn(
-            "%s has been deprecated in favor of %s" % (attr, new_attr),
-            DeprecationWarning
+            "%s has been deprecated in favor of %s since %s !" % (
+                attr, new_attr, version
+            ), DeprecationWarning
         )
         return new_attr
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -72,7 +72,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
     ]
     name = None
     fields_desc = []
-    alias_fields = None
+    deprecated_fields = None
     overload_fields = {}
     payload_guess = []
     show_indent = 1
@@ -159,7 +159,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
             self.fields[fname] = self.get_field(fname).any2i(self, value)
         # The remaining fields are unknown
         for fname in fields:
-            if self.alias_fields and fname in self.alias_fields:
+            if self.deprecated_fields and fname in self.deprecated_fields:
                 # Resolve deprecated fields
                 value = fields[fname]
                 fname = self._resolve_alias(fname)
@@ -317,16 +317,15 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return clone
 
     def _resolve_alias(self, attr):
-        new_attr, dpr = self.alias_fields[attr]
-        if dpr:
-            warnings.warn(
-                "%s has been deprecated in favor of %s" % (attr, new_attr),
-                DeprecationWarning
-            )
+        new_attr = self.deprecated_fields[attr]
+        warnings.warn(
+            "%s has been deprecated in favor of %s" % (attr, new_attr),
+            DeprecationWarning
+        )
         return new_attr
 
     def getfieldval(self, attr):
-        if self.alias_fields and attr in self.alias_fields:
+        if self.deprecated_fields and attr in self.deprecated_fields:
             attr = self._resolve_alias(attr)
         if attr in self.fields:
             return self.fields[attr]
@@ -337,7 +336,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return self.payload.getfieldval(attr)
 
     def getfield_and_val(self, attr):
-        if self.alias_fields and attr in self.alias_fields:
+        if self.deprecated_fields and attr in self.deprecated_fields:
             attr = self._resolve_alias(attr)
         if attr in self.fields:
             return self.get_field(attr), self.fields[attr]
@@ -356,7 +355,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         return v
 
     def setfieldval(self, attr, val):
-        if self.alias_fields and attr in self.alias_fields:
+        if self.deprecated_fields and attr in self.deprecated_fields:
             attr = self._resolve_alias(attr)
         if attr in self.default_fields:
             fld = self.get_field(attr)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -72,7 +72,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
     ]
     name = None
     fields_desc = []
-    deprecated_fields = None
+    deprecated_fields = {}
     overload_fields = {}
     payload_guess = []
     show_indent = 1
@@ -159,7 +159,7 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
             self.fields[fname] = self.get_field(fname).any2i(self, value)
         # The remaining fields are unknown
         for fname in fields:
-            if self.deprecated_fields and fname in self.deprecated_fields:
+            if fname in self.deprecated_fields:
                 # Resolve deprecated fields
                 value = fields[fname]
                 fname = self._resolve_alias(fname)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1822,8 +1822,8 @@ class TestPacket(Packet):
         LEShortField("b", 15),
     ]
     deprecated_fields = {
-        "dpr": "a",
-        "B": "b",
+        "dpr": ("a", "1.0"),
+        "B": ("b", "1.0"),
     }
 
 pkt = TestPacket(a=2, B=3)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1811,6 +1811,33 @@ assert(r == data_129["extended"])
 
 ############
 ############
++ AliasField
+
+= AliasField: basic test
+
+class TestPacket(Packet):
+    fields_desc = [
+        ByteField("a", 0),
+        LEShortField("b", 15),
+        AliasField("B", "b"),
+        AliasField("dpr", "a", deprecated=True)
+    ]
+
+pkt = TestPacket(a=2, B=3)
+assert pkt.B == 3
+assert pkt.b == 3
+assert pkt.a == 2
+
+import warnings
+
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    assert pkt.dpr == 2
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+
+############
+############
 + FCSField
 
 = FCSField: basic test

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1811,19 +1811,19 @@ assert(r == data_129["extended"])
 
 ############
 ############
-+ Aliases in Packet
-~ alias
++ Deprecated fields in Packet
+~ deprecated
 
-= Aliases: Deprecation test
+= Field Deprecation test
 
 class TestPacket(Packet):
     fields_desc = [
         ByteField("a", 0),
         LEShortField("b", 15),
     ]
-    alias_fields = {
-        "dpr": ["a", True],
-        "B": ["b", False]
+    deprecated_fields = {
+        "dpr": "a",
+        "B": "b",
     }
 
 pkt = TestPacket(a=2, B=3)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1811,17 +1811,20 @@ assert(r == data_129["extended"])
 
 ############
 ############
-+ AliasField
++ Aliases in Packet
+~ alias
 
-= AliasField: basic test
+= Aliases: Deprecation test
 
 class TestPacket(Packet):
     fields_desc = [
         ByteField("a", 0),
         LEShortField("b", 15),
-        AliasField("B", "b"),
-        AliasField("dpr", "a", deprecated=True)
     ]
+    alias_fields = {
+        "dpr": ["a", True],
+        "B": ["b", False]
+    }
 
 pkt = TestPacket(a=2, B=3)
 assert pkt.B == 3
@@ -1835,6 +1838,7 @@ with warnings.catch_warnings(record=True) as w:
     assert pkt.dpr == 2
     assert len(w) == 1
     assert issubclass(w[-1].category, DeprecationWarning)
+
 
 ############
 ############

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1076,6 +1076,7 @@ r = RadioTap(data)
 r = RadioTap(raw(r))
 assert r.dBm_AntSignal == -59
 assert r.ChannelFrequency == 5785
+assert r.ChannelPlusFrequency == 5785
 assert r.present == 3410027
 assert r.A_MPDU_ref == 2821
 assert r.KnownVHT == 511


### PR DESCRIPTION
Rationale: Scapy is pretty bad at keeping things backward compatible. Fields are renamed often for consistency, therefore breaking older stuff. Moreover, because the release schedule is so slow, people aren't warned of changes.

This PR is an attempt to improve this by:
- implementing `alias_fields` that redirects to another field with an optional`DeprecationWarning`. We already have use cases for that: https://github.com/secdev/scapy/issues/1979 https://github.com/secdev/scapy/pull/1855. This would allow to migrate old scapy fields to newer names, without breaking too much stuff too quickly
- fixes https://github.com/secdev/scapy/issues/1979

Not sure how this affects performance. Adding stuff to `get_field` & co never is great