### PR TITLE
Fixing LLDP MAC Address Bug

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -501,7 +501,12 @@ class MACField(Field):
     def i2m(self, pkt, x):
         if x is None:
             return b"\0\0\0\0\0\0"
-        return mac2str(x)
+        try:
+            x = mac2str(x)
+        except (struct.error, OverflowError):
+            x = bytes_encode(x)
+
+        return x
 
     def m2i(self, pkt, x):
         return str2mac(x)

--- a/test/contrib/lldp.uts
+++ b/test/contrib/lldp.uts
@@ -288,3 +288,17 @@ assert(org_spec_layer._type == 127)
 assert(org_spec_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO)
 assert(org_spec_layer.subtype == 0x42)
 assert(org_spec_layer._length == 34)
+
+l="A" * 24
+c=LLDPDUChassisID.SUBTYPE_CHASSIS_COMPONENT
+p=LLDPDUPortID.SUBTYPE_MAC_ADDRESS
+frm = Ether(dst=LLDP_NEAREST_BRIDGE_MAC)/  \
+    LLDPDUChassisID(subtype=c, id=l)/      \
+    LLDPDUPortID(subtype=p, id=l)/         \
+    LLDPDUTimeToLive(ttl=2)/               \
+    LLDPDUEndOfLLDPDU()
+
+try:
+    frm = frm.build()
+except:
+    assert False


### PR DESCRIPTION
There exists a bug in LLDP where invalid MAC
addresses throw an exception instead of allow
the value, as was the behavior in previous versions

Included in this commit is an LLDP unit test that
should cover this condition.

This is just a checklist to guide you. You can remove it safely.

This is being submitted as a draft to solicit feedback from maintainers.
