### PR TITLE
Removing conf.iface6

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -1028,9 +1028,6 @@ def route_add_loopback(routes=None, ipv6=False, iflist=None):
     if isinstance(conf.iface, NetworkInterface):
         if conf.iface.name == scapy.consts.LOOPBACK_NAME:
             conf.iface = adapter
-    if isinstance(conf.iface6, NetworkInterface):
-        if conf.iface6.name == scapy.consts.LOOPBACK_NAME:
-            conf.iface6 = adapter
     conf.netcache.arp_cache["127.0.0.1"] = "ff:ff:ff:ff:ff:ff"
     conf.netcache.in6_neighbor["::1"] = "ff:ff:ff:ff:ff:ff"
     # Build the packed network addresses

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -567,7 +567,6 @@ class Conf(ConfClass):
     interactive_shell = ""
     stealth = "not implemented"
     iface = None
-    iface6 = None
     layers = LayersList()
     commands = CommandsList()
     dot15d4_protocol = None  # Used in dot15d4.py

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -660,6 +660,9 @@ class Conf(ConfClass):
         if attr == "services_tcp":
             from scapy.data import TCP_SERVICES
             return TCP_SERVICES
+        if attr == "iface6":
+            warning("conf.iface6 is deprecated in favor of conf.iface")
+            attr = "iface"
         return object.__getattribute__(self, attr)
 
 

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1363,7 +1363,7 @@ class DHCPv6_am(AnsweringMachine):
     def usage(self):
         msg = """
 DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
-        duid=None, iface=conf.iface6, advpref=255, sntpservers=None,
+        duid=None, iface=conf.iface, advpref=255, sntpservers=None,
         sipdomains=None, sipservers=None,
         nisdomain=None, nisservers=None,
         nispdomain=None, nispservers=None,
@@ -1377,7 +1377,7 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
             answering machine.
 
    iface : the interface to listen/reply on if you do not want to use
-           conf.iface6.
+           conf.iface.
 
    advpref : Value in [0,255] given to Advertise preference field.
              By default, 255 is used. Be aware that this specific
@@ -1446,7 +1446,7 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
                 return -1
 
         if iface is None:
-            iface = conf.iface6
+            iface = conf.iface
 
         self.debug = debug
 

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -308,7 +308,7 @@ class Route6:
         #  - dst is unicast global. Check if it is 6to4 and we have a source
         #    6to4 address in those available
         #  - dst is link local (unicast or multicast) and multiple output
-        #    interfaces are available. Take main one (conf.iface6)
+        #    interfaces are available. Take main one (conf.iface)
         #  - if none of the previous or ambiguity persists, be lazy and keep
         #    first one
 
@@ -320,7 +320,7 @@ class Route6:
                 tmp = [x for x in res if in6_isaddr6to4(x[2][1])]
             elif in6_ismaddr(dst) or in6_islladdr(dst):
                 # TODO : I'm sure we are not covering all addresses. Check that
-                tmp = [x for x in res if x[2][0] == conf.iface6]
+                tmp = [x for x in res if x[2][0] == conf.iface]
 
             if tmp:
                 res = tmp
@@ -335,7 +335,3 @@ class Route6:
 
 
 conf.route6 = Route6()
-try:
-    conf.iface6 = conf.route6.route(None)[0]
-except Exception:
-    pass

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -66,7 +66,7 @@ a = DHCPv6_am()
 a.usage()
 
 a.parse_options(dns="2001:500::1035", domain="localdomain, local", duid=None,
-        iface=conf.iface6, advpref=255, sntpservers=None, 
+        iface=conf.iface, advpref=255, sntpservers=None,
         sipdomains=None, sipservers=None, 
         nisdomain=None, nisservers=None, 
         nispdomain=None, nispservers=None,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -185,7 +185,7 @@ get_if_list()
 
 get_working_if()
 
-get_if_raw_addr6(conf.iface6)
+get_if_raw_addr6(conf.iface)
 
 = Test read_routes6() - default output
 


### PR DESCRIPTION
While reading some IPv6 related functions, it discovered that `conf.iface6` is not necessary.