### PR TITLE
Fixed random generation for ScalingField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -25,7 +25,8 @@ from scapy.config import conf
 from scapy.dadict import DADict
 from scapy.volatile import RandBin, RandByte, RandEnumKeys, RandInt, \
     RandIP, RandIP6, RandLong, RandMAC, RandNum, RandShort, RandSInt, \
-    RandSByte, RandTermString, RandUUID, VolatileValue, RandSShort, RandSLong
+    RandSByte, RandTermString, RandUUID, VolatileValue, RandSShort, \
+    RandSLong, RandFloat
 from scapy.data import EPOCH
 from scapy.error import log_runtime, Scapy_Exception
 from scapy.compat import bytes_hex, chb, orb, plain_str, raw, bytes_encode
@@ -2316,7 +2317,7 @@ class ScalingField(Field):
             min_value = min(barrier1, barrier2)
             max_value = max(barrier1, barrier2)
 
-            return RandNum(min_value, max_value)
+            return RandFloat(min_value, max_value)
 
 
 class UUIDField(Field):

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -193,6 +193,11 @@ class RandNum(RandField):
         return other | self._fix()
 
 
+class RandFloat(RandNum):
+    def _fix(self):
+        return random.uniform(self.min, self.max)
+
+
 class RandNumGamma(RandNum):
     def __init__(self, alpha, beta):
         self.alpha = alpha

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1592,6 +1592,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -5.0
 assert r.max == 20.5
 
@@ -1606,6 +1607,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -30.5
 assert r.max == -5
 
@@ -1620,6 +1622,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -17.7
 assert r.max == 7.8
 
@@ -1634,6 +1637,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -17.8
 assert r.max == 7.7
 
@@ -1648,6 +1652,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -3281.8
 assert r.max == 3271.7
 
@@ -1662,6 +1667,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -214748369.8
 assert r.max == 214748359.7
 
@@ -1676,6 +1682,7 @@ class DebugPacket(Packet):
 x = DebugPacket()
 
 r = x.fields_desc[0].randval()
+val = r._fix()
 assert r.min == -922337203685477585.8
 assert r.max == 922337203685477575.7
 


### PR DESCRIPTION
This commit https://github.com/secdev/scapy/commit/5065917bb5f74161d650a765ae8b58c4b5127130#diff-cd215f0a012e58174f75a8fc054e35ceR2308 introduced a new bug.

I produced an independent test:
```python
ScalingField('data', 0, scaling=1.01).randval()._fix()
```
It fails after the linked commit. `RandNum` can only generate values for integers, not for floating values. And the linked commit removes the converting from float to integer.

### More examples:

#### Working
```python
ScalingField('data', 0, scaling=1).randval()._fix()
ScalingField('data', 0, scaling=1.0).randval()._fix()
ScalingField('data', 0, scaling=2.0).randval()._fix()
ScalingField('data', 0, scaling=3.0).randval()._fix()
ScalingField('data', 0, scaling=4.0).randval()._fix()
ScalingField('data', 0, scaling=4.8).randval()._fix()
ScalingField('data', 0, scaling=3.6).randval()._fix()
ScalingField('data', 0, scaling=2.4).randval()._fix()
```

#### Not Working
```python
ScalingField('data', 0, scaling=1.1).randval()._fix()
ScalingField('data', 0, scaling=2.5).randval()._fix()
ScalingField('data', 0, scaling=3.9).randval()._fix()
```

It works if the number behind the comma is even at the moment: (1.0, 1.2, 1.4, 1.6, 1.8)
But of course it should work for all numbers.

I added calls to `_fix()` to detect this error since the unit tests had not detected it before.

Instead of converting the values from integer to floats, I added the class `RandFloat` which can generate values for floating ranges with `random.uniform(min, max)`. Works with py2 and 3.

@polybassa 