### PR TITLE
Update install.sh

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -26,10 +26,10 @@ then
 fi
 
 # Check pip
-sudo pip install --upgrade pip setuptools
+sudo pip install --upgrade pip setuptools --ignore-installed
 
 # Make sure tox is installed and up to date
-pip install -U tox
+pip install -U tox --ignore-installed
 
 # Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
 set


### PR DESCRIPTION
This should ignore the failures on Python 3.4 and install tox anyway