### PR TITLE
Remove unstable tests

### DIFF
--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -119,21 +119,6 @@ s.set_nonblock(set_flag=True)
 s.set_nonblock(set_flag=False)
 s.close()
 
-= L2bpfListenSocket - recv as nonblocking
-~ needs_root
-
-s = L2bpfListenSocket()
-s.set_nonblock(set_flag=True)
-
-def test_nonblock_recv(s):
-    for i in range(1, 100):
-        a = s.recv()
-        if not a:
-            return True
-    return False
-
-assert test_nonblock_recv(s)
-
 = L2bpfListenSocket - get_*()
 ~ needs_root
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -12534,21 +12534,6 @@ def test_hexdump():
 
 test_hexdump()
 
-= conversations()
-~ linux
-
-def test_conversations():
-    import tempfile
-    filename = tempfile.mktemp()
-    p = PacketList([IP()/Raw(str(i)) for i in range(2)])
-    p.conversations(prog="echo", target="> %s" % filename)
-    fd = open(filename)
-    assert "-Tsvg" in fd.read()
-    fd.close()
-    os.unlink(filename)
-
-test_conversations()
-
 = import_hexcap()
 
 @mock.patch("scapy.utils.input")


### PR DESCRIPTION
fixes https://github.com/secdev/scapy/issues/2397

- first one is already tested in the nonblock tests above
- second one literally duplicates a few lines below

https://github.com/gpotter2/scapy/blob/f89e5399cf4cf242d04ea55a3b38d5fc1ae9985a/test/regression.uts#L12580