### PR TITLE
WIP: Packetizer and Serial Line IP

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -17,6 +17,7 @@ then
   sudo apt-get update
   sudo apt-get -qy install tshark
   sudo apt-get -qy install can-utils build-essential linux-headers-$(uname -r);
+  sudo apt-get -qy install net-tools
 fi
 
 # Install pcap & dnet

--- a/doc/scapy/index.rst
+++ b/doc/scapy/index.rst
@@ -25,6 +25,7 @@ This document is under a `Creative Commons Attribution - Non-Commercial
    
    usage
    advanced_usage
+   packetizer
 
 .. toctree::
    :maxdepth: 2

--- a/doc/scapy/layers/slip.rst
+++ b/doc/scapy/layers/slip.rst
@@ -1,0 +1,323 @@
+**************
+Serial Line IP
+**************
+
+Serial Line IP is defined in :rfc:`1055`. It is a simple mechanism for encoding
+packets over a serial (or other stream) link.
+
+Despite its name, there's nothing about it that actually requires that you use
+it for IPv4.
+
+Scapy implements SLIP using the :doc:`Packetizer <../packetizer>` interface.
+
+It also acts as a good base for :py:class:`Packetizer` subclasses -- see the
+:ref:`API reference <slip-api>` for more details.
+
+.. _slip-encap:
+
+SLIP encapsulation
+==================
+
+:rfc:`1055` SLIP defines two special characters:
+
+``end``
+  The sequence used to terminate each packet.
+
+``esc``
+  The sequence that precedes all escape sequences.
+
+Then, any use of the ``end`` or ``esc`` byte are escaped in two special escape
+sequences, which are preceded with ``esc``:
+
+``esc_esc``
+  The sequence used to encode a literal ``esc`` in the packet.
+
+``end_esc``
+  The sequence used to encode a literal ``end`` in the packet.
+
+Some protocols similar to SLIP define:
+
+``start``
+  The sequence used to start each packet.
+
+``start_esc``
+  The sequence used to encode a literal ``start`` in the packet.
+
+:py:class:`SLIPPacketizer` also supports both single-byte (used by :rfc:`1055`)
+and multi-byte sequences (used by some variants) for all parameters.
+
+Creating a SLIP connection
+==========================
+
+This example sets up a Serial Line IP connection with IPv4, between Scapy and a
+remote host.
+
+There are two methods described here, which have different requirements:
+
+using a real serial port
+  This requires that you install the `PySerial`__ library, and that you have
+  connected two hosts (or the same host on two ports) with a `null modem
+  cable`__.
+
+__ https://github.com/pyserial/pyserial
+__ https://en.wikipedia.org/wiki/Null_modem
+
+using a virtual PTY
+  This requires that you run Scapy on a UNIX-like operating system.
+
+In both cases, your "remote" host will also need a SLIP client:
+
+  * On Linux, you'll need the :command:`slattach` tool, which is part of the
+    (mostly obsolete) ``net-tools`` package.
+
+  * Mac OS X does not support SLIP natively -- you'll need to use a tool like
+    `slip2tun`__ to attach it to a userspace ``tuntap`` device.
+
+  * Windows 95 through to XP support SLIP natively.
+
+  * Windows Vista and later do not support SLIP.
+
+__ https://github.com/antoinealb/serial-line-ip-osx
+
+This will be a point-to-point link, with these addresses:
+
+  * Scapy IP address: ``192.0.2.1``
+  * Remote IP address: ``192.0.2.2``
+
+To start, we'll create an ICMP Echo Request packet (ping), and add some
+fuzzing to the frame in order make sure we get random sequence numbers:
+
+.. code-block:: python3
+
+    echo = (IP(src='192.0.2.1', dst='192.0.2.2')/
+            ICMP(type='echo-request')/
+            Raw(b'hello!'))
+
+    fuzz(echo[ICMP], 1)
+
+The second parameter to ``fuzz`` causes the operation to be done in-place. This
+causes the packet to become volatile -- causing it change every time it is
+serialized:
+
+.. code-block:: pycon
+
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020800d44551b68e1068656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c000020208b84ab6ffc368da68656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020863d2caeba9f53468656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020812f5faa577188868656c6c6f21'
+
+Now, we can create the SLIP link!
+
+**For a real serial port,** you can use the method ``slip_connect``, with
+something like:
+
+.. code-block:: pycon
+
+    >>> sock = slip_connect('/dev/ttyS0', 9600)
+
+You will need to replace ``/dev/ttyS0`` with the actual serial port you want to
+use, and ``9600`` with the actual baud rate you want to use.
+
+``slip_connect`` returns a ``PacketizerSocket``.
+
+**For a virtual serial port,** you can use the method ``slip_pty``. This
+automatically opens a new PTY, and reports back the name of it for you to use:
+
+.. code-block:: pycon
+
+    >>> sock, child_fn, child_fd = slip_pty()
+    >>> child_fn
+    /dev/pts/6        # example for Linux
+    /dev/ttys006      # example for OSX
+
+This will give you a path to the child PTY on ``child_fn``, and the file
+descriptor number in ``child_fd``. The parent PTY is part of the
+``PacketizerSocket`` (in ``sock``).
+
+**Now that you have a port,** you now need to setup a SLIP client on the other
+end of it:
+
+For Linux, these commands will need to be run as root:
+
+.. code-block:: bash
+
+    modprobe -v slip
+
+    # Pick one of these options:
+    slattach -s 9600 /dev/ttyS0     # for a physical port
+    slattach /dev/pts/6             # for a virtual port
+
+    # Now set an IP and bring it up:
+    ip addr change 192.0.2.2/32 peer 192.0.2.1 dev sl0
+    ip link set sl0 up
+
+For OSX, these commands will need to be run as root:
+
+.. code-block:: bash
+
+    # Note: there should be no output from this command, and the tunnel will
+    # become live immediately.
+    slip2tun -p /dev/ttys006 -l 192.0.2.2 -r 192.0.2.1
+
+You can then start pinging the remote host from Scapy with:
+
+.. code-block:: pycon
+
+    >>> scapy.sendrecv.__sr_loop(pty.sr, [echo])
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 239 / Raw
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 22 / Raw
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 36 / Raw
+
+You can then stop pinging with :kbd:`Control-c`.
+
+You may have tried to ping Scapy back, but that won't work yet, as there's
+nothing configured to answer it yet! ``ICMPEcho_am`` is a basic
+``AnsweringMachine`` that responds to ping requests:
+
+.. code-block:: pycon
+
+    >>> am = sock.am(ICMPEcho_am)
+    >>> am()
+
+Then, in another terminal, you can start pinging Scapy with:
+
+.. code-block:: console
+
+    $ ping -c 3 192.0.2.1
+    PING 192.0.2.1 (192.0.2.1): 56 data bytes
+    64 bytes from 192.0.2.1: icmp_seq=0 ttl=64 time=2.415 ms
+    64 bytes from 192.0.2.1: icmp_seq=1 ttl=64 time=3.610 ms
+    64 bytes from 192.0.2.1: icmp_seq=2 ttl=64 time=3.715 ms
+
+    --- 192.0.2.1 ping statistics ---
+    3 packets transmitted, 3 packets received, 0.0% packet loss
+    round-trip min/avg/max/stddev = 2.415/3.247/3.715/0.590 ms
+
+Switching back to Scapy, you should see the responses being sent:
+
+.. code-block:: pycon
+
+    >>> am()
+    Replying 192.0.2.2 to 192.0.2.1
+    Replying 192.0.2.2 to 192.0.2.1
+    Replying 192.0.2.2 to 192.0.2.1
+
+You can press :kbd:`Control-c` to stop the ``AnsweringMachine``.
+
+Utility functions
+=================
+
+.. py:function:: slip_socket(fd, [packet_class: Type[Packet] = Raw], [default_read_size: int]) -> PacketizerSocket
+
+   Creates a :py:class:`PacketizerSocket` that implements :rfc:`1055` SLIP.
+
+   If ``packet_class`` is not specified, payloads are presumed to be
+   :py:class:`Raw`.
+
+   If ``fd`` is a Text or int type, then it is presumed to be a path to a file
+   or a file descriptor number, respectively.
+
+.. py:function:: slip_ipv4_socket(fd, [default_read_size: int]) -> PacketizerSocket
+
+   Creates a :py:class:`PacketizerSocket` that implements :rfc:`1055` SLIP,
+   where the payload is always :py:class:`IP` (IPv4).
+
+   If ``fd`` is a Text or int type, then it is presumed to be a path to a file
+   or a file descriptor number, respectively.
+
+.. py:function:: slip_serial(port: Text, [baudrate: int = 9600], [timeout: int = 0], [packet_class: Type[Packet] = IP]) -> PacketizerSocket
+
+   Creates a :py:class:`PacketizerSocket` that implements :rfc:`1055` SLIP,
+   using ``pyserial`` to connect to a serial port.
+
+   If ``packet_class`` is not specified, assumes :py:class:`IP` (IPv4) payloads.
+
+.. py:function:: slip_pty([packet_class: Type[Packet] = IP]) -> Tuple[PacketizerSocket, Text, int]
+
+   Creates a :py:class:`PacketizerSocket` that implements :rfc:`1055` SLIP,
+   connected to a new PTY (created with :py:func:`os.openpty`).
+
+   If ``packet_class`` is not specified, assumes :py:class:`IP` (IPv4) payloads.
+
+   The return value is a tuple of:
+
+   ``socket`` (PacketizerSocket)
+     The :py:class:`PacketizerSocket` that is connected to the parent PTY.
+
+   ``child_fn`` (Text)
+     The path to the child PTY.
+
+   ``child_fd`` (int)
+     The file descriptor number for the child PTY.
+
+.. _slip-api:
+
+SLIPPacketizer API
+==================
+
+:py:class:`SLIPPacketizer` extends :py:class:`Packetizer`, and also provides a
+base for similar protocols.
+
+.. py:class:: SLIPPacketizer(Packetizer)
+
+   SLIPPacketizer implements :rfc:`1055` Serial Line IP.
+
+   It also acts as a base for simple :py:class:`Packetizer` types.
+
+   .. py:method:: __init__(esc, esc_esc, end, end_esc, start, start_esc)
+
+      All parameters are defined per :ref:`SLIP encapsulation <slip-encap>`
+      (above).
+
+      All parameters are required, except for ``start`` and ``start_esc``.
+
+      All parameters are available as attributes on this class.
+
+   .. py:method:: handle_escape(i: int, end_msg_pos: int) -> Tuple[int, Optional[bytes]]
+
+      :param int i: The position immediately after the end of the ``esc``
+          sequence.
+      :param int end_msg_pos: The number of bytes in the entire frame.
+
+      Called whenever :py:meth:`.decode_frame` detects an ``esc`` sequence.
+
+      This returns a tuple of:
+
+      ``new_i`` (int)
+        The position where we should continue reading from (i + the number of
+        bytes that this method read from :py:attr:`Packetizer.buffer`)
+
+      ``o`` (bytes)
+        The decoded form of the escape sequence that was read.
+
+      Most simple protocols need not override this -- this is only useful if
+      the protocol implements additional types of escapes that need to be
+      decoded on input.
+
+      Overriding this only impacts decoding packets, and does not impact
+      encoding packets. Subclasses will need to implement
+      :py:class:`Packetizer.encode_frame` if additional escapes are required.
+
+      See :py:class:`PPPPacketizer` in :file:`scapy/layers/ppp.py` for an
+      example of this in action.
+
+Example implementation
+----------------------
+
+This example uses both start and end delimiters:
+
+.. code-block:: python3
+
+   class MyPacketizer(SLIPPacketizer):
+       def __init__(self):
+           super(MyPacketizer, self).__init__(
+               esc=b'\xfe', esc_esc=b'\x02',
+               end=b'\xff', end_esc=b'\x01',
+               start=b'\xfd', start_esc=b'\x03')
+
+This would make the packet ``FF 01 FE FD 02 03`` encode as:
+``(FD) [FE 01] 01 [FE 02] [FE 03] 02 03 (FF)``

--- a/doc/scapy/packetizer.rst
+++ b/doc/scapy/packetizer.rst
@@ -1,0 +1,227 @@
+***********
+Packetizers
+***********
+
+Packetizers are Scapy's interface for taking a stream of bytes, and dividing it
+into packets, and also converting packets into a stream of bytes. They
+implement at least the `medium access control (MAC)`__ sublayer of the `data
+link layer`__.
+
+__ https://en.wikipedia.org/wiki/Medium_access_control
+__ https://en.wikipedia.org/wiki/Data_link_layer
+
+In an Ethernet network, your network card's `PHY`__ is the interface between the
+analogue domain of Ethernet's line modulation and the digital domain of
+link-layer packet signalling used by the MAC. Modern network cards integrate the
+functions of the PHY and MAC into a `single package`__. Your operating system
+normally only sees packets, and not the analogue electrical signals.
+
+__ https://en.wikipedia.org/wiki/PHY_(chip)
+__ https://en.wikipedia.org/wiki/System_in_package
+
+By comparison, serial ports are presented to the operating system as a
+bidirectional stream of bytes. Protocols like :abbr:`HDLC (High-level Data Link
+Control)` (used by :abbr:`PPP (Point to Point Protocol)`) and :abbr:`SLIP
+(Serial Line IP)` define framing semantics for serial links. They enable the
+transmission and reception of *packets*, rather than just *bytes*.
+
+These protocols typically define an end-of-frame sequence (to delimit frames),
+and an escape sequence (for handling frames that contain end-of-frame
+sequences). They might also define a start-of-frame sequence or escapes for
+additional reserved characters.
+
+More sophisticated protocols might implement error-correction codes or
+checksums, but these should be handled further down the stack as a ``Packet``.
+
+While these sorts of serial links are typically obsolete for the purposes of
+providing network access to computers, these protocols have found new life in
+embedded electronics.
+
+Additionally, ``libpcap`` files could be called a form of data layer -- the
+format defines a mechanism to delimit multiple packets within a single file.
+
+Working with Packetizers
+========================
+
+Scapy's Packetizer interface resides in ``scapy/packetizer.py``. It consists of
+two classes:
+
+``Packetizer``
+  This is an abstract class that all Packetizers inherit from. It buffers
+  incoming data, and yields whenever there is a complete frame of data.
+
+  Subclasses implement frame decoding and encoding of frame bytes.
+
+``PacketizerSocket``
+  This implements the ``SuperSocket`` interface (via ``SimpleSocket``), wrapping
+  ``recv`` and ``send`` calls and handling the interface with ``Packetizer``.
+
+Scapy includes two ``Packetizer`` implementations, ``PPPPacketizer`` (for
+PPP) and ``SLIPPacketizer`` (for SLIP).
+
+Packetizer API
+--------------
+
+The Packetizer API defines two important fields:
+
+``buffer``
+  This is a ``bytearray`` containing incomplete packet bytes. Interactions with
+  it must be done with the ``buffer_lock`` (see next), and must only be ever
+  done with the class itself to ensure thread safety.
+
+``buffer_lock``
+  A ``threading.Lock`` which protects use of ``buffer``. ``Packetizer``
+  implementations need not interact with this.
+
+The Packetizer API requires the implementation of three methods:
+
+``find_end``
+  Returns an integer with the length of the frame at the start of ``buffer``, or
+  ``-1`` if there is no complete packet available.
+
+``decode_frame``
+  Decodes a frame at the start of ``buffer`` with a given length (passed from
+  ``find_end``).
+
+``encode_frame(packet)``
+  Encodes a ``Packet`` into bytes that can be transmitted on the wire. This is
+  used directly by ``Packetizer`` callers.
+
+The Packetizer provides three methods for callers:
+
+``clear_buffer``
+  Deletes the contents of the ``buffer``, as well as any partial data that
+  happens to be inside.
+
+  Blocks on acquiring the ``buffer_lock``.
+
+``data_received(data)``
+  Whenever you get new data, call this method. This will yield tuples of
+  ``(frame_bytes, time)`` whenever there is a complete frame available.
+
+  Blocks on acquiring the ``buffer_lock``.
+
+``encode_frame(packet)``
+  Described above.
+
+``make_socket(fd, packet_class, default_read_size)``
+  Wraps this ``Packetizer`` into a ``PacketizerSocket``, consuming the given
+  file-like object (``fd``).
+
+  If no ``packet_class`` is specified, this class returns ``Raw`` packets.
+
+If you're defining a protocol that contains simple delimiters and escaping, it
+can probably be implemented as a subclass of ``SLIPPacketizer``.
+
+Creating a SLIP connection
+==========================
+
+This example sets up a Serial Line IP connection with IPv4, between Scapy and a
+remote host.
+
+There are two methods described here, which have different requirements:
+
+using a real serial port
+  This requires that you install the `PySerial`__ library, and that you have
+  connected two hosts (or the same host on two ports) with a `null modem
+  cable`__.
+
+__ https://github.com/pyserial/pyserial
+__ https://en.wikipedia.org/wiki/Null_modem
+
+using a virtual PTY
+  This requires that you run Scapy on a UNIX-like operating system.
+
+In both cases, your "remote" host will also need a SLIP client:
+
+  * On Linux, you'll need the ``slattach`` tool, which is part of the
+    (mostly obsolete) ``net-tools`` package.
+
+  * Mac OS X does not support SLIP natively -- you'll need to use a tool like
+    ``slip2tun`` to attach it to a userspace ``tuntap`` device.
+
+  * Windows 95 through to XP support SLIP natively.
+
+  * Windows Vista and later do not support SLIP.
+
+This will be a point-to-point link, with these addresses:
+
+  * Scapy IP address: ``192.0.2.1``
+  * Remote IP address: ``192.0.2.2``
+
+To start, we'll create an ICMP Echo Request packet (ping), and add some
+fuzzing to the frame in order make sure we get random sequence numbers:
+
+.. code-block:: python3
+
+    echo = (IP(src='192.0.2.1', dst='192.0.2.2')/
+            ICMP(type='echo-request')/
+            Raw(b'hello!'))
+
+    fuzz(echo[ICMP], 1)
+
+The second parameter to ``fuzz`` causes the operation to be done in-place. This
+causes the packet to become volatile -- causing it change every time it is
+serialized:
+
+.. code-block:: pycon
+
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020800d44551b68e1068656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c000020208b84ab6ffc368da68656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020863d2caeba9f53468656c6c6f21'
+    >>> bytes_hex(echo)
+    b'45000022000100004001f6d6c0000201c00002020812f5faa577188868656c6c6f21'
+
+Now, we can create the SLIP link!
+
+**For a real serial port,** you can use the method ``slip_connect``:
+
+.. code-block:: pycon
+
+    >>> s = slip_connect('/dev/ttyS0', 9600)
+
+This will start a connection at 9600 baud, with the typical ``8N1``
+configuration.
+
+**For a virtual serial port,** you can use the method ``slip_pty``. This
+automatically opens a new PTY, and reports back the name of it for you to use:
+
+.. code-block:: pycon
+
+    >>> s, child_fn, child_fd = slip_pty()
+    >>> child_fn
+    /dev/pts/6
+
+This will give you a path to the child PTY on ``child_fn``, and the file
+descriptor number in ``child_fd``. The parent is part of the
+``PacketizerSocket`` (in ``s``).
+
+**Now that you have a port,** you now need to setup a SLIP client on the other
+end of it.
+
+For Linux, these commands will need to be run as root:
+
+.. code-block:: bash
+
+    modprobe -v slip
+
+    # Pick one of these options:
+    slattach -s 9600 /dev/ttyS0     # for a physical port
+    slattach /dev/pts/6             # for a virtual port
+
+    # Now set an IP and bring it up:
+    ip addr change 192.0.2.2/32 peer 192.0.2.1 dev sl0
+    ip link set sl0 up
+
+You can then start pinging the remote host with:
+
+.. code-block:: pycon
+
+    >>> scapy.sendrecv.__sr_loop(pty.sr, [echo])
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 239 / Raw
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 22 / Raw
+    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 36 / Raw
+

--- a/doc/scapy/packetizer.rst
+++ b/doc/scapy/packetizer.rst
@@ -31,7 +31,8 @@ sequences). They might also define a start-of-frame sequence or escapes for
 additional reserved characters.
 
 More sophisticated protocols might implement error-correction codes or
-checksums, but these should be handled further down the stack as a ``Packet``.
+checksums, but these should be handled further down the stack as a
+:py:class:`Packet`.
 
 While these sorts of serial links are typically obsolete for the purposes of
 providing network access to computers, these protocols have found new life in
@@ -40,188 +41,229 @@ embedded electronics.
 Additionally, ``libpcap`` files could be called a form of data layer -- the
 format defines a mechanism to delimit multiple packets within a single file.
 
+.. tip::
+
+   For a practical demonstration of Packetizers, see
+   :doc:`Serial Line IP <layers/slip>`.
+
 Working with Packetizers
 ========================
 
-Scapy's Packetizer interface resides in ``scapy/packetizer.py``. It consists of
-two classes:
+Scapy's Packetizer interface resides in :file:`scapy/packetizer.py`. It
+consists of two classes:
 
-``Packetizer``
-  This is an abstract class that all Packetizers inherit from. It buffers
-  incoming data, and yields whenever there is a complete frame of data.
+:py:class:`Packetizer`
+
+  An abstract class that all Packetizers inherit from. It buffers incoming
+  data, and yields whenever there is a complete frame of data.
 
   Subclasses implement frame decoding and encoding of frame bytes.
 
-``PacketizerSocket``
-  This implements the ``SuperSocket`` interface (via ``SimpleSocket``), wrapping
-  ``recv`` and ``send`` calls and handling the interface with ``Packetizer``.
+:py:class:`PacketizerSocket`
 
-Scapy includes two ``Packetizer`` implementations, ``PPPPacketizer`` (for
-PPP) and ``SLIPPacketizer`` (for SLIP).
+  This implements the :py:class:`SuperSocket` interface (via
+  :py:class:`SimpleSocket`), wrapping :py:meth:`SuperSocket.recv` and
+  :py:meth:`SuperSocket.send` calls and handling the interface with
+  :py:class:`Packetizer`.
 
-Packetizer API
---------------
+Scapy includes two :py:class:`Packetizer` implementations,
+:py:class:`PPPPacketizer` (for PPP) and :py:class:`SLIPPacketizer` (for SLIP).
 
-The Packetizer API defines two important fields:
+Packetizer API reference
+========================
 
-``buffer``
-  This is a ``bytearray`` containing incomplete packet bytes. Interactions with
-  it must be done with the ``buffer_lock`` (see next), and must only be ever
-  done with the class itself to ensure thread safety.
+.. tip::
 
-``buffer_lock``
-  A ``threading.Lock`` which protects use of ``buffer``. ``Packetizer``
-  implementations need not interact with this.
+   If you're defining a protocol that contains simple delimiters and escaping,
+   it is probably easier to implement a subclass of :py:class:`SLIPPacketizer`.
 
-The Packetizer API requires the implementation of three methods:
+.. py:class:: Packetizer
 
-``find_end``
-  Returns an integer with the length of the frame at the start of ``buffer``, or
-  ``-1`` if there is no complete packet available.
+   :py:class:`Packetizer` provides three methods for users (in addition to
+   :py:meth:`.encode_frame` below):
 
-``decode_frame``
-  Decodes a frame at the start of ``buffer`` with a given length (passed from
-  ``find_end``).
+   .. py:method:: clear_buffer() -> None
 
-``encode_frame(packet)``
-  Encodes a ``Packet`` into bytes that can be transmitted on the wire. This is
-  used directly by ``Packetizer`` callers.
+      Clears :py:attr:`.buffer`.
 
-The Packetizer provides three methods for callers:
+      This discards partially processed packet data, which may cause the next
+      packet received to be corrupted.
 
-``clear_buffer``
-  Deletes the contents of the ``buffer``, as well as any partial data that
-  happens to be inside.
+      This method blocks while acquiring :py:attr:`.buffer_lock`.
 
-  Blocks on acquiring the ``buffer_lock``.
+   .. py:method:: data_received(data: bytes) -> Generator[Tuple[bytes, int]]
 
-``data_received(data)``
-  Whenever you get new data, call this method. This will yield tuples of
-  ``(frame_bytes, time)`` whenever there is a complete frame available.
+      Adds ``data`` to the :py:attr:`.buffer`, and then starts processing it.
+      This method blocks while acquiring :py:attr:`.buffer_lock`.
 
-  Blocks on acquiring the ``buffer_lock``.
+      This will yield a tuple of:
 
-``encode_frame(packet)``
-  Described above.
+      ``data_bytes`` (bytes)
+        The unescaped bytes for a single packet.
 
-``make_socket(fd, packet_class, default_read_size)``
-  Wraps this ``Packetizer`` into a ``PacketizerSocket``, consuming the given
-  file-like object (``fd``).
+      ``time`` (int)
+        The time that the bytes were read.
 
-  If no ``packet_class`` is specified, this class returns ``Raw`` packets.
+   .. py:method:: make_socket(fd: BytesIO, [packet_class: Type[Packet] = Raw], [default_read_size: int = 256]) -> PacketizerSocket
 
-If you're defining a protocol that contains simple delimiters and escaping, it
-can probably be implemented as a subclass of ``SLIPPacketizer``.
+      Creates a :py:class:`PacketizerSocket` connected to this
+      :py:class:`Packetizer`.
 
-Creating a SLIP connection
-==========================
+   .. py:method:: encode_frame(packet: Union[bytes, Packet]) -> bytes
 
-This example sets up a Serial Line IP connection with IPv4, between Scapy and a
-remote host.
+      Encodes frame bytes (or a :py:class:`Packet`) for transmission on the
+      stream.
 
-There are two methods described here, which have different requirements:
+      This is used by :py:class:`PacketizerSocket`, but can also be used by
+      end-users to encode a packet manually.
 
-using a real serial port
-  This requires that you install the `PySerial`__ library, and that you have
-  connected two hosts (or the same host on two ports) with a `null modem
-  cable`__.
+      If the subclass does not implement it, this calls :py:func:`raw`.
 
-__ https://github.com/pyserial/pyserial
-__ https://en.wikipedia.org/wiki/Null_modem
+   :py:class:`Packetizer` automatically buffers the incoming data stream. This
+   is stored in two protected attributes:
 
-using a virtual PTY
-  This requires that you run Scapy on a UNIX-like operating system.
+   .. py:attribute:: buffer (bytearray)
 
-In both cases, your "remote" host will also need a SLIP client:
+      A ``bytearray`` containing incomplete packet bytes. Interactions
+      with it must only be done by the holder of :py:attr:`.buffer_lock` (see
+      next), and must only be done with the class itself to ensure thread
+      safety.
 
-  * On Linux, you'll need the ``slattach`` tool, which is part of the
-    (mostly obsolete) ``net-tools`` package.
+      *Subclasses must not write to this value.*
 
-  * Mac OS X does not support SLIP natively -- you'll need to use a tool like
-    ``slip2tun`` to attach it to a userspace ``tuntap`` device.
+   .. py:attribute:: buffer_lock (threading.Lock)
 
-  * Windows 95 through to XP support SLIP natively.
+      Protects use of :py:attr:`.buffer`. :py:class:`Packetizer` implementations
+      should not need to interact with this.
 
-  * Windows Vista and later do not support SLIP.
+   Subclasses of :py:class:`Packetizer` must implement
+   :py:meth:`.encode_frame` (used by :py:class:`PacketizerSocket` and users to
+   encode data for transmission), and these two protected methods (used by
+   :py:class:`Packetizer` to decode incoming data):
 
-This will be a point-to-point link, with these addresses:
+   .. py:method:: find_end() -> int
 
-  * Scapy IP address: ``192.0.2.1``
-  * Remote IP address: ``192.0.2.2``
+      Return the length (in bytes) of the first packet in :py:attr:`.buffer`, or
+      ``-1`` if there is no complete packet available.
 
-To start, we'll create an ICMP Echo Request packet (ping), and add some
-fuzzing to the frame in order make sure we get random sequence numbers:
+      In the event of desynchronisation (packet unexpectedly terminated), the
+      partial packet must be counted.
 
-.. code-block:: python3
+      The returned value must include the length of any end-of-packet marker.
 
-    echo = (IP(src='192.0.2.1', dst='192.0.2.2')/
-            ICMP(type='echo-request')/
-            Raw(b'hello!'))
+      This method is "protected", and is not to be called outside of
+      :py:class:`Packetizer` or its subclasses.
 
-    fuzz(echo[ICMP], 1)
+   .. py:method:: decode_frame(length: int) -> Optional[bytes]
 
-The second parameter to ``fuzz`` causes the operation to be done in-place. This
-causes the packet to become volatile -- causing it change every time it is
-serialized:
+      Gets the bytes for a single frame in :py:attr:`.buffer`.
 
-.. code-block:: pycon
+      Any start or end markets must be removed, and bytes must be unescaped.
 
-    >>> bytes_hex(echo)
-    b'45000022000100004001f6d6c0000201c00002020800d44551b68e1068656c6c6f21'
-    >>> bytes_hex(echo)
-    b'45000022000100004001f6d6c0000201c000020208b84ab6ffc368da68656c6c6f21'
-    >>> bytes_hex(echo)
-    b'45000022000100004001f6d6c0000201c00002020863d2caeba9f53468656c6c6f21'
-    >>> bytes_hex(echo)
-    b'45000022000100004001f6d6c0000201c00002020812f5faa577188868656c6c6f21'
+      This method is "protected", and is not to be called outside of
+      :py:class:`Packetizer` or its subclasses.
 
-Now, we can create the SLIP link!
+      :param int length: The length of the frame, from :py:meth:`.find_end`.
+      :returns: Raw bytes from the frame, or None if the frame is invalid.
 
-**For a real serial port,** you can use the method ``slip_connect``:
+PacketizerSocket API reference
+==============================
 
-.. code-block:: pycon
+.. py:class:: PacketizerSocket(SimpleSocket)
 
-    >>> s = slip_connect('/dev/ttyS0', 9600)
+   Wrapper for :py:class:`Packetizer` that turns a file-like stream
+   (:py:class:`BytesIO`) into a :py:class:`SuperSocket`.
 
-This will start a connection at 9600 baud, with the typical ``8N1``
-configuration.
+   Regular :py:class:`SuperSocket` methods such as :py:meth:`SuperSocket.recv`,
+   :py:meth:`SuperSocket.send`, :py:meth:`SuperSocket.sniff` and
+   :py:meth:`SuperSocket.am` work with it.
 
-**For a virtual serial port,** you can use the method ``slip_pty``. This
-automatically opens a new PTY, and reports back the name of it for you to use:
+   This class processes packets from :py:meth:`Packetizer.data_received` in a
+   queue (in addition to :py:attr:`Packetizer.buffer`). This is used if there is
+   more than one packet that could fit into ``default_read_size`` (or a custom
+   read size specified in ``recv`` or ``raw_recv``).
 
-.. code-block:: pycon
+   .. py:method:: __init__(fd, packetizer, [packet_class = Raw], [default_read_size = 256])
 
-    >>> s, child_fn, child_fd = slip_pty()
-    >>> child_fn
-    /dev/pts/6
+      :param BytesIO fd: Stream (as a file-like object) to wrap. Must support
+          reading and writing.
 
-This will give you a path to the child PTY on ``child_fn``, and the file
-descriptor number in ``child_fd``. The parent is part of the
-``PacketizerSocket`` (in ``s``).
+      :param Packetizer packetizer: Used to encode and decode packets.
 
-**Now that you have a port,** you now need to setup a SLIP client on the other
-end of it.
+      :param Type[Packet] packet_class: Reference to :py:class:`Packet` type for
+          decoding incoming data packets.
 
-For Linux, these commands will need to be run as root:
+      :param int default_read_size: Number of bytes to read from ``fd`` by
+          default in :py:meth:`.recv` or :py:meth:`.raw_recv`.
 
-.. code-block:: bash
+   :py:class:`PacketizerSocket` attributes:
 
-    modprobe -v slip
+   .. py:attribute:: packet_class (Type[Packet])
 
-    # Pick one of these options:
-    slattach -s 9600 /dev/ttyS0     # for a physical port
-    slattach /dev/pts/6             # for a virtual port
+      Reference to :py:class:`Packet` type for decoding incoming data packets.
 
-    # Now set an IP and bring it up:
-    ip addr change 192.0.2.2/32 peer 192.0.2.1 dev sl0
-    ip link set sl0 up
+   .. py:attribute:: packetizer (Packetizer)
 
-You can then start pinging the remote host with:
+      Instance of :py:class:`Packetizer` for encoding and decoding packets.
 
-.. code-block:: pycon
+   .. py:attribute:: promisc (bool)
 
-    >>> scapy.sendrecv.__sr_loop(pty.sr, [echo])
-    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 239 / Raw
-    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 22 / Raw
-    RECV 1: IP / ICMP 192.0.2.2 > 192.0.2.1 echo-reply 36 / Raw
+      Whether the interface should be considered promiscuous (decodes all
+      packets seen).  Always true.
 
+   :py:class:`PacketizerSocket` methods:
+
+   .. py:method:: has_packets() -> bool
+
+      Returns True if there are packets ready to be processed in the queue.
+
+   .. py:method:: recv_raw([x: int = default_read_size]) -> Tuple[Optional[Type[Packet]], Optional[bytes], Optional[int]]
+
+      This implements the same API as :py:meth:`SuperSocket.recv_raw`, so
+      everything should "just work".
+
+      There are some conditions that control whether a ``read`` is issued to the
+      underlying stream.
+
+      If a Packet is available in the queue, returns it immediately without
+      reading from the underlying stream.
+
+      If no Packet is available in the queue, ``x`` bytes are read from the
+      underlying stream, and then all of the packets are added to the internal
+      queue.
+
+      If a Packet is available in the queue *now*, return it.
+
+      The returned value is always a Tuple with the following layout:
+
+      ``packet_class`` (Type[Packet])
+        Reference to the type of the incoming :py:class:`Packet`.
+
+      ``packet`` (bytes)
+        The packet data, as bytes.
+
+      ``time`` (int)
+        The time that the packet was received.
+
+      If no packet is available, returns ``tuple(None, None, None)``.
+
+   .. py:method:: send(x: Union[Packet, bytes])
+
+      Encodes a packet with :py:meth:`Packetizer.encode_frame` for transmission,
+      and writes it to the underlying stream.
+
+      If a :py:class:`Packet` of type :py:attr:`.packet_class` is passed, this
+      is encoded and then written to the underlying stream.
+
+      If a :py:class:`Packet` is passed that is not of type
+      :py:attr:`.packet_class`, it is appended to a new instance of
+      :py:attr:`.packet_class` with default values. This new instance is then
+      encoded and written no the underlying stream.
+
+      This is the same behaviour as :py:meth:`L3PacketSocket.send`.
+
+      If bytes are passed, this is presumed to be of :py:attr:`.packet_class`
+      type, and they are encoded and written to the stream.
+
+      If the passed value has a ``sent_time`` attribute, this is set to the
+      current time (according to :py:func:`time.time()`).

--- a/scapy/all.py
+++ b/scapy/all.py
@@ -30,6 +30,7 @@ from scapy.sessions import *
 from scapy.supersocket import *
 from scapy.volatile import *
 from scapy.as_resolvers import *
+from scapy.packetizer import *
 
 from scapy.automaton import *
 from scapy.autorun import *

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -31,9 +31,10 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
     function_name = ""
     filter = None
     sniff_options = {"store": 0}
-    sniff_options_list = ["store", "iface", "count", "promisc", "filter", "type", "prn", "stop_filter"]  # noqa: E501
+    sniff_options_list = ["store", "iface", "count", "promisc", "filter",
+                          "type", "prn", "stop_filter", "opened_socket"]
     send_options = {"verbose": 0}
-    send_options_list = ["iface", "inter", "loop", "verbose"]
+    send_options_list = ["iface", "inter", "loop", "verbose", "socket"]
     send_function = staticmethod(send)
 
     def __init__(self, **kargs):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -9,12 +9,21 @@ Python 2 and 3 link classes.
 """
 
 from __future__ import absolute_import
+import abc
 import base64
 import binascii
 import gzip
 import struct
+import sys
 
 import scapy.modules.six as six
+
+
+# Abstract Base Classes - this makes Python < 3.4 act like >= 3.4
+if sys.version_info >= (3, 4):
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta('ABC', (), {})
 
 ###########
 # Python3 #

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -630,7 +630,7 @@ recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
                    'inet6', 'ipsec', 'ir', 'isakmp', 'l2', 'l2tp',
                    'llmnr', 'lltd', 'mgcp', 'mobileip', 'netbios',
                    'netflow', 'ntp', 'ppi', 'ppp', 'pptp', 'radius', 'rip',
-                   'rtp', 'sctp', 'sixlowpan', 'skinny', 'smb', 'snmp',
+                   'rtp', 'sctp', 'sixlowpan', 'skinny', 'slip', 'smb', 'snmp',
                    'tftp', 'vrrp', 'vxlan', 'x509', 'zigbee']
     contribs = dict()
     crypto_valid = isCryptographyValid()

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -19,6 +19,7 @@ from collections import defaultdict
 
 from scapy.utils import checksum, do_graph, incremental_label, \
     linehexdump, strxor, whois, colgen
+from scapy.ansmachine import AnsweringMachine
 from scapy.base_classes import Gen, Net
 from scapy.data import ETH_P_IP, ETH_P_ALL, DLT_RAW, DLT_RAW_ALT, DLT_IPV4, \
     IP_PROTOS, TCP_SERVICES, UDP_SERVICES
@@ -1934,6 +1935,50 @@ def fragleak2(target, timeout=0.4, onlyasc=0, count=None):
                     linehexdump(leak, onlyasc=onlyasc)
     except Exception:
         pass
+
+
+class ICMPEcho_am(AnsweringMachine):
+    """Responds to ICMP Echo-Requests (ping)"""
+    function_name = "icmpechod"
+    # filter = "icmp"
+
+    def parse_options(self, listen_addr=None):
+        """Set options for ICMPEcho_am.
+
+        :param listen_addr: Address(es) to listen for pings on (default listens to all addresses)
+        """
+        self.listen_addr = listen_addr
+
+    def is_request(self, req):
+        if not req.haslayer(ICMP):
+            return False
+        icmp_req = req.getlayer(ICMP)
+        if icmp_req.type != 8:  # echo-request
+            return False
+        if self.listen_addr is not None:
+            if not req.haslayer(IP):
+                return False
+            # ip_rep = req.getlayer(IP)
+            # Check netmask
+            pass
+
+        return True
+
+    def print_reply(self, req, reply):
+        print("Replying %s to %s" % (reply.getlayer(IP).dst, req.dst))
+
+    def make_reply(self, req):
+        reply = req.copy()
+        reply[ICMP].type = 0  # echo-reply
+        # Force re-generation of the checksum
+        reply[ICMP].chksum = None
+        if req.haslayer(IP):
+            reply[IP].src, reply[IP].dst = req[IP].dst, req[IP].src
+            reply[IP].chksum = None
+        if req.haslayer(Ether):
+            reply[Ether].src, reply[Ether].dst = req[Ether].dst, req[Ether].src
+
+        return reply
 
 
 conf.stats_classic_protocols += [TCP, UDP, ICMP]

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -870,6 +870,8 @@ class PPPPacketizer(SLIPPacketizer):
             if c < 0x20 or c in self.end or c in self.esc:
                 o.extend(self.esc)
                 o.append(c ^ 0x20)
+            else:
+                o.append(c)
         return bytes(o)
 
 

--- a/scapy/layers/slip.py
+++ b/scapy/layers/slip.py
@@ -1,0 +1,253 @@
+# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
+# slip.py - Serial Line IP (RFC 1055)
+#
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Michael Farrell <micolous+git@gmail.com>
+# This program is published under a GPLv2 (or later) license
+
+from __future__ import absolute_import
+
+import os
+
+from scapy.compat import raw
+from scapy.error import warning
+from scapy.layers.inet import IP
+from scapy.packetizer import Packetizer
+from scapy.modules.six import string_types
+
+try:
+    import serial
+except ImportError:
+    serial = None
+
+
+class SLIPPacketizer(Packetizer):
+    """
+    SLIPPacketizer implements RFC 1055 Serial Line "IP".
+
+    "IP" is in quotation marks, because nothing about the RFC requires that
+    you use it for IPv4.
+
+    Each packet is followed by the ``end`` (bytes). When this is read, the
+    ``callback`` parameter of the ``data_recived`` method is called with the
+    decoded bytes.
+
+    In order to include literals containing ``start`` or ``end``, one escapes
+    them with ``esc``, followed by the ``start_esc`` or ``end_esc``
+    respectively.
+
+    In order to include a literal ``esc``, then the sequence is ``esc`` then
+    ``esc_esc``.
+
+    In addition to the RFC::
+
+    * one can **also** require that ``start`` (bytes) must be at the start of
+      each message. This makes it easier for each side to restart a packet
+      mid-transmission.
+    * this supports multi-byte ``end``, ``esc`` and ``start`` sequences
+      (and also for escape sequences).
+
+    By default, this class operates according to RFC 1055.
+
+    :param esc: (bytes) sequence that precedes all escape sequences
+    :param esc_esc: (bytes) sequence for including a literal ``esc``
+    :param end: (bytes) sequence that terminates each packet
+    :param end_esc: (bytes) sequence for including a literal ``end``
+    :param start: (optional, bytes) sequence that precedes each packet.
+    :param start_esc: (optional, bytes) sequence for including a literal
+                      ``start``.
+    """
+    def __init__(self, esc=b"\333", esc_esc=b"\335", end=b"\300",
+                 end_esc=b"\334", start=None, start_esc=None):
+        super(SLIPPacketizer, self).__init__()
+        if (not esc) or (not esc_esc):
+            raise ValueError("Both esc and esc_esc must be always declared")
+
+        if (not end) or (not end_esc):
+            raise ValueError("Both end and end_esc must be always declared")
+
+        if bool(start) != bool(start_esc):
+            raise ValueError("start, start_esc must both be declared, or "
+                             "neither declared")
+
+        self.esc = raw(esc)
+        self.esc_esc = raw(esc_esc)
+
+        self.start = raw(start) if start else None
+        self.start_esc = raw(start_esc) if start_esc else None
+
+        self.end = raw(end)
+        self.end_esc = raw(end_esc)
+
+    def find_end(self):
+        p = self.buffer.find(self.end)
+        if p > -1:
+            p += len(self.end)
+        return p
+
+    def decode_frame(self, length):
+        # Internal-only method. This is called by data_received to fetch a
+        # single bucket.
+        o = bytearray()
+        i = 0
+
+        # Discard end-of-packet marker
+        length -= len(self.end)
+
+        if self.start:
+            start_idx = self.buffer.find(self.start, i, length)
+            if start_idx == -1:
+                # No start flag, or start is after the end.
+                # Discard this message.
+                return
+
+            while start_idx > -1:
+                i = start_idx + len(self.start)
+                start_idx = self.buffer.find(self.start, i, length)
+
+        # start decoding packets
+        # stop when we reach an "end" sequence
+        while i < length:
+            # find an escape sequence
+            esc_pos = self.buffer.find(self.esc, i, length)
+
+            if esc_pos == -1:
+                # There was no escape sequence, copy the rest of the message.
+                o.extend(self.buffer[i:length])
+                i = length
+            else:
+                # There was an escape sequence. Handle it.
+                if i < esc_pos:
+                    # Add everything before the sequence to the buffer
+                    o.extend(self.buffer[i:esc_pos])
+
+                i = esc_pos + len(self.esc)
+                if i >= length:
+                    # EOF at position!
+                    break
+
+                i, r = self.handle_escape(i, length)
+                if r is None:
+                    # buffer overrun
+                    break
+
+                o.extend(r)
+
+        return o
+
+    def handle_escape(self, i, end_msg_pos):
+        """Called after an escape sequence was read."""
+        if self.buffer.startswith(self.esc_esc, i):
+            i += len(self.esc_esc)
+            o = self.esc
+        elif self.buffer.startswith(self.end_esc, i):
+            i += len(self.end_esc)
+            o = self.end
+        elif self.start_esc and self.buffer.startswith(self.start_esc, i):
+            i += len(self.start_esc)
+            o = self.start
+        else:
+            # Unknown sequence (protocol violation).
+            # "leave the byte alone" per RFC
+            i += 1
+            o = self.esc
+
+        if i >= end_msg_pos:
+            # buffer overrun
+            return i, None
+
+        return i, o
+
+    def encode_frame(self, pkt):
+        """Encodes a packet in binary form with SLIP."""
+        d = super(SLIPPacketizer, self).encode_frame(pkt)
+        o = bytearray()
+        if self.start:
+            o.extend(self.start)
+
+        i = 0
+        while i < len(d):
+            # find an escape sequence
+            esc_pos = d.find(self.esc, i)
+            end_pos = d.find(self.end, i)
+            start_pos = d.find(self.start, i) if self.start else -1
+
+            apos = list(filter(lambda x: x > -1,
+                               (esc_pos, end_pos, start_pos)))
+
+            if not apos:
+                # There are no more escape characters to escape.
+                o.extend(d[i:])
+                break
+
+            fpos = min(apos)
+            if fpos > i:
+                # copy bytes up to the first section to escape
+                o.extend(d[i:fpos])
+
+            o.extend(self.esc)
+            if esc_pos == fpos:
+                # escape the escape
+                o.extend(self.esc_esc)
+                i = fpos + len(self.esc)
+            elif end_pos == fpos:
+                # escape the end
+                o.extend(self.end_esc)
+                i = fpos + len(self.end)
+            elif start_pos == fpos:
+                # escape the end
+                o.extend(self.start_esc)
+                i = fpos + len(self.start)
+
+        o.extend(self.end)
+        return bytes(o)
+
+
+def _fd_to_file(fd):
+    if isinstance(fd, string_types + (int,)):
+        return open(fd, mode='r+b', buffering=0)
+    return fd
+
+
+def slip_socket(fd, packet_class=None, default_read_size=None):
+    """SLIP socket around a given file-like object."""
+    fd = _fd_to_file(fd)
+    return SLIPPacketizer().make_socket(fd, packet_class, default_read_size)
+
+
+def slip_ipv4_socket(fd, default_read_size=None):
+    """SLIP socket around a given file-like object for IPv4 payloads."""
+    fd = _fd_to_file(fd)
+    return slip_socket(fd, IP, default_read_size)
+
+
+def slip_serial(port, baudrate=9600, timeout=0, packet_class=IP):
+    """
+    Creates a SLIP connection on a given serial port.
+
+    This method requires PySerial.
+
+    :param port: Path to the port to use, eg: ``/dev/ttyS0``
+    :param baudrate: Baud rate to connect at.
+    :param timeout: Set to 0, so that select-based polling works.
+    :param packet_class: Packet class to use on the link. Defaults to IP.
+    :return: A SuperSocket which is connected to the serial port.
+    """
+    if serial is None:
+        warning("pyserial is required to use a real serial port!")
+        return
+
+    fd = serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
+    return SLIPPacketizer().make_socket(fd, packet_class)
+
+
+def slip_pty(packet_class=IP):
+    """Makes a slip PTY"""
+
+    parent_fd, child_fd = os.openpty()
+    child_fn = os.ttyname(child_fd)
+    parent_fh = open(parent_fd, mode='r+b', buffering=0)
+    parent_socket = SLIPPacketizer().make_socket(parent_fh, packet_class)
+
+    return parent_socket, child_fn, child_fd

--- a/scapy/packetizer.py
+++ b/scapy/packetizer.py
@@ -1,0 +1,177 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Michael Farrell <micolous+git@gmail.com>
+# This program is published under a GPLv2 (or later) license
+
+from __future__ import absolute_import
+
+import abc
+from threading import Lock
+import time
+from scapy.modules.six.moves.queue import Queue, Empty
+
+from scapy.compat import ABC, raw
+from scapy.config import conf
+from scapy.supersocket import SimpleSocket, SuperSocket
+
+
+class Packetizer(ABC):
+    """
+    Packetizer defines an interface for the implementation of data-link layers.
+
+    It contains some buffering semantics for handling incomplete data.
+
+    """
+    def __init__(self):
+        self.buffer = bytearray()
+        self.buffer_lock = Lock()
+
+    def clear_buffer(self):
+        """
+        Clears the buffer.
+
+        This will cause any partial packets to be discarded.
+
+        If ``start`` is not set and a packet is in progress, a corrupted packet
+        will be returned in the next callback.
+
+        This method blocks while acquiring the buffer lock.
+        """
+        with self.buffer_lock:
+            self.buffer = bytearray()
+
+    def data_received(self, data):
+        """
+        Adds data to the decoding buffer, and starts processing it.
+
+        This method blocks while acquiring the buffer lock.
+
+        This method yields tuples of (frame_bytes, time) for every frame
+        available.
+
+        :param data: (bytes) data to append to the buffer.
+        """
+        with self.buffer_lock:
+            self.buffer.extend(data)
+
+            frame_length = self.find_end()
+            while frame_length > -1:
+                p = self.decode_frame(frame_length)
+                del self.buffer[:frame_length]
+
+                if p:
+                    yield p, time.time()
+
+                frame_length = self.find_end()
+
+    @abc.abstractmethod
+    def find_end(self):
+        """Find the end of the first packet in the buffer (``self.buffer``).
+
+        In the event of desynchronisation (a packet has been unexpectedly
+        terminated), the partial packet must be counted.
+
+        The returned value must include the length of any end-of-packet marker.
+
+        :return: The length of the packet in the buffer (in bytes), or -1 if
+                 there is no completed packet available.
+        """
+        return -1
+
+    @abc.abstractmethod
+    def decode_frame(self, length):
+        """Gets the bytes for a single frame in the buffer (``self.buffer``).
+
+        Any start or ending makers must be removed, and bytes must be
+        unescaped.
+
+        If the frame is invalid and should be skipped, return None.
+
+        This is an internal method, and only be called by ``data_received``.
+
+        :param length: The length of the frame.
+        :return: The bytes of the frame.
+        """
+        pass
+
+    @abc.abstractmethod
+    def encode_frame(self, pkt):
+        """Encodes frame bytes (or a Packet) for transmission on the stream.
+
+        By default, this uses ``raw``.
+
+        :param pkt: frame bytes, or a Packet
+        :return: bytes that can be transmitted on the stream.
+        """
+        return raw(pkt)
+
+    def make_socket(self, fd, packet_class=None, default_read_size=None):
+        return PacketizerSocket(fd, self, packet_class, default_read_size)
+
+
+class PacketizerSocket(SimpleSocket):
+    """Wrapper for Packetizer that turns a file-like object into a SuperSocket.
+
+    :param fd: The file-like object to wrap.
+    :param packetizer: An implementation of Packetizer
+    :param default_read_size: The default read size for recv, defaults to
+                              256 bytes
+    """
+    def __init__(self, fd, packetizer, packet_class=None,
+                 default_read_size=None):
+        # This allows subclasses to pass "None" to accept our default.
+        default_read_size = (default_read_size if default_read_size is not None
+                             else 256)
+
+        super(PacketizerSocket, self).__init__(fd, default_read_size)
+        if not isinstance(packetizer, Packetizer):
+            raise TypeError('packetizer must implement Packetizer interface')
+
+        self.packet_class = packet_class or conf.raw_layer
+        self.packetizer = packetizer
+        self._packet_queue = Queue()
+
+        self.promisc = True
+
+    def recv_raw(self, x=None):
+        try:
+            pkt, ts = self._packet_queue.get_nowait()
+            return self.packet_class, pkt, ts
+        except Empty:
+            # Well, looks like we need to do some work...
+            pass
+
+        # read some bytes
+        for p in self.packetizer.data_received(self.ins.read(x)):
+            self._packet_queue.put(p)
+
+        # Do we have some packets now?
+        try:
+            pkt, ts = self._packet_queue.get_nowait()
+            return self.packet_class, pkt, ts
+        except Empty:
+            return None, None, None
+
+    def send(self, x):
+        if not isinstance(x, self.packet_class):
+            x = self.packet_class()/x
+
+        sx = raw(x)
+        if hasattr(x, 'sent_time'):
+            x.sent_time = time.time()
+        self.ins.write(self.packetizer.encode_frame(sx))
+
+    def has_packets(self):
+        """Returns True if there are packets already in the queue."""
+        return not self._packet_queue.empty()
+
+    @staticmethod
+    def select(sockets, remain=conf.recv_poll_rate):
+        # Before passing off to base select, see if we have anything ready in
+        # a queue
+        queued = [s for s in sockets
+                  if isinstance(s, PacketizerSocket) and s.has_packets()]
+        if queued:
+            return queued, None
+
+        return SuperSocket.select(sockets, remain)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -88,6 +88,31 @@ def get_temp_dir(keep=False):
     return dname
 
 
+def get_temp_fifo(keep=False):
+    """Creates a temporary FIFO, and returns its name.
+
+    The FIFO is not opened.
+
+    This only works on UNIX-like platforms (per :py:func:`os.mkfifo`).
+
+    :param keep: If False (default), the FIFO will be deleted when Scapy exits.
+    :return: A full path to a temporary FIFO.
+    """
+
+    dname = get_temp_dir(keep=keep)
+
+    # The directory name above will be "unique" and "new", so there should be
+    # no need to generate a directory name.
+    fname = os.path.join(dname, "fifo")
+
+    os.mkfifo(fname, 0o600)
+
+    if not keep:
+        conf.temp_files.append(fname)
+
+    return fname
+
+
 def sane_color(x):
     r = ""
     for i in x:

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             'pyx',
             'cryptography>=2.0',
             'matplotlib'
+            'pyserial>=3.0.0',
         ]
     },
     # We use __file__ in scapy/__init__.py, therefore Scapy isn't zip safe

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -376,3 +376,11 @@ t_sniffer.join(1)
 assert(dot1q_count == 2)
 
 veth.destroy()
+
+= Test get_temp_fifo
+~ linux
+
+import stat
+fname = get_temp_fifo()
+s = os.stat(fname)
+assert stat.S_ISFIFO(s.st_mode)

--- a/test/ppp.uts
+++ b/test/ppp.uts
@@ -1,0 +1,120 @@
+% PPP tests (scapy.layers.ppp)
+
++ PPPPacketizer
+
+= Handle simple packet
+
+p = PPPPacketizer()
+d = b"~\xff}#\xc0!}!}!} }4}\"}&} } } } }%}&\xc3y\x9d3}'}\"}(}\"I\xde~"
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 1
+assert p.fcs_errors == 0
+
+pkt = PPP(pkts[0][0])
+
+pkt.show()
+assert pkt.haslayer(HDLC)
+assert pkt.haslayer(PPP)
+assert not pkt.haslayer(PPP_)
+assert pkt[PPP_LCP_Configure].id == 1
+assert pkt[PPP_LCP_Magic_Number_Option].magic_number == 0xc3799d33
+
+d
+d2 = p.encode_frame(pkt)
+d2
+assert d == d2
+
+d3 = p.encode_frame(pkts[0][0])
+d3
+assert d == d3
+
+del d, d2, d3
+
+= Handle wrong FCS
+
+p = PPPPacketizer()
+d = b"~\xff}#\xc0!}!}!} }4}\"}&} } } } }%}&\xc3y\x9d3}'}\"}(}\"\xff\xff~"
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 0
+assert p.fcs_errors == 1
+
+= ACFC (RFC 1661 section 6.6)
+
+p = PPPPacketizer()
+d = b'\x80!}!}!} }0}"}&} -}/}!}#}&\xc0} }"}!06~'
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 1
+assert p.fcs_errors == 0
+
+pkt = PPP(pkts[0][0])
+assert not pkt.haslayer(HDLC)
+assert pkt.haslayer(PPP)
+assert not pkt.haslayer(PPP_)
+
+assert pkt[PPP_IPCP_Option_IPAddress].data == '192.0.2.1'
+assert d[:-1] in p.encode_frame(pkt)
+
++ PacketizerSocket
+
+= Setup
+
+try:
+    from io import BytesIO
+except ImportError:
+    # py2
+    from cStringIO import StringIO as BytesIO
+
+def bio_ppp(buf=b''):
+    f = BytesIO(buf)
+    if not hasattr(f, 'getbuffer'):
+        # py2 compat
+        f.getbuffer = lambda: f.getvalue()
+    ppp = ppp_socket(f)
+    assert isinstance(ppp, PPPPacketizerSocket)
+    return f, ppp
+
+= PacketizerSocket: recv ACFC, send without ACFC
+
+d = b'~\x80!}!}!} }0}"}&} -}/}!}#}&\xc0} }"}!06~'
+f, ppp = bio_ppp(d)
+
+p = ppp.recv()
+assert ppp.recv() is None
+assert not p.haslayer(HDLC)
+assert p.haslayer(PPP)
+assert not p.haslayer(PPP_)
+
+t = f.tell()
+ppp.send(p)
+d2 = bytes(f.getbuffer()[t:])
+
+# check for HDLC
+assert d2.startswith(b'~\xFF')
+# skip checksum
+d[1:-3]
+d2[4:-3]
+assert d[1:-3] == d2[4:-3]
+
+# Read back the packet again
+f.seek(t)
+p2 = ppp.recv()
+assert ppp.recv() is None
+assert raw(p[PPP]) == raw(p2[PPP])
+
+del f, ppp, t, d, d2, p, p2
+
+= PacketizerSocket: recv with explicit ACFC setting
+
+f, ppp = bio_ppp(b'\x80!}!}!} }0}"}&} -}/}!}#}&\xc0} }"}!06~')
+
+p = ppp.recv()
+assert ppp.recv() is None
+
+
+
+del f, ppp, p
+
+

--- a/test/slip.uts
+++ b/test/slip.uts
@@ -1,0 +1,70 @@
+% Serial Line IP tests (scapy.layers.slip)
+
++ SLIPPacketizer
+
+= Encode and decode a SLIP packet that contains escapes
+
+p = SLIPPacketizer()
+d = b'Hello, \333w\334o\300rld'
+de = b'Hello, \333\335w\334o\333\334rld\300'
+
+assert de == p.encode_frame(d)
+
+pkts = list(p.data_received(de))
+assert len(pkts) == 1
+assert pkts[0][0] == d
+
+= Handle multiple messages
+
+p = SLIPPacketizer()
+d = b'Message 1\300Message 2\300'
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 2
+assert pkts[0][0] == b'Message 1'
+assert pkts[1][0] == b'Message 2'
+
+= Handle incomplete message
+
+p = SLIPPacketizer()
+d = b'Message 1\300Message 2\300Incomplete message'
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 2
+assert pkts[0][0] == b'Message 1'
+assert pkts[1][0] == b'Message 2'
+
+# now complete it:
+
+pkts = list(p.data_received(b' now complete!\300Incomplete more'))
+assert len(pkts) == 1
+assert pkts[0][0] == b'Incomplete message now complete!'
+
+
++ PacketizerSocket
+
+= BytesIO / StringIO: read and write packets
+
+try:
+    from io import BytesIO
+except ImportError:
+    # py2
+    from cStringIO import StringIO as BytesIO
+
+f = BytesIO(b'Message 1\300Message 2\300Message incomplete')
+slip = slip_socket(f)
+
+assert slip.recv() == Raw(b'Message 1')
+assert slip.recv() == Raw(b'Message 2')
+assert slip.recv() is None
+
+t = f.tell()
+slip.send(Raw(b'Sent message'))
+# py2/3 compat
+buf = f.getbuffer() if hasattr(f, 'getbuffer') else f.getvalue()
+
+assert buf[t:] == b'Sent message\300'
+
+slip.close()
+del slip, f, buf, t
+

--- a/test/slip.uts
+++ b/test/slip.uts
@@ -1,5 +1,16 @@
 % Serial Line IP tests (scapy.layers.slip)
 
++ Tools
+
+= ExpectException
+
+def expect_exception(e, c):
+    try:
+        c()
+        return False
+    except e:
+        return True
+
 + SLIPPacketizer
 
 = Encode and decode a SLIP packet that contains escapes
@@ -40,6 +51,50 @@ pkts = list(p.data_received(b' now complete!\300Incomplete more'))
 assert len(pkts) == 1
 assert pkts[0][0] == b'Incomplete message now complete!'
 
+= Unknown or premature escapes
+
+p = SLIPPacketizer()
+d = b'Message \3331\300Message 2\333\300Message 3\333\300'
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 3
+assert pkts[0][0] == b'Message 1'
+assert pkts[1][0] == b'Message 2'
+assert pkts[2][0] == b'Message 3'
+
+
++ Customisations
+
+= SLIPPacketizer invalid args
+
+expect_exception(ValueError, lambda: SLIPPacketizer(esc_esc=None))
+expect_exception(ValueError, lambda: SLIPPacketizer(esc=None))
+expect_exception(ValueError, lambda: SLIPPacketizer(end_esc=None))
+expect_exception(ValueError, lambda: SLIPPacketizer(end=None))
+expect_exception(ValueError, lambda: SLIPPacketizer(start=b'\xff'))
+expect_exception(ValueError, lambda: SLIPPacketizer(start_esc=b'\xfe'))
+
+= Start of frame: simple
+
+p = SLIPPacketizer(start=b'\310', start_esc=b'\336')
+d = b'\310Message 1\300\310Message 2\300'
+
+pkts = list(p.data_received(d))
+assert len(pkts) == 2
+assert pkts[0][0] == b'Message 1'
+assert pkts[1][0] == b'Message 2'
+
+= Start of frame: Encode and decode a SLIP packet that contains escapes
+
+p = SLIPPacketizer(start=b'\310', start_esc=b'\336')
+d = b'Hell\310o, \333w\334o\300rld'
+de = b'\310Hell\333\336o, \333\335w\334o\333\334rld\300'
+
+assert de == p.encode_frame(d)
+
+pkts = list(p.data_received(de))
+assert len(pkts) == 1
+assert pkts[0][0] == d
 
 + PacketizerSocket
 
@@ -68,3 +123,62 @@ assert buf[t:] == b'Sent message\300'
 slip.close()
 del slip, f, buf, t
 
++ Linux compatibility
+= Test slattach with SLIP (Linux)
+~ linux needs_root slip
+
+def sp_call(*args):
+    assert subprocess.check_call(args) == 0
+
+def sp_expect_eversion(*args):
+    # E_VERSION = 5
+    assert subprocess.call(args) in (0, 5)
+
+def sp_expect_fail(*args):
+    assert subprocess.call(args) != 0
+
+# Setup and check environment
+
+# Check for `slattach`, as it's not always available, and fail early.
+sp_expect_eversion("slattach", "-V")
+
+# We expect the interface `sl0` to _not_ exist. Fail early if it's there.
+sp_expect_fail("ip", "link", "show", "sl0")
+
+# Load the `slip` kernel module. This might fail if `slip` is compiled into the
+# kernel, or we don't have root. So we ignore the result.
+_ = subprocess.call(["modprobe", "slip"])
+
+# Check for the `slip_open` symbol in the kernel.
+#
+# This is expected to suceeed if the `slip` module was loaded successfully, or
+# if `slip` was compiled into the kernel.
+#
+# A failure here could indicate that the module hasn't loaded!
+sp_call("grep", "-q", "slip_open", "/proc/kallsyms")
+
+remote = '192.0.2.2'
+local = '192.0.2.1'
+
+echo = (IP(src=local, dst=remote)/
+        ICMP(type='echo-request')/
+        Raw(b'hello!'))
+fuzz(echo[ICMP], 1)
+
+s, child_fn, _ = slip_pty()
+try:
+    sp_call("slattach", "-he", child_fn)
+    sp_call("ip", "addr",
+            "change", remote + "/32", "peer", local, "dev", "sl0")
+    sp_call("ip", "link", "set", "sl0", "up")
+    # Debugging -- makes sure that the device is there!
+    sp_call("ip", "addr", "show", "sl0")
+    ans, uans = srsloop(s, [echo], count=3)
+    assert len(ans) == 3
+    assert len(uans) == 0
+finally:
+    # tear down
+    s.close()
+
+# Make sure sl0 went away after.
+sp_expect_fail("ip", "link", "show", "sl0")


### PR DESCRIPTION
This adds a new `Packetizer` construct, used for splitting a stream of bytes into packets (ie: MAC sublayer of the data link layer).  This is useful for bringing serial connections into Scapy.

I implemented RFC 1055 Serial Line IP and made it a core layer.  The protocol itself is very simple, and it's useful for implementing both very similar protocols (such as nRF Sniffer's serial interface) and vaguely similar protocols (such as HDLC/PPP on serial).

The SLIP implementation includes enough glue and examples that are enough to work with `slattach` (Linux) and `slip2tun` (OSX).

I also added some functionality to the existing HDLC implementation to use it, but getting enough of the "glue" to make `pppd` work is very complex (as there are multiple negotiation steps).

There's a couple of more things I want to split out of this PR, so this is a slight work-in-progress:

* To make experimenting with interfaces in userspace friendlier, I implemented a `ICMPEcho_am` `AnsweringMachine`.  I use this in the examples here, but it is otherwise independent from the rest of the code.

* `SuperSocket` is hard coded to a single value for `recv` and `raw_recv` default calls, which is the default Ethernet MTU.  This is problematic for the packets I'm working with, so I have added `default_recv_size` as a constructor param for this.

* Adds a `SuperSocket.am()` convenience method.