### PR TITLE
Interface's name isn't necessary to be ended with a digit

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -163,7 +163,7 @@ def get_working_ifaces():
             # Check if the interface can be used
             try:
                 fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x", ifname.encode()))  # noqa: E501
-                interfaces.append((ifname, int(ifname[-1])))
+                interfaces.append((ifname, ifname[-1]))
             except IOError:
                 pass
 


### PR DESCRIPTION
Remove the step to convert to integer as it doesn't affect the result.