### PR TITLE
Vagrant based *BSD CI

### DIFF
--- a/doc/scapy/development.rst
+++ b/doc/scapy/development.rst
@@ -279,6 +279,7 @@ signing a commit, the maintainer that wishes to create a release must:
 * check that the corresponding Travis and AppVeyor tests pass
 * run ``./run_scapy`` locally
 * run ``tox``
+* run unit tests on BSD using the Vagrant setup from ``scapy/doc/vagrant_ci/``
 
 Taking v2.4.3 as an example, the following commands can be used to sign and
 publish the release::

--- a/doc/vagrant_ci/README.md
+++ b/doc/vagrant_ci/README.md
@@ -1,0 +1,4 @@
+# Scapy Unit Tests
+
+This directory contains a Vagrant setup to ease starting `tox` based Scapy unit
+tests.

--- a/doc/vagrant_ci/Vagrantfile
+++ b/doc/vagrant_ci/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define "openbsd" do |bsd|
+    bsd.vm.box = "generic/openbsd6"
+    bsd.vm.provision "shell", path: "provision_openbsd.sh"
+  end
+
+  config.vm.define "freebsd" do |bsd|
+    bsd.vm.box = "freebsd/FreeBSD-11.3-RELEASE"
+    bsd.vm.provision "shell", path: "provision_freebsd.sh"
+  end
+
+  config.vm.define "netbsd" do |bsd|
+    bsd.vm.box = "generic/netbsd8"
+    bsd.vm.provision "shell", path: "provision_netbsd.sh"
+  end
+
+end

--- a/doc/vagrant_ci/provision_freebsd.sh
+++ b/doc/vagrant_ci/provision_freebsd.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+sudo pkg install --yes git python2 python3 py27-virtualenv bash
+bash
+git clone https://github.com/secdev/scapy
+cd scapy
+export PATH=/usr/local/bin/:$PATH
+virtualenv -p python2.7 venv
+source venv/bin/activate
+pip install tox

--- a/doc/vagrant_ci/provision_netbsd.sh
+++ b/doc/vagrant_ci/provision_netbsd.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+sudo -s
+export PATH="/sbin:/usr/pkg/sbin:/usr/pkg/bin:$PATH"
+export PKG_PATH="http://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/8.0_2018Q4/All/"
+pkg_delete curl
+pkg_add git python27 python36 py27-virtualenv py36-expat
+git -c http.sslVerify=false clone https://github.com/secdev/scapy
+cd scapy
+virtualenv-2.7 venv
+. venv/bin/activate
+pip install tox
+chown -R vagrant:vagrant ../scapy/

--- a/doc/vagrant_ci/provision_openbsd.sh
+++ b/doc/vagrant_ci/provision_openbsd.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+sudo pkg_add git python-2.7.15p0 python-3.6.6p1 py-virtualenv
+sudo mkdir -p /usr/local/test/
+sudo chown -R vagrant:vagrant /usr/local/test/
+cd /usr/local/test/
+git clone https://github.com/secdev/scapy
+cd scapy
+virtualenv venv
+source venv/bin/activate
+pip install tox
+sudo chown -R vagrant:vagrant /usr/local/test/


### PR DESCRIPTION
This PR simplifies the setup of *BSD VMs to launch Scapy unit tests with tox.