### PR TITLE
Add a unit test format to get the output directly (live)

### DIFF
--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -121,11 +121,42 @@ def autorun_get_interactive_session(cmds, **kargs):
     return sw.s, res
 
 
+def autorun_get_interactive_live_session(cmds, **kargs):
+    """Create an interactive session and execute the
+    commands passed as "cmds" and return all output
+
+    :param cmds: a list of commands to run
+    :returns: (output, returned) contains both sys.stdout and sys.stderr logs
+    """
+    sstdout, sstderr = sys.stdout, sys.stderr
+    sw = StringWriter(debug=sstdout)
+    try:
+        try:
+            sys.stdout = sys.stderr = sw
+            res = autorun_commands(cmds, **kargs)
+        except StopAutorun as e:
+            e.code_run = sw.s
+            raise
+    finally:
+        sys.stdout, sys.stderr = sstdout, sstderr
+    return sw.s, res
+
+
 def autorun_get_text_interactive_session(cmds, **kargs):
     ct = conf.color_theme
     try:
         conf.color_theme = NoTheme()
         s, res = autorun_get_interactive_session(cmds, **kargs)
+    finally:
+        conf.color_theme = ct
+    return s, res
+
+
+def autorun_get_live_interactive_session(cmds, **kargs):
+    ct = conf.color_theme
+    try:
+        conf.color_theme = DefaultTheme()
+        s, res = autorun_get_interactive_live_session(cmds, **kargs)
     finally:
         conf.color_theme = ct
     return s, res

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -150,6 +150,7 @@ class Format(EnumClass):
     HTML = 3
     LATEX = 4
     XUNIT = 5
+    LIVE = 6
 
 
 #    TEST CLASSES    #
@@ -697,7 +698,7 @@ def campaign_to_LATEX(test_campaign):
 #### USAGE ####
 
 def usage():
-    print("""Usage: UTscapy [-m module] [-f {text|ansi|HTML|LaTeX}] [-o output_file]
+    print("""Usage: UTscapy [-m module] [-f {text|ansi|HTML|LaTeX|live}] [-o output_file]
                [-t testfile] [-T testfile] [-k keywords [-k ...]] [-K keywords [-K ...]]
                [-l] [-b] [-d|-D] [-F] [-q[q]] [-P preexecute_python_code]
                [-c configfile]
@@ -776,6 +777,8 @@ def execute_campaign(TESTFILE, OUTPUTFILE, PREEXEC, NUM, KW_OK, KW_KO, DUMP,
         output = campaign_to_LATEX(test_campaign)
     elif FORMAT == Format.XUNIT:
         output = campaign_to_xUNIT(test_campaign)
+    elif FORMAT == Format.LIVE:
+        output = ""
 
     return output, (result == 0), test_campaign
 
@@ -934,6 +937,7 @@ def main():
         Format.HTML: scapy.autorun_get_html_interactive_session,
         Format.LATEX: scapy.autorun_get_latex_interactive_session,
         Format.XUNIT: scapy.autorun_get_text_interactive_session,
+        Format.LIVE: scapy.autorun_get_live_interactive_session,
     }
 
     if VERB > 2:


### PR DESCRIPTION
Add a new Format option to UTScapy in order to be able to get the output of the tests still to stdout, while the tests are running. This helps me during debugging of long running jobs.
In my laboratory I use UTScapy to run hardware in the loop tests against ECUs. Such tests can take multiple days, sometimes.