### PR TITLE
Warn when different packet types are written to a PCAP file

### DIFF
--- a/doc/scapy/extending.rst
+++ b/doc/scapy/extending.rst
@@ -71,7 +71,9 @@ Once you've done that, you can launch Scapy and import your file, but this is st
     
     # Set log level to benefit from Scapy warnings
     import logging
-    logging.getLogger("scapy").setLevel(1)
+    logger = logging.getLogger("scapy")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(logging.StreamHandler())
     
     from scapy.all import *
     

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1305,8 +1305,16 @@ nano:       use nanosecond-precision (requires libpcap >= 1.5.0)
             else:
                 pkt = pkt.__iter__()
             for p in pkt:
+
                 if not self.header_present:
                     self._write_header(p)
+
+                if self.linktype != conf.l2types.get(type(p), None):
+                    warning("Inconsistent linktypes detected!"
+                            " The resulting PCAP file might contain"
+                            " invalid packets."
+                            )
+
                 self._write_packet(p)
 
     def _write_packet(self, packet, sec=None, usec=None, caplen=None,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7144,6 +7144,18 @@ wrpcap(filename, SndRcvList(res=[(Ether()/IP(), Ether()/IP())]))
 assert len(rdpcap(filename)) == 2
 os.remove(filename)
 
+= Check wrpcap() with different packets types
+
+import mock
+import os
+import tempfile
+
+with mock.patch("scapy.utils.warning") as warning:
+    filename = tempfile.mktemp()
+    wrpcap(filename, [IP(), Ether(), IP(), IP()])
+    os.remove(filename)
+    assert any("Inconsistent" in arg for arg in warning.call_args[0])
+
 ############
 ############
 + Sessions


### PR DESCRIPTION
Fix #2193 