### PR TITLE
Port 80 is hard-coded in the tcp_client

### DIFF
--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -616,7 +616,7 @@ def http_request(host, path="/", port=80, timeout=3,
     }
     http_headers.update(headers)
     req = HTTP() / HTTPRequest(**http_headers)
-    tcp_client = TCP_client.tcplink(HTTP, host, 80)
+    tcp_client = TCP_client.tcplink(HTTP, host, port)
     ans = None
     try:
         ans = tcp_client.sr1(req, timeout=timeout, verbose=verbose)


### PR DESCRIPTION
Fix for https://github.com/secdev/scapy/issues/2461