### PR TITLE
Display the manufacturer name in arping results

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -614,8 +614,21 @@ class ARPingResult(SndRcvList):
         SndRcvList.__init__(self, res, name, stats)
 
     def show(self):
+        """
+        Print the list of discovered MAC addresses.
+        """
+
+        data = list()
+        padding = 0
+
         for s, r in self.res:
-            print(r.sprintf("%19s,Ether.src% %ARP.psrc%"))
+            manuf = conf.manufdb._get_short_manuf(r.src)
+            manuf = "unknown" if manuf == r.src else manuf
+            padding = max(padding, len(manuf))
+            data.append((r[Ether].src, manuf, r[ARP].psrc))
+
+        for src, manuf, psrc in data:
+            print("  %-17s %-*s %s" % (src, padding, manuf, psrc))
 
 
 @conf.commands.register

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -615,6 +615,16 @@ b.reverse_lookup("Secdevcorp") == {'00:01:12': ('SecdevCorp', 'Secdev Corporatio
 
 scapy_delete_temp_files()
 
+= Test ARPingResult output
+~ manufdb
+
+ar = ARPingResult([(None, Ether(src='70:ee:50:50:ee:70')/ARP(psrc='192.168.0.1'))])
+with ContextManagerCaptureOutput() as cmco:
+    ar.show()
+    result_ar = cmco.get_output()
+
+assert result_ar.startswith("  70:ee:50:50:ee:70 Netatmo 192.168.0.1")
+
 = Test utility functions - network related
 ~ netaccess
 


### PR DESCRIPTION
This PR adds a missing feature to `arping`: display the manufacturer name.

For example:
```
>>> ar = ARPingResult([(None, Ether(src='70:ee:50:5f:4e:ee')/ARP(psrc='192.168.0.1'))])                  
>>> ar.show()             
  70:ee:50:5f:4e:ee Netatmo 192.168.0.1
```