### PR TITLE
Add ERSPAN Fake header

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -424,7 +424,9 @@ def l2_register_l3_arp(l2, l3):
 
 conf.neighbor.register_l3(Ether, ARP, l2_register_l3_arp)
 
-
+class ERSPANfake(Packet):
+    name = "ERSPANfake"
+    
 class ERSPAN(Packet):
     name = "ERSPAN"
     fields_desc = [BitField("ver", 0, 4),
@@ -553,6 +555,7 @@ bind_layers(Dot1AD, Dot1AD, type=0x88a8)
 bind_layers(Dot1AD, Dot1Q, type=0x8100)
 bind_layers(Dot1Q, Dot1AD, type=0x88a8)
 bind_layers(ERSPAN, Ether)
+bind_layers(ERSPANfake, Ether)
 bind_layers(Ether, Ether, type=1)
 bind_layers(Ether, ARP, type=2054)
 bind_layers(CookedLinux, LLC, proto=122)
@@ -565,6 +568,7 @@ bind_layers(GRE, Dot1Q, proto=33024)
 bind_layers(GRE, Dot1AD, type=0x88a8)
 bind_layers(GRE, Ether, proto=0x6558)
 bind_layers(GRE, ARP, proto=2054)
+bind_layers(GRE, ERSPANfake, proto=0x88be, seqnum_present=0)
 bind_layers(GRE, ERSPAN, proto=0x88be, seqnum_present=1)
 bind_layers(GRE, GRErouting, {"routing_present": 1})
 bind_layers(GRErouting, conf.raw_layer, {"address_family": 0, "SRE_len": 0})

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -426,7 +426,7 @@ conf.neighbor.register_l3(Ether, ARP, l2_register_l3_arp)
 
 class ERSPANfake(Packet):
     name = "ERSPANfake"
-    
+
 class ERSPAN(Packet):
     name = "ERSPAN"
     fields_desc = [BitField("ver", 0, 4),


### PR DESCRIPTION
Multiple network devices vendors (even Cisco on Nexus 3000) use a faked ERSPAN header that contain no fields at all. Adding it so scapy can sniff those packet types. 