### PR TITLE
Use osx_image to change the Python interpreter version

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -23,11 +23,15 @@ then
   $SCAPY_SUDO apt-get -qy install libpcap-dev
 fi
 
-# Update pip & setuptools (tox uses those)
-python -m pip install --upgrade pip setuptools --ignore-installed
+# On Travis, "osx" dependencies are installed in .travis.yml
+if [ "$TRAVIS_OS_NAME" != "osx" ]
+then
+  # Update pip & setuptools (tox uses those)
+  python -m pip install --upgrade pip setuptools --ignore-installed
 
-# Make sure tox is installed and up to date
-python -m pip install -U tox --ignore-installed
+  # Make sure tox is installed and up to date
+  python -m pip install -U tox --ignore-installed
+fi
 
 # Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
 openssl version

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,22 @@ jobs:
 
         # run OSX
         - os: osx
-          language: generic
+          osx_image: xcode9.3
+          language: shell
+          before_install:
+              - python --version
+              - pip install --upgrade --ignore-installed --user pip tox setuptools
           env:
             - TOXENV=py27-bsd_non_root,py27-bsd_root,codecov
 
         - os: osx
-          language: generic
+          osx_image: xcode10.2
+          language: shell
+          before_install:
+              - python3 --version
+              - pip3 install --upgrade --ignore-installed pip tox setuptools
           env:
-            - TOXENV=py36-bsd_non_root,py36-bsd_root,codecov
+            - TOXENV=py37-bsd_non_root,py37-bsd_root,codecov
 
         # run custom root tests
         # isotp

--- a/run_scapy
+++ b/run_scapy
@@ -9,9 +9,14 @@ then
     in
       -2) PYTHON=python2; shift;;
       -3) PYTHON=python3; shift;;
-      --) break;;
+      --) PYTHON=python3; break;;
     esac
   done
-  PYTHON=${PYTHON:-python3}
+fi
+$PYTHON --version > /dev/null 2>&1
+if [ ! $? -eq 0 ]
+then
+  echo "WARNING: '$PYTHON' not found, using 'python' instead."
+  PYTHON=python
 fi
 PYTHONPATH=$DIR exec "$PYTHON" -m scapy "$@"


### PR DESCRIPTION
@serpilliere noticed that the Python 3.6 tests do not work. They last 1 minute, and the logs indicate that the python3.6 interpreter is not detected. It seems that this is broken since 3 to 4 months.

According to Travis documentation (https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci), we must select the xcode version to change the python interpreter. This PR attempts to fix this.