### PR TITLE
arch: fix unclosed socket warning

### DIFF
--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -55,9 +55,10 @@ def get_if(iff, cmd):
     """Ease SIOCGIF* ioctl calls"""
 
     sck = socket.socket()
-    ifreq = ioctl(sck, cmd, struct.pack("16s16x", iff.encode("utf8")))
-    sck.close()
-    return ifreq
+    try:
+        return ioctl(sck, cmd, struct.pack("16s16x", iff.encode("utf8")))
+    finally:
+        sck.close()
 
 
 def get_if_raw_hwaddr(iff):


### PR DESCRIPTION
When forging a packet with no `Ether` source address and `conf.iface` holds an interface that does not exist on the system, we get a pertinent warning:

```
WARNING: Could not get the source MAC: [Errno 19] No such device
```

However, it is followed by a resource warning:

```
scapy/layers/l2.py:143: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('0.0.0.0', 0)>
```

Indeed, when the ioctl call fails, the socket is not closed. Make sure to close it in all cases.