### PR TITLE
Make NativeCANSockets blocking [ready for merge]

### DIFF
--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -28,7 +28,6 @@ CAN_INV_FILTER = 0x20000000
 
 class NativeCANSocket(SuperSocket):
     desc = "read/write packets at a given CAN interface using PF_CAN sockets"
-    nonblocking_socket = True
 
     def __init__(self, channel=None, receive_own_messages=False,
                  can_filters=None, remove_padding=True, basecls=CAN, **kwargs):

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -216,11 +216,8 @@ started.wait(timeout=5)
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     starttime = time.time() # may be inaccurate -> on some systems only seconds precision
     result = GMLAN_RequestDownload(isotpsock, 4, timeout=repeats*tout+0.5)
-    print(result)
     assert result
     endtime = time.time()
-    print(endtime - starttime)
-    print(tout * (repeats - 1))
     assert (endtime - starttime) >= tout * (repeats - 1)
 
 thread.join(timeout=5)

--- a/test/contrib/automotive/gm/gmlanutils.uts
+++ b/test/contrib/automotive/gm/gmlanutils.uts
@@ -196,7 +196,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, base
 thread.join(timeout=5)
 
 = Positive, hold response pending for several messages
-tout = 0.3
+tout = 0.8
 repeats = 4
 started = threading.Event()
 def ecusim():
@@ -215,9 +215,13 @@ started.wait(timeout=5)
 
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x242, did=0x642, basecls=GMLAN) as isotpsock:
     starttime = time.time() # may be inaccurate -> on some systems only seconds precision
-    assert GMLAN_RequestDownload(isotpsock, 4, timeout=repeats*tout+0.5) == True
+    result = GMLAN_RequestDownload(isotpsock, 4, timeout=repeats*tout+0.5)
+    print(result)
+    assert result
     endtime = time.time()
-    assert (endtime - starttime) >= tout*repeats
+    print(endtime - starttime)
+    print(tout * (repeats - 1))
+    assert (endtime - starttime) >= tout * (repeats - 1)
 
 thread.join(timeout=5)
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1175,7 +1175,8 @@ candump_fd = BytesIO(b'''  vcan0  541   [8]  10 0A DE AD BE EF AA AA
   vcan0  541   [5]  21 AA AA AA AA''')
 
 with ISOTPSocket(CandumpReader(candump_fd), sid=0x241, did=0x541, listen_only=True) as s:
-    pkts = s.sniff(timeout=1, count=6)
+    pkts = s.sniff(timeout=2, count=6)
+    print(len(pkts))
     assert(len(pkts) == 6)
     isotp = pkts[0]
     print(repr(isotp))

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1176,7 +1176,6 @@ candump_fd = BytesIO(b'''  vcan0  541   [8]  10 0A DE AD BE EF AA AA
 
 with ISOTPSocket(CandumpReader(candump_fd), sid=0x241, did=0x541, listen_only=True) as s:
     pkts = s.sniff(timeout=2, count=6)
-    print(len(pkts))
     assert(len(pkts) == 6)
     isotp = pkts[0]
     print(repr(isotp))

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -639,10 +639,15 @@ def test_isotpscan_none_random_ids(sniff_time=0.02):
     print(ids)
     semaphore = threading.Semaphore(0)
     def isotpserver(i):
-        with new_can_socket0() as isocan, \
-                ISOTPSocket(isocan, sid=0x100 + i, did=i) as s:
-            s.sniff(timeout=700 * sniff_time, count=1,
-                    started_callback=semaphore.release)
+        try:
+            with new_can_socket0() as isocan, \
+                    ISOTPSocket(isocan, sid=0x100 + i, did=i) as s:
+                s.sniff(timeout=1400 * sniff_time, count=1,
+                        started_callback=semaphore.release)
+            warning("ISOTPServer 0x%x finished" % i)
+        except Exception as e:
+            warning("ERROR in isotpserver 0x%x" % i)
+            warning(e)
     pkt = CAN(identifier=0x701, length=8, data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
     thread_noise = threading.Thread(target=make_noise, args=(pkt, sniff_time,))
     threads = [threading.Thread(target=isotpserver, args=(x,)) for x in ids]
@@ -690,10 +695,13 @@ def test_isotpscan_none_random_ids_padding(sniff_time=0.02):
     ids = set(rnd._fix() for _ in range(10))
     semaphore = threading.Semaphore(0)
     def isotpserver(i):
-        with new_can_socket0() as isocan, \
-                ISOTPSocket(isocan, sid=0x100 + i, did=i, padding=True) as s:
-            s.sniff(timeout=700 * sniff_time, count=1,
-                    started_callback=semaphore.release)
+        try:
+            with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x100 + i, did=i, padding=True) as s:
+                s.sniff(timeout=1400 * sniff_time, count=1, started_callback=semaphore.release)
+            warning("ISOTPServer 0x%x finished" % i)
+        except Exception as e:
+            warning("ERROR in isotpserver 0x%x" % i)
+            warning(e)
     pkt = CAN(identifier=0x701, length=8,
               data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
     thread_noise = threading.Thread(target=make_noise, args=(pkt, sniff_time,))


### PR DESCRIPTION
@akorb mentioned this bug.
After my last refactoring of Python-can Sockets, I forgot to remove the non_blocking flag. The intention of this last refactoring was to make Python-can Sockets behave identical to NativeCANSockets. Therefore, this flag has to be removed. 

During the work on this PR, I also mentioned, that NativeCANSockets were treated wrong. These sockets are actually blocking sockets, too. 

This PR aims to standardize the runtime behaviour of NativeCANSockets and PythonCANSockets.