### PR TITLE
Autodoc PR leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ MANIFEST
 scapy/VERSION
 test/*.html
 .tox
+.mypy_cache
 doc/scapy/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - os: linux
           python: 3.8
           env:
-            - TOXENV=docs
+            - TOXENV=apitree,docs
 
         - os: linux
           python: 3.8

--- a/doc/generate_docs.bat
+++ b/doc/generate_docs.bat
@@ -1,3 +1,3 @@
 @echo off
 cd ..
-tox -e generate_docs
+tox -e docs2

--- a/doc/scapy/_ext/scapy_doc.py
+++ b/doc/scapy/_ext/scapy_doc.py
@@ -1,0 +1,138 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Gabriel Potter <gabriel@potter.fr>
+# This program is published under a GPLv2 license
+
+"""
+A Sphinx Extension for Scapy's doc preprocessing
+"""
+
+from scapy.packet import Packet, _pkt_ls
+
+from sphinx.ext.autodoc import AttributeDocumenter
+
+# Utils
+
+def generate_rest_table(items):
+    """
+    Generates a ReST table from a list of tuples
+    """
+    lengths = [max(len(y) for y in x) for x in zip(*items)]
+    sep = "+%s+" % "+".join("-" * x for x in lengths)
+    sized = "|%s|" % "|".join("{:%ss}" % x for x in lengths)
+    output = []
+    for i in items:
+        output.append(sep)
+        output.append(sized.format(*i))
+    output.append(sep)
+    return output
+
+
+def tab(items):
+    """
+    Tabulize a generator.
+    """
+    for i in items:
+        # Tabs are 3-wide in autodoc
+        yield "   " + i
+
+
+def class_ref(cls):
+    """
+    Get Sphinx reference to a class
+    """
+    return ":class:`~%s`" % (
+        cls.__module__ + '.' + cls.__name__
+    )
+
+
+def get_fields_desc(obj):
+    """
+    Create a readable documentation for fields_desc
+    """
+    output = []
+    for value in _pkt_ls(obj):
+        fname, cls, clsne, dflt, long_attrs = value
+        output.append(
+            (
+                "**%s**" % fname,
+                class_ref(cls) + ((" " + clsne) if clsne else ""),
+                "``%s``" % repr(dflt)
+            )
+        )
+    if output:
+        output = list(
+            tab(
+                generate_rest_table(output)
+            )
+        )
+        # Add header
+        output.insert(0, ".. table:: %s fields" % obj.__name__)
+        output.insert(1, "   :widths: grid")
+        output.insert(2, "   ")
+    return output
+
+# Documenter
+
+class AttrsDocumenter(AttributeDocumenter):
+    """
+    Mock of AttributeDocumenter to handle Scapy settings
+    """
+
+    def add_directive_header(self, *args, **kwargs):
+        def call_parent():
+            """Calls the super.super.add_directive_header"""
+            super(AttributeDocumenter, self).add_directive_header(
+                *args, **kwargs
+            )
+        sourcename = self.get_sourcename()
+        # Custom additions
+        if issubclass(self.parent, Packet):
+            # Packet
+            if self.object_name == "fields_desc":
+                # Display custom field table
+                call_parent()
+                table = list(tab(get_fields_desc(self.parent)))
+                if table:
+                    self.add_line("   ", sourcename)
+                    for line in table:
+                        self.add_line(line, sourcename)
+                    self.add_line("   ", sourcename)
+                return
+            elif self.object_name == "payload_guess":
+                # Display list of possible children
+                call_parent()
+                children = sorted(set(class_ref(x[1]) for x in self.object))
+                if children:
+                    lines = [
+                        "",
+                        "Possible sublayers:",
+                        ", ".join(children),
+                        ""
+                    ]
+                    for line in tab(lines):
+                        self.add_line(line, sourcename)
+                return
+            elif self.object_name in ["aliastypes"]:
+                # Ignore
+                call_parent()
+                return
+        # The field is unknown: continue normally
+        super(AttrsDocumenter, self).add_directive_header(*args, **kwargs)
+
+# Setup
+
+def setup(app):
+    """
+    Entry point of the scapy_doc extension.
+
+    Called by sphinx while booting up.
+    """
+    app.add_autodocumenter(AttrsDocumenter, override=True)
+
+    # Dummy. We won't publish this
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/scapy/api/scapy.ansmachine.rst
+++ b/doc/scapy/api/scapy.ansmachine.rst
@@ -1,5 +1,5 @@
-scapy.ansmachine module
-=======================
+scapy.ansmachine
+================
 
 .. automodule:: scapy.ansmachine
    :members:

--- a/doc/scapy/api/scapy.as_resolvers.rst
+++ b/doc/scapy/api/scapy.as_resolvers.rst
@@ -1,5 +1,5 @@
-scapy.as\_resolvers module
-==========================
+scapy.as\_resolvers
+===================
 
 .. automodule:: scapy.as_resolvers
    :members:

--- a/doc/scapy/api/scapy.asn1.asn1.rst
+++ b/doc/scapy/api/scapy.asn1.asn1.rst
@@ -1,5 +1,5 @@
-scapy.asn1.asn1 module
-======================
+scapy.asn1.asn1
+===============
 
 .. automodule:: scapy.asn1.asn1
    :members:

--- a/doc/scapy/api/scapy.asn1.ber.rst
+++ b/doc/scapy/api/scapy.asn1.ber.rst
@@ -1,5 +1,5 @@
-scapy.asn1.ber module
-=====================
+scapy.asn1.ber
+==============
 
 .. automodule:: scapy.asn1.ber
    :members:

--- a/doc/scapy/api/scapy.asn1.mib.rst
+++ b/doc/scapy/api/scapy.asn1.mib.rst
@@ -1,5 +1,5 @@
-scapy.asn1.mib module
-=====================
+scapy.asn1.mib
+==============
 
 .. automodule:: scapy.asn1.mib
    :members:

--- a/doc/scapy/api/scapy.asn1fields.rst
+++ b/doc/scapy/api/scapy.asn1fields.rst
@@ -1,5 +1,5 @@
-scapy.asn1fields module
-=======================
+scapy.asn1fields
+================
 
 .. automodule:: scapy.asn1fields
    :members:

--- a/doc/scapy/api/scapy.asn1packet.rst
+++ b/doc/scapy/api/scapy.asn1packet.rst
@@ -1,5 +1,5 @@
-scapy.asn1packet module
-=======================
+scapy.asn1packet
+================
 
 .. automodule:: scapy.asn1packet
    :members:

--- a/doc/scapy/api/scapy.automaton.rst
+++ b/doc/scapy/api/scapy.automaton.rst
@@ -1,5 +1,5 @@
-scapy.automaton module
-======================
+scapy.automaton
+===============
 
 .. automodule:: scapy.automaton
    :members:

--- a/doc/scapy/api/scapy.autorun.rst
+++ b/doc/scapy/api/scapy.autorun.rst
@@ -1,5 +1,5 @@
-scapy.autorun module
-====================
+scapy.autorun
+=============
 
 .. automodule:: scapy.autorun
    :members:

--- a/doc/scapy/api/scapy.base_classes.rst
+++ b/doc/scapy/api/scapy.base_classes.rst
@@ -1,5 +1,5 @@
-scapy.base\_classes module
-==========================
+scapy.base\_classes
+===================
 
 .. automodule:: scapy.base_classes
    :members:

--- a/doc/scapy/api/scapy.compat.rst
+++ b/doc/scapy/api/scapy.compat.rst
@@ -1,5 +1,5 @@
-scapy.compat module
-===================
+scapy.compat
+============
 
 .. automodule:: scapy.compat
    :members:

--- a/doc/scapy/api/scapy.config.rst
+++ b/doc/scapy/api/scapy.config.rst
@@ -1,5 +1,5 @@
-scapy.config module
-===================
+scapy.config
+============
 
 .. automodule:: scapy.config
    :members:

--- a/doc/scapy/api/scapy.consts.rst
+++ b/doc/scapy/api/scapy.consts.rst
@@ -1,5 +1,5 @@
-scapy.consts module
-===================
+scapy.consts
+============
 
 .. automodule:: scapy.consts
    :members:

--- a/doc/scapy/api/scapy.contrib.altbeacon.rst
+++ b/doc/scapy/api/scapy.contrib.altbeacon.rst
@@ -1,5 +1,5 @@
-scapy.contrib.altbeacon module
-==============================
+scapy.contrib.altbeacon
+=======================
 
 .. automodule:: scapy.contrib.altbeacon
    :members:

--- a/doc/scapy/api/scapy.contrib.aoe.rst
+++ b/doc/scapy/api/scapy.contrib.aoe.rst
@@ -1,5 +1,5 @@
-scapy.contrib.aoe module
-========================
+scapy.contrib.aoe
+=================
 
 .. automodule:: scapy.contrib.aoe
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.bmw.enet.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.bmw.enet.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.bmw.enet module
-========================================
+scapy.contrib.automotive.bmw.enet
+=================================
 
 .. automodule:: scapy.contrib.automotive.bmw.enet
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.bmw.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.bmw.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.bmw package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.bmw.enet

--- a/doc/scapy/api/scapy.contrib.automotive.ccp.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.ccp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.ccp module
-===================================
+scapy.contrib.automotive.ccp
+============================
 
 .. automodule:: scapy.contrib.automotive.ccp
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.ecu.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.ecu.rst
@@ -1,0 +1,7 @@
+scapy.contrib.automotive.ecu
+============================
+
+.. automodule:: scapy.contrib.automotive.ecu
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.automotive.gm.gmlan.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.gm.gmlan.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.gm.gmlan module
-========================================
+scapy.contrib.automotive.gm.gmlan
+=================================
 
 .. automodule:: scapy.contrib.automotive.gm.gmlan
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.gm.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.gm.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.gm package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.gm.gmlan

--- a/doc/scapy/api/scapy.contrib.automotive.obd.iid.iids.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.iid.iids.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.iid.iids module
-============================================
+scapy.contrib.automotive.obd.iid.iids
+=====================================
 
 .. automodule:: scapy.contrib.automotive.obd.iid.iids
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.iid.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.iid.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.obd.iid package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.iid.iids

--- a/doc/scapy/api/scapy.contrib.automotive.obd.mid.mids.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.mid.mids.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.mid.mids module
-============================================
+scapy.contrib.automotive.obd.mid.mids
+=====================================
 
 .. automodule:: scapy.contrib.automotive.obd.mid.mids
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.mid.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.mid.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.obd.mid package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.mid.mids

--- a/doc/scapy/api/scapy.contrib.automotive.obd.obd.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.obd.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.obd module
-=======================================
+scapy.contrib.automotive.obd.obd
+================================
 
 .. automodule:: scapy.contrib.automotive.obd.obd
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.packet.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.packet.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.packet module
-==========================================
+scapy.contrib.automotive.obd.packet
+===================================
 
 .. automodule:: scapy.contrib.automotive.obd.packet
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids module
-============================================
+scapy.contrib.automotive.obd.pid.pids
+=====================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_00_1F.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_00_1F.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_00\_1F module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_00\_1F
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_00_1F
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_20_3F.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_20_3F.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_20\_3F module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_20\_3F
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_20_3F
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_40_5F.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_40_5F.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_40\_5F module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_40\_5F
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_40_5F
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_60_7F.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_60_7F.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_60\_7F module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_60\_7F
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_60_7F
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_80_9F.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_80_9F.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_80\_9F module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_80\_9F
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_80_9F
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_A0_C0.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.pids_A0_C0.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.pid.pids\_A0\_C0 module
-====================================================
+scapy.contrib.automotive.obd.pid.pids\_A0\_C0
+=============================================
 
 .. automodule:: scapy.contrib.automotive.obd.pid.pids_A0_C0
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.pid.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.pid.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.obd.pid package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.pid.pids

--- a/doc/scapy/api/scapy.contrib.automotive.obd.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.obd package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.iid
@@ -16,11 +13,9 @@ Subpackages
    scapy.contrib.automotive.obd.pid
    scapy.contrib.automotive.obd.tid
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.obd
    scapy.contrib.automotive.obd.packet
+   scapy.contrib.automotive.obd.scanner
    scapy.contrib.automotive.obd.services

--- a/doc/scapy/api/scapy.contrib.automotive.obd.scanner.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.scanner.rst
@@ -1,0 +1,7 @@
+scapy.contrib.automotive.obd.scanner
+====================================
+
+.. automodule:: scapy.contrib.automotive.obd.scanner
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.services.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.services.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.services module
-============================================
+scapy.contrib.automotive.obd.services
+=====================================
 
 .. automodule:: scapy.contrib.automotive.obd.services
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.obd.tid.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.tid.rst
@@ -6,9 +6,6 @@ scapy.contrib.automotive.obd.tid package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.obd.tid.tids

--- a/doc/scapy/api/scapy.contrib.automotive.obd.tid.tids.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.obd.tid.tids.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.obd.tid.tids module
-============================================
+scapy.contrib.automotive.obd.tid.tids
+=====================================
 
 .. automodule:: scapy.contrib.automotive.obd.tid.tids
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.rst
@@ -6,21 +6,16 @@ scapy.contrib.automotive package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
-
 .. toctree::
 
    scapy.contrib.automotive.bmw
    scapy.contrib.automotive.gm
    scapy.contrib.automotive.obd
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.automotive.ccp
+   scapy.contrib.automotive.ecu
    scapy.contrib.automotive.someip
    scapy.contrib.automotive.someip_sd
    scapy.contrib.automotive.uds

--- a/doc/scapy/api/scapy.contrib.automotive.someip.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.someip.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.someip module
-======================================
+scapy.contrib.automotive.someip
+===============================
 
 .. automodule:: scapy.contrib.automotive.someip
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.someip_sd.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.someip_sd.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.someip\_sd module
-==========================================
+scapy.contrib.automotive.someip\_sd
+===================================
 
 .. automodule:: scapy.contrib.automotive.someip_sd
    :members:

--- a/doc/scapy/api/scapy.contrib.automotive.uds.rst
+++ b/doc/scapy/api/scapy.contrib.automotive.uds.rst
@@ -1,5 +1,5 @@
-scapy.contrib.automotive.uds module
-===================================
+scapy.contrib.automotive.uds
+============================
 
 .. automodule:: scapy.contrib.automotive.uds
    :members:

--- a/doc/scapy/api/scapy.contrib.avs.rst
+++ b/doc/scapy/api/scapy.contrib.avs.rst
@@ -1,5 +1,5 @@
-scapy.contrib.avs module
-========================
+scapy.contrib.avs
+=================
 
 .. automodule:: scapy.contrib.avs
    :members:

--- a/doc/scapy/api/scapy.contrib.bgp.rst
+++ b/doc/scapy/api/scapy.contrib.bgp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.bgp module
-========================
+scapy.contrib.bgp
+=================
 
 .. automodule:: scapy.contrib.bgp
    :members:

--- a/doc/scapy/api/scapy.contrib.bier.rst
+++ b/doc/scapy/api/scapy.contrib.bier.rst
@@ -1,5 +1,5 @@
-scapy.contrib.bier module
-=========================
+scapy.contrib.bier
+==================
 
 .. automodule:: scapy.contrib.bier
    :members:

--- a/doc/scapy/api/scapy.contrib.bp.rst
+++ b/doc/scapy/api/scapy.contrib.bp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.bp module
-=======================
+scapy.contrib.bp
+================
 
 .. automodule:: scapy.contrib.bp
    :members:

--- a/doc/scapy/api/scapy.contrib.carp.rst
+++ b/doc/scapy/api/scapy.contrib.carp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.carp module
-=========================
+scapy.contrib.carp
+==================
 
 .. automodule:: scapy.contrib.carp
    :members:

--- a/doc/scapy/api/scapy.contrib.cdp.rst
+++ b/doc/scapy/api/scapy.contrib.cdp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.cdp module
-========================
+scapy.contrib.cdp
+=================
 
 .. automodule:: scapy.contrib.cdp
    :members:

--- a/doc/scapy/api/scapy.contrib.chdlc.rst
+++ b/doc/scapy/api/scapy.contrib.chdlc.rst
@@ -1,5 +1,5 @@
-scapy.contrib.chdlc module
-==========================
+scapy.contrib.chdlc
+===================
 
 .. automodule:: scapy.contrib.chdlc
    :members:

--- a/doc/scapy/api/scapy.contrib.coap.rst
+++ b/doc/scapy/api/scapy.contrib.coap.rst
@@ -1,5 +1,5 @@
-scapy.contrib.coap module
-=========================
+scapy.contrib.coap
+==================
 
 .. automodule:: scapy.contrib.coap
    :members:

--- a/doc/scapy/api/scapy.contrib.dce_rpc.rst
+++ b/doc/scapy/api/scapy.contrib.dce_rpc.rst
@@ -1,5 +1,5 @@
-scapy.contrib.dce\_rpc module
-=============================
+scapy.contrib.dce\_rpc
+======================
 
 .. automodule:: scapy.contrib.dce_rpc
    :members:

--- a/doc/scapy/api/scapy.contrib.diameter.rst
+++ b/doc/scapy/api/scapy.contrib.diameter.rst
@@ -1,5 +1,5 @@
-scapy.contrib.diameter module
-=============================
+scapy.contrib.diameter
+======================
 
 .. automodule:: scapy.contrib.diameter
    :members:

--- a/doc/scapy/api/scapy.contrib.dtp.rst
+++ b/doc/scapy/api/scapy.contrib.dtp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.dtp module
-========================
+scapy.contrib.dtp
+=================
 
 .. automodule:: scapy.contrib.dtp
    :members:

--- a/doc/scapy/api/scapy.contrib.eddystone.rst
+++ b/doc/scapy/api/scapy.contrib.eddystone.rst
@@ -1,5 +1,5 @@
-scapy.contrib.eddystone module
-==============================
+scapy.contrib.eddystone
+=======================
 
 .. automodule:: scapy.contrib.eddystone
    :members:

--- a/doc/scapy/api/scapy.contrib.eigrp.rst
+++ b/doc/scapy/api/scapy.contrib.eigrp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.eigrp module
-==========================
+scapy.contrib.eigrp
+===================
 
 .. automodule:: scapy.contrib.eigrp
    :members:

--- a/doc/scapy/api/scapy.contrib.enipTCP.rst
+++ b/doc/scapy/api/scapy.contrib.enipTCP.rst
@@ -1,5 +1,5 @@
-scapy.contrib.enipTCP module
-============================
+scapy.contrib.enipTCP
+=====================
 
 .. automodule:: scapy.contrib.enipTCP
    :members:

--- a/doc/scapy/api/scapy.contrib.ethercat.rst
+++ b/doc/scapy/api/scapy.contrib.ethercat.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ethercat module
-=============================
+scapy.contrib.ethercat
+======================
 
 .. automodule:: scapy.contrib.ethercat
    :members:

--- a/doc/scapy/api/scapy.contrib.etherip.rst
+++ b/doc/scapy/api/scapy.contrib.etherip.rst
@@ -1,5 +1,5 @@
-scapy.contrib.etherip module
-============================
+scapy.contrib.etherip
+=====================
 
 .. automodule:: scapy.contrib.etherip
    :members:

--- a/doc/scapy/api/scapy.contrib.geneve.rst
+++ b/doc/scapy/api/scapy.contrib.geneve.rst
@@ -1,5 +1,5 @@
-scapy.contrib.geneve module
-===========================
+scapy.contrib.geneve
+====================
 
 .. automodule:: scapy.contrib.geneve
    :members:

--- a/doc/scapy/api/scapy.contrib.gtp.rst
+++ b/doc/scapy/api/scapy.contrib.gtp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.gtp module
-========================
+scapy.contrib.gtp
+=================
 
 .. automodule:: scapy.contrib.gtp
    :members:

--- a/doc/scapy/api/scapy.contrib.gtp_v2.rst
+++ b/doc/scapy/api/scapy.contrib.gtp_v2.rst
@@ -1,5 +1,5 @@
-scapy.contrib.gtp\_v2 module
-============================
+scapy.contrib.gtp\_v2
+=====================
 
 .. automodule:: scapy.contrib.gtp_v2
    :members:

--- a/doc/scapy/api/scapy.contrib.homeplugav.rst
+++ b/doc/scapy/api/scapy.contrib.homeplugav.rst
@@ -1,5 +1,5 @@
-scapy.contrib.homeplugav module
-===============================
+scapy.contrib.homeplugav
+========================
 
 .. automodule:: scapy.contrib.homeplugav
    :members:

--- a/doc/scapy/api/scapy.contrib.http2.rst
+++ b/doc/scapy/api/scapy.contrib.http2.rst
@@ -1,5 +1,5 @@
-scapy.contrib.http2 module
-==========================
+scapy.contrib.http2
+===================
 
 .. automodule:: scapy.contrib.http2
    :members:

--- a/doc/scapy/api/scapy.contrib.ibeacon.rst
+++ b/doc/scapy/api/scapy.contrib.ibeacon.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ibeacon module
-============================
+scapy.contrib.ibeacon
+=====================
 
 .. automodule:: scapy.contrib.ibeacon
    :members:

--- a/doc/scapy/api/scapy.contrib.icmp_extensions.rst
+++ b/doc/scapy/api/scapy.contrib.icmp_extensions.rst
@@ -1,5 +1,5 @@
-scapy.contrib.icmp\_extensions module
-=====================================
+scapy.contrib.icmp\_extensions
+==============================
 
 .. automodule:: scapy.contrib.icmp_extensions
    :members:

--- a/doc/scapy/api/scapy.contrib.ife.rst
+++ b/doc/scapy/api/scapy.contrib.ife.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ife module
-========================
+scapy.contrib.ife
+=================
 
 .. automodule:: scapy.contrib.ife
    :members:

--- a/doc/scapy/api/scapy.contrib.igmp.rst
+++ b/doc/scapy/api/scapy.contrib.igmp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.igmp module
-=========================
+scapy.contrib.igmp
+==================
 
 .. automodule:: scapy.contrib.igmp
    :members:

--- a/doc/scapy/api/scapy.contrib.igmpv3.rst
+++ b/doc/scapy/api/scapy.contrib.igmpv3.rst
@@ -1,5 +1,5 @@
-scapy.contrib.igmpv3 module
-===========================
+scapy.contrib.igmpv3
+====================
 
 .. automodule:: scapy.contrib.igmpv3
    :members:

--- a/doc/scapy/api/scapy.contrib.ikev2.rst
+++ b/doc/scapy/api/scapy.contrib.ikev2.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ikev2 module
-==========================
+scapy.contrib.ikev2
+===================
 
 .. automodule:: scapy.contrib.ikev2
    :members:

--- a/doc/scapy/api/scapy.contrib.isis.rst
+++ b/doc/scapy/api/scapy.contrib.isis.rst
@@ -1,5 +1,5 @@
-scapy.contrib.isis module
-=========================
+scapy.contrib.isis
+==================
 
 .. automodule:: scapy.contrib.isis
    :members:

--- a/doc/scapy/api/scapy.contrib.isotp.rst
+++ b/doc/scapy/api/scapy.contrib.isotp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.isotp module
-==========================
+scapy.contrib.isotp
+===================
 
 .. automodule:: scapy.contrib.isotp
    :members:

--- a/doc/scapy/api/scapy.contrib.lacp.rst
+++ b/doc/scapy/api/scapy.contrib.lacp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.lacp module
-=========================
+scapy.contrib.lacp
+==================
 
 .. automodule:: scapy.contrib.lacp
    :members:

--- a/doc/scapy/api/scapy.contrib.ldp.rst
+++ b/doc/scapy/api/scapy.contrib.ldp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ldp module
-========================
+scapy.contrib.ldp
+=================
 
 .. automodule:: scapy.contrib.ldp
    :members:

--- a/doc/scapy/api/scapy.contrib.lldp.rst
+++ b/doc/scapy/api/scapy.contrib.lldp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.lldp module
-=========================
+scapy.contrib.lldp
+==================
 
 .. automodule:: scapy.contrib.lldp
    :members:

--- a/doc/scapy/api/scapy.contrib.ltp.rst
+++ b/doc/scapy/api/scapy.contrib.ltp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ltp module
-========================
+scapy.contrib.ltp
+=================
 
 .. automodule:: scapy.contrib.ltp
    :members:

--- a/doc/scapy/api/scapy.contrib.mac_control.rst
+++ b/doc/scapy/api/scapy.contrib.mac_control.rst
@@ -1,5 +1,5 @@
-scapy.contrib.mac\_control module
-=================================
+scapy.contrib.mac\_control
+==========================
 
 .. automodule:: scapy.contrib.mac_control
    :members:

--- a/doc/scapy/api/scapy.contrib.macsec.rst
+++ b/doc/scapy/api/scapy.contrib.macsec.rst
@@ -1,5 +1,5 @@
-scapy.contrib.macsec module
-===========================
+scapy.contrib.macsec
+====================
 
 .. automodule:: scapy.contrib.macsec
    :members:

--- a/doc/scapy/api/scapy.contrib.modbus.rst
+++ b/doc/scapy/api/scapy.contrib.modbus.rst
@@ -1,5 +1,5 @@
-scapy.contrib.modbus module
-===========================
+scapy.contrib.modbus
+====================
 
 .. automodule:: scapy.contrib.modbus
    :members:

--- a/doc/scapy/api/scapy.contrib.mount.rst
+++ b/doc/scapy/api/scapy.contrib.mount.rst
@@ -1,0 +1,7 @@
+scapy.contrib.mount
+===================
+
+.. automodule:: scapy.contrib.mount
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.mpls.rst
+++ b/doc/scapy/api/scapy.contrib.mpls.rst
@@ -1,5 +1,5 @@
-scapy.contrib.mpls module
-=========================
+scapy.contrib.mpls
+==================
 
 .. automodule:: scapy.contrib.mpls
    :members:

--- a/doc/scapy/api/scapy.contrib.mqtt.rst
+++ b/doc/scapy/api/scapy.contrib.mqtt.rst
@@ -1,5 +1,5 @@
-scapy.contrib.mqtt module
-=========================
+scapy.contrib.mqtt
+==================
 
 .. automodule:: scapy.contrib.mqtt
    :members:

--- a/doc/scapy/api/scapy.contrib.mqttsn.rst
+++ b/doc/scapy/api/scapy.contrib.mqttsn.rst
@@ -1,5 +1,5 @@
-scapy.contrib.mqttsn module
-===========================
+scapy.contrib.mqttsn
+====================
 
 .. automodule:: scapy.contrib.mqttsn
    :members:

--- a/doc/scapy/api/scapy.contrib.nfs.rst
+++ b/doc/scapy/api/scapy.contrib.nfs.rst
@@ -1,0 +1,7 @@
+scapy.contrib.nfs
+=================
+
+.. automodule:: scapy.contrib.nfs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.nlm.rst
+++ b/doc/scapy/api/scapy.contrib.nlm.rst
@@ -1,0 +1,7 @@
+scapy.contrib.nlm
+=================
+
+.. automodule:: scapy.contrib.nlm
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.nsh.rst
+++ b/doc/scapy/api/scapy.contrib.nsh.rst
@@ -1,5 +1,5 @@
-scapy.contrib.nsh module
-========================
+scapy.contrib.nsh
+=================
 
 .. automodule:: scapy.contrib.nsh
    :members:

--- a/doc/scapy/api/scapy.contrib.oncrpc.rst
+++ b/doc/scapy/api/scapy.contrib.oncrpc.rst
@@ -1,0 +1,7 @@
+scapy.contrib.oncrpc
+====================
+
+.. automodule:: scapy.contrib.oncrpc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.opc_da.rst
+++ b/doc/scapy/api/scapy.contrib.opc_da.rst
@@ -1,5 +1,5 @@
-scapy.contrib.opc\_da module
-============================
+scapy.contrib.opc\_da
+=====================
 
 .. automodule:: scapy.contrib.opc_da
    :members:

--- a/doc/scapy/api/scapy.contrib.openflow.rst
+++ b/doc/scapy/api/scapy.contrib.openflow.rst
@@ -1,5 +1,5 @@
-scapy.contrib.openflow module
-=============================
+scapy.contrib.openflow
+======================
 
 .. automodule:: scapy.contrib.openflow
    :members:

--- a/doc/scapy/api/scapy.contrib.openflow3.rst
+++ b/doc/scapy/api/scapy.contrib.openflow3.rst
@@ -1,5 +1,5 @@
-scapy.contrib.openflow3 module
-==============================
+scapy.contrib.openflow3
+=======================
 
 .. automodule:: scapy.contrib.openflow3
    :members:

--- a/doc/scapy/api/scapy.contrib.ospf.rst
+++ b/doc/scapy/api/scapy.contrib.ospf.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ospf module
-=========================
+scapy.contrib.ospf
+==================
 
 .. automodule:: scapy.contrib.ospf
    :members:

--- a/doc/scapy/api/scapy.contrib.pnio.rst
+++ b/doc/scapy/api/scapy.contrib.pnio.rst
@@ -1,5 +1,5 @@
-scapy.contrib.pnio module
-=========================
+scapy.contrib.pnio
+==================
 
 .. automodule:: scapy.contrib.pnio
    :members:

--- a/doc/scapy/api/scapy.contrib.pnio_dcp.rst
+++ b/doc/scapy/api/scapy.contrib.pnio_dcp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.pnio\_dcp module
-==============================
+scapy.contrib.pnio\_dcp
+=======================
 
 .. automodule:: scapy.contrib.pnio_dcp
    :members:

--- a/doc/scapy/api/scapy.contrib.pnio_rpc.rst
+++ b/doc/scapy/api/scapy.contrib.pnio_rpc.rst
@@ -1,5 +1,5 @@
-scapy.contrib.pnio\_rpc module
-==============================
+scapy.contrib.pnio\_rpc
+=======================
 
 .. automodule:: scapy.contrib.pnio_rpc
    :members:

--- a/doc/scapy/api/scapy.contrib.portmap.rst
+++ b/doc/scapy/api/scapy.contrib.portmap.rst
@@ -1,0 +1,7 @@
+scapy.contrib.portmap
+=====================
+
+.. automodule:: scapy.contrib.portmap
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/scapy/api/scapy.contrib.ppi_cace.rst
+++ b/doc/scapy/api/scapy.contrib.ppi_cace.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ppi\_cace module
-==============================
+scapy.contrib.ppi\_cace
+=======================
 
 .. automodule:: scapy.contrib.ppi_cace
    :members:

--- a/doc/scapy/api/scapy.contrib.ppi_geotag.rst
+++ b/doc/scapy/api/scapy.contrib.ppi_geotag.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ppi\_geotag module
-================================
+scapy.contrib.ppi\_geotag
+=========================
 
 .. automodule:: scapy.contrib.ppi_geotag
    :members:

--- a/doc/scapy/api/scapy.contrib.ripng.rst
+++ b/doc/scapy/api/scapy.contrib.ripng.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ripng module
-==========================
+scapy.contrib.ripng
+===================
 
 .. automodule:: scapy.contrib.ripng
    :members:

--- a/doc/scapy/api/scapy.contrib.rst
+++ b/doc/scapy/api/scapy.contrib.rst
@@ -6,7 +6,6 @@ scapy.contrib package
    :undoc-members:
    :show-inheritance:
 
-
 .. toctree::
 
    scapy.contrib.automotive
@@ -52,10 +51,14 @@ scapy.contrib package
    scapy.contrib.mac_control
    scapy.contrib.macsec
    scapy.contrib.modbus
+   scapy.contrib.mount
    scapy.contrib.mpls
    scapy.contrib.mqtt
    scapy.contrib.mqttsn
+   scapy.contrib.nfs
+   scapy.contrib.nlm
    scapy.contrib.nsh
+   scapy.contrib.oncrpc
    scapy.contrib.opc_da
    scapy.contrib.openflow
    scapy.contrib.openflow3
@@ -63,6 +66,7 @@ scapy.contrib package
    scapy.contrib.pnio
    scapy.contrib.pnio_dcp
    scapy.contrib.pnio_rpc
+   scapy.contrib.portmap
    scapy.contrib.ppi_cace
    scapy.contrib.ppi_geotag
    scapy.contrib.ripng

--- a/doc/scapy/api/scapy.contrib.rsvp.rst
+++ b/doc/scapy/api/scapy.contrib.rsvp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.rsvp module
-=========================
+scapy.contrib.rsvp
+==================
 
 .. automodule:: scapy.contrib.rsvp
    :members:

--- a/doc/scapy/api/scapy.contrib.rtr.rst
+++ b/doc/scapy/api/scapy.contrib.rtr.rst
@@ -1,5 +1,5 @@
-scapy.contrib.rtr module
-========================
+scapy.contrib.rtr
+=================
 
 .. automodule:: scapy.contrib.rtr
    :members:

--- a/doc/scapy/api/scapy.contrib.scada.iec104.iec104.rst
+++ b/doc/scapy/api/scapy.contrib.scada.iec104.iec104.rst
@@ -1,5 +1,5 @@
-scapy.contrib.scada.iec104.iec104 module
-========================================
+scapy.contrib.scada.iec104.iec104
+=================================
 
 .. automodule:: scapy.contrib.scada.iec104.iec104
    :members:

--- a/doc/scapy/api/scapy.contrib.scada.iec104.iec104_fields.rst
+++ b/doc/scapy/api/scapy.contrib.scada.iec104.iec104_fields.rst
@@ -1,5 +1,5 @@
-scapy.contrib.scada.iec104.iec104\_fields module
-================================================
+scapy.contrib.scada.iec104.iec104\_fields
+=========================================
 
 .. automodule:: scapy.contrib.scada.iec104.iec104_fields
    :members:

--- a/doc/scapy/api/scapy.contrib.scada.iec104.iec104_information_elements.rst
+++ b/doc/scapy/api/scapy.contrib.scada.iec104.iec104_information_elements.rst
@@ -1,5 +1,5 @@
-scapy.contrib.scada.iec104.iec104\_information\_elements module
-===============================================================
+scapy.contrib.scada.iec104.iec104\_information\_elements
+========================================================
 
 .. automodule:: scapy.contrib.scada.iec104.iec104_information_elements
    :members:

--- a/doc/scapy/api/scapy.contrib.scada.iec104.iec104_information_objects.rst
+++ b/doc/scapy/api/scapy.contrib.scada.iec104.iec104_information_objects.rst
@@ -1,5 +1,5 @@
-scapy.contrib.scada.iec104.iec104\_information\_objects module
-==============================================================
+scapy.contrib.scada.iec104.iec104\_information\_objects
+=======================================================
 
 .. automodule:: scapy.contrib.scada.iec104.iec104_information_objects
    :members:

--- a/doc/scapy/api/scapy.contrib.scada.iec104.rst
+++ b/doc/scapy/api/scapy.contrib.scada.iec104.rst
@@ -6,9 +6,6 @@ scapy.contrib.scada.iec104 package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.contrib.scada.iec104.iec104

--- a/doc/scapy/api/scapy.contrib.scada.rst
+++ b/doc/scapy/api/scapy.contrib.scada.rst
@@ -6,9 +6,6 @@ scapy.contrib.scada package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
-
 .. toctree::
 
    scapy.contrib.scada.iec104

--- a/doc/scapy/api/scapy.contrib.sdnv.rst
+++ b/doc/scapy/api/scapy.contrib.sdnv.rst
@@ -1,5 +1,5 @@
-scapy.contrib.sdnv module
-=========================
+scapy.contrib.sdnv
+==================
 
 .. automodule:: scapy.contrib.sdnv
    :members:

--- a/doc/scapy/api/scapy.contrib.sebek.rst
+++ b/doc/scapy/api/scapy.contrib.sebek.rst
@@ -1,5 +1,5 @@
-scapy.contrib.sebek module
-==========================
+scapy.contrib.sebek
+===================
 
 .. automodule:: scapy.contrib.sebek
    :members:

--- a/doc/scapy/api/scapy.contrib.send.rst
+++ b/doc/scapy/api/scapy.contrib.send.rst
@@ -1,5 +1,5 @@
-scapy.contrib.send module
-=========================
+scapy.contrib.send
+==================
 
 .. automodule:: scapy.contrib.send
    :members:

--- a/doc/scapy/api/scapy.contrib.skinny.rst
+++ b/doc/scapy/api/scapy.contrib.skinny.rst
@@ -1,5 +1,5 @@
-scapy.contrib.skinny module
-===========================
+scapy.contrib.skinny
+====================
 
 .. automodule:: scapy.contrib.skinny
    :members:

--- a/doc/scapy/api/scapy.contrib.socks.rst
+++ b/doc/scapy/api/scapy.contrib.socks.rst
@@ -1,5 +1,5 @@
-scapy.contrib.socks module
-==========================
+scapy.contrib.socks
+===================
 
 .. automodule:: scapy.contrib.socks
    :members:

--- a/doc/scapy/api/scapy.contrib.spbm.rst
+++ b/doc/scapy/api/scapy.contrib.spbm.rst
@@ -1,5 +1,5 @@
-scapy.contrib.spbm module
-=========================
+scapy.contrib.spbm
+==================
 
 .. automodule:: scapy.contrib.spbm
    :members:

--- a/doc/scapy/api/scapy.contrib.tacacs.rst
+++ b/doc/scapy/api/scapy.contrib.tacacs.rst
@@ -1,5 +1,5 @@
-scapy.contrib.tacacs module
-===========================
+scapy.contrib.tacacs
+====================
 
 .. automodule:: scapy.contrib.tacacs
    :members:

--- a/doc/scapy/api/scapy.contrib.tzsp.rst
+++ b/doc/scapy/api/scapy.contrib.tzsp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.tzsp module
-=========================
+scapy.contrib.tzsp
+==================
 
 .. automodule:: scapy.contrib.tzsp
    :members:

--- a/doc/scapy/api/scapy.contrib.ubberlogger.rst
+++ b/doc/scapy/api/scapy.contrib.ubberlogger.rst
@@ -1,5 +1,5 @@
-scapy.contrib.ubberlogger module
-================================
+scapy.contrib.ubberlogger
+=========================
 
 .. automodule:: scapy.contrib.ubberlogger
    :members:

--- a/doc/scapy/api/scapy.contrib.vqp.rst
+++ b/doc/scapy/api/scapy.contrib.vqp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.vqp module
-========================
+scapy.contrib.vqp
+=================
 
 .. automodule:: scapy.contrib.vqp
    :members:

--- a/doc/scapy/api/scapy.contrib.vtp.rst
+++ b/doc/scapy/api/scapy.contrib.vtp.rst
@@ -1,5 +1,5 @@
-scapy.contrib.vtp module
-========================
+scapy.contrib.vtp
+=================
 
 .. automodule:: scapy.contrib.vtp
    :members:

--- a/doc/scapy/api/scapy.contrib.wireguard.rst
+++ b/doc/scapy/api/scapy.contrib.wireguard.rst
@@ -1,5 +1,5 @@
-scapy.contrib.wireguard module
-==============================
+scapy.contrib.wireguard
+=======================
 
 .. automodule:: scapy.contrib.wireguard
    :members:

--- a/doc/scapy/api/scapy.contrib.wpa_eapol.rst
+++ b/doc/scapy/api/scapy.contrib.wpa_eapol.rst
@@ -1,5 +1,5 @@
-scapy.contrib.wpa\_eapol module
-===============================
+scapy.contrib.wpa\_eapol
+========================
 
 .. automodule:: scapy.contrib.wpa_eapol
    :members:

--- a/doc/scapy/api/scapy.dadict.rst
+++ b/doc/scapy/api/scapy.dadict.rst
@@ -1,5 +1,5 @@
-scapy.dadict module
-===================
+scapy.dadict
+============
 
 .. automodule:: scapy.dadict
    :members:

--- a/doc/scapy/api/scapy.data.rst
+++ b/doc/scapy/api/scapy.data.rst
@@ -1,5 +1,5 @@
-scapy.data module
-=================
+scapy.data
+==========
 
 .. automodule:: scapy.data
    :members:

--- a/doc/scapy/api/scapy.error.rst
+++ b/doc/scapy/api/scapy.error.rst
@@ -1,5 +1,5 @@
-scapy.error module
-==================
+scapy.error
+===========
 
 .. automodule:: scapy.error
    :members:

--- a/doc/scapy/api/scapy.extlib.rst
+++ b/doc/scapy/api/scapy.extlib.rst
@@ -1,5 +1,5 @@
-scapy.extlib module
-===================
+scapy.extlib
+============
 
 .. automodule:: scapy.extlib
    :members:

--- a/doc/scapy/api/scapy.fields.rst
+++ b/doc/scapy/api/scapy.fields.rst
@@ -1,5 +1,5 @@
-scapy.fields module
-===================
+scapy.fields
+============
 
 .. automodule:: scapy.fields
    :members:

--- a/doc/scapy/api/scapy.layers.bluetooth.rst
+++ b/doc/scapy/api/scapy.layers.bluetooth.rst
@@ -1,5 +1,5 @@
-scapy.layers.bluetooth module
-=============================
+scapy.layers.bluetooth
+======================
 
 .. automodule:: scapy.layers.bluetooth
    :members:

--- a/doc/scapy/api/scapy.layers.bluetooth4LE.rst
+++ b/doc/scapy/api/scapy.layers.bluetooth4LE.rst
@@ -1,5 +1,5 @@
-scapy.layers.bluetooth4LE module
-================================
+scapy.layers.bluetooth4LE
+=========================
 
 .. automodule:: scapy.layers.bluetooth4LE
    :members:

--- a/doc/scapy/api/scapy.layers.can.rst
+++ b/doc/scapy/api/scapy.layers.can.rst
@@ -1,5 +1,5 @@
-scapy.layers.can module
-=======================
+scapy.layers.can
+================
 
 .. automodule:: scapy.layers.can
    :members:

--- a/doc/scapy/api/scapy.layers.clns.rst
+++ b/doc/scapy/api/scapy.layers.clns.rst
@@ -1,5 +1,5 @@
-scapy.layers.clns module
-========================
+scapy.layers.clns
+=================
 
 .. automodule:: scapy.layers.clns
    :members:

--- a/doc/scapy/api/scapy.layers.dhcp.rst
+++ b/doc/scapy/api/scapy.layers.dhcp.rst
@@ -1,5 +1,5 @@
-scapy.layers.dhcp module
-========================
+scapy.layers.dhcp
+=================
 
 .. automodule:: scapy.layers.dhcp
    :members:

--- a/doc/scapy/api/scapy.layers.dhcp6.rst
+++ b/doc/scapy/api/scapy.layers.dhcp6.rst
@@ -1,5 +1,5 @@
-scapy.layers.dhcp6 module
-=========================
+scapy.layers.dhcp6
+==================
 
 .. automodule:: scapy.layers.dhcp6
    :members:

--- a/doc/scapy/api/scapy.layers.dns.rst
+++ b/doc/scapy/api/scapy.layers.dns.rst
@@ -1,5 +1,5 @@
-scapy.layers.dns module
-=======================
+scapy.layers.dns
+================
 
 .. automodule:: scapy.layers.dns
    :members:

--- a/doc/scapy/api/scapy.layers.dot11.rst
+++ b/doc/scapy/api/scapy.layers.dot11.rst
@@ -1,5 +1,5 @@
-scapy.layers.dot11 module
-=========================
+scapy.layers.dot11
+==================
 
 .. automodule:: scapy.layers.dot11
    :members:

--- a/doc/scapy/api/scapy.layers.dot15d4.rst
+++ b/doc/scapy/api/scapy.layers.dot15d4.rst
@@ -1,5 +1,5 @@
-scapy.layers.dot15d4 module
-===========================
+scapy.layers.dot15d4
+====================
 
 .. automodule:: scapy.layers.dot15d4
    :members:

--- a/doc/scapy/api/scapy.layers.eap.rst
+++ b/doc/scapy/api/scapy.layers.eap.rst
@@ -1,5 +1,5 @@
-scapy.layers.eap module
-=======================
+scapy.layers.eap
+================
 
 .. automodule:: scapy.layers.eap
    :members:

--- a/doc/scapy/api/scapy.layers.gprs.rst
+++ b/doc/scapy/api/scapy.layers.gprs.rst
@@ -1,5 +1,5 @@
-scapy.layers.gprs module
-========================
+scapy.layers.gprs
+=================
 
 .. automodule:: scapy.layers.gprs
    :members:

--- a/doc/scapy/api/scapy.layers.hsrp.rst
+++ b/doc/scapy/api/scapy.layers.hsrp.rst
@@ -1,5 +1,5 @@
-scapy.layers.hsrp module
-========================
+scapy.layers.hsrp
+=================
 
 .. automodule:: scapy.layers.hsrp
    :members:

--- a/doc/scapy/api/scapy.layers.http.rst
+++ b/doc/scapy/api/scapy.layers.http.rst
@@ -1,5 +1,5 @@
-scapy.layers.http module
-========================
+scapy.layers.http
+=================
 
 .. automodule:: scapy.layers.http
    :members:

--- a/doc/scapy/api/scapy.layers.inet.rst
+++ b/doc/scapy/api/scapy.layers.inet.rst
@@ -1,5 +1,5 @@
-scapy.layers.inet module
-========================
+scapy.layers.inet
+=================
 
 .. automodule:: scapy.layers.inet
    :members:

--- a/doc/scapy/api/scapy.layers.inet6.rst
+++ b/doc/scapy/api/scapy.layers.inet6.rst
@@ -1,5 +1,5 @@
-scapy.layers.inet6 module
-=========================
+scapy.layers.inet6
+==================
 
 .. automodule:: scapy.layers.inet6
    :members:

--- a/doc/scapy/api/scapy.layers.ipsec.rst
+++ b/doc/scapy/api/scapy.layers.ipsec.rst
@@ -1,5 +1,5 @@
-scapy.layers.ipsec module
-=========================
+scapy.layers.ipsec
+==================
 
 .. automodule:: scapy.layers.ipsec
    :members:

--- a/doc/scapy/api/scapy.layers.ir.rst
+++ b/doc/scapy/api/scapy.layers.ir.rst
@@ -1,5 +1,5 @@
-scapy.layers.ir module
-======================
+scapy.layers.ir
+===============
 
 .. automodule:: scapy.layers.ir
    :members:

--- a/doc/scapy/api/scapy.layers.isakmp.rst
+++ b/doc/scapy/api/scapy.layers.isakmp.rst
@@ -1,5 +1,5 @@
-scapy.layers.isakmp module
-==========================
+scapy.layers.isakmp
+===================
 
 .. automodule:: scapy.layers.isakmp
    :members:

--- a/doc/scapy/api/scapy.layers.l2.rst
+++ b/doc/scapy/api/scapy.layers.l2.rst
@@ -1,5 +1,5 @@
-scapy.layers.l2 module
-======================
+scapy.layers.l2
+===============
 
 .. automodule:: scapy.layers.l2
    :members:

--- a/doc/scapy/api/scapy.layers.l2tp.rst
+++ b/doc/scapy/api/scapy.layers.l2tp.rst
@@ -1,5 +1,5 @@
-scapy.layers.l2tp module
-========================
+scapy.layers.l2tp
+=================
 
 .. automodule:: scapy.layers.l2tp
    :members:

--- a/doc/scapy/api/scapy.layers.llmnr.rst
+++ b/doc/scapy/api/scapy.layers.llmnr.rst
@@ -1,5 +1,5 @@
-scapy.layers.llmnr module
-=========================
+scapy.layers.llmnr
+==================
 
 .. automodule:: scapy.layers.llmnr
    :members:

--- a/doc/scapy/api/scapy.layers.lltd.rst
+++ b/doc/scapy/api/scapy.layers.lltd.rst
@@ -1,5 +1,5 @@
-scapy.layers.lltd module
-========================
+scapy.layers.lltd
+=================
 
 .. automodule:: scapy.layers.lltd
    :members:

--- a/doc/scapy/api/scapy.layers.mgcp.rst
+++ b/doc/scapy/api/scapy.layers.mgcp.rst
@@ -1,5 +1,5 @@
-scapy.layers.mgcp module
-========================
+scapy.layers.mgcp
+=================
 
 .. automodule:: scapy.layers.mgcp
    :members:

--- a/doc/scapy/api/scapy.layers.mobileip.rst
+++ b/doc/scapy/api/scapy.layers.mobileip.rst
@@ -1,5 +1,5 @@
-scapy.layers.mobileip module
-============================
+scapy.layers.mobileip
+=====================
 
 .. automodule:: scapy.layers.mobileip
    :members:

--- a/doc/scapy/api/scapy.layers.netbios.rst
+++ b/doc/scapy/api/scapy.layers.netbios.rst
@@ -1,5 +1,5 @@
-scapy.layers.netbios module
-===========================
+scapy.layers.netbios
+====================
 
 .. automodule:: scapy.layers.netbios
    :members:

--- a/doc/scapy/api/scapy.layers.netflow.rst
+++ b/doc/scapy/api/scapy.layers.netflow.rst
@@ -1,5 +1,5 @@
-scapy.layers.netflow module
-===========================
+scapy.layers.netflow
+====================
 
 .. automodule:: scapy.layers.netflow
    :members:

--- a/doc/scapy/api/scapy.layers.ntp.rst
+++ b/doc/scapy/api/scapy.layers.ntp.rst
@@ -1,5 +1,5 @@
-scapy.layers.ntp module
-=======================
+scapy.layers.ntp
+================
 
 .. automodule:: scapy.layers.ntp
    :members:

--- a/doc/scapy/api/scapy.layers.pflog.rst
+++ b/doc/scapy/api/scapy.layers.pflog.rst
@@ -1,5 +1,5 @@
-scapy.layers.pflog module
-=========================
+scapy.layers.pflog
+==================
 
 .. automodule:: scapy.layers.pflog
    :members:

--- a/doc/scapy/api/scapy.layers.ppi.rst
+++ b/doc/scapy/api/scapy.layers.ppi.rst
@@ -1,5 +1,5 @@
-scapy.layers.ppi module
-=======================
+scapy.layers.ppi
+================
 
 .. automodule:: scapy.layers.ppi
    :members:

--- a/doc/scapy/api/scapy.layers.ppp.rst
+++ b/doc/scapy/api/scapy.layers.ppp.rst
@@ -1,5 +1,5 @@
-scapy.layers.ppp module
-=======================
+scapy.layers.ppp
+================
 
 .. automodule:: scapy.layers.ppp
    :members:

--- a/doc/scapy/api/scapy.layers.pptp.rst
+++ b/doc/scapy/api/scapy.layers.pptp.rst
@@ -1,5 +1,5 @@
-scapy.layers.pptp module
-========================
+scapy.layers.pptp
+=================
 
 .. automodule:: scapy.layers.pptp
    :members:

--- a/doc/scapy/api/scapy.layers.radius.rst
+++ b/doc/scapy/api/scapy.layers.radius.rst
@@ -1,5 +1,5 @@
-scapy.layers.radius module
-==========================
+scapy.layers.radius
+===================
 
 .. automodule:: scapy.layers.radius
    :members:

--- a/doc/scapy/api/scapy.layers.rip.rst
+++ b/doc/scapy/api/scapy.layers.rip.rst
@@ -1,5 +1,5 @@
-scapy.layers.rip module
-=======================
+scapy.layers.rip
+================
 
 .. automodule:: scapy.layers.rip
    :members:

--- a/doc/scapy/api/scapy.layers.rtp.rst
+++ b/doc/scapy/api/scapy.layers.rtp.rst
@@ -1,5 +1,5 @@
-scapy.layers.rtp module
-=======================
+scapy.layers.rtp
+================
 
 .. automodule:: scapy.layers.rtp
    :members:

--- a/doc/scapy/api/scapy.layers.sctp.rst
+++ b/doc/scapy/api/scapy.layers.sctp.rst
@@ -1,5 +1,5 @@
-scapy.layers.sctp module
-========================
+scapy.layers.sctp
+=================
 
 .. automodule:: scapy.layers.sctp
    :members:

--- a/doc/scapy/api/scapy.layers.sixlowpan.rst
+++ b/doc/scapy/api/scapy.layers.sixlowpan.rst
@@ -1,5 +1,5 @@
-scapy.layers.sixlowpan module
-=============================
+scapy.layers.sixlowpan
+======================
 
 .. automodule:: scapy.layers.sixlowpan
    :members:

--- a/doc/scapy/api/scapy.layers.skinny.rst
+++ b/doc/scapy/api/scapy.layers.skinny.rst
@@ -1,5 +1,5 @@
-scapy.layers.skinny module
-==========================
+scapy.layers.skinny
+===================
 
 .. automodule:: scapy.layers.skinny
    :members:

--- a/doc/scapy/api/scapy.layers.smb.rst
+++ b/doc/scapy/api/scapy.layers.smb.rst
@@ -1,5 +1,5 @@
-scapy.layers.smb module
-=======================
+scapy.layers.smb
+================
 
 .. automodule:: scapy.layers.smb
    :members:

--- a/doc/scapy/api/scapy.layers.snmp.rst
+++ b/doc/scapy/api/scapy.layers.snmp.rst
@@ -1,5 +1,5 @@
-scapy.layers.snmp module
-========================
+scapy.layers.snmp
+=================
 
 .. automodule:: scapy.layers.snmp
    :members:

--- a/doc/scapy/api/scapy.layers.tftp.rst
+++ b/doc/scapy/api/scapy.layers.tftp.rst
@@ -1,5 +1,5 @@
-scapy.layers.tftp module
-========================
+scapy.layers.tftp
+=================
 
 .. automodule:: scapy.layers.tftp
    :members:

--- a/doc/scapy/api/scapy.layers.tls.all.rst
+++ b/doc/scapy/api/scapy.layers.tls.all.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.all module
-===========================
+scapy.layers.tls.all
+====================
 
 .. automodule:: scapy.layers.tls.all
    :members:

--- a/doc/scapy/api/scapy.layers.tls.automaton.rst
+++ b/doc/scapy/api/scapy.layers.tls.automaton.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.automaton module
-=================================
+scapy.layers.tls.automaton
+==========================
 
 .. automodule:: scapy.layers.tls.automaton
    :members:

--- a/doc/scapy/api/scapy.layers.tls.automaton_cli.rst
+++ b/doc/scapy/api/scapy.layers.tls.automaton_cli.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.automaton\_cli module
-======================================
+scapy.layers.tls.automaton\_cli
+===============================
 
 .. automodule:: scapy.layers.tls.automaton_cli
    :members:

--- a/doc/scapy/api/scapy.layers.tls.automaton_srv.rst
+++ b/doc/scapy/api/scapy.layers.tls.automaton_srv.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.automaton\_srv module
-======================================
+scapy.layers.tls.automaton\_srv
+===============================
 
 .. automodule:: scapy.layers.tls.automaton_srv
    :members:

--- a/doc/scapy/api/scapy.layers.tls.basefields.rst
+++ b/doc/scapy/api/scapy.layers.tls.basefields.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.basefields module
-==================================
+scapy.layers.tls.basefields
+===========================
 
 .. automodule:: scapy.layers.tls.basefields
    :members:

--- a/doc/scapy/api/scapy.layers.tls.cert.rst
+++ b/doc/scapy/api/scapy.layers.tls.cert.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.cert module
-============================
+scapy.layers.tls.cert
+=====================
 
 .. automodule:: scapy.layers.tls.cert
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.all.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.all.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.all module
-==================================
+scapy.layers.tls.crypto.all
+===========================
 
 .. automodule:: scapy.layers.tls.crypto.all
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.cipher_aead.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.cipher_aead.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.cipher\_aead module
-===========================================
+scapy.layers.tls.crypto.cipher\_aead
+====================================
 
 .. automodule:: scapy.layers.tls.crypto.cipher_aead
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.cipher_block.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.cipher_block.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.cipher\_block module
-============================================
+scapy.layers.tls.crypto.cipher\_block
+=====================================
 
 .. automodule:: scapy.layers.tls.crypto.cipher_block
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.cipher_stream.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.cipher_stream.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.cipher\_stream module
-=============================================
+scapy.layers.tls.crypto.cipher\_stream
+======================================
 
 .. automodule:: scapy.layers.tls.crypto.cipher_stream
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.ciphers.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.ciphers.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.ciphers module
-======================================
+scapy.layers.tls.crypto.ciphers
+===============================
 
 .. automodule:: scapy.layers.tls.crypto.ciphers
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.common.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.common.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.common module
-=====================================
+scapy.layers.tls.crypto.common
+==============================
 
 .. automodule:: scapy.layers.tls.crypto.common
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.compression.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.compression.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.compression module
-==========================================
+scapy.layers.tls.crypto.compression
+===================================
 
 .. automodule:: scapy.layers.tls.crypto.compression
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.groups.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.groups.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.groups module
-=====================================
+scapy.layers.tls.crypto.groups
+==============================
 
 .. automodule:: scapy.layers.tls.crypto.groups
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.h_mac.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.h_mac.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.h\_mac module
-=====================================
+scapy.layers.tls.crypto.h\_mac
+==============================
 
 .. automodule:: scapy.layers.tls.crypto.h_mac
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.hash.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.hash.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.hash module
-===================================
+scapy.layers.tls.crypto.hash
+============================
 
 .. automodule:: scapy.layers.tls.crypto.hash
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.hkdf.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.hkdf.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.hkdf module
-===================================
+scapy.layers.tls.crypto.hkdf
+============================
 
 .. automodule:: scapy.layers.tls.crypto.hkdf
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.kx_algs.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.kx_algs.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.kx\_algs module
-=======================================
+scapy.layers.tls.crypto.kx\_algs
+================================
 
 .. automodule:: scapy.layers.tls.crypto.kx_algs
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.pkcs1.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.pkcs1.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.pkcs1 module
-====================================
+scapy.layers.tls.crypto.pkcs1
+=============================
 
 .. automodule:: scapy.layers.tls.crypto.pkcs1
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.prf.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.prf.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.prf module
-==================================
+scapy.layers.tls.crypto.prf
+===========================
 
 .. automodule:: scapy.layers.tls.crypto.prf
    :members:

--- a/doc/scapy/api/scapy.layers.tls.crypto.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.rst
@@ -6,9 +6,6 @@ scapy.layers.tls.crypto package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
-
 .. toctree::
 
    scapy.layers.tls.crypto.all

--- a/doc/scapy/api/scapy.layers.tls.crypto.suites.rst
+++ b/doc/scapy/api/scapy.layers.tls.crypto.suites.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.crypto.suites module
-=====================================
+scapy.layers.tls.crypto.suites
+==============================
 
 .. automodule:: scapy.layers.tls.crypto.suites
    :members:

--- a/doc/scapy/api/scapy.layers.tls.extensions.rst
+++ b/doc/scapy/api/scapy.layers.tls.extensions.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.extensions module
-==================================
+scapy.layers.tls.extensions
+===========================
 
 .. automodule:: scapy.layers.tls.extensions
    :members:

--- a/doc/scapy/api/scapy.layers.tls.handshake.rst
+++ b/doc/scapy/api/scapy.layers.tls.handshake.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.handshake module
-=================================
+scapy.layers.tls.handshake
+==========================
 
 .. automodule:: scapy.layers.tls.handshake
    :members:

--- a/doc/scapy/api/scapy.layers.tls.handshake_sslv2.rst
+++ b/doc/scapy/api/scapy.layers.tls.handshake_sslv2.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.handshake\_sslv2 module
-========================================
+scapy.layers.tls.handshake\_sslv2
+=================================
 
 .. automodule:: scapy.layers.tls.handshake_sslv2
    :members:

--- a/doc/scapy/api/scapy.layers.tls.keyexchange.rst
+++ b/doc/scapy/api/scapy.layers.tls.keyexchange.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.keyexchange module
-===================================
+scapy.layers.tls.keyexchange
+============================
 
 .. automodule:: scapy.layers.tls.keyexchange
    :members:

--- a/doc/scapy/api/scapy.layers.tls.keyexchange_tls13.rst
+++ b/doc/scapy/api/scapy.layers.tls.keyexchange_tls13.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.keyexchange\_tls13 module
-==========================================
+scapy.layers.tls.keyexchange\_tls13
+===================================
 
 .. automodule:: scapy.layers.tls.keyexchange_tls13
    :members:

--- a/doc/scapy/api/scapy.layers.tls.record.rst
+++ b/doc/scapy/api/scapy.layers.tls.record.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.record module
-==============================
+scapy.layers.tls.record
+=======================
 
 .. automodule:: scapy.layers.tls.record
    :members:

--- a/doc/scapy/api/scapy.layers.tls.record_sslv2.rst
+++ b/doc/scapy/api/scapy.layers.tls.record_sslv2.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.record\_sslv2 module
-=====================================
+scapy.layers.tls.record\_sslv2
+==============================
 
 .. automodule:: scapy.layers.tls.record_sslv2
    :members:

--- a/doc/scapy/api/scapy.layers.tls.record_tls13.rst
+++ b/doc/scapy/api/scapy.layers.tls.record_tls13.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.record\_tls13 module
-=====================================
+scapy.layers.tls.record\_tls13
+==============================
 
 .. automodule:: scapy.layers.tls.record_tls13
    :members:

--- a/doc/scapy/api/scapy.layers.tls.rst
+++ b/doc/scapy/api/scapy.layers.tls.rst
@@ -6,15 +6,9 @@ scapy.layers.tls package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
-
 .. toctree::
 
    scapy.layers.tls.crypto
-
-Submodules
-----------
 
 .. toctree::
 

--- a/doc/scapy/api/scapy.layers.tls.session.rst
+++ b/doc/scapy/api/scapy.layers.tls.session.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.session module
-===============================
+scapy.layers.tls.session
+========================
 
 .. automodule:: scapy.layers.tls.session
    :members:

--- a/doc/scapy/api/scapy.layers.tls.tools.rst
+++ b/doc/scapy/api/scapy.layers.tls.tools.rst
@@ -1,5 +1,5 @@
-scapy.layers.tls.tools module
-=============================
+scapy.layers.tls.tools
+======================
 
 .. automodule:: scapy.layers.tls.tools
    :members:

--- a/doc/scapy/api/scapy.layers.usb.rst
+++ b/doc/scapy/api/scapy.layers.usb.rst
@@ -1,5 +1,5 @@
-scapy.layers.usb module
-=======================
+scapy.layers.usb
+================
 
 .. automodule:: scapy.layers.usb
    :members:

--- a/doc/scapy/api/scapy.layers.vrrp.rst
+++ b/doc/scapy/api/scapy.layers.vrrp.rst
@@ -1,5 +1,5 @@
-scapy.layers.vrrp module
-========================
+scapy.layers.vrrp
+=================
 
 .. automodule:: scapy.layers.vrrp
    :members:

--- a/doc/scapy/api/scapy.layers.vxlan.rst
+++ b/doc/scapy/api/scapy.layers.vxlan.rst
@@ -1,5 +1,5 @@
-scapy.layers.vxlan module
-=========================
+scapy.layers.vxlan
+==================
 
 .. automodule:: scapy.layers.vxlan
    :members:

--- a/doc/scapy/api/scapy.layers.x509.rst
+++ b/doc/scapy/api/scapy.layers.x509.rst
@@ -1,5 +1,5 @@
-scapy.layers.x509 module
-========================
+scapy.layers.x509
+=================
 
 .. automodule:: scapy.layers.x509
    :members:

--- a/doc/scapy/api/scapy.layers.zigbee.rst
+++ b/doc/scapy/api/scapy.layers.zigbee.rst
@@ -1,5 +1,5 @@
-scapy.layers.zigbee module
-==========================
+scapy.layers.zigbee
+===================
 
 .. automodule:: scapy.layers.zigbee
    :members:

--- a/doc/scapy/api/scapy.main.rst
+++ b/doc/scapy/api/scapy.main.rst
@@ -1,5 +1,5 @@
-scapy.main module
-=================
+scapy.main
+==========
 
 .. automodule:: scapy.main
    :members:

--- a/doc/scapy/api/scapy.packet.rst
+++ b/doc/scapy/api/scapy.packet.rst
@@ -1,5 +1,5 @@
-scapy.packet module
-===================
+scapy.packet
+============
 
 .. automodule:: scapy.packet
    :members:

--- a/doc/scapy/api/scapy.pipetool.rst
+++ b/doc/scapy/api/scapy.pipetool.rst
@@ -1,5 +1,5 @@
-scapy.pipetool module
-=====================
+scapy.pipetool
+==============
 
 .. automodule:: scapy.pipetool
    :members:

--- a/doc/scapy/api/scapy.plist.rst
+++ b/doc/scapy/api/scapy.plist.rst
@@ -1,5 +1,5 @@
-scapy.plist module
-==================
+scapy.plist
+===========
 
 .. automodule:: scapy.plist
    :members:

--- a/doc/scapy/api/scapy.pton_ntop.rst
+++ b/doc/scapy/api/scapy.pton_ntop.rst
@@ -1,5 +1,5 @@
-scapy.pton\_ntop module
-=======================
+scapy.pton\_ntop
+================
 
 .. automodule:: scapy.pton_ntop
    :members:

--- a/doc/scapy/api/scapy.route.rst
+++ b/doc/scapy/api/scapy.route.rst
@@ -1,5 +1,5 @@
-scapy.route module
-==================
+scapy.route
+===========
 
 .. automodule:: scapy.route
    :members:

--- a/doc/scapy/api/scapy.route6.rst
+++ b/doc/scapy/api/scapy.route6.rst
@@ -1,5 +1,5 @@
-scapy.route6 module
-===================
+scapy.route6
+============
 
 .. automodule:: scapy.route6
    :members:

--- a/doc/scapy/api/scapy.rst
+++ b/doc/scapy/api/scapy.rst
@@ -1,5 +1,5 @@
-Scapy Reference
-===============
+Scapy API reference
+===================
 
 .. automodule:: scapy
    :members:

--- a/doc/scapy/api/scapy.scapypipes.rst
+++ b/doc/scapy/api/scapy.scapypipes.rst
@@ -1,5 +1,5 @@
-scapy.scapypipes module
-=======================
+scapy.scapypipes
+================
 
 .. automodule:: scapy.scapypipes
    :members:

--- a/doc/scapy/api/scapy.sendrecv.rst
+++ b/doc/scapy/api/scapy.sendrecv.rst
@@ -1,5 +1,5 @@
-scapy.sendrecv module
-=====================
+scapy.sendrecv
+==============
 
 .. automodule:: scapy.sendrecv
    :members:

--- a/doc/scapy/api/scapy.sessions.rst
+++ b/doc/scapy/api/scapy.sessions.rst
@@ -1,5 +1,5 @@
-scapy.sessions module
-=====================
+scapy.sessions
+==============
 
 .. automodule:: scapy.sessions
    :members:

--- a/doc/scapy/api/scapy.supersocket.rst
+++ b/doc/scapy/api/scapy.supersocket.rst
@@ -1,5 +1,5 @@
-scapy.supersocket module
-========================
+scapy.supersocket
+=================
 
 .. automodule:: scapy.supersocket
    :members:

--- a/doc/scapy/api/scapy.themes.rst
+++ b/doc/scapy/api/scapy.themes.rst
@@ -1,5 +1,5 @@
-scapy.themes module
-===================
+scapy.themes
+============
 
 .. automodule:: scapy.themes
    :members:

--- a/doc/scapy/api/scapy.utils.rst
+++ b/doc/scapy/api/scapy.utils.rst
@@ -1,5 +1,5 @@
-scapy.utils module
-==================
+scapy.utils
+===========
 
 .. automodule:: scapy.utils
    :members:

--- a/doc/scapy/api/scapy.utils6.rst
+++ b/doc/scapy/api/scapy.utils6.rst
@@ -1,5 +1,5 @@
-scapy.utils6 module
-===================
+scapy.utils6
+============
 
 .. automodule:: scapy.utils6
    :members:

--- a/doc/scapy/api/scapy.volatile.rst
+++ b/doc/scapy/api/scapy.volatile.rst
@@ -1,5 +1,5 @@
-scapy.volatile module
-=====================
+scapy.volatile
+==============
 
 .. automodule:: scapy.volatile
    :members:

--- a/doc/scapy/conf.py
+++ b/doc/scapy/conf.py
@@ -21,6 +21,7 @@ import datetime
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../../'))
+sys.path.append(os.path.abspath('_ext'))
 
 
 # -- General configuration ------------------------------------------------
@@ -35,7 +36,8 @@ sys.path.insert(0, os.path.abspath('../../'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'scapy_doc'
 ]
 
 # Autodoc configuration

--- a/doc/scapy/index.rst
+++ b/doc/scapy/index.rst
@@ -50,7 +50,7 @@ This document is under a `Creative Commons Attribution - Non-Commercial
    backmatter
  
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 4
    :caption: API Reference
 
    api/scapy.rst

--- a/doc/scapy/sphinx_apidoc_postprocess.py
+++ b/doc/scapy/sphinx_apidoc_postprocess.py
@@ -1,0 +1,53 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Gabriel Potter <gabriel@potter.fr>
+# This program is published under a GPLv2 license
+
+"""
+Scapy's post process of sphinx-api command
+"""
+
+import glob
+import os
+import sys
+
+files = list(glob.iglob('./api/*.rst'))
+parents = set(
+    "%s.rst" % x for x in (
+        f.rsplit('.', 1)[0] for f in (
+            f[:-4] for f in files
+        )
+    ) if x
+)
+
+for f in files:
+    # Post process each file
+    _e = False
+    with open(f) as fd:
+        content = fd.readlines()
+    if f in parents:
+        # Process "parent files", i.e. with subfiles
+        # Remove sub categories (better indexation)
+        for name in ["Subpackages", "Submodules"]:
+            try:
+                sub = content.index(name+"\n")
+            except ValueError:
+                continue
+            del content[sub:sub+3]
+            _e = True
+        # Custom
+        if f.endswith("scapy.rst"):
+            content[0] = "Scapy API reference\n"
+            content[1] = "=" * (len(content[0]) - 1) + "\n"
+            _e = True
+    else:
+        # File / module file
+        for name in ["package", "module"]:
+            if name in content[0]:
+                content[0] = content[0].replace(" " + name, "")
+                content[1] = "=" * (len(content[0]) - 1) + "\n"
+                _e = True
+    if _e:
+        print("Post-processed '%s'" % f)
+        with open(f, "w") as fd:
+            fd.writelines(content)

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -930,7 +930,7 @@ class RandUUID(RandField):
 # Automatic timestamp
 
 
-class AutoTime(VolatileValue):
+class AutoTime(RandNum):
     def __init__(self, base=None):
         if base is None:
             self.diff = 0

--- a/tox.ini
+++ b/tox.ini
@@ -112,15 +112,16 @@ deps = codecov
 commands = codecov -e TOXENV
 
 
-[testenv:generate_docs]
+# The files listed in thr sphinx-apidoc are ignored
+# (past the first argument)
+[testenv:apitree]
 description = "Regenerates the API reference doc tree"
 skip_install = true
 changedir = doc/scapy
 deps = sphinx
-       sphinx_rtd_theme
 commands =
-  sphinx-apidoc --no-toc --separate --module-first --output-dir api ../../scapy ../../scapy/modules/ ../../scapy/tools/ ../../scapy/arch/ ../../scapy/contrib/cansocket* ../../scapy/all.py ../../scapy/layers/all.py
-  sphinx-build -b html . _build/html
+  sphinx-apidoc -f --no-toc --separate --module-first --output-dir api ../../scapy ../../scapy/modules/ ../../scapy/tools/ ../../scapy/arch/ ../../scapy/contrib/cansocket* ../../scapy/all.py ../../scapy/layers/all.py
+  python sphinx_apidoc_postprocess.py
 
 
 [testenv:mypy]
@@ -138,6 +139,16 @@ deps = sphinx
        sphinx_rtd_theme
 commands =
   sphinx-build -q -W -b html . _build/html
+
+
+# Debug mode
+[testenv:docs2]
+skip_install = true
+changedir = doc/scapy
+deps = sphinx
+       sphinx_rtd_theme
+commands =
+  sphinx-build -E -b html . _build/html
 
 
 [testenv:spell]


### PR DESCRIPTION
**Leftovers from the Autodoc PR. #hacktoberfest**

This PR:
- removes some of the non_root Travis tests: they are currently ran as root anyways, and mostly duplicate the others. I left 1 for good measure, and the specific ones (no-cryptography...)
- separate mypy test from others
- adds a sphinx extension that automatically renders `fields_desc` and `payload_fields` into ReST tables
- implements post processing of the apidocs .rst files to clear up the doc tree.
- fixes some small rendering bugs: some Packet classes could not be rendered (`repr()` crashes. There was a type misdeclaration of a VolatileValue)

![image](https://user-images.githubusercontent.com/10530980/66703442-037a0280-ed13-11e9-816e-d405431f8902.png)
