### PR TITLE
Add option to raise exception if no dst MAC found

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -569,6 +569,8 @@ class Conf(ConfClass):
         debug_tls: When 1, print some TLS session secrets
             when they are computed.
         recv_poll_rate: how often to check for new packets. Defaults to 0.05s.
+        raise_no_dst_mac: When True, raise exception if no dst MAC found
+            otherwise broadcast. Default is False.
     """
     version = ReadOnlyAttribute("version", VERSION)
     session = ""
@@ -654,6 +656,7 @@ class Conf(ConfClass):
     fancy_prompt = True
     auto_crop_tables = True
     recv_poll_rate = 0.05
+    raise_no_dst_mac = False
 
     def __getattr__(self, attr):
         # Those are loaded on runtime to avoid import loops

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -268,7 +268,7 @@ class AbstractUVarIntField(fields.Field):
             value += (byte ^ 0x80) << (7 * (i - 1))
             if value > max_value:
                 raise error.Scapy_Exception(
-                    'out-of-bound value: the string encodes a value that is too large (>2^{64}): {}'.format(value)  # noqa: E501
+                    'out-of-bound value: the string encodes a value that is too large (>2^{{64}}): {}'.format(value)  # noqa: E501
                 )
             i += 1
             assert i < tmp_len, 'EINVAL: x: out-of-bound read: the string ends before the AbstractUVarIntField!'  # noqa: E501

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -25,6 +25,10 @@ class ScapyInvalidPlatformException(Scapy_Exception):
     pass
 
 
+class ScapyNoDstMacException(Scapy_Exception):
+    pass
+
+
 class ScapyFreqFilter(logging.Filter):
     def __init__(self):
         logging.Filter.__init__(self)

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -23,7 +23,7 @@ from scapy import consts
 from scapy.data import ARPHDR_ETHER, ARPHDR_LOOPBACK, ARPHDR_METRICOM, \
     DLT_LINUX_IRDA, DLT_LINUX_SLL, DLT_LOOP, DLT_NULL, ETHER_ANY, \
     ETHER_BROADCAST, ETHER_TYPES, ETH_P_ARP, ETH_P_MACSEC
-from scapy.error import warning
+from scapy.error import warning, ScapyNoDstMacException
 from scapy.fields import BCDFloatField, BitField, ByteField, \
     ConditionalField, FieldLenField, IntEnumField, IntField, IP6Field, \
     IPField, LenField, MACField, MultipleTypeField, ShortEnumField, \
@@ -116,8 +116,11 @@ class DestMACField(MACField):
             except socket.error:
                 pass
             if x is None:
-                x = "ff:ff:ff:ff:ff:ff"
-                warning("Mac address to reach destination not found. Using broadcast.")  # noqa: E501
+                if conf.raise_no_dst_mac:
+                    raise ScapyNoDstMacException()
+                else:
+                    x = "ff:ff:ff:ff:ff:ff"
+                    warning("Mac address to reach destination not found. Using broadcast.")  # noqa: E501
         return MACField.i2h(self, pkt, x)
 
     def i2m(self, pkt, x):


### PR DESCRIPTION
-   [x] I added unit tests or explained why they are not relevant
IMHO it is not needed because it is single `if`. I can add tests if you think differently.

> brief description what this PR will do:   

In current behavior if MAC can not be found/resolved for dst ip, scapy is broadcasting:
```python
>>> send(IP(dst='10.36.1.77')/TCP(), count=3)
WARNING: Mac address to reach destination not found. Using broadcast.
.WARNING: Mac address to reach destination not found. Using broadcast.
.WARNING: more Mac address to reach destination not found. Using broadcast.
.
Sent 3 packets.
```
It is ok when you use scapy via python shell as you can stop it by CTRL+C etc.

But it is become inconvenient when you use scapy in programmatic way(e.g. as traffic generator in pytest tests)     
`send(...., count=5000, inter=0.001)` - will be executed long time(despite of `inter` value).

I think in such use-case/scenario is very convenient to raise exception(because there is no sense to continue).   
So with my fix:
```python
>>> conf.raise_no_dst_mac = True
>>> send(IP(dst='10.36.1.77')/TCP(), count=3)
/usr/lib/python3/dist-packages/apport/report.py:13: PendingDeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import fnmatch, glob, traceback, errno, sys, atexit, locale, imp
Traceback (most recent call last):
  File "/usr/lib/python3.5/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/home/mityagin/github/scapy/scapy/sendrecv.py", line 331, in send
    realtime=realtime, return_packets=return_packets)
  File "/home/mityagin/github/scapy/scapy/sendrecv.py", line 291, in __gen_send
    s.send(p)
  File "/home/mityagin/github/scapy/scapy/arch/linux.py", line 598, in send
    sx = raw(ll(x))
  File "/home/mityagin/github/scapy/scapy/compat.py", line 52, in raw
    return bytes(x)
  File "/home/mityagin/github/scapy/scapy/packet.py", line 487, in __bytes__
    return self.build()
  File "/home/mityagin/github/scapy/scapy/packet.py", line 607, in build
    p = self.do_build()
  File "/home/mityagin/github/scapy/scapy/packet.py", line 589, in do_build
    pkt = self.self_build()
  File "/home/mityagin/github/scapy/scapy/packet.py", line 570, in self_build
    p = f.addfield(self, p, val)
  File "/home/mityagin/github/scapy/scapy/fields.py", line 142, in addfield
    return s + struct.pack(self.fmt, self.i2m(pkt, val))
  File "/home/mityagin/github/scapy/scapy/layers/l2.py", line 127, in i2m
    return MACField.i2m(self, pkt, self.i2h(pkt, x))
  File "/home/mityagin/github/scapy/scapy/layers/l2.py", line 120, in i2h
    raise ScapyNoDstMacException()
scapy.error.ScapyNoDstMacException
>>>
```

