### PR TITLE
Add sponsors badge to Scapy

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [gpotter2, guedou, p-l-]


### PR DESCRIPTION
https://github.com/secdev/scapy/pull/2313
We'll wait for p-l- to get approved before merging. Otherwise GitHub raises errors