### PR TITLE
Speedup Isotpscan, fix automotive unit tests [ready for merge]

### DIFF
--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -2018,7 +2018,7 @@ def scan_extended(sock, scan_range=range(0x800), scan_block_size=32,
             scan_range: hexadecimal range of IDs to scan.
                         Default is 0x0 - 0x7ff
             scan_block_size: count of packets send at once
-            extended_scan_range: range to search for extended ISOTP adresses
+            extended_scan_range: range to search for extended ISOTP addresses
             noise_ids: list of packet IDs which will not be considered when
                        received during scan
             sniff_time: time the scan waits for isotp flow control responses

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -1487,10 +1487,11 @@ class ISOTPSocketImplementation(automaton.SelectableObject):
             self.begin_send(p)
 
             # Wait until the tx callback is called
-            if not self.tx_done.wait(30):
-                raise Scapy_Exception("ISOTP send not completed in 30s")
+            send_done = self.tx_done.wait(30)
             if self.tx_exception is not None:
                 raise Scapy_Exception(self.tx_exception)
+            if not send_done:
+                raise Scapy_Exception("ISOTP send not completed in 30s")
             return
 
     def recv(self, timeout=None):

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1283,33 +1283,33 @@ assert (isotp.dst == 0x241)
 
 = Receive a two-frame ISOTP message
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
-    cans = new_can_socket(iface0)
-    cans.send(CAN(identifier = 0x241, data = dhex("10 0B 01 02 03 04 05 06")))
-    cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 10 11")))
+    with new_can_socket(iface0) as cans:
+        cans.send(CAN(identifier = 0x241, data = dhex("10 0B 01 02 03 04 05 06")))
+        cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 10 11")))
     isotp = s.recv()
     assert(isotp.data == dhex("01 02 03 04 05 06 07 08 09 10 11"))
 
 = Check what happens when a CAN frame with wrong identifier gets received
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
-    cans = new_can_socket(iface0)
-    cans.send(CAN(identifier = 0x141, data = dhex("05 01 02 03 04 05")))
+    with new_can_socket(iface0) as cans:
+        cans.send(CAN(identifier = 0x141, data = dhex("05 01 02 03 04 05")))
     assert(s.ins.rx_queue.empty())
 
 + Testing ISOTPSocket timeouts
 
 = Check if not sending the last CF will make the socket timeout
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
-    cans = new_can_socket(iface0)
-    cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
-    cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 0A 0B 0C 0D")))
+    with new_can_socket(iface0) as cans:
+        cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
+        cans.send(CAN(identifier = 0x241, data = dhex("21 07 08 09 0A 0B 0C 0D")))
     isotp = s.sniff(timeout=1)
 
 assert(len(isotp) == 0)
 
 = Check if not sending the first CF will make the socket timeout
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:
-    cans = new_can_socket(iface0)
-    cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
+    with new_can_socket(iface0) as cans:
+        cans.send(CAN(identifier = 0x241, data = dhex("10 11 01 02 03 04 05 06")))
     isotp = s.sniff(timeout=1)
 
 assert(len(isotp) == 0)
@@ -1647,9 +1647,9 @@ with new_can_socket0() as cs1, ISOTPSocket(cs1, sid=0x641, did=0x241) as s1, \
 
 = Send a single frame ISOTP message with padding
 with new_can_socket0() as cs1, ISOTPSocket(cs1, sid=0x641, did=0x241, padding=True) as s:
-    cans = new_can_socket(iface0)
-    s.send(ISOTP(data=dhex("01")))
-    res = cans.sniff(timeout=1, count=1)[0]
+    with new_can_socket(iface0) as cans:
+        s.send(ISOTP(data=dhex("01")))
+        res = cans.sniff(timeout=1, count=1)[0]
     assert(res.length == 8)
 
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1326,7 +1326,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s
         exception = ex
 
 print(exception)
-assert(str(exception) == "TX state was reset due to timeout")
+assert(str(exception) == "TX state was reset due to timeout" or str(exception) == "ISOTP send not completed in 30s")
 
 = Check if not sending the second FC will make the socket timeout
 exception = None

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -250,6 +250,7 @@ def test_scan_extended(sniff_time=0.02):
     semaphore.acquire()
     with new_can_socket0() as scansock:
         found_packets = scan_extended(scansock, [0x600, 0x601],
+                                      extended_scan_range=range(0xb0, 0xc0),
                                       sniff_time=sniff_time)
     with new_can_socket0() as cans:
         cans.send(CAN(identifier=0x601, data=b'\xbb\x01\xaa'))
@@ -406,6 +407,7 @@ def test_extended_isotpscan_code(sniff_time=0.02):
     thread_noise.start()
     with new_can_socket0() as scansock:
         result = ISOTPScan(scansock, range(0x5ff, 0x603 + 1),
+                           extended_scan_range=range(0x20, 0x30),
                            extended_addressing=True, sniff_time=sniff_time,
                            noise_listen_time=sniff_time * 6,
                            output_format="code",
@@ -449,6 +451,7 @@ def test_extended_isotpscan_code_extended_can_id(sniff_time=0.02):
     with new_can_socket0() as scansock:
         result = ISOTPScan(scansock, range(0x1ffff5ff, 0x1ffff604 + 1),
                            extended_can_id=True,
+                           extended_scan_range=range(0x20, 0x30),
                            extended_addressing=True,
                            sniff_time=sniff_time,
                            noise_listen_time=sniff_time * 6,
@@ -526,7 +529,7 @@ def test_isotpscan_none_2(sniff_time=0.02):
     def isotpserver(i):
         with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x700 + i,
                                                       did=0x600 + i) as s:
-            s.sniff(timeout=1500 * sniff_time, count=1,
+            s.sniff(timeout=1000 * sniff_time, count=1,
                     started_callback=semaphore.release)
     pkt = CAN(identifier=0x701, length=8,
               data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
@@ -540,7 +543,7 @@ def test_isotpscan_none_2(sniff_time=0.02):
     thread_noise.start()
     with new_can_socket0() as socks_interface:
         with new_can_socket0() as scansock:
-            result = ISOTPScan(scansock, range(0x607, 0x6A0),
+            result = ISOTPScan(scansock, range(0x607, 0x60A),
                                can_interface=socks_interface,
                                sniff_time=sniff_time,
                                noise_listen_time=sniff_time * 6,
@@ -575,7 +578,7 @@ def test_extended_isotpscan_none(sniff_time=0.02):
         with new_can_socket0() as isocan, \
                 ISOTPSocket(isocan, sid=0x700 + i, did=0x600 + i,
                             extended_addr=0x11, extended_rx_addr=0x22) as s:
-            s.sniff(timeout=1500 * sniff_time, count=1,
+            s.sniff(timeout=500 * sniff_time, count=1,
                     started_callback=semaphore.release)
     pkt = CAN(identifier=0x701, length=8,
               data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
@@ -590,6 +593,7 @@ def test_extended_isotpscan_none(sniff_time=0.02):
         thread_noise.start()
         with new_can_socket0() as scansock:
             result = ISOTPScan(scansock, range(0x5ff, 0x603 + 1),
+                               extended_scan_range=range(0x20, 0x30),
                                extended_addressing=True,
                                can_interface=socks_interface,
                                sniff_time=sniff_time,
@@ -597,14 +601,14 @@ def test_extended_isotpscan_none(sniff_time=0.02):
                                verbose=True)
         result = sorted(result, key=lambda x: x.src)
         with new_can_socket0() as cans:
-            cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-            cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+            cans.send(CAN(identifier=0x602, data=b'\x22\x01\xaa'))
+            cans.send(CAN(identifier=0x603, data=b'\x22\x01\xaa'))
             time.sleep(0.00)
-            cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-            cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+            cans.send(CAN(identifier=0x602, data=b'\x22\x01\xaa'))
+            cans.send(CAN(identifier=0x603, data=b'\x22\x01\xaa'))
             time.sleep(0.00)
-            cans.send(CAN(identifier=0x602, data=b'\x01\xaa'))
-            cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+            cans.send(CAN(identifier=0x602, data=b'\x22\x01\xaa'))
+            cans.send(CAN(identifier=0x603, data=b'\x22\x01\xaa'))
             for s in result:
                 # This helps to close ISOTPSoftSockets
                 cans.send(CAN(identifier=0x702, data=b'\x11\x01\xaa'))
@@ -630,14 +634,14 @@ def test_extended_isotpscan_none(sniff_time=0.02):
 
 
 def test_isotpscan_none_random_ids(sniff_time=0.02):
-    rnd = RandNum(0x1, 0x100)
+    rnd = RandNum(0x1, 0x50)
     ids = set(rnd._fix() for _ in range(10))
     print(ids)
     semaphore = threading.Semaphore(0)
     def isotpserver(i):
         with new_can_socket0() as isocan, \
                 ISOTPSocket(isocan, sid=0x100 + i, did=i) as s:
-            s.sniff(timeout=1500 * sniff_time, count=1,
+            s.sniff(timeout=700 * sniff_time, count=1,
                     started_callback=semaphore.release)
     pkt = CAN(identifier=0x701, length=8,
               data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
@@ -649,7 +653,7 @@ def test_isotpscan_none_random_ids(sniff_time=0.02):
     with new_can_socket0() as socks_interface:
         thread_noise.start()
         with new_can_socket0() as scansock:
-            result = ISOTPScan(scansock, range(0x000, 0x101),
+            result = ISOTPScan(scansock, range(0x000, 0x51),
                                can_interface=socks_interface,
                                noise_listen_time=sniff_time * 6,
                                sniff_time=sniff_time,
@@ -659,8 +663,10 @@ def test_isotpscan_none_random_ids(sniff_time=0.02):
             for i in ids:
                 # This helps to close ISOTPSoftSockets
                 cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+                cans.send(CAN(identifier=0x100 + i, data=b'\x01\xaa'))
                 time.sleep(0)
                 cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+                cans.send(CAN(identifier=0x100 + i, data=b'\x01\xaa'))
             for s in result:
                 # This helps to close ISOTPSoftSockets
                 cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))
@@ -681,13 +687,13 @@ def test_isotpscan_none_random_ids(sniff_time=0.02):
 
 
 def test_isotpscan_none_random_ids_padding(sniff_time=0.02):
-    rnd = RandNum(0x1, 0x100)
+    rnd = RandNum(0x1, 0x50)
     ids = set(rnd._fix() for _ in range(10))
     semaphore = threading.Semaphore(0)
     def isotpserver(i):
         with new_can_socket0() as isocan, \
                 ISOTPSocket(isocan, sid=0x100 + i, did=i, padding=True) as s:
-            s.sniff(timeout=1500 * sniff_time, count=1,
+            s.sniff(timeout=700 * sniff_time, count=1,
                     started_callback=semaphore.release)
     pkt = CAN(identifier=0x701, length=8,
               data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
@@ -699,7 +705,7 @@ def test_isotpscan_none_random_ids_padding(sniff_time=0.02):
     with new_can_socket0() as socks_interface:
         thread_noise.start()
         with new_can_socket0() as scansock:
-            result = ISOTPScan(scansock, range(0x000, 0x101),
+            result = ISOTPScan(scansock, range(0x000, 0x51),
                                can_interface=socks_interface,
                                noise_listen_time=sniff_time * 6,
                                sniff_time=sniff_time,
@@ -709,8 +715,10 @@ def test_isotpscan_none_random_ids_padding(sniff_time=0.02):
             for i in ids:
                 # This helps to close ISOTPSoftSockets
                 cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+                cans.send(CAN(identifier=0x100 + i, data=b'\x01\xaa'))
                 time.sleep(0)
                 cans.send(CAN(identifier=i, data=b'\x01\xaa'))
+                cans.send(CAN(identifier=0x100 + i, data=b'\x01\xaa'))
             for s in result:
                 # This helps to close ISOTPSoftSockets
                 cans.send(CAN(identifier=s.dst, data=b'\x01\xaa'))


### PR DESCRIPTION
This PR fixes two instabilities in automotive unit tests, recently discussed in #2478. Besides that, this PR speeds up the execution of isotpscanner unit tests. 