### PR TITLE
Add support for tuples in pipetool.ConsoleSink.

### DIFF
--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -459,10 +459,10 @@ class ConsoleSink(Sink):
     """
 
     def push(self, msg):
-        print(">%r" % msg)
+        print(">" + repr(msg))
 
     def high_push(self, msg):
-        print(">>%r" % msg)
+        print(">>" + repr(msg))
 
 
 class RawConsoleSink(Sink):


### PR DESCRIPTION
Hi!

This PR fixes a small bug in ConsoleSink.

Now, we call repr(msg) instead of using "%r" % msg, as the latter triggers a
TypeError Exception when msg is a tuple ("not all arguments converted
during string formatting"). This happens when connecting the high
output of a TCPListenPipe to a ConsoleSink.

No unit tests added: there are already unit tests covering ConsoleSink.