### PR TITLE
Add IDs for Apple BTLE overflow area

### DIFF
--- a/doc/scapy/layers/bluetooth.rst
+++ b/doc/scapy/layers/bluetooth.rst
@@ -567,9 +567,11 @@ also advertised within their manufacturer-specific data field, including:
  * AirPods
  * `Handoff`__
  * Nearby
+ * `Overflow area`__
 
 __ https://en.wikipedia.org/wiki/AirDrop
 __ https://en.wikipedia.org/wiki/OS_X_Yosemite#Continuity
+__ https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/1393252-startadvertising
 
 For compatibility with these other broadcasts, Apple BLE frames in Scapy are
 layered on top of ``Apple_BLE_Submessage`` and ``Apple_BLE_Frame``:

--- a/test/contrib/ibeacon.uts
+++ b/test/contrib/ibeacon.uts
@@ -68,3 +68,18 @@ assert p[HCI_LE_Meta_Advertising_Report].addr == 'd6:ee:d4:16:ed:fc'
 assert len(p[Apple_BLE_Frame].plist) == 1
 assert p[IBeacon_Data].uuid == UUID('b9407f30-f5f8-466e-aff9-25556b57fe6d')
 
++ Overflow area
+
+= Basic overflow area packet
+
+d = hex_bytes('14ff4c000100000000000000000000000000000080')
+p = EIR_Hdr(d)
+
+assert raw(p) == d
+assert len(p[Apple_BLE_Frame].plist) == 1
+assert p[Apple_BLE_Submessage].subtype == 0x01
+assert p[Apple_BLE_Submessage].len == None
+
+payload = p[Apple_BLE_Submessage].payload
+assert isinstance(payload, Raw)
+assert raw(payload) == hex_bytes('00000000000000000000000000000080')


### PR DESCRIPTION
This is used by CoreBluetooth framework on iOS and macOS when an application is advertising a Peripheral, but there's not enough space in regular advertisements to include it.

Overflow area beacons omit the Apple-specific length field, and are always 16 bytes.  The OS hashes each application's UUIDs and produces a 7-bit value; this is used to pick which bit to set high in the resulting 128-bit mask.  I've left this as `Raw` for now as that's easiest to work with.

Test data based on beacons observed from real devices.

References:

* [Apple: CBPeripheralManager.startAdvertising](https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/1393252-startadvertising)
* [Hacking the overflow area](http://www.davidgyoungtech.com/2020/05/07/hacking-the-overflow-area)