### PR TITLE
fix dissection of ipfix template with enterprise-specific Information Elements.

### DIFF
--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -1245,10 +1245,10 @@ class NetflowTemplateFieldV9(Packet):
     name = "Netflow Flowset Template Field V9/10"
     fields_desc = [BitField("enterpriseBit", 0, 1),
                    BitEnumField("fieldType", None, 15,
-                                  NetflowV910TemplateFieldTypes),
+                                NetflowV910TemplateFieldTypes),
                    ShortField("fieldLength", 0),
                    ConditionalField(IntField("enterpriseNumber", 0),
-                                    lambda p: p.enterpriseBit )]
+                                    lambda p: p.enterpriseBit)]
 
     def __init__(self, *args, **kwargs):
         Packet.__init__(self, *args, **kwargs)
@@ -1525,10 +1525,10 @@ class NetflowOptionsFlowsetOptionV9(Packet):
     name = "Netflow Options Template FlowSet V9/10 - Option"
     fields_desc = [BitField("enterpriseBit", 0, 1),
                    BitEnumField("optionFieldType", None, 15,
-                                  NetflowV910TemplateFieldTypes),
+                                NetflowV910TemplateFieldTypes),
                    ShortField("optionFieldlength", 0),
                    ConditionalField(ShortField("enterpriseNumber", 0),
-                                    lambda p: p.enterpriseBit )]
+                                    lambda p: p.enterpriseBit)]
 
     def default_payload_class(self, p):
         return conf.padding_layer

--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -34,7 +34,7 @@ from scapy.fields import ByteEnumField, ByteField, Field, FieldLenField, \
     FlagsField, IPField, IntField, MACField, \
     PacketListField, PadField, SecondsIntField, ShortEnumField, ShortField, \
     StrField, StrFixedLenField, ThreeBytesField, UTCTimeField, XByteField, \
-    XShortField, LongField
+    XShortField, LongField, BitField, ConditionalField, BitEnumField
 from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.plist import PacketList
 from scapy.sessions import IPSession, DefaultSession
@@ -1243,9 +1243,12 @@ class NetflowHeaderV10(Packet):
 
 class NetflowTemplateFieldV9(Packet):
     name = "Netflow Flowset Template Field V9/10"
-    fields_desc = [ShortEnumField("fieldType", None,
+    fields_desc = [BitField("enterpriseBit", 0, 1),
+                   BitEnumField("fieldType", None, 15,
                                   NetflowV910TemplateFieldTypes),
-                   ShortField("fieldLength", 0)]
+                   ShortField("fieldLength", 0),
+                   ConditionalField(IntField("enterpriseNumber", 0),
+                                    lambda p: p.enterpriseBit )]
 
     def __init__(self, *args, **kwargs):
         Packet.__init__(self, *args, **kwargs)
@@ -1520,9 +1523,12 @@ class NetflowOptionsRecordOptionV9(NetflowRecordV9):
 # Aka Set
 class NetflowOptionsFlowsetOptionV9(Packet):
     name = "Netflow Options Template FlowSet V9/10 - Option"
-    fields_desc = [ShortEnumField("optionFieldType", None,
+    fields_desc = [BitField("enterpriseBit", 0, 1),
+                   BitEnumField("optionFieldType", None, 15,
                                   NetflowV910TemplateFieldTypes),
-                   ShortField("optionFieldlength", 0)]
+                   ShortField("optionFieldlength", 0),
+                   ConditionalField(ShortField("enterpriseNumber", 0),
+                                    lambda p: p.enterpriseBit )]
 
     def default_payload_class(self, p):
         return conf.padding_layer

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -6750,6 +6750,12 @@ assert pkt3.scopes[0].scopeFieldType == 5
 assert pkt3.scopes[0].scopeFieldlength == 2
 assert pkt3[NetflowOptionsFlowset10].options[0].optionFieldType == 36
 
+# Templates with enterprise-specific Information Elements.
+s=b'\x01\x07\x00\x12\x01\n\x00\x04\x84\x0c\x00\x02\x00\x00\x00\t\x01\n\x00&\x00\x0b\x00\x02\x00\x07\x00\x02\x00\x04\x00\x01\x00\x0c\x00\x04\x00\x08\x00\x04\x00\xea\x00\x02\x01\n\x00\x01\x84\x10\x00\x06\x00\x00\x00\t\x84\x0e\x00\x06\x00\x00\x00\t\x84\x0f\x00\x06\x00\x00\x00\t\x00\x01\x00\x04\x00\x02\x00\x04\x00\xf3\x00\x02\x00\x06\x00\x01\x01\n\x00#'
+pkt4 = NetflowTemplateV9(s)
+assert len(pkt4.template_fields) == pkt4.fieldCount
+assert sum([template.fieldLength for template in pkt4.template_fields]) == 124
+
 ############
 ############
 + pcap / pcapng format support


### PR DESCRIPTION
fixes broken dissection of ipfix when template defines enterprise-specific information elements.

According to IPFIX RFC, the first bit of Information Element id indicates whether it is IANA-assigned or enterprise-specific Information Elements.

```
     |0| Information Element id. 1.2 |        Field Length 1.2       |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |             ...               |              ...              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |1| Information Element id. 1.N |        Field Length 1.N       |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                    Enterprise Number  1.N                     |
```

This PR added BitField and ConditionalField to NetflowTemplateFieldV9. It adds a test case as well. I can provide a pcap file if needed.

fixes #2236
