### PR TITLE
Improve request/response matching for GTPv2 packets.

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -222,9 +222,16 @@ class GTPHeader(Packet):
                    ByteEnumField("gtp_type", None, GTPmessageType),
                    ShortField("length", None),
                    IntField("teid", 0),
-                   ConditionalField(XBitField("seq", 0, 16), lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),  # noqa: E501
-                   ConditionalField(ByteField("npdu", 0), lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),  # noqa: E501
-                   ConditionalField(ByteEnumField("next_ex", 0, ExtensionHeadersTypes), lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1), ]  # noqa: E501
+                   ConditionalField(
+                       XBitField("seq", 0, 16),
+                       lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ConditionalField(
+                       ByteField("npdu", 0),
+                       lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ConditionalField(
+                       ByteEnumField("next_ex", 0, ExtensionHeadersTypes),
+                       lambda pkt:pkt.E == 1 or pkt.S == 1 or pkt.PN == 1),
+                   ]
 
     def post_build(self, p, pay):
         p += pay

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -247,7 +247,7 @@ IEType = {1: "IMSI",
           }
 
 
-class GTPHeader(Packet):
+class GTPHeader(gtp.GTPHeader):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     # without the version
     name = "GTP v2 Header"
@@ -264,21 +264,6 @@ class GTPHeader(Packet):
                    ThreeBytesField("seq", RandShort()),
                    ByteField("SPARE", 0)
                    ]
-
-    def post_build(self, p, pay):
-        p += pay
-        if self.length is None:
-            tmp_len = len(p) - 8
-            p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
-        return p
-
-    def hashret(self):
-        return struct.pack("B", self.version) + self.payload.hashret()
-
-    def answers(self, other):
-        return (isinstance(other, GTPHeader) and
-                self.version == other.version and
-                self.payload.answers(other.payload))
 
 
 class IE_IP_Address(gtp.IE_Base):
@@ -1530,6 +1515,9 @@ class GTPV2EchoRequest(GTPV2Command):
 class GTPV2EchoResponse(GTPV2Command):
     name = "GTPv2 Echo Response"
 
+    def answers(self, other):
+        return isinstance(other, GTPV2EchoRequest)
+
 
 class GTPV2CreateSessionRequest(GTPV2Command):
     name = "GTPv2 Create Session Request"
@@ -1538,6 +1526,9 @@ class GTPV2CreateSessionRequest(GTPV2Command):
 class GTPV2CreateSessionResponse(GTPV2Command):
     name = "GTPv2 Create Session Response"
 
+    def answers(self, other):
+        return isinstance(other, GTPV2CreateSessionRequest)
+
 
 class GTPV2DeleteSessionRequest(GTPV2Command):
     name = "GTPv2 Delete Session Request"
@@ -1545,6 +1536,9 @@ class GTPV2DeleteSessionRequest(GTPV2Command):
 
 class GTPV2DeleteSessionResponse(GTPV2Command):
     name = "GTPv2 Delete Session Request"
+
+    def answers(self, other):
+        return isinstance(other, GTPV2DeleteSessionRequest)
 
 
 class GTPV2ModifyBearerCommand(GTPV2Command):
@@ -1582,6 +1576,9 @@ class GTPV2ModifyBearerRequest(GTPV2Command):
 class GTPV2ModifyBearerResponse(GTPV2Command):
     name = "GTPv2 Modify Bearer Response"
 
+    def answers(self, other):
+        return isinstance(other, GTPV2ModifyBearerRequest)
+
 
 class GTPV2CreateBearerRequest(GTPV2Command):
     name = "GTPv2 Create Bearer Request"
@@ -1590,6 +1587,9 @@ class GTPV2CreateBearerRequest(GTPV2Command):
 class GTPV2CreateBearerResponse(GTPV2Command):
     name = "GTPv2 Create Bearer Response"
 
+    def answers(self, other):
+        return isinstance(other, GTPV2CreateBearerRequest)
+
 
 class GTPV2UpdateBearerRequest(GTPV2Command):
     name = "GTPv2 Update Bearer Request"
@@ -1597,6 +1597,9 @@ class GTPV2UpdateBearerRequest(GTPV2Command):
 
 class GTPV2UpdateBearerResponse(GTPV2Command):
     name = "GTPv2 Update Bearer Response"
+
+    def answers(self, other):
+        return isinstance(other, GTPV2UpdateBearerRequest)
 
 
 class GTPV2DeleteBearerRequest(GTPV2Command):
@@ -1630,6 +1633,9 @@ class GTPV2ContextRequest(GTPV2Command):
 class GTPV2ContextResponse(GTPV2Command):
     name = "GTPv2 Context Response"
 
+    def answers(self, other):
+        return isinstance(other, GTPV2ContextRequest)
+
 
 class GTPV2ContextAcknowledge(GTPV2Command):
     name = "GTPv2 Context Acknowledge"
@@ -1642,6 +1648,12 @@ class GTPV2CreateIndirectDataForwardingTunnelRequest(GTPV2Command):
 class GTPV2CreateIndirectDataForwardingTunnelResponse(GTPV2Command):
     name = "GTPv2 Create Indirect Data Forwarding Tunnel Response"
 
+    def answers(self, other):
+        return isinstance(
+            other,
+            GTPV2CreateIndirectDataForwardingTunnelRequest
+        )
+
 
 class GTPV2DeleteIndirectDataForwardingTunnelRequest(GTPV2Command):
     name = "GTPv2 Delete Indirect Data Forwarding Tunnel Request"
@@ -1650,6 +1662,12 @@ class GTPV2DeleteIndirectDataForwardingTunnelRequest(GTPV2Command):
 class GTPV2DeleteIndirectDataForwardingTunnelResponse(GTPV2Command):
     name = "GTPv2 Delete Indirect Data Forwarding Tunnel Response"
 
+    def answers(self, other):
+        return isinstance(
+            other,
+            GTPV2DeleteIndirectDataForwardingTunnelRequest
+        )
+
 
 class GTPV2ReleaseBearerRequest(GTPV2Command):
     name = "GTPv2 Release Bearer Request"
@@ -1657,6 +1675,9 @@ class GTPV2ReleaseBearerRequest(GTPV2Command):
 
 class GTPV2ReleaseBearerResponse(GTPV2Command):
     name = "GTPv2 Release Bearer Response"
+
+    def answers(self, other):
+        return isinstance(other, GTPV2ReleaseBearerRequest)
 
 
 class GTPV2DownlinkDataNotif(GTPV2Command):

--- a/test/contrib/gtp_v2.uts
+++ b/test/contrib/gtp_v2.uts
@@ -412,16 +412,26 @@ ie = IE_MMBR(ietype='Max MBR/APN-AMBR (MMBR)',
                     length=8, uplink_rate=5696, downlink_rate=21000)
 ie.ietype == 161 and ie.uplink_rate == 5696 and ie.downlink_rate == 21000
 
-= GTPHeader answers to not GTPHeader instance
+= GTPHeader isn't an answer to not GTPHeader instance
 GTPHeader(gtp_type=2).answers(Ether()) == False
+
+= GTPHeader is an answer to a message with the same sequence number
+GTPHeader(seq=42).answers(GTPHeader(seq=42)) == True
+
+= GTPHeader isn't an answer to a message with a different sequence number
+GTPHeader(seq=42).answers(GTPHeader(seq=24)) == False
+
+= GTPV2EchoResponse answers
+assert (GTPHeader(seq=1)/GTPV2EchoResponse()).answers(GTPHeader(seq=1)/GTPV2EchoRequest())
+assert not (GTPHeader(seq=1)/GTPV2EchoResponse()).answers(GTPHeader(seq=1)/GTPV2EchoResponse())
 
 = GTPHeader post_build
 gtp = GTPHeader(gtp_type="create_session_req") / ("X"*32)
 gtp.show2()
 
 = GTPHeader hashret
-req = GTPHeader(gtp_type="create_session_req") / ("X"*32)
-res = GTPHeader(gtp_type="create_session_res") / ("Y"*32)
+req = GTPHeader(gtp_type="create_session_req", seq=1) / ("X"*32)
+res = GTPHeader(gtp_type="create_session_res", seq=1) / ("Y"*32)
 req.hashret() == res.hashret()
 
 = IE_NotImplementedTLV


### PR DESCRIPTION
**Edited by gpotter2: refactored to use GTPv1 methods, and add the correct answers() calls**

Before this commit, `GTPHeader.answers` was calling to its payload's
`answers` method, which is not implemented for any of the possible
payloads for `GTPHeader`.  Thus, the default implementation from
`Packet.answers` was used, which returns `False` if packet subclasses
don't match, as is the case with e.g. `GTPV2EchoRequest` and
`GTPV2EchoResponse` classes.

That, in particular, was preventing `sr*` functions from matching GTPv2
requests and responses.

This commit changes the `GTPHeader.answers` method to consider messages
with the same sequence number to be a request/response pair.  This is
true most of the time, but can be wrong in these cases:

* Ideally `GTPHeader.answers` should check that the packet on which
  `answers` was called is a "*Request" or a "*Command", and that the
  other packet is of the corresponding response message type.
* In the case of "triggered response" messages there can be three
  messages with the same sequence number: a command, a request message
  triggered by the command, and a response to the triggered message.
* The case of piggybacked messages seems to be different: if I'm reading
  the spec correctly, a response to a piggybacked message will have the
  sequence number of the piggybacked request, not the message the
  request was piggybacked to.