### PR TITLE
Subfolders support in explore()

### DIFF
--- a/scapy/contrib/scada/__init__.py
+++ b/scapy/contrib/scada/__init__.py
@@ -1,14 +1,14 @@
-"""contains packages related to SCADA protocol layers."""
-
-from scapy.contrib.scada.iec104 import *  # noqa F403,F401
-
 # This file is part of Scapy
 # See http://www.secdev.org/projects/scapy for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
 # This program is published under a GPLv2 license
 #
-# scapy.contrib.description = SCADA related layers
-# scapy.contrib.status = loads
+# scapy.contrib.status = skip
 
 
 # Package of contrib SCADA modules.
+
+
+"""contains packages related to SCADA protocol layers."""
+
+from scapy.contrib.scada.iec104 import *  # noqa F403,F401

--- a/scapy/contrib/scada/iec104/__init__.py
+++ b/scapy/contrib/scada/iec104/__init__.py
@@ -1,17 +1,16 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
+# This program is published under a GPLv2 license
+#
+# scapy.contrib.status = skip
+
+
+# Package of contrib SCADA IEC-60870-5-104 specific modules
+
 """contains the IEC 60870-5-104 package."""
 
 from scapy.contrib.scada.iec104.iec104_fields import *  # noqa F403,F401
 from scapy.contrib.scada.iec104.iec104_information_elements import *  # noqa F403,F401
 from scapy.contrib.scada.iec104.iec104_information_objects import *  # noqa F403,F401
 from scapy.contrib.scada.iec104.iec104 import *  # noqa F403,F401
-
-# This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
-#
-# scapy.contrib.description = IEC-60870-5-104 APCI / APDU layer definitions
-# scapy.contrib.status = loads
-
-
-# Package of contrib SCADA IEC-60870-5-104 specific modules

--- a/scapy/contrib/scada/iec104/iec104.py
+++ b/scapy/contrib/scada/iec104/iec104.py
@@ -58,6 +58,9 @@ from scapy.layers.inet import TCP
 from scapy.packet import Raw
 from scapy.packet import Packet, bind_layers
 
+from . import iec104, iec104_fields, iec104_information_elements, \
+    iec104_information_objects  # noqa: F401
+
 IEC_104_IANA_PORT = 2404
 
 # direction - from the central station to the substation

--- a/scapy/contrib/scada/iec104/iec104_fields.py
+++ b/scapy/contrib/scada/iec104/iec104_fields.py
@@ -3,8 +3,7 @@
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
 # This program is published under a GPLv2 license
 
-# scapy.contrib.description = IEC-60870-5-104 layer specific fields
-# scapy.contrib.status = loads
+# scapy.contrib.status = skip
 
 """
     field type definitions used by iec 60870-5-104 layer (iec104)

--- a/scapy/contrib/scada/iec104/iec104_information_elements.py
+++ b/scapy/contrib/scada/iec104/iec104_information_elements.py
@@ -3,8 +3,7 @@
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
 # This program is published under a GPLv2 license
 
-# scapy.contrib.description = IEC-60870-5-104 information elements
-# scapy.contrib.status = loads
+# scapy.contrib.status = skip
 
 """
     information element definitions used by IEC 60870-5-101/104


### PR DESCRIPTION
This PR:
- fixes the way `scapy.contrib.scada` protocols are registered in `list_contribs()`
- adds support for subfolders handling in `explore()`:
![image](https://user-images.githubusercontent.com/10530980/61897045-8363ae00-af16-11e9-9599-7927bda0ef74.png)
