### PR TITLE
Add 'drop to interpreter' option for UTScapy.

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -485,6 +485,7 @@ def import_UTscapy_tools(ses):
     ses["retry_test"] = retry_test
     ses["Bunch"] = Bunch
 
+
 def run_campaign(test_campaign, get_interactive_session, drop_to_interpreter=False, verb=3, ignore_globals=None):  # noqa: E501
     passed = failed = 0
     scapy_ses = importlib.import_module(".all", "scapy").__dict__

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -724,7 +724,7 @@ def usage():
 -D\t\t: dump campaign and stop
 -C\t\t: don't calculate CRC and SHA
 -c\t\t: load a .utsc config file
--i\t\t: drop into python interpreter if test failed
+-i\t\t: drop into Python interpreter if test failed
 -q\t\t: quiet mode
 -qq\t\t: [silent mode]
 -x\t\t: use pyannotate


### PR DESCRIPTION
This allows the investigation of a failed unit-test right away. All
locals are preserved and passed to an interpreter for manual retesting.