### PR TITLE
Fix fuzzing on MultipleTypeField

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -587,7 +587,7 @@ class L3PacketSocket(L2Socket):
         return pkt
 
     def send(self, x):
-        iff, a, gw = x.route()
+        iff = x.route()[0]
         if iff is None:
             iff = conf.iface
         sdto = (iff, self.type)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -336,10 +336,10 @@ the value to set is also known) of ._find_fld_pkt() instead.
             except KeyError:
                 pass
             else:
-                if not pkt.default_fields:
-                    # Packet not initialized
-                    return self.dflt
                 if isinstance(pkt, tuple(self.dflt.owners)):
+                    if not pkt.default_fields:
+                        # Packet not initialized
+                        return self.dflt
                     return self._find_fld_pkt(pkt)
             frame = frame.f_back
         return self.dflt
@@ -1176,6 +1176,8 @@ class StrFixedLenField(StrField):
 
     def addfield(self, pkt, s, val):
         len_pkt = self.length_from(pkt)
+        if len_pkt is None:
+            return s + self.i2m(pkt, val)
         return s + struct.pack("%is" % len_pkt, self.i2m(pkt, val))
 
     def randval(self):

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -405,7 +405,7 @@ class ARP(Packet):
         elif isinstance(fld, IPField):
             return conf.route.route(dst)
         else:
-            return None
+            return None, None, None
 
     def extract_padding(self, s):
         return "", s

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -2018,20 +2018,45 @@ def ls(obj=None, case_sensitive=False, verbose=False):
 
 @conf.commands.register
 def fuzz(p, _inplace=0):
-    """Transform a layer into a fuzzy layer by replacing some default values by random objects"""  # noqa: E501
+    """
+    Transform a layer into a fuzzy layer by replacing some default values
+    by random objects.
+
+    :param p: the Packet instance to fuzz
+    :returns: the fuzzed packet.
+    """
     if not _inplace:
         p = p.copy()
     q = p
     while not isinstance(q, NoPayload):
+        new_default_fields = {}
+        multiple_type_fields = []
         for f in q.fields_desc:
             if isinstance(f, PacketListField):
                 for r in getattr(q, f.name):
                     print("fuzzing", repr(r))
                     fuzz(r, _inplace=1)
+            elif isinstance(f, MultipleTypeField):
+                # the type of the field will depend on others
+                multiple_type_fields.append(f.name)
             elif f.default is not None:
                 if not isinstance(f, ConditionalField) or f._evalcond(q):
                     rnd = f.randval()
                     if rnd is not None:
-                        q.default_fields[f.name] = rnd
+                        new_default_fields[f.name] = rnd
+        # Process packets with MultipleTypeFields
+        if multiple_type_fields:
+            # freeze the other random values
+            new_default_fields = {
+                key: (val._fix() if isinstance(val, VolatileValue) else val)
+                for key, val in six.iteritems(new_default_fields)
+            }
+            q.default_fields.update(new_default_fields)
+            # add the random values of the MultipleTypeFields
+            for name in multiple_type_fields:
+                rnd = q.get_field(name)._find_fld_pkt(q).randval()
+                if rnd is not None:
+                    new_default_fields[name] = rnd
+        q.default_fields.update(new_default_fields)
         q = q.payload
     return p

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -209,7 +209,7 @@ True
 = Packet.route()
 assert (Ether() / ARP()).route()[0] is not None
 assert (Ether() / ARP()).payload.route()[0] is not None
-
+assert (ARP(ptype=0, pdst="hello. this isn't a valid IP")).route()[0] is None
 
 
 = plain_str test
@@ -739,6 +739,11 @@ assert r in [
     b'E\xa7\x00\x1c\xb0c\xc0\x00\xf6\x01U\xd3\x7f\x00\x00\x01\x7f\x00\x00\x01\xfex\xb3\x92B<\x0b\xb8',
     '\x85\x7f\x00\x1c\xc2\xf6\x00\x00\xde\x01\xdbh\x7f\x00\x00\x01\x7f\x00\x00\x01y\xc9>\xa6\x84\xd8\xc2\xb7'
 ]
+
+= fuzz a Packet with MultipleTypeField
+
+fuzz(ARP(pdst="127.0.0.1"))
+fuzz(IP()/ARP(pdst='10.0.0.254'))
 
 = fuzz on packets with advanced RandNum
 


### PR DESCRIPTION
This fixes https://github.com/secdev/scapy/issues/2166

Currently:
```
>>> fuzz(ARP(pdst="127.0.0.1"))
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-dc0d41f97613> in <module>
----> 1 fuzz(ARP(pdst="127.0.0.1"))

~\Documents\Gabriel\secdev\scapy\scapy\packet.py in fuzz(p, _inplace)
   2029                     print("fuzzing", repr(r))
   2030                     fuzz(r, _inplace=1)
-> 2031             elif f.default is not None:
   2032                 if not isinstance(f, ConditionalField) or f._evalcond(q):
   2033                     rnd = f.randval()

~\Documents\Gabriel\secdev\scapy\scapy\fields.py in __getattr__(self, attr)
    382
    383     def __getattr__(self, attr):
--> 384         return getattr(self._find_fld(), attr)
    385
    386

~\Documents\Gabriel\secdev\scapy\scapy\fields.py in _find_fld(self)
    337                 pass
    338             else:
--> 339                 if not pkt.default_fields:
    340                     # Packet not initialized
    341                     return self.dflt

AttributeError: 'TerminalInteractiveShell' object has no attribute 'default_fields'
```