### PR TITLE
Fix solaris support

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -269,6 +269,15 @@ In a similar manner, to install Scapy on OpenBSD 5.9+, you **may** want to insta
 Then install Scapy via ``pip`` or ``pkg_add`` (bundled under ``python-scapy``)
 All dependencies may be installed either via the platform-specific installer, or via PyPI. See `Optional Dependencies <#optional-dependencies>`_ for more information.
 
+SunOS / Solaris
+---------------
+
+Solaris / SunOS requires ``libpcap`` (installed by default) to work.
+
+.. note::
+    In fact, Solaris doesn't support `AF_PACKET`, which Scapy uses on Linux, but rather uses its own system `DLPI`. See `this page <https://www.oracle.com/technetwork/server-storage/solaris/solaris-linux-app-139382.html>`_.
+    We prefer using the very universal `libpcap` that spending time implementing support for `DLPI`.
+
 .. _windows_installation:
 
 Windows

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -61,7 +61,12 @@ def get_if(iff, cmd):
     return ifreq
 
 
+def get_if_raw_hwaddr(iff):
+    from scapy.arch import SIOCGIFHWADDR
+    return struct.unpack("16xh6s8x", get_if(iff, SIOCGIFHWADDR))
+
 # SOCKET UTILS
+
 
 def _select_nonblock(sockets, remain=None):
     """This function is called during sendrecv() routine to select

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -62,6 +62,14 @@ def get_if(iff, cmd):
 
 
 def get_if_raw_hwaddr(iff):
+    """Get the raw MAC address of a local interface.
+
+    This function uses SIOCGIFHWADDR calls, therefore only works
+    on some distros.
+
+    :param iff: the network interface name as a string
+    :returns: the corresponding raw MAC address
+    """
     from scapy.arch import SIOCGIFHWADDR
     return struct.unpack("16xh6s8x", get_if(iff, SIOCGIFHWADDR))
 

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -36,6 +36,7 @@ from scapy.arch.common import get_if, compile_filter
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
 
+from scapy.arch.common import get_if_raw_hwaddr  # noqa: F401
 
 # From bits/ioctls.h
 SIOCGIFHWADDR = 0x8927          # Get hardware address
@@ -111,10 +112,6 @@ class tpacket_auxdata(ctypes.Structure):
 
 
 # Utils
-
-def get_if_raw_hwaddr(iff):
-    return struct.unpack("16xh6s8x", get_if(iff, SIOCGIFHWADDR))
-
 
 def get_if_raw_addr(iff):
     try:

--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -7,8 +7,30 @@
 Customization for the Solaris operation system.
 """
 
-from scapy.arch.unix import *  # noqa: F401,F403
+import socket
+import scapy.consts
+
+from scapy.config import conf
+conf.use_pcap = True
 
 # IPPROTO_GRE is missing on Solaris
-import socket
 socket.IPPROTO_GRE = 47
+
+# From sys/sockio.h and net/if.h
+SIOCGIFHWADDR = 0xc02069b9  # Get hardware address
+
+from scapy.arch.pcapdnet import *  # noqa: F401, F403
+from scapy.arch.unix import *  # noqa: F401, F403
+from scapy.arch.common import get_if_raw_hwaddr  # noqa: F401, F403
+
+
+def get_working_if():
+    """Return an interface that works"""
+    try:
+        # return the interface associated with the route with smallest
+        # mask (route by default if it exists)
+        iface = min(conf.route.routes, key=lambda x: x[1])[3]
+    except ValueError:
+        # no route
+        iface = scapy.consts.LOOPBACK_INTERFACE
+    return iface

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -42,12 +42,16 @@ def _guess_iface_name(netif):
 
 
 def read_routes():
+    """Return a list of IPv4 routes than can be used by Scapy.
+
+    This function parses netstat.
+    """
     if SOLARIS:
-        f = os.popen("netstat -rvn")  # -f inet
+        f = os.popen("netstat -rvn -f inet")
     elif FREEBSD:
         f = os.popen("netstat -rnW")  # -W to handle long interface names
     else:
-        f = os.popen("netstat -rn")  # -f inet
+        f = os.popen("netstat -rn -f inet")
     ok = 0
     mtu_present = False
     prio_present = False
@@ -58,42 +62,39 @@ def read_routes():
     for line in f.readlines():
         if not line:
             break
-        line = line.strip()
+        line = line.strip().lower()
         if line.find("----") >= 0:  # a separation line
             continue
         if not ok:
-            if line.find("Destination") >= 0:
+            if line.find("destination") >= 0:
                 ok = 1
-                mtu_present = "Mtu" in line
-                prio_present = "Prio" in line
-                refs_present = "Refs" in line
-                use_present = "Use" in line
+                mtu_present = "mtu" in line
+                prio_present = "prio" in line
+                refs_present = "ref" in line  # There is no s on Solaris
+                use_present = "use" in line
             continue
         if not line:
             break
+        rt = line.split()
         if SOLARIS:
-            lspl = line.split()
-            if len(lspl) == 10:
-                dest, mask, gw, netif, mxfrg, rtt, ref, flg = lspl[:8]
-            else:  # missing interface
-                dest, mask, gw, mxfrg, rtt, ref, flg = lspl[:7]
-                netif = None
+            dest, netmask, gw, netif = rt[:4]
+            flg = rt[4 + mtu_present + refs_present]
         else:
-            rt = line.split()
             dest, gw, flg = rt[:3]
-            locked = OPENBSD and rt[6] == "L"
+            locked = OPENBSD and rt[6] == "l"
             offset = mtu_present + prio_present + refs_present + locked
             offset += use_present
             netif = rt[3 + offset]
-        if flg.find("Lc") >= 0:
+        if flg.find("lc") >= 0:
             continue
-        if dest == "default":
+        elif dest == "default":
             dest = 0
             netmask = 0
+        elif SOLARIS:
+            dest = scapy.utils.atol(dest)
+            netmask = scapy.utils.atol(netmask)
         else:
-            if SOLARIS:
-                netmask = scapy.utils.atol(mask)
-            elif "/" in dest:
+            if "/" in dest:
                 dest, netmask = dest.split("/")
                 netmask = scapy.utils.itom(int(netmask))
             else:
@@ -102,7 +103,7 @@ def read_routes():
             dest = scapy.utils.atol(dest)
         # XXX: TODO: add metrics for unix.py (use -e option on netstat)
         metric = 1
-        if "G" not in flg:
+        if "g" not in flg:
             gw = '0.0.0.0'
         if netif is not None:
             try:
@@ -183,6 +184,7 @@ def _in6_getifaddr(ifname):
         scope = in6_getscope(addr)
         ret.append((addr, scope, ifname))
 
+    f.close()
     return ret
 
 
@@ -197,9 +199,13 @@ def in6_getifaddr():
     """
 
     # List all network interfaces
-    if OPENBSD:
+    if OPENBSD or SOLARIS:
+        if SOLARIS:
+            cmd = "%s -a6"
+        else:
+            cmd = "%s"
         try:
-            f = os.popen("%s" % conf.prog.ifconfig)
+            f = os.popen(cmd % conf.prog.ifconfig)
         except OSError:
             log_interactive.warning("Failed to execute ifconfig.")
             return []
@@ -224,11 +230,15 @@ def in6_getifaddr():
     ret = []
     for i in splitted_line:
         ret += _in6_getifaddr(i)
+    f.close()
     return ret
 
 
 def read_routes6():
-    """Return a list of IPv6 routes than can be used by Scapy."""
+    """Return a list of IPv6 routes than can be used by Scapy.
+
+    This function parses netstat.
+    """
 
     # Call netstat to retrieve IPv6 routes
     fd_netstat = os.popen("netstat -rn -f inet6")
@@ -236,6 +246,7 @@ def read_routes6():
     # List interfaces IPv6 addresses
     lifaddr = in6_getifaddr()
     if not lifaddr:
+        fd_netstat.close()
         return []
 
     # Routes header information

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -17,7 +17,7 @@ import socket
 import sys
 
 from scapy import VERSION, base_classes
-from scapy.consts import DARWIN, WINDOWS, LINUX, BSD
+from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
 from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
 from scapy.modules import six
 from scapy.themes import NoTheme, apply_ipython_style
@@ -441,6 +441,11 @@ def _set_conf_sockets():
     if conf.use_bpf and not BSD:
         Interceptor.set_from_hook(conf, "use_bpf", False)
         raise ScapyInvalidPlatformException("BSD-like (OSX, *BSD...) only !")
+    if not conf.use_pcap and SOLARIS:
+        Interceptor.set_from_hook(conf, "use_pcap", True)
+        raise ScapyInvalidPlatformException(
+            "Scapy only supports libpcap on Solaris !"
+        )
     # we are already in an Interceptor hook, use Interceptor.set_from_hook
     if conf.use_pcap or conf.use_dnet:
         try:

--- a/test/configs/solaris.utsc
+++ b/test/configs/solaris.utsc
@@ -1,0 +1,29 @@
+{
+  "testfiles": [
+    "test/*.uts",
+    "test/contrib/*.uts"
+  ],
+  "remove_testfiles": [
+    "test/linux.uts",
+    "test/bpf.uts",
+    "test/windows.uts",
+    "test/contrib/cansocket_native.uts",
+    "test/contrib/cansocket_python_can.uts"
+  ],
+  "onlyfailed": true,
+  "preexec": {
+    "test/contrib/*.uts": "load_contrib(\"%name%\")",
+    "test/cert.uts": "load_layer(\"tls\")",
+    "test/sslv2.uts": "load_layer(\"tls\")",
+    "test/tls*.uts": "load_layer(\"tls\")"
+  },
+  "format": "text",
+  "kw_ko": [
+    "osx",
+    "linux",
+    "windows",
+    "crypto_advanced",
+    "ipv6",
+    "vcan_socket"
+  ]
+}

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7990,7 +7990,7 @@ default            192.168.122.1      UGSc           en0
     routes = read_routes()
     for r in routes:
         print(r)
-    assert(len(routes) == 11)
+    assert len(routes) == 11
     default_route = [r for r in routes if r[0] == 0][0]
     assert default_route[3] == "en0" and default_route[4] == "192.168.122.42"
 
@@ -8037,22 +8037,61 @@ default            10.0.1.254         UGS        0        0     -     8 bge0
     mock_openbsd = True
     # Test the function
     from scapy.arch.unix import read_routes
-    routes = read_routes()
-    for r in routes:
-        print(ltoa(r[0]), ltoa(r[1]), r)
-        # check that default route exists in parsed data structure
-        if ltoa(r[0]) == "0.0.0.0":
-            default=r
-        # check that route with locked mtu exists in parsed data structure
-        if ltoa(r[0]) == "10.188.135.0":
-            locked=r
-    assert(len(routes) == 11)
-    assert(default[2] == "10.0.1.254")
-    assert(default[3] == "bge0")
-    assert(locked[2] == "10.0.1.135")
-    assert(locked[3] == "bge0")
+    return read_routes()
 
-test_openbsd_6_3()
+routes = test_openbsd_6_3()
+
+for r in routes:
+    print(ltoa(r[0]), ltoa(r[1]), r)
+    # check that default route exists in parsed data structure
+    if ltoa(r[0]) == "0.0.0.0":
+        default = r
+    # check that route with locked mtu exists in parsed data structure
+    if ltoa(r[0]) == "10.188.135.0":
+        locked = r
+
+assert len(routes) == 11
+assert default[2] == "10.0.1.254"
+assert default[3] == "bge0"
+assert locked[2] == "10.0.1.135"
+assert locked[3] == "bge0"
+
+= Solaris 11.1
+~ mock_read_routes_bsd
+
+import mock
+from io import StringIO
+
+# Mocked Solaris 11.1 parsing behavior
+
+@mock.patch("scapy.arch.unix.SOLARIS", True)
+@mock.patch("scapy.arch.unix.os")
+def test_solaris_111(mock_os):
+    """Test read_routes() on Solaris 11.1"""
+    # 'netstat -rvn -f inet' output
+    netstat_output = u"""
+IRE Table: IPv4
+  Destination             Mask           Gateway          Device  MTU  Ref Flg  Out  In/Fwd 
+-------------------- --------------- -------------------- ------ ----- --- --- ----- ------ 
+default              0.0.0.0         10.0.2.2             net0    1500   2 UG       5      0 
+10.0.2.0             255.255.255.0   10.0.2.15            net0    1500   3 U        0      0 
+127.0.0.1            255.255.255.255 127.0.0.1            lo0     8232   2 UH    1517   1517
+"""
+    # Mocked file descriptor
+    strio = StringIO(netstat_output)
+    mock_os.popen = mock.MagicMock(return_value=strio)
+    print(scapy.arch.unix.SOLARIS)
+    
+    # Test the function
+    from scapy.arch.unix import read_routes
+    return read_routes()
+
+routes = test_solaris_111()
+print(routes)
+assert len(routes) == 3
+assert routes[0][:4] == (0, 0, '10.0.2.2', 'net0')
+assert routes[1][:4] == (167772672, 4294967040, '0.0.0.0', 'net0')
+assert routes[2][:4] == (2130706433, 4294967295, '0.0.0.0', 'lo0')
 
 
 ############

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,6 +1,6 @@
 #! /bin/sh
 DIR=$(dirname $0)/..
-PYTHON=${PYTHON:-python}
+PYTHON=${PYTHON:-python3}
 PYTHONDONTWRITEBYTECODE="True"
 if [ -z "$*" ]
 then


### PR DESCRIPTION
This PR:
- fixes Solaris support: tested on a VM with Solaris 11.1
- cleanup un-required stuff
- **Solaris will only work WITH Libpcap**: it's much easier for us than implement `DLPI`, which is required for Solaris. In fact, according to [this page](https://www.oracle.com/technetwork/server-storage/solaris/solaris-linux-app-139382.html) Solaris doesn't support `AF_PACKET` but rather uses `DLPI`.

fixes https://github.com/secdev/scapy/pull/2141