### PR TITLE
Add TLSClientAutomaton socket support

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -427,6 +427,7 @@ class _ATMT_supersocket(SuperSocket, SelectableObject):
         # Register recv hook
         self.spb.register_hook(self.call_release)
         kargs["external_fd"] = {ioevent: (self.spa, self.spb)}
+        kargs["is_atmt_socket"] = True
         self.atmt = automaton(*args, **kargs)
         self.atmt.runbg()
 
@@ -730,6 +731,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
         external_fd = kargs.pop("external_fd", {})
         self.send_sock_class = kargs.pop("ll", conf.L3socket)
         self.recv_sock_class = kargs.pop("recvsock", conf.L2listen)
+        self.is_atmt_socket = kargs.pop("is_atmt_socket", False)
         self.started = threading.Lock()
         self.threadid = None
         self.breakpointed = None

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1703,6 +1703,9 @@ class TCP_client(Automaton):
         >>> a = TCP_client.tcplink(HTTP, "www.google.com", 80)
         >>> a.send(HTTPRequest())
         >>> a.recv()
+
+    :param ip: the ip to connect to
+    :param port:
     """
     def parse_args(self, ip, port, *args, **kargs):
         from scapy.sessions import TCPSession
@@ -1714,7 +1717,7 @@ class TCP_client(Automaton):
         self.src = self.l4.src
         self.sack = self.l4[TCP].ack
         self.rel_seq = None
-        self.rcvbuf = TCPSession(self._transmit_packet, False)
+        self.rcvbuf = TCPSession(prn=self._transmit_packet, store=False)
         bpf = "host %s  and host %s and port %i and port %i" % (self.src,
                                                                 self.dst,
                                                                 self.sport,

--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -1547,8 +1547,8 @@ class NetflowSession(IPSession):
     """Session used to defragment NetflowV9/10 packets on the flow.
     See help(scapy.layers.netflow) for more infos.
     """
-    def __init__(self, *args):
-        IPSession.__init__(self, *args)
+    def __init__(self, *args, **kwargs):
+        IPSession.__init__(self, *args, **kwargs)
         self.definitions = {}
         self.definitions_opts = {}
         self.ignored = set()

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -210,6 +210,10 @@ class TLSServerAutomaton(_TLSAutomaton):
         raise self.WAITING_CLIENT()
 
     @ATMT.state()
+    def SOCKET_CLOSED(self):
+        raise self.WAITING_CLIENT()
+
+    @ATMT.state()
     def WAITING_CLIENT(self):
         self.buffer_out = []
         self.buffer_in = []

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -826,7 +826,8 @@ class AsyncSniffer(object):
         # instantiate session
         if not isinstance(session, DefaultSession):
             session = session or DefaultSession
-            session = session(prn, store, *session_args, **session_kwargs)
+            session = session(prn=prn, store=store,
+                              *session_args, **session_kwargs)
         else:
             session.prn = prn
             session.store = store

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -346,3 +346,22 @@ test_tls_client("1305", "0304", key_update=True)
 ~ crypto_advanced
 
 test_tls_client("1305", "0304", client_auth=True, sess_in_out=True)
+
+# Automaton as Socket tests
+
++ TLSAutomatonClient socket tests
+~ netaccess
+
+= Connect to google.com
+
+load_layer("tls")
+load_layer("http")
+
+def _test_connection():
+    a = TLSClientAutomaton.tlslink(HTTP, server="www.google.com", dport=443,
+                                   server_name="www.google.com")
+    pkt = a.sr1(HTTP()/HTTPRequest(), session=TCPSession(app=True), timeout=2, retry=3)
+    assert HTTPResponse in pkt
+    assert b"</html>" in pkt[HTTPResponse].load
+
+retry_test(_test_connection)


### PR DESCRIPTION
My last tls pr

- Add proper handling of peer socket closed in `TLSClientAutomaton`
- Add support for socket in the `TLSClientAutomaton`, in the same way it was implemented in `TCP_client`:

```python
a = TLSClientAutomaton.tlslink(HTTP, server="www.google.com", dport=443)
pkt = a.sr1(HTTP()/HTTPRequest(), session=TCPSession(app=True), timeout=2, retry=3)
```
- doc