### PR TITLE
[TLS 1.3] x448 support

### DIFF
--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -981,7 +981,7 @@ class TLSClientAutomaton(_TLSAutomaton):
     @ATMT.condition(TLS13_START)
     def tls13_should_add_ClientHello(self):
         # we have to use the legacy, plaintext TLS record here
-        supported_groups = ["secp256r1", "secp384r1"]
+        supported_groups = ["secp256r1", "secp384r1", "x448"]
         if conf.crypto_valid_advanced:
             supported_groups.append("x25519")
         self.add_record(is_tls13=False)

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -1,14 +1,14 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """
 TLS client automaton. This makes for a primitive TLS stack.
 Obviously you need rights for network access.
 
-We support versions SSLv2 to TLS 1.2, along with many features.
-There is no session resumption mechanism for now.
+We support versions SSLv2 to TLS 1.3, along with many features.
 
 In order to run a client to tcp/50000 with one cipher suite of your choice:
 > from scapy.all import *

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -1,14 +1,14 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """
 TLS server automaton. This makes for a primitive TLS stack.
 Obviously you need rights for network access.
 
-We support versions SSLv2 to TLS 1.2, along with many features.
-There is no session resumption mechanism for now.
+We support versions SSLv2 to TLS 1.3, along with many features.
 
 In order to run a server listening on tcp/4433:
 > from scapy.all import *

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -1,6 +1,7 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -1,6 +1,7 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """

--- a/scapy/layers/tls/keyexchange_tls13.py
+++ b/scapy/layers/tls/keyexchange_tls13.py
@@ -1,5 +1,6 @@
 # This file is part of Scapy
 # Copyright (C) 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """

--- a/scapy/layers/tls/keyexchange_tls13.py
+++ b/scapy/layers/tls/keyexchange_tls13.py
@@ -26,6 +26,7 @@ if conf.crypto_valid:
     from cryptography.hazmat.primitives.asymmetric import dh, ec
 if conf.crypto_valid_advanced:
     from cryptography.hazmat.primitives.asymmetric import x25519
+    from cryptography.hazmat.primitives.asymmetric import x448
 
 
 class KeyShareEntry(Packet):
@@ -67,16 +68,19 @@ class KeyShareEntry(Packet):
             pubkey = privkey.public_key()
             self.key_exchange = pubkey.public_numbers().y
         elif self.group in _tls_named_curves:
-            if _tls_named_curves[self.group] == "x25519":
+            if _tls_named_curves[self.group] in ["x25519", "x448"]:
                 if conf.crypto_valid_advanced:
-                    privkey = x25519.X25519PrivateKey.generate()
+                    if _tls_named_curves[self.group] == "x25519":
+                        privkey = x25519.X25519PrivateKey.generate()
+                    else:
+                        privkey = x448.X448PrivateKey.generate()
                     self.privkey = privkey
                     pubkey = privkey.public_key()
                     self.key_exchange = pubkey.public_bytes(
                         serialization.Encoding.Raw,
                         serialization.PublicFormat.Raw
                     )
-            elif _tls_named_curves[self.group] != "x448":
+            else:
                 curve = ec._CURVE_TYPES[_tls_named_curves[self.group]]()
                 privkey = ec.generate_private_key(curve, default_backend())
                 self.privkey = privkey
@@ -116,11 +120,14 @@ class KeyShareEntry(Packet):
             public_numbers = dh.DHPublicNumbers(self.key_exchange, pn)
             self.pubkey = public_numbers.public_key(default_backend())
         elif self.group in _tls_named_curves:
-            if _tls_named_curves[self.group] == "x25519":
+            if _tls_named_curves[self.group] in ["x25519", "x448"]:
                 if conf.crypto_valid_advanced:
-                    import_point = x25519.X25519PublicKey.from_public_bytes
+                    if _tls_named_curves[self.group] == "x25519":
+                        import_point = x25519.X25519PublicKey.from_public_bytes
+                    else:
+                        import_point = x448.X448PublicKey.from_public_bytes
                     self.pubkey = import_point(self.key_exchange)
-            elif _tls_named_curves[self.group] != "x448":
+            else:
                 curve = ec._CURVE_TYPES[_tls_named_curves[self.group]]()
                 try:  # cryptography >= 2.5
                     import_point = ec.EllipticCurvePublicKey.from_encoded_point  # noqa: E501
@@ -203,7 +210,7 @@ class TLS_Ext_KeyShare_SH(TLS_Ext_Unknown):
                 if group_name in six.itervalues(_tls_named_ffdh_groups):
                     pms = privkey.exchange(pubkey)
                 elif group_name in six.itervalues(_tls_named_curves):
-                    if group_name == "x25519":
+                    if group_name in ["x25519", "x448"]:
                         pms = privkey.exchange(pubkey)
                     else:
                         pms = privkey.exchange(ec.ECDH(), pubkey)
@@ -226,7 +233,7 @@ class TLS_Ext_KeyShare_SH(TLS_Ext_Unknown):
                 if group_name in six.itervalues(_tls_named_ffdh_groups):
                     pms = privkey.exchange(pubkey)
                 elif group_name in six.itervalues(_tls_named_curves):
-                    if group_name == "x25519":
+                    if group_name in ["x25519", "x448"]:
                         pms = privkey.exchange(pubkey)
                     else:
                         pms = privkey.exchange(ec.ECDH(), pubkey)
@@ -237,7 +244,7 @@ class TLS_Ext_KeyShare_SH(TLS_Ext_Unknown):
                 if group_name in six.itervalues(_tls_named_ffdh_groups):
                     pms = privkey.exchange(pubkey)
                 elif group_name in six.itervalues(_tls_named_curves):
-                    if group_name == "x25519":
+                    if group_name in ["x25519", "x448"]:
                         pms = privkey.exchange(pubkey)
                     else:
                         pms = privkey.exchange(ec.ECDH(), pubkey)

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -1,6 +1,8 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
-# 2015, 2016, 2017 Maxence Tury
+#               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
+#               2019 Gabriel Potter
 # This program is published under a GPLv2 license
 
 """

--- a/scapy/layers/tls/record_tls13.py
+++ b/scapy/layers/tls/record_tls13.py
@@ -1,5 +1,6 @@
 # This file is part of Scapy
 # Copyright (C) 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -1,6 +1,7 @@
 # This file is part of Scapy
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
+#               2019 Romain Perez
 # This program is published under a GPLv2 license
 
 """

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -43,6 +43,7 @@ parser.add_argument("--res_master",
                     help="Resumption master secret (for TLS 1.3)")
 parser.add_argument("--sni",
                     help="Server Name Indication")
+parser.add_argument("--curve", help="ECC group to advertise")
 parser.add_argument("--debug", action="store_const", const=5, default=0,
                     help="Enter debug mode")
 parser.add_argument("server", nargs="?", default="127.0.0.1",
@@ -94,6 +95,7 @@ t = TLSClientAutomaton(server=args.server, dport=args.port,
                        resumption_master_secret=args.res_master,
                        session_ticket_file_in=args.session_ticket_file_in,
                        session_ticket_file_out=args.session_ticket_file_out,
+                       curve=args.curve,
                        debug=args.debug)
 t.run()
 

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -322,6 +322,11 @@ test_tls_client("1303", "0304")
 
 test_tls_client("1305", "0304")
 
+= Testing TLS server and client with TLS 1.3 and TLS_AES_128_CCM_8_SHA256 and x448
+~ crypto_advanced
+
+test_tls_client("1305", "0304", curve="x448")
+
 = Testing TLS server and client with TLS 1.3 and a retry
 ~ crypto_advanced
 


### PR DESCRIPTION
- rebase of https://github.com/romain-perez/scapy/tree/add-tls13-x448 (last commit only)
- add tests
- credits

This was the TLS 1.3 last PR made by romain-perez 🎉 The x448 branch also contained an attempt to add early data support, but it seems it's unfinished so it's not included here. I've rebased it [here](https://github.com/gpotter2/scapy/tree/romain-perez-add-tls13-early-data)