### PR TITLE
fix hashret/answers for contrib/gtp.py

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -234,11 +234,15 @@ class GTPHeader(Packet):
         return p
 
     def hashret(self):
-        return struct.pack("B", self.version) + self.payload.hashret()
+        hsh = struct.pack("B", self.version)
+        if self.seq:
+            hsh += struct.pack("H", self.seq)
+        return hsh + self.payload.hashret()
 
     def answers(self, other):
         return (isinstance(other, GTPHeader) and
                 self.version == other.version and
+                (not self.seq or self.seq == other.seq) and
                 self.payload.answers(other.payload))
 
     @classmethod
@@ -340,16 +344,10 @@ class GTPPDUSessionContainer(Packet):
             p = struct.pack("!B", hdr_len) + p[1:]
         return p
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
 
 class GTPEchoRequest(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Echo Request"
-
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
 
 
 class IE_Base(Packet):
@@ -868,12 +866,8 @@ class GTPEchoResponse(Packet):
     name = "GTP Echo Response"
     fields_desc = [PacketListField("IE_list", [], IE_Dispatcher)]
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
     def answers(self, other):
-        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
-                                                          "seq")
+        return isinstance(other, GTPEchoRequest)
 
 
 class GTPCreatePDPContextRequest(Packet):
@@ -884,21 +878,14 @@ class GTPCreatePDPContextRequest(Packet):
                                                IE_NotImplementedTLV(ietype=135, length=15, data=RandString(15))],  # noqa: E501
                                    IE_Dispatcher)]
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
 
 class GTPCreatePDPContextResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Create PDP Context Response"
     fields_desc = [PacketListField("IE_list", [], IE_Dispatcher)]
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
     def answers(self, other):
-        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
-                                                          "seq")
+        return isinstance(other, GTPCreatePDPContextRequest)
 
 
 class GTPUpdatePDPContextRequest(Packet):
@@ -926,21 +913,14 @@ class GTPUpdatePDPContextRequest(Packet):
         IE_PrivateExtension()],
         IE_Dispatcher)]
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
 
 class GTPUpdatePDPContextResponse(Packet):
     # 3GPP TS 29.060 V9.1.0 (2009-12)
     name = "GTP Update PDP Context Response"
     fields_desc = [PacketListField("IE_list", None, IE_Dispatcher)]
 
-    def hashret(self):
-        return struct.pack("H", getattr(self.underlayer, "seq"))
-
     def answers(self, other):
-        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
-                                                          "seq")
+        return isinstance(other, GTPUpdatePDPContextRequest)
 
 
 class GTPErrorIndication(Packet):

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -341,7 +341,7 @@ class GTPPDUSessionContainer(Packet):
         return p
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
 
 class GTPEchoRequest(Packet):
@@ -349,7 +349,7 @@ class GTPEchoRequest(Packet):
     name = "GTP Echo Request"
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
 
 class IE_Base(Packet):
@@ -869,10 +869,11 @@ class GTPEchoResponse(Packet):
     fields_desc = [PacketListField("IE_list", [], IE_Dispatcher)]
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
     def answers(self, other):
-        return self.seq == other.seq
+        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
+                                                          "seq")
 
 
 class GTPCreatePDPContextRequest(Packet):
@@ -884,7 +885,7 @@ class GTPCreatePDPContextRequest(Packet):
                                    IE_Dispatcher)]
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
 
 class GTPCreatePDPContextResponse(Packet):
@@ -893,10 +894,11 @@ class GTPCreatePDPContextResponse(Packet):
     fields_desc = [PacketListField("IE_list", [], IE_Dispatcher)]
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
     def answers(self, other):
-        return self.seq == other.seq
+        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
+                                                          "seq")
 
 
 class GTPUpdatePDPContextRequest(Packet):
@@ -925,7 +927,7 @@ class GTPUpdatePDPContextRequest(Packet):
         IE_Dispatcher)]
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
 
 
 class GTPUpdatePDPContextResponse(Packet):
@@ -934,7 +936,11 @@ class GTPUpdatePDPContextResponse(Packet):
     fields_desc = [PacketListField("IE_list", None, IE_Dispatcher)]
 
     def hashret(self):
-        return struct.pack("H", self.seq)
+        return struct.pack("H", getattr(self.underlayer, "seq"))
+
+    def answers(self, other):
+        return getattr(self.underlayer, "seq") == getattr(other.underlayer,
+                                                          "seq")
 
 
 class GTPErrorIndication(Packet):

--- a/test/contrib/gtp.uts
+++ b/test/contrib/gtp.uts
@@ -57,6 +57,12 @@ h = "fa163e7da573fa163e43f8e708004500008400000000fd119f520a0a05010a0a05020868086
 gtp = Ether(hex_bytes(h))
 gtp[GTP_U_Header].ExtHdrLen == 2 and gtp[GTP_U_Header].extraPadding == b'\x00\x00\x00\x00' and gtp[GTP_U_Header][IP].src == '10.10.8.2' and gtp[GTP_U_Header][IP][ICMP].type == 0
 
+= GTPEchoResponse matches GTPEchoRequest by seq
+req = GTPHeader(seq=12345)/GTPEchoRequest()
+res = GTPHeader(seq=12345)/GTPEchoResponse()
+assert req.hashret() == res.hashret()
+assert res.answers(req)
+
 = GTPCreatePDPContextRequest(), basic instantiation
 gtp = IP(src="127.0.0.1", dst="127.0.0.1")/UDP(dport=2123, sport=2123)/GTPHeader(teid=2807)/GTPCreatePDPContextRequest()
 gtp.dport == 2123 and gtp.teid == 2807 and len(gtp.IE_list) == 5


### PR DESCRIPTION
`seq` has been moved up to `GTPHeader` but `GTPEchoRequest` and others still reference it by `self.seq` which results in `AttributeError`.

Not sure if this is the best fix, I suppose it would be best not to duplicate the code but not sure how to make scapy understand this logic by implementing it in `GTPHeader`, did not work for me.