### PR TITLE
Fix *args/**kwargs on Sessions

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -765,11 +765,13 @@ class AsyncSniffer(object):
              prn=None, lfilter=None,
              L2socket=None, timeout=None, opened_socket=None,
              stop_filter=None, iface=None, started_callback=None,
-             session=None, *arg, **karg):
+             session=None, session_args=[], session_kwargs={},
+             *arg, **karg):
         self.running = True
         # Start main thread
+        # instantiate session
         session = session or DefaultSession
-        session = session(prn, store, *arg, **karg)  # instantiate session
+        session = session(prn, store, *session_args, **session_kwargs)
         # sniff_sockets follows: {socket: label}
         sniff_sockets = {}
         if opened_socket is not None:

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1066,7 +1066,7 @@ candump_fd = BytesIO(b'''  vcan0  541   [8]  10 0A DE AD BE EF AA AA
   vcan0  241   [3]  30 00 00
   vcan0  541   [5]  21 AA AA AA AA''')
 
-pkts = sniff(opened_socket=CandumpReader(candump_fd), session=ISOTPSession, timeout=1, use_ext_addr=False)
+pkts = sniff(opened_socket=CandumpReader(candump_fd), session=ISOTPSession, timeout=1, session_kwargs={"use_ext_addr": False})
 assert(len(pkts) == 6)
 isotp = pkts[0]
 assert(isotp.data == dhex("DE AD BE EF AA AA AA AA AA AA"))


### PR DESCRIPTION
Reverts @polybassa 'a changes.

It actually broke things like
`sniff(filter="tcp port 80")`
`sniff(monitor=True)`

What do you think of the new changes ?