### PR TITLE
Update dead link in extending.rst

### DIFF
--- a/doc/scapy/extending.rst
+++ b/doc/scapy/extending.rst
@@ -57,7 +57,7 @@ Here is another tool that will constantly monitor all interfaces on a machine an
     
     sniff(prn=arp_monitor_callback, filter="arp", store=0)
 
-For a real life example, you can check `Wifitap <http://sid.rstack.org/static/articles/w/i/f/Wifitap_EN_9613.html>`_.
+For a real life example, you can check `Wifitap <https://github.com/gdssecurity/wifitap/>`_.
 
 
 Extending Scapy with add-ons

--- a/doc/scapy/extending.rst
+++ b/doc/scapy/extending.rst
@@ -57,7 +57,7 @@ Here is another tool that will constantly monitor all interfaces on a machine an
     
     sniff(prn=arp_monitor_callback, filter="arp", store=0)
 
-For a real life example, you can check `Wifitap <https://github.com/gdssecurity/wifitap/>`_.
+For a real life example, you can check `Wifitap <https://github.com/gdssecurity/wifitap/>`_. Sadly, Wifitap is no longer maintained but nonetheless demonstrates Scapy's Wi-Fi capabilities.
 
 
 Extending Scapy with add-ons

--- a/doc/scapy/extending.rst
+++ b/doc/scapy/extending.rst
@@ -57,7 +57,7 @@ Here is another tool that will constantly monitor all interfaces on a machine an
     
     sniff(prn=arp_monitor_callback, filter="arp", store=0)
 
-For a real life example, you can check `Wifitap <https://github.com/gdssecurity/wifitap/>`_. Sadly, Wifitap is no longer maintained but nonetheless demonstrates Scapy's Wi-Fi capabilities.
+For a real life example, you can check `Wifitap <https://github.com/gdssecurity/wifitap/>`_. `[original archive] <https://web.archive.org/web/20180309055843/http://sid.rstack.org/static/articles/w/i/f/Wifitap_EN_9613.html>`_ Sadly, Wifitap is no longer maintained but nonetheless demonstrates Scapy's Wi-Fi capabilities.
 
 
 Extending Scapy with add-ons


### PR DESCRIPTION
> brief description what this PR will do, e.g. fixes broken dissection of XXX

### Improve Documentation

Reading over the docs, the link to [Wifitap](http://sid.rstack.org/static/articles/w/i/f/Wifitap_EN_9613.html) is dead. I found Wifitap's GitHub [repo](https://github.com/gdssecurity/wifitap/) and replaced the link with it. 
