### PR TITLE
ECU_am default value change [Ready for merge]

### DIFF
--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -283,7 +283,7 @@ class ECU_am(AnsweringMachine):
 
     def parse_options(self, supported_responses=None,
                       main_socket=None, broadcast_socket=None, basecls=Raw,
-                      timeout=1):
+                      timeout=None):
         self.main_socket = main_socket
         self.sockets = [self.main_socket]
 


### PR DESCRIPTION
Changed default value for timeout of `ECU_am` to `None`. The previous default value led to a not intuitive behaviour.
