### PR TITLE
Rework timestamp detection

### DIFF
--- a/scapy/data.py
+++ b/scapy/data.py
@@ -26,6 +26,12 @@ import scapy.modules.six as six
 ETHER_ANY = b"\x00" * 6
 ETHER_BROADCAST = b"\xff" * 6
 
+# From bits/socket.h
+SOL_PACKET = 263
+# From asm/socket.h
+SO_ATTACH_FILTER = 26
+SO_TIMESTAMPNS = 35
+
 ETH_P_ALL = 3
 ETH_P_IP = 0x800
 ETH_P_ARP = 0x806

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1360,6 +1360,20 @@ def _test():
 
 retry_test(_test)
 
+= Latency check: localhost ICMP
+~ netaccess linux latency
+
+sock = conf.L3socket
+conf.L3socket = L3RawSocket
+
+def _test():
+    req = IP(dst="127.0.0.1")/ICMP()
+    ans = sr1(req)
+    assert (ans.time - req.sent_time) >= 0
+    assert (ans.time - req.sent_time) <= 1e-3
+
+conf.L3socket = sock
+
 = Sending an ICMP message 'forever' at layer 2 and layer 3
 ~ netaccess IP ICMP
 def _test():


### PR DESCRIPTION
This was an attempt to solve https://github.com/secdev/scapy/issues/2277. I forgot to push it.
There are still issues to be solved, but this currently helps a lot when it comes to very fast answers.

- threaded mode is now optional in `sndrcv`
- use ancillary data by default to get a more accurate timestamp. This allowed to drastically reduce the timestamp during a localhost ping (now ~1e-5)