### PR TITLE
Fix IPv6 fragmentation support

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1090,21 +1090,31 @@ def defragment6(packets):
 
 def fragment6(pkt, fragSize):
     """
-    Performs fragmentation of an IPv6 packet. Provided packet ('pkt') must
-    already contain an IPv6ExtHdrFragment() class. 'fragSize' argument is the
-    expected maximum size of fragments (MTU). The list of packets is returned.
+    Performs fragmentation of an IPv6 packet. 'fragSize' argument is the
+    expected maximum size of fragment data (MTU). The list of packets is
+    returned.
 
-    If packet does not contain an IPv6ExtHdrFragment class, it is returned in
-    result list.
+    If packet does not contain an IPv6ExtHdrFragment class, it is added to
+    first IPv6 layer found. If no IPv6 layer exists packet is returned in
+    result list unmodified.
     """
 
     pkt = pkt.copy()
 
     if IPv6ExtHdrFragment not in pkt:
-        # TODO : automatically add a fragment before upper Layer
-        #        at the moment, we do nothing and return initial packet
-        #        as single element of a list
-        return [pkt]
+        if IPv6 not in pkt:
+            return [pkt]
+
+        layer3 = pkt[IPv6]
+        data = layer3.payload
+        frag = IPv6ExtHdrFragment(nh=layer3.nh)
+
+        layer3.remove_payload()
+        del(layer3.nh)
+        del(layer3.plen)
+
+        frag.add_payload(data)
+        layer3.add_payload(frag)
 
     # If the payload is bigger than 65535, a Jumbo payload must be used, as
     # an IPv6 packet can't be bigger than 65535 bytes.

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1073,7 +1073,7 @@ def defragment6(packets):
         fragmentable += raw(q.payload)
 
     # Regenerate the unfragmentable part.
-    q = res[0]
+    q = res[0].copy()
     nh = q[IPv6ExtHdrFragment].nh
     q[IPv6ExtHdrFragment].underlayer.nh = nh
     q[IPv6ExtHdrFragment].underlayer.plen = len(fragmentable)
@@ -1081,7 +1081,11 @@ def defragment6(packets):
     q /= conf.raw_layer(load=fragmentable)
     del(q.plen)
 
-    return IPv6(raw(q))
+    if q[IPv6].underlayer:
+        q[IPv6] = IPv6(raw(q[IPv6]))
+    else:
+        q = IPv6(raw(q))
+    return q
 
 
 def fragment6(pkt, fragSize):

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1023,6 +1023,12 @@ class IPv6ExtHdrFragment(_IPv6ExtHdr):
                    IntField("id", None)]
     overload_fields = {IPv6: {"nh": 44}}
 
+    def guess_payload_class(self, p):
+        if self.offset > 0:
+            return Raw
+        else:
+            return super(IPv6ExtHdrFragment, self).guess_payload_class(p)
+
 
 def defragment6(packets):
     """

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4071,6 +4071,11 @@ l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280)
 raw(defragment6(l)) == (b'`\x00\x00\x00\x9cT\x06@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x14\x00P\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xe92\x00\x00' + b'A'*40000)
 
 
+= defragment6 - test against packets with L2 header
+l=defragment6(fragment6(Ether()/IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*2000), 1280))
+Ether in l
+
+
 = defragment6 - test against a large TCP packet fragmented with a 1280 bytes MTU and missing fragments
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280) 
 del(l[2])

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4061,6 +4061,10 @@ a.nh == 0xff and a.res1 == 0xee and a.offset==0x1fff and a.res2==1 and a.m == 1 
 l=fragment6(IPv6()/IPv6ExtHdrFragment()/TCP()/Raw(load="A"*40000), 1280) 
 len(l) == 33 and len(raw(l[-1])) == 644
 
+= fragment6 - test against a long TCP packet with a 1280 MTU without fragment header
+l=fragment6(IPv6()/TCP()/Raw(load="A"*40000), 1280)
+len(l) == 33 and len(raw(l[-1])) == 644
+
 
 ############
 ############


### PR DESCRIPTION
This series fixes few small shortcomings of IPv6 fragment handling.

First patch makes non-first packets have always Raw payload (as you can't correctly represent the data).
Second patch makes defragment6() work correctly for packets with L2 headers present (uses first packet's structure instead of forcing it into L3-only).
Third fixes fragment6() to add fragment extension header automatically.