### PR TITLE
A few latency improvements

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -581,6 +581,7 @@ recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
     BTsocket = None
     USBsocket = None
     min_pkt_size = 60
+    bufsize = 2**16
     histfile = os.getenv('SCAPY_HISTFILE',
                          os.path.join(os.path.expanduser("~"),
                                       ".scapy_history"))

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -129,13 +129,14 @@ class SndRcvHandler(object):
                 target=self._sndrcv_snd
             )
             snd_thread.setDaemon(True)
-            snd_thread.start()
-            # Receive packets
-            self._sndrcv_rcv()
+
+            # Start routine with callback
+            self._sndrcv_rcv(snd_thread.start)
+
+            # Ended. Let's close gracefully
             if _flood:
                 # Flood: stop send thread
                 _flood[1]()
-
             snd_thread.join()
 
             if multi:
@@ -232,7 +233,7 @@ class SndRcvHandler(object):
             if conf.debug_match:
                 debug.recv.append(r)
 
-    def _sndrcv_rcv(self):
+    def _sndrcv_rcv(self, callback):
         """Function used to receive packets and check their hashret"""
         self.sniffer = None
         try:
@@ -241,7 +242,8 @@ class SndRcvHandler(object):
                 prn=self._process_packet,
                 timeout=self.timeout,
                 store=False,
-                opened_socket=self.pks
+                opened_socket=self.pks,
+                started_callback=callback
             )
         except KeyboardInterrupt:
             if self.chainCC:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -46,9 +46,12 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
 
     def send(self, x):
         sx = raw(x)
-        if hasattr(x, "sent_time"):
+        sent = self.outs.send(sx)
+        try:
             x.sent_time = time.time()
-        return self.outs.send(sx)
+        except AttributeError:
+            pass
+        return sent
 
     def recv_raw(self, x=MTU):
         """Returns a tuple containing (cls, pkt_data, time)"""

--- a/test/benchmark/latency_router.py
+++ b/test/benchmark/latency_router.py
@@ -11,8 +11,8 @@ from common import *
 # Router IP
 dest = conf.route.route("0.0.0.0")[2]
 
-send_tcp = False
-send_icmp = True
+send_tcp = True
+send_icmp = False
 
 pkts = []
 for i in range(1,50):

--- a/test/benchmark/latency_router.py
+++ b/test/benchmark/latency_router.py
@@ -27,8 +27,13 @@ ans, unans = sr(pkts, filter="host {0}".format(dest), inter=0, timeout=1, prebui
 
 print("scapy version: {}".format(conf.version))
 
+average = 0
+
 for pkt in ans:
     sent = pkt[0]
     received = pkt[1]
     res = (received.time - sent.sent_time)
+    average += res
     print("%s %s : %s" % (received.time, sent.sent_time, res))
+
+print("AVERAGE RESPONSE TIME: %ss" % (average / len(ans)))


### PR DESCRIPTION
I don't expect the effects to be impressive, but that'll help
- register more accurate timestamps
- reduce default socket buffer size to 65536 (configurable in `conf.bufsize`)
- use `started_callback` to start sending packets more accurately. IMH this will be useful mostly for BPF