### PR TITLE
fix bug for issue #1862, that is with new posts today.

### DIFF
--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -42,7 +42,8 @@ def _check_tcpdump():
         return False
 
     # On some systems, --version does not exist on tcpdump
-    return proc.returncode == 0 or output.startswith(b'Usage: tcpdump ') \
+    return proc.returncode == 0 \
+            or output.startswith(b'Usage: tcpdump ') \
             or output.startswith(b'tcpdump: unrecognized option')
 
 

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -42,7 +42,8 @@ def _check_tcpdump():
         return False
 
     # On some systems, --version does not exist on tcpdump
-    return proc.returncode == 0 or output.startswith(b'Usage: tcpdump ') or output.startswith(b'tcpdump: unrecognized option')
+    return proc.returncode == 0 or output.startswith(b'Usage: tcpdump ') \
+            or output.startswith(b'tcpdump: unrecognized option')
 
 
 # This won't be used on Windows

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -43,8 +43,8 @@ def _check_tcpdump():
 
     # On some systems, --version does not exist on tcpdump
     return proc.returncode == 0 \
-            or output.startswith(b'Usage: tcpdump ') \
-            or output.startswith(b'tcpdump: unrecognized option')
+        or output.startswith(b'Usage: tcpdump ') \
+        or output.startswith(b'tcpdump: unrecognized option')
 
 
 # This won't be used on Windows

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -42,7 +42,7 @@ def _check_tcpdump():
         return False
 
     # On some systems, --version does not exist on tcpdump
-    return proc.returncode == 0 or output.startswith(b'Usage: tcpdump ')
+    return proc.returncode == 0 or output.startswith(b'Usage: tcpdump ') or output.startswith(b'tcpdump: unrecognized option')
 
 
 # This won't be used on Windows


### PR DESCRIPTION
Improve the method to recognize tcpdump existence, covering more output cases in which tcpdump does not support '--version' option
Issue link:
https://github.com/secdev/scapy/issues/1862#issuecomment-532684551

fixes #1862 with new posts today.