### PR TITLE
Add Tungsten Fabric VRouter agent protocol

### DIFF
--- a/scapy/contrib/tf_agent.py
+++ b/scapy/contrib/tf_agent.py
@@ -1,0 +1,75 @@
+"""Tungsten Fabric vrouter punted packets helper.
+
+Parses packets encapsulated into additional layer of ethernet and
+agent header.
+
+NOTE: do not import it for non-vrouter traces, it rebinds IP from Ether
+(because vrouter uses same ethertype as IPv4)"""
+
+# scapy.contrib.description = Tungsten Fabric vrouter punted packets
+# scapy.contrib.status = loads
+
+from scapy.packet import Packet, bind_layers, split_layers
+from scapy.fields import IntField, ByteField, ShortField, ShortEnumField, \
+    ThreeBytesField
+from scapy.layers.inet import IP
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Ether, ARP
+
+# Some encapsulated packets are MPLSoGRE or MPLSoUDP
+import scapy.contrib.mpls               # noqa: F401
+
+vrouter_agent_cmd_no = {0: "AGENT_CMD_SWITCH",
+                        1: "AGENT_CMD_ROUTE",
+                        2: "AGENT_TRAP_ARP",
+                        3: "AGENT_TRAP_L2_PROTOCOLS",
+                        4: "AGENT_TRAP_NEXTHOP",
+                        5: "AGENT_TRAP_RESOLVE",
+                        6: "AGENT_TRAP_FLOW_MISS",
+                        7: "AGENT_TRAP_L3_PROTOCOLS",
+                        8: "AGENT_TRAP_DIAG",
+                        9: "AGENT_TRAP_ECMP_RESOLVE",
+                        10: "AGENT_TRAP_SOURCE_MISMATCH",
+                        11: "AGENT_TRAP_HANDLE_DF",
+                        12: "AGENT_TRAP_ZERO_TTL",
+                        13: "AGENT_TRAP_ICMP_ERROR",
+                        14: "AGENT_TRAP_TOR_CONTROL_PKT",
+                        15: "AGENT_TRAP_FLOW_ACTION_HOLD",
+                        16: "AGENT_TRAP_ROUTER_ALERT"}
+
+
+class InnerEther(Packet):
+    name = "Ethernet"
+    fields_desc = Ether.fields_desc[:]
+
+
+class VrouterAgentHdr(Packet):
+    name = "VrAgentHdr"
+    fields_desc = [ShortField("ifindex", None),
+                   ShortField("vrf", None),
+                   ShortEnumField("cmd", 1, vrouter_agent_cmd_no),
+                   IntField("param", None),
+                   IntField("param_1", None),
+                   IntField("param_2", None),
+                   IntField("param_3", None),
+                   IntField("param_4", None),
+                   ByteField("param_5", None),
+                   ThreeBytesField("param_5_pack", None)]
+
+    def mysummary(self):
+        summary = self.sprintf("%cmd% vif0/%ifindex% Vrf:%vrf%")
+        if self.cmd == 6 or self.cmd == 15:
+            summary += self.sprintf(" Flow:%param% Gen:%param_5%"
+                                    " K(nh)=%param_1%")
+
+        return summary
+
+    def guess_payload_class(self, payload):
+        return InnerEther
+
+
+split_layers(Ether, IP, type=0x800)
+bind_layers(Ether, VrouterAgentHdr, type=0x800)
+bind_layers(InnerEther, IP, type=0x800)
+bind_layers(InnerEther, IPv6, type=0x86DD)
+bind_layers(InnerEther, ARP, type=0x0806)

--- a/test/contrib/tf_agent.uts
+++ b/test/contrib/tf_agent.uts
@@ -1,0 +1,20 @@
+# TF vrouter-agent test
+#
+# Type the following command to launch start the tests:
+# $ test/run_tests -P "load_contrib('tf_agent')" -t test/contrib/tf_agent.uts
+
++ TF vrouter-agent
+
+= Build & dissect - Flow packet
+
+hdr = VrouterAgentHdr(ifindex=3, vrf=1, cmd="AGENT_TRAP_FLOW_MISS",
+                      param=100500, param_1=20, param_5=1)
+assert raw(hdr) == b"\x00\x03\x00\x01\x00\x06\x00\x01\x88\x94\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+print(hdr.summary())
+assert hdr.summary() == "AGENT_TRAP_FLOW_MISS vif0/3 Vrf:1 Flow:100500 Gen:1 K(nh)=20"
+
+pkt = Ether(type=0x800)/hdr/Ether()
+
+s = raw(pkt)
+pkt2 = Ether(s)
+assert VrouterAgentHdr in pkt2


### PR DESCRIPTION
This Pull Request adds `scapy.contrib.tf_agent` module which can be used for pcaps captured on pkt0 interface (it is used to punt packets from Tungsten Fabric VRouter to user-space agent, but has special encapsulation header)

More info on how pkt0 works is here:
https://tungstenfabric.github.io/website/Tungsten-Fabric-Architecture.html#packet-processing

Usage example:
```
#!/usr/bin/python3
from scapy.all import rdpcap
import scapy.contrib.tf_agent

pcap = rdpcap("pkt0.pcap")
for pkt in pcap:
    print(pkt[1].mysummary(), "|", pkt[2].summary())
```
