### PR TITLE
[WIP] Implement Interfaces

### DIFF
--- a/scapy/all.py
+++ b/scapy/all.py
@@ -16,6 +16,7 @@ from scapy.data import *
 from scapy.error import *
 from scapy.themes import *
 from scapy.arch import *
+from scapy.interfaces import *
 
 from scapy.plist import *
 from scapy.fields import *

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -52,6 +52,8 @@ def get_if_hwaddr(iff):
 # def get_if(iff,cmd):
 # def get_if_index(iff):
 
+from scapy.interfaces import get_working_if # noqa F401
+
 if LINUX:
     from scapy.arch.linux import *  # noqa F403
 elif BSD:
@@ -59,7 +61,7 @@ elif BSD:
     from scapy.arch.bpf.core import *  # noqa F403
     if not (conf.use_pcap or conf.use_dnet):
         # Native
-        from scapy.arch.bpf.supersocket import * # noqa F403
+        from scapy.arch.bpf.supersocket import *  # noqa F403
         conf.use_bpf = True
 elif SOLARIS:
     from scapy.arch.solaris import *  # noqa F403

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -19,6 +19,7 @@ from scapy.config import conf
 from scapy.consts import FREEBSD, NETBSD, DARWIN
 from scapy.data import ETH_P_ALL
 from scapy.error import Scapy_Exception, warning
+from scapy.interfaces import network_name
 from scapy.supersocket import SuperSocket
 from scapy.compat import raw
 
@@ -48,10 +49,7 @@ class _L2bpfSocket(SuperSocket):
         else:
             self.promisc = promisc
 
-        if iface is None:
-            self.iface = conf.iface
-        else:
-            self.iface = iface
+        self.iface = network_name(iface or conf.iface)
 
         # Get the BPF handle
         (self.ins, self.dev_bpf) = get_dev_bpf()

--- a/scapy/arch/pcapdnet.py
+++ b/scapy/arch/pcapdnet.py
@@ -19,6 +19,7 @@ from scapy.compat import raw, plain_str, chb
 from scapy.config import conf
 from scapy.consts import WINDOWS
 from scapy.data import MTU, ETH_P_ALL, ARPHDR_ETHER, ARPHDR_LOOPBACK
+from scapy.interfaces import network_name
 from scapy.pton_ntop import inet_ntop
 from scapy.utils import mac2str
 from scapy.supersocket import SuperSocket
@@ -186,6 +187,7 @@ if conf.use_pcap:
         """Wrapper for the WinPcap calls"""
 
         def __init__(self, device, snaplen, promisc, to_ms, monitor=None):
+            device = network_name(device)
             self.errbuf = create_string_buffer(PCAP_ERRBUF_SIZE)
             self.iface = create_string_buffer(device.encode("utf8"))
             if monitor:

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -24,12 +24,14 @@ from scapy.arch.windows.structures import _windows_title, \
 from scapy.consts import WINDOWS, WINDOWS_XP
 from scapy.config import conf, ConfClass
 from scapy.error import Scapy_Exception, log_loading, log_runtime, warning
+from scapy.interfaces import NetworkInterface, InterfaceProvider, IFACES, \
+    dev_from_index, resolve_iface
 from scapy.pton_ntop import inet_ntop, inet_pton
-from scapy.utils import atol, itom, pretty_list, mac2str, str2mac
+from scapy.utils import atol, itom, mac2str, str2mac
 from scapy.utils6 import construct_source_candidate_set, in6_getscope
 from scapy.data import ARPHDR_ETHER, load_manuf
 import scapy.modules.six as six
-from scapy.modules.six.moves import input, winreg, UserDict
+from scapy.modules.six.moves import input, winreg
 from scapy.compat import plain_str
 from scapy.supersocket import SuperSocket
 
@@ -258,7 +260,7 @@ def get_windows_if_list(extended=False):
     return [
         {
             "name": _str_decode(x["friendly_name"]),
-            "win_index": x["interface_index"],
+            "index": x["interface_index"],
             "description": _str_decode(x["description"]),
             "guid": _str_decode(x["adapter_name"]),
             "mac": _get_mac(x),
@@ -267,28 +269,6 @@ def get_windows_if_list(extended=False):
             "ips": _get_ips(x)
         } for x in GetAdaptersAddresses()
     ]
-
-
-def get_ips(v6=False):
-    """Returns all available IPs matching to interfaces, using the windows system.
-    Should only be used as a WinPcapy fallback."""
-    res = {}
-    for iface in six.itervalues(IFACES):
-        ips = []
-        for ip in iface.ips:
-            if v6 and ":" in ip:
-                ips.append(ip)
-            elif not v6 and ":" not in ip:
-                ips.append(ip)
-        res[iface] = ips
-    return res
-
-
-def get_ip_from_name(ifname, v6=False):
-    """Backward compatibility: indirectly calls get_ips
-    Deprecated."""
-    iface = IFACES.dev_from_name(ifname)
-    return get_ips(v6=v6).get(iface, [""])[0]
 
 
 def _pcapname_to_guid(pcap_name):
@@ -300,86 +280,29 @@ def _pcapname_to_guid(pcap_name):
     return pcap_name
 
 
-class NetworkInterface(object):
+class NetworkInterface_Win(NetworkInterface):
     """A network interface of your local host"""
 
-    def __init__(self, data=None):
-        self.name = None
-        self.ip = None
-        self.mac = None
-        self.pcap_name = None
-        self.description = None
-        self.invalid = False
+    def __init__(self, provider, data=None):
         self.raw80211 = None
         self.cache_mode = None
         self.ipv4_metric = None
         self.ipv6_metric = None
         self.ips = None
-        self.flags = None
-        if data is not None:
-            self.update(data)
+        self.guid = None
+        super(NetworkInterface_Win, self).__init__(provider, data)
 
     def update(self, data):
-        """Update info about a network interface according
-        to a given dictionary. Such data is provided by get_windows_if_list
-        """
-        self.data = data
-        self.name = data['name']
-        self.description = data['description']
-        self.win_index = data['win_index']
-        self.guid = data['guid']
-        self.mac = data['mac']
+        super(NetworkInterface_Win, self).update(data)
         self.ipv4_metric = data['ipv4_metric']
         self.ipv6_metric = data['ipv6_metric']
         self.ips = data['ips']
-        if 'invalid' in data:
-            self.invalid = data['invalid']
-        # Other attributes are optional
-        self._update_pcapdata()
-
-        try:
-            # Npcap loopback interface
-            if conf.use_npcap:
-                pcap_name_loopback = _get_npcap_config("LoopbackAdapter")
-                if pcap_name_loopback:  # May not be defined
-                    guid = _pcapname_to_guid(pcap_name_loopback)
-                    if self.guid == guid:
-                        # https://nmap.org/npcap/guide/npcap-devguide.html
-                        self.mac = "00:00:00:00:00:00"
-                        self.ip = "127.0.0.1"
-                        return
-        except KeyError:
-            pass
-
+        self.ip = ""
+        self.guid = data['guid']
         try:
             self.ip = next(x for x in self.ips if ":" not in x)
         except StopIteration:
             pass
-
-        try:
-            # Windows native loopback interface
-            if not self.ip and self.name == scapy.consts.LOOPBACK_NAME:
-                self.ip = "127.0.0.1"
-        except (KeyError, AttributeError, NameError) as e:
-            print(e)
-
-    def _update_pcapdata(self):
-        # https://github.com/nmap/nmap/issues/1422
-        # Lookup for the Winpcap/Npcap pcap_name according to the GUID
-        if self.is_invalid():
-            return
-        for pcap_name, if_data in six.iteritems(conf.cache_iflist):
-            _, ips, flags = if_data
-            if pcap_name.endswith(self.guid):
-                self.pcap_name = pcap_name
-                self.flags = flags
-                self.ips.extend(x for x in ips if x not in self.ips)
-                return
-        # No matching pcap_name found: won't be able to sniff on it
-        self.invalid = True
-
-    def is_invalid(self):
-        return self.invalid
 
     def _check_npcap_requirement(self):
         if not conf.use_npcap:
@@ -549,51 +472,9 @@ class NetworkInterface(object):
         m = _modus.get(modu, "unknown") if isinstance(modu, int) else modu
         return self._npcap_set("modu", str(m))
 
-    def __repr__(self):
-        return "<%s [%s] %s>" % (self.__class__.__name__,
-                                 self.description,
-                                 self.guid)
 
-
-def get_if_raw_addr(iff):
-    """Return the raw IPv4 address of interface"""
-    if not iff.ip:
-        return None
-    return inet_pton(socket.AF_INET, iff.ip)
-
-
-def pcap_service_name():
-    """Return the pcap adapter service's name"""
-    return "npcap" if conf.use_npcap else "npf"
-
-
-def pcap_service_status():
-    """Returns whether the windows pcap adapter is running or not"""
-    status = get_service_status(pcap_service_name())
-    return status["dwCurrentState"] == 4
-
-
-def _pcap_service_control(action, askadmin=True):
-    """Internal util to run pcap control command"""
-    command = action + ' ' + pcap_service_name()
-    res, code = _exec_cmd(_encapsulate_admin(command) if askadmin else command)
-    if code != 0:
-        warning(res.decode("utf8", errors="ignore"))
-    return (code == 0)
-
-
-def pcap_service_start(askadmin=True):
-    """Starts the pcap adapter. Will ask for admin. Returns True if success"""
-    return _pcap_service_control('sc start', askadmin=askadmin)
-
-
-def pcap_service_stop(askadmin=True):
-    """Stops the pcap adapter. Will ask for admin. Returns True if success"""
-    return _pcap_service_control('sc stop', askadmin=askadmin)
-
-
-class NetworkInterfaceDict(UserDict):
-    """Store information about network interfaces and convert between names"""
+class WindowsInterfacesProvider(InterfaceProvider):
+    name = "Libpcap"
 
     @classmethod
     def _pcap_check(cls):
@@ -642,151 +523,160 @@ class NetworkInterfaceDict(UserDict):
                 "Scapy might help. Check your winpcap/npcap installation "
                 "and access rights.")
 
-    def load(self):
+    def load(self, NetworkInterface_Win=NetworkInterface_Win):
+        data = {}
         if not get_if_list():
             # Try a restart
-            NetworkInterfaceDict._pcap_check()
+            WindowsInterfacesProvider._pcap_check()
 
-        for i in get_windows_if_list():
+        interfaces = get_windows_if_list()
+
+        # Npcap loopback interface
+        loopback_guid = -1
+        try:
+            if conf.use_npcap:
+                pcap_name_loopback = _get_npcap_config("LoopbackAdapter")
+                if pcap_name_loopback:  # May not be defined
+                    loopback_guid = _pcapname_to_guid(pcap_name_loopback)
+        except KeyError:
+            pass
+
+        # Post process of Npcap interfaces
+        for iface in interfaces:
+            for pcap_name, if_data in six.iteritems(conf.cache_iflist):
+                _, ips, flags = if_data
+                if pcap_name.endswith(iface["guid"]):
+                    iface["network_name"] = pcap_name
+                    iface["flags"] = flags
+                    iface["ips"].extend(
+                        x for x in ips if x not in iface["ips"]
+                    )
+                    break
+            else:
+                # No matching network_name found: won't be able to sniff on it
+                iface["invalid"] = True
+
+            # Invalid loopback should be discarded
+            if "127.0.0.1" in iface["ips"] and iface["invalid"]:
+                continue
+
+            # Build the interface
             try:
-                interface = NetworkInterface(i)
-                self.data[interface.guid] = interface
+                interface = NetworkInterface_Win(self, iface)
+                data[interface.guid] = interface
             except KeyError:
                 pass
 
-        # Remove invalid loopback interfaces (not usable)
-        for key, iface in self.data.copy().items():
-            if iface.ip == "127.0.0.1" and iface.is_invalid():
-                del self.data[key]
+            # https://github.com/nmap/nmap/issues/1422
+            # Lookup for the Winpcap/Npcap network_name according to the GUID
+            if interface.guid == loopback_guid:
+                # https://nmap.org/npcap/guide/npcap-devguide.html
+                interface.mac = "00:00:00:00:00:00"
+                interface.ip = "127.0.0.1"
 
-        # Replace LOOPBACK_INTERFACE
-        try:
-            scapy.consts.LOOPBACK_INTERFACE = self.dev_from_name(
-                scapy.consts.LOOPBACK_NAME,
-            )
-        except ValueError:
-            pass
+            try:
+                # Windows native loopback interface
+                if not interface.ip and \
+                   interface.name == scapy.consts.LOOPBACK_NAME:
+                    interface.ip = "127.0.0.1"
+            except (KeyError, AttributeError, NameError) as e:
+                print(e)
+
         # Support non-windows cards (e.g. Napatech)
         index = 0
         for pcap_name, if_data in six.iteritems(conf.cache_iflist):
             name, _, _ = if_data
             guid = _pcapname_to_guid(pcap_name)
-            if guid not in self.data:
+            if guid not in data:
                 index -= 1
                 dummy_data = {
                     'name': name,
-                    'description': "[Unknown] %s" % name,
-                    'win_index': index,
+                    'description': name,
+                    'index': index,
                     'guid': guid,
+                    'network_name': pcap_name,
                     'invalid': False,
-                    'mac': 'ff:ff:ff:ff:ff:ff',
+                    'mac': '00:00:00:00:00:00',
                     'ipv4_metric': 0,
                     'ipv6_metric': 0,
                     'ips': []
                 }
                 # No KeyError will happen here, as we get it from cache
-                self.data[guid] = NetworkInterface(dummy_data)
-
-    def dev_from_name(self, name):
-        """Return the first pcap device name for a given Windows
-        device name.
-        """
-        try:
-            return next(iface for iface in six.itervalues(self)
-                        if (iface.name == name or iface.description == name))
-        except (StopIteration, RuntimeError):
-            raise ValueError("Unknown network interface %r" % name)
-
-    def dev_from_pcapname(self, pcap_name):
-        """Return Windows device name for given pcap device name."""
-        try:
-            return next(iface for iface in six.itervalues(self)
-                        if iface.pcap_name == pcap_name)
-        except (StopIteration, RuntimeError):
-            raise ValueError("Unknown pypcap network interface %r" % pcap_name)
-
-    def dev_from_index(self, if_index):
-        """Return interface name from interface index"""
-        try:
-            if_index = int(if_index)  # Backward compatibility
-            return next(iface for iface in six.itervalues(self)
-                        if iface.win_index == if_index)
-        except (StopIteration, RuntimeError):
-            if str(if_index) == "1":
-                # Test if the loopback interface is set up
-                if isinstance(scapy.consts.LOOPBACK_INTERFACE, NetworkInterface):  # noqa: E501
-                    return scapy.consts.LOOPBACK_INTERFACE
-            raise ValueError("Unknown network interface index %r" % if_index)
+                data[guid] = NetworkInterface_Win(self, dummy_data)
+        return data
 
     def reload(self):
         """Reload interface list"""
         self.restarted_adapter = False
-        self.data.clear()
         if conf.use_pcap:
             # Reload from Winpcapy
             from scapy.arch.pcapdnet import load_winpcapy
             load_winpcapy()
-        self.load()
-        # Reload conf.iface
-        conf.iface = get_working_if()
-
-    def show(self, resolve_mac=True, print_result=True):
-        """Print list of available network interfaces in human readable form"""
-        res = []
-        for iface_name in sorted(self.data):
-            dev = self.data[iface_name]
-            mac = dev.mac
-            if resolve_mac and conf.manufdb:
-                mac = conf.manufdb._resolve_MAC(mac)
-            validity_color = lambda x: conf.color_theme.red if x else \
-                conf.color_theme.green
-            description = validity_color(dev.is_invalid())(
-                str(dev.description)
-            )
-            index = str(dev.win_index)
-            res.append((index, description, str(dev.ip), mac))
-
-        res = pretty_list(res, [("INDEX", "IFACE", "IP", "MAC")], sortBy=2)
-        if print_result:
-            print(res)
-        else:
-            return res
-
-    def __repr__(self):
-        return self.show(print_result=False)
+        return self.load()
 
 
-IFACES = ifaces = NetworkInterfaceDict()
-IFACES.load()
+# Register provider
+IFACES.register_provider(WindowsInterfacesProvider)
 
 
-def pcapname(dev):
-    """Get the device pcap name by device name or Scapy NetworkInterface
-
-    """
-    if isinstance(dev, NetworkInterface):
-        if dev.is_invalid():
-            return None
-        return dev.pcap_name
-    try:
-        return IFACES.dev_from_name(dev).pcap_name
-    except ValueError:
-        return IFACES.dev_from_pcapname(dev).pcap_name
-
-
-def dev_from_pcapname(pcap_name):
-    """Return Scapy device name for given pcap device name"""
-    return IFACES.dev_from_pcapname(pcap_name)
+def get_ips(v6=False):
+    """Returns all available IPs matching to interfaces, using the windows system.
+    Should only be used as a WinPcapy fallback."""
+    res = {}
+    for iface in six.itervalues(IFACES):
+        ips = []
+        for ip in iface.ips:
+            if v6 and ":" in ip:
+                ips.append(ip)
+            elif not v6 and ":" not in ip:
+                ips.append(ip)
+        res[iface] = ips
+    return res
 
 
-def dev_from_index(if_index):
-    """Return Windows adapter name for given Windows interface index"""
-    return IFACES.dev_from_index(if_index)
+def get_if_raw_addr(iff):
+    """Return the raw IPv4 address of interface"""
+    iff = resolve_iface(iff)
+    if not iff.ip:
+        return None
+    return inet_pton(socket.AF_INET, iff.ip)
 
 
-def show_interfaces(resolve_mac=True):
-    """Print list of available network interfaces"""
-    return IFACES.show(resolve_mac)
+def get_ip_from_name(ifname, v6=False):
+    """Backward compatibility: indirectly calls get_ips
+    Deprecated."""
+    iface = IFACES.dev_from_name(ifname)
+    return get_ips(v6=v6).get(iface, [""])[0]
+
+
+def pcap_service_name():
+    """Return the pcap adapter service's name"""
+    return "npcap" if conf.use_npcap else "npf"
+
+
+def pcap_service_status():
+    """Returns whether the windows pcap adapter is running or not"""
+    status = get_service_status(pcap_service_name())
+    return status["dwCurrentState"] == 4
+
+
+def _pcap_service_control(action, askadmin=True):
+    """Internal util to run pcap control command"""
+    command = action + ' ' + pcap_service_name()
+    res, code = _exec_cmd(_encapsulate_admin(command) if askadmin else command)
+    if code != 0:
+        warning(res.decode("utf8", errors="ignore"))
+    return (code == 0)
+
+
+def pcap_service_start(askadmin=True):
+    """Starts the pcap adapter. Will ask for admin. Returns True if success"""
+    return _pcap_service_control('sc start', askadmin=askadmin)
+
+
+def pcap_service_stop(askadmin=True):
+    """Stops the pcap adapter. Will ask for admin. Returns True if success"""
+    return _pcap_service_control('sc stop', askadmin=askadmin)
 
 
 if conf.use_pcap:
@@ -796,11 +686,9 @@ if conf.use_pcap:
         """open_pcap: Windows routine for creating a pcap from an interface.
         This function is also responsible for detecting monitor mode.
         """
-        iface_pcap_name = pcapname(iface)
-        if not isinstance(iface, NetworkInterface) and \
-           iface_pcap_name is not None:
-            iface = IFACES.dev_from_name(iface)
-        if iface.is_invalid():
+        iface = resolve_iface(iface)
+        iface_pcap_name = iface.network_name
+        if not iface:
             raise Scapy_Exception(
                 "Interface is invalid (no pcap match found) !"
             )
@@ -817,9 +705,10 @@ if conf.use_pcap:
         return _orig_open_pcap(iface_pcap_name, *args, **kargs)
     pcapdnet.open_pcap = open_pcap
 
-get_if_raw_hwaddr = pcapdnet.get_if_raw_hwaddr = lambda iface, *args, **kargs: (  # noqa: E501
-    ARPHDR_ETHER, mac2str(IFACES.dev_from_pcapname(pcapname(iface)).mac)
-)
+
+def get_if_raw_hwaddr(iface):
+    iface = resolve_iface(iface)
+    return ARPHDR_ETHER, mac2str(iface.mac)
 
 
 def _read_routes_c_v1():
@@ -960,24 +849,6 @@ def read_routes6():
     return routes6
 
 
-def get_working_if():
-    """Return an interface that works"""
-    try:
-        # return the interface associated with the route with smallest
-        # mask (route by default if it exists)
-        iface = min(conf.route.routes, key=lambda x: x[1])[3]
-    except ValueError:
-        # no route
-        iface = scapy.consts.LOOPBACK_INTERFACE
-    if iface.is_invalid():
-        # Backup mode: try them all
-        for iface in six.itervalues(IFACES):
-            if not iface.is_invalid():
-                return iface
-        return None
-    return iface
-
-
 def _get_valid_guid():
     if scapy.consts.LOOPBACK_INTERFACE:
         return scapy.consts.LOOPBACK_INTERFACE.guid
@@ -999,24 +870,10 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
     else:
         if not conf.route.routes:
             return
-    data = {
-        'name': scapy.consts.LOOPBACK_NAME,
-        'description': "Loopback",
-        'win_index': -1,
-        'guid': "{0XX00000-X000-0X0X-X00X-00XXXX000XXX}",
-        'invalid': True,
-        'mac': '00:00:00:00:00:00',
-        'ipv4_metric': 0,
-        'ipv6_metric': 0,
-        'ips': ["127.0.0.1", "::"]
-    }
-    adapter = NetworkInterface()
-    adapter.pcap_name = "\\Device\\NPF_{0XX00000-X000-0X0X-X00X-00XXXX000XXX}"
-    adapter.update(data)
-    adapter.invalid = False
-    adapter.ip = "127.0.0.1"
+    IFACES._add_fake_iface(scapy.consts.LOOPBACK_NAME)
+    adapter = IFACES.dev_from_name(scapy.consts.LOOPBACK_NAME)
     if iflist:
-        iflist.append(adapter.pcap_name)
+        iflist.append(adapter.network_name)
         return
     # Remove all LOOPBACK_NAME routes
     for route in list(conf.route.routes):

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -1,0 +1,259 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# Copyright (C) Gabriel Potter <gabriel@potter.fr>
+# This program is published under a GPLv2 license
+
+"""
+Interfaces management
+"""
+
+from collections import defaultdict
+
+import scapy
+from scapy.config import conf
+from scapy.consts import WINDOWS
+from scapy.utils import pretty_list
+
+from scapy.modules.six.moves import UserDict
+import scapy.modules.six as six
+
+
+class InterfaceProvider(object):
+    name = "Unknown"
+
+    def load(self):
+        """Returns a dictionary of the loaded interfaces, by their
+        name."""
+        raise Exception("load() should be implemented !")
+
+    def l2socket(self):
+        """Return L2 socket used by interfaces of this provider"""
+        return conf.L2socket
+
+    def l2listen(self):
+        """Return L2listen socket used by interfaces of this provider"""
+        return conf.L2listen
+
+    def l3socket(self):
+        """Return L3 socket used by interfaces of this provider"""
+        return conf.L3socket
+
+
+class NetworkInterface(object):
+    def __init__(self, provider, data=None):
+        self.provider = provider
+        if data is not None:
+            self.update(data)
+
+    def update(self, data):
+        """Update info about a network interface according
+        to a given dictionary. Such data is provided by providers
+        """
+        self.name = data.get('name', "")
+        self.description = data.get('description', "")
+        self.network_name = data.get('network_name', "")
+        self.index = data.get('index', 0)
+        self.ip = data.get('ip', None) or ""
+        self.mac = data.get('mac', None) or ""
+        self.invalid = data.get('invalid', False)
+
+    def is_invalid(self):
+        return self.invalid
+
+    def l2socket(self):
+        return self.provider.l2socket()
+
+    def l2listen(self):
+        return self.provider.l2listen()
+
+    def l3socket(self):
+        return self.provider.l3socket()
+
+    def __repr__(self):
+        return "<%s [%s] %s>" % (self.__class__.__name__,
+                                 self.description,
+                                 self.network_name)
+
+
+class NetworkInterfaceDict(UserDict):
+    """Store information about network interfaces and convert between names"""
+
+    def __init__(self):
+        self.providers = {}
+        UserDict.__init__(self)
+
+    def _load(self, dat):
+        self.data.update(dat)
+
+    def _reload_loopback(self):
+        # Replace LOOPBACK_INTERFACE
+        try:
+            scapy.consts.LOOPBACK_INTERFACE = self.dev_from_name(
+                scapy.consts.LOOPBACK_NAME,
+            )
+        except ValueError:
+            pass
+
+    def register_provider(self, provider):
+        prov = provider()
+        self.providers[provider] = prov
+        self._load(prov.load())
+        self._reload_loopback()
+
+    def reload(self):
+        self.clear()
+        for prov in self.providers.values():
+            self._load(prov.load())
+        # Reload conf.iface
+        conf.iface = get_working_if()
+        self._reload_loopback()
+
+    def dev_from_name(self, name):
+        """Return the first network device name for a given
+        device name.
+        """
+        try:
+            return next(iface for iface in six.itervalues(self)
+                        if (iface.name == name or iface.description == name))
+        except (StopIteration, RuntimeError):
+            raise ValueError("Unknown network interface %r" % name)
+
+    def dev_from_networkname(self, network_name):
+        """Return interface for a given network device name."""
+        try:
+            return next(iface for iface in six.itervalues(self)
+                        if iface.network_name == network_name)
+        except (StopIteration, RuntimeError):
+            raise ValueError(
+                "Unknown network interface %r" %
+                network_name)
+
+    def dev_from_index(self, if_index):
+        """Return interface name from interface index"""
+        try:
+            if_index = int(if_index)  # Backward compatibility
+            return next(iface for iface in six.itervalues(self)
+                        if iface.index == if_index)
+        except (StopIteration, RuntimeError):
+            if str(if_index) == "1":
+                # Test if the loopback interface is set up
+                if isinstance(scapy.consts.LOOPBACK_INTERFACE, NetworkInterface):  # noqa: E501
+                    return scapy.consts.LOOPBACK_INTERFACE
+            raise ValueError("Unknown network interface index %r" % if_index)
+
+    def _add_fake_iface(self, ifname):
+        """Internal function used for a testing purpose"""
+        data = {
+            'name': ifname,
+            'description': ifname,
+            'network_name': ifname,
+            'index': -1,
+            'invalid': True,
+            'mac': '00:00:00:00:00:00',
+            # Windows only
+            'guid': "{0XX00000-X000-0X0X-X00X-00XXXX000XXX}",
+            'ipv4_metric': 0,
+            'ipv6_metric': 0,
+            'ips': ["127.0.0.1", "::"]
+        }
+        if WINDOWS:
+            from scapy.arch.windows import NetworkInterface_Win, \
+                WindowsInterfacesProvider
+            self.data[ifname] = NetworkInterface_Win(
+                WindowsInterfacesProvider(),
+                data
+            )
+        else:
+            self.data[ifname] = NetworkInterface(InterfaceProvider(), data)
+
+    def show(self, resolve_mac=True, print_result=True):
+        """Print list of available network interfaces in human readable form"""
+        res = defaultdict(list)
+        for iface_name in sorted(self.data):
+            dev = self.data[iface_name]
+            mac = dev.mac
+            if resolve_mac and conf.manufdb:
+                mac = conf.manufdb._resolve_MAC(mac)
+            validity_color = lambda x: conf.color_theme.red if x else \
+                conf.color_theme.green
+            description = validity_color(dev.is_invalid())(
+                str(dev.description)
+            )
+            index = str(dev.index)
+            res[dev.provider].append((index, description, str(dev.ip), mac))
+
+        output = ""
+        for provider in res:
+            output += "\n### %s ###\n" % provider.name
+            output += pretty_list(res[provider],
+                                  [("INDEX", "IFACE", "IP", "MAC")], sortBy=2)
+        output = output[1:]
+        if print_result:
+            print(output)
+        else:
+            return output
+
+    def __repr__(self):
+        return self.show(print_result=False)
+
+
+IFACES = ifaces = NetworkInterfaceDict()
+
+
+def get_working_if():
+    """Return an interface that works"""
+    try:
+        # return the interface associated with the route with smallest
+        # mask (route by default if it exists)
+        iface = min(conf.route.routes, key=lambda x: x[1])[3]
+    except ValueError:
+        # no route
+        iface = scapy.consts.LOOPBACK_INTERFACE
+    iface = resolve_iface(iface)
+    if iface and iface.is_invalid():
+        # Backup mode: try them all
+        for iface in six.itervalues(IFACES):
+            if not iface.is_invalid():
+                return iface
+        return None
+    return iface
+
+
+def dev_from_networkname(network_name):
+    """Return Scapy device name for given network device name"""
+    return IFACES.dev_from_networkname(network_name)
+
+
+def dev_from_index(if_index):
+    """Return interface for a given interface index"""
+    return IFACES.dev_from_index(if_index)
+
+
+def resolve_iface(dev, _internal=False):
+    """Resolve an interface name into the interface"""
+    if isinstance(dev, NetworkInterface):
+        return dev
+    try:
+        return IFACES.dev_from_name(dev)
+    except ValueError:
+        try:
+            return IFACES.dev_from_networkname(dev)
+        except ValueError:
+            if _internal:
+                raise
+            IFACES.reload()
+            return resolve_iface(dev, _internal=True)
+
+
+def network_name(dev):
+    """Get the device network name of a device or Scapy NetworkInterface
+    """
+    dev = resolve_iface(dev)
+    if dev:
+        return dev.network_name
+
+
+def show_interfaces(resolve_mac=True):
+    """Print list of available network interfaces"""
+    return IFACES.show(resolve_mac)

--- a/scapy/layers/usb.py
+++ b/scapy/layers/usb.py
@@ -22,6 +22,8 @@ from scapy.error import warning
 from scapy.fields import ByteField, XByteField, ByteEnumField, LEShortField, \
     LEShortEnumField, LEIntField, LEIntEnumField, XLELongField, \
     LenField
+from scapy.interfaces import NetworkInterface, InterfaceProvider, \
+    network_name, IFACES
 from scapy.packet import Packet, bind_top_down
 from scapy.supersocket import SuperSocket
 from scapy.utils import PcapReader
@@ -172,7 +174,7 @@ def _extcap_call(prog, args, keyword, values):
         if not ifa.startswith(keyword):
             continue
         res.append(tuple([re.search(r"{%s=([^}]*)}" % val, ifa).group(1)
-                   for val in values]))
+                          for val in values]))
     return res
 
 
@@ -190,6 +192,36 @@ if WINDOWS:
             "interface",
             ["value", "display"]
         )
+
+    class UsbpcapInterfaceProvider(InterfaceProvider):
+        name = "USBPcap"
+
+        def load(self):
+            data = {}
+            for netw_name, name in get_usbpcap_interfaces():
+                index = re.search(r".*(\d+)", name)
+                if index:
+                    index = int(index.group(1)) + 100
+                else:
+                    index = 100
+                if_data = {
+                    "name": name,
+                    "network_name": netw_name,
+                    "description": name,
+                    "invalid": False,
+                    "flags": None,
+                    "index": index,
+                    "ip": None,
+                    "mac": None
+                }
+                data[netw_name] = NetworkInterface(self, if_data)
+            return data
+
+        def l2socket(self):
+            return conf.USBsocket
+        l2listen = l2socket
+
+    IFACES.register_provider(UsbpcapInterfaceProvider)
 
     def get_usbpcap_devices(iface, enabled=True):
         """Return a list of devices on an USBpcap interface"""
@@ -226,6 +258,7 @@ if WINDOWS:
                         " ".join(x[0] for x in get_usbpcap_interfaces()))
                 raise NameError("No interface specified !"
                                 " See get_usbpcap_interfaces()")
+            iface = network_name(iface)
             self.outs = None
             args = ['-d', iface, '-b', '134217728', '-A', '-o', '-']
             self.usbpcap_proc = subprocess.Popen(

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -229,21 +229,22 @@ def list_contrib(name=None, ret=False, _debug=False):
         if mod.endswith(".py"):
             mod = mod[:-3]
         desc = {"description": None, "status": None, "name": mod}
-        for l in io.open(f, errors="replace"):
-            if l[0] != "#":
-                continue
-            p = l.find("scapy.contrib.")
-            if p >= 0:
-                p += 14
-                q = l.find("=", p)
-                key = l[p:q].strip()
-                value = l[q + 1:].strip()
-                desc[key] = value
-            if desc["status"] == "skip":
-                break
-            if desc["description"] and desc["status"]:
-                results.append(desc)
-                break
+        with io.open(f, errors="replace") as fd:
+            for l in fd:
+                if l[0] != "#":
+                    continue
+                p = l.find("scapy.contrib.")
+                if p >= 0:
+                    p += 14
+                    q = l.find("=", p)
+                    key = l[p:q].strip()
+                    value = l[q + 1:].strip()
+                    desc[key] = value
+                if desc["status"] == "skip":
+                    break
+                if desc["description"] and desc["status"]:
+                    results.append(desc)
+                    break
         if _debug:
             if desc["status"] == "skip":
                 pass

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import socket
 import scapy.consts
 from scapy.config import conf
+from scapy.interfaces import network_name
 from scapy.utils6 import in6_ptop, in6_cidr2mask, in6_and, \
     in6_islladdr, in6_ismlladdr, in6_isincluded, in6_isgladdr, \
     in6_isaddr6to4, in6_ismaddr, construct_source_candidate_set, \
@@ -210,7 +211,7 @@ class Route6:
         # Deal with dev-specific request for cache search
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)  # noqa: E501
+            k = dst + "%%" + network_name(dev)
         if k in self.cache:
             return self.cache[k]
 
@@ -276,7 +277,7 @@ class Route6:
         # Fill the cache (including dev-specific request)
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)  # noqa: E501
+            k = dst + "%%" + network_name(dev)
         self.cache[k] = res[0][2]
 
         return res[0][2]

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -20,6 +20,7 @@ from scapy.consts import LINUX, DARWIN, WINDOWS
 from scapy.data import MTU, ETH_P_IP
 from scapy.compat import raw, bytes_encode
 from scapy.error import warning, log_runtime
+from scapy.interfaces import network_name
 import scapy.modules.six as six
 import scapy.packet
 from scapy.utils import PcapReader, tcpdump
@@ -149,6 +150,7 @@ class L3RawSocket(SuperSocket):
         self.outs.setsockopt(socket.SOL_IP, socket.IP_HDRINCL, 1)
         self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
         if iface is not None:
+            iface = network_name(iface)
             self.ins.bind((iface, type))
 
     def recv(self, x=MTU):
@@ -270,13 +272,7 @@ class L2ListenTcpdump(SuperSocket):
         self.outs = None
         args = ['-w', '-', '-s', '65535']
         if iface is not None:
-            if WINDOWS:
-                try:
-                    args.extend(['-i', iface.pcap_name])
-                except AttributeError:
-                    args.extend(['-i', iface])
-            else:
-                args.extend(['-i', iface])
+            args.extend(['-i', network_name(iface)])
         elif WINDOWS or DARWIN:
             args.extend(['-i', conf.iface.pcap_name if WINDOWS else conf.iface])  # noqa: E501
         if not promisc:

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -44,6 +44,7 @@ class ColorTable:
         "blink": ("\033[5m", ""),
         "invert": ("\033[7m", ""),
     }
+    inv_map = {v[0]: v[1] for k, v in colors.items()}
 
     def __repr__(self):
         return "<ColorTable>"
@@ -52,8 +53,7 @@ class ColorTable:
         return self.colors.get(attr, [""])[0]
 
     def ansi_to_pygments(self, x):  # Transform ansi encoded text to Pygments text  # noqa: E501
-        inv_map = {v[0]: v[1] for k, v in self.colors.items()}
-        for k, v in inv_map.items():
+        for k, v in self.inv_map.items():
             x = x.replace(k, " " + v)
         return x.strip()
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1764,7 +1764,7 @@ def pretty_list(rtlst, header, sortBy=0, borders=False):
     # Append tag
     rtlst = header + rtlst
     # Detect column's width
-    colwidth = [max([len(y) for y in x]) for x in zip(*rtlst)]
+    colwidth = [max(len(y) for y in x) for x in zip(*rtlst)]
     # Make text fit in box (if required)
     width = get_terminal_width()
     if conf.auto_crop_tables and width:

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -177,6 +177,8 @@ assert(exit_status == 0)
 
 = IPv6 link-local address selection
 
+IFACES._add_fake_iface("scapy0")
+
 from mock import patch
 bck_conf_route6_routes = conf.route6.routes
 conf.route6.routes =  [('fe80::', 64, '::', 'scapy0', ['fe80::e039:91ff:fe79:1910'], 256)]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -140,10 +140,12 @@ def get_dummy_interface():
         data["ipv6_metric"] = 1
         data["mac"] = "00:00:00:00:00:00"
         data["ips"] = ["127.0.0.1", "::1"]
-        dummy_int = NetworkInterface(data)
+        dummy_int = NetworkInterface_Win(InterfaceProvider(), data)
         dummy_int.pcap_name = "\\Device\\NPF_" + data["guid"]
+        IFACES[dummy_int.pcap_name] = dummy_int
         return dummy_int
     else:
+        IFACES._add_fake_iface("dummy0")
         return "dummy0"
 
 get_if_raw_addr(get_dummy_interface())
@@ -4011,6 +4013,11 @@ assert defragment6(pkts).plen == 1508
 ############
 + Test Route6 class
 
+= Fake interfaces
+IFACES._add_fake_iface("eth0")
+IFACES._add_fake_iface("lo")
+IFACES._add_fake_iface("scapy0")
+
 = Route6 - Route6 flushing
 conf_iface = conf.iface
 conf.iface = "eth0"
@@ -4021,6 +4028,7 @@ conf.route6.flush()
 not conf.route6.routes
 
 = Route6 - Route6.route
+
 conf.route6.flush()
 conf.route6.routes=[
 (                               '::1', 128,                       '::',   'lo', ['::1'], 1), 
@@ -8157,6 +8165,9 @@ test_netbsd_7_0()
 
 import scapy
 
+IFACES._add_fake_iface("enp3s0")
+IFACES._add_fake_iface("lo")
+
 old_routes = conf.route.routes
 old_iface = conf.iface
 old_loopback = scapy.consts.LOOPBACK_INTERFACE
@@ -8186,9 +8197,13 @@ finally:
     conf.iface = old_iface
     conf.route.routes = old_routes
     conf.route.invalidate_cache()
+    IFACES.reload()
 
 
 = Mocked IPv6 routes calls
+
+IFACES._add_fake_iface("enp3s0")
+IFACES._add_fake_iface("lo")
 
 old_routes = conf.route6.routes
 old_iface = conf.iface


### PR DESCRIPTION
# Not for 2.4.3

**Still a lot of work to do**

This is an attempt of unifying how interfaces work between the various architectures.
It implements a `NetworkInterface`, similar to what we already have on Windows, but for the other systems. Note that it remains fully backward compatible.

The purpose of this change is that:
- interfaces will now have a "type", linked to a specific kind of SuperSockets. This allows to make `sniff()`, `sr1()`... choose the correct socket for interfaces like Bluetooth or USB
- all interfaces of all kinds will be listed under the same `IFACES` utilitary class.
- interaces are now safer to use: Scapy won't try to call un-existing interfaces.
- people will be able to hook in their own interfaces/sockets, using this new mechanism, like wireshark [extcap](https://wiki.wireshark.org/Development/Extcap)

It also makes the `IFACES` utilitary class usable on non-windows systems

**Demo:**

Windows: Scapy handles both USBpcap & normal interfaces through the default commands.

![image](https://user-images.githubusercontent.com/10530980/60389357-409dea00-9ac0-11e9-97b2-2c55b054dacc.png)
