### PR TITLE
String comparision for EnumFields

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -82,6 +82,9 @@ class Field(six.with_metaclass(Field_metaclass, object)):
     holds_packets = 0
 
     def __init__(self, name, default, fmt="H"):
+        if name.endswith("_repr"):
+            raise Scapy_Exception("Don't use the postfix '_repr' "
+                                  "for a field name")
         self.name = name
         if fmt[0] in "@=<>!":
             self.fmt = fmt

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -357,12 +357,18 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
             return self.get_field(attr), self.default_fields[attr]
 
     def __getattr__(self, attr):
+        ret_repr = attr.endswith("_repr")
+        if ret_repr:
+            attr = attr[: -5]
         try:
             fld, v = self.getfield_and_val(attr)
         except TypeError:
             return self.payload.__getattr__(attr)
         if fld is not None:
-            return fld.i2h(self, v)
+            if ret_repr:
+                return fld.i2repr(self, v)
+            else:
+                return fld.i2h(self, v)
         return v
 
     def setfieldval(self, attr, val):


### PR DESCRIPTION
This PR adds additional getters to `Packet`. 
The idea behind this: I would like to have a string comparison for `EnumFields`. 

With this modification, the following use case will be possible:
```python
class Test(Packet):
     fields_desc = [EnumField("field", 0, {1: "state1", 2: "state2"})]

pkt = Test(field=1)
pkt.field == 1
pkt.field_repr == "state1"

pkt.field = "state2"
pkt.field_repr == "state2"
```

I thought a lot about other approaches to achieve this feature. This approach was the nicest I found.

I truly understand that this modification is very deep in the core of Scapy and might change the user experience. Therefore, feel free to drop this PR. If you accept such a change, I will add additional unit tests for that.     