### PR TITLE
Implementation of SignalField and SignalPacket

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2293,13 +2293,13 @@ class ScalingField(Field):
         if x is None:
             x = 0
         x = (x - self.offset) / self.scaling
-        if isinstance(x, float):
+        if isinstance(x, float) and self.fmt[-1] != "f":
             x = int(round(x))
         return x
 
     def m2i(self, pkt, x):
         x = x * self.scaling + self.offset
-        if isinstance(x, float):
+        if isinstance(x, float) and self.fmt[-1] != "f":
             x = round(x, self.ndigits)
         return x
 
@@ -2315,13 +2315,12 @@ class ScalingField(Field):
     def randval(self):
         value = super(ScalingField, self).randval()
         if value is not None:
-            barrier1 = self.m2i(None, value.max)
-            barrier2 = self.m2i(None, value.min)
+            min_val = round(value.min * self.scaling + self.offset,
+                            self.ndigits)
+            max_val = round(value.max * self.scaling + self.offset,
+                            self.ndigits)
 
-            min_value = min(barrier1, barrier2)
-            max_value = max(barrier1, barrier2)
-
-            return RandFloat(min_value, max_value)
+            return RandFloat(min(min_val, max_val), max(min_val, max_val))
 
 
 class UUIDField(Field):

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -276,7 +276,7 @@ class BEFloatSignalField(SignalField):
 
 class SignalPacket(Packet):
     def pre_dissect(self, s):
-        if not all([isinstance(f, SignalField) for f in self.fields_desc]):
+        if not all(isinstance(f, SignalField) for f in self.fields_desc):
             raise Scapy_Exception("Use only SignalFields in a SignalPacket")
         return s
 

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -15,11 +15,15 @@ import scapy.modules.six as six
 from scapy.config import conf
 from scapy.data import DLT_CAN_SOCKETCAN
 from scapy.fields import FieldLenField, FlagsField, StrLenField, \
-    ThreeBytesField, XBitField
+    ThreeBytesField, XBitField, ScalingField
+from scapy.volatile import RandFloat, RandBinFloat
 from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import CookedLinux
+from scapy.error import Scapy_Exception
 
-__all__ = ["CAN", "rdcandump"]
+__all__ = ["CAN", "SignalPacket", "SignalField", "LESignedSignalField",
+           "LEUnsignedSignalField", "LEFloatSignalField", "BEFloatSignalField",
+           "BESignedSignalField", "BEUnsignedSignalField", "rdcandump"]
 
 # Mimics the Wireshark CAN dissector parameter 'Byte-swap the CAN ID/flags field'  # noqa: E501
 #   set to True when working with PF_CAN sockets
@@ -82,6 +86,211 @@ class CAN(Packet):
 
 conf.l2types.register(DLT_CAN_SOCKETCAN, CAN)
 bind_layers(CookedLinux, CAN, proto=12)
+
+
+class SignalField(ScalingField):
+    __slots__ = ["start", "size"]
+
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3, fmt="B"):
+        ScalingField.__init__(self, name, default, scaling, unit, offset,
+                              ndigits, fmt)
+        self.start = start
+        self.size = abs(size)
+
+        if fmt[-1] == "f" and self.size != 32:
+            raise Scapy_Exception("SignalField size has to be 32 for floats")
+
+    _lookup_table = [7, 6, 5, 4, 3, 2, 1, 0,
+                     15, 14, 13, 12, 11, 10, 9, 8,
+                     23, 22, 21, 20, 19, 18, 17, 16,
+                     31, 30, 29, 28, 27, 26, 25, 24,
+                     39, 38, 37, 36, 35, 34, 33, 32,
+                     47, 46, 45, 44, 43, 42, 41, 40,
+                     55, 54, 53, 52, 51, 50, 49, 48,
+                     63, 62, 61, 60, 59, 58, 57, 56]
+
+    @staticmethod
+    def _msb_lookup(start):
+        return SignalField._lookup_table.index(start)
+
+    @staticmethod
+    def _lsb_lookup(start, size):
+        return SignalField._lookup_table[SignalField._msb_lookup(start) +
+                                         size - 1]
+
+    @staticmethod
+    def _convert_to_unsigned(number, bitlength):
+        mask = (2 ** bitlength)
+        if number & (1 << (bitlength - 1)):
+            return mask + number
+        else:
+            return number
+
+    @staticmethod
+    def _convert_to_signed(number, bitlength):
+        mask = (2 ** bitlength) - 1
+        if number & (1 << (bitlength - 1)):
+            return number | ~mask
+        else:
+            return number & mask
+
+    def _is_little_endian(self):
+        return True if self.fmt[0] == "<" else False
+
+    def _is_signed_number(self):
+        return True if self.fmt[-1].islower() else False
+
+    def _is_float_number(self):
+        return True if self.fmt[-1] == "f" else False
+
+    def addfield(self, pkt, s, val):
+        if not isinstance(pkt, SignalPacket):
+            raise Scapy_Exception("Only use SignalFields in a SignalPacket")
+
+        val = self.i2m(pkt, val)
+
+        if self._is_little_endian():
+            msb_pos = self.start + self.size - 1
+            lsb_pos = self.start
+            shift = lsb_pos
+            fmt = "<Q"
+        else:
+            msb_pos = self.start
+            lsb_pos = self._lsb_lookup(self.start, self.size)
+            shift = (64 - self._msb_lookup(msb_pos) - self.size)
+            fmt = ">Q"
+
+        field_len = max(msb_pos, lsb_pos) // 8 + 1
+        if len(s) < field_len:
+            s += b"\x00" * (field_len - len(s))
+
+        if self._is_float_number():
+            val = struct.unpack(self.fmt[0] + "I",
+                                struct.pack(self.fmt, val))[0]
+        elif self._is_signed_number():
+            val = self._convert_to_unsigned(val, self.size)
+
+        pkt_val = struct.unpack(fmt, (s + b"\x00" * 8)[:8])[0]
+        pkt_val |= val << shift
+        tmp_s = struct.pack(fmt, pkt_val)
+        return tmp_s[:len(s)]
+
+    def getfield(self, pkt, s):
+        if not isinstance(pkt, SignalPacket):
+            raise Scapy_Exception("Only use SignalFields in a SignalPacket")
+
+        if isinstance(s, tuple):
+            s, _ = s
+
+        if self._is_little_endian():
+            msb_pos = self.start + self.size - 1
+            lsb_pos = self.start
+            shift = self.start
+            fmt = "<Q"
+        else:
+            msb_pos = self.start
+            lsb_pos = self._lsb_lookup(self.start, self.size)
+            shift = (64 - self._msb_lookup(self.start) - self.size)
+            fmt = ">Q"
+
+        field_len = max(msb_pos, lsb_pos) // 8 + 1
+
+        if pkt.wirelen is None:
+            pkt.wirelen = field_len
+
+        pkt.wirelen = max(pkt.wirelen, field_len)
+
+        fld_val = struct.unpack(fmt, (s + b"\x00" * 8)[:8])[0] >> shift
+        fld_val &= ((1 << self.size) - 1)
+
+        if self._is_float_number():
+            fld_val = struct.unpack(self.fmt,
+                                    struct.pack(self.fmt[0] + "I", fld_val))[0]
+        elif self._is_signed_number():
+            fld_val = self._convert_to_signed(fld_val, self.size)
+
+        return s, self.m2i(pkt, fld_val)
+
+    def randval(self):
+        if self._is_float_number():
+            return RandBinFloat(0, 0)
+
+        if self._is_signed_number():
+            min_val = -2**(self.size - 1)
+            max_val = 2**(self.size - 1) - 1
+        else:
+            min_val = 0
+            max_val = 2 ** self.size - 1
+
+        min_val = round(min_val * self.scaling + self.offset, self.ndigits)
+        max_val = round(max_val * self.scaling + self.offset, self.ndigits)
+
+        return RandFloat(min(min_val, max_val), max(min_val, max_val))
+
+    def i2len(self, pkt, x):
+        return float(self.size) / 8
+
+
+class LEUnsignedSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, "<B")
+
+
+class LESignedSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, "<b")
+
+
+class BEUnsignedSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, ">B")
+
+
+class BESignedSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, ">b")
+
+
+class LEFloatSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, "<f")
+
+
+class BEFloatSignalField(SignalField):
+    def __init__(self, name, default, start, size, scaling=1, unit="",
+                 offset=0, ndigits=3):
+        SignalField.__init__(self, name, default, start, size,
+                             scaling, unit, offset, ndigits, ">f")
+
+
+class SignalPacket(Packet):
+    def pre_dissect(self, s):
+        if not all([isinstance(f, SignalField) for f in self.fields_desc]):
+            raise Scapy_Exception("Use only SignalFields in a SignalPacket")
+        return s
+
+    def post_dissect(self, s):
+        """ SignalFields can be dissected on packets with unordered fields.
+        The order of SignalFields is defined from the start parameter.
+        After a build, the consumed bytes of the length of all SignalFields
+        have to be removed from the SignalPacket.
+        """
+        if self.wirelen > 8:
+            raise Scapy_Exception("Only 64 bits for all SignalFields "
+                                  "are supported")
+        self.raw_packet_cache = None  # Reset packet to allow post_build
+        return s[self.wirelen:]
 
 
 def rdcandump(filename, count=None,

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -15,6 +15,7 @@ import time
 import math
 import re
 import uuid
+import struct
 
 from scapy.base_classes import Net
 from scapy.compat import bytes_encode, chb, plain_str
@@ -196,6 +197,11 @@ class RandNum(RandField):
 class RandFloat(RandNum):
     def _fix(self):
         return random.uniform(self.min, self.max)
+
+
+class RandBinFloat(RandNum):
+    def _fix(self):
+        return struct.unpack("!f", bytes(RandBin(4)))[0]
 
 
 class RandNumGamma(RandNum):

--- a/test/can.uts
+++ b/test/can.uts
@@ -10,6 +10,8 @@
 
 = Load module
 
+import math
+
 load_layer("can")
 
 = Build a packet
@@ -387,3 +389,851 @@ assert packets[1].length == 8
 assert packets[-1].data == b'\x11\x22\x33\x44'
 assert packets[0].data == b'\x11\x22\x33\x44\x55\x66\x77\x88'
 assert packets[1].data == b'\x11\x22\x33\x44\x55\x66\x77\x88'
+
+
+########
+########
++ CAN Signals
+
+= Motorola byte order (Big Endian) dissect test
+
+class testFrame1(SignalPacket):
+    fields_desc = [
+        SignalField("sig0", default=0, start=1, size=2, fmt=">B"),
+        SignalField("sig1", default=0, start=7, size=6, fmt=">B"),
+        SignalField("sig2", default=0, start=15, size=11, fmt=">B"),
+        SignalField("sig3", default=0, start=20, size=12, fmt=">B"),
+        SignalField("sig4", default=0, start=24, size=9, fmt=">B"),
+        SignalField("sig7", default=0, start=47, size=10, fmt=">B"),
+        SignalField("sig5", default=0, start=50, size=3, fmt=">B"),
+        SignalField("sig6", default=0, start=53, size=3, fmt=">B"),
+        SignalField("sig8", default=0, start=58, size=3, fmt=">B"),
+        SignalField("sig9", default=0, start=61, size=3, fmt=">B"),
+        SignalField("sig10", default=0, start=63, size=2, fmt=">B")
+    ]
+
+pkt = testFrame1(b'\xff\xff\xff\xff\xff\xff\xff\xff')
+assert pkt.sig0 == 3
+assert pkt.sig1 == 0x3f
+assert pkt.sig2 == 0x7ff
+assert pkt.sig3 == 0xfff
+assert pkt.sig4 == 0x1ff
+assert pkt.sig7 == 0x3ff
+assert pkt.sig5 == 7
+assert pkt.sig6 == 7
+assert pkt.sig8 == 7
+assert pkt.sig9 == 7
+assert pkt.sig10 == 3
+
+
+pkt = testFrame1(struct.pack("<Q", int("10010101" # byte 7: 63 - 56
+                                       "11010101" 
+                                       "10000000" 
+                                       "00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "01010101",2))) # byte 0: 7 - 0
+assert pkt.sig0 == 1
+assert pkt.sig1 == 21
+assert pkt.sig2 == 15
+assert pkt.sig3 == 0x7f
+assert pkt.sig4 == 0x1
+assert pkt.sig7 == 0x203
+assert pkt.sig5 == 5
+assert pkt.sig6 == 2
+assert pkt.sig8 == 5
+assert pkt.sig9 == 2
+assert pkt.sig10 == 2
+
+
+= Motorola byte order (Big Endian) build test
+
+pkt = testFrame1()
+pkt.sig0 = 1
+pkt.sig1 = 21
+pkt.sig2 = 15
+pkt.sig3 = 0x7f
+pkt.sig4 = 0x1
+pkt.sig7 = 0x203
+pkt.sig5 = 5
+pkt.sig6 = 2
+pkt.sig8 = 5
+pkt.sig9 = 2
+pkt.sig10 = 2
+
+test = bytes(pkt)
+assert bytes(test) == b'U\x01\xe0\xfe\x01\x80\xd5\x95'
+
+
+= Motorola byte order (Big Endian) dissect test with mixed field order
+
+class testFrame1(SignalPacket):
+    fields_desc = [
+        SignalField("sig10", default=0, start=63, size=2, fmt=">B"),
+        SignalField("sig0", default=0, start=1, size=2, fmt=">B"),
+        SignalField("sig9", default=0, start=61, size=3, fmt=">B"),
+        SignalField("sig5", default=0, start=50, size=3, fmt=">B"),
+        SignalField("sig4", default=0, start=24, size=9, fmt=">B"),
+        SignalField("sig7", default=0, start=47, size=10, fmt=">B"),
+        SignalField("sig3", default=0, start=20, size=12, fmt=">B"),
+        SignalField("sig6", default=0, start=53, size=3, fmt=">B"),
+        SignalField("sig2", default=0, start=15, size=11, fmt=">B"),
+        SignalField("sig8", default=0, start=58, size=3, fmt=">B"),
+        SignalField("sig1", default=0, start=7, size=6, fmt=">B"),
+    ]
+
+pkt = testFrame1(struct.pack("<Q", int("10010101" # byte 7: 63 - 56
+                                       "11010101" 
+                                       "10000000" 
+                                       "00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "01010101",2))) # byte 0: 7 - 0
+assert pkt.sig0 == 1
+assert pkt.sig1 == 21
+assert pkt.sig2 == 15
+assert pkt.sig3 == 0x7f
+assert pkt.sig4 == 0x1
+assert pkt.sig7 == 0x203
+assert pkt.sig5 == 5
+assert pkt.sig6 == 2
+assert pkt.sig8 == 5
+assert pkt.sig9 == 2
+assert pkt.sig10 == 2
+
+
+= Motorola byte order (Big Endian) build test with mixed field order
+
+class testFrame1(SignalPacket):
+    fields_desc = [
+        SignalField("sig3", default=0, start=20, size=12, fmt=">B"),
+        SignalField("sig4", default=0, start=24, size=9, fmt=">B"),
+        SignalField("sig10", default=0, start=63, size=2, fmt=">B"),
+        SignalField("sig2", default=0, start=15, size=11, fmt=">B"),
+        SignalField("sig5", default=0, start=50, size=3, fmt=">B"),
+        SignalField("sig1", default=0, start=7, size=6, fmt=">B"),
+        SignalField("sig6", default=0, start=53, size=3, fmt=">B"),
+        SignalField("sig7", default=0, start=47, size=10, fmt=">B"),
+        SignalField("sig9", default=0, start=61, size=3, fmt=">B"),
+        SignalField("sig0", default=0, start=1, size=2, fmt=">B"),
+        SignalField("sig8", default=0, start=58, size=3, fmt=">B"),
+    ]
+
+pkt = testFrame1()
+pkt.sig0 = 1
+pkt.sig1 = 21
+pkt.sig2 = 15
+pkt.sig3 = 0x7f
+pkt.sig4 = 0x1
+pkt.sig7 = 0x203
+pkt.sig5 = 5
+pkt.sig6 = 2
+pkt.sig8 = 5
+pkt.sig9 = 2
+pkt.sig10 = 2
+
+test = bytes(pkt)
+print(test)
+assert bytes(test) == b'U\x01\xe0\xfe\x01\x80\xd5\x95'
+
+
+= Intel byte order (Little Endian) dissect test
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig5",  default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig6",  default=0, start=37, size=3, fmt="<B"),
+        SignalField("secSig9",  default=0, start=52, size=3, fmt="<B"),
+        SignalField("secSig2",  default=0, start=55, size=1, fmt="<B"),
+        SignalField("secSig8",  default=0, start=56, size=3, fmt="<B"),
+        SignalField("secSig7",  default=0, start=59, size=1, fmt="<B"),
+        SignalField("secSig1",  default=0, start=60, size=2, fmt="<B"),
+        SignalField("secSig4",  default=0, start=62, size=2, fmt="<B"),
+    ]
+
+pkt = testFrame2(b'\xff\xff\xff\xff\xff\xff\xff\xff')
+assert pkt.secSig1 == 0x3
+assert pkt.secSig2 == 0x1
+assert pkt.secSig3 == 0xf
+assert pkt.secSig4 == 0x3
+assert pkt.secSig7 == 0x1
+assert pkt.secSig5 == 7
+assert pkt.secSig6 == 7
+assert pkt.secSig8 == 7
+assert pkt.secSig9 == 7
+assert pkt.secSig10 == 0xfff
+assert pkt.secSig11 == 0x3ff
+assert pkt.secSig12 == 0xff
+
+
+pkt = testFrame2(struct.pack("<Q", int("10010101" # byte 7: 63 - 56
+                                       "11010101" 
+                                       "10000000" 
+                                       "00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "10100101",2))) # byte 0: 7 - 0
+
+assert pkt.secSig1 == 0x1
+assert pkt.secSig2 == 0x1
+assert pkt.secSig3 == 0xe
+assert pkt.secSig4 == 0x2
+assert pkt.secSig7 == 0x0
+assert pkt.secSig5 == 0
+assert pkt.secSig6 == 0
+assert pkt.secSig8 == 5
+assert pkt.secSig9 == 5
+assert pkt.secSig10 == 1
+assert pkt.secSig11 == 0x1fe
+assert pkt.secSig12 == 0xA5
+
+= Intel byte order (Little Endian) build test
+
+pkt = testFrame2()
+
+pkt.secSig12 = 0xA5
+pkt.secSig10 = 1
+pkt.secSig3 = 14
+pkt.secSig11 = 0x1fe
+pkt.secSig5 = 0
+pkt.secSig6 = 0
+pkt.secSig9 = 5
+pkt.secSig2 = 1
+pkt.secSig8 = 5
+pkt.secSig7 = 0
+pkt.secSig1 = 1
+pkt.secSig4 = 2
+
+assert bytes(pkt) == b'\xa5\x01\xe0\xfe\x01\x00\xd0\x95'
+
+
+= Intel byte order (Little Endian) build test with mixed field order
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig1",  default=0, start=60, size=2, fmt="<B"),
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+        SignalField("secSig2",  default=0, start=55, size=1, fmt="<B"),
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig5",  default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig9",  default=0, start=52, size=3, fmt="<B"),
+        SignalField("secSig8",  default=0, start=56, size=3, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig7",  default=0, start=59, size=1, fmt="<B"),
+        SignalField("secSig6",  default=0, start=37, size=3, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig4",  default=0, start=62, size=2, fmt="<B"),
+    ]
+
+pkt = testFrame2()
+
+pkt.secSig12 = 0xA5
+pkt.secSig10 = 1
+pkt.secSig3 = 14
+pkt.secSig11 = 0x1fe
+pkt.secSig5 = 0
+pkt.secSig6 = 0
+pkt.secSig9 = 5
+pkt.secSig2 = 1
+pkt.secSig8 = 5
+pkt.secSig7 = 0
+pkt.secSig1 = 1
+pkt.secSig4 = 2
+
+assert bytes(pkt) == b'\xa5\x01\xe0\xfe\x01\x00\xd0\x95'
+
+
+= Intel byte order (Little Endian) build test with short package
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+    ]
+
+pkt = testFrame2()
+
+pkt.secSig12 = 0xA5
+pkt.secSig10 = 1
+pkt.secSig3 = 14
+pkt.secSig11 = 0x1fe
+
+assert bytes(pkt) == b'\xa5\x01\xe0\xfe\x01'
+assert len(pkt) == 5
+
+pkt.secSig11 = 0x0fe
+
+assert bytes(pkt) == b'\xa5\x01\xe0\xfe\x00'
+assert len(pkt) == 5
+
+= Packet with mixed endianness fields build test
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, fmt="<B"),
+        SignalField("muxSig5", default=0, start=22, size=7, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, fmt=">B"),
+        SignalField("muxSig8", default=0, start=3, size=3, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, fmt="<B"),
+    ]
+
+pkt = testFrame3()
+
+pkt.myMuxer = 0x7
+pkt.muxSig5 = 0x72
+pkt.muxSig6 = 0x10f
+pkt.muxSig7 = 0xA5
+pkt.muxSig8 = 0x03
+pkt.muxSig9 = 0x11
+
+assert bytes(pkt) == b'\x1d\x28\x80\x1c\x0f\x23\xe0'
+assert len(pkt) == 7
+
+
+= Intel byte order (Little Endian) SignalPacket dissect test
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig5",  default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig6",  default=0, start=37, size=3, fmt="<B"),
+        SignalField("secSig9",  default=0, start=52, size=3, fmt="<B"),
+        SignalField("secSig2",  default=0, start=55, size=1, fmt="<B"),
+        SignalField("secSig8",  default=0, start=56, size=3, fmt="<B"),
+        SignalField("secSig7",  default=0, start=59, size=1, fmt="<B"),
+        SignalField("secSig1",  default=0, start=60, size=2, fmt="<B"),
+        SignalField("secSig4",  default=0, start=62, size=2, fmt="<B"),
+    ]
+
+pkt = testFrame2(b'\xff\xff\xff\xff\xff\xff\xff\xff')
+assert pkt.secSig1 == 0x3
+assert pkt.secSig2 == 0x1
+assert pkt.secSig3 == 0xf
+assert pkt.secSig4 == 0x3
+assert pkt.secSig7 == 0x1
+assert pkt.secSig5 == 7
+assert pkt.secSig6 == 7
+assert pkt.secSig8 == 7
+assert pkt.secSig9 == 7
+assert pkt.secSig10 == 0xfff
+assert pkt.secSig11 == 0x3ff
+assert pkt.secSig12 == 0xff
+
+assert len(pkt) == 8
+
+pkt = testFrame2(struct.pack("<Q", int("10010101" # byte 7: 63 - 56
+                                       "11010101" 
+                                       "10000000" 
+                                       "00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "10100101",2))) # byte 0: 7 - 0
+
+assert pkt.secSig1 == 0x1
+assert pkt.secSig2 == 0x1
+assert pkt.secSig3 == 0xe
+assert pkt.secSig4 == 0x2
+assert pkt.secSig7 == 0x0
+assert pkt.secSig5 == 0
+assert pkt.secSig6 == 0
+assert pkt.secSig8 == 5
+assert pkt.secSig9 == 5
+assert pkt.secSig10 == 1
+assert pkt.secSig11 == 0x1fe
+assert pkt.secSig12 == 0xA5
+
+assert len(pkt) == 8
+
+
+= Intel byte order (Little Endian) short SignalPacket dissect test
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig5",  default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig6",  default=0, start=37, size=3, fmt="<B"),
+    ]
+
+pkt = testFrame2(b'\xff\xff\xff\xff\xff')
+assert pkt.secSig3 == 0xf
+assert pkt.secSig5 == 7
+assert pkt.secSig6 == 7
+assert pkt.secSig10 == 0xfff
+assert pkt.secSig11 == 0x3ff
+assert pkt.secSig12 == 0xff
+
+assert len(pkt) == 5
+
+pkt = testFrame2(struct.pack("<Q", int("00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "10100101",2))[0:5])
+
+assert pkt.secSig3 == 0xe
+assert pkt.secSig5 == 0
+assert pkt.secSig6 == 0
+assert pkt.secSig10 == 1
+assert pkt.secSig11 == 0x1fe
+assert pkt.secSig12 == 0xA5
+
+assert len(pkt) == 5
+
+= Intel byte order (Little Endian) short SignalPacket dissect test mixed field order
+
+class testFrame2(SignalPacket):
+    fields_desc = [
+        SignalField("secSig3",  default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig6",  default=0, start=37, size=3, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig5",  default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B"),
+    ]
+
+pkt = testFrame2(b'\xff\xff\xff\xff\xff')
+assert pkt.secSig3 == 0xf
+assert pkt.secSig5 == 7
+assert pkt.secSig6 == 7
+assert pkt.secSig10 == 0xfff
+assert pkt.secSig11 == 0x3ff
+assert pkt.secSig12 == 0xff
+
+assert len(pkt) == 5
+
+pkt = testFrame2(struct.pack("<Q", int("00000001" 
+                                       "11111110"
+                                       "11100000"
+                                       "00000001"
+                                       "10100101",2))[0:5])
+
+assert pkt.secSig3 == 0xe
+assert pkt.secSig5 == 0
+assert pkt.secSig6 == 0
+assert pkt.secSig10 == 1
+assert pkt.secSig11 == 0x1fe
+assert pkt.secSig12 == 0xA5
+
+assert len(pkt) == 5
+
+
+= Packet with mixed endianness fields build test
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, fmt="<B"),
+        SignalField("muxSig5", default=0, start=22, size=7, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, fmt=">B"),
+        SignalField("muxSig8", default=0, start=3, size=3, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, fmt="<B"),
+    ]
+
+pkt = testFrame3()
+
+pkt.myMuxer = 0x7
+pkt.muxSig5 = 0x72
+pkt.muxSig6 = 0x10f
+pkt.muxSig7 = 0xA5
+pkt.muxSig8 = 0x03
+pkt.muxSig9 = 0x11
+
+assert bytes(pkt) == b'\x1d\x28\x80\x1c\x0f\x23\xe0'
+assert len(pkt) == 7
+
+
+= Packet with mixed endianness fields build test, mixed field order
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, fmt=">B"),
+        SignalField("muxSig8", default=0, start=3, size=3, fmt="<B"),
+        SignalField("muxSig5", default=0, start=22, size=7, fmt="<B"),
+    ]
+
+pkt = testFrame3()
+
+pkt.myMuxer = 0x7
+pkt.muxSig5 = 0x72
+pkt.muxSig6 = 0x10f
+pkt.muxSig7 = 0xA5
+pkt.muxSig8 = 0x03
+pkt.muxSig9 = 0x11
+
+assert bytes(pkt) == b'\x1d\x28\x80\x1c\x0f\x23\xe0'
+assert len(pkt) == 7
+
+= Packet with mixed endianness fields dissect test, mixed field order
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 0x7
+assert pkt.muxSig5 == 0x72
+assert pkt.muxSig6 == 0x10f
+assert pkt.muxSig7 == 0xA5
+assert pkt.muxSig8 == 0x03
+assert pkt.muxSig9 == 0x11
+
+
+= Packet with mixed endianness fields dissect test, mixed field order and scaling
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, scaling=0.1, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, scaling=100, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, scaling=2, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, scaling=0.5, fmt=">B"),
+        SignalField("muxSig8", default=0, start=3, size=3, scaling=10, fmt="<B"),
+        SignalField("muxSig5", default=0, start=22, size=7, scaling=0.01, fmt="<B"),
+    ]
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 0.7
+assert pkt.muxSig5 == 1.14
+assert pkt.muxSig6 == 0x10f << 1
+assert pkt.muxSig7 == 82.5
+assert pkt.muxSig8 == 30
+assert pkt.muxSig9 == 1700
+
+
+= Packet with mixed endianness fields dissect test, mixed field order and scaling and offset
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, scaling=0.1, offset=5, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, scaling=100, offset=1, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, scaling=2, offset=-10, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, scaling=0.5, offset=0.1, fmt=">B"),
+        SignalField("muxSig8", default=0, start=3, size=3, scaling=10, offset=100, fmt="<B"),
+        SignalField("muxSig5", default=0, start=22, size=7, scaling=0.01, fmt="<B"),
+    ]
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 5.7
+assert pkt.muxSig5 == 1.14
+assert pkt.muxSig6 == 532
+assert pkt.muxSig7 == 82.6
+assert pkt.muxSig8 == 130
+assert pkt.muxSig9 == 1701
+
+
+= Packet with mixed endianness fields dissect test, mixed field order and scaling and offset
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        LEUnsignedSignalField("myMuxer", default=0, start=53, size=3, scaling=0.1, offset=5),
+        LEUnsignedSignalField("muxSig9", default=0, start=41, size=7, scaling=100, offset=1),
+        LEUnsignedSignalField("muxSig6", default=0, start=32, size=9, scaling=2, offset=-10),
+        BEUnsignedSignalField("muxSig7", default=0, start=2, size=8, scaling=0.5, offset=0.1),
+        LEUnsignedSignalField("muxSig8", default=0, start=3, size=3, scaling=10, offset=100),
+        LEUnsignedSignalField("muxSig5", default=0, start=22, size=7, scaling=0.01),
+    ]
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 5.7
+assert pkt.muxSig5 == 1.14
+assert pkt.muxSig6 == 532
+assert pkt.muxSig7 == 82.6
+assert pkt.muxSig8 == 130
+assert pkt.muxSig9 == 1701
+
+
+= Packet with mixed endianness fields dissect test, mixed field order and scaling with signed values
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        SignalField("myMuxer", default=0, start=53, size=3, scaling=0.1, fmt="<B"),
+        SignalField("muxSig9", default=0, start=41, size=7, scaling=100, fmt="<B"),
+        SignalField("muxSig6", default=0, start=32, size=9, scaling=2, fmt="<B"),
+        SignalField("muxSig7", default=0, start=2, size=8, scaling=0.5, fmt=">b"),
+        SignalField("muxSig8", default=0, start=3, size=3, scaling=10, fmt="<b"),
+        SignalField("muxSig5", default=0, start=22, size=7, scaling=0.01, fmt="<b"),
+    ]
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 0.7
+assert pkt.muxSig5 == -0.14
+assert pkt.muxSig6 == 0x10f << 1
+assert pkt.muxSig7 == -45.5
+assert pkt.muxSig8 == 30
+assert pkt.muxSig9 == 1700
+
+
+= Packet with mixed endianness fields dissect test, mixed field order and scaling with signed values
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        LEUnsignedSignalField("myMuxer", default=0, start=53, size=3, scaling=0.1),
+        LEUnsignedSignalField("muxSig9", default=0, start=41, size=7, scaling=100),
+        LEUnsignedSignalField("muxSig6", default=0, start=32, size=9, scaling=2),
+        BESignedSignalField("muxSig7", default=0, start=2, size=8, scaling=0.5),
+        LESignedSignalField("muxSig8", default=0, start=3, size=3, scaling=10),
+        LESignedSignalField("muxSig5", default=0, start=22, size=7, scaling=0.01),
+    ]
+
+pkt = testFrame3(b'\x1d\x28\x80\x1c\x0f\x23\xe0')
+assert len(pkt) == 7
+assert pkt.myMuxer == 0.7
+assert pkt.muxSig5 == -0.14
+assert pkt.muxSig6 == 0x10f << 1
+assert pkt.muxSig7 == -45.5
+assert pkt.muxSig8 == 30
+assert pkt.muxSig9 == 1700
+
+
+
+= Packet with big endianness signals
+
+class testFrame4(SignalPacket):
+    fields_desc = [
+        SignalField("sig0", default=0, start=1, size=2, fmt=">B"),
+        SignalField("sig1", default=0, start=7, size=6, fmt=">B"),
+        SignalField("sig2", default=0, start=15, size=11, fmt=">B"),
+        SignalField("sig3", default=0, start=20, size=12, fmt=">B"),
+        SignalField("sig4", default=0, start=24, size=9, fmt=">B"),
+        SignalField("sig5", default=0, start=50, size=3, fmt=">B"),
+        SignalField("sig6", default=0, start=53, size=3, fmt=">B"),
+        SignalField("sig7", default=0, start=47, size=10, fmt=">B"),
+        SignalField("sig8", default=0, start=58, size=3, fmt=">B"),
+        SignalField("sig9", default=0, start=61, size=3, fmt=">B"),
+        SignalField("sig10", default=0, start=63, size=2, fmt=">B")
+    ]
+
+pkt = testFrame4()
+
+pkt.sig0 = 1
+pkt.sig1 = 35
+pkt.sig2 = 0
+pkt.sig3 = 2048
+pkt.sig4 = 256
+pkt.sig5 = 1
+pkt.sig6 = 0
+pkt.sig7 = 520
+pkt.sig8 = 0
+pkt.sig9 = 0
+pkt.sig10 = 0
+
+assert bytes(pkt) == b'\x8d\x00\x10\x01\x00\x82\x01\x00'
+
+
+= Packet with little endianness signals
+
+class testFrame5(SignalPacket):
+    fields_desc = [
+        SignalField("secSig1", default=0, start=60, size=2, fmt="<B"),
+        SignalField("secSig2", default=0, start=55, size=1, fmt="<B"),
+        SignalField("secSig3", default=0, start=20, size=4, fmt="<B"),
+        SignalField("secSig4", default=0, start=62, size=2, fmt="<B"),
+        SignalField("secSig5", default=0, start=34, size=3, fmt="<B"),
+        SignalField("secSig6", default=0, start=37, size=3, fmt="<B"),
+        SignalField("secSig7", default=0, start=59, size=1, fmt="<B"),
+        SignalField("secSig8", default=0, start=56, size=3, fmt="<B"),
+        SignalField("secSig9", default=0, start=52, size=3, fmt="<B"),
+        SignalField("secSig10", default=0, start=8, size=12, fmt="<B"),
+        SignalField("secSig11", default=0, start=24, size=10, fmt="<b"),
+        SignalField("secSig12", default=0, start=0, size=8, fmt="<B")
+    ]
+
+pkt = testFrame5()
+
+pkt.secSig1 = 0
+pkt.secSig2 = 0
+pkt.secSig3 = 0
+pkt.secSig4 = 2
+pkt.secSig5 = 0
+pkt.secSig6 = 0
+pkt.secSig7 = 0
+pkt.secSig8 = 3
+pkt.secSig9 = 1
+pkt.secSig10 = 1280
+pkt.secSig11 = -144
+pkt.secSig12 = 12
+
+assert bytes(pkt) == b'\x0c\x00\x05p\x03\x00\x10\x83'
+
+
+= Packet with float signals build test
+
+class testFrame6(SignalPacket):
+    fields_desc = [
+        SignalField("floatSignal2", default=0, start=32, size=32, fmt="<f"),
+        SignalField("floatSignal1", default=0, start=7, size=32, fmt=">f")
+    ]
+
+pkt = testFrame6()
+
+pkt.floatSignal1 = 5.424999835668132e-05
+pkt.floatSignal2 = 6.176799774169922
+
+assert bytes(pkt) == b'8c\x8a~X\xa8\xc5@'
+
+= Packet with float signals dissect test
+
+pkt = testFrame6(b'8c\x8a~X\xa8\xc5@')
+
+assert pkt.floatSignal1 == 5.424999835668132e-05
+assert pkt.floatSignal2 == 6.176799774169922
+
+
+= Packet with float signals build test 2
+
+class testFrame6(SignalPacket):
+    fields_desc = [
+        LEFloatSignalField("floatSignal2", default=0, start=32, size=32),
+        BEFloatSignalField("floatSignal1", default=0, start=7, size=32)
+    ]
+
+pkt = testFrame6()
+
+pkt.floatSignal1 = 5.424999835668132e-05
+pkt.floatSignal2 = 6.176799774169922
+
+assert bytes(pkt) == b'8c\x8a~X\xa8\xc5@'
+
+= Packet with float signals dissect test 2
+
+pkt = testFrame6(b'8c\x8a~X\xa8\xc5@')
+
+assert pkt.floatSignal1 == 5.424999835668132e-05
+assert pkt.floatSignal2 == 6.176799774169922
+
+= Packet with float signals randval
+
+assert pkt.fields_desc[0].randval() != 6.176799774169922
+assert pkt.fields_desc[1].randval() != 5.424999835668132e-05
+
+= Packet with float signals fuzz
+
+pkt = testFrame6()
+
+f = fuzz(pkt)
+assert bytes(f) != bytes(f)
+
+= Test signal fuzzing offset 1
+
+test_offset = 100
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        BEUnsignedSignalField("muxSig7", default=0, start=2, size=8, scaling=1, offset=test_offset),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+li = [pkt.muxSig7._fix() for x in range(100000)]
+
+assert abs(round(sum(li) / len(li)) - 128 - test_offset) < 2
+
+= Test signal fuzzing offset 2 and scaling
+
+test_offset = 100
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        BEUnsignedSignalField("muxSig7", default=0, start=2, size=8, scaling=0.1, offset=test_offset),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+li = [pkt.muxSig7._fix() for x in range(100000)]
+
+assert abs(round(sum(li) / len(li)) - 12.8 - test_offset) < 2
+
+
+= Test signal fuzzing offset 3
+
+test_offset = -100
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        BESignedSignalField("muxSig7", default=0, start=2, size=8, scaling=1, offset=test_offset),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+li = [pkt.muxSig7._fix() for x in range(100000)]
+
+assert abs(round(sum(li) / len(li)) - test_offset) < 2
+
+= Test signal fuzzing offset 4 and scaling
+
+test_offset = 10
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        LESignedSignalField("muxSig7", default=0, start=2, size=8, scaling=10, offset=test_offset),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+li = [pkt.muxSig7._fix() for x in range(100000)]
+
+assert abs(round(sum(li) / len(li)) - test_offset) < 20
+
+
+= Test signal fuzzing offset 5 and scaling
+
+test_offset = 10
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        BESignedSignalField("muxSig7", default=0, start=2, size=8, scaling=0.271, offset=test_offset),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+li = [pkt.muxSig7._fix() for x in range(100000)]
+
+assert abs(round(sum(li) / len(li)) - test_offset) < 2
+
+
+= Test FloatSignal fuzzing 1
+#Test if fuzz function works.
+#Asserts are not really useful at the moment.
+
+class testFrame3(SignalPacket):
+    fields_desc = [
+        BEFloatSignalField("muxSig7", default=0, start=7, size=32),
+    ]
+
+pkt = testFrame3()
+pkt = fuzz(pkt)
+
+testlen = 10000
+
+li = [pkt.muxSig7._fix() for x in range(testlen)]
+gz = [x for x in li if math.isnan(x) == False and x > 0]
+lz = [x for x in li if math.isnan(x) == False and x < 0]
+nan = [x for x in li if math.isnan(x)]
+
+assert len(nan) > 0
+assert abs(len(gz) - len(lz)) < testlen // 50

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1686,6 +1686,11 @@ val = r._fix()
 assert r.min == -922337203685477585.8
 assert r.max == 922337203685477575.7
 
+= ScalingField signed randval long
+
+y = fuzz(x)
+assert bytes(y) != bytes(y)
+
 ############
 ############
 + BitExtendedField


### PR DESCRIPTION
This might be useful to dissect CAN communication which is
described by DBC files.

I've implemented SignalFields in a way that the can only used in a SignalPacket. This is because SignalFields can be described unordered and the Packet has to discard the correct amount of bytes after dissection.

Here are examples how this fields behave:

![](https://user-images.githubusercontent.com/4096406/57210659-c11efd80-6fdd-11e9-911a-a83a01420268.png)

![](https://user-images.githubusercontent.com/4096406/57210668-ca0fcf00-6fdd-11e9-8026-72942a0bee1b.png)

![](https://user-images.githubusercontent.com/4096406/57210704-e7449d80-6fdd-11e9-8dfc-e0a6c68a877b.png)

Here is the DBC file which described these fields: https://github.com/ebroecker/canmatrix/blob/development/src/canmatrix/tests/test_frame_decoding.dbc



