### PR TITLE
Rename duplicate field in ICMP()

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -814,7 +814,7 @@ class ICMP(Packet):
                    ConditionalField(IPField("addr_mask", "0.0.0.0"), lambda pkt:pkt.type in [17, 18]),  # noqa: E501
                    ConditionalField(ShortField("nexthopmtu", 0), lambda pkt:pkt.type == 3),  # noqa: E501
                    ConditionalField(ShortField("unused", 0), lambda pkt:pkt.type in [11, 12]),  # noqa: E501
-                   ConditionalField(IntField("unused", 0), lambda pkt:pkt.type not in [0, 3, 5, 8, 11, 12, 13, 14, 15, 16, 17, 18])  # noqa: E501
+                   ConditionalField(IntField("unused2", 0), lambda pkt:pkt.type not in [0, 3, 5, 8, 11, 12, 13, 14, 15, 16, 17, 18])  # noqa: E501
                    ]
 
     def post_build(self, p, pay):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -179,6 +179,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         Initialize each fields of the fields_desc dict
         """
         for f in flist:
+            if f.name in self.default_fields:
+                raise Exception('Field "{}" is repeated for type "{}"'.format(f.name, self.name))
             self.default_fields[f.name] = copy.deepcopy(f.default)
             self.fieldtype[f.name] = f
             if f.holds_packets:


### PR DESCRIPTION
I renamed a duplicate unused field in ICMP().

Additionally, I think it would be useful with some sort of warning when this happens. Here I made the __init__() in Packet raise an exception,  but I don't know if that is too drastic.
