### PR TITLE
Decrease verbosity of the Flake8/Twine/Sphinx docs for readibility

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,3 +27,6 @@ fi
 
 # Make sure tox is installed and up to date
 pip install -U tox
+
+# Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
+set

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -31,7 +31,7 @@ then
   UT_FLAGS+=" -K vcan_socket"
 fi
 
-# Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
-set
+# Dump UT_FLAGS (the others were already dumped in install.sh)
+echo UT_FLAGS=$UT_FLAGS
 
 tox -- $UT_FLAGS

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include MANIFEST.in
 include LICENSE
 include run_scapy
-recursive-include bin *
 include scapy/VERSION

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ commands = codecov -e TOXENV
 changedir = doc/scapy
 deps = sphinx
        sphinx_rtd_theme
-commands = sphinx-build -W . _build/html
+commands = sphinx-build -q -W . _build/html
 
 [testenv:spell]
 deps = codespell
@@ -109,7 +109,7 @@ skip_install = true
 deps = twine
        setuptools>=38.6.0
        cmarkgfm
-commands = python setup.py sdist
+commands = python setup.py --quiet sdist
            twine check dist/*
 
 [testenv:flake8]


### PR DESCRIPTION
That will make the first Travis test much more readable.

Notes:
- `set` was moved to `install.sh`, as its logs are not expanded by default (there is a drop-down to expand it)
- `-q` in Sphinx reduces verbosity (errors will still be shown)
- `--quiet` to `python setup.py sdist` will reduce the verbosity. We don't really care about what it said, as we only focus on what `twine` will report afterwards

This allowed me to notice & fix the following:
- `recursive-include bin *` remains even after the `setuptools` migration