### PR TITLE
Slightly better error handling

### DIFF
--- a/scapy/layers/tls/__init__.py
+++ b/scapy/layers/tls/__init__.py
@@ -62,6 +62,10 @@ TODO list (may it be carved away by good souls):
 
     - About the automatons:
 
+        - Allow upgrade from TLS 1.2 to TLS 1.3 in the Automaton client.
+          Currently we'll use TLS 1.3 only if the automaton client was given
+          version="tls13".
+
         - Add various checks for discrepancies between client and server.
           Is the ServerHello ciphersuite ok? What about the SKE params? Etc.
 

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -42,7 +42,6 @@ import struct
 import time
 
 from scapy.config import conf
-from scapy.pton_ntop import inet_pton
 from scapy.utils import randstring, repr_hex
 from scapy.automaton import ATMT, select_objects
 from scapy.error import warning
@@ -112,20 +111,10 @@ class TLSClientAutomaton(_TLSAutomaton):
                                                    mykey=mykey,
                                                    **kargs)
         tmp = socket.getaddrinfo(server, dport)
-        try:
-            if ':' in server:
-                inet_pton(socket.AF_INET6, server)
-            else:
-                inet_pton(socket.AF_INET, server)
-        except Exception:
-            remote_name = socket.getfqdn(server)
-            if remote_name != server:
-                tmp = socket.getaddrinfo(remote_name, dport)
-
-        self.remote_name = server_name
         self.remote_family = tmp[0][0]
         self.remote_ip = tmp[0][4][0]
         self.remote_port = dport
+        self.server_name = server_name
         self.local_ip = None
         self.local_port = None
         self.socket = None
@@ -304,9 +293,9 @@ class TLSClientAutomaton(_TLSAutomaton):
         if self.cur_session.advertised_tls_version == 0x0303:
             ext += [TLS_Ext_SignatureAlgorithms(sig_algs=["sha256+rsa"])]
         # Add TLS_Ext_ServerName
-        if self.remote_name:
+        if self.server_name:
             ext += TLS_Ext_ServerName(
-                servernames=[ServerName(servername=self.remote_name)]
+                servernames=[ServerName(servername=self.server_name)]
             )
         p.ext = ext
         self.add_msg(p)
@@ -1091,9 +1080,9 @@ class TLSClientAutomaton(_TLSAutomaton):
             ext += TLS_Ext_SignatureAlgorithms(sig_algs=["sha256+rsaepss",
                                                          "sha256+rsa"])
         # Add TLS_Ext_ServerName
-        if self.remote_name:
+        if self.server_name:
             ext += TLS_Ext_ServerName(
-                servernames=[ServerName(servername=self.remote_name)]
+                servernames=[ServerName(servername=self.server_name)]
             )
         p.ext = ext
         self.add_msg(p)
@@ -1146,7 +1135,13 @@ class TLSClientAutomaton(_TLSAutomaton):
     @ATMT.condition(TLS13_RECEIVED_SERVERFLIGHT1, prio=3)
     def tls13_should_handle_AlertMessage_(self):
         self.raise_on_packet(TLSAlert,
-                             self.CLOSE_NOTIFY)
+                             self.TLS13_HANDLED_ALERT_FROM_SERVERFLIGHT1)
+
+    @ATMT.state()
+    def TLS13_HANDLED_ALERT_FROM_SERVERFLIGHT1(self):
+        self.vprint("Received Alert message !")
+        self.vprint(self.cur_pkt.mysummary())
+        raise self.CLOSE_NOTIFY()
 
     @ATMT.condition(TLS13_RECEIVED_SERVERFLIGHT1, prio=4)
     def tls13_missing_ServerHello(self):

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -781,7 +781,7 @@ class TLSAlert(_GenericTLSSessionInheritance):
                    ByteEnumField("descr", None, _tls_alert_description)]
 
     def mysummary(self):
-        return self.sprintf("Alert %level%: %desc%")
+        return self.sprintf("Alert %level%: %descr%")
 
     def post_dissection_tls_session_update(self, msg_str):
         pass

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -63,6 +63,11 @@ v = _tls_version_options.get(args.version, None)
 if not v:
     sys.exit("Unrecognized TLS version option.")
 
+try:
+    socket.getaddrinfo(args.server, args.port)
+except socket.error as ex:
+    sys.exit("Could not resolve host server: %s" % ex)
+
 if args.ciphersuite:
     ciphers = int(args.ciphersuite, 16)
     if ciphers not in list(range(0x1301, 0x1306)):


### PR DESCRIPTION
Very light PR with slighly better error handling.
- rename `remote_name` into `server_name` because that's the SNI
- display the TLSAlert also in the TLS client
- check before running the client that the host is joinable