### PR TITLE
Fix scapy.1 and scapy -h

### DIFF
--- a/doc/scapy.1
+++ b/doc/scapy.1
@@ -101,7 +101,7 @@ split_layers(UDP,DNS)
 .SH EXAMPLES
 
 More verbose examples are available in the documentation
-http://scapy.readthedocs.io/
+https://scapy.readthedocs.io/
 Just run \fBscapy\fP and try the following commands in the interpreter.
 
 .LP

--- a/doc/scapy.1
+++ b/doc/scapy.1
@@ -67,6 +67,11 @@ lists supported protocol layers.
 If a protocol layer is given as parameter, lists its fields and types of fields.
 If a string is given as parameter, it is used to filter the layers.
 .TP
+\fBexplore()\fR
+explores available protocols.
+Allows to look for a layer or protocol through an interactive GUI.
+If a Scapy module is given as parameter, explore this specific module.
+.TP
 \fBlsc()\fR
 lists scapy's main user commands.
 .TP
@@ -95,14 +100,14 @@ split_layers(UDP,DNS)
 
 .SH EXAMPLES
 
-More verbose examples are available at
-https://scapy.net/demo/
+More verbose examples are available in the documentation
+http://scapy.readthedocs.io/
 Just run \fBscapy\fP and try the following commands in the interpreter.
 
 .LP
 Test the robustness of a network stack with invalid packets:
 .nf
-sr(IP(dst="172.16.1.1", ihl=2, options="\everb$\ex02$", version=3)/ICMP())
+sr(IP(dst="172.16.1.1", ihl=2, options=["verb$2"], version=3)/ICMP(), timeout=2)
 .fi
 
 .LP

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1103,7 +1103,7 @@ class PacketListField(PacketField):
         if x is None:
             return None
         else:
-            return [p if isinstance(p, six.string_types) else p.copy() for p in x]  # noqa: E501
+            return [p if isinstance(p, (str, bytes)) else p.copy() for p in x]
 
     def getfield(self, pkt, s):
         c = len_pkt = cls = None
@@ -1150,7 +1150,7 @@ class PacketListField(PacketField):
         return remain + ret, lst
 
     def addfield(self, pkt, s, val):
-        return s + b"".join(raw(v) for v in val)
+        return s + b"".join(bytes_encode(v) for v in val)
 
 
 class StrFixedLenField(StrField):

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -109,9 +109,12 @@ SESSION = None
 
 
 def _usage():
-    print("""Usage: scapy.py [-s sessionfile] [-c new_startup_file] [-p new_prestart_file] [-C] [-P]  # noqa: E501
-    -C: do not read startup file
-    -P: do not read pre-startup file""")
+    print(
+        "Usage: scapy.py [-s sessionfile] [-c new_startup_file]"
+        "[-p new_prestart_file] [-C] [-P]\n"
+        "\t-C: do not read startup file\n"
+        "\t-P: do not read pre-startup file\n"
+    )
     sys.exit(0)
 
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -110,7 +110,7 @@ SESSION = None
 
 def _usage():
     print(
-        "Usage: scapy.py [-s sessionfile] [-c new_startup_file]"
+        "Usage: scapy.py [-s sessionfile] [-c new_startup_file] "
         "[-p new_prestart_file] [-C] [-P]\n"
         "\t-C: do not read startup file\n"
         "\t-P: do not read pre-startup file\n"


### PR DESCRIPTION
This PR:
- removes "#noqa: E501" from `scapy -h`
- fixes invalid escaping in `scapy.1`
- very minor bugs that happened when running the scapy.1 commands