### PR TITLE
Added functionality for ISOTP with extended frames

### DIFF
--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -52,12 +52,12 @@ def usage():
     -t SNIFF_TIME, --sniff_time SNIFF_TIME
                           Duration in milliseconds a sniff is waiting for a
                           flow-control response.
-    -x, --extended        Scan with ISOTP extended addressing. 
-                          This has nothing to do with extended CAN Frames                          
+    -x, --extended        Scan with ISOTP extended addressing.
+                          This has nothing to do with extended CAN identifiers
     -C, --piso            Print 'Copy&Paste'-ready ISOTPSockets.
     -v, --verbose         Display information during scan.\n
     -w, --wide            Enable scanning spaces greater than 0x800
-    	--extended_can_id    Use extended CAN Frames 
+        --extended_can_id Use extended CAN identifiers
     Example of use:\n
     Python2 or Windows:
     python2 -m scapy.tools.automotive.isotpscanner --interface=pcan --channel=PCAN_USBBUS1 --bitrate=250000 --start 0 --end 100
@@ -86,7 +86,8 @@ def main():
         sys.argv[1:],
         'vxCt:n:i:c:b:s:e:h:w',
         ['verbose', 'noise_listen_time=', 'sniff_time=', 'interface=', 'piso',
-         'channel=', 'bitrate=', 'start=', 'end=', 'help', 'extended', 'wide', 'extended_can_id'])
+         'channel=', 'bitrate=', 'start=', 'end=', 'help', 'extended', 'wide',
+         'extended_can_id'])
 
     try:
         for opt, arg in options[0]:
@@ -134,13 +135,15 @@ def main():
         print("end must be < " + hex(2**29), file=sys.stderr)
         sys.exit(-1)
     elif not extended_can_id and end >= 0x800:
-        print("Standard IDs must be <= 0x800.\n"
-              "Use --extended_can_id option for extended CAN range.", file=sys.stderr)
+        print("Standard IDs must be < 0x800.\n"
+              "Use --extended_can_id option for extended CAN range.",
+              file=sys.stderr)
         sys.exit(-1)
 
     if end - start > 0x800 and not wide_option:
         print("Scanning big address spaces takes a lot of time.\n"
-              "Please use --wide option in order to scan spaces greater than 0x800", file=sys.stderr)
+              "Please use --wide option in order to scan identifiers > 0x800",
+              file=sys.stderr)
         sys.exit(-1)
 
     if end < start:

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -14,6 +14,7 @@ import threading, time, six, subprocess
 from six.moves.queue import Queue
 from subprocess import call
 from io import BytesIO
+from scapy.contrib.isotp import get_isotp_packet
 
 
 
@@ -353,6 +354,17 @@ assert(p.type == 0)
 assert(p.message_size == 4)
 assert(p.data == b'abcd')
 
+= Construct ISOTP_packet with extended can frame
+p = get_isotp_packet(identifier=0x1234, extended=False, extended_can_id=True)
+print(p)
+assert (p.identifier == 0x1234)
+assert (p.flags == "extended")
+
+= Construct ISOTPEA_Packet with extended can frame
+p = get_isotp_packet(identifier=0x1234, extended=True, extended_can_id=True)
+print(p)
+assert (p.identifier == 0x1234)
+assert (p.flags == "extended")
 
 + ISOTP fragment and defragment checks
 

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -251,6 +251,46 @@ assert "0x702" in result
 assert "0x703" in result
 assert "No Padding" in result
 
+= Test ISOTPScan(output_format=text) extended_can_id
+done = False
+
+drain_bus(iface0)
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x1ffff700+i, did=0x1ffff600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    global done
+    while not done:
+        new_can_socket0().send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x1ffff701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=(pkt))
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+result = ISOTPScan(new_can_socket0(), range(0x1ffff5ff, 0x1ffff604+1), output_format="text", noise_listen_time=1, sniff_time=0.1, extended_can_id=True)
+assert 0 == subprocess.call(['cansend', 'vcan0', '1ffff601#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '1ffff602#01aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '1ffff603#01aa'])
+thread1.join()
+thread2.join()
+done = True
+thread_noise.join()
+print(result)
+text = "\nFound 2 ISOTP-FlowControl Packet(s):"
+assert text in result
+assert "0x1ffff602" in result
+assert "0x1ffff603" in result
+assert "0x1ffff702" in result
+assert "0x1ffff703" in result
+assert "No Padding" in result
+
 
 = Test ISOTPScan(output_format=code)
 done = False
@@ -325,6 +365,44 @@ thread_noise.join()
 
 s1 = "ISOTPSocket(can0, sid=0x602, did=0x702, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
 s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
+print(result)
+assert s1 in result
+assert s2 in result
+
+
+= Test extended ISOTPScan(output_format=code) extended_can_id
+drain_bus(iface0)
+
+def isotpserver(i):
+    with ISOTPSocket(new_can_socket0(), sid=0x1ffff700+i, did=0x1ffff600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1)
+
+def make_noise(pkt):
+    s = new_can_socket0()
+    for _ in range(20):
+        s.send(pkt)
+        time.sleep(0.1)
+
+pkt = CAN(identifier=0x1ffff701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise.start()
+
+thread1 = threading.Thread(target=isotpserver, args=[2])
+thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1.start()
+thread2.start()
+time.sleep(0.1)
+
+result = ISOTPScan(new_can_socket0(), range(0x1ffff5ff, 0x1ffff604+1), extended_can_id=True, extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code")
+
+assert 0 == subprocess.call(['cansend', 'vcan0', '1ffff602#2201aa'])
+assert 0 == subprocess.call(['cansend', 'vcan0', '1ffff603#2201aa'])
+thread1.join()
+thread2.join()
+thread_noise.join()
+
+s1 = "ISOTPSocket(can0, sid=0x1ffff602, did=0x1ffff702, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
+s2 = "ISOTPSocket(can0, sid=0x1ffff603, did=0x1ffff703, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
 print(result)
 assert s1 in result
 assert s2 in result


### PR DESCRIPTION
ISOTP messages can be sent with extended can IDs now
    1. Added --extended_can_id option for isotpscanner
    2. Added --wide(-w) option for scanning ranges greater than 0x7FF
    3. Maxmim CAN ID can be `0x1FFF FFFF` now. for isotpscanner
    4. Added extended_can_id argument for functions : get_isotp_packet, scan and scan extended
    5. Added untitests for extended can ids

fixes #2298 
