### PR TITLE
Parse WEP frames when cryptography is not available

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1050,11 +1050,10 @@ class Dot11WEP(Dot11Encrypted):
                    StrField("wepdata", None, remain=4),
                    IntField("icv", None)]
 
-    @crypto_validator
     def decrypt(self, key=None):
         if key is None:
             key = conf.wepkey
-        if key:
+        if key and conf.crypto_valid:
             d = Cipher(
                 algorithms.ARC4(self.iv + key.encode("utf8")),
                 None,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1034,6 +1034,12 @@ assert raw(pkt) == w_payload
 
 = WEP tests
 ~ wifi crypto Dot11 LLC SNAP IP TCP
+conf.wepkey = ""
+bck_conf_crypto_valid = conf.crypto_valid
+p = Dot11WEP(b'\x00\x00\x00\x00\xe3OjYLw\xc3x_%\xd0\xcf\xdeu-\xc3pH#\x1eK\xae\xf5\xde\xe7\xb8\x1d,\xa1\xfe\xe83\xca\xe1\xfe\xbd\xfe\xec\x00)T`\xde.\x93Td\x95C\x0f\x07\xdd')
+assert isinstance(p, Dot11WEP)
+conf.crypto_valid = bck_conf_crypto_valid
+
 conf.wepkey = "Fobar"
 r = raw(Dot11WEP()/LLC()/SNAP()/IP()/TCP(seq=12345678))
 r


### PR DESCRIPTION
Fixes #2063 by removing the `crypto_validator` decorator.