### PR TITLE
Enhancements for the zigbee and dot15d4 layers

### DIFF
--- a/scapy/layers/zigbee.py
+++ b/scapy/layers/zigbee.py
@@ -4,7 +4,6 @@
 # Copyright (C) Ryan Speers <ryan@rmspeers.com> 2011-2012
 # Copyright (C) Roger Meyer <roger.meyer@csus.edu>: 2012-03-10 Added frames
 # Copyright (C) Gabriel Potter <gabriel@potter.fr>: 2018
-# Intern at INRIA Grand Nancy Est
 # Copyright (C) 2020 Dimitrios-Georgios Akestoridis <akestoridis@cmu.edu>
 # This program is published under a GPLv2 license
 
@@ -591,10 +590,10 @@ class ZigbeeAppDataPayload(Packet):
         # Destination endpoint (0/1 octet)
         ConditionalField(
             ByteField("dst_endpoint", 10),
-            lambda pkt: ((pkt.aps_frametype == 0
-                          and pkt.delivery_mode in [0, 2])
-                         or (pkt.aps_frametype == 2
-                             and not pkt.frame_control.ack_format))
+            lambda pkt: ((pkt.aps_frametype == 0 and
+                          pkt.delivery_mode in [0, 2]) or
+                         (pkt.aps_frametype == 2 and not
+                          pkt.frame_control.ack_format))
         ),
         # Group address (0/2 octets)
         ConditionalField(
@@ -605,23 +604,23 @@ class ZigbeeAppDataPayload(Packet):
         ConditionalField(
             # unsigned short (little-endian)
             EnumField("cluster", 0, _zcl_cluster_identifier, fmt="<H"),
-            lambda pkt: (pkt.aps_frametype == 0
-                         or (pkt.aps_frametype == 2
-                             and not pkt.frame_control.ack_format))
+            lambda pkt: ((pkt.aps_frametype == 0) or
+                         (pkt.aps_frametype == 2 and not
+                          pkt.frame_control.ack_format))
         ),
         # Profile identifier (0/2 octets)
         ConditionalField(
             EnumField("profile", 0, _zcl_profile_identifier, fmt="<H"),
-            lambda pkt: (pkt.aps_frametype == 0
-                         or (pkt.aps_frametype == 2
-                             and not pkt.frame_control.ack_format))
+            lambda pkt: ((pkt.aps_frametype == 0) or
+                         (pkt.aps_frametype == 2 and not
+                          pkt.frame_control.ack_format))
         ),
         # Source endpoint (0/1 octets)
         ConditionalField(
             ByteField("src_endpoint", 10),
-            lambda pkt: (pkt.aps_frametype == 0
-                         or (pkt.aps_frametype == 2
-                             and not pkt.frame_control.ack_format))
+            lambda pkt: ((pkt.aps_frametype == 0) or
+                         (pkt.aps_frametype == 2 and not
+                          pkt.frame_control.ack_format))
         ),
         # APS counter (1 octet)
         ByteField("counter", 0),
@@ -631,18 +630,18 @@ class ZigbeeAppDataPayload(Packet):
             ByteEnumField(
                 "fragmentation", 0,
                 {0: "none", 1: "first_block", 2: "middle_block"}),
-            lambda pkt: (pkt.aps_frametype in [0, 2]
-                         and pkt.frame_control.extended_hdr)
+            lambda pkt: (pkt.aps_frametype in [0, 2] and
+                         pkt.frame_control.extended_hdr)
         ),
         ConditionalField(
             ByteField("block_number", 0),
-            lambda pkt: (pkt.aps_frametype in [0, 2]
-                         and pkt.fragmentation in [1, 2])
+            lambda pkt: (pkt.aps_frametype in [0, 2] and
+                         pkt.fragmentation in [1, 2])
         ),
         ConditionalField(
             ByteField("ack_bitfield", 0),
-            lambda pkt: (pkt.aps_frametype == 2
-                         and pkt.fragmentation in [1, 2])
+            lambda pkt: (pkt.aps_frametype == 2 and
+                         pkt.fragmentation in [1, 2])
         ),
         # variable length frame payload:
         # 3 frame types: data, APS command, and acknowledgement
@@ -741,24 +740,24 @@ class ZigbeeAppCommandPayload(Packet):
             lambda pkt: pkt.cmd_identifier == 5),
         ConditionalField(
             ByteField("key_seqnum", 0),
-            lambda pkt: (pkt.cmd_identifier == 5
-                         and pkt.key_type in [0x01, 0x05])),
+            lambda pkt: (pkt.cmd_identifier == 5 and
+                         pkt.key_type in [0x01, 0x05])),
         ConditionalField(
             dot15d4AddressField("dest_addr", 0, adjust=lambda pkt, x: 8),
-            lambda pkt: (pkt.cmd_identifier == 5
-                         and pkt.key_type not in [0x02, 0x03])),
+            lambda pkt: (pkt.cmd_identifier == 5 and
+                         pkt.key_type not in [0x02, 0x03])),
         ConditionalField(
             dot15d4AddressField("src_addr", 0, adjust=lambda pkt, x: 8),
-            lambda pkt: (pkt.cmd_identifier == 5
-                         and pkt.key_type not in [0x02, 0x03])),
+            lambda pkt: (pkt.cmd_identifier == 5 and
+                         pkt.key_type not in [0x02, 0x03])),
         ConditionalField(
             dot15d4AddressField("partner_addr", 0, adjust=lambda pkt, x: 8),
-            lambda pkt: (pkt.cmd_identifier == 5
-                         and pkt.key_type in [0x02, 0x03])),
+            lambda pkt: (pkt.cmd_identifier == 5 and
+                         pkt.key_type in [0x02, 0x03])),
         ConditionalField(
             ByteField("initiator_flag", 0),
-            lambda pkt: (pkt.cmd_identifier == 5
-                         and pkt.key_type in [0x02, 0x03])),
+            lambda pkt: (pkt.cmd_identifier == 5 and
+                         pkt.key_type in [0x02, 0x03])),
         # Update-Device Command
         ConditionalField(dot15d4AddressField("address", 0,
                                              adjust=lambda pkt, x: 8),
@@ -783,8 +782,8 @@ class ZigbeeAppCommandPayload(Packet):
                          lambda pkt: pkt.cmd_identifier == 9),
         # Un-implemented: 10-13 (+?)
         ConditionalField(StrField("data", ""),
-                         lambda pkt: (pkt.cmd_identifier >= 10
-                                      and pkt.cmd_identifier <= 13)),
+                         lambda pkt: (pkt.cmd_identifier >= 10 and
+                                      pkt.cmd_identifier <= 13)),
         # Tunnel Command
         ConditionalField(
             dot15d4AddressField("dest_addr", 0, adjust=lambda pkt, x: 8),

--- a/scapy/layers/zigbee.py
+++ b/scapy/layers/zigbee.py
@@ -776,9 +776,6 @@ class ZigbeeAppCommandPayload(Packet):
             ByteEnumField("key_type", 0, _RequestKeyKeyTypes),
             lambda pkt: pkt.cmd_identifier == 8),
         ConditionalField(
-            StrFixedLenField("key", None, 16),
-            lambda pkt: pkt.cmd_identifier == 8),
-        ConditionalField(
             dot15d4AddressField("partner_addr", 0, adjust=lambda pkt, x: 8),
             lambda pkt: (pkt.cmd_identifier == 8 and pkt.key_type == 0x02)),
         # Switch-Key Command

--- a/scapy/layers/zigbee.py
+++ b/scapy/layers/zigbee.py
@@ -5,6 +5,7 @@
 # Copyright (C) Roger Meyer <roger.meyer@csus.edu>: 2012-03-10 Added frames
 # Copyright (C) Gabriel Potter <gabriel@potter.fr>: 2018
 # Intern at INRIA Grand Nancy Est
+# Copyright (C) 2020 Dimitrios-Georgios Akestoridis <akestoridis@cmu.edu>
 # This program is published under a GPLv2 license
 
 """
@@ -277,6 +278,7 @@ class ZigbeeNWK(Packet):
 
 class LinkStatusEntry(Packet):
     name = "ZigBee Link Status Entry"
+
     fields_desc = [
         # Neighbor network address (2 octets)
         XLEShortField("neighbor_network_address", 0x0000),
@@ -286,6 +288,9 @@ class LinkStatusEntry(Packet):
         BitField("reserved2", 0, 1),
         BitField("incoming_cost", 0, 3),
     ]
+
+    def extract_padding(self, p):
+        return b"", p
 
 
 class ZigbeeNWKCommandPayload(Packet):
@@ -301,8 +306,10 @@ class ZigbeeNWKCommandPayload(Packet):
             7: "rejoin response",
             8: "link status",
             9: "network report",
-            10: "network update"
-            # 0x0b - 0xff reserved
+            10: "network update",
+            11: "end device timeout request",
+            12: "end device timeout response"
+            # 0x0d - 0xff reserved
         }),
 
         # - Route Request Command - #
@@ -453,6 +460,51 @@ class ZigbeeNWKCommandPayload(Packet):
         ConditionalField(XLEShortField("new_PAN_ID", 0x0000),
                          lambda pkt: (pkt.cmd_identifier == 10 and pkt.update_command_identifier == 0)),  # noqa: E501
 
+        # - End Device Timeout Request Command - #
+        # Requested Timeout (1 octet)
+        ConditionalField(
+            ByteEnumField("req_timeout", 3, {
+                0: "10 seconds",
+                1: "2 minutes",
+                2: "4 minutes",
+                3: "8 minutes",
+                4: "16 minutes",
+                5: "32 minutes",
+                6: "64 minutes",
+                7: "128 minutes",
+                8: "256 minutes",
+                9: "512 minutes",
+                10: "1024 minutes",
+                11: "2048 minutes",
+                12: "4096 minutes",
+                13: "8192 minutes",
+                14: "16384 minutes"
+            }),
+            lambda pkt: pkt.cmd_identifier == 11),
+        # End Device Configuration (1 octet)
+        ConditionalField(
+            ByteField("ed_conf", 0),
+            lambda pkt: pkt.cmd_identifier == 11),
+
+        # - End Device Timeout Response Command - #
+        # Status (1 octet)
+        ConditionalField(
+            ByteEnumField("status", 0, {
+                0: "Success",
+                1: "Incorrect Value"
+            }),
+            lambda pkt: pkt.cmd_identifier == 12),
+        # Parent Information (1 octet)
+        ConditionalField(
+            BitField("reserved", 0, 6),
+            lambda pkt: pkt.cmd_identifier == 12),
+        ConditionalField(
+            BitField("ed_timeout_req_keepalive", 0, 1),
+            lambda pkt: pkt.cmd_identifier == 12),
+        ConditionalField(
+            BitField("mac_data_poll_keepalive", 0, 1),
+            lambda pkt: pkt.cmd_identifier == 12)
+
         # StrField("data", ""),
     ]
 
@@ -530,7 +582,7 @@ class ZigbeeAppDataPayload(Packet):
     fields_desc = [
         # Frame control (1 octet)
         FlagsField("frame_control", 2, 4,
-                   ['reserved1', 'security', 'ack_req', 'extended_hdr']),
+                   ['ack_format', 'security', 'ack_req', 'extended_hdr']),
         BitEnumField("delivery_mode", 0, 2,
                      {0: 'unicast', 1: 'indirect',
                       2: 'broadcast', 3: 'group_addressing'}),
@@ -539,24 +591,37 @@ class ZigbeeAppDataPayload(Packet):
         # Destination endpoint (0/1 octet)
         ConditionalField(
             ByteField("dst_endpoint", 10),
-            lambda pkt: (pkt.frame_control.ack_req or pkt.aps_frametype == 2)
+            lambda pkt: ((pkt.aps_frametype == 0
+                          and pkt.delivery_mode in [0, 2])
+                         or (pkt.aps_frametype == 2
+                             and not pkt.frame_control.ack_format))
         ),
-        # Group address (0/2 octets) TODO
+        # Group address (0/2 octets)
+        ConditionalField(
+            XLEShortField("group_addr", 0x0000),
+            lambda pkt: (pkt.aps_frametype == 0 and pkt.delivery_mode == 3)
+        ),
         # Cluster identifier (0/2 octets)
         ConditionalField(
             # unsigned short (little-endian)
             EnumField("cluster", 0, _zcl_cluster_identifier, fmt="<H"),
-            lambda pkt: (pkt.frame_control.ack_req or pkt.aps_frametype == 2)
+            lambda pkt: (pkt.aps_frametype == 0
+                         or (pkt.aps_frametype == 2
+                             and not pkt.frame_control.ack_format))
         ),
         # Profile identifier (0/2 octets)
         ConditionalField(
             EnumField("profile", 0, _zcl_profile_identifier, fmt="<H"),
-            lambda pkt: (pkt.frame_control.ack_req or pkt.aps_frametype == 2)
+            lambda pkt: (pkt.aps_frametype == 0
+                         or (pkt.aps_frametype == 2
+                             and not pkt.frame_control.ack_format))
         ),
         # Source endpoint (0/1 octets)
         ConditionalField(
             ByteField("src_endpoint", 10),
-            lambda pkt: (pkt.frame_control.ack_req or pkt.aps_frametype == 2)
+            lambda pkt: (pkt.aps_frametype == 0
+                         or (pkt.aps_frametype == 2
+                             and not pkt.frame_control.ack_format))
         ),
         # APS counter (1 octet)
         ByteField("counter", 0),
@@ -566,10 +631,19 @@ class ZigbeeAppDataPayload(Packet):
             ByteEnumField(
                 "fragmentation", 0,
                 {0: "none", 1: "first_block", 2: "middle_block"}),
-            lambda pkt: pkt.frame_control.extended_hdr
+            lambda pkt: (pkt.aps_frametype in [0, 2]
+                         and pkt.frame_control.extended_hdr)
         ),
-        ConditionalField(ByteField("block_number", 0),
-                         lambda pkt: pkt.fragmentation),
+        ConditionalField(
+            ByteField("block_number", 0),
+            lambda pkt: (pkt.aps_frametype in [0, 2]
+                         and pkt.fragmentation in [1, 2])
+        ),
+        ConditionalField(
+            ByteField("ack_bitfield", 0),
+            lambda pkt: (pkt.aps_frametype == 2
+                         and pkt.fragmentation in [1, 2])
+        ),
         # variable length frame payload:
         # 3 frame types: data, APS command, and acknowledgement
         # ConditionalField(StrField("data", ""), lambda pkt:pkt.aps_frametype == 0),  # noqa: E501
@@ -579,7 +653,10 @@ class ZigbeeAppDataPayload(Packet):
         if self.frame_control & 0x02:  # we have a security header
             return ZigbeeSecurityHeader
         elif self.aps_frametype == 0:  # data
-            return ZigbeeClusterLibrary  # TODO might also be another frame
+            if self.profile == 0x0000:
+                return ZigbeeDeviceProfile
+            else:
+                return ZigbeeClusterLibrary
         elif self.aps_frametype == 1:  # command
             return ZigbeeAppCommandPayload
         else:
@@ -596,6 +673,34 @@ _TransportKeyKeyTypes = {
 }
 
 
+_RequestKeyKeyTypes = {
+    0x02: "Application Link Key",
+    0x04: "Trust Center Link Key",
+}
+
+
+_ApsStatusValues = {
+    0x00: "SUCCESS",
+    0xa0: "ASDU_TOO_LONG",
+    0xa1: "DEFRAG_DEFERRED",
+    0xa2: "DEFRAG_UNSUPPORTED",
+    0xa3: "ILLEGAL_REQUEST",
+    0xa4: "INVALID_BINDING",
+    0xa5: "INVALID_GROUP",
+    0xa6: "INVALID_PARAMETER",
+    0xa7: "NO_ACK",
+    0xa8: "NO_BOUND_DEVICE",
+    0xa9: "NO_SHORT_ADDRESS",
+    0xaa: "NOT_SUPPORTED",
+    0xab: "SECURED_LINK_KEY",
+    0xac: "SECURED_NWK_KEY",
+    0xad: "SECURITY_FAIL",
+    0xae: "TABLE_FULL",
+    0xaf: "UNSECURED",
+    0xb0: "UNSUPPORTED_ATTRIBUTE"
+}
+
+
 class ZigbeeAppCommandPayload(Packet):
     name = "Zigbee Application Layer Command Payload"
     fields_desc = [
@@ -609,12 +714,14 @@ class ZigbeeAppCommandPayload(Packet):
             7: "APS_CMD_REMOVE_DEVICE",
             8: "APS_CMD_REQUEST_KEY",
             9: "APS_CMD_SWITCH_KEY",
-            # TODO: implement 10 to 14
+            # TODO: implement 10 to 13
             10: "APS_CMD_EA_INIT_CHLNG",
             11: "APS_CMD_EA_RSP_CHLNG",
             12: "APS_CMD_EA_INIT_MAC_DATA",
             13: "APS_CMD_EA_RSP_MAC_DATA",
-            14: "APS_CMD_TUNNEL"
+            14: "APS_CMD_TUNNEL",
+            15: "APS_CMD_VERIFY_KEY",
+            16: "APS_CMD_CONFIRM_KEY"
         }),
         # SKKE Commands
         ConditionalField(dot15d4AddressField("initiator", 0,
@@ -626,19 +733,32 @@ class ZigbeeAppCommandPayload(Packet):
         ConditionalField(StrFixedLenField("data", 0, length=16),
                          lambda pkt: pkt.cmd_identifier in [1, 2, 3, 4]),
         # Transport-key Command
-        ConditionalField(ByteEnumField("key_type", 0, _TransportKeyKeyTypes),
-                         lambda pkt: pkt.cmd_identifier == 5),
-        ConditionalField(StrFixedLenField("key", None, 16),
-                         lambda pkt: pkt.cmd_identifier == 5),
-        ConditionalField(ByteField("key_seqnum", 0),
-                         lambda pkt: (pkt.cmd_identifier == 5 and
-                                      pkt.key_type in [0x01, 0x05])),
-        ConditionalField(dot15d4AddressField("dest_addr", 0,
-                                             adjust=lambda pkt, x: 8),
-                         lambda pkt: pkt.cmd_identifier == 5),
-        ConditionalField(dot15d4AddressField("src_addr", 0,
-                                             adjust=lambda pkt, x: 8),
-                         lambda pkt: pkt.cmd_identifier == 5),
+        ConditionalField(
+            ByteEnumField("key_type", 0, _TransportKeyKeyTypes),
+            lambda pkt: pkt.cmd_identifier == 5),
+        ConditionalField(
+            StrFixedLenField("key", None, 16),
+            lambda pkt: pkt.cmd_identifier == 5),
+        ConditionalField(
+            ByteField("key_seqnum", 0),
+            lambda pkt: (pkt.cmd_identifier == 5
+                         and pkt.key_type in [0x01, 0x05])),
+        ConditionalField(
+            dot15d4AddressField("dest_addr", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: (pkt.cmd_identifier == 5
+                         and pkt.key_type not in [0x02, 0x03])),
+        ConditionalField(
+            dot15d4AddressField("src_addr", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: (pkt.cmd_identifier == 5
+                         and pkt.key_type not in [0x02, 0x03])),
+        ConditionalField(
+            dot15d4AddressField("partner_addr", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: (pkt.cmd_identifier == 5
+                         and pkt.key_type in [0x02, 0x03])),
+        ConditionalField(
+            ByteField("initiator_flag", 0),
+            lambda pkt: (pkt.cmd_identifier == 5
+                         and pkt.key_type in [0x02, 0x03])),
         # Update-Device Command
         ConditionalField(dot15d4AddressField("address", 0,
                                              adjust=lambda pkt, x: 8),
@@ -652,18 +772,80 @@ class ZigbeeAppCommandPayload(Packet):
                                              adjust=lambda pkt, x: 8),
                          lambda pkt: pkt.cmd_identifier == 7),
         # Request-Key Command
-        ConditionalField(ByteEnumField("key_type", 0, _TransportKeyKeyTypes),
-                         lambda pkt: pkt.cmd_identifier == 8),
-        ConditionalField(StrFixedLenField("key", None, 16),
-                         lambda pkt: pkt.cmd_identifier == 8),
+        ConditionalField(
+            ByteEnumField("key_type", 0, _RequestKeyKeyTypes),
+            lambda pkt: pkt.cmd_identifier == 8),
+        ConditionalField(
+            StrFixedLenField("key", None, 16),
+            lambda pkt: pkt.cmd_identifier == 8),
+        ConditionalField(
+            dot15d4AddressField("partner_addr", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: (pkt.cmd_identifier == 8 and pkt.key_type == 0x02)),
         # Switch-Key Command
         ConditionalField(StrFixedLenField("seqnum", None, 8),
                          lambda pkt: pkt.cmd_identifier == 9),
-        # Un-implemented: 10-14 (+?)
+        # Un-implemented: 10-13 (+?)
         ConditionalField(StrField("data", ""),
-                         lambda pkt: (pkt.cmd_identifier < 0 or
-                                      pkt.cmd_identifier > 9))
+                         lambda pkt: (pkt.cmd_identifier >= 10
+                                      and pkt.cmd_identifier <= 13)),
+        # Tunnel Command
+        ConditionalField(
+            dot15d4AddressField("dest_addr", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: pkt.cmd_identifier == 14),
+        ConditionalField(
+            FlagsField("frame_control", 2, 4, [
+                "ack_format",
+                "security",
+                "ack_req",
+                "extended_hdr"
+            ]),
+            lambda pkt: pkt.cmd_identifier == 14),
+        ConditionalField(
+            BitEnumField("delivery_mode", 0, 2, {
+                0: "unicast",
+                1: "indirect",
+                2: "broadcast",
+                3: "group_addressing"
+            }),
+            lambda pkt: pkt.cmd_identifier == 14),
+        ConditionalField(
+            BitEnumField("aps_frametype", 1, 2, {
+                0: "data",
+                1: "command",
+                2: "ack"
+            }),
+            lambda pkt: pkt.cmd_identifier == 14),
+        ConditionalField(
+            ByteField("counter", 0),
+            lambda pkt: pkt.cmd_identifier == 14),
+        # Verify-Key Command
+        ConditionalField(
+            ByteEnumField("key_type", 0, _TransportKeyKeyTypes),
+            lambda pkt: pkt.cmd_identifier == 15),
+        ConditionalField(
+            dot15d4AddressField("address", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: pkt.cmd_identifier == 15),
+        ConditionalField(
+            StrFixedLenField("key_hash", None, 16),
+            lambda pkt: pkt.cmd_identifier == 15),
+        # Confirm-Key Command
+        ConditionalField(
+            ByteEnumField("status", 0, _ApsStatusValues),
+            lambda pkt: pkt.cmd_identifier == 16),
+        ConditionalField(
+            ByteEnumField("key_type", 0, _TransportKeyKeyTypes),
+            lambda pkt: pkt.cmd_identifier == 16),
+        ConditionalField(
+            dot15d4AddressField("address", 0, adjust=lambda pkt, x: 8),
+            lambda pkt: pkt.cmd_identifier == 16)
     ]
+
+    def guess_payload_class(self, payload):
+        if self.cmd_identifier == 14:
+            # Tunneled APS Auxiliary Header
+            return ZigbeeSecurityHeader
+        else:
+            return Packet.guess_payload_class(self, payload)
 
 
 class ZigBeeBeacon(Packet):
@@ -732,6 +914,20 @@ class ZigbeeAppDataPayloadStub(Packet):
             lambda pkt: pkt.frametype == 3
         ),
     ]
+
+
+# Zigbee Device Profile #
+
+
+class ZigbeeDeviceProfile(Packet):
+    name = "Zigbee Device Profile (ZDP) Frame"
+    fields_desc = [
+        # Transaction Sequence Number (1 octet)
+        ByteField("trans_seqnum", 0),
+
+        # TODO: Transaction Data (variable)
+    ]
+
 
 # ZigBee Cluster Library #
 

--- a/test/dot15d4.uts
+++ b/test/dot15d4.uts
@@ -9,7 +9,7 @@
 = Dot15D4 layers
 
 # a crazy packet with all classes in it!
-pkt = Dot15d4()/Dot15d4Ack()/Dot15d4AuxSecurityHeader()/Dot15d4Beacon()/Dot15d4Cmd()/Dot15d4CmdAssocReq()/Dot15d4CmdAssocResp()/Dot15d4CmdCoordRealign()/Dot15d4CmdDisassociation()/Dot15d4CmdGTSReq()/Dot15d4Data()/Dot15d4FCS()
+pkt = Dot15d4()/Dot15d4Ack()/Dot15d4AuxSecurityHeader()/Dot15d4Beacon()/Dot15d4Cmd()/Dot15d4CmdAssocReq()/Dot15d4CmdAssocResp()/Dot15d4CmdCoordRealign()/Dot15d4CmdCoordRealignPage()/Dot15d4CmdDisassociation()/Dot15d4CmdGTSReq()/Dot15d4Data()/Dot15d4FCS()
 assert Dot15d4 in pkt.layers()
 assert Dot15d4Ack in pkt.layers()
 assert Dot15d4AuxSecurityHeader in pkt.layers()
@@ -18,6 +18,7 @@ assert Dot15d4Cmd in pkt.layers()
 assert Dot15d4CmdAssocReq in pkt.layers()
 assert Dot15d4CmdAssocResp in pkt.layers()
 assert Dot15d4CmdCoordRealign in pkt.layers()
+assert Dot15d4CmdCoordRealignPage in pkt.layers()
 assert Dot15d4CmdDisassociation in pkt.layers()
 assert Dot15d4CmdGTSReq in pkt.layers()
 assert Dot15d4Data in pkt.layers()
@@ -27,6 +28,126 @@ assert Dot15d4FCS in pkt.layers()
 
 pkt = Ether()/IP()/Dot15d4FCS()
 assert pkt[Dot15d4]
+
+= Dot15d4FCS - Beacon (without pending addresses)
+
+pkt = Dot15d4FCS(b'\x00\x80\x89\xaa\x99\x00\x00\xff\xcf\x00\x00\x00"\x84\xfe\xca\xef\xbe\xed\xfe\xce\xfa\xff\xff\xff\x00X\xa4')
+assert Dot15d4FCS in pkt.layers()
+assert pkt[Dot15d4FCS].fcf_frametype == 0
+assert pkt[Dot15d4FCS].fcf_security == False
+assert pkt[Dot15d4FCS].fcf_pending == False
+assert pkt[Dot15d4FCS].fcf_ackreq == False
+assert pkt[Dot15d4FCS].fcf_panidcompress == False
+assert pkt[Dot15d4FCS].fcf_destaddrmode == 0
+assert pkt[Dot15d4FCS].fcf_framever == 0
+assert pkt[Dot15d4FCS].fcf_srcaddrmode == 2
+assert pkt[Dot15d4FCS].seqnum == 137
+assert Dot15d4Beacon in pkt.layers()
+assert pkt[Dot15d4Beacon].src_panid == 0x99aa
+assert pkt[Dot15d4Beacon].src_addr == 0x0000
+assert pkt[Dot15d4Beacon].sf_beaconorder == 15
+assert pkt[Dot15d4Beacon].sf_sforder == 15
+assert pkt[Dot15d4Beacon].sf_finalcapslot == 15
+assert pkt[Dot15d4Beacon].sf_battlifeextend == False
+assert pkt[Dot15d4Beacon].sf_pancoord == True
+assert pkt[Dot15d4Beacon].sf_assocpermit == True
+assert pkt[Dot15d4Beacon].gts_spec_permit == False
+assert pkt[Dot15d4Beacon].gts_spec_reserved == 0
+assert pkt[Dot15d4Beacon].gts_spec_desccount == 0
+assert pkt[Dot15d4Beacon].pa_num_short == 0
+assert pkt[Dot15d4Beacon].pa_num_long == 0
+assert pkt[Dot15d4Beacon].pa_short_addresses == []
+assert pkt[Dot15d4Beacon].pa_long_addresses == []
+assert raw(pkt[Dot15d4Beacon].payload) == b'\x00"\x84\xfe\xca\xef\xbe\xed\xfe\xce\xfa\xff\xff\xff\x00'
+assert pkt[Dot15d4FCS].fcs == 0xa458
+
+= Dot15d4FCS - Beacon (with pending addresses)
+
+pkt = Dot15d4FCS(b'\x00\x80\x89\xaa\x99\x00\x00\xff\xcf\x00\x124\x12xV\x88wfUD3"\x11\x00"\x84\xfe\xca\xef\xbe\xed\xfe\xce\xfa\xff\xff\xff\x00\x96\xd3')
+assert Dot15d4FCS in pkt.layers()
+assert pkt[Dot15d4FCS].fcf_frametype == 0
+assert pkt[Dot15d4FCS].fcf_security == False
+assert pkt[Dot15d4FCS].fcf_pending == False
+assert pkt[Dot15d4FCS].fcf_ackreq == False
+assert pkt[Dot15d4FCS].fcf_panidcompress == False
+assert pkt[Dot15d4FCS].fcf_destaddrmode == 0
+assert pkt[Dot15d4FCS].fcf_framever == 0
+assert pkt[Dot15d4FCS].fcf_srcaddrmode == 2
+assert pkt[Dot15d4FCS].seqnum == 137
+assert Dot15d4Beacon in pkt.layers()
+assert pkt[Dot15d4Beacon].src_panid == 0x99aa
+assert pkt[Dot15d4Beacon].src_addr == 0x0000
+assert pkt[Dot15d4Beacon].sf_beaconorder == 15
+assert pkt[Dot15d4Beacon].sf_sforder == 15
+assert pkt[Dot15d4Beacon].sf_finalcapslot == 15
+assert pkt[Dot15d4Beacon].sf_battlifeextend == False
+assert pkt[Dot15d4Beacon].sf_pancoord == True
+assert pkt[Dot15d4Beacon].sf_assocpermit == True
+assert pkt[Dot15d4Beacon].gts_spec_permit == False
+assert pkt[Dot15d4Beacon].gts_spec_reserved == 0
+assert pkt[Dot15d4Beacon].gts_spec_desccount == 0
+assert pkt[Dot15d4Beacon].pa_num_short == 2
+assert pkt[Dot15d4Beacon].pa_num_long == 1
+assert pkt[Dot15d4Beacon].pa_short_addresses == [0x1234, 0x5678]
+assert pkt[Dot15d4Beacon].pa_long_addresses == [0x1122334455667788]
+assert raw(pkt[Dot15d4Beacon].payload) == b'\x00"\x84\xfe\xca\xef\xbe\xed\xfe\xce\xfa\xff\xff\xff\x00'
+assert pkt[Dot15d4FCS].fcs == 0xd396
+
+= Dot15d4FCS - Coordinator Realignment (without the channel page)
+
+pkt = Dot15d4FCS(b'#\xcc\x89\xff\xff\x88wfUD3"\x11\xaa\x99\xff\xee\xdd\xcc\xbb\xaa\x99\x88\x08\xaa\x99\xde\xc0\x14\xad\xde\\!')
+assert Dot15d4FCS in pkt.layers()
+assert pkt[Dot15d4FCS].fcf_frametype == 3
+assert pkt[Dot15d4FCS].fcf_security == False
+assert pkt[Dot15d4FCS].fcf_pending == False
+assert pkt[Dot15d4FCS].fcf_ackreq == True
+assert pkt[Dot15d4FCS].fcf_panidcompress == False
+assert pkt[Dot15d4FCS].fcf_destaddrmode == 3
+assert pkt[Dot15d4FCS].fcf_framever == 0
+assert pkt[Dot15d4FCS].fcf_srcaddrmode == 3
+assert pkt[Dot15d4FCS].seqnum == 137
+assert Dot15d4Cmd in pkt.layers()
+assert pkt[Dot15d4Cmd].dest_panid == 0xffff
+assert pkt[Dot15d4Cmd].dest_addr == 0x1122334455667788
+assert pkt[Dot15d4Cmd].src_panid == 0x99aa
+assert pkt[Dot15d4Cmd].src_addr == 0x8899aabbccddeeff
+assert pkt[Dot15d4Cmd].cmd_id == 0x08
+assert Dot15d4CmdCoordRealign in pkt.layers()
+assert pkt[Dot15d4CmdCoordRealign].panid == 0x99aa
+assert pkt[Dot15d4CmdCoordRealign].coord_address == 0xc0de
+assert pkt[Dot15d4CmdCoordRealign].channel == 20
+assert pkt[Dot15d4CmdCoordRealign].dev_address == 0xdead
+assert raw(pkt[Dot15d4CmdCoordRealign].payload) == b''
+assert pkt[Dot15d4FCS].fcs == 0x215c
+
+= Dot15d4FCS - Coordinator Realignment (with the channel page)
+
+pkt = Dot15d4FCS(b'#\xcc\x89\xff\xff\x88wfUD3"\x11\xaa\x99\xff\xee\xdd\xcc\xbb\xaa\x99\x88\x08\xaa\x99\xde\xc0\x14\xad\xde\x00\xc8\x98')
+assert Dot15d4FCS in pkt.layers()
+assert pkt[Dot15d4FCS].fcf_frametype == 3
+assert pkt[Dot15d4FCS].fcf_security == False
+assert pkt[Dot15d4FCS].fcf_pending == False
+assert pkt[Dot15d4FCS].fcf_ackreq == True
+assert pkt[Dot15d4FCS].fcf_panidcompress == False
+assert pkt[Dot15d4FCS].fcf_destaddrmode == 3
+assert pkt[Dot15d4FCS].fcf_framever == 0
+assert pkt[Dot15d4FCS].fcf_srcaddrmode == 3
+assert pkt[Dot15d4FCS].seqnum == 137
+assert Dot15d4Cmd in pkt.layers()
+assert pkt[Dot15d4Cmd].dest_panid == 0xffff
+assert pkt[Dot15d4Cmd].dest_addr == 0x1122334455667788
+assert pkt[Dot15d4Cmd].src_panid == 0x99aa
+assert pkt[Dot15d4Cmd].src_addr == 0x8899aabbccddeeff
+assert pkt[Dot15d4Cmd].cmd_id == 0x08
+assert Dot15d4CmdCoordRealign in pkt.layers()
+assert pkt[Dot15d4CmdCoordRealign].panid == 0x99aa
+assert pkt[Dot15d4CmdCoordRealign].coord_address == 0xc0de
+assert pkt[Dot15d4CmdCoordRealign].channel == 20
+assert pkt[Dot15d4CmdCoordRealign].dev_address == 0xdead
+assert Dot15d4CmdCoordRealignPage in pkt.layers()
+assert pkt[Dot15d4CmdCoordRealignPage].channel_page == 0
+assert raw(pkt[Dot15d4CmdCoordRealignPage].payload) == b''
+assert pkt[Dot15d4FCS].fcs == 0x98c8
 
 ###################
 #### SixLoWPAN ####
@@ -348,12 +469,13 @@ conf.dot15d4_protocol = "zigbee"
 = Zigbee - layers
 
 # a crazy packet with all classes in it!
-pkt = ZigBeeBeacon()/ZigbeeAppCommandPayload()/ZigbeeAppDataPayload()/ZigbeeAppDataPayloadStub()/ZigbeeClusterLibrary()/ZigbeeNWK()/ZigbeeNWKCommandPayload()/ZigbeeNWKStub()/ZigbeeSecurityHeader()
+pkt = ZigBeeBeacon()/ZigbeeAppCommandPayload()/ZigbeeAppDataPayload()/ZigbeeAppDataPayloadStub()/ZigbeeClusterLibrary()/ZigbeeDeviceProfile()/ZigbeeNWK()/ZigbeeNWKCommandPayload()/ZigbeeNWKStub()/ZigbeeSecurityHeader()
 assert ZigBeeBeacon in pkt.layers()
 assert ZigbeeAppCommandPayload in pkt.layers()
 assert ZigbeeAppDataPayload in pkt.layers()
 assert ZigbeeAppDataPayloadStub in pkt.layers()
 assert ZigbeeClusterLibrary in pkt.layers()
+assert ZigbeeDeviceProfile in pkt.layers()
 assert ZigbeeNWK in pkt.layers()
 assert ZigbeeNWKCommandPayload in pkt.layers()
 assert ZigbeeNWKStub in pkt.layers()
@@ -449,3 +571,148 @@ assert f.i2repr(None, v) == "00:0f:ff:00:00:41:5b:1a"
 assert pkt1[ZigbeeAppCommandPayload].src_addr == 18446744073709551615
 f,v = pkt1[ZigbeeAppCommandPayload].getfield_and_val("src_addr")
 assert f.i2repr(None, v) == "ff:ff:ff:ff:ff:ff:ff:ff"
+
+= Zigbee - Link Status
+
+pkt = ZigbeeNWKCommandPayload(b'\x08c\x00\x00\x11\xad\xde\x11\xde\xc0\x11')
+assert ZigbeeNWKCommandPayload in pkt.layers()
+assert pkt[ZigbeeNWKCommandPayload].cmd_identifier == 0x08
+assert pkt[ZigbeeNWKCommandPayload].entry_count == 3
+assert pkt[ZigbeeNWKCommandPayload].first_frame == 1
+assert pkt[ZigbeeNWKCommandPayload].last_frame == 1
+assert len(pkt[ZigbeeNWKCommandPayload].link_status_list) == 3
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[0].neighbor_network_address == 0x0000
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[0].incoming_cost == 1
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[0].outgoing_cost == 1
+assert raw(pkt[ZigbeeNWKCommandPayload].link_status_list[0].payload) == b''
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[1].neighbor_network_address == 0xdead
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[1].incoming_cost == 1
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[1].outgoing_cost == 1
+assert raw(pkt[ZigbeeNWKCommandPayload].link_status_list[1].payload) == b''
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[2].neighbor_network_address == 0xc0de
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[2].incoming_cost == 1
+assert pkt[ZigbeeNWKCommandPayload].link_status_list[2].outgoing_cost == 1
+assert raw(pkt[ZigbeeNWKCommandPayload].link_status_list[2].payload) == b''
+assert raw(pkt[ZigbeeNWKCommandPayload].payload) == b''
+
+= Zigbee - End Device Timeout Request
+
+pkt = ZigbeeNWKCommandPayload(b'\x0b\x03\x00')
+assert ZigbeeNWKCommandPayload in pkt.layers()
+assert pkt[ZigbeeNWKCommandPayload].cmd_identifier == 0x0b
+assert pkt[ZigbeeNWKCommandPayload].req_timeout == 3
+assert pkt[ZigbeeNWKCommandPayload].ed_conf == 0
+assert raw(pkt[ZigbeeNWKCommandPayload].payload) == b''
+
+= Zigbee - End Device Timeout Response
+
+pkt = ZigbeeNWKCommandPayload(b'\x0c\x00\x03')
+assert ZigbeeNWKCommandPayload in pkt.layers()
+assert pkt[ZigbeeNWKCommandPayload].cmd_identifier == 0x0c
+assert pkt[ZigbeeNWKCommandPayload].status == 0
+assert pkt[ZigbeeNWKCommandPayload].mac_data_poll_keepalive == 1
+assert pkt[ZigbeeNWKCommandPayload].ed_timeout_req_keepalive == 1
+assert raw(pkt[ZigbeeNWKCommandPayload].payload) == b''
+
+= Zigbee - Transport Key
+
+pkt = ZigbeeAppCommandPayload(b'\x05\x01\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x00\x88wfUD3"\x11\xff\xee\xdd\xcc\xbb\xaa\x99\x88')
+assert ZigbeeAppCommandPayload in pkt.layers()
+assert pkt[ZigbeeAppCommandPayload].cmd_identifier == 0x05
+assert pkt[ZigbeeAppCommandPayload].key_type == 1
+assert pkt[ZigbeeAppCommandPayload].key == b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'
+assert pkt[ZigbeeAppCommandPayload].key_seqnum == 0
+assert pkt[ZigbeeAppCommandPayload].dest_addr == 0x1122334455667788
+assert pkt[ZigbeeAppCommandPayload].src_addr == 0x8899aabbccddeeff
+assert raw(pkt[ZigbeeAppCommandPayload].payload) == b''
+
+= Zigbee - Request Key
+
+pkt = ZigbeeAppCommandPayload(b'\x08\x04')
+assert ZigbeeAppCommandPayload in pkt.layers()
+assert pkt[ZigbeeAppCommandPayload].cmd_identifier == 0x08
+assert pkt[ZigbeeAppCommandPayload].key_type == 0x04
+assert raw(pkt[ZigbeeAppCommandPayload].payload) == b''
+
+= Zigbee - Tunnel
+
+pkt = ZigbeeAppCommandPayload(b'\x0e\x88wfUD3"\x11!\xe20\x0bP\x00\x00\xff\xee\xdd\xcc\xbb\xaa\x99\x88\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xcc\xcc\xcc\xcc')
+assert ZigbeeAppCommandPayload in pkt.layers()
+assert pkt[ZigbeeAppCommandPayload].cmd_identifier == 0x0e
+assert pkt[ZigbeeAppCommandPayload].dest_addr == 0x1122334455667788
+assert pkt[ZigbeeAppCommandPayload].aps_frametype == 1
+assert pkt[ZigbeeAppCommandPayload].delivery_mode == 0
+assert pkt[ZigbeeAppCommandPayload].frame_control == 0b0010
+assert ZigbeeSecurityHeader in pkt.layers()
+assert raw(pkt[ZigbeeSecurityHeader]) == b'0\x0bP\x00\x00\xff\xee\xdd\xcc\xbb\xaa\x99\x88\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xcc\xcc\xcc\xcc'
+
+= Zigbee - Verify Key
+
+pkt = ZigbeeAppCommandPayload(b'\x0f\x04\x88wfUD3"\x11\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f')
+assert ZigbeeAppCommandPayload in pkt.layers()
+assert pkt[ZigbeeAppCommandPayload].cmd_identifier == 0x0f
+assert pkt[ZigbeeAppCommandPayload].key_type == 0x04
+assert pkt[ZigbeeAppCommandPayload].address == 0x1122334455667788
+assert pkt[ZigbeeAppCommandPayload].key_hash == b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f'
+assert raw(pkt[ZigbeeAppCommandPayload].payload) == b''
+
+= Zigbee - Confirm Key
+
+pkt = ZigbeeAppCommandPayload(b'\x10\x00\x04\x88wfUD3"\x11')
+assert ZigbeeAppCommandPayload in pkt.layers()
+assert pkt[ZigbeeAppCommandPayload].cmd_identifier == 0x10
+assert pkt[ZigbeeAppCommandPayload].status == 0
+assert pkt[ZigbeeAppCommandPayload].key_type == 0x04
+assert pkt[ZigbeeAppCommandPayload].address == 0x1122334455667788
+assert raw(pkt[ZigbeeAppCommandPayload].payload) == b''
+
+= Zigbee - APS acknowledgment (with the Acknowledgment Format enabled)
+pkt = ZigbeeAppDataPayload(b'\x12\xa8')
+assert ZigbeeAppDataPayload in pkt.layers()
+assert pkt[ZigbeeAppDataPayload].aps_frametype == 2
+assert pkt[ZigbeeAppDataPayload].delivery_mode == 0
+assert pkt[ZigbeeAppDataPayload].frame_control == 0b0001
+assert pkt[ZigbeeAppDataPayload].counter == 168
+assert raw(pkt[ZigbeeAppDataPayload].payload) == b''
+
+= Zigbee - APS acknowledgment (with the Acknowledgment Format disabled)
+pkt = ZigbeeAppDataPayload(b'\x02\x00\x02\x00\x00\x00\x00\xa6')
+assert ZigbeeAppDataPayload in pkt.layers()
+pkt.show()
+assert pkt[ZigbeeAppDataPayload].aps_frametype == 2
+assert pkt[ZigbeeAppDataPayload].delivery_mode == 0
+assert pkt[ZigbeeAppDataPayload].frame_control == 0b0000
+assert pkt[ZigbeeAppDataPayload].dst_endpoint == 0
+assert pkt[ZigbeeAppDataPayload].cluster == 0x0002
+assert pkt[ZigbeeAppDataPayload].profile == 0x0000
+assert pkt[ZigbeeAppDataPayload].src_endpoint == 0
+assert pkt[ZigbeeAppDataPayload].counter == 166
+assert raw(pkt[ZigbeeAppDataPayload].payload) == b''
+
+= Zigbee - ZDP command
+pkt = ZigbeeAppDataPayload(b'\x08\x006\x00\x00\x00\x00\xb5\x01\x14\x01')
+assert ZigbeeAppDataPayload in pkt.layers()
+assert pkt[ZigbeeAppDataPayload].aps_frametype == 0
+assert pkt[ZigbeeAppDataPayload].delivery_mode == 2
+assert pkt[ZigbeeAppDataPayload].frame_control == 0b0000
+assert pkt[ZigbeeAppDataPayload].dst_endpoint == 0
+assert pkt[ZigbeeAppDataPayload].cluster == 0x0036
+assert pkt[ZigbeeAppDataPayload].profile == 0x0000
+assert pkt[ZigbeeAppDataPayload].src_endpoint == 0
+assert pkt[ZigbeeAppDataPayload].counter == 181
+assert ZigbeeDeviceProfile in pkt.layers()
+assert raw(pkt[ZigbeeDeviceProfile]) == b'\x01\x14\x01'
+
+= Zigbee - ZCL command
+pkt = ZigbeeAppDataPayload(b'@\x01\n\x00\x04\x01\x01\x9d\x00\x00\x00\x00\x00')
+assert ZigbeeAppDataPayload in pkt.layers()
+assert pkt[ZigbeeAppDataPayload].aps_frametype == 0
+assert pkt[ZigbeeAppDataPayload].delivery_mode == 0
+assert pkt[ZigbeeAppDataPayload].frame_control == 0b0100
+assert pkt[ZigbeeAppDataPayload].dst_endpoint == 1
+assert pkt[ZigbeeAppDataPayload].cluster == 0x000a
+assert pkt[ZigbeeAppDataPayload].profile == 0x0104
+assert pkt[ZigbeeAppDataPayload].src_endpoint == 1
+assert pkt[ZigbeeAppDataPayload].counter == 157
+assert ZigbeeClusterLibrary in pkt.layers()
+assert raw(pkt[ZigbeeClusterLibrary]) == b'\x00\x00\x00\x00\x00'


### PR DESCRIPTION
* Dissect End Device Timeout Request commands
* Dissect End Device Timeout Response commands
* Fix bug in the dissection of Link Status commands
* Fix conditions and add fields to ZigbeeAppDataPayload
* Fix the fields of the Transport-Key command
* Add the optional Partner Address field of the Request-Key command
* Dissect Tunnel commands
* Dissect Verify-Key commands
* Dissect Confirm-Key commands
* Define the ZigbeeDeviceProfile class
* Fix bug in the Pending Address Specification field
* Dissect short and extended pending addresses in beacons
* Dissect the Channel Page field of Coordinator Realignment commands