### PR TITLE
Implemented ISOTPScan function and commandline utility 

### DIFF
--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -1888,6 +1888,12 @@ def ISOTPScan(sock, scan_range=range(0x7ff + 1), extended_addressing=False,
 
 
 def generate_text_output(found_packets):
+    """Generate a human readable output from the result of the `scan` or
+        the `scan_extended` function.
+
+        Args:
+                found_packets: result of the `scan` or `scan_extended` function
+    """
     if not found_packets:
         return "No packets found."
 
@@ -1925,6 +1931,14 @@ def generate_text_output(found_packets):
 
 
 def generate_code_output(found_packets, can_interface):
+    """Generate a copy&past-able output from the result of the `scan` or
+        the `scan_extended` function.
+
+        Args:
+                found_packets: result of the `scan` or `scan_extended` function
+                can_interface: description string for a CAN interface to be
+                                used for the creation of the output.
+    """
     result = ""
     if not found_packets:
         return result
@@ -1959,6 +1973,14 @@ def generate_code_output(found_packets, can_interface):
 
 
 def generate_isotp_list(found_packets, can_interface):
+    """Generate a list of ISOTPSocket objects from the result of the `scan` or
+        the `scan_extended` function.
+
+        Args:
+            found_packets: result of the `scan` or `scan_extended` function
+            can_interface: description string for a CAN interface to be
+                            used for the creation of the output.
+    """
     socket_list = []
     for pack in found_packets:
         extended_id = pack > 0x7ff

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -4,6 +4,7 @@
 # See http://www.secdev.org/projects/scapy for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Enrico Pozzobon <enricopozzobon@gmail.com>
+# Copyright (C) Alexander Schroeder <alexander1.schroeder@st.othr.de>
 # This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2)
@@ -34,10 +35,12 @@ from scapy.error import Scapy_Exception, warning, log_loading
 from scapy.supersocket import SuperSocket
 from scapy.config import conf
 from scapy.consts import LINUX
+from scapy.contrib.cansocket import PYTHON_CAN
 
 __all__ = ["ISOTP", "ISOTPHeader", "ISOTPHeaderEA", "ISOTP_SF", "ISOTP_FF",
            "ISOTP_CF", "ISOTP_FC", "ISOTPSniffer", "ISOTPSoftSocket",
-           "ISOTPSocket", "ISOTPSocketImplementation", "ISOTPMessageBuilder"]
+           "ISOTPSocket", "ISOTPSocketImplementation", "ISOTPMessageBuilder",
+           "ISOTPScan"]
 
 USE_CAN_ISOTP_KERNEL_MODULE = False
 if six.PY3 and LINUX:
@@ -1611,3 +1614,372 @@ if six.PY3 and LINUX:
 
 if USE_CAN_ISOTP_KERNEL_MODULE:
     ISOTPSocket = ISOTPNativeSocket
+
+
+# ###################################################################
+# #################### ISOTPSCAN ####################################
+# ###################################################################
+def send_multiple_ext(sock, ext_id, packet, number_of_packets):
+    """ Send multiple packets with extended addresses at once
+
+    Args:
+        sock: socket for can interface
+        ext_id: extended id. First id to send.
+        packet: packet to send
+        number_of_packets: number of packets send
+
+    This function is used for scanning with extended addresses.
+    It sends multiple packets at once. The number of packets
+    is defined in the number_of_packets variable.
+    It only iterates the extended ID, NOT the actual ID of the packet.
+    This method is used in extended scan function.
+    """
+    end_id = min(ext_id + number_of_packets, 255)
+    for i in range(ext_id, end_id + 1):
+        packet.extended_address = i
+        sock.send(packet)
+
+
+def get_isotp_packet(identifier=0x0, extended=False):
+    """ Craft ISO TP packet
+    Args:
+        identifier: identifier of crafted packet
+        extended: boolean if packet uses extended address
+    """
+
+    if extended:
+        pkt = ISOTPHeaderEA() / ISOTP_FF()
+        pkt.extended_address = 0
+        pkt.data = b'\x00\x00\x00\x00\x00'
+    else:
+        pkt = ISOTPHeader() / ISOTP_FF()
+        pkt.data = b'\x00\x00\x00\x00\x00\x00'
+
+    pkt.identifier = identifier
+    pkt.message_size = 100
+    return pkt
+
+
+def filter_periodic_packets(packet_dict, verbose=False):
+    """ Filter for periodic packets
+
+    Args:
+        packet_dict: Dictionary with Send-to-ID as key and a tuple
+                     (received packet, Recv_ID)
+        verbose: Displays further information
+
+    ISOTP-Filter for periodic packets (same ID, always same timegap)
+    Deletes periodic packets in packet_dict
+    """
+    filter_dict = {}
+
+    for key, value in packet_dict.items():
+        pkt = value[0]
+        idn = value[1]
+        if idn not in filter_dict:
+            filter_dict[idn] = ([key], [pkt])
+        else:
+            key_lst, pkt_lst = filter_dict[idn]
+            filter_dict[idn] = (key_lst + [key], pkt_lst + [pkt])
+
+    for idn in filter_dict:
+        key_lst = filter_dict[idn][0]
+        pkt_lst = filter_dict[idn][1]
+        if len(pkt_lst) < 3:
+            continue
+
+        tg = [p1.time - p2.time for p1, p2 in zip(pkt_lst[1:], pkt_lst[:-1])]
+        if all(abs(t1 - t2) < 0.001 for t1, t2 in zip(tg[1:], tg[:-1])):
+            if verbose:
+                print("[i] Identifier 0x%03x seems to be periodic. "
+                      "Filtered.")
+            for k in key_lst:
+                del packet_dict[k]
+
+
+def get_isotp_fc(id_value, id_list, noise_ids, extended, packet,
+                 verbose=False):
+    """Callback for sniff function when packet received
+
+    Args:
+            id_value: packet id of send packet
+            id_list: list of received IDs
+            noise_ids: list of packet IDs which will not be considered when
+                       received during scan
+            extended: boolean if extended scan
+            packet: received packet
+            verbose: displays information during scan
+
+    If received packet is a FlowControl
+    and not in noise_ids
+    append it to id_list
+    """
+    if packet.flags:
+        return
+
+    if noise_ids is not None and packet.identifier in noise_ids:
+        return
+
+    try:
+        index = 1 if extended else 0
+        isotp_pci = orb(packet.data[index]) >> 4
+        isotp_fc = orb(packet.data[index]) & 0x0f
+        if isotp_pci == 3 and 0 <= isotp_fc <= 2:
+            if verbose:
+                print("[+] Found flow-control frame from identifier 0x%03x"
+                      " when testing identifier 0x%03x" %
+                      (packet.identifier, id_value))
+            if isinstance(id_list, dict):
+                id_list[id_value] = (packet, packet.identifier)
+            elif isinstance(id_list, list):
+                id_list.append(id_value)
+            else:
+                raise TypeError("Unknown type of id_list")
+        else:
+            noise_ids.append(packet.identifier)
+    except Exception as e:
+        print("[!] Unknown message Exception: %s on packet: %s" %
+              (e, repr(packet)))
+
+
+def scan(sock, scan_range=range(0x800), noise_ids=None, sniff_time=0.1,
+         verbose=False):
+    """Scan and return dictionary of detections
+
+    Args:
+            sock: socket for can interface
+            scan_range: hexadecimal range of IDs to scan.
+                        Default is 0x0 - 0x7ff
+            noise_ids: list of packet IDs which will not be considered when
+                       received during scan
+            sniff_time: time the scan waits for isotp flow control responses
+                        after sending a first frame
+            verbose: displays information during scan
+
+    ISOTP-Scan - NO extended IDs
+    found_packets = Dictionary with Send-to-ID as
+    key and a tuple (received packet, Recv_ID)
+    """
+    return_values = dict()
+    for value in scan_range:
+        sock.sniff(prn=lambda pkt: get_isotp_fc(value, return_values,
+                                                noise_ids, False, pkt,
+                                                verbose),
+                   timeout=sniff_time,
+                   started_callback=lambda: sock.send(
+                       get_isotp_packet(value)))
+    return return_values
+
+
+def scan_extended(sock, scan_range=range(0x800), scan_block_size=100,
+                  noise_ids=None, sniff_time=0.1, verbose=False):
+    """Scan with extended addresses and return dictionary of detections
+
+    Args:
+            sock: socket for can interface
+            scan_range: hexadecimal range of IDs to scan.
+                        Default is 0x0 - 0x7ff
+            scan_block_size: count of packets send at once
+            noise_ids: list of packet IDs which will not be considered when
+                       received during scan
+            sniff_time: time the scan waits for isotp flow control responses
+                        after sending a first frame
+            verbose: displays information during scan
+
+    If an answer-packet found -> slow scan with
+    single packages with extended ID 0 - 255
+    found_packets = Dictionary with Send-to-ID
+    as key and a tuple (received packet, Recv_ID)
+    """
+
+    return_values = dict()
+    scan_block_size = scan_block_size or 1
+
+    for value in scan_range:
+        pkt = get_isotp_packet(value, extended=True)
+        id_list = []
+
+        for extended_id in range(0, 256, scan_block_size):
+            sock.sniff(prn=lambda p: get_isotp_fc(extended_id, id_list,
+                                                  noise_ids, True, p,
+                                                  verbose),
+                       timeout=sniff_time * 3,
+                       started_callback=send_multiple_ext(sock, extended_id,
+                                                          pkt,
+                                                          scan_block_size))
+            # sleep to prevent flooding
+            time.sleep(1)
+
+        # remove duplicate IDs
+        id_list = list(set(id_list))
+        for extended_id in id_list:
+            for ext_id in range(extended_id, min(extended_id +
+                                                 scan_block_size, 256)):
+                pkt.extended_address = ext_id
+                full_id = (value << 8) + ext_id
+                sock.sniff(prn=lambda pkt: get_isotp_fc(full_id,
+                                                        return_values,
+                                                        noise_ids, True,
+                                                        pkt, verbose),
+                           timeout=sniff_time,
+                           started_callback=lambda: sock.send(pkt))
+    return return_values
+
+
+def ISOTPScan(sock, scan_range=range(0x7ff + 1), extended_addressing=False,
+              noise_listen_time=2,
+              sniff_time=0.1,
+              output_format=None,
+              can_interface="can0",
+              verbose=False):
+
+    """Scan for ISOTP Sockets on a bus and return findings
+
+    Args:
+            sock: CANSocket object to communicate with the bus under scan
+            scan_range: hexadecimal range of CAN-Identifiers to scan.
+                        Default is 0x0 - 0x7ff
+            extended_addressing: scan with ISOTP extended addressing
+            noise_listen_time: seconds to listen for default
+                               communication on the bus
+            sniff_time: time the scan waits for isotp flow control responses
+                        after sending a first frame
+            output_format: defines the format of the returned
+                           results (text, code or sockets). Provide a string
+                           e.g. "text". Default is "socket".
+            can_interface: interface used to create the returned code/sockets
+            verbose: displays information during scan
+
+    Scan for ISOTP Sockets in the defined range and returns found sockets
+    in a specified format. The format can be:
+    text: human readable output
+    code: python code for copy&paste
+    sockets: if output format is not specified, ISOTPSockets will be
+             created and returned in a list
+    """
+
+    if verbose:
+        print("Filtering background noise...")
+
+    # Send dummy packet. In most cases, this triggers activity on the bus.
+    dummy_pkt = CAN(identifier=0x123,
+                    data=b'\xaa\xbb\xcc\xdd\xee\xff\xaa\xbb')
+
+    background_pkts = sock.sniff(timeout=noise_listen_time,
+                                 started_callback=lambda:
+                                 sock.send(dummy_pkt))
+
+    noise_ids = list(set(pkt.identifier for pkt in background_pkts))
+
+    if extended_addressing:
+        found_packets = scan_extended(sock, scan_range, noise_ids=noise_ids,
+                                      sniff_time=sniff_time, verbose=verbose)
+    else:
+        found_packets = scan(sock, scan_range, noise_ids=noise_ids,
+                             sniff_time=sniff_time, verbose=verbose)
+
+    filter_periodic_packets(found_packets, verbose)
+
+    if output_format == "text":
+        return generate_text_output(found_packets)
+    if output_format == "code":
+        return generate_code_output(found_packets, can_interface)
+    return generate_isotp_list(found_packets, can_interface)
+
+
+def generate_text_output(found_packets):
+    if not found_packets:
+        return "No packets found."
+
+    text = "\nFound %s ISOTP-FlowControl Packet(s):" % len(found_packets)
+    for pack in found_packets:
+        extended_id = pack > 0x7ff
+        if extended_id:
+            send_id = pack // 256
+            send_ext = pack - (send_id * 256)
+            ext_id = hex(orb(found_packets[pack][0].data[0]))
+            text += "\nSend to ID:             %s" \
+                    "\nSend to extended ID:    %s" \
+                    "\nReceived ID:            %s" \
+                    "\nReceived extended ID:   %s" \
+                    "\nMessage:                %s" % \
+                    (hex(send_id), hex(send_ext),
+                     hex(found_packets[pack][0].identifier), ext_id,
+                     repr(found_packets[pack][0]))
+        else:
+            text += "\nSend to ID:             %s" \
+                    "\nReceived ID:            %s" \
+                    "\nMessage:                %s" % \
+                    (hex(pack),
+                     hex(found_packets[pack][0].identifier),
+                     repr(found_packets[pack][0]))
+
+        padding = found_packets[pack][0].length == 8
+        if padding:
+            text += "\nPadding enabled"
+        else:
+            text += "\nNo Padding"
+
+        text += "\n"
+    return text
+
+
+def generate_code_output(found_packets, can_interface):
+    result = ""
+    if not found_packets:
+        return result
+
+    header = "\n\nimport can\n" \
+             "conf.contribs['CANSocket'] = {'use-python-can': %s}\n" \
+             "load_contrib('cansocket')\n" \
+             "load_contrib('isotp')\n\n" % PYTHON_CAN
+
+    for pack in found_packets:
+        extended_id = pack > 0x7ff
+        if extended_id:
+            send_id = pack // 256
+            send_ext = pack - (send_id * 256)
+            ext_id = orb(found_packets[pack][0].data[0])
+            result += "ISOTPSocket(%s, sid=%s, did=%s, padding=%s, " \
+                      "extended_addr=%s, extended_rx_addr=%s, " \
+                      "basecls=ISOTP)\n" % \
+                      (can_interface, hex(send_id),
+                       hex(int(found_packets[pack][0].identifier)),
+                       found_packets[pack][0].length == 8,
+                       hex(send_ext),
+                       hex(ext_id))
+
+        else:
+            result += "ISOTPSocket(%s, sid=%s, did=%s, padding=%s, " \
+                      "basecls=ISOTP)\n" % \
+                      (can_interface, hex(pack),
+                       hex(int(found_packets[pack][0].identifier)),
+                       found_packets[pack][0].length == 8)
+    return header + result
+
+
+def generate_isotp_list(found_packets, can_interface):
+    socket_list = []
+    for pack in found_packets:
+        extended_id = pack > 0x7ff
+        pkt = found_packets[pack][0]
+
+        dest_id = pkt.identifier
+        pad = True if pkt.length == 8 else False
+
+        if extended_id:
+            source_id = pack >> 8
+            source_ext = int(pack - (source_id * 256))
+            dest_ext = orb(pkt.data[0])
+            socket_list.append(ISOTPSocket(can_interface, sid=source_id,
+                                           extended_addr=source_ext,
+                                           did=dest_id,
+                                           extended_rx_addr=dest_ext,
+                                           padding=pad,
+                                           basecls=ISOTP))
+        else:
+            source_id = pack
+            socket_list.append(ISOTPSocket(can_interface, sid=source_id,
+                                           did=dest_id, padding=pad,
+                                           basecls=ISOTP))
+    return socket_list

--- a/scapy/tools/automotive/__init__.py
+++ b/scapy/tools/automotive/__init__.py
@@ -1,0 +1,8 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+# This program is published under a GPLv2 license
+
+"""
+Automotive related tools to be run separately
+"""

--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -1,0 +1,182 @@
+#! /usr/bin/env python
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+# Copyright (C) Alexander Schroeder <alexander1.schroeder@st.othr.de>
+# This program is published under a GPLv2 license
+
+from __future__ import print_function
+
+import getopt
+import sys
+
+import scapy.modules.six as six
+from scapy.config import conf
+from scapy.consts import LINUX
+
+if six.PY2 or not LINUX:
+    conf.contribs['CANSocket'] = {'use-python-can': True}
+
+from scapy.contrib.cansocket import CANSocket, PYTHON_CAN   # noqa: E402
+from scapy.contrib.isotp import ISOTPScan                   # noqa: E402
+
+
+def usage():
+    print('''usage:\tisotpscanner [-i interface] [-c channel] [-b bitrate]
+                [-n NOISE_LISTEN_TIME] [-t SNIFF_TIME] [-x|--extended]
+                [-C|--piso] [-v|--verbose] [-h|--help] [-s start] [-e end]\n
+    Scan for open ISOTP-Sockets.\n
+    required arguments:
+    -c, --channel         python-can channel or Linux SocketCAN interface name
+    -s, --start           Start scan at this identifier (hex)
+    -e, --end             End scan at this identifier (hex)\n
+    additional required arguments for WINDOWS or Python 2:
+    -i, --interface       python-can interface for the scan.
+                          Depends on used interpreter and system,
+                          see examples below. Any python-can interface can
+                          be provided. Please see:
+                          https://python-can.readthedocs.io for
+                          further interface examples.
+    -b, --bitrate         python-can bitrate.\n
+    optional arguments:
+    -h, --help            show this help message and exit
+    -n NOISE_LISTEN_TIME, --noise_listen_time NOISE_LISTEN_TIME
+                          Seconds listening for noise before scan.
+    -t SNIFF_TIME, --sniff_time SNIFF_TIME
+                          Duration in milliseconds a sniff is waiting for a
+                          flow-control response.
+    -x, --extended        Scan with ISOTP extended addressing.
+    -C, --piso            Print 'Copy&Paste'-ready ISOTPSockets.
+    -v, --verbose         Display information during scan.\n
+    Example of use:\n
+    Python2 or Windows:
+    python2 -m scapy.tools.automotive.isotpscanner --interface=pcan --channel=PCAN_USBBUS1 --bitrate=250000 --start 0 --end 100
+    python2 -m scapy.tools.automotive.isotpscanner --interface vector --channel 0 --bitrate 250000 --start 0 --end 100
+    python2 -m scapy.tools.automotive.isotpscanner --interface socketcan --channel=can0 --bitrate=250000 --start 0 --end 100 \n
+    Python3 on Linux:
+    python3 -m scapy.tools.automotive.isotpscanner --channel can0 --start 0 --end 100 \n''',  # noqa: E501
+          file=sys.stderr)
+
+
+def main():
+    extended = False
+    piso = False
+    verbose = False
+    sniff_time = 100
+    noise_listen_time = 2
+    start = None
+    end = None
+    channel = None
+    interface = None
+    bitrate = None
+
+    options = getopt.getopt(
+        sys.argv[1:],
+        'vxCt:n:i:c:b:s:e:h',
+        ['verbose', 'noise_listen_time=', 'sniff_time=', 'interface=', 'piso',
+         'channel=', 'bitrate=', 'start=', 'end=', 'help', 'extended'])
+
+    try:
+        for opt, arg in options[0]:
+            if opt in ('-v', '--verbose'):
+                verbose = True
+            elif opt in ('-x', '--extended'):
+                extended = True
+            elif opt in ('-C', '--piso'):
+                piso = True
+            elif opt in ('-h', '--help'):
+                usage()
+                sys.exit(-1)
+            elif opt in ('-t', '--sniff_time'):
+                sniff_time = int(arg)
+            elif opt in ('-n', '--noise_listen_time'):
+                noise_listen_time = int(arg)
+            elif opt in ('-i', '--interface'):
+                interface = arg
+            elif opt in ('-c', '--channel'):
+                channel = arg
+            elif opt in ('-b', '--bitrate'):
+                bitrate = int(arg)
+            elif opt in ('-s', '--start'):
+                start = int(arg, 16)
+            elif opt in ('-e', '--end'):
+                end = int(arg, 16)
+    except getopt.GetoptError as msg:
+        usage()
+        print("ERROR:", msg, file=sys.stderr)
+        raise SystemExit
+
+    if PYTHON_CAN:
+        if start is None or \
+                end is None or \
+                channel is None or \
+                bitrate is None or \
+                interface is None:
+            usage()
+            print("\nPlease provide all required arguments.\n",
+                  file=sys.stderr)
+            sys.exit(-1)
+    else:
+        if start is None or \
+                end is None or \
+                channel is None:
+            usage()
+            print("\nPlease provide all required arguments.\n",
+                  file=sys.stderr)
+            sys.exit(-1)
+
+    if end >= 0x800:
+        print("end must be < 0x800.", file=sys.stderr)
+        sys.exit(-1)
+
+    if end < start:
+        print("start must be smaller than end.", file=sys.stderr)
+        sys.exit(-1)
+
+    if PYTHON_CAN:
+        import can
+        try:
+            can.rc['interface'] = interface
+            can.rc['channel'] = channel
+            can.rc['bitrate'] = bitrate
+            scan_interface = can.interface.Bus()
+            interface_string = "CANSocket(iface=can.interface.Bus(bustype=" \
+                               "'%s', channel='%s', bitrate=%d))" % \
+                               (interface, channel, bitrate)
+        except Exception as e:
+            usage()
+            print("\nCheck python-can interface assignment.\n",
+                  file=sys.stderr)
+            print(e, file=sys.stderr)
+            sys.exit(-1)
+    else:
+        scan_interface = channel
+        interface_string = "\"%s\"" % channel
+
+    try:
+        sock = CANSocket(iface=scan_interface)
+    except Exception as e:
+        usage()
+        print("\nSocket couldn't be created. Check your arguments.\n",
+              file=sys.stderr)
+        print(e, file=sys.stderr)
+        sys.exit(-1)
+
+    if verbose:
+        print("Start scan (%s - %s)" % (hex(start), hex(end)))
+
+    result = ISOTPScan(sock,
+                       range(start, end + 1),
+                       extended_addressing=extended,
+                       noise_listen_time=noise_listen_time,
+                       sniff_time=float(sniff_time) / 1000,
+                       output_format="code" if piso else "text",
+                       can_interface=interface_string,
+                       verbose=verbose)
+
+    print("Scan: \n%s" % result)
+
+
+if __name__ == '__main__':
+    main()

--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import getopt
 import sys
+import signal
 
 import scapy.modules.six as six
 from scapy.config import conf
@@ -20,6 +21,11 @@ if six.PY2 or not LINUX:
 
 from scapy.contrib.cansocket import CANSocket, PYTHON_CAN   # noqa: E402
 from scapy.contrib.isotp import ISOTPScan                   # noqa: E402
+
+
+def signal_handler(sig, frame):
+    print('Interrupting scan!')
+    sys.exit(0)
 
 
 def usage():
@@ -165,6 +171,8 @@ def main():
 
     if verbose:
         print("Start scan (%s - %s)" % (hex(start), hex(end)))
+
+    signal.signal(signal.SIGINT, signal_handler)
 
     result = ISOTPScan(sock,
                        range(start, end + 1),

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -23,7 +23,6 @@ import struct
 import array
 import subprocess
 import tempfile
-import threading
 
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
@@ -1908,31 +1907,3 @@ def whois(ip_address):
         else:
             break
     return b"\n".join(lines[3:])
-
-#######################
-#   PERIODIC SENDER   #
-#######################
-
-
-class PeriodicSenderThread(threading.Thread):
-    def __init__(self, sock, pkt, interval=0.5):
-        """ Thread to send packets periodically
-
-        Args:
-            sock: socket where packet is sent periodically
-            pkt: packet to send
-            interval: interval between two packets
-        """
-        self._pkt = pkt
-        self._socket = sock
-        self._stopped = threading.Event()
-        self.keep_awake_interval = interval
-        threading.Thread.__init__(self)
-
-    def run(self):
-        while not self._stopped.is_set():
-            self._socket.send(self._pkt)
-            time.sleep(self.keep_awake_interval)
-
-    def stop(self):
-        self._stopped.set()

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -23,6 +23,7 @@ import struct
 import array
 import subprocess
 import tempfile
+import threading
 
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
@@ -1907,3 +1908,31 @@ def whois(ip_address):
         else:
             break
     return b"\n".join(lines[3:])
+
+#######################
+#   PERIODIC SENDER   #
+#######################
+
+
+class PeriodicSenderThread(threading.Thread):
+    def __init__(self, sock, pkt, interval=0.5):
+        """ Thread to send packets periodically
+
+        Args:
+            sock: socket where packet is sent periodically
+            pkt: packet to send
+            interval: interval between two packets
+        """
+        self._pkt = pkt
+        self._socket = sock
+        self._stopped = threading.Event()
+        self.keep_awake_interval = interval
+        threading.Thread.__init__(self)
+
+    def run(self):
+        while not self._stopped.is_set():
+            self._socket.send(self._pkt)
+            time.sleep(self.keep_awake_interval)
+
+    def stop(self):
+        self._stopped.set()

--- a/test/configs/linux.utsc
+++ b/test/configs/linux.utsc
@@ -2,6 +2,7 @@
   "testfiles": [
     "test/*.uts",
     "test/contrib/*.uts",
+    "test/tools/*.uts",
     "test/tls/tests_tls_netaccess.uts"
   ],
   "remove_testfiles": [

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -7,7 +7,6 @@
 ~ conf
 
 = Imports
-~ conf
 
 load_layer("can")
 import threading, time, six, subprocess
@@ -16,11 +15,9 @@ from subprocess import call
 
 
 = Definition of constants, utility functions and mock classes
-~ conf
 
 iface0 = "vcan0"
 iface1 = "vcan1"
-
 
 class MockCANSocket(SuperSocket):
     nonblocking_socket = True
@@ -72,7 +69,7 @@ def exit_if_no_isotp_module():
 
 
 = Initialize a virtual CAN interface
-~ needs_root linux conf
+~ needs_root linux
 if 0 != call("cansend %s 000#" % iface0, shell=True):
     # vcan0 is not enabled
     if 0 != call("sudo modprobe vcan", shell=True):
@@ -127,8 +124,8 @@ def drain_bus(iface=iface0, assert_empty=True):
 print("CAN sockets should work now")
 
 
-# Verify that a CAN socket can be created and closed
-~ conf linux needs_root
+= Verify that a CAN socket can be created and closed
+~ linux needs_root
 s = new_can_socket(iface0)
 s.close()
 

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -1,0 +1,594 @@
+% ISOTPScan Tests
+~ vcan_socket linux needs_root
+* Tests for ISOTPScan
+
++ Configuration
+~ conf
+
+= Imports
+
+load_layer("can")
+import threading, time, six, subprocess
+from subprocess import call
+from scapy.contrib.isotp import send_multiple_ext, filter_periodic_packets, scan, scan_extended
+
+= Definition of constants, utility functions
+
+iface0 = "vcan0"
+iface1 = "vcan1"
+
+# function to exit when the can-isotp kernel module is not available
+ISOTP_KERNEL_MODULE_AVAILABLE = False
+def exit_if_no_isotp_module():
+    if not ISOTP_KERNEL_MODULE_AVAILABLE:
+        err = "TEST SKIPPED: can-isotp not available"
+        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        warning("Can't test ISOTP native socket because kernel module is not loaded")
+        exit(0)
+
+
+= Initialize a virtual CAN interface
+if 0 != call("cansend %s 000#" % iface0, shell=True):
+    # vcan0 is not enabled
+    if 0 != call("sudo modprobe vcan", shell=True):
+        raise Exception("modprobe vcan failed")
+    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+        print("add %s failed: Maybe it was already up?" % iface0)
+    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+        raise Exception("could not bring up %s" % iface0)
+
+if 0 != call("cansend %s 000#" % iface0, shell=True):
+    raise Exception("cansend doesn't work")
+
+if 0 != call("cansend %s 000#" % iface1, shell=True):
+    # vcan1 is not enabled
+    if 0 != call("sudo modprobe vcan", shell=True):
+        raise Exception("modprobe vcan failed")
+    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+        print("add %s failed: Maybe it was already up?" % iface1)
+    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+        raise Exception("could not bring up %s" % iface1)
+
+if 0 != call("cansend %s 000#" % iface1, shell=True):
+    raise Exception("cansend doesn't work")
+
+print("CAN should work now")
+
+
+= Import CANSocket
+
+if six.PY3:
+    from scapy.contrib.cansocket_native import *
+else:
+    from scapy.contrib.cansocket_python_can import *
+
+
+if "python_can" in CANSocket.__module__:
+    import can as python_can
+    new_can_socket = lambda iface: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface, bitrate=250000))
+    new_can_socket0 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface0, bitrate=250000), timeout=0.01)
+    new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface1, bitrate=250000), timeout=0.01)
+else:
+    new_can_socket = lambda iface: CANSocket(iface)
+    new_can_socket0 = lambda: CANSocket(iface0)
+    new_can_socket1 = lambda: CANSocket(iface1)
+
+# utility function for draining a can interface, asserting that no packets are there
+def drain_bus(iface=iface0, assert_empty=True):
+    s = new_can_socket(iface)
+    pkts = s.sniff(timeout=0.1)
+    if assert_empty:
+        assert len(pkts) == 0
+    s.close()
+
+print("CAN sockets should work now")
+
+
+= Verify that a CAN socket can be created and closed
+s = new_can_socket0()
+s.close()
+
+
+= Check if can-isotp and can-utils are installed on this system
+p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout=subprocess.PIPE, shell=True)
+if p.wait() == 0:
+    if b"can_isotp" in p.stdout.read():
+        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin=subprocess.PIPE, shell=True)
+        p.stdin.write(b"01")
+        p.stdin.close()
+        r = p.wait()
+        if r == 0:
+            ISOTP_KERNEL_MODULE_AVAILABLE = True
+
+
++ Syntax check
+
+= Import isotp
+if not ISOTP_KERNEL_MODULE_AVAILABLE:
+    conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': False}
+else:
+    conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': True}
+
+
+load_contrib("isotp")
+
+
+= Test send_multiple_ext()
+pkt = ISOTPHeaderEA(identifier=0x100, extended_address=1)/ISOTP_FF(message_size=100, data=b'\x00\x00\x00\x00\x00')
+number_of_packets = 100
+
+drain_bus(iface0)
+def sender():
+    send_multiple_ext(new_can_socket0(), 0, pkt, number_of_packets)
+
+thread = threading.Thread(target=sender)
+pkts = new_can_socket0().sniff(timeout=4, count=number_of_packets, started_callback=thread.start)
+thread.join()
+assert len(pkts) == number_of_packets
+
+
+= Test filter_periodic_packets() with periodic packets
+pkt = CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+received_packets = dict()
+for i in range(40):
+    temp_pkt = pkt.copy()
+    temp_pkt.time = i / 1000
+    received_packets[i] = (temp_pkt, temp_pkt.identifier)
+
+filter_periodic_packets(received_packets)
+assert len(received_packets) == 0
+
+
+= Test filter_periodic_packets() with periodic packets and one outlier
+outlier = CAN(identifier=300, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+outlier.time = 50 / 1000
+
+pkt = CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+received_packets = dict()
+for i in range(40):
+    temp_pkt = pkt.copy()
+    temp_pkt.time = i / 1000
+    received_packets[i] = (temp_pkt, temp_pkt.identifier)
+
+received_packets[40] = (outlier, outlier.identifier)
+
+filter_periodic_packets(received_packets)
+assert len(received_packets) == 1
+
+
+= Test filter_periodic_packets() with nonperiodic packets
+pkt = CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+received_packets = dict()
+for i in range(40):
+    temp_pkt = pkt.copy()
+    temp_pkt.time = (i * i) / 1000
+    received_packets[i] = (temp_pkt, temp_pkt.identifier)
+
+filter_periodic_packets(received_packets)
+assert len(received_packets) == 40
+
+= Test scan()
+drain_bus(iface0)
+def isotpserver(idx):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+idx, did=0x600+idx) as sock:
+        sock.sniff(timeout=100 ,count=1)
+
+listen_sockets = list()
+for i in range(1, 4):
+    listen_sockets.append(threading.Thread(target=isotpserver, args=[i]))
+    listen_sockets[-1].start()
+
+found_packets = scan(new_can_socket0(), range(0x5ff, 0x610), noise_ids=[0x701], sniff_time=0.1)
+assert 0 == subprocess.call(['cansend', iface0, '601#01aa'])
+assert 0 == subprocess.call(['cansend', iface0, '602#01aa'])
+assert 0 == subprocess.call(['cansend', iface0, '603#01aa'])
+
+for thread in listen_sockets:
+    thread.join()
+
+assert len(found_packets) == 2
+
+
+= Test scan_extended()
+recvpacket = CAN(flags=0, identifier=0x700, length=4, data=b'\xaa0\x00\x00')
+
+drain_bus(iface0)
+def isotpserver():
+    with ISOTPSocket(new_can_socket0(), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1)
+
+thread = threading.Thread(target=isotpserver)
+thread.start()
+time.sleep(0.1)
+found_packets = scan_extended(new_can_socket0(), [0x601], sniff_time=0.1)
+assert 0 == subprocess.call(['cansend', 'vcan0', '601#BB01aa'])
+thread.join()
+fpkt = found_packets[list(found_packets.keys())[0]][0]
+rpkt = recvpacket
+
+assert fpkt.length == rpkt.length
+assert fpkt.data == rpkt.data
+assert fpkt.identifier == rpkt.identifier
+
+
+= Test ISOTPScan(output_format=text)
+done = False
+
+drain_bus(iface0)
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    global done
+    while not done:
+        new_can_socket0().send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=(pkt))
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), output_format="text", noise_listen_time=1, sniff_time=0.1)
+assert 0 == subprocess.call(['cansend', 'vcan0', '601#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '602#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '603#01aa'])
+thread1.join()
+thread2.join()
+done = True
+thread_noise.join()
+
+text = "\nFound 2 ISOTP-FlowControl Packet(s):"
+assert text in result
+assert "0x602" in result
+assert "0x603" in result
+assert "0x702" in result
+assert "0x703" in result
+assert "No Padding" in result
+
+
+= Test ISOTPScan(output_format=code)
+done = False
+
+drain_bus(iface0)
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    global done
+    while not done:
+        new_can_socket0().send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), output_format="code", noise_listen_time=1, sniff_time=0.1)
+assert 0 == subprocess.call(['cansend', 'vcan0', '601#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '602#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '603#01aa'])
+thread1.join()
+thread2.join()
+done = True
+thread_noise.join()
+
+s1 = "ISOTPSocket(can0, sid=0x602, did=0x702, padding=False, basecls=ISOTP)\n"
+s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, padding=False, basecls=ISOTP)\n"
+
+print(result)
+assert s1 in result
+assert s2 in result
+
+
+= Test extended ISOTPScan(output_format=code)
+drain_bus(iface0)
+
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code")
+
+assert 0 == subprocess.call(['cansend', 'vcan0', '602#2201aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '603#2201aa'])
+thread1.join()
+thread2.join()
+thread_noise.join()
+
+s1 = "ISOTPSocket(can0, sid=0x602, did=0x702, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
+s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
+print(result)
+assert s1 in result
+assert s2 in result
+
+
+= Test ISOTPScan(output_format=None)
+drain_bus(iface0)
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+result = sorted(result, key=lambda x:x.src)
+
+assert 0 == subprocess.call(['cansend', 'vcan0', '601#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '602#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '603#01aa'])
+thread1.join()
+thread2.join()
+thread_noise.join()
+
+assert len(result) == 2
+assert 0x602 == result[0].src
+assert 0x702 == result[0].dst
+assert 0x603 == result[1].src
+assert 0x703 == result[1].dst
+
+for s in result:
+    # This helps to close ISOTPSoftSockets
+    assert 0 == subprocess.call(['cansend', 'vcan0', '702#01aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '703#01aa'])
+    s.close()
+    assert 0 == subprocess.call(['cansend', 'vcan0', '702#01aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '703#01aa'])
+
+for s in result:
+    del s
+
+
+= Test ISOTPScan(output_format=None) 2
+drain_bus(iface0)
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[9])
+thread2 = threading.Thread(target=isotpserver, args=[8])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x6A0), can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+result = sorted(result, key=lambda x:x.src)
+
+assert 0 == subprocess.call(['cansend', 'vcan0', '609#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '608#01aa'])
+
+thread1.join()
+thread2.join()
+thread_noise.join()
+
+assert len(result) == 2
+assert 0x608 == result[0].src
+assert 0x708 == result[0].dst
+assert 0x609 == result[1].src
+assert 0x709 == result[1].dst
+
+for s in result:
+    # This helps to close ISOTPSoftSockets
+    assert 0 == subprocess.call(['cansend', 'vcan0', '709#01aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '708#01aa'])
+    s.close()
+    assert 0 == subprocess.call(['cansend', 'vcan0', '709#01aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '708#01aa'])
+
+for s in result:
+    del s
+
+
+= Test extended ISOTPScan(output_format=None)
+drain_bus(iface0)
+
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), extended_addressing=True, can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+result = sorted(result, key=lambda x:x.src)
+
+assert 0 == subprocess.call(['cansend', 'vcan0', '602#2201aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '603#2201aa'])
+thread1.join()
+thread2.join()
+thread_noise.join()
+
+assert len(result) == 2
+assert 0x602 == result[0].src
+assert 0x702 == result[0].dst
+assert 0x22 == result[0].exsrc
+assert 0x11 == result[0].exdst
+assert 0x603 == result[1].src
+assert 0x703 == result[1].dst
+assert 0x22 == result[1].exsrc
+assert 0x11 == result[1].exdst
+
+for s in result:
+    # This helps to close ISOTPSoftSockets
+    assert 0 == subprocess.call(['cansend', 'vcan0', '702#1101aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '703#1101aa'])
+    s.close()
+    assert 0 == subprocess.call(['cansend', 'vcan0', '702#1101aa'])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '703#1101aa'])
+
+for s in result:
+    del s
+
+= Test ISOTPScan(output_format=None) random IDs
+drain_bus(iface0)
+
+rnd = RandNum(0x0, 0x100)
+
+ids = set(rnd._fix() for _ in range(10))
+
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x100+i, did=i) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+threads = [threading.Thread(target=isotpserver, args=[x]) for x in ids]
+_ = [t.start() for t in threads]
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x000, 0x101), can_interface=new_can_socket0(), noise_listen_time=1, sniff_time=0.1, verbose=True)
+result = sorted(result, key=lambda x:x.src)
+
+for i in ids:
+    ret = subprocess.call(['cansend', 'vcan0', '%03x#01aa' % i])
+    assert ret == 0
+
+_ = [t.join() for t in threads]
+thread_noise.join()
+
+assert len(result) == len(ids)
+ids = sorted(ids)
+for i, s in zip(ids, result):
+    assert i == s.src
+    assert i+0x100 == s.dst
+
+for s in result:
+    # This helps to close ISOTPSoftSockets
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.dst])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.src])
+    s.close()
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.dst])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.src])
+    time.sleep(0.1)
+
+for s in result:
+    del s
+
+
+= Test ISOTPScan(output_format=None) random IDs padding
+drain_bus(iface0)
+
+rnd = RandNum(0x0, 0x100)
+
+ids = set(rnd._fix() for _ in range(10))
+
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x100+i, did=i, padding=True) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+threads = [threading.Thread(target=isotpserver, args=[x]) for x in ids]
+_ = [t.start() for t in threads]
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x000, 0x101), can_interface=new_can_socket0(), noise_listen_time=1, sniff_time=0.1, verbose=True)
+result = sorted(result, key=lambda x:x.src)
+
+for i in ids:
+    ret = subprocess.call(['cansend', 'vcan0', '%03x#01aa' % i])
+    assert ret == 0
+
+_ = [t.join() for t in threads]
+thread_noise.join()
+
+assert len(result) == len(ids)
+ids = sorted(ids)
+for i, s in zip(ids, result):
+    assert i == s.src
+    assert i+0x100 == s.dst
+    if isinstance(s, ISOTPSoftSocket):
+        assert s.impl.padding == True
+
+for s in result:
+    # This helps to close ISOTPSoftSockets
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.dst])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.src])
+    s.close()
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.dst])
+    assert 0 == subprocess.call(['cansend', 'vcan0', '%03x#01aa' % s.src])
+    time.sleep(0.1)
+
+for s in result:
+    del s
+

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -1,0 +1,263 @@
+% Regression tests for isotpscanner
+~ vcan_socket needs_root linux
+
+
++ Configuration
+~ conf
+
+= Imports
+load_layer("can")
+import threading, time, six, subprocess, sys
+from subprocess import call
+
+
+= Definition of constants, utility functions and mock classes
+iface0 = "vcan0"
+iface1 = "vcan1"
+
+# function to exit when the can-isotp kernel module is not available
+ISOTP_KERNEL_MODULE_AVAILABLE = False
+def exit_if_no_isotp_module():
+    if not ISOTP_KERNEL_MODULE_AVAILABLE:
+        err = "TEST SKIPPED: can-isotp not available"
+        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        warning("Can't test ISOTP native socket because kernel module is not loaded")
+        exit(0)
+
+
+= Initialize a virtual CAN interface
+if 0 != call("cansend %s 000#" % iface0, shell=True):
+    # vcan0 is not enabled
+    if 0 != call("sudo modprobe vcan", shell=True):
+        raise Exception("modprobe vcan failed")
+    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+        print("add %s failed: Maybe it was already up?" % iface0)
+    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+        raise Exception("could not bring up %s" % iface0)
+
+if 0 != call("cansend %s 000#" % iface0, shell=True):
+    raise Exception("cansend doesn't work")
+
+if 0 != call("cansend %s 000#" % iface1, shell=True):
+    # vcan1 is not enabled
+    if 0 != call("sudo modprobe vcan", shell=True):
+        raise Exception("modprobe vcan failed")
+    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+        print("add %s failed: Maybe it was already up?" % iface1)
+    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+        raise Exception("could not bring up %s" % iface1)
+
+if 0 != call("cansend %s 000#" % iface1, shell=True):
+    raise Exception("cansend doesn't work")
+
+print("CAN should work now")
+
+
+if six.PY3:
+    from scapy.contrib.cansocket_native import *
+else:
+    from scapy.contrib.cansocket_python_can import *
+
+
+if "python_can" in CANSocket.__module__:
+    import can as python_can
+    new_can_socket = lambda iface: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface, bitrate=250000))
+    new_can_socket0 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface0, bitrate=250000), timeout=0.01)
+    new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='socketcan', channel=iface1, bitrate=250000), timeout=0.01)
+    can_socket_string = "-i socketcan -c %s -b 250000" % iface0
+else:
+    new_can_socket = lambda iface: CANSocket(iface)
+    new_can_socket0 = lambda: CANSocket(iface0)
+    new_can_socket1 = lambda: CANSocket(iface1)
+    can_socket_string = "-c %s" % iface0
+
+# utility function for draining a can interface, asserting that no packets are there
+def drain_bus(iface=iface0, assert_empty=True):
+    s = new_can_socket(iface)
+    pkts = s.sniff(timeout=0.1)
+    if assert_empty:
+        assert len(pkts) == 0
+    s.close()
+
+print("CAN sockets should work now")
+
+
+= Verify that a CAN socket can be created and closed
+s = new_can_socket(iface0)
+s.close()
+
+
+= Check if can-isotp and can-utils are installed on this system
+p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout=subprocess.PIPE, shell=True)
+if p.wait() == 0:
+    if b"can_isotp" in p.stdout.read():
+        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin=subprocess.PIPE, shell=True)
+        p.stdin.write(b"01")
+        p.stdin.close()
+        r = p.wait()
+        if r == 0:
+            ISOTP_KERNEL_MODULE_AVAILABLE = True
+
+
++ Syntax check
+
+= Import isotp
+conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': False}
+load_contrib("isotp")
+
+
++ Usage tests
+
+= Test wrong usage
+print(sys.executable)
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+returncode = result.wait()
+
+std_out, std_err = result.communicate()
+if returncode:
+    print(std_out)
+    print(std_err)
+
+assert returncode != 0
+
+expected_output = plain_str(b'usage:')
+assert expected_output in plain_str(std_err)
+
+
+= Test show help
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py --help" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+if result.wait() == 0:
+    std_out, std_err = result.communicate()
+    assert std_err == None
+    expected_output = plain_str(b'Scan for open ISOTP-Sockets.')
+    print(std_out)
+    assert expected_output in plain_str(std_out)
+
+
+= Test wrong socket for Python2 or Windows
+if six.PY2:
+    version = subprocess.Popen("python --version", stdout=subprocess.PIPE, shell=True)
+    if 0 == version.wait():
+        print(version.communicate())
+    result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -c vcan0 -s 0x600 -e 0x600" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    if result.wait() == 0:
+        expected_output = plain_str(b'Wrong interface')
+        std_out, std_err = result.communicate()
+        assert std_err == None
+        print(std_out)
+        print(expected_output)
+        assert expected_output in plain_str(std_out)
+
+
+= Test Python2 call
+
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -i socketcan -c vcan0 -b 250000 -s 0x600 -e 0x600 -v" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+returncode = result.wait()
+print(returncode)
+assert returncode == 0
+expected_output = plain_str(b'Start scan')
+std_out, std_err = result.communicate()
+print(std_out)
+print(expected_output)
+assert expected_output in plain_str(std_out)
+
+
++ Scan tests
+
+= Test standard scan
+drain_bus(iface0)
+
+def isotpserver():
+    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600) as s:
+        s.sniff(timeout=100, count=1)
+
+sniffer = threading.Thread(target=isotpserver)
+sniffer.start()
+time.sleep(0.1)
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x600 -e 0x600" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+returncode = result.wait()
+std_out, std_err = result.communicate()
+
+print(std_out)
+print(std_err)
+
+send = subprocess.Popen(['cansend', 'vcan0', '600#01aa'])
+assert 0 == send.wait()
+assert returncode == 0
+
+expected_output = [b'0x600', b'0x700']
+print(std_out)
+for out in expected_output:
+    assert plain_str(out) in plain_str(std_out)
+
+
+= Test extended scan
+drain_bus(iface0)
+def isotpserver():
+    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1)
+
+sniffer = threading.Thread(target=isotpserver)
+sniffer.start()
+time.sleep(0.1)
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+returncode = result.wait()
+
+send = subprocess.Popen(['cansend', 'vcan0', '601#BB01aa'])
+assert 0 == send.wait()
+assert returncode == 0
+
+expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
+std_out, std_err = result.communicate()
+assert std_err == None
+print(std_out)
+for out in expected_output:
+    assert plain_str(out) in plain_str(std_out)
+
+
+= Test extended only scan
+drain_bus(iface0)
+def isotpserver():
+    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1)
+
+sniffer = threading.Thread(target=isotpserver)
+sniffer.start()
+time.sleep(0.1)
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+returncode = result.wait()
+
+send = subprocess.Popen(['cansend', 'vcan0', '601#BB01aa'])
+assert 0 == send.wait()
+assert returncode == 0
+
+expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
+std_out, std_err = result.communicate()
+assert std_err == None
+print(std_out)
+for out in expected_output:
+    assert plain_str(out) in plain_str(std_out)
+
+
+= Test scan with piso flag
+drain_bus(iface0)
+def isotpserver():
+    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1)
+
+sniffer = threading.Thread(target=isotpserver)
+sniffer.start()
+time.sleep(0.1)
+result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x -C" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+returncode = result.wait()
+
+send = subprocess.Popen(['cansend', 'vcan0', '601#BB01aa'])
+assert 0 == send.wait()
+assert returncode == 0
+
+expected_output = [b'sid=0x601', b'did=0x700', b'padding=False', b'extended_addr=0xbb', b'extended_rx_addr=0xaa']
+std_out, std_err = result.communicate()
+assert std_err == None
+print(std_out)
+for out in expected_output:
+    assert plain_str(out) in plain_str(std_out)


### PR DESCRIPTION
This PR adds a functionality to scan for ISOTP-Sockets in CAN-networks. The function `ISOTPScan` can be used from a interpreter session. A command-line utility allows the access to this scanner from a terminal. 