### PR TITLE
Correct extension length in ServerHello TLS handshake and add test

### DIFF
--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -412,8 +412,7 @@ class TLSServerHello(_TLSHandshake):
                    _ExtensionsField("ext", None,
                                     length_from=lambda pkt: (pkt.msglen -
                                                              (pkt.sidlen or 0) -  # noqa: E501
-                                                             38))]
-    # 40)) ]
+                                                             40))]
 
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -863,7 +863,6 @@ assert(sh.cipher == 0xc02f)
 assert(len(sh.ext) == 6)
 sh.ext[-1].protocols[-1].protocol == b"http/1.1"
 
-
 = Reading TLS test session - Certificate
 from scapy.layers.tls.cert import Cert
 cert = t3.msg[0]
@@ -1309,10 +1308,17 @@ test_tls_tools()
 
 = Dissect TLSCertificateVerify
 
+from scapy.layers.tls.handshake import TLSCertificateVerify
 t = TLS(b'\x16\x03\x03\x00P\x0f\x00\x00L\x04\x03\x00H0F\x02!\x00\xcf\xf1\xd0:1\xb8\xe4JCU\x00\x8c\xcdg\xf9=g\x84\xa3h;V@\xfd\xd1\\\xf0\xc4f\xfa\x18\xdc\x02!\x00\x82\x1dF\xc1\xd1\xab\x86\xaa\xb9"\x0eA\xf2\xc3Rj\xd7\xf1\xe9\xaf\x9b\xa5?R\n\xca\x15\xfe)\xa9j\x84')
 assert TLSCertificateVerify in t
 assert t[TLSCertificateVerify].sig.sig_len == 72
 
+= ServerHello with trailing bytes
+server_hello =  b"\x02\x00\x00Q\x03\x03\x9e\x06.\xfc@\xd2\x89\xf7\x8b\xb8\x96l\x83\xd8B0\x06W\x7f\xbcZ[\xb4F\xdd\x10\xcf\xf1q9>\x0b l\xa6\x06\x81#\xa5miv\xe0\xfbG\xfb\x7ff\xb1\xccg\x84\x9022\xcb\xa6\xe9|\xaf7h\x9a\xef\xbd\xc0/\x00\x00\t\xff\x01\x00\x01\x00\x00\x17\x00\x00012345"
+p = TLSServerHello(server_hello)
+assert(p.cipher == 0xc02f)
+assert(p.extlen == 9)
+assert(p.load == b"012345")
 
 ###############################################################################
 ############################ Automaton behaviour ##############################


### PR DESCRIPTION
According to RFC 5246, the size of ServerHello structure is:

- Version: 2 bytes
- Random: 32 bytes
- Session ID length: 1 bytes
- Cipher: 2 bytes
- Compression: 1 byte
- Extensions Len: 2 bytes

Total: 40 bytes.

Previously is was set to 38 which parse incorrectly the two next bytes of the following record.
