### PR TITLE
Filter out some badges from PyPI description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 # Scapy
 
-[![Travis Build Status](https://travis-ci.com/secdev/scapy.svg?branch=master)](https://travis-ci.com/secdev/scapy)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/os03daotfja0wtp7/branch/master?svg=true)](https://ci.appveyor.com/project/secdev/scapy/branch/master)
-[![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/30ee6772bb264a689a2604f5cdb0437b)](https://www.codacy.com/app/secdev/scapy)
+[![Travis Build Status](https://travis-ci.com/secdev/scapy.svg?branch=master)](https://travis-ci.com/secdev/scapy) <!-- ignore_ppi -->
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/os03daotfja0wtp7/branch/master?svg=true)](https://ci.appveyor.com/project/secdev/scapy/branch/master) <!-- ignore_ppi -->
+[![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy) <!-- ignore_ppi -->
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/30ee6772bb264a689a2604f5cdb0437b)](https://www.codacy.com/app/secdev/scapy) <!-- ignore_ppi -->
 [![PyPI Version](https://img.shields.io/pypi/v/scapy.svg)](https://pypi.python.org/pypi/scapy/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/scapy.svg)](https://pypi.python.org/pypi/scapy/)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
-[![Join the chat at https://gitter.im/secdev/scapy](https://badges.gitter.im/secdev/scapy.svg)](https://gitter.im/secdev/scapy)
+[![Join the chat at https://gitter.im/secdev/scapy](https://badges.gitter.im/secdev/scapy.svg)](https://gitter.im/secdev/scapy) <!-- ignore_ppi -->
 
 Scapy is a powerful Python-based interactive packet manipulation program and
 library.

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,17 @@ import os
 
 def get_long_description():
     """Extract description from README.md, for PyPI's usage"""
+    def process_ignore_tags(buffer):
+        return "\n".join(
+            x for x in buffer.split("\n") if "<!-- ignore_ppi -->" not in x
+        )
     try:
         fpath = os.path.join(os.path.dirname(__file__), "README.md")
         with io.open(fpath, encoding="utf-8") as f:
             readme = f.read()
             desc = readme.partition("<!-- start_ppi_description -->")[2]
             desc = desc.partition("<!-- stop_ppi_description -->")[0]
-            return desc.strip()
+            return process_ignore_tags(desc.strip())
     except IOError:
         return None
 


### PR DESCRIPTION
We don't actually want to have the Travis & Appveyor badges displayed on the PyPI page.
Probably nor the Codacy & codecov ones