### PR TITLE
Linux 802.1Q support

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1060,12 +1060,24 @@ Arguments:
 
 @conf.commands.register
 def tshark(*args, **kargs):
-    """Sniff packets and print them calling pkt.summary(), a bit like text wireshark"""  # noqa: E501
-    print("Capturing on '" + str(kargs.get('iface') if 'iface' in kargs else conf.iface) + "'")  # noqa: E501
-    i = [0]  # This should be a nonlocal variable, using a mutable object for Python 2 compatibility  # noqa: E501
+    """Sniff packets and print them calling pkt.summary().
+    This tries to replicate what text-wireshark (tshark) would look like"""
+
+    if 'iface' in kargs:
+        iface = kargs.get('iface')
+    elif 'opened_socket' in kargs:
+        iface = kargs.get('opened_socket').iface
+    else:
+        iface = conf.iface
+    print("Capturing on '%s'" % iface)
+
+    # This should be a nonlocal variable, using a mutable object
+    # for Python 2 compatibility
+    i = [0]
 
     def _cb(pkt):
         print("%5d\t%s" % (i[0], pkt.summary()))
         i[0] += 1
+
     sniff(prn=_cb, store=False, *args, **kargs)
     print("\n%d packet%s captured" % (i[0], 's' if i[0] > 1 else ''))

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -329,3 +329,50 @@ exit_status = os.system("ip addr add 192.0.2.1/24 dev scapy0")
 exit_status = os.system("ip link set scapy0 up")
 assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == "scapy0"
 exit_status = os.system("ip link del name dev scapy0")
+
+= Test 802.Q sniffing
+~ linux needs_root
+
+from threading import Thread, Condition
+
+veth = VEthPair("left0", "right0")
+veth.setup()
+veth.up()
+exit_status = os.system("ip link add link right0 name vlanright0 type vlan id 42")
+exit_status = os.system("ip link add link left0 name vlanleft0 type vlan id 42")
+exit_status = os.system("ip link set vlanright0 up")
+exit_status = os.system("ip link set vlanleft0 up")
+exit_status = os.system("ip addr add 198.51.100.1/24 dev vlanleft0")
+exit_status = os.system("ip addr add 198.51.100.2/24 dev vlanright0")
+
+cond_started = Condition()
+
+def _sniffer_started():
+
+    global cond_started
+    cond_started.acquire()
+    cond_started.notify()
+    cond_started.release()
+
+cond_started.acquire()
+
+dot1q_count = 0
+
+def _sniffer():
+    sniffed = sniff(iface="right0",
+                    lfilter=lambda p: Dot1Q in p,
+                    count=2,
+                    timeout=5,
+                    started_callback=_sniffer_started)
+    global dot1q_count
+    dot1q_count = len(sniffed)
+
+t_sniffer = Thread(target=_sniffer)
+t_sniffer.start()
+cond_started.wait()
+sendp(Ether()/IP(dst="198.51.100.2")/ICMP(), iface='vlanleft0', count=2)
+
+t_sniffer.join(1)
+assert(dot1q_count == 2)
+
+veth.destroy()

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -331,7 +331,7 @@ assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == "scapy0"
 exit_status = os.system("ip link del name dev scapy0")
 
 = Test 802.Q sniffing
-~ linux needs_root
+~ linux needs_root python3_only
 
 from threading import Thread, Condition
 


### PR DESCRIPTION
See https://github.com/secdev/scapy/issues/969

**This only works with Python 3**

IMH we shouldn't bother supporting Python 2.7. I'm against implementing the whole shabang of `ctypes` calls to support something which EOL is so soon.