### PR TITLE
Less shell scripts (windows)

### DIFF
--- a/run_scapy.bat
+++ b/run_scapy.bat
@@ -1,8 +1,17 @@
 @echo off
 set PYTHONPATH=%~dp0
+REM shift will not work with %*
+set "_args=%*"
+IF "%1" == "--2" (
+  set PYTHON=python
+  set "_args=%_args:~3%"
+) ELSE IF "%1" == "--3" (
+  set PYTHON=python3
+  set "_args=%_args:~3%"
+)
 IF "%PYTHON%" == "" set PYTHON=python3
 WHERE %PYTHON% >nul 2>&1
 IF %ERRORLEVEL% NEQ 0 set PYTHON=python
-%PYTHON% -m scapy %*
+%PYTHON% -m scapy %_args%
 title Scapy - dead
 PAUSE

--- a/run_scapy_py2.bat
+++ b/run_scapy_py2.bat
@@ -1,4 +1,0 @@
-@echo off
-set PYTHONPATH=%~dp0
-set PYTHON=python
-call run_scapy.bat

--- a/run_scapy_py3.bat
+++ b/run_scapy_py3.bat
@@ -1,4 +1,0 @@
-@echo off
-set PYTHONPATH=%~dp0
-set PYTHON=python3
-call run_scapy.bat

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -700,6 +700,9 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
             if int(IPython.__version__[0]) >= 6:
                 cfg.TerminalInteractiveShell.term_title_format = ("Scapy v%s" %
                                                                   conf.version)
+                # As of IPython 6-7, the jedi completion module is a dumpster
+                # of fire that should be scrapped never to be seen again.
+                cfg.Completer.use_jedi = False
             else:
                 cfg.TerminalInteractiveShell.term_title = False
             cfg.HistoryAccessor.hist_file = conf.histfile


### PR DESCRIPTION
- https://github.com/secdev/scapy/pull/2520 but for Windows
- get rid of global keys in `main.py`