### PR TITLE
Smarter interface selection when sending one packet

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -462,9 +462,25 @@ def sr(x, promisc=None, filter=None, iface=None, nofilter=0, *args, **kargs):
     return result
 
 
+def _interface_selection(iface, packet):
+    """
+    Select the network interface according to the layer 3 destination
+    """
+
+    if iface is None:
+        try:
+            iff = packet.route()[0]
+        except AttributeError:
+            iff = None
+        return iff or conf.iface
+
+    return iface
+
+
 @conf.commands.register
 def sr1(x, promisc=None, filter=None, iface=None, nofilter=0, *args, **kargs):
     """Send packets at layer 3 and return only the first answer"""
+    iface = _interface_selection(iface, x)
     s = conf.L3socket(promisc=promisc, filter=filter,
                       nofilter=nofilter, iface=iface)
     ans, _ = sndrcv(s, x, *args, **kargs)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -366,3 +366,15 @@ saved_conf_prog_tcpdump = conf.prog.tcpdump
 conf.prog.tcpdump = "does_not_exist"
 assert _check_tcpdump() == False
 conf.prog.tcpdump = saved_conf_prog_tcpdump
+
+= Test _interface_selection
+~ netaccess linux needs_root
+
+import os
+from scapy.sendrecv import _interface_selection
+assert _interface_selection(None, IP(dst="8.8.8.8")/UDP()) == conf.iface
+exit_status = os.system("ip link add name scapy0 type dummy")
+exit_status = os.system("ip addr add 192.0.2.1/24 dev scapy0")
+exit_status = os.system("ip link set scapy0 up")
+assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == "scapy0"
+exit_status = os.system("ip link del name dev scapy0")


### PR DESCRIPTION
This PR fixes #1975.

`sr()` and `srloop()` are not candidates for this fix as they could be used to send packets to destinations available from different network interfaces. I do not think that it is a good idea to iterate over packets to select the interface, then to iterate again to send them.