### PR TITLE
Fix codecov on github actions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -70,3 +70,5 @@ jobs:
         run: ./.config/ci/test.sh ${{ matrix.python }} non_root
       - name: Codecov
         uses: codecov/codecov-action@v1
+        with:
+            file: /home/runner/work/scapy/scapy/.coverage


### PR DESCRIPTION
This PR fixes codecov on github actions. Currently, the codecov action output `==> Python coveragepy not found`