### PR TITLE
Faster tests / Github CI / Fixes

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -29,8 +29,6 @@ python -m pip install --upgrade pip setuptools --ignore-installed
 # Make sure tox is installed and up to date
 python -m pip install -U tox --ignore-installed
 
-# Make sure brotli is installed and up to date
-python -m pip install -U brotli --ignore-installed
-
 # Dump Environment (so that we can check PATH, UT_FLAGS, etc.)
+openssl version
 set

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -68,7 +68,7 @@ echo UT_FLAGS=$UT_FLAGS
 echo TOXENV=$TOXENV
 
 # Launch Scapy unit tests
-tox -- ${UT_FLAGS} || exit 1;
+tox -- ${UT_FLAGS} || exit 1
 
 # Start Scapy in interactive mode
 TEMPFILE=$(mktemp)
@@ -76,5 +76,5 @@ cat << EOF > "${TEMPFILE}"
 print("Scapy on %s" % sys.version)
 sys.exit()
 EOF
-./run_scapy -H -c "${TEMPFILE}" || exit 1;
+./run_scapy -H -c "${TEMPFILE}" || exit 1
 rm ${TEMPFILE}

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -32,6 +32,7 @@ fi
 
 # Create version tag (github actions)
 PY_VERSION="py${1//./}"
+PY_VERSION=${PY_VERSION/pypypy/pypy}
 TESTVER="$PY_VERSION-$OSTOX"
 
 # Chose whether to run root or non_root
@@ -51,13 +52,13 @@ if [ -z $TOXENV ]
 then
   case ${SCAPY_TOX_CHOSEN} in
     both)
-      TOXENV="${TESTVER}_non_root,${TESTVER}_root"
+      export TOXENV="${TESTVER}_non_root,${TESTVER}_root"
       ;;
     root)
-      TOXENV="${TESTVER}_root"
+      export TOXENV="${TESTVER}_root"
       ;;
     *)
-      TOXENV="${TESTVER}_non_root"
+      export TOXENV="${TESTVER}_non_root"
       ;;
   esac
 fi
@@ -67,13 +68,13 @@ echo UT_FLAGS=$UT_FLAGS
 echo TOXENV=$TOXENV
 
 # Launch Scapy unit tests
-tox -- ${UT_FLAGS}
+tox -- ${UT_FLAGS} || exit 1;
 
 # Start Scapy in interactive mode
 TEMPFILE=$(mktemp)
-cat << EOF > ${TEMPFILE}
+cat << EOF > "${TEMPFILE}"
 print("Scapy on %s" % sys.version)
 sys.exit()
 EOF
-./run_scapy -H -c ${TEMPFILE}
+./run_scapy -H -c "${TEMPFILE}" || exit 1;
 rm ${TEMPFILE}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   health:
+    name: Code health check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +21,7 @@ jobs:
       - name: Run twine check
         run: tox -e twine
   docs:
+    name: Build doc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +34,7 @@ jobs:
       - name: Build docs
         run: tox -e docs
   mypy:
+    name: Type hints check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -44,20 +47,20 @@ jobs:
       - name: Run mypy
         run: tox -e mypy
 
-# Github Actions block ICMP. We can still use it for non root tests
-
-#  utscapy:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python: [2.7, pypy2, pypy3, 3.5, 3.6, 3.7, 3.8]
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Setup Python
-#        uses: actions/setup-python@v1
-#        with:
-#          python-version: ${{ matrix.python }}
-#      - name: Install Tox and any other packages
-#        run: ./.config/ghci/install.sh
-#      - name: Run Tox
-#        run: ./.config/ghci/test.sh ${{ matrix.python }} non_root
+  # Github Actions block ICMP. We can still use it for non root tests
+  utscapy:
+    name: Non-sudo unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [2.7, pypy2, pypy3, 3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: ./.config/ci/install.sh
+      - name: Run Tox
+        run: ./.config/ci/test.sh ${{ matrix.python }} non_root

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,63 +6,52 @@ cache:
 
 jobs:
     include:
-        # Run as root
+        # Run linux as root (non root tested by github ci)
         - os: linux
           python: 2.7
           env:
-            - TOXENV=py27-linux_non_root,py27-linux_root,codecov
+            - TOXENV=py27-linux_root,codecov
 
         - os: linux
           python: pypy
           env:
-            - TOXENV=pypy-linux_non_root,pypy-linux_root,codecov
+            - TOXENV=pypy-linux_root,codecov
 
         - os: linux
           python: pypy3
           env:
-            - TOXENV=pypy3-linux_non_root,pypy3-linux_root,codecov
-
-        - os: linux
-          python: 3.5
-          env:
-            - TOXENV=py35-linux_root,codecov
-
-        - os: linux
-          python: 3.6
-          env:
-            - TOXENV=py36-linux_root,codecov
-
-        - os: linux
-          python: 3.7
-          env:
-            - TOXENV=py37-linux_root,codecov
+            - TOXENV=pypy3-linux_root,codecov
 
         - os: linux
           python: 3.8
           env:
-            - TOXENV=py38-linux_non_root,py38-linux_root,codecov
+            - TOXENV=py38-linux_root,codecov
 
+        # run OSX
         - os: osx
           language: generic
           env:
             - TOXENV=py27-bsd_non_root,py27-bsd_root,codecov
+
         - os: osx
           language: generic
           env:
             - TOXENV=py36-bsd_non_root,py36-bsd_root,codecov
 
+        # run custom root tests
+        # isotp
         - os: linux
           python: 3.8
           env:
             - TOXENV=py38-isotp_kernel_module,codecov
 
+        # libpcap
         - os: linux
           python: 3.8
           env:
             - SCAPY_USE_PCAPDNET=yes TOXENV=py38-linux_root,codecov
 
-        # Other root tests
-        # Test scapy against all warnings
+        # warnings/deprecations
         - os: linux
           python: 3.8
           env:

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -396,7 +396,8 @@ class ASN1_OID(ASN1_Object):
     tag = ASN1_Class_UNIVERSAL.OID
 
     def __init__(self, val):
-        val = conf.mib._oid(plain_str(val))
+        val = plain_str(val)
+        val = conf.mib._oid(val)
         ASN1_Object.__init__(self, val)
         self.oidname = conf.mib._oidname(val)
 

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -769,6 +769,7 @@ def usage():
 -qq\t\t: [silent mode]
 -x\t\t: use pyannotate
 -n <testnum>\t: only tests whose numbers are given (eg. 1,3-7,12)
+-N\t\t: force non root
 -m <module>\t: additional module to put in the namespace
 -k <kw1>,<kw2>,...\t: include only tests with one of those keywords (can be used many times)
 -K <kw1>,<kw2>,...\t: remove tests with one of those keywords (can be used many times)
@@ -860,6 +861,7 @@ def main():
     OUTPUTFILE = sys.stdout
     LOCAL = 0
     NUM = None
+    NON_ROOT = False
     KW_OK = []
     KW_KO = []
     DUMP = 0
@@ -875,7 +877,7 @@ def main():
     ANNOTATIONS_MODE = False
     INTERPRETER = False
     try:
-        opts = getopt.getopt(argv, "o:t:T:c:f:hbln:m:k:K:DRdCiFqP:s:x")
+        opts = getopt.getopt(argv, "o:t:T:c:f:hbln:m:k:K:DRdCiFqNP:s:x")
         for opt, optarg in opts[0]:
             if opt == "-h":
                 usage()
@@ -950,6 +952,8 @@ def main():
                     except ValueError:
                         v1, v2 = [int(e) for e in v.split('-', 1)]
                         NUM.extend(range(v1, v2 + 1))
+            elif opt == "-N":
+                NON_ROOT = True
             elif opt == "-m":
                 MODULES.append(optarg)
             elif opt == "-k":
@@ -965,7 +969,7 @@ def main():
             if VERB > 2:
                 print("### Python 2 mode ###")
         try:
-            if os.getuid() != 0:  # Non root
+            if NON_ROOT or os.getuid() != 0:  # Non root
                 # Discard root tests
                 KW_KO.append("netaccess")
                 KW_KO.append("needs_root")

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -12037,6 +12037,9 @@ assert a.src == '00:00:00:00:00:00'
 = MIB
 ~ mib
 
+import copy
+old_mib = copy.copy(conf.mib)
+
 import tempfile
 fd, fname = tempfile.mkstemp()
 os.write(fd, b"-- MIB test\nscapy       OBJECT IDENTIFIER ::= {test 2807}\n")
@@ -12067,6 +12070,10 @@ def get_mib_graph(do_graph):
     conf.mib._make_graph()
 
 get_mib_graph()
+
+= Restore conf.mib
+~ mib
+conf.mib = old_mib
 
 = DADict tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ platform =
   bsd_non_root,bsd_root: darwin|freebsd|openbsd|netbsd
   windows: win32
 commands =
-  linux_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K random_weird_py3 {posargs}
+  linux_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K random_weird_py3 -N {posargs}
   linux_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K random_weird_py3 {posargs}
-  bsd_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -K random_weird_py3 {posargs}
+  bsd_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -K random_weird_py3 -N {posargs}
   bsd_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -K random_weird_py3 {posargs}
   windows: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/windows.utsc -K random_weird_py3 {posargs}
   coverage combine
@@ -90,7 +90,7 @@ commands = python .config/mypy/mypy_check.py
 description = "Build the docs"
 skip_install = true
 changedir = doc/scapy
-deps = sphinx<2.4.0
+deps = sphinx>=2.4.2
        sphinx_rtd_theme
 commands =
   sphinx-build -W --keep-going -b html . _build/html


### PR DESCRIPTION
- move non root tests to GithubCI: they take ~ 8 minutes in total. Speeds up the travis builds by a lot & give instant feedback to PRs
- fix tests failures after guedou's tests: https://github.com/secdev/scapy/pull/2541 (tox would fail silently)
- pin sphinx >= 2.4.2 (contains fix to https://github.com/secdev/scapy/issues/2475)
- Update Github workflow for better names
- add non root keyword to UTscapy: `-N`
- work around https://github.com/secdev/scapy/issues/2542 (still needs to be fixed !)