### PR TITLE
Fix EDecimal<->float arithmetic

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -54,35 +54,56 @@ def issubtype(x, t):
 class EDecimal(Decimal):
     """Extended Decimal
 
-    This implement comparison with float for backward compatibility
+    This implements arithmetic and comparison with float for backward compatibility
     """
 
     def __add__(self, other, **kwargs):
-        return EDecimal(Decimal.__add__(self, other, **kwargs))
+        return EDecimal(Decimal.__add__(self, Decimal(other), **kwargs))
+
+    def __radd__(self, other, **kwargs):
+        return EDecimal(Decimal.__add__(self, Decimal(other), **kwargs))
 
     def __sub__(self, other, **kwargs):
-        return EDecimal(Decimal.__sub__(self, other, **kwargs))
+        return EDecimal(Decimal.__sub__(self, Decimal(other), **kwargs))
+
+    def __rsub__(self, other, **kwargs):
+        return EDecimal(Decimal.__rsub__(self, Decimal(other), **kwargs))
 
     def __mul__(self, other, **kwargs):
-        return EDecimal(Decimal.__mul__(self, other, **kwargs))
+        return EDecimal(Decimal.__mul__(self, Decimal(other), **kwargs))
+
+    def __rmul__(self, other, **kwargs):
+        return EDecimal(Decimal.__mul__(self, Decimal(other), **kwargs))
 
     def __truediv__(self, other, **kwargs):
-        return EDecimal(Decimal.__truediv__(self, other, **kwargs))
+        return EDecimal(Decimal.__truediv__(self, Decimal(other), **kwargs))
 
     def __floordiv__(self, other, **kwargs):
-        return EDecimal(Decimal.__floordiv__(self, other, **kwargs))
+        return EDecimal(Decimal.__floordiv__(self, Decimal(other), **kwargs))
 
     def __div__(self, other, **kwargs):
-        return EDecimal(Decimal.__div__(self, other, **kwargs))
+        return EDecimal(Decimal.__div__(self, Decimal(other), **kwargs))
+
+    def __rdiv__(self, other, **kwargs):
+        return EDecimal(Decimal.__rdiv__(self, Decimal(other), **kwargs))
 
     def __mod__(self, other, **kwargs):
-        return EDecimal(Decimal.__mod__(self, other, **kwargs))
+        return EDecimal(Decimal.__mod__(self, Decimal(other), **kwargs))
+
+    def __rmod__(self, other, **kwargs):
+        return EDecimal(Decimal.__rmod__(self, Decimal(other), **kwargs))
 
     def __divmod__(self, other, **kwargs):
-        return EDecimal(Decimal.__divmod__(self, other, **kwargs))
+        return EDecimal(Decimal.__divmod__(self, Decimal(other), **kwargs))
+
+    def __rdivmod__(self, other, **kwargs):
+        return EDecimal(Decimal.__rdivmod__(self, Decimal(other), **kwargs))
 
     def __pow__(self, other, **kwargs):
-        return EDecimal(Decimal.__pow__(self, other, **kwargs))
+        return EDecimal(Decimal.__pow__(self, Decimal(other), **kwargs))
+
+    def __rpow__(self, other, **kwargs):
+        return EDecimal(Decimal.__rpow__(self, Decimal(other), **kwargs))
 
     def __eq__(self, other, **kwargs):
         return super(EDecimal, self).__eq__(other) or float(self) == other

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -54,7 +54,8 @@ def issubtype(x, t):
 class EDecimal(Decimal):
     """Extended Decimal
 
-    This implements arithmetic and comparison with float for backward compatibility
+    This implements arithmetic and comparison with float for
+    backward compatibility
     """
 
     def __add__(self, other, **kwargs):


### PR DESCRIPTION
### Fix broken arithmetic with Packet.time due to the introduction of `EDecimal` in b3bfc9b (#2352)

This pull request fixes arithmetic involving `Packet.time` and `float` values, that broke as a result of #2352, which introduced the class `EDecimal`.
To fix the problems any other value is converted to `Decimal` before calling the corresponding operator function of `Decimal`. In addition the appropriate functions for right values have been inserted.

`run_tests_py2` and `run_tests_py3` show the same number of passes/fails as for the commit before (dcfb63d0).

fixes #2433
