### PR TITLE
Net6 format

### DIFF
--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -882,7 +882,7 @@ class Net6(Gen):  # syntax ex. fec0::/126
                                for i in range(*self.parsed[n])
                                for y in l])
 
-        return iter(rec(0, ['']))
+        return (in6_ptop(addr) for addr in iter(rec(0, [''])))
 
     def __iterlen__(self):
         self._parse()

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10617,6 +10617,10 @@ assert isinstance(n1, Net6)
 assert n1.ip_regex.match(str(n1))
 ip.show()
 
+ip = IPv6(dst="www.yahoo.com")
+addrs = [ip.dst, IPv6(raw(ip)).dst, [p.dst for p in ip][0]]
+assert addrs[0] == addrs[1] == addrs[2]
+
 = Multiple IPv6 addresses test
 ~ netaccess ipv6
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6966,6 +6966,7 @@ print(data)
 assert b'127.0.0.1 > 127.0.0.1: ICMP' in data[0].upper()
 
 = Check tcpdump() command with linktype
+~ tcpdump
 
 f = BytesIO()
 pkt = Ether()/IP()/ICMP()
@@ -6986,6 +6987,7 @@ f.close()
 del f, pkt
 
 = Check tcpdump() command with linktype and args
+~ tcpdump
 
 f = BytesIO()
 pkt = Ether()/IP()/ICMP()


### PR DESCRIPTION
This PR fixes https://bitbucket.org/secdev/scapy/issues/5089

The second commit adds missing UTScapy flags.