### PR TITLE
Fix MultipleTypeField default values handling

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -1071,7 +1071,6 @@ TCP/IP
     MACField
     DestMACField(MACField)
     SourceMACField(MACField)
-    ARPSourceMACField(MACField)
     
     ICMPTimeStampField
 

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -723,6 +723,8 @@ class NetworkInterfaceDict(UserDict):
             from scapy.arch.pcapdnet import load_winpcapy
             load_winpcapy()
         self.load()
+        # Reload conf.iface
+        conf.iface = get_working_if()
 
     def show(self, resolve_mac=True, print_result=True):
         """Print list of available network interfaces in human readable form"""

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -37,7 +37,7 @@ r = m.addfield(None, b"FOO", "c0:01:be:ef:ba:be")
 r
 assert(r == b"FOO\xc0\x01\xbe\xef\xba\xbe" )
 
-= SourceMACField, ARPSourceMACField
+= SourceMACField, SourceMACField
 conf.route.add(net="1.2.3.4/32", dev=conf.iface)
 p = Ether() / ARP(pdst="1.2.3.4")
 assert p.src == p.hwsrc == p[ARP].hwsrc == get_if_hwaddr(conf.iface)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1283,6 +1283,35 @@ a = DebugPacket(addr="scapy.net", atyp=0x3)
 a = DebugPacket(raw(a))
 assert a.addr == b"scapy.net."
 
+= Test default values auto-update
+
+class SweetPacket(Packet):
+    name = 'Sweet Celestian Packet'
+    fields_desc = [
+        IntField('switch', 0),
+        MultipleTypeField([
+            (XShortField('subfield', 0xDEAD), lambda pkt: pkt.switch == 1),
+            (XIntField('subfield',  0xBEEFBEEF), lambda pkt: pkt.switch == 2)],
+            XByteField('subfield', 0x88)
+        )
+    ]
+
+o = SweetPacket()
+assert o.subfield == 0x88
+
+o = SweetPacket(switch=1)
+assert o.subfield == 0xDEAD
+
+o = SweetPacket(switch=2)
+assert o.subfield == 0xBEEFBEEF
+
+o = SweetPacket()
+assert o.subfield == 0x88
+o.switch = 1
+assert o.subfield == 0xDEAD
+o.switch = 2
+assert o.subfield == 0xBEEFBEEF
+
 ########
 ########
 + FlagsField


### PR DESCRIPTION
This PR:
- fixes https://github.com/secdev/scapy/issues/1955
- this PR led to the discovery of a small ARP bug when using IPv6 addresses (the routing would try to perform IPv4 routing with an IPv6 address)
- merges the two `_find_field` functions together
- add tests