### PR TITLE
contrib: provide support for MQTT-SN

### DIFF
--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -9,7 +9,7 @@
 # scapy.contrib.description = MQTT for Sensor Networks (MQTT-SN)
 # scapy.contrib.status = loads
 
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.fields import BitField, BitEnumField, ByteField, ByteEnumField, \
     ConditionalField, FieldLenField, ShortField, StrFixedLenField, \
     StrLenField, XByteEnumField
@@ -434,8 +434,9 @@ class MQTTSNEncaps(Packet):
 
 
 # Layer bindings
-bind_layers(UDP, MQTTSN, sport=1883)
-bind_layers(UDP, MQTTSN, dport=1883)
+bind_bottom_up(UDP, MQTTSN, sport=1883)
+bind_bottom_up(UDP, MQTTSN, dport=1883)
+bind_layers(UDP, MQTTSN, dport=1883, sport=1883)
 bind_layers(MQTTSN, MQTTSNAdvertise, type=ADVERTISE)
 bind_layers(MQTTSN, MQTTSNSearchGW, type=SEARCHGW)
 bind_layers(MQTTSN, MQTTSNGwInfo, type=GWINFO)

--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -17,6 +17,7 @@ from scapy.layers.inet import UDP
 from scapy.error import Scapy_Exception
 from scapy.compat import chb, orb
 from scapy.volatile import RandNum
+import struct
 
 
 # Constants
@@ -80,9 +81,9 @@ class VariableFieldLenField(FieldLenField):
             raise Scapy_Exception("%s: invalid length field value" %
                                   self.__class__.__name__)
         elif val > 0xff:
-            return s + b"".join([chb(0x01), chb(val >> 8), chb(val & 0xff)])
+            return s + b"\x01" + struct.pack("!H", val)
         else:
-            return s + b"".join([chb(val)])
+            return s + chb(val)
 
     def getfield(self, pkt, s):
         if orb(s[0]) == 0x01:

--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -1,0 +1,465 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) 2019 Freie Universitaet Berlin
+# This program is published under GPLv2 license
+#
+# Specification:
+#   http://www.mqtt.org/new/wp-content/uploads/2009/06/MQTT-SN_spec_v1.2.pdf
+
+# scapy.contrib.description = MQTT for Sensor Networks (MQTT-SN)
+# scapy.contrib.status = loads
+
+from scapy.packet import Packet, bind_layers
+from scapy.fields import BitField, BitEnumField, ByteField, ByteEnumField, \
+    ConditionalField, FieldLenField, ShortField, StrFixedLenField, \
+    StrLenField, XByteEnumField
+from scapy.layers.inet import UDP
+from scapy.error import Scapy_Exception
+from scapy.compat import chb, orb
+from scapy.volatile import RandNum
+
+
+# Constants
+ADVERTISE = 0x00
+SEARCHGW = 0x01
+GWINFO = 0x02
+CONNECT = 0x04
+CONNACK = 0x05
+WILLTOPICREQ = 0x06
+WILLTOPIC = 0x07
+WILLMSGREQ = 0x08
+WILLMSG = 0x09
+REGISTER = 0x0a
+REGACK = 0x0b
+PUBLISH = 0x0c
+PUBACK = 0x0d
+PUBCOMP = 0x0e
+PUBREC = 0x0f
+PUBREL = 0x10
+SUBSCRIBE = 0x12
+SUBACK = 0x13
+UNSUBSCRIBE = 0x14
+UNSUBACK = 0x15
+PINGREQ = 0x16
+PINGRESP = 0x17
+DISCONNECT = 0x18
+WILLTOPICUPD = 0x1a
+WILLTOPICRESP = 0x1b
+WILLMSGUPD = 0x1c
+WILLMSGRESP = 0x1d
+ENCAPS_MSG = 0xfe
+
+QOS_0 = 0b00
+QOS_1 = 0b01
+QOS_2 = 0b10
+QOS_NEG1 = 0b11
+
+TID_NORMAL = 0b00
+TID_PREDEF = 0b01
+TID_SHORT = 0b10
+TID_RESVD = 0b11
+
+
+ACCEPTED = 0x00
+REJ_CONJ = 0x01
+REJ_TID = 0x02
+REJ_NOTSUP = 0x03
+
+
+# Custom fields
+class VariableFieldLenField(FieldLenField):
+    """
+    MQTT-SN length field either has 1 byte for values [0x02, 0xff] or 3 bytes
+    for values [0x0100, 0xffff]. If the first byte is 0x01 the length value
+    comes in network byte-order in the next 2 bytes. MQTT-SN packets are at
+    least 2 bytes long (length field + type field).
+    """
+    def addfield(self, pkt, s, val):
+        val = self.i2m(pkt, val)
+        if (val < 2) or (val > 0xffff):
+            raise Scapy_Exception("%s: invalid length field value" %
+                                  self.__class__.__name__)
+        elif val > 0xff:
+            return s + b"".join([chb(0x01), chb(val >> 8), chb(val & 0xff)])
+        else:
+            return s + b"".join([chb(val)])
+
+    def getfield(self, pkt, s):
+        if orb(s[0]) == 0x01:
+            if len(s) < 3:
+                raise Scapy_Exception("%s: malformed length field" %
+                                      self.__class__.__name__)
+            return s[3:], (orb(s[1]) << 8) | orb(s[2])
+        else:
+            return s[1:], orb(s[0])
+
+    def randval(self):
+        return RandVariableFieldLen()
+
+    def __init__(self, *args, **kwargs):
+        super(VariableFieldLenField, self).__init__(*args, **kwargs)
+
+
+class RandVariableFieldLen(RandNum):
+    def __init__(self):
+        super(RandVariableFieldLen, self).__init__(0, 0xffff)
+
+
+# Layers
+PACKET_TYPE = {
+    ADVERTISE: "ADVERTISE",
+    SEARCHGW: "SEARCHGW",
+    GWINFO: "GWINFO",
+    CONNECT: "CONNECT",
+    CONNACK: "CONNACK",
+    WILLTOPICREQ: "WILLTOPICREQ",
+    WILLTOPIC: "WILLTOPIC",
+    WILLMSGREQ: "WILLMSGREQ",
+    WILLMSG: "WILLMSG",
+    REGISTER: "REGISTER",
+    REGACK: "REGACK",
+    PUBLISH: "PUBLISH",
+    PUBACK: "PUBACK",
+    PUBCOMP: "PUBCOMP",
+    PUBREC: "PUBREC",
+    PUBREL: "PUBREL",
+    SUBSCRIBE: "SUBSCRIBE",
+    SUBACK: "SUBACK",
+    UNSUBSCRIBE: "UNSUBSCRIBE",
+    UNSUBACK: "UNSUBACK",
+    PINGREQ: "PINGREQ",
+    PINGRESP: "PINGRESP",
+    DISCONNECT: "DISCONNECT",
+    WILLTOPICUPD: "WILLTOPICUPD",
+    WILLTOPICRESP: "WILLTOPICRESP",
+    WILLMSGUPD: "WILLMSGUPD",
+    WILLMSGRESP: "WILLMSGRESP",
+    ENCAPS_MSG: "Encapsulated message",
+}
+
+
+QOS_LEVELS = {
+    QOS_0: 'Fire and Forget',
+    QOS_1: 'Acknowledged deliver',
+    QOS_2: 'Assured Delivery',
+    QOS_NEG1: 'No Connection required',
+}
+
+
+TOPIC_ID_TYPES = {
+    TID_NORMAL: 'Normal ID',
+    TID_PREDEF: 'Pre-defined ID',
+    TID_SHORT: 'Short Topic Name',
+    TID_RESVD: 'Reserved',
+}
+
+
+RETURN_CODES = {
+    ACCEPTED: "Accepted",
+    REJ_CONJ: "Rejected: congestion",
+    REJ_TID: "Rejected: invalid topic ID",
+    REJ_NOTSUP: "Rejected: not supported",
+}
+
+
+FLAG_FIELDS = [
+    BitField("dup", 0, 1),
+    BitEnumField("qos", QOS_0, 2, QOS_LEVELS),
+    BitField("retain", 0, 1),
+    BitField("will", 0, 1),
+    BitField("cleansess", 0, 1),
+    BitEnumField("tid_type", TID_NORMAL, 2, TOPIC_ID_TYPES),
+]
+
+
+def _mqttsn_length_from(size_until):
+    def fun(pkt):
+        if (hasattr(pkt.underlayer, "len")):
+            if pkt.underlayer.len > 0xff:
+                return pkt.underlayer.len - size_until - 4
+            elif (pkt.underlayer.len > 1) and (pkt.underlayer.len < 0xffff):
+                return pkt.underlayer.len - size_until - 2
+        # assume string to be of length 0
+        return len(pkt.payload) - size_until + 1
+    return fun
+
+
+def _mqttsn_len_adjust(pkt, x):
+    res = x + len(pkt.payload)
+    if (pkt.type == DISCONNECT) and \
+       (getattr(pkt.payload, "duration", None) is None):
+        res -= 2    # duration is optional with DISCONNECT
+    elif (pkt.type == ENCAPS_MSG) and \
+         (getattr(pkt.payload, "w_node_id", None) is not None):
+        res = x + len(pkt.payload.w_node_id) + 1
+    return res
+
+
+class MQTTSN(Packet):
+    name = "MQTT-SN header"
+    fields_desc = [
+        # Since the size of the len field depends on the next layer, we
+        # need to "cheat" with the length_of parameter and use adjust
+        # parameter to calculate the value.
+        VariableFieldLenField("len", None, length_of="len",
+                              adjust=_mqttsn_len_adjust),
+        XByteEnumField("type", 0, PACKET_TYPE),
+    ]
+
+
+class MQTTSNAdvertise(Packet):
+    name = "MQTT-SN advertise gateway"
+    fields_desc = [
+        ByteField("gw_id", 0),
+        ShortField("duration", 0),
+    ]
+
+
+class MQTTSNSearchGW(Packet):
+    name = "MQTT-SN search gateway"
+    fields_desc = [
+        ByteField("radius", 0),
+    ]
+
+
+class MQTTSNGwInfo(Packet):
+    name = "MQTT-SN gateway info"
+    fields_desc = [
+        ByteField("gw_id", 0),
+        StrLenField("gw_addr", "", length_from=_mqttsn_length_from(1)),
+    ]
+
+
+class MQTTSNConnect(Packet):
+    name = "MQTT-SN connect command"
+    fields_desc = FLAG_FIELDS + [
+        ByteField("prot_id", 1),
+        ShortField("duration", 0),
+        StrLenField("client_id", "", length_from=_mqttsn_length_from(4)),
+    ]
+
+
+class MQTTSNConnack(Packet):
+    name = "MQTT-SN connect ACK"
+    fields_desc = [
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNWillTopicReq(Packet):
+    name = "MQTT-SN will topic request"
+
+
+class MQTTSNWillTopic(Packet):
+    name = "MQTT-SN will topic"
+    fields_desc = FLAG_FIELDS + [
+        StrLenField("will_topic", "", length_from=_mqttsn_length_from(1)),
+    ]
+
+
+class MQTTSNWillMsgReq(Packet):
+    name = "MQTT-SN will message request"
+
+
+class MQTTSNWillMsg(Packet):
+    name = "MQTT-SN will message"
+    fields_desc = [
+        StrLenField("will_msg", "", length_from=_mqttsn_length_from(0))
+    ]
+
+
+class MQTTSNRegister(Packet):
+    name = "MQTT-SN register"
+    fields_desc = [
+        ShortField("tid", 0),
+        ShortField("mid", 0),
+        StrLenField("topic_name", "", length_from=_mqttsn_length_from(4)),
+    ]
+
+
+class MQTTSNRegack(Packet):
+    name = "MQTT-SN register ACK"
+    fields_desc = [
+        ShortField("tid", 0),
+        ShortField("mid", 0),
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNPublish(Packet):
+    name = "MQTT-SN publish message"
+    fields_desc = FLAG_FIELDS + [
+        ShortField("tid", 0),
+        ShortField("mid", 0),
+        StrLenField("data", "", length_from=_mqttsn_length_from(5)),
+    ]
+
+
+class MQTTSNPuback(Packet):
+    name = "MQTT-SN publish ACK"
+    fields_desc = [
+        ShortField("tid", 0),
+        ShortField("mid", 0),
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNPubcomp(Packet):
+    name = "MQTT-SN publish complete"
+    fields_desc = [
+        ShortField("mid", 0),
+    ]
+
+
+class MQTTSNPubrec(Packet):
+    name = "MQTT-SN publish received"
+    fields_desc = [
+        ShortField("mid", 0),
+    ]
+
+
+class MQTTSNPubrel(Packet):
+    name = "MQTT-SN publish release"
+    fields_desc = [
+        ShortField("mid", 0),
+    ]
+
+
+class MQTTSNSubscribe(Packet):
+    name = "MQTT-SN subscribe request"
+    fields_desc = FLAG_FIELDS + [
+        ShortField("mid", 0),
+        ConditionalField(ShortField("tid", None),
+                         lambda pkt: pkt.tid_type == 0b01),
+        ConditionalField(StrFixedLenField("short_topic", None, length=2),
+                         lambda pkt: pkt.tid_type == 0b10),
+        ConditionalField(StrLenField("topic_name", None,
+                                     length_from=_mqttsn_length_from(3)),
+                         lambda pkt: pkt.tid_type not in [0b01, 0b10]),
+    ]
+
+
+class MQTTSNSuback(Packet):
+    name = "MQTT-SN subscribe ACK"
+    fields_desc = FLAG_FIELDS + [
+        ShortField("tid", 0),
+        ShortField("mid", 0),
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNUnsubscribe(Packet):
+    name = "MQTT-SN unsubscribe request"
+    fields_desc = FLAG_FIELDS + [
+        ShortField("mid", 0),
+        ConditionalField(ShortField("tid", None),
+                         lambda pkt: pkt.tid_type == 0b01),
+        ConditionalField(StrFixedLenField("short_topic", None, length=2),
+                         lambda pkt: pkt.tid_type == 0b10),
+        ConditionalField(StrLenField("topic_name", None,
+                                     length_from=_mqttsn_length_from(3)),
+                         lambda pkt: pkt.tid_type not in [0b01, 0b10]),
+    ]
+
+
+class MQTTSNUnsuback(Packet):
+    name = "MQTT-SN unsubscribe ACK"
+    fields_desc = [
+        ShortField("mid", 0),
+    ]
+
+
+class MQTTSNPingReq(Packet):
+    name = "MQTT-SN ping request"
+    fields_desc = [
+        StrLenField("client_id", "", length_from=_mqttsn_length_from(0)),
+    ]
+
+
+class MQTTSNPingResp(Packet):
+    name = "MQTT-SN ping response"
+
+
+class MQTTSNDisconnect(Packet):
+    name = "MQTT-SN disconnect request"
+    fields_desc = [
+        ConditionalField(
+            ShortField("duration", None),
+            lambda pkt: hasattr(pkt.underlayer, "len") and
+            ((pkt.underlayer.len is None) or (pkt.underlayer.len > 2))
+        ),
+    ]
+
+
+class MQTTSNWillTopicUpd(Packet):
+    name = "MQTT-SN will topic update"
+    fields_desc = FLAG_FIELDS + [
+        StrLenField("will_topic", "", length_from=_mqttsn_length_from(1)),
+    ]
+
+
+class MQTTSNWillTopicResp(Packet):
+    name = "MQTT-SN will topic response"
+    fields_desc = [
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNWillMsgUpd(Packet):
+    name = "MQTT-SN will message update"
+    fields_desc = [
+        StrLenField("will_msg", "", length_from=_mqttsn_length_from(0))
+    ]
+
+
+class MQTTSNWillMsgResp(Packet):
+    name = "MQTT-SN will message response"
+    fields_desc = [
+        ByteEnumField("return_code", ACCEPTED, RETURN_CODES),
+    ]
+
+
+class MQTTSNEncaps(Packet):
+    name = "MQTT-SN encapsulated message"
+    fields_desc = [
+        BitField("resvd", 0, 6),
+        BitField("radius", 0, 2),
+        StrLenField(
+            "w_node_id", "",
+            length_from=_mqttsn_length_from(1)
+        ),
+    ]
+
+
+# Layer bindings
+bind_layers(UDP, MQTTSN, sport=1883)
+bind_layers(UDP, MQTTSN, dport=1883)
+bind_layers(MQTTSN, MQTTSNAdvertise, type=ADVERTISE)
+bind_layers(MQTTSN, MQTTSNSearchGW, type=SEARCHGW)
+bind_layers(MQTTSN, MQTTSNGwInfo, type=GWINFO)
+bind_layers(MQTTSN, MQTTSNConnect, type=CONNECT)
+bind_layers(MQTTSN, MQTTSNConnack, type=CONNACK)
+bind_layers(MQTTSN, MQTTSNWillTopicReq, type=WILLTOPICREQ)
+bind_layers(MQTTSN, MQTTSNWillTopic, type=WILLTOPIC)
+bind_layers(MQTTSN, MQTTSNWillMsgReq, type=WILLMSGREQ)
+bind_layers(MQTTSN, MQTTSNWillMsg, type=WILLMSG)
+bind_layers(MQTTSN, MQTTSNRegister, type=REGISTER)
+bind_layers(MQTTSN, MQTTSNRegack, type=REGACK)
+bind_layers(MQTTSN, MQTTSNPublish, type=PUBLISH)
+bind_layers(MQTTSN, MQTTSNPuback, type=PUBACK)
+bind_layers(MQTTSN, MQTTSNPubcomp, type=PUBCOMP)
+bind_layers(MQTTSN, MQTTSNPubrec, type=PUBREC)
+bind_layers(MQTTSN, MQTTSNPubrel, type=PUBREL)
+bind_layers(MQTTSN, MQTTSNSubscribe, type=SUBSCRIBE)
+bind_layers(MQTTSN, MQTTSNSuback, type=SUBACK)
+bind_layers(MQTTSN, MQTTSNUnsubscribe, type=UNSUBSCRIBE)
+bind_layers(MQTTSN, MQTTSNUnsuback, type=UNSUBACK)
+bind_layers(MQTTSN, MQTTSNPingReq, type=PINGREQ)
+bind_layers(MQTTSN, MQTTSNPingResp, type=PINGRESP)
+bind_layers(MQTTSN, MQTTSNDisconnect, type=DISCONNECT)
+bind_layers(MQTTSN, MQTTSNWillTopicUpd, type=WILLTOPICUPD)
+bind_layers(MQTTSN, MQTTSNWillTopicResp, type=WILLTOPICRESP)
+bind_layers(MQTTSN, MQTTSNWillMsgUpd, type=WILLMSGUPD)
+bind_layers(MQTTSN, MQTTSNWillMsgResp, type=WILLMSGRESP)
+bind_layers(MQTTSN, MQTTSNEncaps, type=ENCAPS_MSG)
+bind_layers(MQTTSNEncaps, MQTTSN)

--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -192,6 +192,8 @@ def _mqttsn_len_adjust(pkt, x):
     elif (pkt.type == ENCAPS_MSG) and \
          (getattr(pkt.payload, "w_node_id", None) is not None):
         res = x + len(pkt.payload.w_node_id) + 1
+    if res > 0xff:
+        res += 2
     return res
 
 

--- a/test/contrib/mqttsn.uts
+++ b/test/contrib/mqttsn.uts
@@ -256,9 +256,9 @@ assert p.mid == 36181
 assert p.data == 726 * b"X"
 # Check if length field was constructed correctly
 b = bytes(p)
-assert b[:3] == b'\x01\x02\xdd'
+assert b[:3] == b'\x01\x02\xdf'
 p = MQTTSN(b)
-assert p.len == 733
+assert p.len == 735
 assert p.data == 726 * b"X"
 
 = MQTTSNPublish, packet dissection

--- a/test/contrib/mqttsn.uts
+++ b/test/contrib/mqttsn.uts
@@ -1,0 +1,810 @@
+# MQTT-SN layer unit tests
+# Copyright (C) 2019 Martine Lenders <m.lenders@fu-berlin.de>
+#
+# This program is published under GPLv2 license
+#
+# Type the following command to start the test
+# $ test/run_tests -P "load_contrib('mqttsn')" -t test/contrib/mqttsn.uts
+
++ Syntax check
+= Import the MQTT-SN layer
+from scapy.contrib.mqttsn import *
+
++ MQTT-SN protocol test
+
+= MQTTSN + MQTTSNAdvertise, packet instantiation and len field adjust
+p = MQTTSN() / MQTTSNAdvertise(gw_id=142, duration=54403)
+assert p.len is None
+assert p.type == ADVERTISE
+assert p.gw_id == 142
+assert p.duration == 54403
+b = bytes(p)
+p = MQTTSN(b)
+assert p.len == 5
+assert p.type == ADVERTISE
+assert p.gw_id == 142
+assert p.duration == 54403
+
+= MQTTSNAdvertise, packet dissection
+b = b"\x05\x00\x98\x2b\x9a"
+p = MQTTSN(b)
+assert p.len == 5
+assert p.type == ADVERTISE
+assert p.gw_id == 0x98
+assert p.duration == 0x2b9a
+
+= MQTTSNSearchGW, packet instantiation
+p = MQTTSN() / MQTTSNSearchGW(radius=175)
+assert p.len is None
+assert p.type == SEARCHGW
+assert p.radius == 175
+
+= MQTTSNSearchGW, packet dissection
+b = b"\x03\x01\xcc"
+p = MQTTSN(b)
+assert p.len == 3
+assert p.type == SEARCHGW
+assert p.radius == 0xcc
+
+= MQTTSNGwInfo, packet instantiation
+p = MQTTSN() / MQTTSNGwInfo(gw_id=135, gw_addr="test\0test")
+assert p.len is None
+assert p.type == GWINFO
+assert p.gw_id == 135
+assert p.gw_addr == b"test\x00test"
+
+= MQTTSN + MQTTSNGwInfo, packet instantiation and len field adjust
+p = MQTTSN(len=7) / MQTTSNGwInfo(gw_id=7, gw_addr="test") / "xyz"
+assert p.len == 7
+assert p.type == GWINFO
+assert p.gw_id == 7
+assert p.gw_addr == b"test"
+assert p.load == b"xyz"
+b = bytes(p)
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == GWINFO
+assert p.gw_id == 7
+assert p.gw_addr == b"test"
+assert p.load == b"xyz"
+
+= MQTTSNGwInfo, packet dissection
+b = b"\x07\x02\x14testing"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == GWINFO
+assert p.gw_id == 0x14
+assert p.gw_addr == b"test"
+assert p.load == b"ing"
+
+= MQTTSNGwInfo, packet dissection - invalid length
+b = "\x01\x00\x01\x02\x14test"
+p = MQTTSN(b)
+print(type(p), repr(p))
+assert p.len == 1
+assert p.type == GWINFO
+assert p.gw_id == 0x14
+assert p.gw_addr == b""
+
+= MQTTSNConnect, packet instantiation
+p = MQTTSN() / MQTTSNConnect(duration=40666, client_id="test")
+assert p.len is None
+assert p.type == CONNECT
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.prot_id == 1
+assert p.duration == 40666
+assert p.client_id == b"test"
+
+= MQTTSNConnect, packet dissection
+b = b"\x0a\x04\x04\x1a\x77\x5btesting"
+p = MQTTSN(b)
+assert p.len == 10
+assert p.type == CONNECT
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 1
+assert p.tid_type == TID_NORMAL
+assert p.prot_id == 0x1a
+assert p.duration == 0x775b
+assert p.client_id == b"test"
+assert p.load == b"ing"
+
+= MQTTSNConnack, packet instantiation
+p = MQTTSN() / MQTTSNConnack()
+assert p.len is None
+assert p.type == CONNACK
+assert p.return_code == ACCEPTED
+
+= MQTTSNConnack, packet dissection
+b = b"\x03\x05\x02"
+p = MQTTSN(b)
+assert p.len == 3
+assert p.type == CONNACK
+assert p.return_code == REJ_TID
+
+= MQTTSNWillTopicReq, packet instantiation
+p = MQTTSN() / MQTTSNWillTopicReq()
+assert p.len is None
+assert p.type == WILLTOPICREQ
+
+= MQTTSNWillTopicReq, packet dissection
+b = b"\x02\x06"
+p = MQTTSN(b)
+assert p.len == 2
+assert p.type == WILLTOPICREQ
+
+= MQTTSNWillTopic, packet instantiation
+p = MQTTSN() / MQTTSNWillTopic(will_topic="/test")
+assert p.len is None
+assert p.type == WILLTOPIC
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.will_topic == b"/test"
+
+= MQTTSNWillTopic, packet dissection
+b = b"\x08\x07\x00/testing"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == WILLTOPIC
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.will_topic == b"/test"
+
+= MQTTSNWillMsgReq, packet instantiation
+p = MQTTSN() / MQTTSNWillMsgReq()
+assert p.len is None
+assert p.type == WILLMSGREQ
+
+= MQTTSNWillMsgReq, packet dissection
+b = b"\x02\x08"
+p = MQTTSN(b)
+assert p.len == 2
+assert p.type == WILLMSGREQ
+
+= MQTTSNWillMsg, packet instantiation
+p = MQTTSN() / MQTTSNWillMsg(will_msg="test")
+assert p.len is None
+assert p.type == WILLMSG
+assert p.will_msg == b"test"
+
+= MQTTSNWillMsg, packet dissection
+b = b"\x06\x09testing"
+p = MQTTSN(b)
+assert p.len == 6
+assert p.type == WILLMSG
+assert p.will_msg == b"test"
+assert p.load == b"ing"
+
+= MQTTSNRegister, packet instantiation
+p = MQTTSN() / MQTTSNRegister(mid=30533, topic_name="/test")
+assert p.len is None
+assert p.type == REGISTER
+assert p.tid == 0
+assert p.mid == 30533
+assert p.topic_name == b"/test"
+
+= MQTTSNRegister, packet dissection
+b = b"\x0b\x0a\0\0\x48\x8a/testing"
+p = MQTTSN(b)
+assert p.len == 11
+assert p.type == REGISTER
+assert p.tid == 0
+assert p.mid == 0x488a
+assert p.topic_name == b"/test"
+assert p.load == b"ing"
+
+= MQTTSNRegack, packet instantiation
+p = MQTTSN() / MQTTSNRegack(tid=61547, mid=8593, return_code=REJ_NOTSUP)
+assert p.len is None
+assert p.type == REGACK
+assert p.tid == 61547
+assert p.mid == 8593
+assert p.return_code == REJ_NOTSUP
+
+= MQTTSNRegack, packet dissection
+b = b"\x08\x0b\xc5\xe8\x31\x87\x01"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == REGACK
+assert p.tid == 0xc5e8
+assert p.mid == 0x3187
+assert p.return_code == REJ_CONJ
+
+= MQTTSNPublish, packet instantiation
+p = MQTTSN() / MQTTSNPublish(qos=QOS_1, tid=52032, mid=35252,
+                             data="Hello world!")
+assert p.len is None
+assert p.type == PUBLISH
+assert p.dup == 0
+assert p.qos == QOS_1
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.tid == 52032
+assert p.mid == 35252
+assert p.data == b"Hello world!"
+
+= MQTTSNPublish, packet instantiation - long data
+p = MQTTSN() / MQTTSNPublish(qos=QOS_NEG1, tid=62839, mid=36181,
+                             data=726 * "X")
+assert p.len is None
+assert p.type == PUBLISH
+assert p.dup == 0
+assert p.qos == QOS_NEG1
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.tid == 62839
+assert p.mid == 36181
+assert p.data == 726 * b"X"
+# Check if length field was constructed correctly
+b = bytes(p)
+assert b[:3] == b'\x01\x02\xdd'
+p = MQTTSN(b)
+assert p.len == 733
+
+= MQTTSNPublish, packet dissection
+b = b"\x0b\x0c\x40\x19\x7f\x6a\x26testing"
+p = MQTTSN(b)
+assert p.len == 11
+assert p.type == PUBLISH
+assert p.dup == 0
+assert p.qos == QOS_2
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.tid == 0x197f
+assert p.mid == 0x6a26
+assert p.data == b"test"
+assert p.load == b"ing"
+
+= MQTTSNPublish, packet dissection - long data
+b = b"\x01\x04\x64\x0c" + b"\x00\xb1\x39\xd7\x4a" + (1115 * b"X")
+p = MQTTSN(b)
+assert p.len == 0x0464 == (4 + 5 + 1115)
+assert p.type == PUBLISH
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.tid == 0xb139
+assert p.mid == 0xd74a
+assert p.data == 1115 * b"X"
+
+= MQTTSNPuback, packet instantiation
+p = MQTTSN() / MQTTSNPuback(tid=27610, mid=30284, return_code=ACCEPTED)
+assert p.len is None
+assert p.type == PUBACK
+assert p.tid == 27610
+assert p.mid == 30284
+assert p.return_code == ACCEPTED
+
+= MQTTSNPuback, packet dissection
+b = b"\x08\x0d\x03\xda\x73\x9a\x02"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == PUBACK
+assert p.tid == 0x03da
+assert p.mid == 0x739a
+assert p.return_code == REJ_TID
+
+= MQTTSNPubcomp, packet instantiation
+p = MQTTSN() / MQTTSNPubcomp(mid=36193)
+assert p.len is None
+assert p.type == PUBCOMP
+assert p.mid == 36193
+
+= MQTTSNPubcomp, packet dissection
+b = b"\x04\x0e\x26\xa2"
+p = MQTTSN(b)
+assert p.len == 4
+assert p.type == PUBCOMP
+assert p.mid == 0x26a2
+
+= MQTTSNPubrec, packet instantiation
+p = MQTTSN() / MQTTSNPubrec(mid=44837)
+assert p.len is None
+assert p.type == PUBREC
+assert p.mid == 44837
+
+= MQTTSNPubrec, packet dissection
+b = b"\x04\x0f\x36\xc4"
+p = MQTTSN(b)
+assert p.len == 4
+assert p.type == PUBREC
+assert p.mid == 0x36c4
+
+= MQTTSNPubrel, packet instantiation
+p = MQTTSN() / MQTTSNPubrel(mid=42834)
+assert p.len is None
+assert p.type == PUBREL
+assert p.mid == 42834
+
+= MQTTSNPubrel, packet dissection
+b = b"\x04\x10\x94\x0f"
+p = MQTTSN(b)
+assert p.len == 4
+assert p.type == PUBREL
+assert p.mid == 0x940f
+
+= MQTTSNSubscribe, packet instantiation - topic name
+p = MQTTSN() / MQTTSNSubscribe(mid=63780, topic_name="/test")
+assert p.len is None
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.topic_name == b"/test"
+assert p.short_topic is None
+assert p.tid is None
+
+= MQTTSNSubscribe, packet instantiation - predefined topic ID
+p = MQTTSN() / MQTTSNSubscribe(mid=63780, tid_type=TID_PREDEF,
+                               tid=1187)
+assert p.len is None
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_PREDEF
+assert p.topic_name is None
+assert p.short_topic is None
+assert p.tid == 1187
+
+= MQTTSNSubscribe, packet instantiation - short topic
+p = MQTTSN() / MQTTSNSubscribe(mid=63780, tid_type=TID_SHORT, short_topic="fx")
+assert p.len is None
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_SHORT
+assert p.topic_name is None
+assert p.short_topic == b"fx"
+assert p.tid is None
+
+= MQTTSNSubscribe, packet dissection - topic name
+b = b"\x07\x12\x00\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.mid == 0x668a
+assert p.topic_name == b"/t"
+assert p.short_topic is None
+assert p.tid is None
+
+= MQTTSNSubscribe, packet dissection - short topic
+b = b"\x07\x12\x01\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_PREDEF
+assert p.mid == 0x668a
+assert p.topic_name is None
+assert p.short_topic is None
+assert p.tid == (ord("/") << 8 | ord("t")) == 12148
+
+= MQTTSNSubscribe, packet dissection - predefined topic ID
+b = b"\x07\x12\x02\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == SUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_SHORT
+assert p.mid == 0x668a
+assert p.topic_name is None
+assert p.short_topic == b"/t"
+assert p.tid is None
+
+= MQTTSNSuback, packet instantiation
+p = MQTTSN() / MQTTSNSuback(qos=QOS_0, tid=5496, mid=63108,
+                             return_code=REJ_TID)
+assert p.len is None
+assert p.type == SUBACK
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.tid == 5496
+assert p.mid == 63108
+assert p.return_code == REJ_TID
+
+= MQTTSNSuback, packet dissection
+b = b"\x08\x13\xa4\x93\x0b\x02\xc6\x00"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == SUBACK
+assert p.dup == 1
+assert p.qos == QOS_1
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 1
+assert p.tid_type == TID_NORMAL
+assert p.tid == 0x930b
+assert p.mid == 0x02c6
+assert p.return_code == ACCEPTED
+
+= MQTTSNUnsubscribe, packet instantiation - topic name
+p = MQTTSN() / MQTTSNUnsubscribe(mid=63780, topic_name="/test")
+assert p.len is None
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.topic_name == b"/test"
+assert p.short_topic is None
+assert p.tid is None
+
+= MQTTSNUnsubscribe, packet instantiation - predefined topic ID
+p = MQTTSN() / MQTTSNUnsubscribe(mid=63780, tid_type=TID_PREDEF,
+                                 tid=1187)
+assert p.len is None
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_PREDEF
+assert p.topic_name is None
+assert p.short_topic is None
+assert p.tid == 1187
+
+= MQTTSNUnsubscribe, packet instantiation - short topic
+p = MQTTSN() / MQTTSNUnsubscribe(mid=63780, tid_type=TID_SHORT,
+                                 short_topic="fx")
+assert p.len is None
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_SHORT
+assert p.topic_name is None
+assert p.short_topic == b"fx"
+assert p.tid is None
+
+= MQTTSNUnsubscribe, packet dissection - topic name
+b = b"\x07\x14\x00\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.mid == 0x668a
+assert p.topic_name == b"/t"
+assert p.short_topic is None
+assert p.tid is None
+
+= MQTTSNUnsubscribe, packet dissection - short topic
+b = b"\x07\x14\x01\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_PREDEF
+assert p.mid == 0x668a
+assert p.topic_name is None
+assert p.short_topic is None
+assert p.tid == (ord("/") << 8 | ord("t")) == 12148
+
+= MQTTSNUnsubscribe, packet dissection - predefined topic ID
+b = b"\x07\x14\x02\x66\x8a/t"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == UNSUBSCRIBE
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_SHORT
+assert p.mid == 0x668a
+assert p.topic_name is None
+assert p.short_topic == b"/t"
+assert p.tid is None
+
+= MQTTSNUnsuback, packet instantiation
+p = MQTTSN() / MQTTSNUnsuback(mid=44541)
+assert p.len is None
+assert p.type == UNSUBACK
+assert p.mid == 44541
+
+= MQTTSNUnsuback, packet dissection
+b = b"\x08\x15\xcb\x3d"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == UNSUBACK
+assert p.mid == 0xcb3d
+
+= MQTTSNPingReq, packet instantiation - no client ID
+p = MQTTSN() / MQTTSNPingReq()
+assert p.len is None
+assert p.type == PINGREQ
+assert p.client_id == b""
+
+= MQTTSNPingReq, packet instantiation - with client ID
+p = MQTTSN() / MQTTSNPingReq(client_id="test")
+assert p.len is None
+assert p.type == PINGREQ
+assert p.client_id == b"test"
+
+= MQTTSNPingReq, packet dissection
+b = b"\x07\x16hello"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == PINGREQ
+assert p.client_id == b"hello"
+
+= MQTTSNPingResp, packet instantiation
+p = MQTTSN() / MQTTSNPingResp()
+assert p.len is None
+assert p.type == PINGRESP
+
+= MQTTSNPingResp, packet dissection
+b = b"\x02\x17"
+p = MQTTSN(b)
+assert p.len == 2
+assert p.type == PINGRESP
+
+= MQTTSNDisconnect, packet instantiation and len field adjust - w/o duration
+p = MQTTSN() / MQTTSNDisconnect()
+assert p.len is None
+assert p.type == DISCONNECT
+assert p.duration is None
+b = bytes(p)
+p = MQTTSN(b)
+assert p.len == 2
+assert p.type == DISCONNECT
+
+= MQTTSNDisconnect, packet instantiation and len field adjust - w duration
+p = MQTTSN() / MQTTSNDisconnect(duration=19567)
+assert p.len is None
+assert p.type == DISCONNECT
+assert p.duration == 19567
+b = bytes(p)
+p = MQTTSN(b)
+assert p.len == 4
+assert p.type == DISCONNECT
+assert p.duration == 19567
+
+= MQTTSNDisconnect, packet dissection - w/o duration
+b = b"\x02\x18"
+p = MQTTSN(b)
+assert p.len == 2
+assert p.type == DISCONNECT
+
+= MQTTSNDisconnect, packet dissection - w duration
+b = b"\x04\x18\x03\x12"
+p = MQTTSN(b)
+assert p.len == 4
+assert p.type == DISCONNECT
+assert p.duration == 0x0312
+
+= MQTTSNWillTopicUpd, packet instantiation
+p = MQTTSN() / MQTTSNWillTopicUpd(will_topic="/test")
+assert p.len is None
+assert p.type == WILLTOPICUPD
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.will_topic == b"/test"
+
+= MQTTSNWillTopicUpd, packet dissection
+b = b"\x08\x1a\x00/testing"
+p = MQTTSN(b)
+assert p.len == 8
+assert p.type == WILLTOPICUPD
+assert p.dup == 0
+assert p.qos == QOS_0
+assert p.retain == 0
+assert p.will == 0
+assert p.cleansess == 0
+assert p.tid_type == TID_NORMAL
+assert p.will_topic == b"/test"
+
+= MQTTSNWillTopicResp, packet instantiation
+p = MQTTSN() / MQTTSNWillTopicResp()
+assert p.len is None
+assert p.type == WILLTOPICRESP
+assert p.return_code == ACCEPTED
+
+= MQTTSNWillTopicResp, packet dissection
+b = b"\x03\x1b\x02"
+p = MQTTSN(b)
+assert p.len == 3
+assert p.type == WILLTOPICRESP
+assert p.return_code == REJ_TID
+
+= MQTTSNWillMsgUpd, packet instantiation
+p = MQTTSN() / MQTTSNWillMsgUpd(will_msg="test")
+assert p.len is None
+assert p.type == WILLMSGUPD
+assert p.will_msg == b"test"
+
+= MQTTSNWillMsgUpd, packet dissection
+b = b"\x06\x1ctesting"
+p = MQTTSN(b)
+assert p.len == 6
+assert p.type == WILLMSGUPD
+assert p.will_msg == b"test"
+assert p.load == b"ing"
+
+= MQTTSNWillMsgResp, packet instantiation
+p = MQTTSN() / MQTTSNWillMsgResp()
+assert p.len is None
+assert p.type == WILLMSGRESP
+assert p.return_code == ACCEPTED
+
+= MQTTSNWillMsgResp, packet dissection
+b = b"\x03\x1d\x02"
+p = MQTTSN(b)
+assert p.len == 3
+assert p.type == WILLMSGRESP
+assert p.return_code == REJ_TID
+
+= MQTTSNEncaps, packet instantiation
+p = MQTTSN() / MQTTSNEncaps(radius=1, w_node_id="test") / MQTTSN() / \
+    MQTTSNConnack()
+assert p.len is None
+assert p.type == ENCAPS_MSG
+assert p.radius == 1
+assert p.w_node_id == b"test"
+assert p.payload.payload.len is None
+assert p.payload.payload.type == CONNACK
+assert p.payload.payload.return_code == ACCEPTED
+b = bytes(p)
+p = MQTTSN(p)
+assert p.len == 7
+assert p.type == ENCAPS_MSG
+assert p.radius == 1
+assert p.w_node_id == b"test"
+assert p.return_code == ACCEPTED
+assert p.payload.payload.len == 3
+assert p.payload.payload.type == CONNACK
+assert p.payload.payload.return_code == ACCEPTED
+
+= MQTTSNEncaps, packet dissection
+b = b"\x07\xfe\x02test\x03\x05\x00"
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == ENCAPS_MSG
+assert p.radius == 2
+assert p.w_node_id == b"test"
+assert p.payload.payload.len == 3
+assert p.payload.payload.type == CONNACK
+assert p.payload.payload.return_code == ACCEPTED
+
+= MQTTSNEncaps, packet dissection -- long payload
+b = b"\x07\xfe\x02test" + b"\x01\x04\x64\x0c" + b"\x00\xb1\x39\xd7\x4a" + \
+        (1115 * b"X")
+p = MQTTSN(b)
+assert p.len == 7
+assert p.type == ENCAPS_MSG
+assert p.radius == 2
+assert p.w_node_id == b"test"
+assert p.payload.payload.len == 4 + 5 + 1115 == 0x0464
+assert p.payload.payload.type == PUBLISH
+assert p.payload.payload.dup == 0
+assert p.payload.payload.qos == QOS_0
+assert p.payload.payload.retain == 0
+assert p.payload.payload.will == 0
+assert p.payload.payload.cleansess == 0
+assert p.payload.payload.tid_type == TID_NORMAL
+assert p.payload.payload.tid == 0xb139
+assert p.payload.payload.mid == 0xd74a
+assert p.payload.payload.data == 1115 * b"X"
+
+= MQTTSN without payload
+p = MQTTSN()
+assert(bytes(p) == b"\x02\x00")
+
+= MQTTSN without payload -- invalid lengths
+p = MQTTSN(len=1)
+try:
+    bytes(p)        # expect Scapy_Exception
+    assert(false)
+except Scapy_Exception:
+    pass
+
+p = MQTTSN(len=0x10000)
+try:
+    bytes(p)        # expect Scapy_Exception
+    assert(false)
+except Scapy_Exception:
+    pass
+
+b = '\x01'
+try:
+    p = MQTTSN(b)   # expect Scapy_Exception
+    assert(false)
+except Scapy_Exception:
+    pass
+
+b = '\x01\x02'
+try:
+    p = MQTTSN(b)   # expect Scapy_Exception
+    assert(false)
+except Scapy_Exception:
+    pass
+
+
+= MQTT-SN RandVariableFieldLen
+assert(type(MQTTSN().fieldtype["len"].randval()) == RandVariableFieldLen)
+assert(type(MQTTSN().fieldtype["len"].randval() + 0) == int)
+
+= Disect full IPv6 packages
+~ dport == 1883 (0x75b)
+b = b"\x60\x00\x00\x00\x00\x2c\x11\x40\x20\x01\x0d\xb8\x00\x00\x00\x00" \
+    b"\x17\x11\x6b\x10\x65\xf7\x5f\x0a\x20\x01\x0d\xb8\x00\x00\x00\x00" \
+    b"\x17\x11\x6b\x10\x65\xfd\xbe\x06\xc0\x00\x07\x5b\x00\x2c\x40\x7e" \
+    b"\x0b\x0a\0\0\x48\x8a/testing"
+p = IPv6(b)
+assert MQTTSNRegister in p
+
+~ sport == 1883 (0x75b)
+b = b"\x60\x00\x00\x00\x00\x0f\x11\x40\x20\x01\x0d\xb8\x00\x00\x00\x00" \
+    b"\x17\x11\x6b\x10\x65\xfd\xbe\x06\x20\x01\x0d\xb8\x00\x00\x00\x00" \
+    b"\x17\x11\x6b\x10\x65\xf7\x5f\x0a\x07\x5b\xc0\x00\x00\x0f\x62\x7c" \
+    b"\x07\x0d\x00\x01\x86\x2f\x00"
+p = IPv6(b)
+assert MQTTSNPuback in p

--- a/test/contrib/mqttsn.uts
+++ b/test/contrib/mqttsn.uts
@@ -809,3 +809,10 @@ b = b"\x60\x00\x00\x00\x00\x0f\x11\x40\x20\x01\x0d\xb8\x00\x00\x00\x00" \
     b"\x07\x0d\x00\x01\x86\x2f\x00"
 p = IPv6(b)
 assert MQTTSNPuback in p
+
+= UDP packet instantiation
+b = bytes(UDP() / MQTTSN() / MQTTSNConnack())
+p = UDP(b)
+assert MQTTSNConnack in p
+assert p.sport == 1883
+assert p.dport == 1883

--- a/test/contrib/mqttsn.uts
+++ b/test/contrib/mqttsn.uts
@@ -259,6 +259,7 @@ b = bytes(p)
 assert b[:3] == b'\x01\x02\xdd'
 p = MQTTSN(b)
 assert p.len == 733
+assert p.data == 726 * b"X"
 
 = MQTTSNPublish, packet dissection
 b = b"\x0b\x0c\x40\x19\x7f\x6a\x26testing"


### PR DESCRIPTION
MQTT-SN is a sister protocol to MQTT that allows for MQTT-like traffic over UDP. It was designed to be as close as possible to MQTT but has some differences in its header format, so the MQTT layer of `scapy` can't be used to handle MQTT-SN packets.