### PR TITLE
Fix bluetooth example

### DIFF
--- a/doc/scapy/layers/bluetooth.rst
+++ b/doc/scapy/layers/bluetooth.rst
@@ -178,7 +178,7 @@ You can then inspect the response:
 
    >>> # ans[0] = Answered packet #0
    >>> # ans[0][1] = The response packet
-   >>> ans[0][1]
+   >>> p = ans[0][1]
    >>> p.show()
    ###[ HCI header ]###
      type= Event


### PR DESCRIPTION
Just adding the assignment so `p` is defined when calling `p.show()`

Didn't see guidelines for docs in the contributing guide, so let me know if I need anything else. 

