### PR TITLE
Add VRRPv3 support for IPv6 address list (#2430)

### DIFF
--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -10,7 +10,7 @@ VRRP (Virtual Router Redundancy Protocol).
 
 from scapy.packet import Packet, bind_layers
 from scapy.fields import BitField, ByteField, FieldLenField, FieldListField, \
-    IPField, IntField, XShortField
+    IPField, IP6Field, IntField, MultipleTypeField, StrField, XShortField
 from scapy.compat import chb, orb
 from scapy.layers.inet import IP, in4_chksum, checksum
 from scapy.layers.inet6 import IPv6, in6_chksum
@@ -62,9 +62,18 @@ class VRRPv3(Packet):
         BitField("res", 0, 4),
         BitField("adv", 100, 12),
         XShortField("chksum", None),
-        # FIXME: addrlist should also allow IPv6 addresses :/
-        FieldListField("addrlist", [], IPField("", "0.0.0.0"),
-                       count_from=lambda pkt: pkt.ipcount)]
+        MultipleTypeField(
+            [
+                (FieldListField("addrlist", [], IPField("", "0.0.0.0"),
+                                count_from=lambda pkt: pkt.ipcount),
+                 lambda p: isinstance(p.underlayer, IP)),
+                (FieldListField("addrlist", [], IP6Field("", "::"),
+                                count_from=lambda pkt: pkt.ipcount),
+                 lambda p: isinstance(p.underlayer, IPv6)),
+            ],
+            StrField("addrlist", "")
+        )
+    ]
 
     def post_build(self, p, pay):
         if self.chksum is None:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10572,6 +10572,14 @@ s == b'E\x00\x00$\x00\x01\x00\x00@p|g\x7f\x00\x00\x01\x7f\x00\x00\x01!\x01d\x00\
 p = IP(s)
 VRRP in p and p[VRRP].chksum == 0x7afd
 
+= VRRP IPv6 - build
+s6 = raw(IPv6()/VRRPv3())
+s6 == b'`\x00\x00\x00\x00\x08p@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x011\x01d\x01\x00dj\x1f'
+
+= VRRP IPv6 - dissection
+p6 = IPv6(s6)
+VRRPv3 in p6 and p6[VRRPv3].chksum == 0x6a1f
+
 = VRRP - chksums
 # VRRPv3
 p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRPv3(priority=254,vrid=2,version=3,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
@@ -10581,6 +10589,12 @@ assert a[VRRPv3].chksum == 0xb25e
 p = Ether(src="00:00:5e:00:02:02",dst="01:00:5e:00:00:12")/IP(src="20.0.0.3", dst="224.0.0.18",ttl=255)/VRRP(priority=254,vrid=2,version=1,adv=1,addrlist=["20.0.1.2","20.0.1.3"])
 b = Ether(raw(p))
 assert b[VRRP].chksum == 0xc6f4
+
+= VRRP IPv6 - chksums
+# VRRPv3 IPv6
+p = Ether(src="00:00:5e:00:02:02",dst="33:33:00:00:00:12")/IPv6(src="2001:db8::1", dst="ff02::12",hlim=255)/VRRPv3(priority=254,vrid=2,version=3,adv=1,ipcount=2,addrlist=["2001:db8::2","2001:db8::3"])
+c = Ether(raw(p))
+assert c[VRRPv3].chksum == 0x481b
 
 ############
 ############


### PR DESCRIPTION
Add VRRPv3 support for IPv6 address list. The addrlist field only
supports IPv4 addresses. Make it conditional on IP as the underlayer
and add another conditional addrlist6 which is conditional on IPv6
as the underlayer.

fixes #2430 