### PR TITLE
Filtering

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1690,6 +1690,34 @@ Discussion
 __ https://www.wireshark.org
 __ https://wiki.wireshark.org/ProtocolReference
 
+Performance of Scapy
+--------------------
+
+Problem
+^^^^^^^
+
+Scapy dissects slowly and/or misses packets under heavy loads.
+
+.. note::
+
+    Please bare in mind that Scapy is not designed to be blazing fast, but rather easily hackable & extensible. The packet model makes it VERY easy to create new layers, compared to pretty much all other alternatives, but comes with a performance cost. Of course, we still do our best to make Scapy as fast as possible, but it's not the absolute main goal. Just a quick disclaimer
+
+Solution
+^^^^^^^^
+
+There are quite a few ways of speeding up scapy's dissection. You can use all of them
+
+- **Using a BPF filter**: The OS is faster than Scapy. If you make the OS filter the packets instead of Scapy, it will only handle a fraction of the load. Use the ``filter=`` argument of the :py:func:`~scapy.sendrecv.sniff` function.
+- **By disabling layers you don't use**: If you are not using some layers, why dissect them? You can let Scapy know which layers to dissect and all the others will simply be parsed as ``Raw``. This comes with a great performance boost but requires you to know what you're doing.
+
+.. code:: python
+
+    # Enable filtering: only Ether, IP and ICMP will be dissected
+    conf.layers.filter([Ether, IP, ICMP])
+    # Disable filtering: restore everything to normal
+    conf.layers.unfilter()
+
+
 OS Fingerprinting
 -----------------
 

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1700,7 +1700,7 @@ Scapy dissects slowly and/or misses packets under heavy loads.
 
 .. note::
 
-    Please bare in mind that Scapy is not designed to be blazing fast, but rather easily hackable & extensible. The packet model makes it VERY easy to create new layers, compared to pretty much all other alternatives, but comes with a performance cost. Of course, we still do our best to make Scapy as fast as possible, but it's not the absolute main goal. Just a quick disclaimer
+    Please bare in mind that Scapy is not designed to be blazing fast, but rather easily hackable & extensible. The packet model makes it VERY easy to create new layers, compared to pretty much all other alternatives, but comes with a performance cost. Of course, we still do our best to make Scapy as fast as possible, but it's not the absolute main goal.
 
 Solution
 ^^^^^^^^

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -138,6 +138,17 @@ except:
 
 assert not conf.use_bpf
 
+= Test layer filtering
+~ filter
+
+pkt = NetflowHeader()/NetflowHeaderV5()/NetflowRecordV5()
+
+conf.layers.filter([NetflowHeader, NetflowHeaderV5])
+assert NetflowRecordV5 not in NetflowHeader(bytes(pkt))
+
+conf.layers.unfilter()
+assert NetflowRecordV5 in NetflowHeader(bytes(pkt))
+
 
 ###########
 ###########


### PR DESCRIPTION
- Inspired by https://github.com/secdev/scapy/issues/253#issuecomment-237552580 but probably easier to use (while being less efficient)

Usage:

```
conf.layers.filter([Ether, IP, ICMP])
conf.layers.unfilter()
```

I should probably add unit tests/doc first