### PR TITLE
Route link-local addresses to a valid IPv6 interface

### DIFF
--- a/test/linux.uts
+++ b/test/linux.uts
@@ -113,8 +113,8 @@ assert(exit_status == 0)
 = IPv6 link-local address selection
 
 from mock import patch
-bck_conf_route6_routes = conf.route6.routes
 conf.route6.routes =  [('fe80::', 64, '::', 'scapy0', ['fe80::e039:91ff:fe79:1910'], 256)]
+conf.route6.ipv6_ifaces = set(['scapy0'])
 bck_conf_iface = conf.iface
 conf.iface = "scapy0"
 with patch("scapy.layers.l2.get_if_hwaddr") as mgih:
@@ -128,8 +128,8 @@ with patch("scapy.layers.l2.get_if_hwaddr") as mgih:
     print(p[Ether].src, mac_address)
     assert p[Ether].src == mac_address
 
-conf.route6.routes = bck_conf_route6_routes
 conf.iface = bck_conf_iface
+conf.route6.resync()
 
 = IPv6
 ~ linux
@@ -139,7 +139,7 @@ if len(addrs) == 0:
     assert True
 else:
     assert all([in6_isvalid(addr[0]) for addr in in6_getifaddr()])
-    assert set([addr[2] for addr in in6_getifaddr()]) == set(get_if_list())
+    assert set([addr[2] for addr in in6_getifaddr()]) == conf.route6.ipv6_ifaces
 
 
 = veth interface error handling

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -162,6 +162,7 @@ routes6
 
 # Expected results:
 # - one route if there is only the loopback interface
+# - one route if IPv6 is supported but disabled on network interfaces
 # - three routes if there is a network interface
 # - on OpenBSD, only two routes on lo0 are expected
 
@@ -174,17 +175,18 @@ if routes6:
     elif iflist == [LOOPBACK_NAME]:
         len(routes6) == 1
     elif len(iflist) >= 2:
-        len(routes6) >= 3
+        len(routes6) >= 1
     else:
         False
 else:
     # IPv6 seems disabled. Force a route to ::1
     conf.route6.routes.append(("::1", 128, "::", LOOPBACK_NAME, ["::1"], 1))
+    conf.route6.ipv6_ifaces = set([LOOPBACK_NAME])
     True
 
 = Test read_routes6() - check mandatory routes
 
-if len(routes6) and not WINDOWS:
+if len(routes6) > 1 and not WINDOWS:
     assert(sum(1 for r in routes6 if r[0] == "::1" and r[4] == ["::1"]) >= 1)
     if not OPENBSD and len(iflist) >= 2:
         assert sum(1 for r in routes6 if r[0] == "fe80::" and r[1] == 64) >= 1
@@ -4137,6 +4139,7 @@ not conf.route6.routes
 
 = Route6 - Route6.route
 conf.route6.flush()
+conf.route6.ipv6_ifaces = set(['lo', 'eth0'])
 conf.route6.routes=[
 (                               '::1', 128,                       '::',   'lo', ['::1'], 1), 
 (          'fe80::20f:1fff:feca:4650', 128,                       '::',   'lo', ['::1'], 1), 
@@ -8712,10 +8715,10 @@ finally:
 
 = Mocked IPv6 routes calls
 
-old_routes = conf.route6.routes
 old_iface = conf.iface
 old_loopback = scapy.consts.LOOPBACK_INTERFACE
 try:
+    conf.route6.ipv6_ifaces = set(['enp3s0', 'wlan0', 'lo'])
     conf.iface = 'enp3s0'
     scapy.consts.LOOPBACK_INTERFACE = 'lo'
     conf.route6.invalidate_cache()
@@ -8739,8 +8742,17 @@ try:
 finally:
     scapy.consts.LOOPBACK_INTERFACE = old_loopback
     conf.iface = old_iface
-    conf.route6.routes = old_routes
-    conf.route6.invalidate_cache()
+    conf.route6.resync()
+
+= Find a link-local address when conf.iface does not support IPv6
+
+old_iface = conf.iface
+conf.route6.ipv6_ifaces = set(['eth1', 'lo'])
+conf.iface = "eth0"
+conf.route6.routes = [("fe80::", 64, "::", "eth1", ["fe80::a00:28ff:fe07:1980"], 256), ("::1", 128, "::", "lo", ["::1"], 0), ("fe80::a00:28ff:fe07:1980", 128, "::", "lo", ["::1"], 0)]
+assert(conf.route6.route("fe80::2807") == ("eth1", "fe80::a00:28ff:fe07:1980", "::"))
+conf.iface = old_iface
+conf.route6.resync()
 
 = Windows: reset routes properly
 


### PR DESCRIPTION
This PR fixes an issue reported on gitter. Scapy routes IPv6 packets to link-local address to `conf.iface`. This is problematic when IPv6 is not enabled on this interface.