### PR TITLE
Fixed uncaught FileNotFoundError in _test_pyx()

### DIFF
--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -45,6 +45,8 @@ def _test_pyx():
                                       stdout=devnull, stderr=subprocess.STDOUT)
     except (subprocess.CalledProcessError, OSError):
         return False
+    except FileNotFoundError as fnfe:
+        return False
     else:
         return r == 0
 

--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -43,9 +43,7 @@ def _test_pyx():
         with open(os.devnull, 'wb') as devnull:
             r = subprocess.check_call(["pdflatex", "--version"],
                                       stdout=devnull, stderr=subprocess.STDOUT)
-    except (subprocess.CalledProcessError, OSError):
-        return False
-    except FileNotFoundError as fnfe:
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         return False
     else:
         return r == 0


### PR DESCRIPTION
While installing scapy on a fresh system, I discovered that pdflatex was missing.

While extlib._text_pyx() tests if PyX is installed correctly, it does not take into account pdflatex might not be installed on the system.