### PR TITLE
Invoke temporary files deletion routine when terminating

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -15,6 +15,7 @@ import re
 import time
 import socket
 import sys
+import atexit
 
 from scapy import VERSION, base_classes
 from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
@@ -686,3 +687,16 @@ def crypto_validator(func):
                               "Please install python-cryptography v1.7 or later.")  # noqa: E501
         return func(*args, **kwargs)
     return func_in
+
+
+def scapy_delete_temp_files():
+    # type: () -> None
+    for f in conf.temp_files:
+        try:
+            os.unlink(f)
+        except Exception:
+            pass
+    del conf.temp_files[:]
+
+
+atexit.register(scapy_delete_temp_files)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -452,17 +452,6 @@ def init_session(session_name,  # type: Optional[Union[str, None]]
 ################
 
 
-def scapy_delete_temp_files():
-    # type: () -> None
-    from scapy.config import conf
-    for f in conf.temp_files:
-        try:
-            os.unlink(f)
-        except Exception:
-            pass
-    del(conf.temp_files[:])
-
-
 def _prepare_quote(quote, author, max_len=78):
     # type: (str, str, int) -> List[str]
     """This function processes a quote and returns a string that is ready


### PR DESCRIPTION
Hey,
Scapy's generated temp files are never get deleted.
I've noticed that after playing with the `offline` sniff feature.
it seems that the function `scapy_delete_temp_files` is used only in the regression test, but not when exit the program.

I'm not sure why but I seems that `scapy_delete_temp_files` was registered with `atexit`, and was removed in `887a967`. I can't see any reason why it was removed. Anyway, right now temporary files aren't get deleted, and it's bad.

Thanks