### PR TITLE
Discard stderr messages when using offline `sniff`

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -767,6 +767,8 @@ class AsyncSniffer(object):
                  --Ex: lfilter = lambda x: x.haslayer(Padding)
         offline: PCAP file (or list of PCAP files) to read packets from,
                  instead of sniffing them
+        quiet:   when set to True, the process stderr is discarded
+                 (default: False).
         timeout: stop sniffing after a given time (default: None).
         L2socket: use the provided L2socket (default: use conf.L2listen).
         opened_socket: provide an object (or a list of objects) ready to use
@@ -824,7 +826,7 @@ class AsyncSniffer(object):
 
     def _run(self,
              count=0, store=True, offline=None,
-             prn=None, lfilter=None,
+             quiet=False, prn=None, lfilter=None,
              L2socket=None, timeout=None, opened_socket=None,
              stop_filter=None, iface=None, started_callback=None,
              session=None, session_args=[], session_kwargs={},
@@ -882,7 +884,10 @@ class AsyncSniffer(object):
 
                 sniff_sockets[PcapReader(
                     offline if flt is None else
-                    tcpdump(offline, args=["-w", "-", flt], getfd=True)
+                    tcpdump(offline,
+                            args=["-w", "-", flt],
+                            getfd=True,
+                            quiet=quiet)
                 )] = offline
         if not sniff_sockets or iface is not None:
             if L2socket is None:


### PR DESCRIPTION
I'm opening this PR, because in my project i'm doing a lot of offline sniffing (mostly for filtering purposes). each time i'm using `offline` feature of `sniff` I get tcpdump's stderr, which is very very annoying to me, and for the user who uses my project.

I didn't make `quiet` an option in `sniff` for two reasons:
1. I don't think anyone would want to see this `reading from file -, link-type EN10MB (Ethernet)` message from tcpdump. it's not indicative and tells the user nothing. it's just very disturbing.
2. this PR affects only the offline `sniff` outputs, not other features of `sniff`, so putting `quiet` flag in sniff just doesn't make sense.

i'll be glad if you'll merge this, or to get suggestion for other solutions!
Thanks