### PR TITLE
Fix SEGV in pcap after pcap_open_live() failed

### DIFF
--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -37,7 +37,7 @@ else:
     _lib_name = find_library("pcap")
     if not _lib_name:
         raise OSError("Cannot find libpcap.so library")
-    _lib = CDLL(_lib_name)
+    _lib = CDLL(_lib_name, use_errno=True)
 
 
 ##


### PR DESCRIPTION
**Checklist:**

-   [x] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
    - WIP
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
    - WIP
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

> brief description what this PR will do, e.g. fixes broken dissection of XXX

`errno` set by pcap_open_live(3) (typically `EPERM` or `ENXIO`) was not checked, eventually causing a segmentation violation at `pcap_get_selectable_fd()`:

```sh
$ python3 -c 'from scapy.all import *; conf.use_pcap = True; sendp("", iface="eth0")'
fish: “python3 -c 'from scapy.all impo…” terminated by signal SIGSEGV (Address boundary error)
```

because pcap_get_selectable_fd(3) refered to `NULL`:

```hs
(gdb) bt
#0  pcap_get_selectable_fd (p=0x0) at ./pcap.c:1419
#1  0x00007f963a72781e in ffi_call_unix64 () from /lib/x86_64-linux-gnu/libffi.so.6
#2  0x00007f963a7271ef in ffi_call () from /lib/x86_64-linux-gnu/libffi.so.6
#3  0x00007f963b17cf49 in _call_function_pointer (flags=flags@entry=4353, pProc=pProc@entry=0x7f96382d1300 <pcap_get_selectable_fd>, avalues=0x7ffd96028bd0,
atypes=<optimized out>, restype=<optimized out>, resmem=resmem@entry=0x7ffd96028be0, argcount=1) at ./Modules/_ctypes/callproc.c:827
#4  0x00007f963b17d965 in _ctypes_callproc (pProc=pProc@entry=0x7f96382d1300 <pcap_get_selectable_fd>, argtuple=argtuple@entry=0x7f963b263608, flags=4353,
argtypes=argtypes@entry=0x7f9638360d58, restype=restype@entry=0x18d7628, checker=checker@entry=0x0) at ./Modules/_ctypes/callproc.c:1184
#5  0x00007f963b176401 in PyCFuncPtr_call (self=0x7f963836bcf0, inargs=<optimized out>, kwds=<optimized out>) at ./Modules/_ctypes/_ctypes.c:3969
#6  0x000000000043730f in ?? ()
#7  0x00007f96382823b8 in ?? ()
#8  0x0000000000000000 in ?? ()

(gdb) l
1414
1415    #if !defined(_WIN32) && !defined(MSDOS)
1416    int
1417    pcap_get_selectable_fd(pcap_t *p)
1418    {
1419        return (p->selectable_fd);
1420    }
1421    #endif
1422
1423    void

(gdb) p p
$1 = (pcap_t *) 0x0
```

For `EPERM` and `ENXIO`, I added user-friendly error messages:

```
OSError: Could not open iface eth0: Operation not permitted (needs sudo?)
OSError: Could not open iface nonexist0: Device not configured (nonexist0 not exist?)
```

c.f. usage of `use_errno=True` in `ctypes.CDLL`: https://github.com/python/cpython/blob/v3.8.1/Lib/ctypes/test/test_errno.py

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library

fixes #xxx (add issue number here if appropriate, else remove this line)
