### PR TITLE
Add initial support for RoCE packets

### DIFF
--- a/scapy/contrib/roce.py
+++ b/scapy/contrib/roce.py
@@ -1,0 +1,183 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Haggai Eran <haggai.eran@gmail.com>
+# This program is published under a GPLv2 license
+
+# scapy.contrib.description = RoCE v2
+# scapy.contrib.status = loads
+
+"""
+RoCE: RDMA over Converged Ethernet
+"""
+
+from scapy.packet import Packet, bind_layers, Raw
+from scapy.fields import ByteEnumField, XByteField, XShortField, \
+    BitField, FCSField
+from scapy.layers.inet import IP, UDP
+from scapy.compat import raw
+from scapy.error import warning
+from zlib import crc32
+import struct
+
+_transports = {
+    'RC': 0x00,
+    'UC': 0x20,
+    'RD': 0x40,
+    'UD': 0x60,
+}
+
+_ops = {
+    'SEND_FIRST': 0x00,
+    'SEND_MIDDLE': 0x01,
+    'SEND_LAST': 0x02,
+    'SEND_LAST_WITH_IMMEDIATE': 0x03,
+    'SEND_ONLY': 0x04,
+    'SEND_ONLY_WITH_IMMEDIATE': 0x05,
+    'RDMA_WRITE_FIRST': 0x06,
+    'RDMA_WRITE_MIDDLE': 0x07,
+    'RDMA_WRITE_LAST': 0x08,
+    'RDMA_WRITE_LAST_WITH_IMMEDIATE': 0x09,
+    'RDMA_WRITE_ONLY': 0x0a,
+    'RDMA_WRITE_ONLY_WITH_IMMEDIATE': 0x0b,
+    'RDMA_READ_REQUEST': 0x0c,
+    'RDMA_READ_RESPONSE_FIRST': 0x0d,
+    'RDMA_READ_RESPONSE_MIDDLE': 0x0e,
+    'RDMA_READ_RESPONSE_LAST': 0x0f,
+    'RDMA_READ_RESPONSE_ONLY': 0x10,
+    'ACKNOWLEDGE': 0x11,
+    'ATOMIC_ACKNOWLEDGE': 0x12,
+    'COMPARE_SWAP': 0x13,
+    'FETCH_ADD': 0x14,
+}
+
+
+def opcode(transport, op):
+    return (_transports[transport] + _ops[op], '{}_{}'.format(transport, op))
+
+
+_bth_opcodes = dict([
+    opcode('RC', 'SEND_FIRST'),
+    opcode('RC', 'SEND_MIDDLE'),
+    opcode('RC', 'SEND_LAST'),
+    opcode('RC', 'SEND_LAST_WITH_IMMEDIATE'),
+    opcode('RC', 'SEND_ONLY'),
+    opcode('RC', 'SEND_ONLY_WITH_IMMEDIATE'),
+    opcode('RC', 'RDMA_WRITE_FIRST'),
+    opcode('RC', 'RDMA_WRITE_MIDDLE'),
+    opcode('RC', 'RDMA_WRITE_LAST'),
+    opcode('RC', 'RDMA_WRITE_LAST_WITH_IMMEDIATE'),
+    opcode('RC', 'RDMA_WRITE_ONLY'),
+    opcode('RC', 'RDMA_WRITE_ONLY_WITH_IMMEDIATE'),
+    opcode('RC', 'RDMA_READ_REQUEST'),
+    opcode('RC', 'RDMA_READ_RESPONSE_FIRST'),
+    opcode('RC', 'RDMA_READ_RESPONSE_MIDDLE'),
+    opcode('RC', 'RDMA_READ_RESPONSE_LAST'),
+    opcode('RC', 'RDMA_READ_RESPONSE_ONLY'),
+    opcode('RC', 'ACKNOWLEDGE'),
+    opcode('RC', 'ATOMIC_ACKNOWLEDGE'),
+    opcode('RC', 'COMPARE_SWAP'),
+    opcode('RC', 'FETCH_ADD'),
+
+    opcode('UC', 'SEND_FIRST'),
+    opcode('UC', 'SEND_MIDDLE'),
+    opcode('UC', 'SEND_LAST'),
+    opcode('UC', 'SEND_LAST_WITH_IMMEDIATE'),
+    opcode('UC', 'SEND_ONLY'),
+    opcode('UC', 'SEND_ONLY_WITH_IMMEDIATE'),
+    opcode('UC', 'RDMA_WRITE_FIRST'),
+    opcode('UC', 'RDMA_WRITE_MIDDLE'),
+    opcode('UC', 'RDMA_WRITE_LAST'),
+    opcode('UC', 'RDMA_WRITE_LAST_WITH_IMMEDIATE'),
+    opcode('UC', 'RDMA_WRITE_ONLY'),
+    opcode('UC', 'RDMA_WRITE_ONLY_WITH_IMMEDIATE'),
+
+    opcode('RD', 'SEND_FIRST'),
+    opcode('RD', 'SEND_MIDDLE'),
+    opcode('RD', 'SEND_LAST'),
+    opcode('RD', 'SEND_LAST_WITH_IMMEDIATE'),
+    opcode('RD', 'SEND_ONLY'),
+    opcode('RD', 'SEND_ONLY_WITH_IMMEDIATE'),
+    opcode('RD', 'RDMA_WRITE_FIRST'),
+    opcode('RD', 'RDMA_WRITE_MIDDLE'),
+    opcode('RD', 'RDMA_WRITE_LAST'),
+    opcode('RD', 'RDMA_WRITE_LAST_WITH_IMMEDIATE'),
+    opcode('RD', 'RDMA_WRITE_ONLY'),
+    opcode('RD', 'RDMA_WRITE_ONLY_WITH_IMMEDIATE'),
+    opcode('RD', 'RDMA_READ_REQUEST'),
+    opcode('RD', 'RDMA_READ_RESPONSE_FIRST'),
+    opcode('RD', 'RDMA_READ_RESPONSE_MIDDLE'),
+    opcode('RD', 'RDMA_READ_RESPONSE_LAST'),
+    opcode('RD', 'RDMA_READ_RESPONSE_ONLY'),
+    opcode('RD', 'ACKNOWLEDGE'),
+    opcode('RD', 'ATOMIC_ACKNOWLEDGE'),
+    opcode('RD', 'COMPARE_SWAP'),
+    opcode('RD', 'FETCH_ADD'),
+
+    opcode('UD', 'SEND_ONLY'),
+    opcode('UD', 'SEND_ONLY_WITH_IMMEDIATE'),
+
+    (0x81, 'CNP'),
+])
+
+
+class BTH(Packet):
+    name = "BTH"
+    fields_desc = [
+        ByteEnumField("opcode", 0, _bth_opcodes),
+        BitField("solicited", 0, 1),
+        BitField("migreq", 0, 1),
+        BitField("padcount", 0, 2),
+        BitField("version", 0, 4),
+        XShortField("pkey", 0xffff),
+        XByteField("resv8", 0),
+        BitField("dqpn", 0, 24),
+        BitField("ackreq", 0, 1),
+        BitField("resv7", 0, 7),
+        BitField("psn", 0, 24),
+
+        FCSField("icrc", None, fmt="!I")]
+
+    @staticmethod
+    def pack_icrc(icrc):
+        return struct.pack("!I", icrc & 0xffffffff)[::-1]
+
+    def compute_icrc(self, p):
+        udp = self.underlayer
+        if udp is None or not isinstance(udp, UDP):
+            warning("Expecting UDP underlayer to compute checksum. Got %s.",
+                    udp and udp.name)
+            return self.pack_icrc(0)
+        ip = udp.underlayer
+        if isinstance(ip, IP):
+            # pseudo-LRH / IP / UDP / BTH / payload
+            pshdr = Raw(b'\xff' * 8) / ip.copy()
+            pshdr.chksum = 0xffff
+            pshdr.ttl = 0xff
+            pshdr.tos = 0xff
+            pshdr[UDP].chksum = 0xffff
+            pshdr[BTH].resv8 = 0xff
+            bth = pshdr[BTH].self_build()
+            payload = raw(pshdr[BTH].payload)
+            # add ICRC placeholder just to get the right IP.totlen and
+            # UDP.length
+            icrc_placeholder = b'\xff\xff\xff\xff'
+            pshdr[UDP].payload = Raw(bth + payload + icrc_placeholder)
+            icrc = crc32(raw(pshdr)[:-4]) & 0xffffffff
+            return self.pack_icrc(icrc)
+        else:
+            # TODO support IPv6
+            warning("The underlayer protocol %s is not supported.",
+                    ip and ip.name)
+            return self.pack_icrc(0)
+
+    # RoCE packets end with ICRC - a 32-bit CRC of the packet payload and
+    # pseudo-header. Add the ICRC header if it is missing and calculate its
+    # value.
+    def post_build(self, p, pay):
+        p += pay
+        if self.icrc is None:
+            p = p[:-4] + self.compute_icrc(p)
+        return p
+
+
+bind_layers(UDP, BTH, dport=4791)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1538,16 +1538,23 @@ class PcapWriter(RawPcapWriter):
 
 
 @conf.commands.register
-def import_hexcap():
+def import_hexcap(input_string=None):
     """Imports a tcpdump like hexadecimal view
 
     e.g: exported via hexdump() or tcpdump or wireshark's "export as hex"
+
+    :param input_string: String containing the hexdump input to parse. If None,
+        read from standard input.
     """
     re_extract_hexcap = re.compile(r"^((0x)?[0-9a-fA-F]{2,}[ :\t]{,3}|) *(([0-9a-fA-F]{2} {,2}){,16})")  # noqa: E501
     p = ""
     try:
+        if input_string:
+            input_function = six.StringIO(input_string).readline
+        else:
+            input_function = input
         while True:
-            line = input().strip()
+            line = input_function().strip()
             if not line:
                 break
             try:

--- a/test/contrib/roce.uts
+++ b/test/contrib/roce.uts
@@ -1,0 +1,34 @@
+# RoCE unit tests
+# run with:
+#   test/run_tests  -P "load_contrib('roce')" -t test/contrib/roce.uts -F
+
+% Regression tests for the RoCE layer
+
+################
+##### RoCE #####
+################
+
++ RoCE tests
+
+= RoCE layer
+
+# an example UC packet 
+pkt = Ether(dst='24:8a:07:a8:fa:22', src='24:8a:07:a8:fa:22')/ \
+      IP(version=4, ihl=5, tos=0x1, id=1144, flags='DF', frag=0, \
+         ttl=64, src='192.168.0.7', dst='192.168.0.7', len=64)/ \
+      UDP(sport=49152, dport=4791, len=44)/ \
+      BTH(opcode='UC_SEND_ONLY', migreq=1, padcount=2, pkey=0xffff, dqpn=211, psn=13571856)/ \
+      Raw(b'F0\x81\x8b\xe2\x895\xd9\x0e\x9a\x95PT\x01\xbe\x88^P\x00\x00')
+
+# include ICRC placeholder
+pkt = Ether(pkt.build() + b'\x00' * 4)
+
+assert IP in pkt.layers()
+print(hex(pkt[IP].chksum))
+assert pkt[IP].chksum == 0xb4d5
+assert UDP in pkt.layers()
+print(hex(pkt[UDP].chksum))
+assert pkt[UDP].chksum == 0xaca2
+assert BTH in pkt.layers()
+assert pkt[BTH].icrc == 0x78f353f3
+

--- a/test/contrib/roce.uts
+++ b/test/contrib/roce.uts
@@ -32,3 +32,48 @@ assert pkt[UDP].chksum == 0xaca2
 assert BTH in pkt.layers()
 assert pkt[BTH].icrc == 0x78f353f3
 
+= RoCE CNP packet
+
+# based on this example packet:
+# https://community.mellanox.com/s/article/rocev2-cnp-packet-format-example
+
+pkt = Ether()/IP(src='22.22.22.8', dst='22.22.22.7', id=0x98c6, flags='DF',
+                 ttl=0x20, tos=0x89)/ \
+      UDP(sport=56238, dport=4791, chksum=0)/ \
+      cnp(dqpn=0xd2)
+pkt = Ether(pkt.build())
+
+assert pkt[IP].len == 60
+assert pkt[UDP].len == 40
+assert pkt[BTH].opcode == 0x81
+assert pkt[BTH].becn
+assert not pkt[BTH].fecn
+assert pkt[BTH].resv6 == 0
+assert pkt[BTH].resv7 == 0
+assert pkt[BTH].dqpn == 0xd2
+assert pkt[BTH].version == 0
+assert not pkt[BTH].solicited
+assert not pkt[BTH].migreq
+assert pkt[BTH].padcount == 0
+assert pkt[BTH].pkey == 0xffff
+assert not pkt[BTH].ackreq
+assert pkt[BTH].psn == 0
+assert pkt[CNPPadding].reserved1 == 0
+assert pkt[CNPPadding].reserved2 == 0
+# assert pkt[BTH].icrc == 0xe42dad81 TODO - does not match example
+
+= RoCE CNP captured on ConnectX-4 Lx
+
+pkt = Ether(import_hexcap('''0x0000:  e41d 2dab 2bc2 7cfe 9064 3b32 0800 45c2
+0x0010:  003c 718c 4000 4011 9161 0a00 1101 0a00
+0x0020:  1201 0000 12b7 0028 0000 8100 ffff 4000
+0x0030:  0118 0000 0000 0000 0000 0000 0000 0000
+0x0040:  0000 0000 0000 82fd 002a
+'''))
+
+assert BTH in pkt.layers()
+assert pkt.opcode == CNP_OPCODE
+del pkt.icrc
+pkt = Ether(pkt.build())
+assert pkt.icrc == 0x82fd002a
+

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -12735,6 +12735,18 @@ assert pkt[Ether].dst == "ff:ff:ff:ff:ff:ff"
 assert pkt[IP].dst == "127.0.0.1"
 assert ICMP in pkt
 
+= import_hexcap(input_string)
+data = """
+0000  FF FF FF FF FF FF AA AA AA AA AA AA 08 00 45 00  ..............E.
+0010  00 1C 00 01 00 00 40 01 7C DE 7F 00 00 01 7F 00  ......@.|.......
+0020  00 01 08 00 F7 FF 00 00 00 00                    ..........
+"""[1:]
+pkt = import_hexcap(data)
+pkt = Ether(pkt)
+assert pkt[Ether].dst == "ff:ff:ff:ff:ff:ff"
+assert pkt[IP].dst == "127.0.0.1"
+assert ICMP in pkt
+
 = padding()
 
 def test_padding():


### PR DESCRIPTION
This PR adds BTH headers and CNP sub-headers, with a few basic tests. We can add other headers (RDMA, acks, or datagrams) later on.

I've added a way to read hexdumps from a string to make it easier to write the test. If there's a better way to do that I'd be happy to learn.

I also wasn't sure whether this belongs in layers or contrib.