### PR TITLE
Fix FlagsField & dissection improvements

### DIFF
--- a/scapy/contrib/ibeacon.uts
+++ b/scapy/contrib/ibeacon.uts
@@ -42,7 +42,7 @@ assert d == d2
 
 = iBeacon (encode LE Set Advertising Data)
 
-d = hex_bytes('1E0201021AFF4C000215FB0B57A2822844CD913A94A122BA120600010002D100')
+d = hex_bytes('1E0201061AFF4C000215FB0B57A2822844CD913A94A122BA120600010002D100')
 p = Apple_BLE_Submessage()/IBeacon_Data(
    uuid='fb0b57a2-8228-44cd-913a-94a122ba1206',
    major=1, minor=2, tx_power=-47)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1971,13 +1971,11 @@ class FlagsField(BitField):
 used in *2i() and i2*() methods.
 
         """
-        if isinstance(x, (list, tuple)):
-            return type(x)(
-                v if v is None or isinstance(v, FlagValue)
-                else FlagValue(v, self.names)
-                for v in x
-            )
-        return x if x is None or isinstance(x, FlagValue) else FlagValue(x, self.names)  # noqa: E501
+        if isinstance(x, FlagValue):
+            return x
+        if x is None:
+            return None
+        return FlagValue(x, self.names)
 
     def any2i(self, pkt, x):
         return self._fixup_val(super(FlagsField, self).any2i(pkt, x))

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -204,8 +204,12 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
 
             # Deepcopy default references
             for fname in Packet.class_default_fields_ref[cls_name]:
-                value = copy.deepcopy(self.default_fields[fname])
-                setattr(self, fname, value)
+                value = self.default_fields[fname]
+                try:
+                    self.fields[fname] = value.copy()
+                except AttributeError:
+                    # Python 2.7 - list only
+                    self.fields[fname] = value[:]
 
     def prepare_cached_fields(self, flist):
         """

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -10,6 +10,7 @@ Fields that hold random numbers.
 """
 
 from __future__ import absolute_import
+import copy
 import random
 import time
 import math
@@ -103,6 +104,9 @@ class VolatileValue(object):
 
     def __len__(self):
         return len(self._fix())
+
+    def copy(self):
+        return copy.copy(self)
 
     def _fix(self):
         return None

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10706,15 +10706,6 @@ assert not any(getattr(p1.flags | p2.flags, f) for f in 'FRPECN')
 assert TCP(flags="SA").flags & TCP(flags="S").flags == TCP(flags="S").flags
 assert TCP(flags="SA").flags | TCP(flags="S").flags == TCP(flags="SA").flags
 
-= Using tuples and lists as flag values
-~ IP TCP
-
-plist = PacketList(list(IP()/TCP(flags=(0, 2**9 - 1))))
-assert [p[TCP].flags for p in plist] == [x for x in range(512)]
-
-plist = PacketList(list(IP()/TCP(flags=["S", "SA", "A"])))
-assert [p[TCP].flags for p in plist] == [2, 18, 16]
-
 
 ############
 ############


### PR DESCRIPTION
This is a part of https://github.com/secdev/scapy/pull/1999 that can be fast tracked.
This PR:
- **Small performances boost: consistent 5-10% on dissection (caching improvements & guess_payload_class)**

```
>>> a = raw(Ether()/IP()/UDP())
>>> %timeit Ether(a)
```

- Fixes `FlagsField` very weird behavior:

**before (?!?!)**
```python
>>> EIR_Hdr() / EIR_Flags(flags=["general_disc_mode", "br_edr_not_supported"])
<EIR_Hdr  type=flags |<EIR_Flags  flags=['general_disc_mode', 'br_edr_not_supported'] |>>
+ when raw(), flags was wrongly built
```
**after**
```python
>>> EIR_Hdr() / EIR_Flags(flags=["general_disc_mode", "br_edr_not_supported"])
<EIR_Hdr  type=flags |<EIR_Flags  flags=general_disc_mode+br_edr_not_supported |>>
```

- Improve dissection speed by reducing number of calls to `hasattr`
- Makes `clear_cache()` work on subpackets