### PR TITLE
Migrate tuntap into own module, add ICMPEcho_am and bugfixing

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -26,7 +26,8 @@ then
 elif [ "$OSTYPE" = "darwin"* ] || [ "$TRAVIS_OS_NAME" = "osx" ]
 then
   OSTOX="osx"
-  UT_FLAGS+=" -K tcpdump"
+  # Travis CI in macOS 10.13+ can't load kexts. Need this for tuntaposx.
+  UT_FLAGS+=" -K tun -K tap"
 fi
 
 # pypy

--- a/.config/codespell_ignore.txt
+++ b/.config/codespell_ignore.txt
@@ -2,6 +2,7 @@ aci
 ans
 archtypes
 ba
+byteorder
 cace
 cas
 cros

--- a/doc/scapy/layers/tuntap.rst
+++ b/doc/scapy/layers/tuntap.rst
@@ -1,0 +1,222 @@
+********************
+TUN / TAP Interfaces
+********************
+
+.. note::
+
+    This module only works on BSD, Linux and macOS.
+
+TUN/TAP lets you create virtual network interfaces from userspace. There are two
+types of devices:
+
+TUN devices
+    Operates at Layer 3 (:py:class:`IP`), and is generally limited to one
+    protocol.
+
+TAP devices
+    Operates at Layer 2 (:py:class:`Ether`), and allows you to use any Layer 3
+    protocol (:py:class:`IP`, :py:class:`IPv6`, IPX, etc.)
+
+Requirements
+============
+
+FreeBSD
+    Requires the ``if_tap`` and ``if_tun`` kernel modules.
+
+    See `tap(4)`__ and `tun(4)`__ manual pages for more information.
+
+Linux
+    Load the ``tun`` kernel module:
+
+    .. code-block:: console
+
+        # modprobe tun
+
+    ``udev`` normally handles the creation of device nodes.
+
+    See `networking/tuntap.txt`__ in the Linux kernel documentation for more
+    information.
+
+macOS
+    On macOS 10.14 and earlier, you need to install `tuntaposx`__. macOS
+    10.14.5 and later will warn about the ``tuntaposx`` kexts not being
+    `notarised`__, but this works because it was built before 2019-04-07.
+
+    On macOS 10.15 and later, you need to use a `notarized build`__ of
+    ``tuntaposx``. `Tunnelblick`__ (OpenVPN client) contains a notarized build
+    of ``tuntaposx`` `which can be extracted`__.
+
+    .. note::
+
+        On macOS 10.13 and later, you need to `explicitly approve loading
+        each third-party kext for the first time`__.
+
+__ https://www.freebsd.org/cgi/man.cgi?query=tap&sektion=4
+__ https://www.freebsd.org/cgi/man.cgi?query=tun&sektion=4
+__ https://www.kernel.org/doc/Documentation/networking/tuntap.txt
+__ http://tuntaposx.sourceforge.net/
+__ https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution?language=objc
+__ https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution?language=objc
+__ https://tunnelblick.net/downloads.html
+__ https://sourceforge.net/p/tuntaposx/bugs/28/#ac64
+__ https://developer.apple.com/library/archive/technotes/tn2459/_index.html
+
+
+Using TUN/TAP in Scapy
+======================
+
+.. tip::
+
+    Using TUN/TAP generally requires running Scapy (and these utilities) as
+    ``root``.
+
+:py:class:`TunTapInterface` lets you easily create a new device:
+
+.. code-block:: pycon3
+
+    >>> t = TunTapInterface('tun0')
+
+You'll then need to bring the interface up, and assign an IP address in another
+terminal.
+
+Because TUN is a layer 3 connection, it acts as a point-to-point link.  We'll
+assign these parameters:
+
+* local address (for your machine): 192.0.2.1
+* remote address (for Scapy): 192.0.2.2
+
+On Linux, you would use:
+
+.. code-block:: shell
+
+    sudo ip link set tun0 up
+    sudo ip addr add 192.0.2.1 peer 192.0.2.2 dev tun0
+
+On BSD and macOS, use:
+
+.. code-block:: shell
+
+    sudo ifconfig tun0 up
+    sudo ifconfig tun0 192.0.2.1 192.0.2.2
+
+Now, nothing will happen when you ping those addresses -- you'll need to make
+Scapy respond to that traffic.
+
+:py:class:`TunTapInterface` works the same as a :py:class:`SuperSocket`, so lets
+setup an :py:class:`AnsweringMachine` to respond to :py:class:`ICMP`
+``echo-request``:
+
+.. code-block:: pycon3
+
+    >>> am = t.am(ICMPEcho_am)
+    >>> am()
+
+Now, you can ping Scapy in another terminal:
+
+.. code-block: console:
+
+    $ ping -c 3 192.0.2.2
+    PING 192.0.2.2 (192.0.2.2): 56 data bytes
+    64 bytes from 192.0.2.2: icmp_seq=0 ttl=64 time=2.414 ms
+    64 bytes from 192.0.2.2: icmp_seq=1 ttl=64 time=3.927 ms
+    64 bytes from 192.0.2.2: icmp_seq=2 ttl=64 time=5.740 ms
+
+    --- 192.0.2.2 ping statistics ---
+    3 packets transmitted, 3 packets received, 0.0% packet loss
+    round-trip min/avg/max/stddev = 2.414/4.027/5.740/1.360 ms
+
+You should see those packets show up in Scapy:
+
+.. code-block:: pycon3
+
+    >>> am()
+    Replying 192.0.2.1 to 192.0.2.2
+    Replying 192.0.2.1 to 192.0.2.2
+    Replying 192.0.2.1 to 192.0.2.2
+
+You might have noticed that didn't configure Scapy with any IP address... and
+there's a trick to this: :py:class:`ICMPEcho_am` swaps the ``source`` and
+``destination`` fields of any :py:class:`Ether` and :py:class:`IP` headers on
+the :py:class:`ICMP` packet that it receives. As a result, it actually responds
+to *any* IP address.
+
+You can stop the :py:class:`ICMPEcho_am` AnsweringMachine with :kbd:`^C`.
+
+When you close Scapy, the ``tun0`` interface will automatically disappear.
+
+TunTapInterface reference
+=========================
+
+.. py:class:: TunTapInterface(SimpleSocket)
+
+    A socket to act as the remote side of a TUN/TAP interface.
+
+    .. py:method:: __init__(iface: Text, [mode_tun], [strip_packet_info = True], [default_read_size = MTU])
+
+        :param Text iface:
+            The name of the interface to use, eg: ``tun0``.
+
+            On BSD and macOS, this must start with either ``tun`` or ``tap``,
+            and have a corresponding :file:`/dev/` node (eg: :file:`/dev/tun0`).
+
+            On Linux, this will be truncated to 16 bytes.
+
+        :param bool mode_tun:
+            If True, create as TUN interface (layer 3). If False, creates a TAP
+            interface (layer 2).
+
+            If not supplied, attempts to detect from the ``iface`` parameter.
+
+        :param bool strip_packet_info:
+            If True (default), any :py:class:`TunPacketInfo` will be stripped
+            from the packet (so you get :py:class:`Ether` or :py:class:`IP`).
+
+            Only Linux TUN interfaces have :py:class:`TunPacketInfo` available.
+
+            This has no effect for interfaces that do not have
+            :py:class:`TunPacketInfo` available.
+
+        :param int default_read_size:
+            Sets the default size that is read by
+            :py:meth:`SuperSocket.raw_recv` and :py:meth:`SuperSocket.recv`.
+            This defaults to :py:data:`scapy.data.MTU`.
+
+            :py:class:`TunTapInterface` always adds overhead for
+            :py:class:`TunPacketInfo` headers, if required.
+
+.. py:class:: TunPacketInfo(Packet)
+
+    Abstract class used to stack layer 3 protocols on a platform-specific
+    header.
+
+    See :py:class:`LinuxTunPacketInfo` for an example.
+
+    .. py:method:: guess_payload_class(payload)
+
+        The default implementation expects the field ``proto`` to be declared,
+        with a value from :py:data:`scapy.data.ETHER_TYPES`.
+
+Linux-specific structures
+-------------------------
+
+.. py:class:: LinuxTunPacketInfo(TunPacketInfo)
+
+    Packet header used for Linux TUN packets.
+
+    This is ``struct tun_pi``, declared in :file:`linux/if_tun.h`.
+
+    .. py:attribute:: flags
+
+        Flags to set on the packet. Only ``TUN_VNET_HDR`` is supported.
+
+    .. py:attribute:: proto
+
+        Layer 3 protocol number, per :py:data:`scapy.data.ETHER_TYPES`.
+
+        Used by :py:meth:`TunTapPacketInfo.guess_payload_class`.
+
+.. py:class:: LinuxTunIfReq(Packet)
+
+    Internal "packet" used for ``TUNSETIFF`` requests on Linux.
+
+    This is ``struct ifreq``, declared in :file:`linux/if.h`.

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -34,9 +34,10 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
     function_name = ""
     filter = None
     sniff_options = {"store": 0}
-    sniff_options_list = ["store", "iface", "count", "promisc", "filter", "type", "prn", "stop_filter"]  # noqa: E501
+    sniff_options_list = ["store", "iface", "count", "promisc", "filter",
+                          "type", "prn", "stop_filter", "opened_socket"]
     send_options = {"verbose": 0}
-    send_options_list = ["iface", "inter", "loop", "verbose"]
+    send_options_list = ["iface", "inter", "loop", "verbose", "socket"]
     send_function = staticmethod(send)
 
     def __init__(self, **kargs):

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -13,7 +13,7 @@ import struct
 import time
 from scapy.consts import WINDOWS
 from scapy.config import conf
-from scapy.data import MTU, ARPHRD_TO_DLT
+from scapy.data import MTU, ARPHDR_ETHER, ARPHRD_TO_DLT
 from scapy.error import Scapy_Exception
 from scapy.interfaces import network_name
 
@@ -131,6 +131,8 @@ def compile_filter(filter_exp, iface=None, linktype=None,
         except Exception:
             # Failed to use linktype: use the interface
             pass
+        if not linktype and conf.use_bpf:
+            linktype = ARPHDR_ETHER
     if linktype is not None:
         ret = pcap_compile_nopcap(
             MTU, linktype, ctypes.byref(bpf), bpf_filter, 0, -1

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -443,7 +443,8 @@ class L2Socket(SuperSocket):
             log_runtime.info(
                 "The 'monitor' argument has no effect on native linux sockets."
             )
-        self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
+        self.ins = socket.socket(
+            socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))
         if not nofilter:
             if conf.except_filter:
                 if filter:

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -805,7 +805,7 @@ class Conf(ConfClass):
                    'llmnr', 'lltd', 'mgcp', 'mobileip', 'netbios',
                    'netflow', 'ntp', 'ppi', 'ppp', 'pptp', 'radius', 'rip',
                    'rtp', 'sctp', 'sixlowpan', 'skinny', 'smb', 'smb2', 'snmp',
-                   'tftp', 'vrrp', 'vxlan', 'x509', 'zigbee']
+                   'tftp', 'tuntap', 'vrrp', 'vxlan', 'x509', 'zigbee']
     #: a dict which can be used by contrib layers to store local
     #: configuration
     contribs = dict()  # type: Dict[str, Any]

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -7,7 +7,7 @@
 This file contains constants
 """
 
-from sys import platform, maxsize
+from sys import byteorder, platform, maxsize
 import platform as platform_lib
 
 LINUX = platform.startswith("linux")
@@ -21,4 +21,5 @@ WINDOWS_XP = platform_lib.release() == "XP"
 BSD = DARWIN or FREEBSD or OPENBSD or NETBSD
 # See https://docs.python.org/3/library/platform.html#cross-platform
 IS_64BITS = maxsize > 2**32
+BIG_ENDIAN = byteorder == 'big'
 # LOOPBACK_NAME moved to conf.loopback_name

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2061,6 +2061,8 @@ class _BitField(Field[I, int]):
                  tot_size=0, end_tot_size=0):
         # type: (str, I, int, int, int) -> None
         Field.__init__(self, name, default)
+        if callable(size):
+            size = size(self)
         self.rev = size < 0 or tot_size < 0 or end_tot_size < 0
         self.size = abs(size)
         if not tot_size:

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -442,7 +442,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             return self.payload.answers(other.payload)
 
 
-class _IPv46(IP):
+class IPv46(IP):
     """
     This class implements a dispatcher that is used to detect the IP version
     while parsing Raw IP pcap files.
@@ -4029,8 +4029,8 @@ _load_dict(ipv6nhcls)
 conf.l3types.register(ETH_P_IPV6, IPv6)
 conf.l2types.register(31, IPv6)
 conf.l2types.register(DLT_IPV6, IPv6)
-conf.l2types.register(DLT_RAW, _IPv46)
-conf.l2types.register_num2layer(DLT_RAW_ALT, _IPv46)
+conf.l2types.register(DLT_RAW, IPv46)
+conf.l2types.register_num2layer(DLT_RAW_ALT, IPv46)
 
 bind_layers(Ether, IPv6, type=0x86dd)
 bind_layers(CookedLinux, IPv6, proto=0x86dd)

--- a/scapy/layers/tuntap.py
+++ b/scapy/layers/tuntap.py
@@ -1,0 +1,238 @@
+# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# Copyright (C) Michael Farrell <micolous+git@gmail.com>
+# This program is published under a GPLv2 license
+
+"""
+Implementation of TUN/TAP interfaces.
+
+These allow Scapy to act as the remote side of a virtual network interface.
+"""
+
+from __future__ import absolute_import
+
+import socket
+import time
+from fcntl import ioctl
+
+from scapy.compat import raw, bytes_encode
+from scapy.config import conf
+from scapy.consts import BIG_ENDIAN, BSD, LINUX
+from scapy.data import ETHER_TYPES, MTU
+from scapy.error import warning, log_runtime
+from scapy.fields import Field, FlagsField, StrFixedLenField, XShortEnumField
+from scapy.layers.inet import IP
+from scapy.layers.inet6 import IPv46, IPv6
+from scapy.layers.l2 import Ether
+from scapy.packet import Packet
+from scapy.supersocket import SimpleSocket
+
+# Linux-specific defines (/usr/include/linux/if_tun.h)
+LINUX_TUNSETIFF = 0x400454ca
+LINUX_IFF_TUN = 0x0001
+LINUX_IFF_TAP = 0x0002
+LINUX_IFF_NO_PI = 0x1000
+LINUX_IFNAMSIZ = 16
+
+
+class NativeShortField(Field):
+    def __init__(self, name, default):
+        Field.__init__(self, name, default, "@H")
+
+
+class TunPacketInfo(Packet):
+    aliastypes = [Ether]
+
+
+class LinuxTunIfReq(Packet):
+    """
+    Structure to request a specific device name for a tun/tap
+    Linux  ``struct ifreq``.
+
+    See linux/if.h (struct ifreq) and tuntap.txt for reference.
+    """
+    fields_desc = [
+        # union ifr_ifrn
+        StrFixedLenField("ifrn_name", b"", 16),
+        # union ifr_ifru
+        NativeShortField("ifru_flags", 0),
+    ]
+
+
+class LinuxTunPacketInfo(TunPacketInfo):
+    """
+    Base for TUN packets.
+
+    See linux/if_tun.h (struct tun_pi) for reference.
+    """
+    fields_desc = [
+        # This is native byte order
+        FlagsField("flags", 0,
+                   (lambda _: 16 if BIG_ENDIAN else -16),
+                   ["TUN_VNET_HDR"] +
+                   ["reserved%d" % x for x in range(1, 16)]),
+        # This is always network byte order
+        XShortEnumField("type", 0x9000, ETHER_TYPES),
+    ]
+
+
+class TunTapInterface(SimpleSocket):
+    """
+    A socket to act as the host's peer of a tun / tap interface.
+
+    This implements kernel interfaces for tun and tap devices.
+
+    :param iface: The name of the interface to use, eg: 'tun0'
+    :param mode_tun: If True, create as TUN interface (layer 3).
+                     If False, creates a TAP interface (layer 2).
+                     If not supplied, attempts to detect from the ``iface``
+                     name.
+    :type mode_tun: bool
+    :param strip_packet_info: If True (default), strips any TunPacketInfo from
+                              the packet. If False, leaves it in tact. Some
+                              operating systems and tunnel types don't include
+                              this sort of data.
+    :type strip_packet_info: bool
+
+    FreeBSD references:
+
+    * tap(4): https://www.freebsd.org/cgi/man.cgi?query=tap&sektion=4
+    * tun(4): https://www.freebsd.org/cgi/man.cgi?query=tun&sektion=4
+
+    Linux references:
+
+    * https://www.kernel.org/doc/Documentation/networking/tuntap.txt
+
+    """
+    desc = "Act as the host's peer of a tun / tap interface"
+
+    def __init__(self, iface=None, mode_tun=None, default_read_size=MTU,
+                 strip_packet_info=True, *args, **kwargs):
+        self.iface = bytes_encode(conf.iface if iface is None else iface)
+
+        self.mode_tun = mode_tun
+        if self.mode_tun is None:
+            if self.iface.startswith(b"tun"):
+                self.mode_tun = True
+            elif self.iface.startswith(b"tap"):
+                self.mode_tun = False
+            else:
+                raise ValueError(
+                    "Could not determine interface type for %r; set "
+                    "`mode_tun` explicitly." % (self.iface,))
+
+        self.strip_packet_info = bool(strip_packet_info)
+
+        # This is non-zero when there is some kernel-specific packet info.
+        # We add this to any MTU value passed to recv(), and use it to
+        # remove leading bytes when strip_packet_info=True.
+        self.mtu_overhead = 0
+
+        # The TUN packet specification sends raw IP at us, and doesn't specify
+        # which version.
+        self.kernel_packet_class = IPv46 if self.mode_tun else Ether
+
+        if LINUX:
+            devname = b"/dev/net/tun"
+
+            # Having an EtherType always helps on Linux, then we don't need
+            # to use auto-detection of IP version.
+            if self.mode_tun:
+                self.kernel_packet_class = LinuxTunPacketInfo
+                self.mtu_overhead = 4  # len(LinuxTunPacketInfo)
+            else:
+                warning("tap devices on Linux do not include packet info!")
+                self.strip_packet_info = True
+
+            if len(self.iface) > LINUX_IFNAMSIZ:
+                warning("Linux interface names are limited to %d bytes, "
+                        "truncating!" % (LINUX_IFNAMSIZ,))
+                self.iface = self.iface[:LINUX_IFNAMSIZ]
+
+        elif BSD:  # also DARWIN
+            if not (self.iface.startswith(b"tap") or
+                    self.iface.startswith(b"tun")):
+                raise ValueError("Interface names must start with `tun` or "
+                                 "`tap` on BSD and Darwin")
+            devname = b"/dev/" + self.iface
+            if not self.strip_packet_info:
+                warning("tun/tap devices on BSD and Darwin never include "
+                        "packet info!")
+                self.strip_packet_info = True
+        else:
+            raise NotImplementedError("TunTapInterface is not supported on "
+                                      "this platform!")
+
+        sock = open(devname, "r+b", buffering=0)
+
+        if LINUX:
+            if self.mode_tun:
+                flags = LINUX_IFF_TUN
+            else:
+                # Linux can send us LinuxTunPacketInfo for TAP interfaces, but
+                # the kernel sends the wrong information!
+                #
+                # Instead of type=1 (Ether), it sends that of the payload
+                # (eg: 0x800 for IPv4 or 0x86dd for IPv6).
+                #
+                # tap interfaces always send Ether frames, which include a
+                # type parameter for the IPv4/v6/etc. payload, so we set
+                # IFF_NO_PI.
+                flags = LINUX_IFF_TAP | LINUX_IFF_NO_PI
+
+            tsetiff = raw(LinuxTunIfReq(
+                ifrn_name=bytes_encode(self.iface),
+                ifru_flags=flags))
+
+            ioctl(sock, LINUX_TUNSETIFF, tsetiff)
+
+        self.closed = False
+        self.default_read_size = default_read_size
+        super(TunTapInterface, self).__init__(sock)
+
+    def __call__(self, *arg, **karg):
+        """Needed when using an instantiated TunTapInterface object for
+        conf.L2listen, conf.L2socket or conf.L3socket.
+
+        """
+        return self
+
+    def recv_raw(self, x=None):
+        if x is None:
+            x = self.default_read_size
+
+        x += self.mtu_overhead
+
+        r = self.kernel_packet_class, self.ins.read(x), time.time()
+        if self.mtu_overhead > 0 and self.strip_packet_info:
+            # Get the packed class of the payload, without triggering a full
+            # decode of the payload data.
+            cls = r[0](r[1][:self.mtu_overhead]).guess_payload_class(b'')
+
+            # Return the payload data only
+            return cls, r[1][self.mtu_overhead:], r[2]
+        else:
+            return r
+
+    def send(self, x):
+        if hasattr(x, "sent_time"):
+            x.sent_time = time.time()
+
+        if self.kernel_packet_class == IPv46:
+            # IPv46 is an auto-detection wrapper; we should just push through
+            # packets normally if we got IP or IPv6.
+            if not isinstance(x, (IP, IPv6)):
+                x = IP() / x
+        elif not isinstance(x, self.kernel_packet_class):
+            x = self.kernel_packet_class() / x
+
+        sx = raw(x)
+
+        try:
+            self.outs.write(sx)
+            self.outs.flush()
+        except socket.error:
+            log_runtime.error("%s send",
+                              self.__class__.__name__, exc_info=True)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1120,11 +1120,11 @@ def bridge_and_sniff(if1, if2, xfrm12=None, xfrm21=None, prn=None, L2socket=None
                 return
             else:
                 if newpkt is True:
-                    newpkt = pkt.original
+                    newpkt = pkt
                 elif not newpkt:
                     return
         else:
-            newpkt = pkt.original
+            newpkt = pkt
         try:
             sendsock.send(newpkt)
         except Exception:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -11,15 +11,14 @@ from __future__ import absolute_import
 from select import select, error as select_error
 import ctypes
 import errno
-import os
 import socket
 import struct
 import time
 
 from scapy.config import conf
-from scapy.consts import LINUX, DARWIN, WINDOWS
+from scapy.consts import DARWIN, WINDOWS
 from scapy.data import MTU, ETH_P_IP, SOL_PACKET, SO_TIMESTAMPNS
-from scapy.compat import raw, bytes_encode
+from scapy.compat import raw
 from scapy.error import warning, log_runtime
 from scapy.interfaces import network_name
 import scapy.modules.six as six
@@ -184,6 +183,14 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
     def tshark(self, *args, **kargs):
         from scapy import sendrecv
         return sendrecv.tshark(opened_socket=self, *args, **kargs)
+
+    def am(self, cls, *args, **kwargs):
+        """
+        Creates an AnsweringMachine associated with this socket.
+
+        :param cls: A subclass of AnsweringMachine to instantiate
+        """
+        return cls(*args, opened_socket=self, socket=self, **kwargs)
 
     @staticmethod
     def select(sockets, remain=conf.recv_poll_rate):
@@ -391,74 +398,3 @@ class L2ListenTcpdump(SuperSocket):
         if (WINDOWS or DARWIN):
             return sockets, None
         return SuperSocket.select(sockets, remain=remain)
-
-
-class TunTapInterface(SuperSocket):
-    """A socket to act as the host's peer of a tun / tap interface.
-
-    """
-    desc = "Act as the host's peer of a tun / tap interface"
-
-    def __init__(self, iface=None, mode_tun=None, *arg, **karg):
-        self.iface = conf.iface if iface is None else iface
-        self.mode_tun = ("tun" in self.iface) if mode_tun is None else mode_tun
-        self.closed = True
-        self.open()
-
-    def open(self):
-        """Open the TUN or TAP device."""
-        if not self.closed:
-            return
-        self.outs = self.ins = open(
-            "/dev/net/tun" if LINUX else ("/dev/%s" % self.iface), "r+b",
-            buffering=0
-        )
-        if LINUX:
-            from fcntl import ioctl
-            # TUNSETIFF = 0x400454ca
-            # IFF_TUN = 0x0001
-            # IFF_TAP = 0x0002
-            # IFF_NO_PI = 0x1000
-            ioctl(self.ins, 0x400454ca, struct.pack(
-                "16sH", bytes_encode(self.iface),
-                0x0001 if self.mode_tun else 0x1002,
-            ))
-        self.closed = False
-
-    def __call__(self, *arg, **karg):
-        """Needed when using an instantiated TunTapInterface object for
-conf.L2listen, conf.L2socket or conf.L3socket.
-
-        """
-        return self
-
-    def recv(self, x=MTU):
-        if self.mode_tun:
-            data = os.read(self.ins.fileno(), x + 4)
-            proto = struct.unpack('!H', data[2:4])[0]
-            return conf.l3types.get(proto, conf.raw_layer)(data[4:])
-        return conf.l2types.get(1, conf.raw_layer)(
-            os.read(self.ins.fileno(), x)
-        )
-
-    def send(self, x):
-        sx = raw(x)
-        if self.mode_tun:
-            try:
-                proto = conf.l3types[type(x)]
-            except KeyError:
-                log_runtime.warning(
-                    "Cannot find layer 3 protocol value to send %s in "
-                    "conf.l3types, using 0",
-                    x.name if hasattr(x, "name") else type(x).__name__
-                )
-                proto = 0
-            sx = struct.pack('!HH', 0, proto) + sx
-        try:
-            try:
-                x.sent_time = time.time()
-            except AttributeError:
-                pass
-            return os.write(self.outs.fileno(), sx)
-        except socket.error:
-            log_runtime.error("%s send", self.__class__.__name__, exc_info=True)  # noqa: E501

--- a/test/configs/solaris.utsc
+++ b/test/configs/solaris.utsc
@@ -30,6 +30,8 @@
     "windows",
     "crypto_advanced",
     "ipv6",
+    "tap",
+    "tun",
     "vcan_socket"
   ]
 }

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -22,15 +22,17 @@
     "test\\tls*.uts": "load_layer(\"tls\")"
   },
   "kw_ko": [
-    "osx",
-    "linux",
-    "crypto_advanced",
-    "mock_read_routes_bsd",
-    "require_gui",
-    "open_ssl_client",
-    "vcan_socket",
-    "ipv6",
     "brotli",
+    "crypto_advanced",
+    "ipv6",
+    "linux",
+    "mock_read_routes_bsd",
+    "open_ssl_client",
+    "osx",
+    "require_gui",
+    "tap",
+    "tun",
+    "vcan_socket",
     "zstd"
   ]
 }

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -1,0 +1,40 @@
+{
+  "testfiles": [
+    "*.uts",
+    "scapy\\layers\\*.uts",
+    "test\\contrib\\automotive\\obd\\*.uts",
+    "test\\contrib\\automotive\\gm\\*.uts",
+    "test\\contrib\\automotive\\bmw\\*.uts",
+    "test\\contrib\\automotive\\*.uts",
+    "tls\\tests_tls_netaccess.uts",
+    "contrib\\*.uts"
+  ],
+  "remove_testfiles": [
+    "bpf.uts",
+    "linux.uts"
+  ],
+  "breakfailed": true,
+  "onlyfailed": true,
+  "preexec": {
+    "contrib\\*.uts": "load_contrib(\"%name%\")",
+    "cert.uts": "load_layer(\"tls\")",
+    "sslv2.uts": "load_layer(\"tls\")",
+    "tls*.uts": "load_layer(\"tls\")"
+  },
+  "format": "html",
+  "kw_ko": [
+    "osx",
+    "linux",
+    "crypto_advanced",
+    "mock_read_routes_bsd",
+    "appveyor_only",
+    "open_ssl_client",
+    "vcan_socket",
+    "ipv6",
+    "manufdb",
+    "tcpdump",
+    "tap",
+    "tun",
+    "tshark"
+  ]
+}

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -358,3 +358,9 @@ t_sniffer.join(1)
 assert(dot1q_count == 2)
 
 veth.destroy()
+
+= Reload interfaces & routes
+
+conf.ifaces.reload()
+conf.route.resync()
+conf.route6.resync()

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -6,7 +6,7 @@
 ############
 + Test bridge_and_sniff() using tap sockets
 
-~ tap linux
+~ tap
 
 = Create two tap interfaces
 
@@ -23,44 +23,46 @@ else:
         assert subprocess.check_call(["ifconfig", "tap%d" % i, "up"]) == 0
 
 = Run a sniff thread on the tap1 **interface**
-* It will terminate when 5 IP packets from 1.2.3.4 have been sniffed
+* It will terminate when 5 IP packets from 192.0.2.1 have been sniffed
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tap1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"}
+            "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"}
 )
 t_sniff.start()
 
 = Run a bridge_and_sniff thread between the taps **sockets**
-* It will terminate when 5 IP packets from 1.2.3.4 have been forwarded
+* It will terminate when 5 IP packets from 192.0.2.1 have been forwarded
 t_bridge = Thread(target=bridge_and_sniff, args=(tap0, tap1),
                   kwargs={"store": False, "count": 5, 'prn': Packet.summary,
-                          "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"})
+                          "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"})
 t_bridge.start()
 
-= Send five IP packets from 1.2.3.4 to the tap0 **interface**
+= Send five IP packets from 192.0.2.1 to the tap0 **interface**
 time.sleep(1)
-sendp([Ether(dst=ETHER_BROADCAST) / IP(src="1.2.3.4") / ICMP()], iface="tap0",
+sendp([Ether(dst=ETHER_BROADCAST) / IP(src="192.0.2.1") / ICMP()], iface="tap0",
       count=5)
 
 = Wait for the threads
-t_bridge.join()
-t_sniff.join()
+t_bridge.join(5)
+t_sniff.join(5)
+assert not t_bridge.is_alive()
+assert not t_sniff.is_alive()
 
 = Run a sniff thread on the tap1 **interface**
-* It will terminate when 5 IP packets from 2.3.4.5 have been sniffed
+* It will terminate when 5 IP packets from 198.51.100.1 have been sniffed
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tap1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5"}
+            "lfilter": lambda p: IP in p and p[IP].src == "198.51.100.1"}
 )
 t_sniff.start()
 
 = Run a bridge_and_sniff thread between the taps **sockets**
-* It will "NAT" packets from 1.2.3.4 to 2.3.4.5 and will terminate when 5 IP packets have been forwarded
+* It will "NAT" packets from 192.0.2.1 to 198.51.100.1 and will terminate when 5 IP packets have been forwarded
 def nat_1_2(pkt):
-    if IP in pkt and pkt[IP].src == "1.2.3.4":
-        pkt[IP].src = "2.3.4.5"
+    if IP in pkt and pkt[IP].src == "192.0.2.1":
+        pkt[IP].src = "198.51.100.1"
         del pkt[IP].chksum
         return pkt
     return False
@@ -68,17 +70,19 @@ def nat_1_2(pkt):
 t_bridge = Thread(target=bridge_and_sniff, args=(tap0, tap1),
                   kwargs={"store": False, "count": 5, 'prn': Packet.summary,
                           "xfrm12": nat_1_2,
-                          "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"})
+                          "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"})
 t_bridge.start()
 
-= Send five IP packets from 1.2.3.4 to the tap0 **interface**
+= Send five IP packets from 192.0.2.1 to the tap0 **interface**
 time.sleep(1)
-sendp([Ether(dst=ETHER_BROADCAST) / IP(src="1.2.3.4") / ICMP()], iface="tap0",
+sendp([Ether(dst=ETHER_BROADCAST) / IP(src="192.0.2.1") / ICMP()], iface="tap0",
       count=5)
 
 = Wait for the threads
-t_bridge.join()
-t_sniff.join()
+t_bridge.join(5)
+t_sniff.join(5)
+assert not t_bridge.is_alive()
+assert not t_sniff.is_alive()
 
 = Delete the tap interfaces
 if conf.use_pypy:
@@ -93,7 +97,7 @@ else:
 ############
 + Test bridge_and_sniff() using tun sockets
 
-~ tun linux not_pcapdnet
+~ tun not_pcapdnet
 
 = Create two tun interfaces
 
@@ -105,51 +109,61 @@ tun0, tun1 = [TunTapInterface("tun%d" % i) for i in range(2)]
 if LINUX:
     for i in range(2):
         assert subprocess.check_call(["ip", "link", "set", "tun%d" % i, "up"]) == 0
+    assert subprocess.check_call([
+        "ip", "addr", "change",
+        "192.0.2.1", "peer", "192.0.2.2", "dev", "tun0"]) == 0
 else:
     for i in range(2):
         assert subprocess.check_call(["ifconfig", "tun%d" % i, "up"]) == 0
+    assert subprocess.check_call(["ifconfig", "tun0", "192.0.2.1", "192.0.2.2"]) == 0
+
+print('waiting a bit...')
+import time
+time.sleep(10)
 
 = Run a sniff thread on the tun1 **interface**
-* It will terminate when 5 IP packets from 1.2.3.4 have been sniffed
+* It will terminate when 5 IP packets from 192.0.2.1 have been sniffed
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tun1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"}
+            "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"}
 )
 t_sniff.start()
 
 = Run a bridge_and_sniff thread between the tuns **sockets**
-* It will terminate when 5 IP packets from 1.2.3.4 have been forwarded.
+* It will terminate when 5 IP packets from 192.0.2.1 have been forwarded.
 t_bridge = Thread(target=bridge_and_sniff, args=(tun0, tun1),
                   kwargs={"store": False, "count": 5, 'prn': Packet.summary,
                           "xfrm12": lambda pkt: pkt,
-                          "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"})
+                          "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"})
 t_bridge.start()
 
-= Send five IP packets from 1.2.3.4 to the tun0 **interface**
+= Send five IP packets from 192.0.2.1 to the tun0 **interface**
 time.sleep(1)
-conf.route.add(net="1.2.3.4/32", dev="tun0")
-send(IP(src="1.2.3.4", dst="1.2.3.4") / ICMP(), count=5)
-conf.route.delt(net="1.2.3.4/32", dev="tun0")
+conf.route.add(net="192.0.2.2/32", dev="tun0")
+send([IP(src="192.0.2.1", dst="192.0.2.2") / ICMP()], count=5, iface="tun0")
+conf.route.delt(net="192.0.2.2/32", dev="tun0")
 
 = Wait for the threads
-t_bridge.join()
-t_sniff.join()
+t_bridge.join(5)
+t_sniff.join(5)
+assert not t_bridge.is_alive()
+assert not t_sniff.is_alive()
 
 = Run a sniff thread on the tun1 **interface**
-* It will terminate when 5 IP packets from 2.3.4.5 have been sniffed
+* It will terminate when 5 IP packets from 198.51.100.1 have been sniffed
 t_sniff = Thread(
     target=sniff,
     kwargs={"iface": "tun1", "count": 5, "prn": Packet.summary,
-            "lfilter": lambda p: IP in p and p[IP].src == "2.3.4.5"}
+            "lfilter": lambda p: IP in p and p[IP].src == "198.51.100.1"}
 )
 t_sniff.start()
 
 = Run a bridge_and_sniff thread between the tuns **sockets**
-* It will "NAT" packets from 1.2.3.4 to 2.3.4.5 and will terminate when 5 IP packets have been forwarded
+* It will "NAT" packets from 192.0.2.1 to 198.51.100.1 and will terminate when 5 IP packets have been forwarded
 def nat_1_2(pkt):
-    if IP in pkt and pkt[IP].src == "1.2.3.4":
-        pkt[IP].src = "2.3.4.5"
+    if IP in pkt and pkt[IP].src == "192.0.2.1":
+        pkt[IP].src = "198.51.100.1"
         del pkt[IP].chksum
         return pkt
     return False
@@ -157,18 +171,20 @@ def nat_1_2(pkt):
 t_bridge = Thread(target=bridge_and_sniff, args=(tun0, tun1),
                   kwargs={"store": False, "count": 5, 'prn': Packet.summary,
                           "xfrm12": nat_1_2,
-                          "lfilter": lambda p: IP in p and p[IP].src == "1.2.3.4"})
+                          "lfilter": lambda p: IP in p and p[IP].src == "192.0.2.1"})
 t_bridge.start()
 
-= Send five IP packets from 1.2.3.4 to the tun0 **interface**
+= Send five IP packets from 192.0.2.1 to the tun0 **interface**
 time.sleep(1)
-conf.route.add(net="1.2.3.4/32", dev="tun0")
-send(IP(src="1.2.3.4", dst="1.2.3.4") / ICMP(), count=5)
-conf.route.delt(net="1.2.3.4/32", dev="tun0")
+conf.route.add(net="192.0.2.2/32", dev="tun0")
+send([IP(src="192.0.2.1", dst="192.0.2.2") / ICMP()], count=5, iface="tun0")
+conf.route.delt(net="192.0.2.2/32", dev="tun0")
 
 = Wait for the threads
-t_bridge.join()
-t_sniff.join()
+t_bridge.join(5)
+t_sniff.join(5)
+assert not t_bridge.is_alive()
+assert not t_sniff.is_alive()
 
 = Delete the tun interfaces
 if conf.use_pypy:
@@ -226,9 +242,9 @@ with VEthPair('a_0', 'a_1') as veth_0:
 ############
 + Test arpleak() using a tap socket
 
-~ tap linux tcpdump
+~ tap tcpdump
 
-= Create two tap interfaces
+= Create a tap interface
 
 import mock
 import struct
@@ -243,10 +259,11 @@ if LINUX:
 else:
     assert subprocess.check_call(["ifconfig", "tap0", "up"]) == 0
 
+= Check for arpleak
 
 def answer_arp_leak(pkt):
     mymac = b"\x00\x01\x02\x03\x04\x06"
-    myip = b"\x01\x02\x03\x02"
+    myip = b"\xc0\x00\x02\x02" # 192.0.2.2
     if not ARP in pkt:
         return
     e_src = pkt.src
@@ -282,10 +299,10 @@ t_answer.start()
 @mock.patch("scapy.layers.l2.get_if_addr")
 @mock.patch("scapy.layers.l2.get_if_hwaddr")
 def test_arpleak(mock_get_if_hwaddr, mock_get_if_addr, hwlen=255, plen=255):
-    conf.route.ifadd("tap0", "1.2.3.0/24")
-    mock_get_if_addr.side_effect = lambda _: "1.2.3.1"
+    conf.route.ifadd("tap0", "192.0.2.0/24")
+    mock_get_if_addr.side_effect = lambda _: "192.0.2.1"
     mock_get_if_hwaddr.side_effect = lambda _: "00:01:02:03:04:05"
-    return arpleak("1.2.3.2/31", timeout=2, hwlen=hwlen, plen=plen)
+    return arpleak("192.0.2.2/31", timeout=2, hwlen=hwlen, plen=plen)
 
 time.sleep(2)
 

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -1,0 +1,250 @@
+% tuntap tests for Scapy
+
+# Packet capture-based tests are in sendsniff.uts
+
+#######
++ Test Linux-specific protocol headers for TunTap
+~ linux tun
+
+= Linux-specific protocol headers
+
+p = LinuxTunPacketInfo()/IP()
+assert p.type == 2048
+
+p = LinuxTunPacketInfo(raw(p))
+assert p.type == 2048
+assert isinstance(p.payload, IP)
+
+p = LinuxTunPacketInfo()/IPv6()
+assert p.type == 0x86dd
+
+p = LinuxTunPacketInfo(raw(p))
+assert p.type == 0x86dd
+
+assert isinstance(p.payload, IPv6)
+
+#######
++ Test tun device
+
+~ tun netaccess
+
+= Create a tun interface
+
+import subprocess
+from threading import Thread
+
+tun0 = TunTapInterface("tun0", strip_packet_info=False)
+
+if LINUX:
+    assert subprocess.check_call(["ip", "link", "set", "tun0", "up"]) == 0
+    assert subprocess.check_call([
+        "ip", "addr", "change",
+        "192.0.2.1", "peer", "192.0.2.2", "dev", "tun0"]) == 0
+elif BSD:
+    assert subprocess.check_call(["ifconfig", "tun0", "up"]) == 0
+    assert subprocess.check_call([
+        "ifconfig", "tun0", "192.0.2.1", "192.0.2.2"]) == 0
+else:
+    raise NotImplementedError()
+
+= Setup ICMPEcho_am on the interface
+
+am = tun0.am(ICMPEcho_am, count=3)
+am.defoptsniff['timeout'] = 5
+t_am = Thread(target=am)
+t_am.start()
+time.sleep(1)
+
+= Send ping packets from OS into scapy
+
+# ping returns non-zero exit code on 100% packet loss
+assert subprocess.check_call(["ping", "-c3", "192.0.2.2"]) == 0
+
+= Cleanup
+
+t_am.join()
+
+tun0.close()
+if not conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    del tun0
+
+#######
++ Test strip_packet_info=False on Linux
+
+~ tun linux netaccess
+
+= Create a tun interface
+
+if not LINUX:
+    raise NotImplementedError()
+
+import subprocess
+
+tun0 = TunTapInterface("tun0", strip_packet_info=False)
+
+assert subprocess.check_call(["ip", "link", "set", "tun0", "up"]) == 0
+assert subprocess.check_call([
+    "ip", "addr", "change",
+    "192.0.2.1", "peer", "192.0.2.2", "dev", "tun0"]) == 0
+
+= Send ping packets from Linux into Scapy
+
+t = AsyncSniffer(opened_socket=tun0)
+t.start()
+
+# We expect this to return exit code 1, because there's nothing in Scapy that
+# responds to these packets.
+assert subprocess.call(["ping", "-c3", "192.0.2.2"]) == 1
+
+time.sleep(1)
+t.stop()
+
+assert len(t.results) >= 3
+icmp4_sequences = set()
+
+for pkt in t.results:
+    pkt
+    assert isinstance(pkt, LinuxTunPacketInfo)
+    if not isinstance(pkt.payload, IP) or ICMP not in pkt:
+        # We might get IPv6 router solicitation or other traffic...
+        continue
+    if pkt[IP].src != '192.0.2.1' or pkt[IP].dst != '192.0.2.2' or pkt[ICMP].type != 8:
+        continue
+    icmp4_sequences.add(pkt.seq)
+
+# Expect to get 3 different ICMP sequence numbers
+assert len(icmp4_sequences) == 3
+
+= Delete the tun interface
+tun0.close()
+if not conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    del tun0
+
++ Test strip_packet_info=True and IPv6
+
+~ tun netaccess ipv6
+
+= Create a tun interface with IPv4 + IPv6
+
+import subprocess
+
+tun0 = TunTapInterface("tun0", strip_packet_info=True)
+
+if LINUX:
+    assert subprocess.check_call(["ip", "link", "set", "tun0", "up"]) == 0
+    assert subprocess.check_call([
+        "ip", "addr", "change",
+        "192.0.2.1", "peer", "192.0.2.2", "dev", "tun0"]) == 0
+    assert subprocess.check_call([
+        "ip", "-6", "addr", "add",
+        "2001:db8::1", "peer", "2001:db8::2", "dev", "tun0"]) == 0
+elif BSD:
+    assert subprocess.check_call(["ifconfig", "tun0", "up"]) == 0
+    assert subprocess.check_call([
+        "ifconfig", "tun0", "192.0.2.1", "192.0.2.2"]) == 0
+    assert subprocess.check_call([
+        "ifconfig", "tun0", "inet6", "2001:db8::1/128", "2001:db8::2"]) == 0
+else:
+    raise NotImplementedError()
+
+= Send ping packets from OS into Scapy
+
+t = AsyncSniffer(opened_socket=tun0)
+t.start()
+
+# There's nothing in Scapy that responds, but we expect the packets to be sent
+# successfully. Linux and BSD (incl. macOS) have different exit codes.
+EXPECTED_EXIT = 1 if LINUX else 2
+assert subprocess.call(["ping", "-c3", "192.0.2.2"]) == EXPECTED_EXIT
+assert subprocess.call(["ping6", "-c3", "2001:db8::2"]) == EXPECTED_EXIT
+
+time.sleep(1)
+t.stop()
+
+assert len(t.results) >= 6
+icmp4_sequences = set()
+icmp6_sequences = set()
+
+for pkt in t.results:
+    pkt
+    assert isinstance(pkt, (IP, IPv6))
+    if (isinstance(pkt, IP) and
+        pkt[IP].src == "192.0.2.1" and pkt[IP].dst == "192.0.2.2" and
+        ICMP in pkt and pkt[ICMP].type == 8):
+        icmp4_sequences.add(pkt[ICMP].seq)
+    if (isinstance(pkt, IPv6) and
+        pkt[IPv6].src == "2001:db8::1" and pkt[IPv6].dst == "2001:db8::2" and
+        ICMPv6EchoRequest in pkt):
+        icmp6_sequences.add(pkt[ICMPv6EchoRequest].seq)
+
+# Expect to get 3 different ICMP sequence numbers
+assert len(icmp4_sequences) == 3, (
+    "Expected 3 IPv4 ICMP ping packets, got: " + repr(icmp4_sequences))
+assert len(icmp6_sequences) == 3, (
+    "Expected 3 IPv6 ICMP ping packets, got: " + repr(icmp6_sequences))
+
+= Delete the tun interface
+tun0.close()
+if not conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    del tun0
+
++ Test tap interfaces
+
+~ tap netaccess
+
+= Create a tap interface with IPv4
+
+import subprocess
+
+tap0 = TunTapInterface("tap0")
+
+if LINUX:
+    assert subprocess.check_call(["ip", "link", "set", "tap0", "up"]) == 0
+    assert subprocess.check_call([
+        "ip", "addr", "change", "192.0.2.1/30", "dev", "tap0"]) == 0
+    assert subprocess.check_call([
+        "ip", "neigh", "replace",
+        "192.0.2.2", "lladdr", "20:00:00:20:00:00", "dev", "tap0"]) == 0
+else:
+    assert subprocess.check_call(["ifconfig", "tap0", "up"]) == 0
+    assert subprocess.check_call([
+        "ifconfig", "tap0", "192.0.2.1", "netmask", "255.255.255.252"]) == 0
+    assert subprocess.check_call([
+        "arp", "-s", "192.0.2.2", "20:00:00:20:00:00", "temp"]) == 0
+
+= Send ping packets from OS into Scapy
+
+t = AsyncSniffer(opened_socket=tap0)
+t.start()
+
+# There's nothing in Scapy that responds, but we expect the packets to be sent
+# successfully. Linux and BSD (incl. macOS) have different exit codes.
+EXPECTED_EXIT = 1 if LINUX else 2
+assert subprocess.call(["ping", "-c3", "192.0.2.2"]) == EXPECTED_EXIT
+
+time.sleep(1)
+t.stop()
+
+assert len(t.results) >= 3
+icmp4_sequences = set()
+
+for pkt in t.results:
+    pkt
+    assert isinstance(pkt, Ether)
+    if (IP in pkt and
+        pkt[IP].src == "192.0.2.1" and pkt[IP].dst == "192.0.2.2" and
+        ICMP in pkt and pkt[ICMP].type == 8):
+        icmp4_sequences.add(pkt[ICMP].seq)
+
+# Expect to get 3 different ICMP sequence numbers
+assert len(icmp4_sequences) == 3, (
+    "Expected 3 IPv4 ICMP ping packets, got: " + repr(icmp4_sequences))
+
+= Delete the tap interface
+tap0.close()
+if not conf.use_pypy:
+    # See https://pypy.readthedocs.io/en/latest/cpython_differences.html
+    del tap0


### PR DESCRIPTION
(draft so I can run this through CI)

This a rework of `TunTapInterface` to fix many issues, and generally improve its tests and documentation.

* New: `ICMPEcho_am`, an `AnsweringMachine` that responds to ICMP Echo requests (IPv4 only).
* New: `BitField`'s `size` parameter to be `callable`.
* Move: `TunTapInterface` from `scapy.supersocket` to `scapy.layers.tuntap`.
* Fix: `tun` on macOS (properly guarded some Linux-specific code), including IPv6 support.
* Fix: `tun` on BSD too (untested).
* Fix/cleanup: endian handling for Linux.
* New: `tun` interfaces on Linux (optionally) expose platform-specific headers (`LinuxTapPacketInfo`) if `strip_packet_info=False`. Other platforms will ignore this setting and emit a warning. By default, `strip_packet_info=True` – packet headers are _stripped_ (for compatibility with existing code, and non-Linux systems).
* New: documentation for TunTap with worked examples.
* New: tests that use `TunTapInterface`'s `recv` / `send` methods (`sendrecv.uts` used packet capture APIs) and IPv6.
* Change: `TunTapInterface` test tags from `linux` to `tun` or `tap`. These tags are disabled on Windows and Solaris by default.
* Change: `scapy.layers.inet6._IPv46` renamed to `IPv46` (ie: it is now public), needed to support IPv6 on BSD/Darwin `tun` devices.
* Change: macOS tests on Travis CI now _include_ `tcpdump` ([these worked fine](https://travis-ci.org/github/micolous/scapy/jobs/567751277)), but now _exclude_ `tun` and `tap` tags (because [Travis CI doesn't let you install third-party kexts](https://travis-ci.community/t/issue-xcode-10-10-13-kernel-extension-user-consent/1287), even when [properly notarised](https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution?language=objc)).

Tested on Linux and macOS 10.15.  Unfortunately macOS on Travis CI doesn't let you load your own kexts, so I had to disable `tap` and `tun` tests there.

This is some of the preliminary work I mentioned in #2185, I've cleaned it up a little and rebased on current master.

**TODO:**

* use `TUNSIFHEAD` on macOS and BSD
* get tests passing on FreeBSD


<!-- This is just a checklist to guide you. You can remove it safely. -->

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->


