### PR TITLE
Fix imports order to make sure AM commands work

### DIFF
--- a/scapy/all.py
+++ b/scapy/all.py
@@ -31,7 +31,6 @@ from scapy.supersocket import *
 from scapy.volatile import *
 from scapy.as_resolvers import *
 
-from scapy.ansmachine import *
 from scapy.automaton import *
 from scapy.autorun import *
 
@@ -51,3 +50,5 @@ from scapy.scapypipes import *
 if conf.ipv6_enabled:  # noqa: F405
     from scapy.utils6 import *  # noqa: F401
     from scapy.route6 import *  # noqa: F401
+
+from scapy.ansmachine import *


### PR DESCRIPTION
Commands created by sub-classing `AnsweringMachine` with a non-empty `function_name` class attribute currently do not exist in Scapy shell (or in Python after `from scapy.all import *` statements).

This can be fixed by changing the imports order in `scapy/all.py`.