### PR TITLE
Add ICMPv6 Paramater Problem type 3 "First Fragment has incomplete IP…

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1391,10 +1391,12 @@ class ICMPv6TimeExceeded(_ICMPv6Error):
 class ICMPv6ParamProblem(_ICMPv6Error):
     name = "ICMPv6 Parameter Problem"
     fields_desc = [ByteEnumField("type", 4, icmp6types),
-                   ByteEnumField("code", 0, {0: "erroneous header field encountered",  # noqa: E501
-                                             1: "unrecognized Next Header type encountered",  # noqa: E501
-                                             2: "unrecognized IPv6 option encountered",  # noqa: E501
-                                             3: "first fragment has incomplete header chain"}),
+                   ByteEnumField(
+                       "code", 0,
+                       {0: "erroneous header field encountered",
+                        1: "unrecognized Next Header type encountered",
+                        2: "unrecognized IPv6 option encountered",
+                        3: "first fragment has incomplete header chain"}),
                    XShortField("cksum", None),
                    IntField("ptr", 6)]
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1393,8 +1393,8 @@ class ICMPv6ParamProblem(_ICMPv6Error):
     fields_desc = [ByteEnumField("type", 4, icmp6types),
                    ByteEnumField("code", 0, {0: "erroneous header field encountered",  # noqa: E501
                                              1: "unrecognized Next Header type encountered",  # noqa: E501
-                                             2: "unrecognized IPv6 option encountered", # noqa: E501
-                                             3: "first fragment has incomplete IPv6 feader chain"}),  
+                                             2: "unrecognized IPv6 option encountered",  # noqa: E501
+                                             3: "first fragment has incomplete header chain"}),
                    XShortField("cksum", None),
                    IntField("ptr", 6)]
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1393,7 +1393,8 @@ class ICMPv6ParamProblem(_ICMPv6Error):
     fields_desc = [ByteEnumField("type", 4, icmp6types),
                    ByteEnumField("code", 0, {0: "erroneous header field encountered",  # noqa: E501
                                              1: "unrecognized Next Header type encountered",  # noqa: E501
-                                             2: "unrecognized IPv6 option encountered"}),  # noqa: E501
+                                             2: "unrecognized IPv6 option encountered", # noqa: E501
+                                             3: "first fragment has incomplete IPv6 feader chain"}),  
                    XShortField("cksum", None),
                    IntField("ptr", 6)]
 


### PR DESCRIPTION
…v6 Header Chain"

As defined in section 6 of RFC7112

This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [ ] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)

> brief description what this PR will do, e.g. fixes broken dissection of XXX

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library

fixes #xxx (add issue number here if appropriate, else remove this line)
