### PR TITLE
Linux - check if auxdata is available

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -31,7 +31,7 @@ from scapy.data import MTU, ETH_P_ALL, SOL_PACKET, SO_ATTACH_FILTER, \
     SO_TIMESTAMPNS
 from scapy.supersocket import SuperSocket
 from scapy.error import warning, Scapy_Exception, \
-    ScapyInvalidPlatformException
+    ScapyInvalidPlatformException, log_runtime
 from scapy.arch.common import get_if, compile_filter
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
@@ -472,7 +472,8 @@ class L2Socket(SuperSocket):
             except OSError:
                 # Note: Auxiliary Data is only supported since
                 #       Linux 2.6.21
-                warning("Your Linux Kernel does not support Auxiliary Data!")
+                msg = "Your Linux Kernel does not support Auxiliary Data!"
+                log_runtime.info(msg)
         if isinstance(self, L2ListenSocket):
             self.outs = None
         else:

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -461,12 +461,18 @@ class L2Socket(SuperSocket):
         )
         if not six.PY2:
             # Receive Auxiliary Data (VLAN tags)
-            self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
-            self.ins.setsockopt(
-                socket.SOL_SOCKET,
-                SO_TIMESTAMPNS,
-                1
-            )
+            try:
+                self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
+                self.ins.setsockopt(
+                    socket.SOL_SOCKET,
+                    SO_TIMESTAMPNS,
+                    1
+                )
+                self.auxdata_available = True
+            except OSError:
+                # Note: Auxiliary Data is only supported since
+                #       Linux 2.6.21
+                warning("Your Linux Kernel does not support Auxiliary Data!")
         if isinstance(self, L2ListenSocket):
             self.outs = None
         else:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -61,6 +61,7 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
     closed = 0
     nonblocking_socket = False
     read_allowed_exceptions = ()
+    auxdata_available = False
 
     def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):  # noqa: E501
         self.ins = socket.socket(family, type, proto)
@@ -85,16 +86,26 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
             """Internal function to receive a Packet,
             and process ancillary data.
             """
-            flags_len = socket.CMSG_LEN(4096)
             timestamp = None
+            if not self.auxdata_available:
+                pkt, _, _, sa_ll = sock.recvmsg(x)
+                return pkt, sa_ll, timestamp
+            flags_len = socket.CMSG_LEN(4096)
             pkt, ancdata, flags, sa_ll = sock.recvmsg(x, flags_len)
             if not pkt:
-                return pkt, sa_ll
+                return pkt, sa_ll, timestamp
             for cmsg_lvl, cmsg_type, cmsg_data in ancdata:
                 # Check available ancillary data
                 if (cmsg_lvl == SOL_PACKET and cmsg_type == PACKET_AUXDATA):
                     # Parse AUXDATA
-                    auxdata = tpacket_auxdata.from_buffer_copy(cmsg_data)
+                    try:
+                        auxdata = tpacket_auxdata.from_buffer_copy(cmsg_data)
+                    except ValueError:
+                        # Note: according to Python documentation, recvmsg()
+                        #       can return a truncated message. A ValueError
+                        #       exception likely indicates that Auxiliary
+                        #       Data is not supported by the Linux kernel.
+                        return pkt, sa_ll, timestamp
                     if auxdata.tp_vlan_tci != 0 or \
                             auxdata.tp_status & TP_STATUS_VLAN_VALID:
                         # Insert VLAN tag
@@ -213,13 +224,19 @@ class L3RawSocket(SuperSocket):
         if iface is not None:
             self.ins.bind((iface, type))
         if not six.PY2:
-            # Receive Auxiliary Data (VLAN tags)
-            self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
-            self.ins.setsockopt(
-                socket.SOL_SOCKET,
-                SO_TIMESTAMPNS,
-                1
-            )
+            try:
+                # Receive Auxiliary Data (VLAN tags)
+                self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
+                self.ins.setsockopt(
+                    socket.SOL_SOCKET,
+                    SO_TIMESTAMPNS,
+                    1
+                )
+                self.auxdata_available = True
+            except OSError:
+                # Note: Auxiliary Data is only supported since
+                #       Linux 2.6.21
+                warning("Your Linux Kernel does not support Auxiliary Data!")
 
     def recv(self, x=MTU):
         pkt, sa_ll, ts = self._recv_raw(self.ins, x)

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -236,7 +236,8 @@ class L3RawSocket(SuperSocket):
             except OSError:
                 # Note: Auxiliary Data is only supported since
                 #       Linux 2.6.21
-                warning("Your Linux Kernel does not support Auxiliary Data!")
+                msg = "Your Linux Kernel does not support Auxiliary Data!"
+                log_runtime.info(msg)
 
     def recv(self, x=MTU):
         pkt, sa_ll, ts = self._recv_raw(self.ins, x)


### PR DESCRIPTION
This PR fixes #2447 and makes Scapy works on Linux kernel < 2.6.21 with Python3.

There are two issues:
1.  no auxdata support before Linux 2.6.21
2.  Python3 recvmsg() returns data when auxdata are not supported

