### PR TITLE
Refactor offline `sniff` code

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -969,7 +969,8 @@ class PcapReader_metaclass(type):
                         i.f.seek(-4, 1)
                     except Exception:
                         pass
-                    raise Scapy_Exception("Not a supported capture file")
+                    raise Scapy_Exception(
+                        "Not a supported capture file, or invalid filter")
 
         return i
 


### PR DESCRIPTION
Few fixes:

1. _write_to_pcap:
- should use `packets_list`, but instead uses the "global"
offline variable. So changed it to `packets_list`.
- Returns `filename` twice. Changed it so it returns just once.

2. in the  `isinstance` checks part:
- _write_to_pcap doesn't return `offline`. it returns the temp pcap file.
- We do not check `isinstance(offline, PacketList)`, which works as well,
and should be exposed as an option for the user. Now it is.

3. In case `offline` is a handle/path to a pcap file, the usage of the variable
`offline` is misleading. Now it is more clearified.

4. Update the comment of `offline` - this attribute
can recieve also Packet, A list of Packets and a PacketList (not only pcap files).
This should be mentioned as this feature is very usefull for these cases too (for example,
filter packets that were sniffed using a raw socket).

In addition, I've noticed that when invalid bpf filter is passed to `filter`, wrong/misleading exception message is being raised (`Not a supported capture file`), so i've added the addition of (`or invalid filter`), so the user won't get confused.