### PR TITLE
Console & Config improvement

### DIFF
--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -159,11 +159,10 @@ if conf.use_winpcapy:
     except OSError:
         conf.use_winpcapy = False
         if conf.interactive:
-            log_loading.warning(conf.color_theme.format(
+            log_loading.critical(
                 "Npcap/Winpcap is not installed ! See "
-                "https://scapy.readthedocs.io/en/latest/installation.html#windows",  # noqa: E501
-                "black+bg_red"
-            ))
+                "https://scapy.readthedocs.io/en/latest/installation.html#windows"  # noqa: E501
+            )
 
     if conf.use_winpcapy:
         def get_if_list():

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -165,11 +165,18 @@ class WinProgPath(ConfClass):
                                 env="SystemRoot")
         if self.wireshark:
             try:
-                manu_path = load_manuf(os.path.sep.join(self.wireshark.split(os.path.sep)[:-1]) + os.path.sep + "manuf")  # noqa: E501
+                new_manuf = load_manuf(
+                    os.path.sep.join(
+                        self.wireshark.split(os.path.sep)[:-1]
+                    ) + os.path.sep + "manuf"
+                )
             except (IOError, OSError):  # FileNotFoundError not available on Py2 - using OSError  # noqa: E501
                 log_loading.warning("Wireshark is installed, but cannot read manuf !")  # noqa: E501
-                manu_path = None
-            scapy.data.MANUFDB = conf.manufdb = manu_path
+                new_manuf = None
+            if new_manuf:
+                # Inject new ManufDB
+                conf.manufdb.__dict__.clear()
+                conf.manufdb.__dict__.update(new_manuf.__dict__)
 
 
 def _exec_cmd(command):

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -115,3 +115,8 @@ class DADict:
 
     def __len__(self):
         return len(self.__dict__)
+
+    def __nonzero__(self):
+        # Always has at least its name
+        return len(self.__dict__) > 1
+    __bool__ = __nonzero__

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -289,14 +289,11 @@ def load_manuf(filename):
 
 
 if WINDOWS:
-    ETHER_TYPES = load_ethertypes("ethertypes")
     IP_PROTOS = load_protocols(os.environ["SystemRoot"] + "\\system32\\drivers\\etc\\protocol")  # noqa: E501
     TCP_SERVICES, UDP_SERVICES = load_services(os.environ["SystemRoot"] + "\\system32\\drivers\\etc\\services")  # noqa: E501
-    # Default value, will be updated by arch.windows
-    try:
-        MANUFDB = load_manuf(os.environ["ProgramFiles"] + "\\wireshark\\manuf")
-    except (IOError, OSError):  # FileNotFoundError not available on Py2 - using OSError  # noqa: E501
-        MANUFDB = None
+    # Default values, will be updated by arch.windows
+    ETHER_TYPES = DADict()
+    MANUFDB = ManufDA()
 else:
     IP_PROTOS = load_protocols("/etc/protocols")
     ETHER_TYPES = load_ethertypes("/etc/ethertypes")

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -78,6 +78,7 @@ class ScapyColoredFormatter(logging.Formatter):
 
 
 log_scapy = logging.getLogger("scapy")
+log_scapy.setLevel(logging.WARNING)
 log_scapy.addHandler(logging.NullHandler())
 # logs at runtime
 log_runtime = logging.getLogger("scapy.runtime")

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -56,12 +56,36 @@ class ScapyFreqFilter(logging.Filter):
         return 1
 
 
+# Inspired from python-colorbg (MIT)
+class ScapyColoredFormatter(logging.Formatter):
+    """A subclass of logging.Formatter that handles colors."""
+    levels_colored = {
+        'DEBUG': 'reset',
+        'INFO': 'reset',
+        'WARNING': 'bold+yellow',
+        'ERROR': 'bold+red',
+        'CRITICAL': 'bold+white+bg_red'
+    }
+
+    def format(self, record):
+        message = super(ScapyColoredFormatter, self).format(record)
+        from scapy.config import conf
+        message = conf.color_theme.format(
+            message,
+            self.levels_colored[record.levelname]
+        )
+        return message
+
+
 log_scapy = logging.getLogger("scapy")
 log_scapy.addHandler(logging.NullHandler())
-log_runtime = logging.getLogger("scapy.runtime")          # logs at runtime
+# logs at runtime
+log_runtime = logging.getLogger("scapy.runtime")
 log_runtime.addFilter(ScapyFreqFilter())
-log_interactive = logging.getLogger("scapy.interactive")  # logs in interactive functions  # noqa: E501
-log_loading = logging.getLogger("scapy.loading")          # logs when loading Scapy  # noqa: E501
+# logs in interactive functions
+log_interactive = logging.getLogger("scapy.interactive")
+# logs when loading Scapy
+log_loading = logging.getLogger("scapy.loading")
 
 
 def warning(x, *args, **kargs):

--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -54,7 +54,7 @@ try:
     if _test_pyx():
         PYX = 1
     else:
-        log_loading.warning("PyX dependencies are not installed ! Please install TexLive or MikTeX.")  # noqa: E501
+        log_loading.info("PyX dependencies are not installed ! Please install TexLive or MikTeX.")  # noqa: E501
         PYX = 0
 except ImportError:
     log_loading.info("Can't import PyX. Won't be able to use psdump() or pdfdump().")  # noqa: E501

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -346,8 +346,10 @@ bind_layers(BOOTP, DHCP, options=b'c\x82Sc')
 @conf.commands.register
 def dhcp_request(iface=None, **kargs):
     """Send a DHCP discover request and return the answer"""
-    if conf.checkIPaddr != 0:
-        warning("conf.checkIPaddr is not 0, I may not be able to match the answer")  # noqa: E501
+    if conf.checkIPaddr:
+        warning(
+            "conf.checkIPaddr is enabled, may not be able to match the answer"
+        )
     if iface is None:
         iface = conf.iface
     fam, hw = get_if_raw_hwaddr(iface)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -25,11 +25,10 @@ import io
 # Never add any global import, in main.py, that would trigger a warning message  # noqa: E501
 # before the console handlers gets added in interact()
 from scapy.error import log_interactive, log_loading, log_scapy, \
-    Scapy_Exception
+    Scapy_Exception, ScapyColoredFormatter
 import scapy.modules.six as six
 from scapy.themes import DefaultTheme, BlackAndWhite, apply_ipython_style
 from scapy.consts import WINDOWS
-from scapy.config import conf, ConfClass
 
 IGNORED = list(six.moves.builtins.__dict__)
 
@@ -273,6 +272,7 @@ def save_session(fname=None, session=None, pickleProto=-1):
      - session: scapy session to use. If None, the console one will be used
      - pickleProto: pickle proto version (default: -1 = latest)"""
     from scapy import utils
+    from scapy.config import conf, ConfClass
     if fname is None:
         fname = conf.session
         if not fname:
@@ -317,6 +317,7 @@ def load_session(fname=None):
 
     params:
      - fname: file to load the scapy session from"""
+    from scapy.config import conf
     if fname is None:
         fname = conf.session
     try:
@@ -341,6 +342,7 @@ def update_session(fname=None):
 
     params:
      - fname: file to load the scapy session from"""
+    from scapy.config import conf
     if fname is None:
         fname = conf.session
     try:
@@ -353,6 +355,7 @@ def update_session(fname=None):
 
 
 def init_session(session_name, mydict=None):
+    from scapy.config import conf
     global SESSION
     global GLOBKEYS
 
@@ -405,6 +408,7 @@ def init_session(session_name, mydict=None):
 
 
 def scapy_delete_temp_files():
+    from scapy.config import conf
     for f in conf.temp_files:
         try:
             os.unlink(f)
@@ -438,17 +442,37 @@ to be used in the fancy prompt.
     return lines
 
 
-def interact(mydict=None, argv=None, mybanner=None, loglevel=20):
+def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
+    """Starts Scapy's console."""
     global SESSION
     global GLOBKEYS
 
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))  # noqa: E501
+    try:
+        # colorama is bundled within IPython.
+        # logging.StreamHandler will be overwritten when called,
+        # We can't wait for IPython to call it
+        import colorama
+        colorama.init()
+        # Success
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(
+            ScapyColoredFormatter(
+                "%(levelname)s: %(message)s",
+            )
+        )
+    except ImportError:
+        # Failure: ignore colors in the logger
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(
+            logging.Formatter(
+                "%(levelname)s: %(message)s",
+            )
+        )
     log_scapy.addHandler(console_handler)
 
     from scapy.config import conf
-    conf.color_theme = DefaultTheme()
     conf.interactive = True
+    conf.color_theme = DefaultTheme()
     if loglevel is not None:
         conf.logLevel = loglevel
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -531,7 +531,9 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
                 "instead.\nAutoCompletion, History are disabled."
             )
             if WINDOWS:
-                log_loading.warning("IPython not available. On Windows, colors are disabled")  # noqa: E501
+                log_loading.warning(
+                    "On Windows, colors are also disabled"
+                )
                 conf.color_theme = BlackAndWhite()
             IPYTHON = False
         else:

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -110,7 +110,9 @@ SESSION = None
 def _usage():
     print(
         "Usage: scapy.py [-s sessionfile] [-c new_startup_file] "
-        "[-p new_prestart_file] [-C] [-P]\n"
+        "[-p new_prestart_file] [-C] [-P] [-H]\n"
+        "Args:\n"
+        "\t-H: header-less start\n"
         "\t-C: do not read startup file\n"
         "\t-P: do not read pre-startup file\n"
     )
@@ -485,10 +487,13 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
         argv = sys.argv
 
     try:
-        opts = getopt.getopt(argv[1:], "hs:Cc:Pp:d")
+        opts = getopt.getopt(argv[1:], "hs:Cc:Pp:d:H")
         for opt, parm in opts[0]:
             if opt == "-h":
                 _usage()
+            elif opt == "-H":
+                conf.fancy_prompt = False
+                conf.verb = 30
             elif opt == "-s":
                 session_name = parm
             elif opt == "-c":

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -105,9 +105,7 @@ class AnsiColorTheme(ColorTheme):
             after = self.style_normal
         elif not isinstance(self, BlackAndWhite) and attr in Color.colors:
             before = Color.colors[attr][0]
-            after = "".join(Color.colors[x][0] for x in [
-                "normal", "reset", "bg_reset"
-            ])
+            after = Color.colors["normal"][0]
         else:
             before = after = ""
 

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -269,7 +269,7 @@ def in6_addrtovendor(addr):
     unknown.
     """
     mac = in6_addrtomac(addr)
-    if mac is None or conf.manufdb is None:
+    if mac is None or not conf.manufdb:
         return None
 
     res = conf.manufdb._get_manuf(mac)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -86,18 +86,20 @@ x is not None and ICMP in x and x[ICMP].type == 0
 #_flush_fd(socket.ins)
 
 = Test legacy attach_filter function
-~ linux needs_root
+~ tcpdump
+import mock
 from scapy.arch.common import get_bpf_pointer
 
-old_pypy = conf.use_pypy
-conf.use_pypy = True
-
 tcpdump_lines = ['12\n', '40 0 0 12\n', '21 0 5 34525\n', '48 0 0 20\n', '21 6 0 6\n', '21 0 6 44\n', '48 0 0 54\n', '21 3 4 6\n', '21 0 3 2048\n', '48 0 0 23\n', '21 0 1 6\n', '6 0 0 1600\n', '6 0 0 0\n']
-pointer = get_bpf_pointer(tcpdump_lines)
-assert six.PY3 or isinstance(pointer, str)
-assert six.PY3 or len(pointer) > 1
 
-conf.use_pypy = old_pypy
+@mock.patch("scapy.arch.common.conf", Bunch(use_pypy=True))
+def _test_get_bpf_pointer():
+    pointer = get_bpf_pointer(tcpdump_lines)
+    assert isinstance(pointer, str)
+    assert len(pointer) > 1
+
+if six.PY2:
+    _test_get_bpf_pointer()
 
 = Interface aliases & sub-interfaces
 ~ linux needs_root


### PR DESCRIPTION
This PR:
- Fixes the `conf` imports that were too early (before the logger is setup) in `main.py`
- Makes some `conf` values read-only.
- Replaces some `conf` default values that are used as booleans by booleans rather than 0/1. Much clearer
- **Implements a colored formatter for the logging (interactive mode only)**: it makes the startup much more readable
![image](https://user-images.githubusercontent.com/10530980/56472760-f9153500-6462-11e9-986f-ffcf9860d5ab.png)
- fixes some log levels (`warning` -> `info` for unimportant issues, and `error` -> `critical` for some major ones)
- load some values on runtime in config (values from Scapy.data) to avoid duplication of the values + import loops