### PR TITLE
Sniffing with TLS sessions

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -760,6 +760,7 @@ Available by default:
 
 - ``IPSession`` -> *defragment IP packets* on-the-flow, to make a stream usable by ``prn``.
 - ``TCPSession`` -> *defragment certain TCP protocols**. Only **HTTP 1.0** currently uses this functionality.
+- ``TLSSession`` -> *matches TLS sessions* on the flow.
 - ``NetflowSession`` -> *resolve Netflow V9 packets* from their NetflowFlowset information objects
 
 Those sessions can be used using the ``session=`` parameter of ``sniff()``. Examples::

--- a/scapy/layers/tls/automaton.py
+++ b/scapy/layers/tls/automaton.py
@@ -180,6 +180,8 @@ class _TLSAutomaton(Automaton):
                     self.buffer_in += p.msg
                 else:
                     self.buffer_in += p.inner.msg
+            else:
+                p = p.payload
 
     def raise_on_packet(self, pkt_cls, state, get_next_msg=True):
         """

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -52,7 +52,7 @@ def _tls_version_check(version, min):
 ###############################################################################
 
 
-class _TLSEncryptedContent(Raw):
+class _TLSEncryptedContent(Raw, _GenericTLSSessionInheritance):
     """
     When the content of a TLS record (more precisely, a TLSCiphertext) could
     not be deciphered, we use this class to represent the encrypted data.
@@ -61,6 +61,12 @@ class _TLSEncryptedContent(Raw):
     version), the nonce_explicit, IV and/or padding will also be parsed.
     """
     name = "Encrypted Content"
+    match_subclass = True
+
+    def mysummary(self):
+        s = _GenericTLSSessionInheritance.mysummary(self)
+        s += " / " + self.name
+        return s
 
 
 class _TLSMsgListField(PacketListField):
@@ -217,6 +223,16 @@ class _TLSMsgListField(PacketListField):
         return hdr + res
 
 
+def _ssl_looks_like_sslv2(dat):
+    """
+    This is a copycat of wireshark's `packet-tls.c` ssl_looks_like_sslv2
+    """
+    if len(dat) < 3:
+        return
+    from scapy.layers.tls.handshake_sslv2 import _sslv2_handshake_type
+    return ord(dat[:1]) >= 0x80 and ord(dat[2:3]) in _sslv2_handshake_type
+
+
 class TLS(_GenericTLSSessionInheritance):
     """
     The generic TLS Record message, based on section 6.2 of RFC 5246.
@@ -301,10 +317,20 @@ class TLS(_GenericTLSSessionInheritance):
             plen = len(_pkt)
             if plen >= 2:
                 byte0, byte1 = struct.unpack("BB", _pkt[:2])
-                if (byte0 not in _tls_type) or (byte1 != 3):
-                    from scapy.layers.tls.record_sslv2 import SSLv2
-                    return SSLv2
                 s = kargs.get("tls_session", None)
+                if byte0 not in _tls_type or byte1 != 3:  # Unknown type
+                    # Check SSLv2: either the session is already SSLv2,
+                    # either the packet looks like one. As said above, this
+                    # isn't 100% reliable, but Wireshark does the same
+                    if s and (s.tls_version == 0x0002 or
+                              s.advertised_tls_version == 0x0002) or \
+                             (_ssl_looks_like_sslv2(_pkt) and (not s or
+                              s.tls_version is None)):
+                        from scapy.layers.tls.record_sslv2 import SSLv2
+                        return SSLv2
+                    # Not SSLv2: continuation
+                    return _TLSEncryptedContent
+                # Check TLS 1.3
                 if s and _tls_version_check(s.tls_version, 0x0304):
                     if s.rcs and not isinstance(s.rcs.cipher, Cipher_NULL):
                         from scapy.layers.tls.record_tls13 import TLS13
@@ -312,7 +338,7 @@ class TLS(_GenericTLSSessionInheritance):
             if plen < 5:
                 # Layer detected as TLS but too small to be a
                 # parsed. Scapy should not try to decode them
-                return conf.raw_layer
+                return _TLSEncryptedContent
         return TLS
 
     # Parsing methods
@@ -691,10 +717,17 @@ class TLS(_GenericTLSSessionInheritance):
 
         return hdr + efrag + pay
 
+    def mysummary(self):
+        s = super(TLS, self).mysummary()
+        if self.msg:
+            s += " / "
+            s += " / ".join(x.name for x in self.msg)
+        return s
 
 ###############################################################################
 #   TLS ChangeCipherSpec                                                      #
 ###############################################################################
+
 
 _tls_changecipherspec_type = {1: "change_cipher_spec"}
 

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -15,7 +15,10 @@ from scapy.compat import raw
 import scapy.modules.six as six
 from scapy.error import log_runtime, warning
 from scapy.packet import Packet
+from scapy.pton_ntop import inet_pton
+from scapy.sessions import DefaultSession
 from scapy.utils import repr_hex, strxor
+from scapy.layers.inet import TCP
 from scapy.layers.tls.crypto.compression import Comp_NULL
 from scapy.layers.tls.crypto.hkdf import TLS13_HKDF
 from scapy.layers.tls.crypto.prf import PRF
@@ -802,8 +805,8 @@ class tlsSession(object):
         family = socket.AF_INET
         if ':' in self.ipsrc:
             family = socket.AF_INET6
-        s1 += socket.inet_pton(family, self.ipsrc)
-        s2 += socket.inet_pton(family, self.ipdst)
+        s1 += inet_pton(family, self.ipsrc)
+        s2 += inet_pton(family, self.ipdst)
         return strxor(s1, s2)
 
     def eq(self, other):
@@ -855,14 +858,41 @@ class _GenericTLSSessionInheritance(Packet):
         except Exception:
             setme = True
 
+        newses = False
         if setme:
             if tls_session is None:
+                newses = True
                 self.tls_session = tlsSession()
             else:
                 self.tls_session = tls_session
 
         self.rcs_snap_init = self.tls_session.rcs.snapshot()
         self.wcs_snap_init = self.tls_session.wcs.snapshot()
+
+        if isinstance(_underlayer, TCP):
+            tcp = _underlayer
+            self.tls_session.sport = tcp.sport
+            self.tls_session.dport = tcp.dport
+            try:
+                self.tls_session.ipsrc = tcp.underlayer.src
+                self.tls_session.ipdst = tcp.underlayer.dst
+            except AttributeError:
+                pass
+            if conf.tls_session_enable:
+                if newses:
+                    s = conf.tls_sessions.find(self.tls_session)
+                    if s:
+                        if s.dport == self.tls_session.dport:
+                            self.tls_session = s
+                        else:
+                            self.tls_session = s.mirror()
+                    else:
+                        conf.tls_sessions.add(self.tls_session)
+            if self.tls_session.connection_end == "server":
+                srk = conf.tls_sessions.server_rsa_key
+                if not self.tls_session.server_rsa_key and \
+                        srk:
+                    self.tls_session.server_rsa_key = srk
 
         Packet.__init__(self, _pkt=_pkt, post_transform=post_transform,
                         _internal=_internal, _underlayer=_underlayer,
@@ -963,9 +993,8 @@ class _GenericTLSSessionInheritance(Packet):
         s.rcs = rcs_snap
         s.wcs = wcs_snap
 
-    # Uncomment this when the automata update IPs and ports properly
-    # def mysummary(self):
-    #    return "TLS %s" % repr(self.tls_session)
+    def mysummary(self):
+        return "TLS %s" % repr(self.tls_session)
 
 
 ###############################################################################
@@ -975,6 +1004,7 @@ class _GenericTLSSessionInheritance(Packet):
 class _tls_sessions(object):
     def __init__(self):
         self.sessions = {}
+        self.server_rsa_key = None
 
     def add(self, session):
         s = self.find(session)
@@ -998,7 +1028,10 @@ class _tls_sessions(object):
         self.sessions[h].remove(session)
 
     def find(self, session):
-        h = session.hash()
+        try:
+            h = session.hash()
+        except Exception:
+            return None
         if h in self.sessions:
             for k in self.sessions[h]:
                 if k.eq(session):
@@ -1019,10 +1052,25 @@ class _tls_sessions(object):
                 if len(sid) > 12:
                     sid = sid[:11] + "..."
                 res.append((src, dst, sid))
-        colwidth = (max([len(y) for y in x]) for x in zip(*res))
+        colwidth = (max(len(y) for y in x) for x in zip(*res))
         fmt = "  ".join(map(lambda x: "%%-%ds" % x, colwidth))
         return "\n".join(map(lambda x: fmt % x, res))
 
 
+class TLSSession(DefaultSession):
+    def __init__(self, *args, **kwargs):
+        server_rsa_key = kwargs.pop("server_rsa_key", None)
+        super(TLSSession, self).__init__(*args, **kwargs)
+        self._old_conf_status = conf.tls_session_enable
+        conf.tls_session_enable = True
+        if server_rsa_key:
+            conf.tls_sessions.server_rsa_key = server_rsa_key
+
+    def toPacketList(self):
+        conf.tls_session_enable = self._old_conf_status
+        return super(TLSSession, self).toPacketList()
+
+
 conf.tls_sessions = _tls_sessions()
+conf.tls_session_enable = False
 conf.tls_verbose = False

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1061,8 +1061,11 @@ assert (t6.payload.payload.mac == b'\x10\xce\xca2\xb4\xc3m\xf1\x16c\xdb\xfc\x08\
 # suite does not provide PFS, we are able to break the data confidentiality.
 
 + Read a vulnerable TLS session
+~ server_rsa_key
 
 = Reading TLS vulnerable session - Decrypt data from using a compromised server key
+load_layer("tls")
+
 from scapy.layers.tls.cert import PrivKeyRSA
 from scapy.layers.tls.record import TLSApplicationData
 import os
@@ -1084,7 +1087,26 @@ t = TLS(data, tls_session=t.tls_session.mirror())
 assert(len(t.msg) == 1)
 assert(isinstance(t.msg[0], TLSApplicationData))
 assert(t.msg[0].data == b"")
-t.getlayer(2).msg[0].data == b"To boldly go where no man has gone before...\n"
+t.getlayer(TLS, 2).msg[0].data == b"To boldly go where no man has gone before...\n"
+
+= Auto provide the session
+
+conf.debug_dissector = 2
+client = "192.168.0.1"
+server = "1.2.3.4"
+bc = Ether()/IP(src=client, dst=server)/TCP(sport=51478, dport=443, seq=1)
+bs = Ether()/IP(src=server, dst=client)/TCP(sport=443, dport=51478, seq=1)
+pcap = [
+    bc/ch,
+    bs/sh,
+    bc/ck,
+    bs/fin,
+    bc/data
+]
+res = sniff(offline=pcap, session=TLSSession(server_rsa_key=key))
+
+res[4].show()
+assert res[4].getlayer(TLS, 2).msg[0].data == b"To boldly go where no man has gone before...\n"
 
 
 ###############################################################################
@@ -1165,7 +1187,7 @@ raw(t) == b'\xde\xad\xbe\xef\xff\x01'
 
 = Building packets - TLS record with bad data
 a = TLS(b'\x17\x03\x03\x00\x03data')
-assert a.haslayer(Raw)
+assert a[Raw]
 
 
 = Building packets - _CipherSuitesField with no cipher

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -32,7 +32,7 @@ from scapy.layers.tls.automaton_srv import TLSServerAutomaton
 
 conf.verb = 4
 conf.debug_tls = True  
-conf.debug_dissector = True
+conf.debug_dissector = 2
 load_layer("tls")
 
 @contextmanager

--- a/test/tls13.uts
+++ b/test/tls13.uts
@@ -622,6 +622,8 @@ assert(m.data == payload)
 = TLS_Ext_EncryptedServerName(), dissect
 ~ crypto_advanced
 
+from scapy.layers.tls.extensions import TLS_Ext_EncryptedServerName
+
 clientHello3 = clean("""
 16030102c4010002c003034b1 40e7d15fc8db422cec056fbaf 0285d306df4eedad1bc6ea57d 5114e6bd52a20a5b9c7445955 e296b886469c974648cda0a68
 5d3c06d884e388f6475c32e03 2d0024130113031302c02bc02 fcca9cca8c02cc030c00ac009 c013c01400330039002f00350 00a0100025300170000ff0100


### PR DESCRIPTION
A rebase of an old thing.

This PR is pretty cool because TLS sessions can now be automatically matched while sniffing. This will allow to always know the correct TLS version while sniffing a client-server exchange for instance. I actually used a piece of code that was already there (courtesy of mtury) but never used elsewhere (`conf.tls_sessions`).

```python3
from scapy.layers.tls import *
tshark(session=TLSSession)
```

### Notes

- Improve SSL2 detection by a lot. This copies how wireshark does it. Previously, any continuation data packet in a TLS stream would have been dissected as SSLv2 before failing.
- There was a `conf.tls_sessions` util that was implemented but never got used. This enables it and create the `TLSSession` util. See the tests
- adds a test