### PR TITLE
Make LLDPDUEndOfLLDPDU optional

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -30,13 +30,14 @@
     :TODO:
         - | organization specific TLV e.g. ProfiNet
           | (see LLDPDUGenericOrganisationSpecific for a starting point)
+        - Ignore everything after EndofLLDPDUTLV
 
     :NOTES:
         - you can find the layer configuration options at the end of this file
         - default configuration enforces standard conform:
 
           * | frame structure
-            | (ChassisIDTLV/PortIDTLV/TimeToLiveTLV/.../EndofLLDPDUTLV)
+            | (ChassisIDTLV/PortIDTLV/TimeToLiveTLV/...)
           * multiplicity of TLVs (if given by the standard)
           * min sizes of strings used by the TLVs
 

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -183,7 +183,7 @@ class LLDPDU(Packet):
         standard_frame_structure = [LLDPDUChassisID.__name__,
                                     LLDPDUPortID.__name__,
                                     LLDPDUTimeToLive.__name__,
-                                    '<...>' ]
+                                    '<...>']
 
         if len(structure_description) < 3:
             raise LLDPInvalidFrameStructure(


### PR DESCRIPTION
As per IEEE 802.1AB-2016 section 8.2 LLDPDU format:
```
If the End Of LLDPDU TLV is present, it shall be the last TLV in the LLDPDU.
```

and 9.1.2.1 Normal LLDPDUs:
```
constructs an LLDPDU as defined in 9.1, containing the following:
a) The mandatory TLVs as specified in 8.2:
   1) Chassis ID TLV (see 8.5.2).
   2) Port ID TLV (see 8.5.3).
   3) Time To Live TLV, with the TTL value set equal to txTTL (see 8.5.4).
b) Additional optional TLVs, from the basic management set or from one or more organizationally
specific sets, as allowed by LLDPDU length restrictions and as selected in the LLDP local system
MIB by network management (see Table 8-1).
c) Optionally, an End Of LLDPDU TLV.
```

in both cases End Of LLDPDU TLV is optional