### PR TITLE
Automotive unit test refactoring

### DIFF
--- a/test/contrib/automotive/ccp.uts
+++ b/test/contrib/automotive/ccp.uts
@@ -967,8 +967,10 @@ sock1.basecls = CCP
 
 = CAN Socket sr1 with dto.ansers(cro) == True
 
+started = threading.Event()
+
 def ecu():
-    pkts = sock2.sniff(count=1, timeout=1)
+    pkts = sock2.sniff(count=1, timeout=1, started_callback=started.set)
     if len(pkts) == 1:
         cro = CRO(pkts[0].data)
         assert cro.cmd == 0x22
@@ -978,7 +980,8 @@ def ecu():
 
 thread = threading.Thread(target=ecu)
 thread.start()
-time.sleep(0.1)
+
+started.wait(timeout=5)
 
 dto = sock1.sr1(CCP(identifier=0x700)/CRO(ctr=0x53)/PROGRAM_6(data=b"\x10\x11\x12\x10\x11\x12"), timeout=1)
 thread.join()
@@ -992,8 +995,10 @@ assert dto.MTA0_address == 0x34002006
 
 = CAN Socket sr1 with dto.ansers(cro) == False
 
+started = threading.Event()
+
 def ecu():
-    pkts = sock2.sniff(count=1, timeout=1)
+    pkts = sock2.sniff(count=1, timeout=1, started_callback=started.set)
     if len(pkts) == 1:
         cro = CRO(pkts[0].data)
         assert cro.cmd == 0x22
@@ -1003,7 +1008,7 @@ def ecu():
 
 thread = threading.Thread(target=ecu)
 thread.start()
-time.sleep(0.1)
+started.wait(timeout=5)
 gotTimeout = False
 try:
     dto = sock1.sr1(CCP(identifier=0x700)/CRO(ctr=0x54)/PROGRAM_6(data=b"\x10\x11\x12\x10\x11\x12"), timeout=1)
@@ -1018,8 +1023,9 @@ thread.join()
 
 = CAN Socket sr1 with error code
 
+started = threading.Event()
 def ecu():
-    pkts = sock2.sniff(count=1, timeout=1)
+    pkts = sock2.sniff(count=1, timeout=1, started_callback=started.set)
     if len(pkts) == 1:
         cro = CRO(pkts[0].data)
         assert cro.cmd == 0x22
@@ -1029,7 +1035,7 @@ def ecu():
 
 thread = threading.Thread(target=ecu)
 thread.start()
-time.sleep(0.1)
+started.wait(timeout=5)
 
 dto = sock1.sr1(CCP(identifier=0x700)/CRO(ctr=0x55)/PROGRAM_6(data=b"\x10\x11\x12\x10\x11\x12"), timeout=1)
 thread.join()
@@ -1045,6 +1051,9 @@ assert dto.MTA0_address == 0xffffffff
 
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
+
+sock1.close()
+sock2.close()
 
 if 0 != call("sudo ip link delete %s" % iface0, shell=True):
         raise Exception("%s could not be deleted" % iface0)

--- a/test/contrib/automotive/ecu_am.uts
+++ b/test/contrib/automotive/ecu_am.uts
@@ -63,11 +63,10 @@ new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='virt
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
-    s = new_can_socket(iface)
-    pkts = s.sniff(timeout=0.1)
-    if assert_empty:
-        assert len(pkts) == 0
-    s.close()
+    with new_can_socket(iface) as s:
+        pkts = s.sniff(timeout=0.1)
+        if assert_empty:
+            assert len(pkts) == 0
 
 print("CAN sockets should work now")
 
@@ -139,10 +138,8 @@ drain_bus(iface0)
 example_responses = \
     [ECUResponse(session=1, security_level=0, responses=UDS() / UDS_RDBIPR(dataIdentifier=0x1234) / Raw(b"deadbeef"))]
 
-
-
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 3})
     sim.start()
@@ -170,8 +167,8 @@ example_responses = \
      ECUResponse(session=[5,6,7], security_level=0, responses=UDS() / UDS_RDBIPR(dataIdentifier=5) / Raw(b"deadbeef3")),
      ECUResponse(session=lambda x: 8 < x <= 10, security_level=0, responses=UDS() / UDS_RDBIPR(dataIdentifier=9) / Raw(b"deadbeef4"))]
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 5})
     sim.start()
@@ -224,8 +221,8 @@ example_responses = \
 
      ]
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 10})
     sim.start()
@@ -296,8 +293,8 @@ example_responses = \
 
      ]
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses,
                                main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 10})
@@ -369,8 +366,8 @@ example_responses = \
      ECUResponse(session=range(0,255), security_level=0, responses=UDS() / UDS_NR(negativeResponseCode=0x7f, requestServiceId=0x10)),
      ]
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses,
                                main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 4})
@@ -414,8 +411,8 @@ example_responses = \
      ECUResponse(session=range(0,255), security_level=0, responses=UDS() / UDS_NR(negativeResponseCode=0x7f, requestServiceId=0x10)),
      ]
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses,
                                main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 4, 'timeout': 10})
@@ -461,8 +458,8 @@ example_responses = \
 
 conf.contribs['UDS']['treat-response-pending-as-answer'] = True
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600, basecls=UDS) as ecu, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x600, did=0x700, basecls=UDS) as tester:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x700, did=0x600, basecls=UDS) as ecu, \
+        new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x600, did=0x700, basecls=UDS) as tester:
     answering_machine = ECU_am(supported_responses=example_responses,
                                main_socket=ecu, basecls=UDS)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 4, 'timeout':5})

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -135,11 +135,12 @@ load_contrib("automotive.gm.gmlanutils")
 ##############################################################################
 = Positive, immediate positive response
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_RD(memorySize=4)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -148,38 +149,40 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == True
 
 thread.join(timeout=5)
 assert ecusimSuccessfullyExecuted == True
 
 = Negative, immediate negative response
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         nr = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x22)
         isotpsock2.send(nr)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == False
 
 thread.join(timeout=5)
 
 = Negative, timeout
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == False
 
 ############################ Response pending
 = Positive, after response pending
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pending = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         isotpsock2.send(pending)
         ack = b"\x74"
@@ -187,8 +190,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == True
 
 thread.join(timeout=5)
@@ -196,9 +199,10 @@ thread.join(timeout=5)
 = Positive, hold response pending for several messages
 tout = 0.3
 repeats = 4
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         for i in range(repeats):
             isotpsock2.send(ack)
@@ -208,9 +212,9 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     starttime = time.time() # may be inaccurate -> on some systems only seconds precision
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=repeats*tout+0.5) == True
     endtime = time.time()
@@ -219,9 +223,10 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as
 thread.join(timeout=5)
 
 = Negative, negative response after response pending
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pending = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         isotpsock2.send(pending)
         nr = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x22)
@@ -229,31 +234,33 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == False
 
 thread.join(timeout=5)
 
 = Negative, timeout after response pending
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pending = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         isotpsock2.send(pending)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=0.3) == False
 
 thread.join(timeout=5)
 
 = Positive, pending message from different service interferes while pending
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pending = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         isotpsock2.send(pending)
         wrongservice = GMLAN()/GMLAN_NR(requestServiceId=0x36, returnCode=0x78)
@@ -264,16 +271,17 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == True
 
 thread.join(timeout=5)
 
 = Positive, negative response from different service interferes while pending
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pending = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x78)
         isotpsock2.send(pending)
         wrongservice = GMLAN()/GMLAN_NR(requestServiceId=0x36, returnCode=0x22)
@@ -284,28 +292,30 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1) == True
 
 thread.join(timeout=5)
 
 ################### RETRY
 = Positive, first: immediate negative response, retry: Positive
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # negative
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_RD(memorySize=4)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         nr = GMLAN()/GMLAN_NR(requestServiceId=0x34, returnCode=0x22)
-        isotpsock2.send(nr)
         # positive retry
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        print("retry")
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(nr))
         pkt = GMLAN()/GMLAN_RD(memorySize=4)
+        print(requ)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x74"
@@ -313,8 +323,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_RequestDownload(isotpsock, 4, timeout=1, retry=1) == True
     assert ecusimSuccessfullyExecuted == True
 
@@ -328,11 +338,12 @@ thread.join(timeout=5)
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000000,
                                  dataRecord=payload)
         if bytes(requ[0]) != bytes(pkt):
@@ -342,8 +353,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x40000000, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -353,11 +364,12 @@ assert ecusimSuccessfullyExecuted == True
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 3
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x400000,
                                  dataRecord=payload)
         if bytes(requ[0]) != bytes(pkt):
@@ -367,8 +379,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x400000, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -378,11 +390,12 @@ assert ecusimSuccessfullyExecuted == True
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 2
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x4000,
                                  dataRecord=payload)
         if bytes(requ[0]) != bytes(pkt):
@@ -392,8 +405,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x4000, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -403,44 +416,45 @@ assert ecusimSuccessfullyExecuted == True
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         nr = GMLAN() / GMLAN_NR(requestServiceId=0x36, returnCode=0x22)
         isotpsock2.send(nr)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x40000000, payload, timeout=1) == False
 
 thread.join(timeout=5)
 
 = Negative, timeout
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x4000, payload, timeout=1) == False
 
 = Positive, long payload
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000000,
                                  dataRecord=payload*2)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x76"
-        isotpsock2.send(ack)
         # second package with inscreased address
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000010,
                                  dataRecord=payload * 2)
         if bytes(requ[0]) != bytes(pkt):
@@ -450,8 +464,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x40000000, payload*4, maxmsglen=16, timeout=1) == True
 
 thread.join(timeout=5)
@@ -462,26 +476,25 @@ assert ecusimSuccessfullyExecuted == True
 = Positive, first part of payload succeeds, second pending, then fails, retry succeeds
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x76"
-        isotpsock2.send(ack)
         # second package with inscreased address
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pending = GMLAN() / GMLAN_NR(requestServiceId=0x36, returnCode=0x78)
         isotpsock2.send(pending)
         time.sleep(0.1)
         nr = GMLAN() / GMLAN_NR(requestServiceId=0x36, returnCode=0x22)
-        isotpsock2.send(nr)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(nr))
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x40000000, payload*4, maxmsglen=16, timeout=1, retry=1) == True
 
 thread.join(timeout=5)
@@ -494,31 +507,35 @@ exit_if_no_isotp_module()
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+sim_started = threading.Event()
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=3, started_callback=sim_started.set)
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000000,
                                  dataRecord=payload*511+payload[:1])
-        if bytes(requ[0]) != bytes(pkt):
+        if len(requ) == 0 or bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
+            return
         ack = b"\x76"
-        isotpsock2.send(ack)
         # second package with inscreased address
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=3, started_callback=lambda: isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000FF9,
                                  dataRecord=payload[1:])
-        if bytes(requ[0]) != bytes(pkt):
+        if len(requ) == 0 or bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
+            return
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
+thread.name = "ECUSimulator" + thread.name
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
-    assert GMLAN_TransferData(isotpsock, 0x40000000, payload*512, maxmsglen=0x1000000, timeout=1) == True
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+    sim_started.wait(timeout=5)
+    assert GMLAN_TransferData(isotpsock, 0x40000000, payload*512, maxmsglen=0x1000000, timeout=8) == True
 
 thread.join(timeout=5)
 assert ecusimSuccessfullyExecuted == True
@@ -527,16 +544,17 @@ assert ecusimSuccessfullyExecuted == True
 = Positive, highest possible address for scheme
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 2**32 - 1, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -544,16 +562,17 @@ thread.join(timeout=5)
 = Negative, invalid address (too large for addressing scheme)
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 2**32, payload, timeout=1) == False
 
 thread.join(timeout=5)
@@ -561,16 +580,17 @@ thread.join(timeout=5)
 = Positive, address zero
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, 0x00, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -578,16 +598,17 @@ thread.join(timeout=5)
 = Negative, negative address
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x76"
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferData(isotpsock, -1, payload, timeout=1) == False
 
 thread.join(timeout=5)
@@ -599,17 +620,17 @@ thread.join(timeout=5)
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_RD(memorySize=len(payload))
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x74"
-        isotpsock2.send(ack)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_TD(startingAddress=0x40000000,
                                  dataRecord=payload)
         if bytes(requ[0]) != bytes(pkt):
@@ -619,8 +640,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_TransferPayload(isotpsock, 0x40000000, payload, timeout=1) == True
 
 thread.join(timeout=5)
@@ -635,19 +656,19 @@ keyfunc = lambda seed : seed - 0x1FBE
 
 = Positive scenario, level 1, tests if keyfunction applied properly
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_SA(subfunction=1)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pkt = GMLAN()/GMLAN_SA(subfunction=2, securityKey=0xbeef)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -659,9 +680,9 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1) == True
 
 thread.join(timeout=5)
@@ -669,19 +690,19 @@ assert ecusimSuccessfullyExecuted == True
 
 = Positive scenario, level 3
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_SA(subfunction=3)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=3, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pkt = GMLAN()/GMLAN_SA(subfunction=4, securityKey=0xbeef)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -693,8 +714,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=3, timeout=1) == True
 
 thread.join(timeout=5)
@@ -703,19 +724,19 @@ assert ecusimSuccessfullyExecuted == True
 
 = Negative scenario, invalid password
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN()/GMLAN_SA(subfunction=1)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pkt = GMLAN()/GMLAN_SA(subfunction=2, securityKey=0xbabe)
         if bytes(requ[0]) != bytes(pkt):
             nr = GMLAN() / GMLAN_NR(requestServiceId=0x27, returnCode=0x35)
@@ -727,105 +748,104 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1) == False
 
 thread.join(timeout=5)
 assert ecusimSuccessfullyExecuted == True
 
 = invalid level (not an odd number)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=2, timeout=1) == False
 
 = zero seed
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0x0000)
         isotpsock2.send(seedmsg)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1) == True
 
 thread.join(timeout=5)
 
 ############### retry
 = Positive scenario, request timeout, retry works
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # timeout
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         # wait for request
         requ = isotpsock2.sniff(count=1, timeout=3)
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pkt = GMLAN()/GMLAN_SA(subfunction=2, securityKey=0xbeef)
         pr = GMLAN()/GMLAN_SAPR(subfunction=2)
         isotpsock2.send(pr)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1, retry=1) == True
 
 thread.join(timeout=5)
 
 = Positive scenario, keysend timeout, retry works
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # timeout
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         # retry from start
         requ = isotpsock2.sniff(count=1, timeout=3)
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pr = GMLAN()/GMLAN_SAPR(subfunction=2)
         isotpsock2.send(pr)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1, retry=1) == True
 
 thread.join(timeout=5)
 
 
 = Positive scenario, request error, retry works
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         nr = GMLAN() / GMLAN_NR(requestServiceId=0x27, returnCode=0x37)
-        isotpsock2.send(nr)
         # wait for request
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(nr))
         seedmsg = GMLAN()/GMLAN_SAPR(subfunction=1, securitySeed=0xdead)
-        isotpsock2.send(seedmsg)
         # wait for key
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(seedmsg))
         pkt = GMLAN()/GMLAN_SA(subfunction=2, securityKey=0xbeef)
         pr = GMLAN()/GMLAN_SAPR(subfunction=2)
         isotpsock2.send(pr)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_GetSecurityAccess(isotpsock, keyfunc, level=1, timeout=1, retry=1) == True
 
 thread.join(timeout=5)
@@ -836,42 +856,40 @@ thread.join(timeout=5)
 ##############################################################################
 = sequence of the correct messages
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN(b"\x28")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN(b"\xa2")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_PM(subfunction=0x1)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = GMLAN(b"\xe5")
-        isotpsock2.send(ack)
         # InitiateProgramming enableProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_PM(subfunction=0x3)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1) == True
 
 thread.join(timeout=5)
@@ -882,15 +900,18 @@ assert ecusimSuccessfullyExecuted == True
 
 exit_if_no_isotp_module()
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2, \
-        ISOTPSocket(new_can_socket(iface0), sid=0x0, did=0x101, basecls=GMLAN, extended_addr=0xfe) as broadcastrcv:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2, \
+        new_can_socket(iface0) as broadcastrcv:
         print("DisableNormalCommunication")
-        requ = broadcastrcv.sniff(count=1, timeout=2)
+        requ = broadcastrcv.sniff(count=1, timeout=2, started_callback=started.set)
         pkt = GMLAN(b"\x28")
-        if bytes(requ[0]) != bytes(pkt):
+        print(requ)
+        assert len(requ) >= 1
+        if bytes(requ[0].data) != b"\xfe\x01" + bytes(pkt):
             ecusimSuccessfullyExecuted = False
         print("ReportProgrammedState")
         requ = isotpsock2.sniff(count=1, timeout=2)
@@ -898,26 +919,24 @@ def ecusim():
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         print("ProgrammingMode requestProgramming")
-        requ = isotpsock2.sniff(count=1, timeout=2)
+        requ = isotpsock2.sniff(count=1, timeout=2, started_callback=lambda: isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_PM(subfunction=0x1)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = GMLAN(b"\xe5")
-        isotpsock2.send(ack)
         print("InitiateProgramming enableProgramming")
-        requ = isotpsock2.sniff(count=1, timeout=2)
+        requ = isotpsock2.sniff(count=1, timeout=2, started_callback=lambda: isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_PM(subfunction=0x3)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
-    assert GMLAN_InitDiagnostics(isotpsock, broadcastsocket=GMLAN_BroadcastSocket(new_can_socket(iface0)), timeout=6, verbose=1) == True
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+    assert GMLAN_InitDiagnostics(isotpsock, broadcastsocket=GMLAN_BroadcastSocket(new_can_socket(iface0)), timeout=8, verbose=1) == True
 
 thread.join(timeout=5)
 assert ecusimSuccessfullyExecuted == True
@@ -926,21 +945,22 @@ assert ecusimSuccessfullyExecuted == True
 ######## timeout
 = timeout DisableNormalCommunication
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN(b"\x28")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1) == False
 
 thread.join(timeout=5)
@@ -949,19 +969,19 @@ assert ecusimSuccessfullyExecuted == True
 
 = timeout ReportProgrammedState
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN(b"\x28")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN(b"\xa2")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -970,9 +990,9 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1) == False
 
 thread.join(timeout=5)
@@ -981,35 +1001,34 @@ assert ecusimSuccessfullyExecuted == True
 
 = timeout ProgrammingMode requestProgramming
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN(b"\x28")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN(b"\xa2")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         pkt = GMLAN() / GMLAN_PM(subfunction=0x1)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1) == False
 
 thread.join(timeout=5)
@@ -1018,12 +1037,13 @@ assert ecusimSuccessfullyExecuted == True
 ###### negative respone
 = timeout DisableNormalCommunication
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN(b"\x28")
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -1032,9 +1052,9 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1) == False
 
 thread.join(timeout=5)
@@ -1042,28 +1062,26 @@ assert ecusimSuccessfullyExecuted == True
 
 ###### retry tests
 = sequence of the correct messages, retry set 
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN(b"\xe5")
-        isotpsock2.send(ack)
         # InitiateProgramming enableProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=0) == True
 
 thread.join(timeout=5)
@@ -1071,22 +1089,22 @@ thread.join(timeout=5)
 
 = negative response, make sure no retries are made
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x28, returnCode=0x12)
-        isotpsock2.send(ack)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         if len(requ) != 0:
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=0) == False
 
 thread.join(timeout=5)
@@ -1094,95 +1112,84 @@ assert ecusimSuccessfullyExecuted == True
 
 
 = first fail at DisableNormalCommunication, then sequence of the correct messages
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x28, returnCode=0x12)
-        isotpsock2.send(ack)
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN(b"\xe5")
-        isotpsock2.send(ack)
         # InitiateProgramming enableProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=1) == True
 
 thread.join(timeout=5)
 
 = first fail at ReportProgrammedState, then sequence of the correct messages
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x68"
-        isotpsock2.send(ack)
         # Fail
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN() / GMLAN_NR(requestServiceId=0xA2, returnCode=0x12)
-        isotpsock2.send(ack)
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN(b"\xe5")
-        isotpsock2.send(ack)
         # InitiateProgramming enableProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=1) == True
 
 thread.join(timeout=5)
 
 = first fail at ProgrammingMode requestProgramming, then sequence of the correct messages
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # Fail
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN() / GMLAN_NR(requestServiceId=0xA5, returnCode=0x12)
-        isotpsock2.send(ack)
         # DisableNormalCommunication
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = b"\x68"
-        isotpsock2.send(ack)
         # ReportProgrammedState
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN()/GMLAN_RPSPR(programmedState=0)
-        isotpsock2.send(ack)
         # ProgrammingMode requestProgramming
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN(b"\xe5")
         isotpsock2.send(ack)
         # InitiateProgramming enableProgramming
@@ -1190,34 +1197,33 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=1) == True
 
 thread.join(timeout=5)
 
 = fail twice
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x28, returnCode=0x12)
-        isotpsock2.send(ack)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x28, returnCode=0x12)
-        isotpsock2.send(ack)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         if len(requ) != 0:
             ecusimSuccessfullyExecuted = False
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
+started.wait(timeout=5)
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_InitDiagnostics(isotpsock, timeout=1, verbose=1, retry=1) == False
 
 thread.join(timeout=5)
@@ -1230,11 +1236,12 @@ assert ecusimSuccessfullyExecuted == True
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
 ecusimSuccessfullyExecuted = True
+started = threading.Event()
 def ecusim():
     global ecusimSuccessfullyExecuted
     ecusimSuccessfullyExecuted= True
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         pkt = GMLAN() / GMLAN_RMBA(memoryAddress=0x0, memorySize=0x8)
         if bytes(requ[0]) != bytes(pkt):
             ecusimSuccessfullyExecuted = False
@@ -1243,8 +1250,8 @@ def ecusim():
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_ReadMemoryByAddress(isotpsock, 0x0, 0x8, timeout=1) == payload
 
 thread.join(timeout=5)
@@ -1254,41 +1261,42 @@ assert ecusimSuccessfullyExecuted == True
 = Negative, negative response
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x23, returnCode=0x31)
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_ReadMemoryByAddress(isotpsock, 0x0, 0x8, timeout=1) is None
 
 thread.join(timeout=5)
 
 = Negative, timeout
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_ReadMemoryByAddress(isotpsock, 0x0, 0x8, timeout=1) is None
 
 ###### RETRY
 = Positive, negative response, retry succeeds
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
 payload = b"\x00\x11\x22\x33\x44\x55\x66\x77"
+started = threading.Event()
 def ecusim():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
-        requ = isotpsock2.sniff(count=1, timeout=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242, basecls=GMLAN) as isotpsock2:
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=started.set)
         ack = GMLAN() / GMLAN_NR(requestServiceId=0x23, returnCode=0x31)
-        isotpsock2.send(ack)
-        requ = isotpsock2.sniff(count=1, timeout=1)
+        requ = isotpsock2.sniff(count=1, timeout=1, started_callback=lambda:isotpsock2.send(ack))
         ack = GMLAN() / GMLAN_RMBAPR(memoryAddress=0x0, dataRecord=payload)
         isotpsock2.send(ack)
 
 thread = threading.Thread(target=ecusim)
 thread.start()
-time.sleep(0.05)
-with ISOTPSocket(new_can_socket(iface0), sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
+started.wait(timeout=5)
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     assert GMLAN_ReadMemoryByAddress(isotpsock, 0x0, 0x8, timeout=1, retry=1) == payload
 
 thread.join(timeout=5)

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -129,8 +129,6 @@ load_contrib('automotive.obd.obd')
 + Load OBD_scan
 = imports
 
-import six.moves.queue as queue
-from threading import Event
 from subprocess import call
 
 from scapy.contrib.automotive.obd.scanner import obd_scan
@@ -141,7 +139,7 @@ from scapy.contrib.automotive.ecu import *
 
 s3 = OBD()/OBD_S03_PR(dtcs=[OBD_DTC()])
 
-s1_pid00 = OBD()/OBD_S01_PR(data_records=[OBD_S01_PR_Record()/OBD_PID00(supported_pids="PID03+PID0B+PID0F")])
+s1_pid00 = OBD() / OBD_S01_PR(data_records=[OBD_S01_PR_Record() / OBD_PID00(supported_pids="PID03+PID0B+PID0F")])
 s6_mid00 = OBD() / OBD_S06_PR(data_records=[OBD_S06_PR_Record() / OBD_MID00(supported_mids="")])
 s8_tid00 = OBD() / OBD_S08_PR(data_records=[OBD_S08_PR_Record() / OBD_TID00(supported_tids="")])
 s9_iid00 = OBD() / OBD_S09_PR(data_records=[OBD_S09_PR_Record() / OBD_IID00(supported_iids="")])
@@ -172,18 +170,18 @@ exit_if_no_isotp_module()
 
 drain_bus(iface0)
 
-with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
+with new_can_socket0() as isocan_ecu, ISOTPSocket(isocan_ecu, 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=OBD)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 12})
     sim.start()
     try:
-        with ISOTPSocket(new_can_socket(iface0), 0x7e0, 0x7e8, basecls=OBD, padding=True) as socket:
+        with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e0, 0x7e8, basecls=OBD, padding=True) as socket:
             all_ids_set = set(range(1, 256))
             supported_ids = _supported_id_numbers(socket, 0.1, OBD_S01, 'pid', False)
             unsupported_ids = all_ids_set - supported_ids
         drain_bus(iface0)
         # timeout to avoid a deadlock if the test which sets this event fails
-        with ISOTPSocket(new_can_socket(iface0), 0x7e0, 0x7e8, basecls=OBD, padding=True) as socket:
+        with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e0, 0x7e8, basecls=OBD, padding=True) as socket:
             data = obd_scan(socket, 0.1, True, True, verbose=False)
             dtc = data[0]
             print(data)

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -136,8 +136,8 @@ drain_bus(iface1)
 packet = ISOTP('Request')
 succ = False
 
-with ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641, basecls=UDS) as sendSock, \
-     ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, basecls=UDS) as recvSock:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, basecls=UDS) as sendSock, \
+     new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x641, did=0x241, basecls=UDS) as recvSock:
     def answer(pkt):
         pkt.service = pkt.service + 0x40
         recvSock.send(pkt)
@@ -163,8 +163,8 @@ drain_bus(iface1)
 packet = ISOTP('Request')
 succ = False
 
-with ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641, basecls=UDS) as sendSock, \
-     ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, basecls=UDS) as recvSock:
+with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, basecls=UDS) as sendSock, \
+     new_can_socket0() as isocan2, ISOTPSocket(isocan2, sid=0x641, did=0x241, basecls=UDS) as recvSock:
     def answer(pkt):
         pkt.service = pkt.service + 0x40
         if pkt.service == 0x7f:

--- a/test/contrib/cansocket_native.uts
+++ b/test/contrib/cansocket_native.uts
@@ -113,7 +113,7 @@ def sender():
 thread = threading.Thread(target=sender)
 thread.start()
 rx = None
-rx = sock1.sr1(tx)
+rx = sock1.sr1(tx, verbose=False)
 rx == tx
 
 sock1.close()
@@ -122,14 +122,14 @@ thread.join()
 = CAN Socket sr1 time check
 
 
-tx.sent_time < rx.time and rx.time > 0
+assert tx.sent_time < rx.time and rx.time > 0
 
-= srcan
+= sr can
 
 
 tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 
-= srcan check init time
+= sr can check init time
 
 
 assert tx.sent_time == None
@@ -140,12 +140,13 @@ def sender():
     sock2.send(tx)
     sock2.close()
 
+sock1 = CANSocket(iface="vcan0")
 thread = threading.Thread(target=sender)
 thread.start()
 rx = None
-rx = srcan(tx, "vcan0", timeout=1)
+rx = sock1.sr(tx, timeout=1, verbose=False)
 rx = rx[0][0][1]
-tx == rx
+assert tx == rx
 thread.join()
 
 = srcan check init time basecls
@@ -157,18 +158,19 @@ def sender():
     sock2.send(tx)
     sock2.close()
 
+sock1 = CANSocket(iface="vcan0", basecls=Raw)
 thread = threading.Thread(target=sender)
 thread.start()
 rx = None
-rx = srcan(tx, "vcan0", timeout=1, basecls=Raw)
+rx = sock1.sr(tx, timeout=1, verbose=False)
 rx = rx[0][0][1]
-Raw(bytes(tx)) == rx
+assert Raw(bytes(tx)) == rx
 thread.join()
 
-= srcan check rx and tx
+= sr can check rx and tx
 
 
-tx.sent_time > 0 and rx.time > 0 and tx.sent_time < rx.time
+assert tx.sent_time > 0 and rx.time > 0 and tx.sent_time < rx.time
 
 = sniff with filtermask 0x7ff
 
@@ -186,7 +188,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 3
 
 sock1.close()
@@ -208,7 +210,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 4
 
 sock1.close()
@@ -230,7 +232,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 4
 
 sock1.close()
@@ -253,7 +255,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 4
 
 sock1.close()
@@ -275,7 +277,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 2
 
 sock1.close()
@@ -297,7 +299,7 @@ def sender():
     sock2.close()
 
 thread = threading.Thread(target=sender)
-packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
 len(packets) == 2
 
 sock1.close()
@@ -310,7 +312,7 @@ sock1 = CANSocket(iface='vcan0', can_filters=[{'can_id': 0x10000000 | CAN_INV_FI
 
 if six.PY3:
     thread = threading.Thread(target=sender)
-    packets = sock1.sniff(timeout=0.2, started_callback=thread.start)
+    packets = sock1.sniff(timeout=0.2, started_callback=thread.start, verbose=False)
     len(packets) == 4
 
 sock1.close()
@@ -321,18 +323,18 @@ sock1.close()
 sock1 = CANSocket(iface="vcan0", receive_own_messages=True)
 tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 rx = None
-rx = sock1.sr1(tx)
+rx = sock1.sr1(tx, verbose=False)
 tx == rx
 tx.sent_time < rx.time and tx == rx and rx.time > 0
 
 sock1.close()
 
-= srcan
+= sr can
 
-
+sock1 = CANSocket(iface="vcan0", receive_own_messages=True)
 tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 rx = None
-rx = srcan(tx, iface="vcan0", receive_own_messages=True, timeout=1)
+rx = sock1.sr(tx, timeout=1, verbose=False)
 tx == rx[0][0][1]
 
 + bridge and sniff tests
@@ -363,7 +365,7 @@ def bridge():
     def pnr(pkt):
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -372,7 +374,7 @@ threadBridge.start()
 threadSender = threading.Thread(target=senderVCan0)
 bridgeStarted.wait()
 
-packetsVCan1 = sock1.sniff(timeout=0.2, started_callback=threadSender.start)
+packetsVCan1 = sock1.sniff(timeout=0.2, started_callback=threadSender.start, verbose=False)
 len(packetsVCan1) == 6
 
 threadSender.join()
@@ -402,7 +404,7 @@ def bridge():
     def pnr(pkt):
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -411,7 +413,7 @@ threadBridge.start()
 threadSender = threading.Thread(target=senderVCan1)
 bridgeStarted.wait()
 
-packetsVCan0 = sock0.sniff(timeout=0.2, started_callback=threadSender.start)
+packetsVCan0 = sock0.sniff(timeout=0.2, started_callback=threadSender.start, verbose=False)
 len(packetsVCan0) == 4
 
 sock0.close()
@@ -447,7 +449,7 @@ def bridge():
     def pnr(pkt):
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -457,8 +459,8 @@ threadSender = threading.Thread(target=senderBothVCans)
 
 bridgeStarted.wait()
 
-packetsVCan0 = sock0.sniff(timeout=0.1, count=6, started_callback=threadSender.start)
-packetsVCan1 = sock1.sniff(timeout=0.1)
+packetsVCan0 = sock0.sniff(timeout=0.1, count=6, started_callback=threadSender.start, verbose=False)
+packetsVCan1 = sock1.sniff(timeout=0.1, verbose=False)
 
 len(packetsVCan0) == 4
 len(packetsVCan1) == 6
@@ -495,7 +497,7 @@ def bridgeWithPackageChangeVCan0ToVCan1():
         pkt.identifier = 0x10010000
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -505,7 +507,7 @@ threadSender = threading.Thread(target=senderVCan0)
 
 bridgeStarted.wait()
 
-packetsVCan1 = sock1.sniff(timeout=0.2,  started_callback=threadSender.start)
+packetsVCan1 = sock1.sniff(timeout=0.2,  started_callback=threadSender.start, verbose=False)
 len(packetsVCan1) == 6
 
 sock0.close()
@@ -538,7 +540,7 @@ def bridgeWithPackageChangeVCan1ToVCan0():
         pkt.identifier = 0x10010000
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -548,7 +550,7 @@ threadSender = threading.Thread(target=senderVCan1)
 
 bridgeStarted.wait()
 
-packetsVCan0 = sock0.sniff(timeout=0.2,  started_callback=threadSender.start)
+packetsVCan0 = sock0.sniff(timeout=0.2,  started_callback=threadSender.start, verbose=False)
 len(packetsVCan0) == 4
 
 sock0.close()
@@ -586,7 +588,7 @@ def bridgeWithPackageChangeBothDirections():
         pkt.identifier = 0x10010000
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -597,8 +599,8 @@ threadSender = threading.Thread(target=senderBothVCans)
 bridgeStarted.wait()
 threadSender.start()
 
-packetsVCan0 = sock0.sniff(timeout=0.1)
-packetsVCan1 = sock1.sniff(timeout=0.1)
+packetsVCan0 = sock0.sniff(timeout=0.1, verbose=False)
+packetsVCan1 = sock1.sniff(timeout=0.1, verbose=False)
 len(packetsVCan0) == 4
 len(packetsVCan1) == 6
 
@@ -635,7 +637,7 @@ def bridgeWithRemovePackageFromVCan0ToVCan1():
             pkt = pkt
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -647,7 +649,7 @@ bridgeStarted.wait()
 
 threadSender.start()
 
-packetsVCan1 = sock1.sniff(timeout=0.2)
+packetsVCan1 = sock1.sniff(timeout=0.2, verbose=False)
 len(packetsVCan1) == 5
 
 sock0.close()
@@ -681,7 +683,7 @@ def bridgeWithRemovePackageFromVCan1ToVCan0():
             pkt = pkt
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm21=pnr, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm21=pnr, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -692,7 +694,7 @@ bridgeStarted.wait()
 
 threadSender.start()
 
-packetsVCan0 = sock0.sniff(timeout=0.2)
+packetsVCan0 = sock0.sniff(timeout=0.2, verbose=False)
 len(packetsVCan0) == 3
 
 sock0.close()
@@ -738,7 +740,7 @@ def bridgeWithRemovePackageInBothDirections():
             pkt = pkt
         return pkt
     bridgeStarted.set()
-    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnrA, xfrm21=pnrB, timeout=0.2)
+    bridge_and_sniff(if1=bSock0, if2=bSock1, xfrm12=pnrA, xfrm21=pnrB, timeout=0.2, verbose=False)
     bSock0.close()
     bSock1.close()
 
@@ -748,8 +750,8 @@ threadSender = threading.Thread(target=senderBothVCans)
 
 bridgeStarted.wait()
 
-packetsVCan0 = sock0.sniff(timeout=0.1, started_callback=threadSender.start)
-packetsVCan1 = sock1.sniff(timeout=0.1)
+packetsVCan0 = sock0.sniff(timeout=0.1, started_callback=threadSender.start, verbose=False)
+packetsVCan1 = sock1.sniff(timeout=0.1, verbose=False)
 
 len(packetsVCan0) == 3
 len(packetsVCan1) == 5

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -721,8 +721,9 @@ test_frames = [
 
 succ = False
 def sender(args=None):
+    tx_sock = new_can_socket(iface0)
     for f in test_frames:
-        call("cansend %s %3x#%s" % (iface0, f[0], "".join(f[1].split())), shell=True)
+        tx_sock.send(CAN(identifier=f[0], data=dhex(f[1])))
     global succ
     succ = True
 
@@ -734,7 +735,7 @@ assert(sniffed[0]['ISOTP'].src == 0x641)
 assert(sniffed[0]['ISOTP'].exsrc is 0xEA)
 assert(sniffed[0]['ISOTP'].dst == 0x241)
 assert(sniffed[0]['ISOTP'].exdst is 0xEA)
-thread.join()
+thread.join(timeout=5)
 assert(succ)
 
 + ISOTPSocket tests
@@ -780,7 +781,7 @@ with ISOTPSoftSocket(cans, sid=0x641, did=0x241) as s:
     thread.start()
     ready.wait()
     msg = s.recv()
-    thread.join()
+    thread.join(timeout=5)
 
 if exception is not None:
     raise exception
@@ -908,41 +909,43 @@ with ISOTPSocket(cans, sid=0x641, did=0x241) as s:
     assert(can.identifier == 0x641)
     assert(can.data == dhex("30 00 00"))
 
+cans.close()
+
 + Testing ISOTPSocket with an actual CAN socket
 
 = Verify that packets are not lost if they arrive before the sniff() is called
-ss = new_can_socket(iface0)
-sr = new_can_socket(iface0)
-print("socket open")
-tx_func = lambda: ss.send(CAN(identifier=0x111, data=b"\x01\x23\x45\x67"))
-p = sr.sniff(count=1, timeout=0.2, started_callback=tx_func)
-assert(len(p)==1)
-tx_func = lambda: ss.send(CAN(identifier=0x111, data=b"\x89\xab\xcd\xef"))
-p = sr.sniff(count=1, timeout=0.2, started_callback=tx_func)
-assert(len(p)==1)
-del ss
-del sr
+with new_can_socket(iface0) as ss, new_can_socket0() as sr:
+    tx_func = lambda: ss.send(CAN(identifier=0x111, data=b"\x01\x23\x45\x67"))
+    p = sr.sniff(count=1, timeout=0.2, started_callback=tx_func)
+    assert(len(p)==1)
+    tx_func = lambda: ss.send(CAN(identifier=0x111, data=b"\x89\xab\xcd\xef"))
+    p = sr.sniff(count=1, timeout=0.2, started_callback=tx_func)
+    assert(len(p)==1)
 
 = Send single frame ISOTP message, using begin_send
-cans = new_can_socket(iface0)
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket(iface0) as isocan, \
+        ISOTPSocket(isocan, sid=0x641, did=0x241) as s, \
+        new_can_socket0() as cans:
     can = cans.sniff(timeout=2, count=1, started_callback=lambda: s.begin_send(ISOTP(data=dhex("01 02 03 04 05"))))
     assert(can[0].identifier == 0x641)
     assert(can[0].data == dhex("05 01 02 03 04 05"))
 
 = Send many single frame ISOTP messages, using begin_send
-cans = new_can_socket(iface0)
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+
+with new_can_socket0() as isocan, \
+        ISOTPSocket(isocan, sid=0x641, did=0x241) as s, \
+        new_can_socket0() as cans:
     for i in range(100):
         data = dhex("01 02 03 04 05") + struct.pack("B", i)
         expected = struct.pack("B", len(data)) + data
-        can = cans.sniff(timeout=1, count=1, started_callback=lambda: s.begin_send(ISOTP(data=data)))
+        can = cans.sniff(timeout=4, count=1, started_callback=lambda: s.begin_send(ISOTP(data=data)))
         assert(can[0].identifier == 0x641)
         print(can[0].data, data)
         assert(can[0].data == expected)
 
+
 = Send two-frame ISOTP message, using begin_send
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     can = cans.sniff(timeout=1, count=1, started_callback=lambda: s.begin_send(ISOTP(data=dhex("01 02 03 04 05 06 07 08"))))
     assert can[0].identifier == 0x641
@@ -951,13 +954,17 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     assert can[0].identifier == 0x641
     assert can[0].data == dhex("21 07 08")
 
+cans.close()
+
 = Send single frame ISOTP message
 cans = new_can_socket(iface0)
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     s.send(ISOTP(data=dhex("01 02 03 04 05")))
     can = cans.sniff(timeout=1, count=1)
     assert(can[0].identifier == 0x641)
     assert(can[0].data == dhex("05 01 02 03 04 05"))
+
+cans.close()
 
 = Send two-frame ISOTP message
 cans = new_can_socket(iface0)
@@ -968,10 +975,11 @@ def acker():
     can_pkt = acks.sniff(timeout=1, count=1)
     can = can_pkt[0]
     acks.send(CAN(identifier = 0x241, data=dhex("30 00 00")))
+    acks.close()
 
 Thread(target=acker).start()
 acker_ready.wait()
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     s.send(ISOTP(data=dhex("01 02 03 04 05 06 07 08")))
     can = cans.sniff(timeout=1, count=1)[0] 
     assert(can.identifier == 0x641)
@@ -983,8 +991,10 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     assert(can.identifier == 0x641)
     assert(can.data == dhex("21 07 08"))
 
+cans.close()
+
 = Receive a single frame ISOTP message
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x241, data = dhex("05 01 02 03 04 05")))
     isotp = s.recv()
@@ -994,8 +1004,10 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     assert(isotp.exsrc == None)
     assert(isotp.exdst == None)
 
+cans.close()
+
 = Receive a single frame ISOTP message, with extended addressing
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241, extended_addr=0xc0, extended_rx_addr=0xea) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, extended_addr=0xc0, extended_rx_addr=0xea) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x241, data = dhex("EA 05 01 02 03 04 05")))
     isotp = s.recv()
@@ -1004,6 +1016,8 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241, extended_addr=0xc
     assert(isotp.dst == 0x241)
     assert(isotp.exsrc == 0xc0)
     assert(isotp.exdst == 0xea)
+
+cans.close()
 
 = Receive frames from CandumpReader
 candump_fd = BytesIO(b'''  vcan0  541   [8]  10 0A DE AD BE EF AA AA
@@ -1126,7 +1140,7 @@ assert(isotp.data == dhex(""))
 assert (isotp.dst == 0x241)
 
 = Receive a two-frame ISOTP message
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x241, data = dhex("10 0B 01 02 03 04 05 06")))
     cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 10 11")))
@@ -1134,7 +1148,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
     assert(isotp.data == dhex("01 02 03 04 05 06 07 08 09 10 11"))
 
 = Check what happens when a CAN frame with wrong identifier gets received
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x141, data = dhex("05 01 02 03 04 05")))
     assert(s.ins.rx_queue.empty())
@@ -1142,7 +1156,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 + Testing ISOTPSocket timeouts
 
 = Check if not sending the last CF will make the socket timeout
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
     cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 0A 0B 0C 0D")))
@@ -1151,7 +1165,7 @@ with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
 assert(len(isotp) == 0)
 
 = Check if not sending the first CF will make the socket timeout
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
     isotp = s.sniff(timeout=1)
@@ -1162,7 +1176,7 @@ assert(len(isotp) == 0)
 exception = None
 isotp = ISOTP(data=dhex("01 02 03 04 05 06 07 08 09 0A"))
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     try:
         s.send(isotp)
         assert(False)
@@ -1188,13 +1202,14 @@ thread = Thread(target=acker)
 thread.start()
 evt.wait()
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     try:
         s.send(isotp)
     except Scapy_Exception as ex:
         exception = ex
 
-thread.join()
+cans.close()
+thread.join(timeout=5)
 
 assert(exception is not None)
 print(exception)
@@ -1216,20 +1231,20 @@ thread = Thread(target=acker)
 thread.start()
 evt.wait()
 
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     try:
         s.send(isotp)
     except Scapy_Exception as ex:
         exception = ex
 
-thread.join()
+thread.join(timeout=5)
 
 assert(exception is not None)
 print(exception)
 assert(str(exception) == "Overflow happened at the receiver side")
 
 = Close the Socket
-with ISOTPSocket(new_can_socket(iface0), sid=0x641, did=0x241) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
     s.close()
 
 + More complex operations
@@ -1241,23 +1256,23 @@ drain_bus(iface1)
 evt = threading.Event()
 msg = ISOTP(b'\x11\x22\x33\x11\x22\x33\x11\x22\x33\x11\x22\x33')
 rx2 = None
+evt2 = threading.Event()
 
-def sender():
+def sender(sock):
     global evt, rx2, msg
-    with ISOTPSoftSocket(new_can_socket(iface0), 0x123, 0x321) as sock:
-        evt.wait()
-        rx2 = sock.sr1(msg, timeout=3, verbose=True)
+    evt2.set()
+    evt.wait()
+    rx2 = sock.sr1(msg, timeout=3, verbose=True)
 
-txThread = threading.Thread(target=sender)
-txThread.start()
-
-with ISOTPSoftSocket(new_can_socket(iface0), 0x321, 0x123) as sock:
-    evt.set()
-    rx = sock.sniff(timeout=3, count=1)[0]
-    sock.send(msg)
+with new_can_socket0() as isocan_tx, ISOTPSoftSocket(isocan_tx, 0x123, 0x321) as sock_tx, \
+    new_can_socket0() as isocan_rx, ISOTPSoftSocket(isocan_rx, 0x321, 0x123) as sock_rx:
+    txThread = threading.Thread(target=sender, args=(sock_tx,))
+    txThread.start()
+    evt2.wait(timeout=1)
+    rx = sock_rx.sniff(timeout=3, count=1, started_callback=evt.set)[0]
+    sock_rx.send(msg)
     sent = True
-
-txThread.join()
+    txThread.join(timeout=5)
 
 assert(rx == msg)
 assert(sent)
@@ -1273,10 +1288,10 @@ sent = False
 evt = threading.Event()
 msg = ISOTP(b'\x11\x22\x33\x11\x22\x33\x11\x22\x33\x11\x22\x33')
 
-with ISOTPSoftSocket(new_can_socket0(), 0x123, 0x321) as txSock:
+with new_can_socket0() as isocan, ISOTPSoftSocket(isocan, 0x123, 0x321) as txSock:
     def receiver():
         global rx2, sent
-        with ISOTPSoftSocket(new_can_socket0(), 0x321, 0x123) as rxSock:
+        with new_can_socket0() as isocan, ISOTPSoftSocket(isocan, 0x321, 0x123) as rxSock:
             evt.set()
             rx2 = rxSock.sniff(count=1)
             rxSock.send(msg)
@@ -1285,7 +1300,7 @@ with ISOTPSoftSocket(new_can_socket0(), 0x123, 0x321) as txSock:
     rxThread.start()
     evt.wait()
     rx = txSock.sr1(msg, timeout=5,verbose=True)
-    rxThread.join()
+    rxThread.join(timeout=5)
 
 assert(rx is not None)
 assert(rx == msg)
@@ -1299,9 +1314,9 @@ succ = False
 
 def receiver():
     global evt, succ, rx
-    with ISOTPSoftSocket(new_can_socket0(), 0x321, 0x123) as sock:
-        evt.set()
-        rx = sock.sniff(count=5, timeout=1)
+    with new_can_socket0() as isocan, \
+            ISOTPSoftSocket(isocan, 0x321, 0x123) as sock:
+        rx = sock.sniff(count=5, timeout=5, started_callback=evt.set)
     succ = True
 
 rxThread = threading.Thread(target=receiver)
@@ -1309,7 +1324,8 @@ rxThread.start()
 evt.wait()
 
 msg = ISOTP(b'\x11\x22\x33\x11\x22\x33\x11\x22\x33\x11\x22\x33')
-with ISOTPSoftSocket(new_can_socket0(), 0x123, 0x321) as sock:
+with new_can_socket0() as isocan, \
+        ISOTPSoftSocket(isocan, 0x123, 0x321) as sock:
     msg.data += b'0'
     sock.send(msg)
     msg.data += b'1'
@@ -1321,7 +1337,7 @@ with ISOTPSoftSocket(new_can_socket0(), 0x123, 0x321) as sock:
     msg.data += b'4'
     sock.send(msg)
 
-rxThread.join()
+rxThread.join(timeout=5)
 msg = ISOTP(b'\x11\x22\x33\x11\x22\x33\x11\x22\x33\x11\x22\x33')
 msg.data += b'0'
 assert(rx[0] == msg)
@@ -1344,10 +1360,14 @@ drain_bus(iface1)
 packet = ISOTP(b'Request')
 succ = False
 
-with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x641, did=0x241) as isoTpSocket1, \
-     ISOTPSoftSocket(new_can_socket0(), sid=0x641, did=0x241) as bSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x241, did=0x641) as bSocket1:
+with new_can_socket0() as can0_0, \
+        new_can_socket0() as can0_1, \
+        new_can_socket1() as can1_0, \
+        new_can_socket1() as can1_1, \
+        ISOTPSoftSocket(can0_0, sid=0x241, did=0x641) as isoTpSocket0, \
+        ISOTPSoftSocket(can1_0, sid=0x541, did=0x141) as isoTpSocket1, \
+        ISOTPSoftSocket(can0_1, sid=0x641, did=0x241) as bSocket0, \
+        ISOTPSoftSocket(can1_1, sid=0x141, did=0x141) as bSocket1:
     evt = threading.Event()
     def forwarding(pkt):
         global forwarded
@@ -1363,7 +1383,7 @@ with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
     threadBridge.start()
     evt.wait()
     packetsVCan1 = isoTpSocket1.sniff(timeout=0.5, started_callback=lambda: isoTpSocket0.send(packet))
-    threadBridge.join()
+    threadBridge.join(timeout=5)
 
 assert forwarded == 1
 assert len(packetsVCan1) == 1
@@ -1378,13 +1398,17 @@ drain_bus(iface1)
 
 packet = ISOTP(b'RequestASDF1234567890')
 N = 3
-T = 3
+T = 20
 
 succ = False
-with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x641, did=0x241) as isoTpSocket1, \
-     ISOTPSoftSocket(new_can_socket0(), sid=0x641, did=0x241) as bSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x241, did=0x641) as bSocket1:
+with new_can_socket0() as can0_0, \
+        new_can_socket0() as can0_1, \
+        new_can_socket1() as can1_0, \
+        new_can_socket1() as can1_1, \
+        ISOTPSoftSocket(can0_0, sid=0x241, did=0x641) as isoTpSocket0, \
+        ISOTPSoftSocket(can1_0, sid=0x541, did=0x141) as isoTpSocket1, \
+        ISOTPSoftSocket(can0_1, sid=0x641, did=0x241) as bSocket0, \
+        ISOTPSoftSocket(can1_1, sid=0x141, did=0x541) as bSocket1:
     evt = threading.Event()
     def forwarding(pkt):
         global forwarded
@@ -1398,14 +1422,17 @@ with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
         succ = True
     def sendpkts():
         for i in range(N):
+            time.sleep(0.2)
             isoTpSocket0.send(packet)
     threadBridge = threading.Thread(target=bridge)
     threadBridge.start()
     evt.wait()
-    packetsVCan1 = isoTpSocket1.sniff(timeout=T, count=N, started_callback=sendpkts)
+    sender = threading.Thread(target=sendpkts)
+    packetsVCan1 = isoTpSocket1.sniff(timeout=T, count=N, started_callback=sender.start)
+    sender.join(timeout=5)
     print("forwarded: %d" % forwarded)
     print("len(packetsVCan1): %d" % len(packetsVCan1))
-    threadBridge.join()
+    threadBridge.join(timeout=5)
 
 assert forwarded == N
 assert len(packetsVCan1) == N
@@ -1420,10 +1447,14 @@ drain_bus(iface1)
 
 packet = ISOTP(b'Request')
 succ = False
-with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x641, did=0x241) as isoTpSocket1, \
-     ISOTPSoftSocket(new_can_socket0(), sid=0x641, did=0x241) as bSocket0, \
-     ISOTPSoftSocket(new_can_socket1(), sid=0x241, did=0x641) as bSocket1:
+with new_can_socket0() as can0_0, \
+        new_can_socket0() as can0_1, \
+        new_can_socket1() as can1_0, \
+        new_can_socket1() as can1_1, \
+        ISOTPSoftSocket(can0_0, sid=0x241, did=0x641) as isoTpSocket0, \
+        ISOTPSoftSocket(can1_0, sid=0x641, did=0x241) as isoTpSocket1, \
+        ISOTPSoftSocket(can0_1, sid=0x641, did=0x241) as bSocket0, \
+        ISOTPSoftSocket(can1_1, sid=0x241, did=0x641) as bSocket1:
     evt = threading.Event()
     def forwarding(pkt):
         pkt.data = 'changed'
@@ -1437,7 +1468,7 @@ with ISOTPSoftSocket(new_can_socket0(), sid=0x241, did=0x641) as isoTpSocket0, \
     threadBridge.start()
     evt.wait()
     packetsVCan1 = isoTpSocket1.sniff(timeout=0.5, started_callback=lambda: isoTpSocket0.send(packet))
-    threadBridge.join()
+    threadBridge.join(timeout=5)
 
 assert len(packetsVCan1) == 1
 assert packetsVCan1[0].data == b'changed'
@@ -1448,8 +1479,8 @@ drain_bus(iface1)
 
 
 = Two ISOTPSockets at the same time, sending and receiving
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
-     ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641) as s2:
+with new_can_socket0() as cs1, ISOTPSocket(cs1, sid=0x641, did=0x241) as s1, \
+        new_can_socket0() as cs2, ISOTPSocket(cs2, sid=0x241, did=0x641) as s2:
     isotp = ISOTP(data=b"\x10\x25" * 43)
     def sender():
         s2.send(isotp)
@@ -1462,8 +1493,8 @@ assert(result.data == isotp.data)
 
 
 = Two ISOTPSockets at the same time, multiple sends/receives
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
-     ISOTPSocket(new_can_socket0(), sid=0x241, did=0x641) as s2:
+with new_can_socket0() as cs1, ISOTPSocket(cs1, sid=0x641, did=0x241) as s1, \
+        new_can_socket0() as cs2, ISOTPSocket(cs2, sid=0x241, did=0x641) as s2:
     def sender(p):
         s2.send(p)
     for i in range(1, 40, 5):
@@ -1476,7 +1507,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241) as s1, \
 
 
 = Send a single frame ISOTP message with padding
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
+with new_can_socket0() as cs1, ISOTPSocket(cs1, sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
     s.send(ISOTP(data=dhex("01")))
     res = cans.sniff(timeout=1, count=1)[0]
@@ -1491,10 +1522,12 @@ def acker():
     acker_ready.set()
     can = acks.sniff(timeout=1, count=1)[0]
     acks.send(CAN(identifier = 0x241, data=dhex("30 00 00")))
+    acks.close()
 
-Thread(target=acker).start()
+ack_thread = Thread(target=acker)
+ack_thread.start()
 acker_ready.wait()
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=True) as s:
     s.send(ISOTP(data=dhex("01 02 03 04 05 06 07 08")))
 
 can = cans.sniff(timeout=1, count=1)[0]
@@ -1506,43 +1539,49 @@ assert(can.data == dhex("30 00 00"))
 can = cans.sniff(timeout=1, count=1)[0]
 assert(can.identifier == 0x641)
 assert(can.data == dhex("21 07 08 00 00 00 00 00"))
+cans.close()
+ack_thread.join(timeout=5)
 
 
 = Receive a padded single frame ISOTP message with padding disabled
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=False) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier=0x241, data=dhex("02 05 06 00 00 00 00 00")))
     res = s.recv()
     assert(res.data == dhex("05 06"))
+    cans.close()
 
 
 = Receive a padded single frame ISOTP message with padding enabled
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier=0x241, data=dhex("02 05 06 00 00 00 00 00")))
     res = s.recv()
     assert(res.data == dhex("05 06"))
+    cans.close()
 
 
 = Receive a non-padded single frame ISOTP message with padding enabled
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier=0x241, data=dhex("02 05 06")))
     res = s.recv()
     assert(res.data == dhex("05 06"))
+    cans.close()
 
 
 = Receive a padded two-frame ISOTP message with padding enabled
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=True) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=True) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier=0x241, data=dhex("10 09 01 02 03 04 05 06")))
     cans.send(CAN(identifier=0x241, data=dhex("21 07 08 09 00 00 00 00")))
     res = s.recv()
     assert(res.data == dhex("01 02 03 04 05 06 07 08 09"))
+    cans.close()
 
 
 = Receive a padded two-frame ISOTP message with padding disabled
-with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padding=False) as s:
     cans = new_can_socket(iface0)
     cans.send(CAN(identifier=0x241, data=dhex("10 09 01 02 03 04 05 06")))
     cans.send(CAN(identifier=0x241, data=dhex("21 07 08 09 00 00 00 00")))
@@ -1551,6 +1590,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x641, did=0x241, padding=False) as s:
     print(res.data)
     print(raw(res))
     assert(res.data == dhex("01 02 03 04 05 06 07 08 09"))
+    cans.close()
 
 
 + Compatibility with can-isotp linux kernel modules
@@ -1561,7 +1601,7 @@ exit_if_no_isotp_module()
 
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
-with ISOTPSocket(new_can_socket0(), sid=0x642, did=0x242) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242) as s:
     cmd = "echo \"%s\" | isotpsend -s 242 -d 642 %s" % (message, iface0)
     print(cmd)
     r = subprocess.call(cmd, shell=True)
@@ -1575,7 +1615,7 @@ with ISOTPSocket(new_can_socket0(), sid=0x642, did=0x242) as s:
 exit_if_no_isotp_module()
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
-with ISOTPSocket(new_can_socket0(), sid=0x644, did=0x244, extended_addr=0xaa, extended_rx_addr=0xee) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x644, did=0x244, extended_addr=0xaa, extended_rx_addr=0xee) as s:
     cmd = "echo \"%s\" | isotpsend -s 244 -d 644 %s -x ee:aa" % (message, iface0)
     print(cmd)
     r = subprocess.call(cmd, shell=True)
@@ -1593,7 +1633,7 @@ cmd = "isotprecv -s 243 -d 643 -b 3 %s" % iface0
 print(cmd)
 p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 time.sleep(0.1)
-with ISOTPSocket(new_can_socket0(), sid=0x643, did=0x243) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x643, did=0x243) as s:
     s.send(isotp)
 
 threading.Timer(1, lambda: p.terminate() if p.poll() else p.wait()).start()  # Timeout the receiver after 1 second
@@ -1621,7 +1661,7 @@ cmd = "isotprecv -s 245 -d 645 -b 3 %s -x ee:aa" % iface0
 print(cmd)
 p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
 time.sleep(0.1)  # Give some time for starting reception
-with ISOTPSocket(new_can_socket0(), sid=0x645, did=0x245, extended_addr=0xaa, extended_rx_addr=0xee) as s:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x645, did=0x245, extended_addr=0xaa, extended_rx_addr=0xee) as s:
     s.send(isotp)
 
 threading.Timer(1, lambda: p.terminate() if p.poll() else p.wait()).start()  # Timeout the receiver after 1 second
@@ -1670,6 +1710,7 @@ s.send(ISOTP(data=dhex("01 02 03 04 05")))
 can = cans.sniff(timeout=1, count=1)[0]
 assert(can.identifier == 0x641)
 assert(can.data == dhex("05 01 02 03 04 05"))
+cans.close()
 
 
 = Send single frame ISOTP message Test init with CANSocket
@@ -1680,6 +1721,7 @@ s.send(ISOTP(data=dhex("01 02 03 04 05")))
 can = cans.sniff(timeout=1, count=1)[0]
 assert(can.identifier == 0x641)
 assert(can.data == dhex("05 01 02 03 04 05"))
+cans.close()
 
 
 = Test init with wrong type
@@ -1729,6 +1771,7 @@ assert(can.length == 8)
 
 = Send a two-frame ISOTP message with padding
 exit_if_no_isotp_module()
+
 cans = new_can_socket0()
 acker_ready = threading.Event()
 def acker():
@@ -1736,6 +1779,7 @@ def acker():
     acker_ready.set()
     can = acks.sniff(timeout=1, count=1)[0]
     acks.send(CAN(identifier = 0x241, data=dhex("30 00 00")))
+    acks.close()
 
 Thread(target=acker).start()
 acker_ready.wait()
@@ -1750,7 +1794,7 @@ assert(can.data == dhex("30 00 00"))
 can = cans.sniff(timeout=1, count=1)[0]
 assert(can.identifier == 0x641)
 assert(can.data == dhex("21 07 08 00 00 00 00 00"))
-
+cans.close()
 
 = Receive a padded single frame ISOTP message with padding disabled
 exit_if_no_isotp_module()
@@ -1873,7 +1917,7 @@ def receiver():
 txThread = threading.Thread(target=sender)
 txThread.start()
 receiver()
-txThread.join()
+txThread.join(timeout=5)
 
 assert(rx2 is not None)
 assert(rx2 == ISOTP(b'\x7f\x22\x33'))
@@ -1902,7 +1946,7 @@ def receiver():
 txThread = threading.Thread(target=sender)
 txThread.start()
 receiver()
-txThread.join()
+txThread.join(timeout=5)
 
 assert(rx == msg)
 assert(rxSock.send(msg))
@@ -1934,7 +1978,7 @@ sent = False
 rxThread = threading.Thread(target=receiver)
 rxThread.start()
 sender()
-rxThread.join()
+rxThread.join(timeout=5)
 
 assert(rx == msg)
 assert(rx2[0] == msg)
@@ -1982,7 +2026,7 @@ def sender():
 rxThread = threading.Thread(target=receiver)
 rxThread.start()
 sender()
-rxThread.join()
+rxThread.join(timeout=5)
 
 assert(succ)
 
@@ -2029,8 +2073,8 @@ len(packetsVCan1) == 1
 isoTpSocket0.close()
 isoTpSocket1.close()
 
-threadSender.join()
-threadBridge.join()
+threadSender.join(timeout=5)
+threadBridge.join(timeout=5)
 
 assert(bSucc)
 assert(rSucc)
@@ -2076,8 +2120,8 @@ len(packetsVCan1) == 1
 isoTpSocket0.close()
 isoTpSocket1.close()
 
-threadSender.join()
-threadBridge.join()
+threadSender.join(timeout=5)
+threadBridge.join(timeout=5)
 
 assert(bSucc)
 assert(rSucc)
@@ -2126,8 +2170,8 @@ len(packetsVCan1) == 1
 isoTpSocket0.close()
 isoTpSocket1.close()
 
-threadSender.join()
-threadBridge.join()
+threadSender.join(timeout=5)
+threadBridge.join(timeout=5)
 
 assert(bSucc)
 assert(rSucc)
@@ -2172,15 +2216,15 @@ packetsVCan0 = isoTpSocket0.sniff(timeout=0.5, started_callback=threadSender.sta
 packetsVCan1 = isoTpSocket1.sniff(timeout=0.5)
 
 packetsVCan0[0].data = b'changed'
-len(packetsVCan0) == 1
+assert len(packetsVCan0) == 1
 packetsVCan1[0].data = b'changed'
-len(packetsVCan1) == 1
+assert len(packetsVCan1) == 1
 
 isoTpSocket0.close()
 isoTpSocket1.close()
 
-threadSender.join()
-threadBridge.join()
+threadSender.join(timeout=5)
+threadBridge.join(timeout=5)
 
 assert(bSucc)
 assert(rSucc)

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -65,11 +65,10 @@ new_can_socket1 = lambda: CANSocket(iface=python_can.interface.Bus(bustype='virt
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
-    s = new_can_socket(iface)
-    pkts = s.sniff(timeout=0.1)
-    if assert_empty:
-        assert len(pkts) == 0
-    s.close()
+    with new_can_socket0() as s:
+        pkts = s.sniff(timeout=0.1)
+        if assert_empty:
+            assert len(pkts) == 0
 
 print("CAN sockets should work now")
 
@@ -124,18 +123,22 @@ else:
     assert ISOTPSocket == ISOTPSoftSocket
 
 = Test send_multiple_ext()
+
 pkt = ISOTPHeaderEA(identifier=0x100, extended_address=1)/ISOTP_FF(message_size=100, data=b'\x00\x00\x00\x00\x00')
 number_of_packets = 100
 
 drain_bus(iface0)
 def sender():
-    send_multiple_ext(new_can_socket0(), 0, pkt, number_of_packets)
+    with new_can_socket0() as sock:
+        send_multiple_ext(sock, 0, pkt, number_of_packets)
 
 thread = threading.Thread(target=sender)
-pkts = new_can_socket0().sniff(timeout=4, count=number_of_packets, started_callback=thread.start)
-thread.join()
-assert len(pkts) == number_of_packets
 
+with new_can_socket0() as sock:
+    pkts = sock.sniff(timeout=4, count=number_of_packets, started_callback=thread.start)
+
+thread.join(timeout=10)
+assert len(pkts) == number_of_packets
 
 = Test filter_periodic_packets() with periodic packets
 pkt = CAN(identifier=0x200, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
@@ -178,43 +181,65 @@ filter_periodic_packets(received_packets)
 assert len(received_packets) == 40
 
 = Test scan()
+
 drain_bus(iface0)
+
+semaphore = threading.Semaphore(0)
+
 def isotpserver(idx):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+idx, did=0x600+idx) as sock:
-        sock.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+idx, did=0x600+idx) as sock:
+        sock.sniff(timeout=20 ,count=1, started_callback=semaphore.release)
 
 listen_sockets = list()
 for i in range(1, 4):
-    listen_sockets.append(threading.Thread(target=isotpserver, args=[i]))
+    listen_sockets.append(threading.Thread(target=isotpserver, args=(int(i*0x10),)))
     listen_sockets[-1].start()
 
-found_packets = scan(new_can_socket0(), range(0x5ff, 0x610), noise_ids=[0x701], sniff_time=0.1)
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+for _ in range(len(listen_sockets)):
+    semaphore.acquire()
+
+with new_can_socket0() as scansock:
+    found_packets = scan(scansock, range(0x5ff, 0x640), noise_ids=[0x710], sniff_time=0.3, verbose=True)
+
+with new_can_socket0() as cans:
+    for _ in range(5):
+        cans.send(CAN(identifier=0x610, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x620, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x630, data=b'\x01\xaa'))
+        time.sleep(0)
+
+print(len(listen_sockets))
 
 for thread in listen_sockets:
-    thread.join()
+    thread.join(timeout=1)
 
+print(len(found_packets))
 assert len(found_packets) == 2
 
 
 = Test scan_extended()
+
 recvpacket = CAN(flags=0, identifier=0x700, length=4, data=b'\xaa0\x00\x00')
 
+semaphore = threading.Semaphore(0)
 drain_bus(iface0)
+
 def isotpserver():
-    with ISOTPSocket(new_can_socket0(), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
-        s.sniff(timeout=100, count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1, started_callback=semaphore.release)
 
 thread = threading.Thread(target=isotpserver)
 thread.start()
-time.sleep(0.1)
-found_packets = scan_extended(new_can_socket0(), [0x601], sniff_time=0.1)
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x601, data=b'\xbb\x01\xaa'))
-thread.join()
+
+semaphore.acquire()
+
+with new_can_socket0() as scansock:
+    found_packets = scan_extended(scansock, [0x601], sniff_time=0.1)
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x601, data=b'\xbb\x01\xaa'))
+    thread.join(timeout=10)
+
 fpkt = found_packets[list(found_packets.keys())[0]][0]
 rpkt = recvpacket
 
@@ -222,39 +247,47 @@ assert fpkt.length == rpkt.length
 assert fpkt.data == rpkt.data
 assert fpkt.identifier == rpkt.identifier
 
-
 = Test ISOTPScan(output_format=text)
 done = False
 
+semaphore = threading.Semaphore(0)
+
 drain_bus(iface0)
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as isotpsock1:
-        isotpsock1.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
-def make_noise(pkt):
+def make_noise(p):
     global done
-    while not done:
-        new_can_socket0().send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as sock:
+        while not done:
+            sock.send(p)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=(pkt))
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), output_format="text", noise_listen_time=1, sniff_time=0.1)
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
-thread1.join()
-thread2.join()
+
+semaphore.acquire()
+semaphore.acquire()
+
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x604+1), output_format="text", noise_listen_time=1, sniff_time=0.1)
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+
+thread1.join(timeout=10)
+thread2.join(timeout=10)
 done = True
-thread_noise.join()
+thread_noise.join(timeout=10)
 
 text = "\nFound 2 ISOTP-FlowControl Packet(s):"
 assert text in result
@@ -267,35 +300,44 @@ assert "No Padding" in result
 = Test ISOTPScan(output_format=text) extended_can_id
 done = False
 
+semaphore = threading.Semaphore(0)
+
 drain_bus(iface0)
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x1ffff700+i, did=0x1ffff600+i) as isotpsock1:
-        isotpsock1.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x1ffff700+i, did=0x1ffff600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
     global done
-    while not done:
-        new_can_socket0().send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as sock:
+        while not done:
+            sock.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x1ffff701, flags="extended", length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=(pkt))
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
-result = ISOTPScan(new_can_socket0(), range(0x1ffff5ff, 0x1ffff604+1), output_format="text", noise_listen_time=1, sniff_time=0.1, extended_can_id=True)
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x1ffff601, flags="extended", data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x1ffff602, flags="extended", data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x1ffff603, flags="extended", data=b'\x01\xaa'))
-thread1.join()
-thread2.join()
+semaphore.acquire()
+semaphore.acquire()
+
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x1ffff5ff, 0x1ffff604+1), output_format="text", noise_listen_time=1, sniff_time=0.1, extended_can_id=True)
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x1ffff601, flags="extended", data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x1ffff602, flags="extended", data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x1ffff603, flags="extended", data=b'\x01\xaa'))
+
+thread1.join(timeout=10)
+thread2.join(timeout=10)
 done = True
-thread_noise.join()
+thread_noise.join(timeout=10)
+
 print(result)
 text = "\nFound 2 ISOTP-FlowControl Packet(s):"
 assert text in result
@@ -309,35 +351,43 @@ assert "No Padding" in result
 = Test ISOTPScan(output_format=code)
 done = False
 
+semaphore = threading.Semaphore(0)
+
 drain_bus(iface0)
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as isotpsock1:
-        isotpsock1.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i) as isotpsock1:
+        isotpsock1.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
     global done
-    while not done:
-        new_can_socket0().send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as sock:
+        while not done:
+            sock.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), output_format="code", noise_listen_time=1, sniff_time=0.1, can_interface="can0")
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
-thread1.join()
-thread2.join()
+semaphore.acquire()
+semaphore.acquire()
+
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x604+1), output_format="code", noise_listen_time=1, sniff_time=0.1, can_interface="can0")
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+
+thread1.join(timeout=10)
+thread2.join(timeout=10)
 done = True
-thread_noise.join()
+thread_noise.join(timeout=10)
 
 s1 = "ISOTPSocket(can0, sid=0x602, did=0x702, padding=False, basecls=ISOTP)\n"
 s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, padding=False, basecls=ISOTP)\n"
@@ -350,34 +400,39 @@ assert s2 in result
 = Test extended ISOTPScan(output_format=code)
 drain_bus(iface0)
 
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code", can_interface="can0")
+semaphore.acquire()
+semaphore.acquire()
 
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x602, data=b'\x22\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x22\x01\xaa'))
-thread1.join()
-thread2.join()
-thread_noise.join()
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x604+1), extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code", can_interface="can0")
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x602, data=b'\x22\x01\xaa'))
+    cans.send(CAN(identifier=0x603, data=b'\x22\x01\xaa'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
 
 s1 = "ISOTPSocket(can0, sid=0x602, did=0x702, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
 s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
@@ -385,38 +440,42 @@ print(result)
 assert s1 in result
 assert s2 in result
 
-
 = Test extended ISOTPScan(output_format=code) extended_can_id
 drain_bus(iface0)
 
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x1ffff700+i, did=0x1ffff600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x1ffff700+i, did=0x1ffff600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x1ffff701, flags="extended", length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x1ffff5ff, 0x1ffff604+1), extended_can_id=True, extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code", can_interface="can0")
+semaphore.acquire()
+semaphore.acquire()
 
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x1ffff602, flags="extended", data=b'\x22\x01\xaa'))
-cans.send(CAN(identifier=0x1ffff603, flags="extended", data=b'\x22\x01\xaa'))
-thread1.join()
-thread2.join()
-thread_noise.join()
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x1ffff5ff, 0x1ffff604+1), extended_can_id=True, extended_addressing=True, sniff_time=0.1, noise_listen_time=1, output_format="code", can_interface="can0")
+
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x1ffff602, flags="extended", data=b'\x22\x01\xaa'))
+    cans.send(CAN(identifier=0x1ffff603, flags="extended", data=b'\x22\x01\xaa'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
 
 s1 = "ISOTPSocket(can0, sid=0x1ffff602, did=0x1ffff702, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
 s2 = "ISOTPSocket(can0, sid=0x1ffff603, did=0x1ffff703, padding=False, extended_addr=0x22, extended_rx_addr=0x11, basecls=ISOTP)"
@@ -427,36 +486,45 @@ assert s2 in result
 
 = Test ISOTPScan(output_format=None)
 drain_bus(iface0)
+
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+semaphore.acquire()
+semaphore.acquire()
+
+socks_interface = new_can_socket0()
+
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x604+1), can_interface=socks_interface, sniff_time=0.1, noise_listen_time=1)
+
 result = sorted(result, key=lambda x:x.src)
 
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
-thread1.join()
-thread2.join()
-thread_noise.join()
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
 
 assert len(result) == 2
 assert 0x602 == result[0].src
@@ -464,51 +532,60 @@ assert 0x702 == result[0].dst
 assert 0x603 == result[1].src
 assert 0x703 == result[1].dst
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    for s in result:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=0x702, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x703, data=b'\x01\xaa'))
+        s.close()
+        cans.send(CAN(identifier=0x702, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x703, data=b'\x01\xaa'))
 
-for s in result:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=0x702, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=0x703, data=b'\x01\xaa'))
-    s.close()
-    cans.send(CAN(identifier=0x702, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=0x703, data=b'\x01\xaa'))
+socks_interface.close()
+time.sleep(0.1)
 
 for s in result:
     del s
 
 = Test ISOTPScan(output_format=None) 2
 drain_bus(iface0)
+
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
 thread1 = threading.Thread(target=isotpserver, args=[9])
 thread2 = threading.Thread(target=isotpserver, args=[8])
 thread1.start()
 thread2.start()
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x6A0), can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+semaphore.acquire()
+semaphore.acquire()
+
+socks_interface = new_can_socket0()
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x6A0), can_interface=socks_interface, sniff_time=0.1, noise_listen_time=1)
+
 result = sorted(result, key=lambda x:x.src)
 
-cans = new_can_socket0()
-cans.send(CAN(identifier=0x609, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x608, data=b'\x01\xaa'))
-
-thread1.join()
-thread2.join()
-thread_noise.join()
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x609, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x608, data=b'\x01\xaa'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
 
 assert len(result) == 2
 assert 0x608 == result[0].src
@@ -516,54 +593,63 @@ assert 0x708 == result[0].dst
 assert 0x609 == result[1].src
 assert 0x709 == result[1].dst
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    for s in result:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=0x709, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x708, data=b'\x01\xaa'))
+        s.close()
+        time.sleep(0)
+        cans.send(CAN(identifier=0x709, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x708, data=b'\x01\xaa'))
 
-for s in result:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=0x709, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=0x708, data=b'\x01\xaa'))
-    s.close()
-    cans.send(CAN(identifier=0x709, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=0x708, data=b'\x01\xaa'))
+socks_interface.close()
+time.sleep(0.1)
 
 for s in result:
     del s
 
-
 = Test extended ISOTPScan(output_format=None)
 drain_bus(iface0)
 
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700+i, did=0x600+i, extended_addr=0x11, extended_rx_addr=0x22) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-thread1 = threading.Thread(target=isotpserver, args=[2])
-thread2 = threading.Thread(target=isotpserver, args=[3])
+thread1 = threading.Thread(target=isotpserver, args=(2,))
+thread2 = threading.Thread(target=isotpserver, args=(3,))
 thread1.start()
 thread2.start()
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x5ff, 0x604+1), extended_addressing=True, can_interface=new_can_socket0(), sniff_time=0.1, noise_listen_time=1)
+semaphore.acquire()
+semaphore.acquire()
+
+socks_interface = new_can_socket0()
+
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x5ff, 0x604+1), extended_addressing=True, can_interface=socks_interface, sniff_time=0.1, noise_listen_time=1)
+
 result = sorted(result, key=lambda x:x.src)
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
+    cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
 
-cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
-
-thread1.join()
-thread2.join()
-thread_noise.join()
+thread1.join(timeout=10)
+thread2.join(timeout=10)
+thread_noise.join(timeout=10)
 
 assert len(result) == 2
 assert 0x602 == result[0].src
@@ -575,15 +661,18 @@ assert 0x703 == result[1].dst
 assert 0x22 == result[1].exsrc
 assert 0x11 == result[1].exdst
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    for s in result:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=0x702, data=b'\x11\x01\xaa'))
+        cans.send(CAN(identifier=0x703, data=b'\x11\x01\xaa'))
+        s.close()
+        time.sleep(0)
+        cans.send(CAN(identifier=0x702, data=b'\x11\x01\xaa'))
+        cans.send(CAN(identifier=0x703, data=b'\x11\x01\xaa'))
 
-for s in result:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=0x702, data=b'\x11\x01\xaa'))
-    cans.send(CAN(identifier=0x703, data=b'\x11\x01\xaa'))
-    s.close()
-    cans.send(CAN(identifier=0x702, data=b'\x11\x01\xaa'))
-    cans.send(CAN(identifier=0x703, data=b'\x11\x01\xaa'))
+socks_interface.close()
+time.sleep(0.1)
 
 for s in result:
     del s
@@ -596,35 +685,40 @@ rnd = RandNum(0x0, 0x10)
 ids = set(rnd._fix() * 10 for _ in range(5))
 print(ids)
 
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x100+i, did=i) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x100+i, did=i) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt,))
 thread_noise.start()
 
-threads = [threading.Thread(target=isotpserver, args=[x]) for x in ids]
+threads = [threading.Thread(target=isotpserver, args=(x,)) for x in ids]
 _ = [t.start() for t in threads]
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x000, 0x101), can_interface=new_can_socket0(), noise_listen_time=1, sniff_time=0.1, verbose=True)
-result = sorted(result, key=lambda x:x.src)
+for _ in range(len(threads)):
+    semaphore.acquire()
 
-cans = new_can_socket0()
+socks_interface = new_can_socket0()
 
-for i in ids:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x000, 0x101), can_interface=socks_interface, noise_listen_time=1, sniff_time=0.1, verbose=True)
+    result = sorted(result, key=lambda x:x.src)
 
-_ = [t.join() for t in threads]
-thread_noise.join()
+with new_can_socket0() as cans:
+    for i in ids:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+    _ = [t.join(timeout=10) for t in threads]
+    thread_noise.join(timeout=10)
 
 assert len(result) == len(ids)
 ids = sorted(ids)
@@ -632,16 +726,18 @@ for i, s in zip(ids, result):
     assert i == s.src
     assert i+0x100 == s.dst
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    for s in result:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
+        s.close()
+        time.sleep(0)
+        cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
 
-for s in result:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
-    s.close()
-    cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
-
+socks_interface.close()
+time.sleep(0.1)
 for s in result:
     del s
 
@@ -653,35 +749,41 @@ rnd = RandNum(0x0, 0x10)
 
 ids = set(rnd._fix() * 10 for _ in range(5))
 
+semaphore = threading.Semaphore(0)
+
 def isotpserver(i):
-    with ISOTPSocket(new_can_socket0(), sid=0x100+i, did=i, padding=True) as s:
-        s.sniff(timeout=100 ,count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x100+i, did=i, padding=True) as s:
+        s.sniff(timeout=100 ,count=1, started_callback=semaphore.release)
 
 def make_noise(pkt):
-    s = new_can_socket0()
-    for _ in range(20):
-        s.send(pkt)
-        time.sleep(0.1)
+    with new_can_socket0() as s:
+        for _ in range(20):
+            s.send(pkt)
+            time.sleep(0.1)
 
 pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
-thread_noise = threading.Thread(target=make_noise, args=pkt)
+thread_noise = threading.Thread(target=make_noise, args=(pkt, ))
 thread_noise.start()
 
-threads = [threading.Thread(target=isotpserver, args=[x]) for x in ids]
+threads = [threading.Thread(target=isotpserver, args=(x,)) for x in ids]
 _ = [t.start() for t in threads]
-time.sleep(0.1)
 
-result = ISOTPScan(new_can_socket0(), range(0x000, 0x101), can_interface=new_can_socket0(), noise_listen_time=1, sniff_time=0.1, verbose=True)
-result = sorted(result, key=lambda x:x.src)
+for _ in range(len(threads)):
+    semaphore.acquire()
 
-cans = new_can_socket0()
+socks_interface = new_can_socket0()
 
-for i in ids:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+with new_can_socket0() as scansock:
+    result = ISOTPScan(scansock, range(0x000, 0x101), can_interface=socks_interface, noise_listen_time=1, sniff_time=0.1, verbose=True)
+    result = sorted(result, key=lambda x:x.src)
 
-_ = [t.join() for t in threads]
-thread_noise.join()
+with new_can_socket0() as cans:
+    for i in ids:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+
+_ = [t.join(timeout=10) for t in threads]
+thread_noise.join(timeout=10)
 
 assert len(result) == len(ids)
 ids = sorted(ids)
@@ -691,15 +793,17 @@ for i, s in zip(ids, result):
     if isinstance(s, ISOTPSoftSocket):
         assert s.impl.padding == True
 
-cans = new_can_socket0()
+with new_can_socket0() as cans:
+    for s in result:
+        # This helps to close ISOTPSoftSockets
+        cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
+        s.close()
+        cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
 
-for s in result:
-    # This helps to close ISOTPSoftSockets
-    cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
-    s.close()
-    cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
-    cans.send(CAN(identifier=s.src, data=b'\x01\xaa'))
+socks_interface.close()
+time.sleep(0.1)
 
 for s in result:
     del s

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -73,11 +73,10 @@ else:
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
-    s = new_can_socket(iface)
-    pkts = s.sniff(timeout=0.1)
-    if assert_empty:
-        assert len(pkts) == 0
-    s.close()
+    with new_can_socket(iface) as s:
+        pkts = s.sniff(timeout=0.1)
+        if assert_empty:
+            assert len(pkts) == 0
 
 print("CAN sockets should work now")
 
@@ -125,6 +124,7 @@ assert expected_output in plain_str(std_err)
 
 
 = Test show help
+
 result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py --help" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 if result.wait() == 0:
     std_out, std_err = result.communicate()
@@ -135,6 +135,7 @@ if result.wait() == 0:
 
 
 = Test wrong socket for Python2 or Windows
+
 if six.PY2:
     version = subprocess.Popen("python --version", stdout=subprocess.PIPE, shell=True)
     if 0 == version.wait():
@@ -165,25 +166,26 @@ assert expected_output in plain_str(std_out)
 + Scan tests
 
 = Test standard scan
+
 drain_bus(iface0)
+started = threading.Event()
 
 def isotpserver():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x600) as s:
-        s.sniff(timeout=100, count=1)
+    with new_can_socket(iface0) as isocan, ISOTPSocket(isocan, sid=0x700, did=0x600) as s:
+        s.sniff(timeout=100, count=1, started_callback=started.set)
 
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
-time.sleep(0.1)
+started.wait(timeout=10)
 result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x600 -e 0x600" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 returncode = result.wait()
 std_out, std_err = result.communicate()
 
-print(std_out)
-print(std_err)
-
 send = subprocess.Popen(['cansend', 'vcan0', '600#01aa'])
 assert 0 == send.wait()
 assert returncode == 0
+
+sniffer.join(timeout=10)
 
 expected_output = [b'0x600', b'0x700']
 print(std_out)
@@ -192,14 +194,17 @@ for out in expected_output:
 
 
 = Test extended scan
+
 drain_bus(iface0)
+started = threading.Event()
+
 def isotpserver():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
-        s.sniff(timeout=100, count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1, started_callback=started.set)
 
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
-time.sleep(0.1)
+started.wait(timeout=10)
 result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
 returncode = result.wait()
 
@@ -209,21 +214,25 @@ assert returncode == 0
 
 expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
 std_out, std_err = result.communicate()
+sniffer.join(timeout=10)
+
 assert std_err == None
-print(std_out)
+
 for out in expected_output:
     assert plain_str(out) in plain_str(std_out)
 
-
 = Test extended only scan
+
 drain_bus(iface0)
+started = threading.Event()
+
 def isotpserver():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
-        s.sniff(timeout=100, count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1, started_callback=started.set)
 
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
-time.sleep(0.1)
+started.wait(timeout=10)
 result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
 returncode = result.wait()
 
@@ -233,21 +242,26 @@ assert returncode == 0
 
 expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
 std_out, std_err = result.communicate()
+sniffer.join(timeout=10)
+
 assert std_err == None
-print(std_out)
+
 for out in expected_output:
     assert plain_str(out) in plain_str(std_out)
 
 
 = Test scan with piso flag
+
 drain_bus(iface0)
+started = threading.Event()
+
 def isotpserver():
-    with ISOTPSocket(new_can_socket(iface0), sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
-        s.sniff(timeout=100, count=1)
+    with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700, did=0x601, extended_addr=0xaa, extended_rx_addr=0xbb) as s:
+        s.sniff(timeout=100, count=1, started_callback=started.set)
 
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
-time.sleep(0.1)
+started.wait(timeout=10)
 result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x -C" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
 returncode = result.wait()
 
@@ -257,7 +271,9 @@ assert returncode == 0
 
 expected_output = [b'sid=0x601', b'did=0x700', b'padding=False', b'extended_addr=0xbb', b'extended_rx_addr=0xaa']
 std_out, std_err = result.communicate()
+sniffer.join(timeout=10)
+
 assert std_err == None
-print(std_out)
+
 for out in expected_output:
     assert plain_str(out) in plain_str(std_out)

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -74,12 +74,10 @@ else:
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
-    s = new_can_socket(iface)
-    pkts = s.sniff(timeout=0.1)
-    if assert_empty:
-        assert len(pkts) == 0
-    s.close()
-
+    with new_can_socket(iface) as s:
+        pkts = s.sniff(timeout=0.1)
+        if assert_empty:
+            assert len(pkts) == 0
 
 = Verify that a CAN socket can be created and closed
 s = new_can_socket(iface0)

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -160,10 +160,10 @@ if six.PY2:
 if six.PY2:
     result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py -i socketcan -c vcan0 -s 0x600 -d 0x601 -b 250000 -v" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     returncode = result.wait()
+    std_out, std_err = result.communicate()
     print(returncode)
     assert returncode == 0
     expected_output = plain_str(b'Starting OBD-Scan...')
-    std_out, std_err = result.communicate()
     print(std_out)
     print(expected_output)
     assert expected_output in plain_str(std_out)
@@ -176,19 +176,9 @@ load_contrib('automotive.obd.obd')
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib('isotp')
 
-
-= imports
-import six.moves.queue as queue
-from threading import Event
-
-from scapy.contrib.automotive.obd.scanner import obd_scan
-from scapy.contrib.automotive.obd.scanner import _supported_id_numbers
-
 + Simulate scanner
 
 = Test DTC scan
-
-exit_if_no_isotp_module()
 
 drain_bus(iface0)
 
@@ -196,8 +186,7 @@ s3 = OBD()/OBD_S03_PR(dtcs=[OBD_DTC()])
 
 example_responses = [ECUResponse(session=range(0,255), security_level=0, responses=s3)]
 
-
-with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=OBD)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 3, 'timeout': 10})
     sim.start()
@@ -206,18 +195,18 @@ with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
         sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         std_out, std_err = result.communicate()
-        assert std_err == b''
+        if six.PY2:
+            expected_output = b"Service 3:\nC\x01\x00\x00"
+        else:
+            expected_output = b"Service 3:\nb'C\\x01\\x00\\x00'"
 
-        expected_output = bytes("Service 3:\nb'C\\x01\\x00\\x00'", 'utf-8')
-        assert plain_str(expected_output) in plain_str(std_out)
+        assert bytes_encode(expected_output) in bytes_encode(std_out)
 
     finally:
         sim.join(timeout=10)
 
 
 = Test supported PIDs scan
-
-exit_if_no_isotp_module()
 
 drain_bus(iface0)
 
@@ -243,7 +232,7 @@ example_responses = \
 
 
 
-with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=OBD)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 10, 'timeout': 10})
     sim.start()
@@ -254,18 +243,26 @@ with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
         std_out, std_err = result.communicate()
         assert std_err == b''
 
-        expected_output = [bytes("Service 3:\nb'C\\x01\\x00\\x00'", 'utf-8'),
-                           bytes("Service 1:\n{3: b'A\\x03\\x00\\x02', 11: b'A\\x0bd', 15: b'A\\x0fZ'}", 'utf-8')]
+        if six.PY2:
+            expected_output = [b"Service 3:\nC\x01\x00\x00",
+                               b"Service 1:\n{",
+                               b"3: 'A\\x03\\x00\\x02'",
+                               b"11: 'A\\x0bd'",
+                               b"15: 'A\\x0fZ'"]
+        else:
+            expected_output = [b"Service 3:\nb'C\\x01\\x00\\x00'",
+                               b"Service 1:\n{",
+                               b"3: b'A\\x03\\x00\\x02'",
+                               b"11: b'A\\x0bd'",
+                               b"15: b'A\\x0fZ'"]
 
         for out in expected_output:
-            assert plain_str(out) in plain_str(std_out)
+            assert bytes_encode(out) in bytes_encode(std_out)
     finally:
         sim.join(timeout=10)
 
 
 = Test full scan
-
-exit_if_no_isotp_module()
 
 drain_bus(iface0)
 
@@ -273,36 +270,52 @@ drain_bus(iface0)
 s1_pid01 = OBD()/OBD_S01_PR(data_records=[OBD_S01_PR_Record()/OBD_PID01()])
 example_responses.append(ECUResponse(session=range(0,255), security_level=0, responses=s1_pid01))
 
-with ISOTPSocket("vcan0", 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
+with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD, padding=True) as ecu:
     answering_machine = ECU_am(supported_responses=example_responses, main_socket=ecu, basecls=OBD)
     sim = threading.Thread(target=answering_machine, kwargs={'count': 11, 'timeout': 10})
     sim.start()
     try:
         result = subprocess.Popen(
-            "%s $PWD/scapy/tools/automotive/obdscanner.py %s -s 0x7e0 -d 0x7e8 -b 250000 -t 0.01 -ru" % (
+            "%s $PWD/scapy/tools/automotive/obdscanner.py %s -s 0x7e0 -d 0x7e8 -b 250000 -t 0.001 -ru" % (
             sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         std_out, std_err = result.communicate()
         assert std_err == b''
 
-        expected_output = [bytes("Service 3:\nb'C\\x01\\x00\\x00'", 'utf-8'),
-                           bytes("Service 1:\n{3: b'A\\x03\\x00\\x02', 11: b'A\\x0bd', 15: b'A\\x0fZ'}", 'utf-8'),
-                           bytes("Service 1:\n{1: b'A\\x01\\x00\\x00\\x00\\x00'}", 'utf-8')]
+        if six.PY2:
+            expected_output = [b"Service 3:\nC\x01\x00\x00",
+                               b"Service 1:\n{3: 'A\x03\x00\x02', 11: 'A\x0bd', 15: 'A\x0fZ'}",
+                               b"Service 1:\n{1: 'A\x01\x00\x00\x00\x00'}"]
+        else:
+            expected_output = [b"Service 3:\nb'C\\x01\\x00\\x00'",
+                               b"Service 1:\n{3: b'A\\x03\\x00\\x02', 11: b'A\\x0bd', 15: b'A\\x0fZ'}",
+                               b"Service 1:\n{1: b'A\\x01\\x00\\x00\\x00\\x00'}"]
+
+        if six.PY2:
+            expected_output = [b"Service 3:\nC\x01\x00\x00",
+                               b"Service 1:\n{",
+                               b"3: 'A\\x03\\x00\\x02'",
+                               b"11: 'A\\x0bd'",
+                               b"15: 'A\\x0fZ'",
+                               b"Service 1:\n{1: 'A\\x01\\x00\\x00\\x00\\x00'}"]
+        else:
+            expected_output = [b"Service 3:\nb'C\\x01\\x00\\x00'",
+                               b"Service 1:\n{",
+                               b"3: b'A\\x03\\x00\\x02'",
+                               b"11: b'A\\x0bd'",
+                               b"15: b'A\\x0fZ'",
+                               b"Service 1:\n{1: b'A\\x01\\x00\\x00\\x00\\x00'}"]
 
         for out in expected_output:
-            assert plain_str(out) in plain_str(std_out)
+            assert bytes_encode(out) in bytes_encode(std_out)
 
     finally:
         sim.join(timeout=10)
 
 
-
-
 + Cleanup
 
 = Cleanup
-
-exit_if_no_isotp_module()
 
 if 0 != call("sudo ip link delete vcan0", shell=True):
         raise Exception("vcan0 could not be deleted")


### PR DESCRIPTION
Big refactoring of automotive related unit tests.
Removed almost all calls to time.sleep()
Changed unit tests to be event-driven
Ensured that every socket is closed after a test