### PR TITLE
Add mandatory fields to IE_NotImplementedTLV.

### DIFF
--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -443,6 +443,8 @@ class IE_NotImplementedTLV(gtp.IE_Base):
     name = "IE not implemented"
     fields_desc = [ByteEnumField("ietype", 0, IEType),
                    ShortField("length", None),
+                   BitField("CR_flag", 0, 4),
+                   BitField("instance", 0, 4),
                    StrLenField("data", "", length_from=lambda x: x.length)]
 
 

--- a/test/contrib/gtp_v2.uts
+++ b/test/contrib/gtp_v2.uts
@@ -344,4 +344,4 @@ req.hashret() == res.hashret()
 h = "333333333333222222222222810080c808004588002937dd0000fd1115490a2a00010a2a0002084b084b00152d0e4001000900000100ff0001000daa000000003f1f382f"
 gtp = Ether(hex_bytes(h))
 isinstance(gtp.IE_list[0], IE_NotImplementedTLV)
-
+isinstance(gtp.IE_list[0].payload, NoPayload)


### PR DESCRIPTION
All information elements are required to have standard 4 byte header (3GPP TS 29.274 section 8.2.1).