### PR TITLE
Radius EAP-Message fix + message_authentication forced zero filling

### DIFF
--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -14,7 +14,7 @@ import hmac
 from scapy.compat import orb, raw
 from scapy.packet import Packet, Padding, bind_layers
 from scapy.fields import ByteField, ByteEnumField, IntField, StrLenField,\
-    XStrLenField, XStrFixedLenField, FieldLenField, PacketField,\
+    XStrLenField, XStrFixedLenField, FieldLenField, PacketLenField,\
     PacketListField, IPField, MultiEnumField
 from scapy.layers.inet import UDP
 from scapy.layers.eap import EAP
@@ -567,8 +567,11 @@ class RadiusAttr_Message_Authenticator(_RadiusAttrHexStringVal):
                                       shared_secret):
         """
         Computes the "Message-Authenticator" of a given RADIUS packet.
+        (RFC 2869 - Page 33)
         """
 
+        attr = radius_packet[RadiusAttr_Message_Authenticator]
+        attr.value = bytearray(attr.len - 2)
         data = prepare_packed_data(radius_packet, packed_req_authenticator)
         radius_hmac = hmac.new(shared_secret, data, hashlib.md5)
 
@@ -992,7 +995,7 @@ class RadiusAttr_NAS_Port_Type(_RadiusAttrIntEnumVal):
     val = 61
 
 
-class _EAPPacketField(PacketField):
+class _EAPPacketField(PacketLenField):
 
     """
     Handles EAP-Message attribute value (the actual EAP packet).
@@ -1025,7 +1028,7 @@ class RadiusAttr_EAP_Message(RadiusAttribute):
             "B",
             adjust=lambda pkt, x: len(pkt.value) + 2
         ),
-        _EAPPacketField("value", "", EAP)
+        _EAPPacketField("value", "", EAP, length_from=lambda p: p.len - 2)
     ]
 
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10153,7 +10153,7 @@ assert f.i2repr(None, v) == '3e6bd4c419560b2a3199c844eac2945a'
 
 = RADIUS - compute_message_authenticator()
 ram = radius_packet[RadiusAttr_Message_Authenticator]
-assert ram.compute_message_authenticator(radius_packet, b"dummy bytes", b"scapy") == b'\x19\xa4\x0e*Y4\xe0l?,\x94\x9f \xb8Jb'
+assert ram.compute_message_authenticator(radius_packet, b"dummy bytes", b"scapy") == b'I\x85l\x8f\xa5\xd6\xbc\xb5\x08\xe0<\xebH\x9d\xfb?'
 
 = RADIUS - Access-Challenge - Dissection (2)
 s = b'\x0b\xae\x00[\xc7\xae\xfc6\xa1=\xb5\x99&^\xdf=\xe9\x00\xa6\xe8\x12\rHello, leapO\x16\x01\x02\x00\x14\x11\x01\x00\x08\xb8\xc4\x1a4\x97x\xd3\x82leapP\x12\xd3\x12\x17\xa6\x0c.\x94\x85\x03]t\xd1\xdb\xd0\x13\x8c\x18\x12iQs\xf7iSb@k\x9d,\xa0\x99\x8ehO'


### PR DESCRIPTION
In response to #1971 and #1973 

* Fragmented EAP-Messages are now correctly handled by using "length_from" property from PacketLenField class

* When digesting Radius packets with message-authenticator attribute already there, compute_message_authenticator now forces this field to be zero filled. Method `prepare_packed_data` is updated to receive one more argument `clear_message_authenticator` which ensure this check in the attribute loop.

* Regression test for `compute_message_authenticator` was updated for this changes as the test was being compared to an incorrect expected result. A more precise test could be achieved if we knew the shared secret of this radius server, so the output of this function would be the exact same value from the message-authenticator attribute in the `radius_packet`.

`./run_tests` was runned to verify if nothing more was affected by this changes.

Please, feel free to edit anything as Quality Review has failed due to the use of `type()` function