### PR TITLE
2 minor issues

### DIFF
--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -11,6 +11,7 @@ import ctypes
 import os
 import socket
 import struct
+import sys
 import time
 from scapy.consts import WINDOWS
 from scapy.config import conf
@@ -133,8 +134,8 @@ def compile_filter(filter_exp, iface=None, linktype=None,
         raise Scapy_Exception(
             "Failed to compile filter expression %s (%s)" % (filter_exp, ret)
         )
-    if conf.use_pypy:
-        # XXX PyPy has a broken behavior.
+    if conf.use_pypy and sys.pypy_version_info <= (7, 3, 0):
+        # PyPy < 7.3.0 has a broken behavior
         # https://bitbucket.org/pypy/pypy/issues/3114
         return struct.pack(
             'HL',

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -127,6 +127,8 @@ class Net(Gen):
         return "Net(%r)" % self.repr
 
     def __eq__(self, other):
+        if not other:
+            return False
         if hasattr(other, "parsed"):
             p2 = other.parsed
         else:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -12127,6 +12127,9 @@ p = ARP(raw(ARP(plen=1, hwlen=1)))
 assert p.hwdst == p.hwsrc == p.pdst == p.psrc == b"\x00"
 assert isinstance(p.payload, NoPayload)
 
+p = ARP(pdst='192.168.178.0/24')
+assert "Net" in repr(p)
+
 
 ############
 ############


### PR DESCRIPTION
- fix https://github.com/secdev/scapy/issues/2393. There might still be other issues with ARP
- if using PyPy 7.3.0+, disable the PyPy workaround