### PR TITLE
Refactoring automotive tests

### DIFF
--- a/test/contrib/automotive/ccp.uts
+++ b/test/contrib/automotive/ccp.uts
@@ -1035,8 +1035,8 @@ assert dto.MTA0_address == 0xffffffff
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/automotive/ccp.uts
+++ b/test/contrib/automotive/ccp.uts
@@ -17,28 +17,28 @@ iface1 = "vcan1"
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")

--- a/test/contrib/automotive/ecu_am.uts
+++ b/test/contrib/automotive/ecu_am.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import threading, six, subprocess
+import os, threading, six, subprocess, sys
 from subprocess import call
 from scapy.consts import LINUX
 
@@ -18,8 +18,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -49,8 +48,6 @@ if 0 != call(["cansend", iface1,  "000#"]):
 
 if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
-
-print("CAN should work now")
 
 print("CAN should work now")
 
@@ -546,8 +543,8 @@ conf.contribs['UDS']['treat-response-pending-as-answer'] = False
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/automotive/ecu_am.uts
+++ b/test/contrib/automotive/ecu_am.uts
@@ -97,9 +97,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/automotive/ecu_am.uts
+++ b/test/contrib/automotive/ecu_am.uts
@@ -26,29 +26,31 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
+
+print("CAN should work now")
 
 print("CAN should work now")
 
@@ -93,24 +95,25 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin = subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
 
 = Import isotp
+
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -26,28 +26,28 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -94,15 +94,15 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin = subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -111,7 +111,7 @@ if p.wait() == 0:
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -98,9 +98,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import threading, six, subprocess, time
+import os, threading, six, subprocess, time, sys
 from subprocess import call
 from scapy.consts import LINUX
 
@@ -18,8 +18,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -1305,8 +1304,8 @@ thread.join(timeout=5)
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -96,9 +96,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -26,29 +26,31 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
+
+print("CAN should work now")
 
 = Import CANSocket
 
@@ -90,25 +92,24 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin = subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
 
 = Import isotp
-
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import six, subprocess
+import os, six, subprocess, sys
 from subprocess import call
 from scapy.consts import LINUX
 
@@ -18,8 +18,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -330,8 +329,8 @@ assert unsupported[1][1] == bytes(s1_pid01)
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -97,10 +97,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    r = p.wait()
-    if r == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import threading, six, subprocess
+import os, threading, six, subprocess, sys
 from subprocess import call
 from scapy.consts import LINUX
 
@@ -18,8 +18,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -207,8 +206,8 @@ assert res_c == ('ExtendedDiagnosticSession', '0x2f: InputOutputControlByIdentif
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -26,28 +26,28 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -93,15 +93,16 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    r = p.wait()
+    if r == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -110,7 +111,7 @@ if p.wait() == 0:
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket

--- a/test/contrib/cansocket.uts
+++ b/test/contrib/cansocket.uts
@@ -293,8 +293,8 @@ threadSender.join()
 
 = Delete vcan interfaces
 
-if 0 != call("sudo ip link delete %s" % "vcan0", shell=True):
-        raise Exception("%s could not be deleted" % "vcan0")
+if 0 != call(["sudo", "ip" ,"link", "delete", "vcan0"]):
+        raise Exception("vcan0 could not be deleted")
 
-if 0 != call("sudo ip link delete %s" % "vcan1", shell=True):
-        raise Exception("%s could not be deleted" % "vcan1")
+if 0 != call(["sudo", "ip" ,"link", "delete", "vcan1"]):
+        raise Exception("vcan1 could not be deleted")

--- a/test/contrib/cansocket_native.uts
+++ b/test/contrib/cansocket_native.uts
@@ -764,8 +764,8 @@ threadBridge.join(timeout=5)
 
 = Delete vcan interfaces
 
-if 0 != call("sudo ip link delete %s" % "vcan0", shell=True):
-        raise Exception("%s could not be deleted" % "vcan0")
+if 0 != call(["sudo", "ip", "link", "delete", "vcan0"]):
+        raise Exception("vcan0 could not be deleted")
 
-if 0 != call("sudo ip link delete %s" % "vcan1", shell=True):
-        raise Exception("%s could not be deleted" % "vcan1")
+if 0 != call(["sudo", "ip", "link", "delete", "vcan1"]):
+        raise Exception("vcan1 could not be deleted")

--- a/test/contrib/cansocket_python_can.uts
+++ b/test/contrib/cansocket_python_can.uts
@@ -661,8 +661,8 @@ sock1.close()
 = Delete vcan interfaces
 ~ needs_root linux vcan_socket
 
-if 0 != call("sudo ip link delete %s" % "vcan0", shell=True):
-        raise Exception("%s could not be deleted" % "vcan0")
+if 0 != call(["sudo", "ip" ,"link", "delete", "vcan0"]):
+        raise Exception("vcan0 could not be deleted")
 
-if 0 != call("sudo ip link delete %s" % "vcan1", shell=True):
-        raise Exception("%s could not be deleted" % "vcan1")
+if 0 != call(["sudo", "ip" ,"link", "delete", "vcan1"]):
+        raise Exception("vcan1 could not be deleted")

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -129,9 +129,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -68,28 +68,28 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -125,15 +125,15 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin = subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -1755,9 +1755,9 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x644, did=0x244, exte
 exit_if_no_isotp_module()
 
 isotp = ISOTP(data=bytearray(range(1,20)))
-cmd = "isotprecv -s 243 -d 643 -b 3 %s" % iface0
-print(cmd)
-p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+cmd = ["isotprecv", "-s", "243", "-d", "643", "-b", "3", iface0]
+print(" ".join(cmd))
+p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 time.sleep(0.1)
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x643, did=0x243) as s:
     s.send(isotp)
@@ -1783,9 +1783,9 @@ assert(result_data == isotp.data)
 = Compatibility with isotprecv - extended addresses
 exit_if_no_isotp_module()
 isotp = ISOTP(data=bytearray(range(1,20)))
-cmd = "isotprecv -s 245 -d 645 -b 3 %s -x ee:aa" % iface0
-print(cmd)
-p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+cmd = ["isotprecv", "-s245", "-d645", "-b3", "-x", "ee:aa", iface0]
+print(" ".join(cmd))
+p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 time.sleep(0.1)  # Give some time for starting reception
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x645, did=0x245, extended_addr=0xaa, extended_rx_addr=0xee) as s:
     s.send(isotp)

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import threading, six, subprocess
+import os, threading, six, subprocess, sys
 from six.moves.queue import Queue
 from subprocess import call
 from io import BytesIO
@@ -60,8 +60,7 @@ else:
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -1728,9 +1727,9 @@ exit_if_no_isotp_module()
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242) as s:
-    cmd = "echo \"%s\" | isotpsend -s 242 -d 642 %s" % (message, iface0)
-    print(cmd)
-    r = subprocess.call(cmd, shell=True)
+    p = subprocess.Popen(["isotpsend", "-s", "242", "-d", "642", iface0], stdin=subprocess.PIPE, universal_newlines=True)
+    p.communicate(message)
+    r = p.returncode
     print("returncode is %d" % r)
     assert(r == 0)
     isotp = s.recv()
@@ -1742,9 +1741,9 @@ exit_if_no_isotp_module()
 message = "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14"
 
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x644, did=0x244, extended_addr=0xaa, extended_rx_addr=0xee) as s:
-    cmd = "echo \"%s\" | isotpsend -s 244 -d 644 %s -x ee:aa" % (message, iface0)
-    print(cmd)
-    r = subprocess.call(cmd, shell=True)
+    p = subprocess.Popen(["isotpsend", "-s", "244", "-d", "644", "-x", "ee:aa", iface0], stdin=subprocess.PIPE, universal_newlines=True)
+    p.communicate(message)
+    r = p.returncode
     print("returncode is %d" % r)
     assert(r == 0)
     isotp = s.recv()
@@ -2364,8 +2363,8 @@ s = None
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -99,9 +99,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -6,7 +6,7 @@
 = Imports
 load_layer("can")
 conf.contribs['CAN']['swap-bytes'] = False
-import threading, six, subprocess
+import os, threading, six, subprocess, sys
 from subprocess import call
 from scapy.contrib.isotp import send_multiple_ext, filter_periodic_packets, scan, scan_extended
 from scapy.consts import LINUX
@@ -20,8 +20,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 
@@ -189,8 +188,7 @@ def test_dynamic(f):
             return True
         except AssertionError as e:
             if t < 10:
-                err = "Test failed. Automatically increase sniff time and retry."
-                subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+                sys.stderr.write("Test failed. Automatically increase sniff time and retry." + os.linesep)
             else:
                 raise e
     return False
@@ -788,8 +786,8 @@ test_dynamic(test_isotpscan_none_random_ids_padding)
 = Delete vcan interfaces
 ~ vcan_socket needs_root linux
 
-if 0 != call("sudo ip link delete %s" % iface0, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface0]):
         raise Exception("%s could not be deleted" % iface0)
 
-if 0 != call("sudo ip link delete %s" % iface1, shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", iface1]):
         raise Exception("%s could not be deleted" % iface1)

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -10,8 +10,6 @@ import threading, six, subprocess
 from subprocess import call
 from scapy.contrib.isotp import send_multiple_ext, filter_periodic_packets, scan, scan_extended
 from scapy.consts import LINUX
-import sys
-import os
 
 = Definition of constants, utility functions
 
@@ -30,28 +28,28 @@ def exit_if_no_isotp_module():
 
 = Initialize a virtual CAN interface
 ~ vcan_socket needs_root linux
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -97,15 +95,15 @@ s.close()
 
 = Check if can-isotp and can-utils are installed on this system
 ~ linux
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout = subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin = subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -114,7 +112,7 @@ if p.wait() == 0:
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket
@@ -122,6 +120,7 @@ else:
     from scapy.contrib.isotp import ISOTPSoftSocket
     ISOTPSocket = ISOTPSoftSocket
     assert ISOTPSocket == ISOTPSoftSocket
+
 
 = Test send_multiple_ext()
 

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -26,28 +26,28 @@ def exit_if_no_isotp_module():
 
 
 = Initialize a virtual CAN interface
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -63,12 +63,12 @@ if "python_can" in CANSocket.__module__:
     new_can_socket = lambda iface: CANSocket(bustype='socketcan', channel=iface)
     new_can_socket0 = lambda: CANSocket(bustype='socketcan', channel=iface0, timeout=0.01)
     new_can_socket1 = lambda: CANSocket(bustype='socketcan', channel=iface1, timeout=0.01)
-    can_socket_string = "-i socketcan -c %s -a bitrate=250000" % iface0
+    can_socket_string_list = ["-i", "socketcan", "-c", iface0, "-a", "bitrate=250000"]
 else:
     new_can_socket = lambda iface: CANSocket(iface)
     new_can_socket0 = lambda: CANSocket(iface0)
     new_can_socket1 = lambda: CANSocket(iface1)
-    can_socket_string = "-c %s" % iface0
+    can_socket_string_list = ["-c", iface0]
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
@@ -86,15 +86,16 @@ s.close()
 
 
 = Check if can-isotp and can-utils are installed on this system
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout=subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin=subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    r = p.wait()
+    if r == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -103,12 +104,14 @@ if p.wait() == 0:
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': False}
 load_contrib("isotp")
 
+ISOTPSocket = ISOTPSoftSocket
+
 
 + Usage tests
 
 = Test wrong usage
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 
 std_out, std_err = result.communicate()
@@ -124,34 +127,31 @@ assert expected_output in plain_str(std_err)
 
 = Test show help
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py --help" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-if result.wait() == 0:
-    std_out, std_err = result.communicate()
-    assert std_err == None
-    expected_output = plain_str(b'Scan for open ISOTP-Sockets.')
-    print(std_out)
-    assert expected_output in plain_str(std_out)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+assert result.wait() == 0
+std_out, std_err = result.communicate()
+assert not std_err
+expected_output = plain_str(b'Scan for open ISOTP-Sockets.')
+print(std_out)
+assert expected_output in plain_str(std_out)
 
 
 = Test wrong socket for Python2 or Windows
 
 if six.PY2:
-    version = subprocess.Popen("python --version", stdout=subprocess.PIPE, shell=True)
+    version = subprocess.Popen(["python2", "--version"], stdout=subprocess.PIPE)
     if 0 == version.wait():
         print(version.communicate())
-    result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -c %s -s 0x600 -e 0x600" % (sys.executable, iface0), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    if result.wait() == 0:
-        expected_output = plain_str(b'Wrong interface')
-        std_out, std_err = result.communicate()
-        assert std_err == None
-        print(std_out)
-        print(expected_output)
-        assert expected_output in plain_str(std_out)
+    result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-c", iface0, "-s", "0x600", "-e", "0x600"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.wait() == 1
+    expected_output = plain_str(b'Please provide all required arguments.')
+    std_out, std_err = result.communicate()
+    assert expected_output in plain_str(std_err)
 
 
 = Test Python2 call
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -i socketcan -c %s -s 0x600 -e 0x600 -v" % (sys.executable, iface0), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 print(returncode)
 expected_output = plain_str(b'Start scan')
@@ -164,7 +164,7 @@ assert expected_output in plain_str(std_out)
 
 = Test Python2 call with one python-can arg
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -i socketcan -c %s -a bitrate=500000 -s 0x600 -e 0x600 -v" % (sys.executable, iface0), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "-a", "bitrate=500000", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 print(returncode)
 expected_output = plain_str(b'Start scan')
@@ -178,7 +178,7 @@ assert expected_output in plain_str(std_out)
 
 = Test Python2 call with multiple python-can args
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -i socketcan -c %s -a 'bitrate=500000 receive_own_messages=True' -s 0x600 -e 0x600 -v" % (sys.executable, iface0), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "-a", "bitrate=500000 receive_own_messages=True", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 print(returncode)
 expected_output = plain_str(b'Start scan')
@@ -191,7 +191,7 @@ assert expected_output in plain_str(std_out)
 
 = Test Python2 call with multiple python-can args 2
 
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py -i socketcan -c %s --python-can_args 'bitrate=500000, receive_own_messages=True' -s 0x600 -e 0x600 -v" % (sys.executable, iface0), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "--python-can_args", "bitrate=500000 receive_own_messages=True", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 print(returncode)
 expected_output = plain_str(b'Start scan')
@@ -217,7 +217,7 @@ def isotpserver():
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
 started.wait(timeout=10)
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x600 -e 0x600" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x600", "-e", "0x600"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 std_out, std_err = result.communicate()
 
@@ -245,7 +245,7 @@ def isotpserver():
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
 started.wait(timeout=10)
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
 send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
@@ -273,7 +273,7 @@ def isotpserver():
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
 started.wait(timeout=10)
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
 send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
@@ -302,7 +302,7 @@ def isotpserver():
 sniffer = threading.Thread(target=isotpserver)
 sniffer.start()
 started.wait(timeout=10)
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/isotpscanner.py %s -s 0x601 -e 0x601 -x -C" % (sys.executable, can_socket_string), stdout=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x", "-C"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
 send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
@@ -323,9 +323,8 @@ for out in expected_output:
 
 = Cleanup
 
-if 0 != call("sudo ip link delete vcan0", shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", "vcan0"]):
         raise Exception("vcan0 could not be deleted")
 
-if 0 != call("sudo ip link delete vcan1", shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", "vcan1"]):
         raise Exception("vcan1 could not be deleted")
-

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -7,7 +7,7 @@
 
 = Imports
 load_layer("can")
-import threading, six, subprocess, sys
+import os, threading, six, subprocess, sys
 from subprocess import call
 
 
@@ -19,8 +19,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        err = "TEST SKIPPED: can-isotp not available"
-        subprocess.call("printf \"%s\r\n\" > /dev/stderr" % err, shell=True)
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -90,10 +90,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    r = p.wait()
-    if r == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
@@ -111,14 +109,13 @@ ISOTPSocket = ISOTPSoftSocket
 = Test wrong usage
 
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-returncode = result.wait()
 
 std_out, std_err = result.communicate()
-if returncode:
+if result.returncode:
     print(std_out)
     print(std_err)
 
-assert returncode != 0
+assert result.returncode != 0
 
 expected_output = plain_str(b'usage:')
 assert expected_output in plain_str(std_err)
@@ -220,8 +217,8 @@ result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.
 returncode = result.wait()
 std_out, std_err = result.communicate()
 
-send = subprocess.Popen(['cansend', iface0, '600#01aa'])
-assert 0 == send.wait()
+send_returncode = subprocess.call(['cansend', iface0, '600#01aa'])
+assert 0 == send_returncode
 assert returncode == 0
 
 sniffer.join(timeout=10)
@@ -247,8 +244,8 @@ started.wait(timeout=10)
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
-send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
-assert 0 == send.wait()
+send_returncode = subprocess.call(['cansend', iface0, '601#BB01aa'])
+assert 0 == send_returncode
 assert returncode == 0
 
 expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
@@ -275,8 +272,8 @@ started.wait(timeout=10)
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
-send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
-assert 0 == send.wait()
+send_returncode = subprocess.call(['cansend', iface0, '601#BB01aa'])
+assert 0 == send_returncode
 assert returncode == 0
 
 expected_output = [b'0x601', b'0xbb', b'0x700', b'0xaa']
@@ -304,8 +301,8 @@ started.wait(timeout=10)
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py"] + can_socket_string_list + ["-s", "0x601", "-e", "0x601", "-x", "-C"], stdout=subprocess.PIPE)
 returncode = result.wait()
 
-send = subprocess.Popen(['cansend', iface0, '601#BB01aa'])
-assert 0 == send.wait()
+send_returncode = subprocess.call(['cansend', iface0, '601#BB01aa'])
+assert 0 == send_returncode
 assert returncode == 0
 
 expected_output = [b'sid=0x601', b'did=0x700', b'padding=False', b'extended_addr=0xbb', b'extended_rx_addr=0xaa']

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -86,9 +86,8 @@ p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1
 p1.stdout.close()
 if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
     p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
-    p.stdin.write(b"01")
-    p.stdin.close()
-    if p.wait() == 0:
+    p.communicate(b"01")
+    if p.returncode == 0:
         ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -27,28 +27,28 @@ def exit_if_no_isotp_module():
 
 
 = Initialize a virtual CAN interface
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     # vcan0 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface0, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface0)
-    if 0 != call("sudo ip link set dev %s up" % iface0, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface0, "up"]):
         raise Exception("could not bring up %s" % iface0)
 
-if 0 != call("cansend %s 000#" % iface0, shell=True):
+if 0 != call(["cansend", iface0,  "000#"]):
     raise Exception("cansend doesn't work")
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     # vcan1 is not enabled
-    if 0 != call("sudo modprobe vcan", shell=True):
+    if 0 != call(["sudo", "modprobe", "vcan"]):
         raise Exception("modprobe vcan failed")
-    if 0 != call("sudo ip link add name %s type vcan" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "add", "name", iface1, "type", "vcan"]):
         print("add %s failed: Maybe it was already up?" % iface1)
-    if 0 != call("sudo ip link set dev %s up" % iface1, shell=True):
+    if 0 != call(["sudo", "ip", "link", "set", "dev", iface1, "up"]):
         raise Exception("could not bring up %s" % iface1)
 
-if 0 != call("cansend %s 000#" % iface1, shell=True):
+if 0 != call(["cansend", iface1,  "000#"]):
     raise Exception("cansend doesn't work")
 
 print("CAN should work now")
@@ -64,12 +64,12 @@ if "python_can" in CANSocket.__module__:
     new_can_socket = lambda iface: CANSocket(bustype='socketcan', channel=iface)
     new_can_socket0 = lambda: CANSocket(bustype='socketcan', channel=iface0, timeout=0.01)
     new_can_socket1 = lambda: CANSocket(bustype='socketcan', channel=iface1, timeout=0.01)
-    can_socket_string = "-i socketcan -c %s" % iface0
+    can_socket_string_list = ["-i", "socketcan", "-c", iface0]
 else:
     new_can_socket = lambda iface: CANSocket(iface)
     new_can_socket0 = lambda: CANSocket(iface0)
     new_can_socket1 = lambda: CANSocket(iface1)
-    can_socket_string = "-c %s" % iface0
+    can_socket_string_list = ["-c", iface0]
 
 # utility function for draining a can interface, asserting that no packets are there
 def drain_bus(iface=iface0, assert_empty=True):
@@ -84,15 +84,15 @@ s.close()
 
 
 = Check if can-isotp and can-utils are installed on this system
-p = subprocess.Popen('lsmod | grep "^can_isotp"', stdout=subprocess.PIPE, shell=True)
-if p.wait() == 0:
-    if b"can_isotp" in p.stdout.read():
-        p = subprocess.Popen("isotpsend -s1 -d0 %s" % iface0, stdin=subprocess.PIPE, shell=True)
-        p.stdin.write(b"01")
-        p.stdin.close()
-        r = p.wait()
-        if r == 0:
-            ISOTP_KERNEL_MODULE_AVAILABLE = True
+p1 = subprocess.Popen(['lsmod'], stdout = subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '^can_isotp'], stdout = subprocess.PIPE, stdin=p1.stdout)
+p1.stdout.close()
+if p1.wait() == 0 and p2.wait() == 0 and b"can_isotp" in p2.stdout.read():
+    p = subprocess.Popen(["isotpsend", "-s1", "-d0", iface0], stdin = subprocess.PIPE)
+    p.stdin.write(b"01")
+    p.stdin.close()
+    if p.wait() == 0:
+        ISOTP_KERNEL_MODULE_AVAILABLE = True
 
 
 + Syntax check
@@ -101,7 +101,7 @@ if p.wait() == 0:
 conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
 load_contrib("isotp")
 
-if ISOTP_KERNEL_MODULE_AVAILABLE:
+if six.PY3 and ISOTP_KERNEL_MODULE_AVAILABLE:
     from scapy.contrib.isotp import ISOTPNativeSocket
     ISOTPSocket = ISOTPNativeSocket
     assert ISOTPSocket == ISOTPNativeSocket
@@ -115,7 +115,7 @@ else:
 
 = Test wrong usage
 print(sys.executable)
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
 
 std_out, std_err = result.communicate()
@@ -130,32 +130,29 @@ assert expected_output in plain_str(std_err)
 
 
 = Test show help
-result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py --help" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-if result.wait() == 0:
-    std_out, std_err = result.communicate()
-    assert std_err == None
-    expected_output = plain_str(b'Scan for open ISOTP-Sockets.')
-    print(std_out)
-    assert expected_output in plain_str(std_out)
+result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py", "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+assert result.wait() == 0
+std_out, std_err = result.communicate()
+assert not std_err
+expected_output = plain_str(b'Scan for all possible obd service classes and their subfunctions.')
+print(std_out)
+assert expected_output in plain_str(std_out)
 
 
 = Test wrong socket for Python2 or Windows
 if six.PY2:
-    version = subprocess.Popen("python --version", stdout=subprocess.PIPE, shell=True)
+    version = subprocess.Popen(["python2", "--version"], stdout=subprocess.PIPE)
     if 0 == version.wait():
         print(version.communicate())
-    result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py -c vcan0 -s 0x600 -d 0x601" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    if result.wait() == 0:
-        expected_output = plain_str(b'Wrong interface')
-        std_out, std_err = result.communicate()
-        assert std_err == None
-        print(std_out)
-        print(expected_output)
-        assert expected_output in plain_str(std_out)
+    result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py", "-c", "vcan0", "-s", "0x600", "-d", "0x601"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.wait() == 1
+    expected_output = plain_str(b'Please provide all required arguments.')
+    std_out, std_err = result.communicate()
+    assert expected_output in plain_str(std_err)
 
 = Test Python2 call
 if six.PY2:
-    result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py -i socketcan -c vcan0 -s 0x600 -d 0x601 -v" % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py", "-i", "socketcan", "-c", "vcan0", "-s", "0x600", "-d", "0x601", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     returncode = result.wait()
     std_out, std_err = result.communicate()
     print(returncode)
@@ -167,7 +164,7 @@ if six.PY2:
 
 = Test Python2 call with python-can args
 if six.PY2:
-    result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py -i socketcan -c vcan0 -s 0x600 -d 0x601 -v -a 'bitrate=250000' " % sys.executable, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py", "-i", "socketcan", "-c", "vcan0", "-s", "0x600", "-d", "0x601", "-v", "-a", "bitrate=250000"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     returncode = result.wait()
     std_out, std_err = result.communicate()
     print(returncode)
@@ -181,9 +178,6 @@ if six.PY2:
 
 = Load contribution layer
 load_contrib('automotive.obd.obd')
-
-conf.contribs['ISOTP'] = {'use-can-isotp-kernel-module': ISOTP_KERNEL_MODULE_AVAILABLE}
-load_contrib('isotp')
 
 + Simulate scanner
 
@@ -200,8 +194,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
     sim = threading.Thread(target=answering_machine, kwargs={'count': 3, 'timeout': 10, 'stop_filter': lambda p: p.service == 0xff})
     sim.start()
     try:
-        result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py %s -s 0x7e0 -d 0x7e8 -t 0.05" % (
-        sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py"] + can_socket_string_list + ["-s", "0x7e0", "-d", "0x7e8", "-t", "0.05"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         std_out, std_err = result.communicate()
         if six.PY2:
             expected_output = b"Service 3:\nC\x01\x00\x00"
@@ -230,8 +223,8 @@ s1_pid0F = OBD()/OBD_S01_PR(data_records=[OBD_S01_PR_Record()/OBD_PID0F(data=50)
 
 # Create answers for 'supported PIDs scan'
 example_responses = \
-    [ECUResponse(session=range(0,255), security_level=0, responses=s3),
-     ECUResponse(session=range(0,255), security_level=0, responses=s1_pid00),
+    [ECUResponse(session=range(0, 255), security_level=0, responses=s3),
+     ECUResponse(session=range(0, 255), security_level=0, responses=s1_pid00),
      ECUResponse(session=range(0, 255), security_level=0, responses=s6_mid00),
      ECUResponse(session=range(0, 255), security_level=0, responses=s8_tid00),
      ECUResponse(session=range(0, 255), security_level=0, responses=s9_iid00),
@@ -246,8 +239,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
     sim = threading.Thread(target=answering_machine, kwargs={'count': 10, 'timeout': 10, 'stop_filter': lambda p: p.service == 0xff})
     sim.start()
     try:
-        result = subprocess.Popen("%s $PWD/scapy/tools/automotive/obdscanner.py %s -s 0x7e0 -d 0x7e8 -t 0.1 -r" % (
-        sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py"] + can_socket_string_list + ["-s", "0x7e0", "-d", "0x7e8", "-t", "0.1", "-r"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         std_out, std_err = result.communicate()
         assert std_err == b''
@@ -284,9 +276,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
     sim = threading.Thread(target=answering_machine, kwargs={'verbose': False, 'count': 1000, 'timeout': 50, 'stop_filter': lambda p: p.service == 0xff})
     sim.start()
     try:
-        result = subprocess.Popen(
-            "%s $PWD/scapy/tools/automotive/obdscanner.py %s -s 0x7e0 -d 0x7e8 -t 0.09 -ru" % (
-            sys.executable, can_socket_string), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        result = subprocess.Popen([sys.executable, "scapy/tools/automotive/obdscanner.py"] + can_socket_string_list + ["-s", "0x7e0", "-d", "0x7e8", "-t", "0.09", "-ru"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         std_out, std_err = result.communicate()
         assert std_err == b''
@@ -320,8 +310,8 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
 
 = Cleanup
 
-if 0 != call("sudo ip link delete vcan0", shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", "vcan0"]):
         raise Exception("vcan0 could not be deleted")
 
-if 0 != call("sudo ip link delete vcan1", shell=True):
+if 0 != call(["sudo", "ip", "link", "delete", "vcan1"]):
         raise Exception("vcan1 could not be deleted")

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -6,12 +6,9 @@
 
 = Imports
 load_layer("can")
-import six, subprocess, sys
+import os, six, subprocess, sys
 from subprocess import call
 from scapy.contrib.automotive.ecu import *
-
-def eprint(*args, **kwargs):
-    subprocess.call("printf \"%s\r\n\" > /dev/stderr" % args, shell=True, **kwargs)
 
 = Definition of constants, utility functions and mock classes
 iface0 = "vcan0"
@@ -21,7 +18,7 @@ iface1 = "vcan1"
 ISOTP_KERNEL_MODULE_AVAILABLE = False
 def exit_if_no_isotp_module():
     if not ISOTP_KERNEL_MODULE_AVAILABLE:
-        eprint("TEST SKIPPED: can-isotp not available")
+        sys.stderr.write("TEST SKIPPED: can-isotp not available" + os.linesep)
         warning("Can't test ISOTP native socket because kernel module is not loaded")
         exit(0)
 


### PR DESCRIPTION
@TabeaSpahn 
@polybassa 

Mainly visual refactoring but also:

- Do not set `ISOTPSocket` hardcoded before testing it. This would check the hardcoded set instead of the former import.
- Only check if ISOTPNativeSocket has been imported if Python3 is used. Python2 can never import the native version.