### PR TITLE
Fix CM_SLAC_MATCH_CNF second RSVD

### DIFF
--- a/scapy/contrib/homepluggp.py
+++ b/scapy/contrib/homepluggp.py
@@ -158,7 +158,7 @@ class SLAC_varfield_cnf(Packet):
                    StrFixedLenField("RunID", b"\x00" * 8, 8),
                    StrFixedLenField("RSVD", b"\x00" * 8, 8),
                    StrFixedLenField("NetworkID", b"\x00" * 7, 7),
-                   ShortField("Reserved", 0),
+                   ByteField("Reserved", 0x0),
                    StrFixedLenField("NMK", b"\x00" * 16, 16)]
 
 


### PR DESCRIPTION
The CM_SLAC_MATCH_CNF second RSVD has 1 byte, replaced ShortField (2 bytes) with ByteField