### PR TITLE
Improve Scapy's installation doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         # PEP 8 checks, build doc and grammar spelling check
         - os: linux
-          python: 2.7
+          python: 3.6
           env:
             - TOXENV=flake8,twine,docs,spell
        

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -137,7 +137,7 @@ Here are the topics involved and some examples that you can use to try if your i
 
 * 3D graphics. ``trace3D()`` needs `VPython-Jupyter <https://github.com/BruceSherwood/vpython-jupyter/>`_.
 
-  Jupyter-IPython is installable via ``pip install vpython``
+  VPython-Jupyter is installable via ``pip install vpython``
 
   .. code-block:: python
 

--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -47,16 +47,20 @@ Latest release
 
 Use pip::
 
-$ pip install scapy
+$ pip install --pre scapy[basic]
 
+In fact, since 2.4.3, Scapy comes in 3 bundles:
 
-You can also download the `latest version <https://github.com/secdev/scapy/archive/master.zip>`_ to a temporary directory and install it in the standard `distutils <http://docs.python.org/inst/inst.html>`_ way::
++----------+------------------------------------------+---------------------------------------+
+| Bundle   | Contains                                 | Pip command                           |
++==========+==========================================+=======================================+
+| Default  | Only Scapy                               | ``pip install scapy``                 |
++----------+------------------------------------------+---------------------------------------+
+| Basic    | Scapy & IPython. **Highly recommended**  | ``pip install --pre scapy[basic]``    |
++----------+------------------------------------------+---------------------------------------+
+| Complete | Scapy & all its main dependencies        | ``pip install --pre scapy[complete]`` |
++----------+------------------------------------------+---------------------------------------+
 
-$ cd /tmp
-$ wget --trust-server-names https://github.com/secdev/scapy/archive/master.zip   # or wget -O master.zip https://github.com/secdev/scapy/archive/master.zip
-$ unzip master.zip
-$ cd master
-$ sudo python setup.py install
  
 Current development version
 ----------------------------
@@ -66,24 +70,25 @@ Current development version
 
 If you always want the latest version with all new features and bugfixes, use Scapy's Git repository:
 
-1. Install the Git version control system. For example, on Debian/Ubuntu use::
-
-      $ sudo apt-get install git
-
-   or on OpenBSD:: 
-    
-      $ doas pkg_add git
+1. `Install the Git version control system <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_.
 
 2. Check out a clone of Scapy's repository::
-    
-   $ git clone https://github.com/secdev/scapy
-    
-3. Install Scapy in the standard distutils way:: 
-    
+
+   $ git clone https://github.com/secdev/scapy.git
+
+.. note::
+	You can also download Scapy's `latest version <https://github.com/secdev/scapy/archive/master.zip>`_ in a zip file::
+
+	$ wget --trust-server-names https://github.com/secdev/scapy/archive/master.zip   # or wget -O master.zip https://github.com/secdev/scapy/archive/master.zip
+	$ unzip master.zip
+	$ cd master
+
+3. Install Scapy in the standard `distutils <https://docs.python.org/3/distutils/setupscript.html>`_ way:: 
+
    $ cd scapy
    $ sudo python setup.py install
-    
-Then you can always update to the latest version::
+
+If you used Git, you can always update to the latest version afterwards::
 
    $ git pull
    $ sudo python setup.py install
@@ -92,64 +97,69 @@ Then you can always update to the latest version::
 
    You can run scapy without installing it using the ``run_scapy`` (unix) or ``run_scapy.bat`` (Windows) script or running it directly from the executable zip file (see the previous section).
 
-Optional software for special features
-======================================
+Optional Dependencies
+=====================
 
-For some special features, you have to install more software. 
+For some special features, Scapy will need some dependencies to be installed.
 Most of those software are installable via ``pip``.
 Here are the topics involved and some examples that you can use to try if your installation was successful.
 
 .. index::
    single: plot()
 
-* Plotting. ``plot()`` needs `Matplotlib <https://matplotlib.org/>`_. It is installable via ``pip install matplotlib``
+* Plotting. ``plot()`` needs `Matplotlib <https://matplotlib.org/>`_.
+
+  Matplotlib is installable via ``pip install matplotlib``
  
   .. code-block:: python
    
-     >>> p=sniff(count=50)
-     >>> p.plot(lambda x:len(x))
+    >>> p=sniff(count=50)
+    >>> p.plot(lambda x:len(x))
  
 * 2D graphics. ``psdump()`` and ``pdfdump()`` need `PyX <http://pyx.sourceforge.net/>`_ which in turn needs a LaTeX distribution: `texlive (Unix) <http://www.tug.org/texlive/>`_ or `MikTex (Windows) <https://miktex.org/>`_.
   
-  Note: PyX requires version 0.12.1 on Python 2.7. This means that on Python 2.7, it needs to be installed via ``pip install pyx==0.12.1``. Otherwise ``pip install pyx``
+  Note: PyX requires version <=0.12.1 on Python 2.7. This means that on Python 2.7, it needs to be installed via ``pip install pyx==0.12.1``. Otherwise ``pip install pyx``
   
   .. code-block:: python
    
-     >>> p=IP()/ICMP()
-     >>> p.pdfdump("test.pdf") 
+    >>> p=IP()/ICMP()
+    >>> p.pdfdump("test.pdf") 
  
 * Graphs. ``conversations()`` needs `Graphviz <http://www.graphviz.org/>`_ and `ImageMagick <http://www.imagemagick.org/>`_.
  
   .. code-block:: python
 
-     >>> p=readpcap("myfile.pcap")
-     >>> p.conversations(type="jpg", target="> test.jpg")
- 
+    >>> p=readpcap("myfile.pcap")
+    >>> p.conversations(type="jpg", target="> test.jpg")
+
+  .. note::
+    ``Graphviz`` and ``ImageMagick`` need to be installed separately, using your platform-specific package manager.
+
 * 3D graphics. ``trace3D()`` needs `VPython-Jupyter <https://github.com/BruceSherwood/vpython-jupyter/>`_.
 
-    Jupyter-IPython is installable via `pip install vpython`
+  Jupyter-IPython is installable via ``pip install vpython``
 
   .. code-block:: python
 
-     >>> a,u=traceroute(["www.python.org", "google.com","slashdot.org"])
-     >>> a.trace3D()
+    >>> a,u=traceroute(["www.python.org", "google.com","slashdot.org"])
+    >>> a.trace3D()
 
 .. index::
    single: WEP, unwep()
 
 * WEP decryption. ``unwep()`` needs `cryptography <https://cryptography.io>`_. Example using a `Weplap test file <http://weplab.sourceforge.net/caps/weplab-64bit-AA-managed.pcap>`_:
 
-    Cryptography is installable via ``pip install cryptography``
+  Cryptography is installable via ``pip install cryptography``
 
   .. code-block:: python
 
-     >>> enc=rdpcap("weplab-64bit-AA-managed.pcap")
-     >>> enc.show()
-     >>> enc[0]
-     >>> conf.wepkey="AA\x00\x00\x00"
-     >>> dec=Dot11PacketList(enc).toEthernet()
-     >>> dec.show()
-     >>> dec[0]
+    >>> enc=rdpcap("weplab-64bit-AA-managed.pcap")
+    >>> enc.show()
+    >>> enc[0]
+    >>> conf.wepkey="AA\x00\x00\x00"
+    >>> dec=Dot11PacketList(enc).toEthernet()
+    >>> dec.show()
+    >>> dec[0]
  
 * PKI operations and TLS decryption. `cryptography <https://cryptography.io>`_ is also needed.
 
@@ -157,15 +167,12 @@ Here are the topics involved and some examples that you can use to try if your i
 
   .. code-block:: python 
   
-     >>> load_module("nmap")
-     >>> nmap_fp("192.168.0.1")
-     Begin emission:
-     Finished to send 8 packets.
-     Received 19 packets, got 4 answers, remaining 4 packets
-     (0.88749999999999996, ['Draytek Vigor 2000 ISDN router'])
-
-.. index::
-   single: VOIP
+    >>> load_module("nmap")
+    >>> nmap_fp("192.168.0.1")
+    Begin emission:
+    Finished to send 8 packets.
+    Received 19 packets, got 4 answers, remaining 4 packets
+    (0.88749999999999996, ['Draytek Vigor 2000 ISDN router'])
  
 * VOIP. ``voip_play()`` needs `SoX <http://sox.sourceforge.net/>`_.
 
@@ -182,37 +189,25 @@ Scapy can run natively on Linux, without libdnet and libpcap.
 * Make sure your kernel has Packet sockets selected (``CONFIG_PACKET``)
 * If your kernel is < 2.6, make sure that Socket filtering is selected ``CONFIG_FILTER``) 
 
-Debian/Ubuntu
--------------
+Debian/Ubuntu/Fedora
+--------------------
 
-Just use the standard packages::
+Make sure tcpdump is installed:
 
-$ sudo apt-get install tcpdump graphviz imagemagick python-matplotlib python-cryptography python-pyx
-
-Scapy optionally uses python-cryptography v1.7 or later. It has not been packaged for ``apt`` in less recent OS versions (e.g. Debian Jessie). If you need the cryptography-related methods, you may install the library with:
+- Debian/Ubuntu:
 
 .. code-block:: text
 
-    # pip install cryptography
+    $ sudo apt-get install tcpdump
 
-Fedora
-------
-
-Here's how to install Scapy on Fedora 9:
+- Fedora:
 
 .. code-block:: text
 
-    # yum install git python-devel
-    # cd /tmp
-    # git clone https://github.com/secdev/scapy
-    # cd scapy
-    # python setup.py install
-    
-Some optional packages:
+	$ yum install tcpdump
 
-.. code-block:: text
-
-    # yum install graphviz python-cryptography sox PyX matplotlib numpy
+Then install Scapy via ``pip`` or ``apt`` (bundled under ``python-scapy``)
+All dependencies may be installed either via the platform-specific installer, or via PyPI. See `Optional Dependencies <#optional-dependencies>`_ for more information.
 
 
 Mac OS X
@@ -232,7 +227,6 @@ Install using Homebrew
    $ brew update
 
 2. Install Python bindings::
-
 
    $ brew install --with-python libdnet
    $ brew install https://raw.githubusercontent.com/secdev/scapy/master/.travis/pylibpcap.rb
@@ -255,69 +249,20 @@ Install using MacPorts
 OpenBSD
 -------
 
-Here's how to install Scapy on OpenBSD 5.9+
+In a similar manner, to install Scapy on OpenBSD 5.9+, you will need to install the libpcap/libdnet bindings:
 
 .. code-block:: text
 
- $ doas pkg_add py-libpcap py-libdnet git
- $ cd /tmp
- $ git clone http://github.com/secdev/scapy
- $ cd scapy
- $ doas python2.7 setup.py install
+	$ doas pkg_add py-libpcap py-libdnet tcpdump
 
-
-Optional packages (OpenBSD only)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-It is recommended to install those packages through `pip` rather than the OS, as the versions tend to be more up-to-date.
-
-py-cryptography
-
-.. code-block:: text
-
- # pkg_add py-cryptography
-
-matplotlib: 
-
-.. code-block:: text
-
- # pkg_add matplotlib
-
-Graphviz (large download, will install several GNOME libraries)
-
-.. code-block:: text
-
- # pkg_add graphviz
-
-   
-ImageMagick (takes long to compile)
-
-.. code-block:: text
-
- # cd /tmp
- # ftp ftp://ftp.openbsd.org/pub/OpenBSD/4.3/ports.tar.gz 
- # cd /usr
- # tar xvfz /tmp/ports.tar.gz 
- # cd /usr/ports/graphics/ImageMagick/
- # make install
-
-PyX (very large download, will install texlive etc.)
-
-.. code-block:: text
-
- # pkg_add py-pyx
-
-/etc/ethertypes
+An OpenBSD install may be lacking the ``/etc/ethertypes`` file. You may install it with
 
 .. code-block:: text
 
  # wget http://git.netfilter.org/ebtables/plain/ethertypes -O /etc/ethertypes
 
-python-bz2 (for UTscapy)
-
-.. code-block:: text
-
- # pkg_add python-bz2    
+Then install Scapy via ``pip`` or ``pkg_add`` (bundled under ``python-scapy``)
+All dependencies may be installed either via the platform-specific installer, or via PyPI. See `Optional Dependencies <#optional-dependencies>`_ for more information.
 
 .. _windows_installation:
 
@@ -332,15 +277,13 @@ Scapy is primarily being developed for Unix-like systems and works best on those
    :scale: 80
    :align: center
 
-You need the following software packages in order to install Scapy on Windows:
+You need the following software in order to install Scapy on Windows:
 
   * `Python <http://www.python.org>`_: `Python 2.7.X or 3.4+ <https://www.python.org/downloads/>`_. After installation, add the Python installation directory and its \Scripts subdirectory to your PATH. Depending on your Python version, the defaults would be ``C:\Python27`` and ``C:\Python27\Scripts`` respectively.
   * `Npcap <https://nmap.org/npcap/>`_: `the latest version <https://nmap.org/npcap/#download>`_. Default values are recommended. Scapy will also work with Winpcap.
-  * `Scapy <http://www.secdev.org/projects/scapy/>`_: `latest development version <https://github.com/secdev/scapy/archive/master.zip>`_ from the `Git repository <https://github.com/secdev/scapy>`_. Unzip the archive, open a command prompt in that directory and run "python setup.py install". 
+  * `Scapy <http://www.secdev.org/projects/scapy/>`_: `latest development version <https://github.com/secdev/scapy/archive/master.zip>`_ from the `Git repository <https://github.com/secdev/scapy>`_. Unzip the archive, open a command prompt in that directory and run ``python setup.py install``. 
 
-Just download the files and run the setup program. Choosing the default installation options should be safe.
-
-For your convenience direct links are given to the version that is supported (Python 2.7 and 3.4+). If these links do not work or if you are using a different Python version (which will surely not work), just visit the homepage of the respective package and look for a Windows binary. As a last resort, search the web for the filename.
+Just download the files and run the setup program. Choosing the default installation options should be safe. (In the case of ``Npcap``, Scapy **will work** with ``802.11`` option enabled. You might want to make sure that this is ticked when installing).
 
 After all packages are installed, open a command prompt (cmd.exe) and run Scapy by typing ``scapy``. If you have set the PATH correctly, this will find a little batch file in your ``C:\Python27\Scripts`` directory and instruct the Python interpreter to load Scapy.
 
@@ -356,32 +299,41 @@ Screenshot
 Known bugs
 ^^^^^^^^^^
 
- * You may not be able to capture WLAN traffic on Windows. Reasons are explained on the Wireshark wiki and in the WinPcap FAQ. Try switching off promiscuous mode with ``conf.sniff_promisc=False``.
+You may bump into the following bugs, which are platform-specific, if Scapy didn't manage work around them automatically:
+
+ * You may not be able to capture WLAN traffic on Windows. Reasons are explained on the `Wireshark wiki <https://wiki.wireshark.org/CaptureSetup/WLAN>`_ and in the `WinPcap FAQ <https://www.winpcap.org/misc/faq.htm>`_. Try switching off promiscuous mode with ``conf.sniff_promisc=False``.
  * Packets sometimes cannot be sent to localhost (or local IP addresses on your own host).
  
 Winpcap/Npcap conflicts
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-As Winpcap is becoming old, it's recommended to use Npcap instead. Npcap is part of the Nmap project.
+As ``Winpcap`` is becoming old, it's recommended to use ``Npcap`` instead. ``Npcap`` is part of the ``Nmap`` project.
 
-1. If you get the message 'Winpcap is installed over Npcap.' it means that you have installed both winpcap and npcap versions, which isn't recommended.
+.. note::
+    This does NOT apply for Windows XP, which isn't supported by ``Npcap``.
 
-You may **uninstall winpcap from your Program Files**, then you will need to remove:
- * C:/Windows/System32/wpcap.dll
- * C:/Windows/System32/Packet.dll
-And if you are on an x64 machine:
- * C:/Windows/SysWOW64/wpcap.dll
- * C:/Windows/SysWOW64/Packet.dll
+1. If you get the message ``'Winpcap is installed over Npcap.'`` it means that you have installed both Winpcap and Npcap versions, which isn't recommended.
 
-To use npcap instead. Those files are not removed by the Winpcap un-installer.
+You may first **uninstall winpcap from your Program Files**, then you will need to remove::
 
-2. If you get the message 'The installed Windump version does not work with Npcap' it surely means that you have installed an old version of Windump.
+    C:/Windows/System32/wpcap.dll
+    C:/Windows/System32/Packet.dll
+
+And if you are on an x64 machine::
+
+   C:/Windows/SysWOW64/wpcap.dll
+   C:/Windows/SysWOW64/Packet.dll
+
+To use ``Npcap`` instead, as those files are not removed by the ``Winpcap`` un-installer.
+
+2. If you get the message ``'The installed Windump version does not work with Npcap'`` it surely means that you have installed an old version of ``Windump``, made for ``Winpcap``.
 Download the correct one on https://github.com/hsluoyz/WinDump/releases
 
-In some cases, it could also mean that you had installed Npcap and Winpcap, and that Windump is using Winpcap. Fully delete Winpcap using the above method to solve the problem.
+In some cases, it could also mean that you had installed ``Npcap`` and ``Winpcap``, and that ``Windump`` is using ``Winpcap``. Fully delete ``Winpcap`` using the above method to solve the problem.
 
 Build the documentation offline
 ===============================
+
 The Scapy project's documentation is written using reStructuredText (files \*.rst) and can be built using
 the `Sphinx <http://www.sphinx-doc.org/>`_ python library. The official online version is available
 on `readthedocs <http://scapy.readthedocs.io/>`_.

--- a/setup.py
+++ b/setup.py
@@ -42,17 +42,18 @@ setup(
         ]
     },
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
+    # pip > 9 handles all the versioning
     extras_require={
         'basic': ["ipython"],
         'complete': [
-            'ipython>=7;  python_version>="3"',
-            'ipython<6;  python_version<"3"',
-            'pyx>=0.14; python_version>="3"',
-            'pyx==0.12.1; python_version<"3"',
-            'cryptography',
+            'ipython',
+            'pyx',
+            'cryptography>=2.0',
             'matplotlib'
         ]
     },
+    # We use __file__ in scapy/__init__.py, therefore Scapy isn't zip safe
+    zip_safe=False,
 
     # Metadata
     author='Philippe BIONDI',


### PR DESCRIPTION
This PR:
- cleans up Scapy's installation doc:
    - Removes OpenBSD-specific dependencies page: it is outdated, since they can all be installed with pip nowadays.
    - Merges very similar platform-specific installation pages
    - Fixes some grammar odities (e.g. "Optional software for special features" -> "Optional dependencies")
    - Add documentation about Scapy's bundles (`basic`, `complete`), available since 2.4.3. (for now they are specified with `--pre`, but that will be updated once 2.4.3 comes out)
    - Fix missing quotes & a few weird spacing that would slightly mess up the indentation
- Since Pip > 9, it will automatically handle the versioning of dependencies. Therefore, as advised by https://github.com/pypa/setuptools/pull/1743#issuecomment-482994157, let Pip handle this.
- mark Scapy as not `zip_safe`. This slightly speeds up the install, as pip/setuptools don't have to guess it
- makes the Code Quality test run on Python 3.6, to remove the Python 2.7 deprecation warnings