### PR TITLE
[TLS 1.3] Extra

### DIFF
--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -93,8 +93,8 @@ class TLSClientAutomaton(_TLSAutomaton):
         super(TLSClientAutomaton, self).parse_args(mycert=mycert,
                                                    mykey=mykey,
                                                    **kargs)
-        tmp = socket.getaddrinfo(server, dport)
         self.remote_name = None
+        tmp = socket.getaddrinfo(server, dport)
         try:
             if ':' in server:
                 inet_pton(socket.AF_INET6, server)

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -69,7 +69,7 @@ class TLSClientAutomaton(_TLSAutomaton):
 
     _'mycert' and 'mykey' may be provided as filenames. They will be used in
     the handshake, should the server ask for client authentication.
-    _'server_name' does not need to be set.
+    _'server_name' is the SNI. It does not need to be set.
     _'client_hello' may hold a TLSClientHello or SSLv2ClientHello to be sent
     to the server. This is particularly useful for extensions tweaking.
     _'version' is a quicker way to advertise a protocol version ("sslv2",
@@ -93,7 +93,6 @@ class TLSClientAutomaton(_TLSAutomaton):
         super(TLSClientAutomaton, self).parse_args(mycert=mycert,
                                                    mykey=mykey,
                                                    **kargs)
-        self.remote_name = None
         tmp = socket.getaddrinfo(server, dport)
         try:
             if ':' in server:
@@ -101,12 +100,11 @@ class TLSClientAutomaton(_TLSAutomaton):
             else:
                 inet_pton(socket.AF_INET, server)
         except Exception:
-            self.remote_name = socket.getfqdn(server)
-            if self.remote_name != server:
-                tmp = socket.getaddrinfo(self.remote_name, dport)
+            remote_name = socket.getfqdn(server)
+            if remote_name != server:
+                tmp = socket.getaddrinfo(remote_name, dport)
 
-        if server_name:
-            self.remote_name = server_name
+        self.remote_name = server_name
         self.remote_family = tmp[0][0]
         self.remote_ip = tmp[0][4][0]
         self.remote_port = dport

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -411,7 +411,7 @@ class TLSServerAutomaton(_TLSAutomaton):
     @ATMT.state()
     def HANDLED_ALERT_FROM_CLIENTCERTIFICATE(self):
         self.vprint("Received Alert message instead of ClientKeyExchange!")
-        self.cur_pkt.show()
+        self.vprint(self.cur_pkt.mysummary())
         raise self.CLOSE_NOTIFY()
 
     @ATMT.condition(HANDLED_CLIENTCERTIFICATE, prio=3)
@@ -460,7 +460,7 @@ class TLSServerAutomaton(_TLSAutomaton):
     @ATMT.state()
     def HANDLED_ALERT_FROM_CLIENTKEYEXCHANGE(self):
         self.vprint("Received Alert message instead of ChangeCipherSpec!")
-        self.cur_pkt.show()
+        self.vprint(self.cur_pkt.mysummary())
         raise self.CLOSE_NOTIFY()
 
     @ATMT.condition(HANDLED_CERTIFICATEVERIFY, prio=3)
@@ -853,7 +853,7 @@ class TLSServerAutomaton(_TLSAutomaton):
     @ATMT.state()
     def TLS13_HANDLED_ALERT_FROM_CLIENTCERTIFICATE(self):
         self.vprint("Received Alert message instead of ClientKeyExchange!")
-        self.cur_pkt.show()
+        self.vprint(self.cur_pkt.mysummary())
         raise self.CLOSE_NOTIFY()
 
     # For Middlebox compatibility (see RFC8446, appendix D.4)

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -253,6 +253,7 @@ class TLSServerAutomaton(_TLSAutomaton):
         pass
 
     #                           TLS handshake                                 #
+
     @ATMT.condition(RECEIVED_CLIENTFLIGHT1, prio=1)
     def tls13_should_handle_ClientHello(self):
         self.raise_on_packet(TLS13ClientHello,
@@ -410,6 +411,7 @@ class TLSServerAutomaton(_TLSAutomaton):
     @ATMT.state()
     def HANDLED_ALERT_FROM_CLIENTCERTIFICATE(self):
         self.vprint("Received Alert message instead of ClientKeyExchange!")
+        self.cur_pkt.show()
         raise self.CLOSE_NOTIFY()
 
     @ATMT.condition(HANDLED_CLIENTCERTIFICATE, prio=3)

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -311,7 +311,12 @@ class TLSClientHello(_TLSHandshake):
         if self.ext:
             for e in self.ext:
                 if isinstance(e, TLS_Ext_SupportedVersion_CH):
-                    s.advertised_tls_version = e.versions[0]
+                    for ver in e.versions:
+                        # RFC 8701: GREASE of TLS will send unknown versions
+                        # here. We have to ignore them
+                        if ver in _tls_version:
+                            s.advertised_tls_version = ver
+                            break
                     if s.sid:
                         s.middlebox_compatibility = True
 
@@ -437,7 +442,12 @@ class TLS13ClientHello(_TLSHandshake):
         if self.ext:
             for e in self.ext:
                 if isinstance(e, TLS_Ext_SupportedVersion_CH):
-                    self.tls_session.advertised_tls_version = e.versions[0]
+                    for ver in e.versions:
+                        # RFC 8701: GREASE of TLS will send unknown versions
+                        # here. We have to ignore them
+                        if ver in _tls_version:
+                            s.advertised_tls_version = ver
+                            break
                 if isinstance(e, TLS_Ext_SignatureAlgorithms):
                     s.advertised_sig_algs = e.sig_algs
 

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -446,7 +446,7 @@ class TLS13ClientHello(_TLSHandshake):
                         # RFC 8701: GREASE of TLS will send unknown versions
                         # here. We have to ignore them
                         if ver in _tls_version:
-                            s.advertised_tls_version = ver
+                            self.tls_session.advertised_tls_version = ver
                             break
                 if isinstance(e, TLS_Ext_SignatureAlgorithms):
                     s.advertised_sig_algs = e.sig_algs

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -880,7 +880,7 @@ class EncryptedPreMasterSecret(_GenericTLSSessionInheritance):
 
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
-        if 'tls_session' in kargs:
+        if _pkt and 'tls_session' in kargs:
             s = kargs['tls_session']
             if s.server_tmp_rsa_key is None and s.server_rsa_key is None:
                 return _UnEncryptedPreMasterSecret

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -63,11 +63,6 @@ class _TLSEncryptedContent(Raw, _GenericTLSSessionInheritance):
     name = "Encrypted Content"
     match_subclass = True
 
-    def mysummary(self):
-        s = _GenericTLSSessionInheritance.mysummary(self)
-        s += " / " + self.name
-        return s
-
 
 class _TLSMsgListField(PacketListField):
     """
@@ -724,7 +719,7 @@ class TLS(_GenericTLSSessionInheritance):
         s = super(TLS, self).mysummary()
         if self.msg:
             s += " / "
-            s += " / ".join(x.name for x in self.msg)
+            s += " / ".join(getattr(x, "_name", x.name) for x in self.msg)
         return s
 
 ###############################################################################
@@ -782,6 +777,9 @@ class TLSAlert(_GenericTLSSessionInheritance):
     name = "TLS Alert"
     fields_desc = [ByteEnumField("level", None, _tls_alert_level),
                    ByteEnumField("descr", None, _tls_alert_description)]
+
+    def mysummary(self):
+        return self.sprintf("Alert %level%: %desc%")
 
     def post_dissection_tls_session_update(self, msg_str):
         pass

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -998,7 +998,8 @@ class _GenericTLSSessionInheritance(Packet):
         s.wcs = wcs_snap
 
     def mysummary(self):
-        return "TLS %s" % repr(self.tls_session)
+        return "TLS %s / %s" % (repr(self.tls_session),
+                                getattr(self, "_name", self.name))
 
 
 ###############################################################################

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -8,9 +8,10 @@ Basic TLS client. A ciphersuite may be commanded via a first argument.
 Default protocol version is TLS 1.3.
 """
 
-import os
-import sys
 import logging
+import os
+import socket
+import sys
 
 logger = logging.getLogger("scapy")
 logger.addHandler(logging.StreamHandler())
@@ -40,6 +41,8 @@ parser.add_argument("--ticket_out", dest='session_ticket_file_out',
                     help="File to write a ticket to (for TLS 1.3)")
 parser.add_argument("--res_master",
                     help="Resumption master secret (for TLS 1.3)")
+parser.add_argument("--sni",
+                    help="Server Name Indication")
 parser.add_argument("--debug", action="store_const", const=5, default=0,
                     help="Enter debug mode")
 parser.add_argument("server", nargs="?", default="127.0.0.1",
@@ -68,8 +71,9 @@ if args.ciphersuite:
 else:
     ch = None
 
-server_name = None
-if args.server:
+server_name = args.sni
+# If server name is unknown, try server
+if not server_name and args.server:
     try:
         inet_aton(args.server)
     except socket.error:


### PR DESCRIPTION
A custom PR in between romain-perez ones. This allows to do more practical tests against real world things..
- add support for RFC 8701: TLS GREASE (the server now works with chrome as a client)
- add support for SNI in the TLS client (server now works with www.google.com)
- add debug options to the TLS client and server
- fix RSA on TLS 1.0, 1.1, 1.2. If you use the client on www.google.com with those versions enforced, there was a dumb crash on EncryptedPreMasterSecret.