### PR TITLE
Error management on non-sudo sockets

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -512,8 +512,11 @@ class L2Socket(SuperSocket):
     def close(self):
         if self.closed:
             return
-        if self.promisc and self.ins:
-            set_promisc(self.ins, self.iface, 0)
+        try:
+            if self.promisc and self.ins:
+                set_promisc(self.ins, self.iface, 0)
+        except AttributeError:
+            pass
         SuperSocket.close(self)
 
     if six.PY2:


### PR DESCRIPTION
Very small patch to remove the second exception when launching a socket in non sudo mode.

It appears people are too lazy to read the exception entirely 😄 