### PR TITLE
Update example to support python3

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1253,7 +1253,7 @@ The fastest way to discover hosts on a local ethernet network is to use the ARP 
 
 Answers can be reviewed with the following command::
 
-    >>> ans.summary(lambda (s,r): r.sprintf("%Ether.src% %ARP.psrc%") )
+    >>> ans.summary(lambda sr: sr[1].sprintf("%Ether.src% %ARP.psrc%") )
 
 Scapy also includes a built-in arping() function which performs similar to the above two commands:
 

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -403,7 +403,7 @@ In order to quickly review responses simply request a summary of collected packe
 
 The above will display stimulus/response pairs for answered probes. We can display only the information we are interested in by using a simple loop:
 
-    >>> ans.summary( lambda(s,r): r.sprintf("%TCP.sport% \t %TCP.flags%") )
+    >>> ans.summary( lambda sr: sr[1].sprintf("%TCP.sport% \t %TCP.flags%") )
     440      RA
     441      RA
     442      RA


### PR DESCRIPTION
Tuple unpacking was removed in python3 ([PEP 3113](https://www.python.org/dev/peps/pep-3113/)) so this example will throw `SyntaxError: invalid syntax`.