### PR TITLE
Bugfix in TLS automaton restart.

### DIFF
--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -158,6 +158,8 @@ class TLSServerAutomaton(_TLSAutomaton):
 
     @ATMT.state()
     def WAITING_CLIENT(self):
+        self.buffer_out = []
+        self.buffer_in = []
         self.vprint()
         self.vprint("Waiting for a new client on %s:%d" % (self.local_ip,
                                                            self.local_port))


### PR DESCRIPTION
When something goes wrong in the TLS server automaton, it may start
the next connection with a non-empty buffer_in, leading to an immediate
error (see #2129).

This commit empties buffer_in and buffer_out on restart.