### PR TITLE
Add support for ESN

### DIFF
--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -338,7 +338,7 @@ class CryptAlgo(object):
 
         return esp
 
-    def encrypt(self, sa, esp, key, esn_en = False, esn = 0):
+    def encrypt(self, sa, esp, key, esn_en=False, esn=0):
         """
         Encrypt an ESP packet
 
@@ -346,7 +346,8 @@ class CryptAlgo(object):
         @param esp:  an unencrypted _ESPPlain packet with valid padding
         @param key:  the secret key used for encryption
         @esn_en:     extended sequence number enable which allows to use 64-bit
-                     sequence number instead of 32-bit when using an AEAD algorithm
+                     sequence number instead of 32-bit when using an AEAD
+                     algorithm
         @esn:        extended sequence number (32 MSB)
         @return:    a valid ESP packet encrypted with this algorithm
         """
@@ -358,10 +359,10 @@ class CryptAlgo(object):
             encryptor = cipher.encryptor()
 
             if self.is_aead:
-                if esn_en == True :
-                  aad = struct.pack('!LLL', esp.spi, esn, esp.seq)
-                else : 
-                  aad = struct.pack('!LL', esp.spi, esp.seq)
+                if esn_en:
+                    aad = struct.pack('!LLL', esp.spi, esn, esp.seq)
+                else:
+                    aad = struct.pack('!LL', esp.spi, esp.seq)
                 encryptor.authenticate_additional_data(aad)
                 data = encryptor.update(data) + encryptor.finalize()
                 data += encryptor.tag[:self.icv_size]
@@ -370,7 +371,7 @@ class CryptAlgo(object):
 
         return ESP(spi=esp.spi, seq=esp.seq, data=esp.iv + data)
 
-    def decrypt(self, sa, esp, key, icv_size=None, esn_en = False, esn = 0):
+    def decrypt(self, sa, esp, key, icv_size=None, esn_en=False, esn=0):
         """
         Decrypt an ESP packet
 
@@ -399,14 +400,12 @@ class CryptAlgo(object):
 
             if self.is_aead:
                 # Tag value check is done during the finalize method
-                if esn_en == True : 
-                  decryptor.authenticate_additional_data(
-                     struct.pack('!LLL', esp.spi, esn, esp.seq))
-                else : 
-                  decryptor.authenticate_additional_data(
-                     struct.pack('!LL', esp.spi, esp.seq)
-                )
-
+                if esn_en:
+                    decryptor.authenticate_additional_data(
+                        struct.pack('!LLL', esp.spi, esn, esp.seq))
+                else:
+                    decryptor.authenticate_additional_data(
+                        struct.pack('!LL', esp.spi, esp.seq))
             try:
                 data = decryptor.update(data) + decryptor.finalize()
             except InvalidTag as err:
@@ -792,7 +791,7 @@ class SecurityAssociation(object):
     SUPPORTED_PROTOS = (IP, IPv6)
 
     def __init__(self, proto, spi, seq_num=1, crypt_algo=None, crypt_key=None,
-                 auth_algo=None, auth_key=None, tunnel_header=None, nat_t_header=None, esn_en = False, esn = 0):   # noqa: E501
+                 auth_algo=None, auth_key=None, tunnel_header=None, nat_t_header=None, esn_en=False, esn=0):   # noqa: E501
         """
         @param proto: the IPsec proto to use (ESP or AH)
         @param spi: the Security Parameters Index of this SA
@@ -807,7 +806,8 @@ class SecurityAssociation(object):
         @param nat_t_header: an instance of a UDP header that will be used
                              for NAT-Traversal.
         @esn_en: extended sequence number enable which allows to use 64-bit
-                 sequence number instead of 32-bit when using an AEAD algorithm
+                 sequence number instead of 32-bit when using an AEAD
+                 algorithm
         @esn:    extended sequence number (32 MSB)
         """
 
@@ -867,7 +867,7 @@ class SecurityAssociation(object):
             raise TypeError('packet spi=0x%x does not match the SA spi=0x%x' %
                             (pkt.spi, self.spi))
 
-    def _encrypt_esp(self, pkt, seq_num=None, iv=None, esn_en = None, esn = None):
+    def _encrypt_esp(self, pkt, seq_num=None, iv=None, esn_en=None, esn=None):
 
         if iv is None:
             iv = self.crypt_algo.generate_iv()
@@ -895,7 +895,9 @@ class SecurityAssociation(object):
         esp.nh = nh
 
         esp = self.crypt_algo.pad(esp)
-        esp = self.crypt_algo.encrypt(self, esp, self.crypt_key, esn_en = esn_en or self.esn_en, esn = esn or self.esn)
+        esp = self.crypt_algo.encrypt(self, esp, self.crypt_key,
+                                      esn_en=esn_en or self.esn_en,
+                                      esn=esn or self.esn)
 
         self.auth_algo.sign(esp, self.auth_key)
 
@@ -972,7 +974,7 @@ class SecurityAssociation(object):
 
         return signed_pkt
 
-    def encrypt(self, pkt, seq_num=None, iv=None, esn_en = None, esn = None):
+    def encrypt(self, pkt, seq_num=None, iv=None, esn_en=None, esn=None):
         """
         Encrypt (and encapsulate) an IP(v6) packet with ESP or AH according
         to this SecurityAssociation.
@@ -980,8 +982,9 @@ class SecurityAssociation(object):
         @param pkt:     the packet to encrypt
         @param seq_num: if specified, use this sequence number instead of the
                         generated one
-        @esn_en:        extended sequence number enable which allows to use 64-bit
-                        sequence number instead of 32-bit when using an AEAD algorithm
+        @esn_en:        extended sequence number enable which allows to
+                        use 64-bit sequence number instead of 32-bit when
+                        using an AEAD algorithm
         @esn:           extended sequence number (32 MSB)
         @param iv:      if specified, use this initialization vector for
                         encryption instead of a random one.
@@ -992,11 +995,13 @@ class SecurityAssociation(object):
             raise TypeError('cannot encrypt %s, supported protos are %s'
                             % (pkt.__class__, self.SUPPORTED_PROTOS))
         if self.proto is ESP:
-            return self._encrypt_esp(pkt, seq_num=seq_num, iv=iv, esn_en = esn_en, esn = esn)
+            return self._encrypt_esp(pkt, seq_num=seq_num,
+                                     iv=iv, esn_en=esn_en,
+                                     esn=esn)
         else:
             return self._encrypt_ah(pkt, seq_num=seq_num)
 
-    def _decrypt_esp(self, pkt, verify=True, esn_en = None , esn = None):
+    def _decrypt_esp(self, pkt, verify=True, esn_en=None, esn=None):
 
         encrypted = pkt[ESP]
 
@@ -1006,7 +1011,9 @@ class SecurityAssociation(object):
 
         esp = self.crypt_algo.decrypt(self, encrypted, self.crypt_key,
                                       self.crypt_algo.icv_size or
-                                      self.auth_algo.icv_size, esn_en = esn_en or self.esn_en, esn = esn or self.esn)
+                                      self.auth_algo.icv_size,
+                                      esn_en=esn_en or self.esn_en,
+                                      esn=esn or self.esn)
 
         if self.tunnel_header:
             # drop the tunnel header and return the payload untouched
@@ -1069,14 +1076,15 @@ class SecurityAssociation(object):
             # reassemble the ip_header with the AH payload
             return ip_header / payload
 
-    def decrypt(self, pkt, verify=True, esn_en = None, esn = None):
+    def decrypt(self, pkt, verify=True, esn_en=None, esn=None):
         """
         Decrypt (and decapsulate) an IP(v6) packet containing ESP or AH.
 
         @param pkt:     the packet to decrypt
         @param verify:  if False, do not perform the integrity check
         @esn_en:     extended sequence number enable which allows to use 64-bit
-                     sequence number instead of 32-bit when using an AEAD algorithm
+                     sequence number instead of 32-bit when using an AEAD
+                     algorithm
         @esn:        extended sequence number (32 MSB)
         @return: the decrypted/decapsulated packet
         @raise IPSecIntegrityError: if the integrity check fails
@@ -1086,7 +1094,8 @@ class SecurityAssociation(object):
                             % (pkt.__class__, self.SUPPORTED_PROTOS))
 
         if self.proto is ESP and pkt.haslayer(ESP):
-            return self._decrypt_esp(pkt, verify=verify, esn_en = esn_en, esn = esn)
+            return self._decrypt_esp(pkt, verify=verify,
+                                     esn_en=esn_en, esn=esn)
         elif self.proto is AH and pkt.haslayer(AH):
             return self._decrypt_ah(pkt, verify=verify)
         else:

--- a/test/ipsec.uts
+++ b/test/ipsec.uts
@@ -1559,6 +1559,60 @@ d_ref
 assert(d_ref.haslayer(ICMP))
 
 #######################################
+= IPv4 / ESP - Transport - AES-GCM - NULL -- ESN
+
+p = IP(src='1.1.1.1', dst='2.2.2.2')
+p /= TCP(sport=45012, dport=80)
+p /= Raw('testdata')
+p = IP(raw(p))
+p
+
+sa = SecurityAssociation(ESP, spi=0x222,
+                         crypt_algo='AES-GCM', crypt_key=b'16bytekey+4bytenonce',
+                         auth_algo='NULL', auth_key=None, esn_en = True, esn = 0x1)
+
+e = sa.encrypt(p)
+e
+
+assert(isinstance(e, IP))
+assert(e.src == '1.1.1.1' and e.dst == '2.2.2.2')
+assert(e.chksum != p.chksum)
+assert(e.proto == socket.IPPROTO_ESP)
+assert(e.haslayer(ESP))
+assert(not e.haslayer(TCP))
+assert(e[ESP].spi == sa.spi)
+* after encryption the original packet payload should NOT be readable
+assert(b'testdata' not in e[ESP].data)
+
+d = sa.decrypt(e)
+d
+
+* after decryption original packet should be preserved
+assert(d[TCP] == p[TCP])
+
+# Generated with Linux 4.4.0-62-generic #83-Ubuntu
+# ip xfrm state add src 10.125.0.2 dst 10.125.0.1 proto esp spi 546 reqid 1 \
+#    mode tunnel aead 'rfc4106(gcm(aes))' '0x3136627974656b65792b34627974656e6f6e6365' 128 flag align4
+ref = IP() \
+    / ESP(spi=0x222,
+          data=b'\x66\x00\x28\x86\xe9\xdf\xc5\x24\xb0\xbd\xfd\x62\x61\x7e\xd3\x76'
+               b'\x7b\x48\x28\x8e\x76\xaa\xea\x48\xb8\x40\x30\x8a\xce\x50\x71\xbb'
+               b'\xc0\xb2\x47\x71\xd7\xa4\xa0\xcb\x03\x68\xd3\x16\x5a\x7c\x37\x84'
+               b'\x87\xc7\x19\x59\xb4\x7c\x76\xe3\x48\xc0\x90\x4b\xd2\x36\x95\xc1'
+               b'\xb7\xa4\xb6\x7b\x89\xe6\x4f\x10\xae\xdb\x84\x47\x46\x00\xb4\x44'
+               b'\xe6\x6d\x16\x55\x5f\x82\x36\xa5\x49\xf7\x52\x81\x65\x90\x4d\x28'
+               b'\xfe\x4d\x22\x83\x6a\x81\x0d\x60\x94\xdb\x45\x22\x03\x92\xf6\x94',
+          seq=1)
+
+d_ref = sa.decrypt(ref)
+d_ref
+
+* Check for ICMP layer in decrypted reference
+assert(d_ref.haslayer(ICMP))
+
+
+#######################################
+
 = IPv4 / ESP - Transport - AES-GCM - NULL - altered packet
 
 p = IP(src='1.1.1.1', dst='2.2.2.2')
@@ -1593,7 +1647,42 @@ try:
     assert(False)
 except IPSecIntegrityError as err:
     err
+    
+#######################################
 
+= IPv4 / ESP - Transport - AES-GCM - NULL - altered packet -- ESN
+
+p = IP(src='1.1.1.1', dst='2.2.2.2')
+p /= TCP(sport=45012, dport=80)
+p /= Raw('testdata')
+p = IP(raw(p))
+p
+
+sa = SecurityAssociation(ESP, spi=0x222,
+                         crypt_algo='AES-GCM', crypt_key=b'16bytekey+4bytenonce',
+                         auth_algo='NULL', auth_key=None, esn_en = True, esn = 0x200)
+
+e = sa.encrypt(p)
+e
+
+assert(isinstance(e, IP))
+assert(e.src == '1.1.1.1' and e.dst == '2.2.2.2')
+assert(e.chksum != p.chksum)
+assert(e.proto == socket.IPPROTO_ESP)
+assert(e.haslayer(ESP))
+assert(not e.haslayer(TCP))
+assert(e[ESP].spi == sa.spi)
+* after encryption the original packet payload should NOT be readable
+assert(b'testdata' not in e[ESP].data)
+
+* simulate the alteration of the packet before decryption
+* integrity verification should fail
+try:
+    d = sa.decrypt(e, esn = 0x201)
+    assert(False)
+except IPSecIntegrityError as err:
+    err
+    
 #######################################
 = IPv4 / ESP - Transport - AES-CCM - NULL
 ~ crypto_advanced
@@ -1793,6 +1882,41 @@ d
 assert(d[TCP] == p[TCP])
 
 #######################################
+= IPv4 / ESP - Tunnel - AES-GCM - NULL -- ESN
+
+p = IP(src='1.1.1.1', dst='2.2.2.2')
+p /= TCP(sport=45012, dport=80)
+p /= Raw('testdata')
+p = IP(raw(p))
+p
+
+sa = SecurityAssociation(ESP, spi=0x222,
+                         crypt_algo='AES-GCM', crypt_key=b'16bytekey+4bytenonce',
+                         auth_algo='NULL', auth_key=None,
+                         tunnel_header=IP(src='11.11.11.11', dst='22.22.22.22'), esn_en = True, esn = 0x2)
+
+e = sa.encrypt(p)
+e
+
+assert(isinstance(e, IP))
+* after encryption packet should be encapsulated with the given ip tunnel header
+assert(e.src == '11.11.11.11' and e.dst == '22.22.22.22')
+assert(e.chksum != p.chksum)
+assert(e.proto == socket.IPPROTO_ESP)
+assert(e.haslayer(ESP))
+assert(not e.haslayer(TCP))
+assert(e[ESP].spi == sa.spi)
+* after encryption the original packet payload should NOT be readable
+assert(b'testdata' not in e[ESP].data)
+
+d = sa.decrypt(e)
+d
+
+* after decryption original packet should be preserved
+assert(d[TCP] == p[TCP])
+
+#######################################
+
 = IPv4 / ESP - Tunnel - AES-GCM - NULL - altered packet
 
 p = IP(src='1.1.1.1', dst='2.2.2.2')
@@ -1829,6 +1953,43 @@ try:
     assert(False)
 except IPSecIntegrityError as err:
     err
+    
+#######################################
+
+= IPv4 / ESP - Tunnel - AES-GCM - NULL - altered packet - ESN
+
+p = IP(src='1.1.1.1', dst='2.2.2.2')
+p /= TCP(sport=45012, dport=80)
+p /= Raw('testdata')
+p = IP(raw(p))
+p
+
+sa = SecurityAssociation(ESP, spi=0x222,
+                         crypt_algo='AES-GCM', crypt_key=b'16bytekey+4bytenonce',
+                         auth_algo='NULL', auth_key=None,
+                         tunnel_header=IP(src='11.11.11.11', dst='22.22.22.22'), esn_en = True, esn = 0x2)
+
+e = sa.encrypt(p)
+e
+
+assert(isinstance(e, IP))
+* after encryption packet should be encapsulated with the given ip tunnel header
+assert(e.src == '11.11.11.11' and e.dst == '22.22.22.22')
+assert(e.chksum != p.chksum)
+assert(e.proto == socket.IPPROTO_ESP)
+assert(e.haslayer(ESP))
+assert(not e.haslayer(TCP))
+assert(e[ESP].spi == sa.spi)
+* after encryption the original packet payload should NOT be readable
+assert(b'testdata' not in e[ESP].data)
+
+* simulate the alteration of the packet before decryption
+* integrity verification should fail
+try:
+    d = sa.decrypt(e, esn = 0x3)
+    assert(False)
+except IPSecIntegrityError as err:
+    err    
 
 #######################################
 = IPv4 / ESP - Tunnel - AES-CCM - NULL


### PR DESCRIPTION
This is a proposal of support for using Extended Sequence Number in Scapy's IPsec for AEAD algorithm such as AES-GCM (see RFC 4303 & RFC 4106).

ESN adds support for 64 bit packet numbers instead of 32 bit. While only the 32 LSB are sent in the packet (in the ESP header), the 32 MSB can be included in the computation of the ICV for AEAD algorithms.

Therefore, for such algorithms, the additional authenticated data (AAD) has the following organization : 
SPI & ESN (96-bits) instead of SPI & SN (64-bits).

In order to do that, I have added two arguments in the encrypt & decrypt functions : esn_en & esn.
- esn_en : ESN Enable
- esn : ESN 32 MSB
If those two arguments are not specified, then the esn_en & esn values are taken from the SA parameters.
By default, sa.esn_en is False and sa.esn is 0.

I added a few tests in ipsec.uts to test this new feature.

Thank you for your feedback.