### PR TITLE
Core typing: compat/config/fields/main/packet

### DIFF
--- a/.config/mypy/mypy.ini
+++ b/.config/mypy/mypy.ini
@@ -1,5 +1,13 @@
 [mypy]
 
+# Internal Scapy modules that we ignore
+
+[mypy-scapy.modules.six,scapy.modules.six.moves,scapy.libs.winpcapy]
+ignore_errors = True
+ignore_missing_imports = True
+
+# External libraries that we ignore
+
 [mypy-IPython]
 ignore_missing_imports = True
 
@@ -9,13 +17,11 @@ ignore_missing_imports = True
 [mypy-traitlets.config.loader]
 ignore_missing_imports = True
 
-[mypy-scapy.modules.six,scapy.modules.six.moves,scapy.libs.winpcapy]
-ignore_errors = True
-ignore_missing_imports = True
-
 [mypy-pyx]
 ignore_missing_imports = True
 
 [mypy-matplotlib.lines]
 ignore_missing_imports = True
 
+[mypy-prompt_toolkit.*]
+ignore_missing_imports = True

--- a/.config/mypy/mypy_check.py
+++ b/.config/mypy/mypy_check.py
@@ -37,14 +37,29 @@ if not FILES:
 # Generate mypy arguments
 
 ARGS = [
-    "--py2",
-    "--follow-imports=skip",
+    # strictness: same as --strict minus --disallow-subclassing-any
+    "--warn-unused-configs",
+    "--disallow-any-generics",
+    "--disallow-untyped-calls",
+    "--disallow-untyped-defs",
+    "--disallow-incomplete-defs",
+    "--check-untyped-defs",
+    "--disallow-untyped-decorators",
+    "--no-implicit-optional",
+    "--warn-redundant-casts",
+    "--warn-unused-ignores",
+    "--warn-return-any",
+    "--no-implicit-reexport",
+    "--strict-equality",
+    "--ignore-missing-imports",
+    # config
+    "--follow-imports=skip",  # Remove eventually
     "--config-file=" + os.path.abspath(
         os.path.join(
             localdir,
             "mypy.ini"
         )
-    )
+    ),
 ] + [os.path.abspath(f) for f in FILES]
 
 # Run mypy over the files

--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -6,5 +6,10 @@
 
 scapy/__init__.py
 scapy/main.py
-scapy/contrib/http2.py
+# Need fixes that mypy is in strict mode :/
+#scapy/contrib/http2.py
+scapy/compat.py
+scapy/config.py
+scapy/fields.py
+scapy/packet.py
 scapy/plist.py

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -14,14 +14,11 @@ import os
 import re
 import subprocess
 
-from scapy.compat import AnyStr
-
-
 _SCAPY_PKG_DIR = os.path.dirname(__file__)
 
 
 def _version_from_git_describe():
-    # type: () -> AnyStr
+    # type: () -> str
     """
     Read the version from ``git describe``. It returns the latest tag with an
     optional suffix if the current directory is not exactly on the tag.
@@ -49,6 +46,7 @@ def _version_from_git_describe():
         raise ValueError('not in scapy git repo')
 
     def _git(cmd):
+        # type: (str) -> str
         process = subprocess.Popen(
             cmd.split(),
             cwd=_SCAPY_PKG_DIR,

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -22,6 +22,7 @@ import socket
 import subprocess
 import types
 
+from scapy.compat import FAKE_TYPING
 from scapy.consts import WINDOWS
 from scapy.modules.six.moves import range
 
@@ -267,11 +268,20 @@ class Packet_metaclass(type):
         return i
 
 
+# Note: see compat.py for an explanation
+
 class Field_metaclass(type):
     def __new__(cls, name, bases, dct):
         dct.setdefault("__slots__", [])
         newcls = super(Field_metaclass, cls).__new__(cls, name, bases, dct)
         return newcls
+
+    if FAKE_TYPING:
+        def __getitem__(self, type):
+            return self
+
+
+PacketList_metaclass = Field_metaclass
 
 
 class BasePacket(Gen):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -68,6 +68,7 @@ __all__ = [
 
 try:
     import typing  # noqa: F401
+    from typing import TYPE_CHECKING
     if sys.version_info[0:2] <= (3, 6):
         # Generic is messed up before Python 3.7
         # https://github.com/python/typing/issues/449
@@ -75,6 +76,7 @@ try:
     FAKE_TYPING = False
 except ImportError:
     FAKE_TYPING = True
+    TYPE_CHECKING = False
 
 if not FAKE_TYPING:
     # Only required if using mypy-lang for static typing
@@ -152,6 +154,12 @@ def lambda_tuple_converter(func):
         return func
 
 
+# This is ugly, but we don't want to move raw() out of compat.py
+# and it makes it much clearer
+if TYPE_CHECKING:
+    from scapy.packet import Packet, RawVal
+
+
 if six.PY2:
     bytes_encode = plain_str = str  # type: Callable[[Any], bytes]
     orb = ord  # type: Callable[[bytes], int]
@@ -163,17 +171,21 @@ if six.PY2:
         return chr(x)
 
     def raw(x):
-        # type: (Any) -> bytes
-        """Builds a packet and returns its bytes representation.
-        This function is and always be cross-version compatible"""
+        # type: (Union[Packet, RawVal]) -> bytes
+        """
+        Builds a packet and returns its bytes representation.
+        This function is and will always be cross-version compatible
+        """
         if hasattr(x, "__bytes__"):
             return x.__bytes__()
         return bytes(x)
 else:
     def raw(x):
-        # type: (Any) -> bytes
-        """Builds a packet and returns its bytes representation.
-        This function is and always be cross-version compatible"""
+        # type: (Union[Packet, RawVal]) -> bytes
+        """
+        Builds a packet and returns its bytes representation.
+        This function is and will always be cross-version compatible
+        """
         return bytes(x)
 
     def bytes_encode(x):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -11,18 +11,135 @@ Python 2 and 3 link classes.
 from __future__ import absolute_import
 import base64
 import binascii
+import collections
 import gzip
 import struct
 import sys
 
 import scapy.modules.six as six
 
+# Very important: will issue typing errors otherwise
+__all__ = [
+    # typing
+    'Any',
+    'AnyStr',
+    'Callable',
+    'DefaultDict',
+    'Dict',
+    'Generic',
+    'Iterator',
+    'List',
+    'NoReturn',
+    'Optional',
+    'Pattern',
+    'Set',
+    'Sized',
+    'Tuple',
+    'TypeVar',
+    'Union',
+    'cast',
+    'FAKE_TYPING',
+    # compat
+    'base64_bytes',
+    'bytes_base64',
+    'bytes_encode',
+    'bytes_hex',
+    'chb',
+    'gzip_compress',
+    'gzip_decompress',
+    'hex_bytes',
+    'lambda_tuple_converter',
+    'orb',
+    'plain_str',
+    'raw',
+]
+
+# Typing compatibility
+
+# Note:
+# supporting typing on multiple python versions is a nightmare.
+# Since Python 3.7, Generic is a type instead of a metaclass,
+# therefore we can't support both at the same time. Our strategy
+# is to only use the typing module if the Python version is >= 3.7
+# and use totally fake replacements otherwise.
+# HOWEVER, when using the fake ones, to emulate stub Generic
+# fields (e.g. _PacketField[str]) we need to add a fake
+# __getitem__ to Field_metaclass
+
+try:
+    import typing  # noqa: F401
+    if sys.version_info[0:2] <= (3, 6):
+        # Generic is messed up before Python 3.7
+        # https://github.com/python/typing/issues/449
+        raise ImportError
+    FAKE_TYPING = False
+except ImportError:
+    FAKE_TYPING = True
+
+if not FAKE_TYPING:
+    # Only required if using mypy-lang for static typing
+    from typing import (
+        Any,
+        AnyStr,
+        Callable,
+        DefaultDict,
+        Dict,
+        Generic,
+        Iterator,
+        List,
+        NoReturn,
+        Optional,
+        Pattern,
+        Set,
+        Sized,
+        Tuple,
+        TypeVar,
+        Union,
+        cast,
+    )
+else:
+    # Let's be creative and make some fake ones.
+    def cast(_type, obj):  # type: ignore
+        return obj
+
+    def _FakeType(name, cls=object):
+        # type: (str, Optional[type]) -> Any
+        class _FT(object):
+            # make the objects subscriptable indefinetly
+            def __getitem__(self, item):  # type: ignore
+                return cls
+        return _FT()
+
+    Any = _FakeType("Any")
+    AnyStr = _FakeType("AnyStr")  # type: ignore
+    Callable = _FakeType("Callable")
+    DefaultDict = _FakeType("DefaultDict",  # type: ignore
+                            collections.defaultdict)
+    Dict = _FakeType("Dict", dict)  # type: ignore
+    Generic = _FakeType("Generic")
+    Iterator = _FakeType("Iterator")  # type: ignore
+    List = _FakeType("List", list)  # type: ignore
+    NoReturn = _FakeType("NoReturn")  # type: ignore
+    Optional = _FakeType("Optional")
+    Pattern = _FakeType("Pattern")  # type: ignore
+    Set = _FakeType("Set", set)  # type: ignore
+    Tuple = _FakeType("Tuple")
+    TypeVar = lambda x, *args: _FakeType("TypeVar %s" % x)
+    Union = _FakeType("Union")
+
+    class Sized(object):  # type: ignore
+        pass
+
+
 ###########
 # Python3 #
 ###########
 
+_CallTupl = TypeVar("_CallTupl", Callable[Ellipsis, Any], None)  # type: ignore
+
 
 def lambda_tuple_converter(func):
+    # type: (_CallTupl) -> _CallTupl
     """
     Converts a Python 2 function as
       lambda (x,y): x + y
@@ -36,11 +153,17 @@ def lambda_tuple_converter(func):
 
 
 if six.PY2:
-    bytes_encode = plain_str = str
-    chb = lambda x: x if isinstance(x, str) else chr(x)
-    orb = ord
+    bytes_encode = plain_str = str  # type: Callable[[Any], bytes]
+    orb = ord  # type: Callable[[bytes], int]
+
+    def chb(x):
+        # type: (int) -> bytes
+        if isinstance(x, str):
+            return x
+        return chr(x)
 
     def raw(x):
+        # type: (Any) -> bytes
         """Builds a packet and returns its bytes representation.
         This function is and always be cross-version compatible"""
         if hasattr(x, "__bytes__"):
@@ -48,11 +171,13 @@ if six.PY2:
         return bytes(x)
 else:
     def raw(x):
+        # type: (Any) -> bytes
         """Builds a packet and returns its bytes representation.
         This function is and always be cross-version compatible"""
         return bytes(x)
 
     def bytes_encode(x):
+        # type: (Any) -> bytes
         """Ensure that the given object is bytes.
         If the parameter is a packet, raw() should be preferred.
         """
@@ -62,6 +187,7 @@ else:
 
     if sys.version_info[0:2] <= (3, 4):
         def plain_str(x):
+            # type: (AnyStr) -> str
             """Convert basic byte objects to str"""
             if isinstance(x, bytes):
                 return x.decode(errors="ignore")
@@ -69,16 +195,19 @@ else:
     else:
         # Python 3.5+
         def plain_str(x):
+            # type: (Any) -> str
             """Convert basic byte objects to str"""
             if isinstance(x, bytes):
                 return x.decode(errors="backslashreplace")
             return str(x)
 
     def chb(x):
+        # type: (int) -> bytes
         """Same than chr() but encode as bytes."""
         return struct.pack("!B", x)
 
     def orb(x):
+        # type: (Union[int, bytes]) -> int
         """Return ord(x) when not already an int."""
         if isinstance(x, int):
             return x
@@ -86,26 +215,30 @@ else:
 
 
 def bytes_hex(x):
+    # type: (AnyStr) -> bytes
     """Hexify a str or a bytes object"""
     return binascii.b2a_hex(bytes_encode(x))
 
 
 def hex_bytes(x):
+    # type: (AnyStr) -> bytes
     """De-hexify a str or a byte object"""
     return binascii.a2b_hex(bytes_encode(x))
 
 
 def base64_bytes(x):
+    # type: (AnyStr) -> bytes
     """Turn base64 into bytes"""
     if six.PY2:
-        return base64.decodestring(x)
+        return base64.decodestring(x)  # type: ignore
     return base64.decodebytes(bytes_encode(x))
 
 
 def bytes_base64(x):
+    # type: (AnyStr) -> bytes
     """Turn bytes into base64"""
     if six.PY2:
-        return base64.encodestring(x).replace('\n', '')
+        return base64.encodestring(x).replace('\n', '')  # type: ignore
     return base64.encodebytes(bytes_encode(x)).replace(b'\n', b'')
 
 
@@ -121,11 +254,13 @@ if six.PY2:
     from StringIO import StringIO
 
     def gzip_decompress(x):
+        # type: (AnyStr) -> bytes
         """Decompress using gzip"""
         with gzip.GzipFile(fileobj=StringIO(x), mode='rb') as fdesc:
             return fdesc.read()
 
     def gzip_compress(x):
+        # type: (AnyStr) -> bytes
         """Compress using gzip"""
         buf = StringIO()
         with gzip.GzipFile(fileobj=buf, mode='wb') as fdesc:
@@ -134,33 +269,3 @@ if six.PY2:
 else:
     gzip_decompress = gzip.decompress
     gzip_compress = gzip.compress
-
-# Typing compatibility
-
-try:
-    # Only required if using mypy-lang for static typing
-    from typing import Optional, List, Union, Callable, Any, AnyStr, Tuple, \
-        Sized, Dict, Pattern, cast
-except ImportError:
-    # Let's make some fake ones.
-
-    def cast(_type, obj):
-        return obj
-
-    class _FakeType(object):
-        # make the objects subscriptable indefinetly
-        def __getitem__(self, item):
-            return _FakeType()
-
-    Optional = _FakeType()
-    Union = _FakeType()
-    Callable = _FakeType()
-    List = _FakeType()
-    Dict = _FakeType()
-    Any = _FakeType()
-    AnyStr = _FakeType()
-    Tuple = _FakeType()
-    Pattern = _FakeType()
-
-    class Sized(object):
-        pass

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -26,7 +26,7 @@ from scapy.base_classes import Packet_metaclass
 from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
 from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
 from scapy.modules import six
-from scapy.themes import ColorTheme, NoTheme, apply_ipython_style
+from scapy.themes import NoTheme, apply_ipython_style
 
 from scapy.compat import (
     Any,
@@ -543,7 +543,7 @@ def isPyPy():
 
 
 def _prompt_changer(attr, val, old):
-    # type: (str, Any, Any) -> None
+    # type: (str, Any, Any) -> Any
     """Change the current prompt theme"""
     Interceptor.set_from_hook(conf, attr, val)
     try:
@@ -624,7 +624,7 @@ def _set_conf_sockets():
 
 
 def _socket_changer(attr, val, old):
-    # type: (str, bool, bool) -> None
+    # type: (str, bool, bool) -> Any
     if not isinstance(val, bool):
         raise TypeError("This argument should be a boolean")
     Interceptor.set_from_hook(conf, attr, val)
@@ -648,13 +648,14 @@ def _socket_changer(attr, val, old):
 
 
 def _loglevel_changer(attr, val, old):
-    # type: (str, int, int) -> None
+    # type: (str, int, int) -> int
     """Handle a change of conf.logLevel"""
     log_scapy.setLevel(val)
     return val
 
 
 def _iface_changer(attr, val, old):
+    # type: (str, Any, Any) -> 'scapy.interfaces.NetworkInterfaceDict'
     """Resolves the interface in conf.iface"""
     if isinstance(val, str):
         from scapy.interfaces import resolve_iface
@@ -741,7 +742,7 @@ class Conf(ConfClass):
     debug_tls = False
     wepkey = ""
     #: holds the Scapy interface list and manager
-    ifaces = None
+    ifaces = None  # type: 'scapy.interfaces.NetworkInterfaceDict'
     #: holds the cache of interfaces loaded from Libpcap
     cache_iflist = {}  # type: Dict[str, Tuple[str, List[str], int]]
     #: holds the Scapy IPv4 routing table and provides methods to

--- a/scapy/contrib/automotive/bmw/definitions.py
+++ b/scapy/contrib/automotive/bmw/definitions.py
@@ -278,7 +278,7 @@ class SVK(Packet):
         ByteField("pad1", 0),
         LEIntField("prog_milage", 0),
         StrFixedLenField("pad2", 0, length=5),
-        PacketListField("entries", [], cls=SVK_Entry,
+        PacketListField("entries", [], SVK_Entry,
                         count_from=lambda x: x.entries_count)]
 
 

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -463,11 +463,11 @@ class SD(_SDPacketBase):
         X3BytesField("res", 0),
         FieldLenField("len_entry_array", None,
                       length_of="entry_array", fmt="!I"),
-        PacketListField("entry_array", None, cls=_sdentry_class,
+        PacketListField("entry_array", None, _sdentry_class,
                         length_from=lambda pkt: pkt.len_entry_array),
         FieldLenField("len_option_array", None,
                       length_of="option_array", fmt="!I"),
-        PacketListField("option_array", None, cls=_sdoption_class,
+        PacketListField("option_array", None, _sdoption_class,
                         length_from=lambda pkt: pkt.len_option_array)
     ]
 

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -47,11 +47,11 @@ import struct
 from scapy.packet import Packet
 from scapy.fields import StrField, IPField, XShortField, FieldLenField, \
     StrLenField, IntField, ByteEnumField, ByteField, ConditionalField, \
-    FlagsField, IP6Field, PacketField, PacketListField, ShortEnumField, \
+    FlagsField, IP6Field, PacketListField, ShortEnumField, \
     ShortField, StrFixedLenField, ThreeBytesField
 from scapy.layers.inet import IP, checksum, bind_layers
 from scapy.layers.inet6 import IPv6
-from scapy.compat import chb, raw
+from scapy.compat import chb
 from scapy.config import conf
 from scapy.utils import inet_aton, inet_ntoa
 from scapy.pton_ntop import inet_ntop, inet_pton
@@ -449,28 +449,6 @@ _eigrp_tlv_cls = {
 }
 
 
-class RepeatedTlvListField(PacketListField):
-    def __init__(self, name, default, cls):
-        PacketField.__init__(self, name, default, cls)
-
-    def getfield(self, pkt, s):
-        lst = []
-        remain = s
-        while len(remain) > 0:
-            p = self.m2i(pkt, remain)
-            if conf.padding_layer in p:
-                pad = p[conf.padding_layer]
-                remain = pad.load
-                del(pad.underlayer.payload)
-            else:
-                remain = b""
-            lst.append(p)
-        return remain, lst
-
-    def addfield(self, pkt, s, val):
-        return s + b"".join(raw(v) for v in val)
-
-
 def _EIGRPGuessPayloadClass(p, **kargs):
     cls = conf.raw_layer
     if len(p) >= 2:
@@ -504,7 +482,7 @@ class EIGRP(Packet):
                    IntField("seq", 0),
                    IntField("ack", 0),
                    IntField("asn", 100),
-                   RepeatedTlvListField("tlvlist", [], _EIGRPGuessPayloadClass)
+                   PacketListField("tlvlist", [], _EIGRPGuessPayloadClass)
                    ]
 
     def post_build(self, p, pay):

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -239,7 +239,7 @@ class MQTTSubscribe(Packet):
     name = "MQTT subscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], cls=MQTTTopicQOS)
+        PacketListField("topics", [], pkt_cls=MQTTTopicQOS)
     ]
 
 
@@ -263,7 +263,7 @@ class MQTTUnsubscribe(Packet):
     name = "MQTT unsubscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], cls=MQTTTopic)
+        PacketListField("topics", [], pkt_cls=MQTTTopic)
     ]
 
 

--- a/scapy/contrib/nfs.py
+++ b/scapy/contrib/nfs.py
@@ -442,7 +442,7 @@ class READDIRPLUS_Reply(Packet):
         ),
         ConditionalField(
             PacketListField(
-                'files', None, cls=File_From_Dir_Plus,
+                'files', None, File_From_Dir_Plus,
                 next_cls_cb=lambda pkt, lst, cur, remain:
                 File_From_Dir_Plus if pkt.value_follows == 1 and
                 (len(lst) == 0 or cur.value_follows == 1) and
@@ -722,7 +722,7 @@ class READDIR_Reply(Packet):
         ),
         ConditionalField(
             PacketListField(
-                'files', None, cls=File_From_Dir,
+                'files', None, File_From_Dir,
                 next_cls_cb=lambda pkt, lst, cur, remain:
                 File_From_Dir if pkt.value_follows == 1 and
                 (len(lst) == 0 or cur.value_follows == 1) and

--- a/scapy/contrib/portmap.py
+++ b/scapy/contrib/portmap.py
@@ -73,7 +73,7 @@ class DUMP_Reply(Packet):
     name = 'PORTMAP DUMP Reply'
     fields_desc = [
         IntField('value_follows', 0),
-        PacketListField('mappings', [], cls=Map_Entry,
+        PacketListField('mappings', [], Map_Entry,
                         next_cls_cb=lambda pkt, lst, cur, remain:
                         Map_Entry if pkt.value_follows == 1 and
                         (len(lst) == 0 or cur.value_follows == 1) and

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -35,11 +35,28 @@ from scapy.pton_ntop import inet_ntop, inet_pton
 from scapy.utils import inet_aton, inet_ntoa, lhex, mac2str, str2mac
 from scapy.utils6 import in6_6to4ExtractAddr, in6_isaddr6to4, \
     in6_isaddrTeredo, in6_ptop, Net6, teredoAddrExtractInfo
-from scapy.base_classes import BasePacket, Gen, Net, Field_metaclass
+from scapy.base_classes import BasePacket, Gen, Net, Field_metaclass, \
+    Packet_metaclass
 from scapy.error import warning
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
 from scapy.modules.six import integer_types
+
+from scapy.compat import (
+    Any,
+    AnyStr,
+    Callable,
+    Dict,
+    List,
+    Generic,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    # func
+    cast,
+)
 
 
 """
@@ -47,25 +64,29 @@ Helper class to specify a protocol extendable for runtime modifications
 """
 
 
-class ObservableDict(dict):
+class ObservableDict(Dict[int, str]):
     def __init__(self, *args, **kw):
-        self.observers = []
+        # type: (*Dict[int, str], **Any) -> None
+        self.observers = []  # type: List[_EnumField[Any]]
         super(ObservableDict, self).__init__(*args, **kw)
 
     def observe(self, observer):
+        # type: (_EnumField[Any]) -> None
         self.observers.append(observer)
 
     def __setitem__(self, key, value):
+        # type: (int, str) -> None
         for o in self.observers:
             o.notify_set(self, key, value)
         super(ObservableDict, self).__setitem__(key, value)
 
     def __delitem__(self, key):
+        # type: (int) -> None
         for o in self.observers:
             o.notify_del(self, key)
         super(ObservableDict, self).__delitem__(key)
 
-    def update(self, anotherDict):
+    def update(self, anotherDict):  # type: ignore
         for k in anotherDict:
             self[k] = anotherDict[k]
 
@@ -74,7 +95,12 @@ class ObservableDict(dict):
 #  Fields  #
 ############
 
-class Field(six.with_metaclass(Field_metaclass, object)):
+I = TypeVar('I')  # Internal storage  # noqa: E741
+M = TypeVar('M')  # Machine storage
+
+
+@six.add_metaclass(Field_metaclass)
+class Field(Generic[I, M]):
     """
     For more information on how this work, please refer to
     http://www.secdev.org/projects/scapy/files/scapydoc.pdf
@@ -93,6 +119,7 @@ class Field(six.with_metaclass(Field_metaclass, object)):
     holds_packets = 0
 
     def __init__(self, name, default, fmt="H"):
+        # type: (str, Any, str) -> None
         if not isinstance(name, str):
             raise ValueError("name should be a string")
         self.name = name
@@ -102,50 +129,63 @@ class Field(six.with_metaclass(Field_metaclass, object)):
             self.fmt = "!" + fmt
         self.struct = struct.Struct(self.fmt)
         self.default = self.any2i(None, default)
-        self.sz = struct.calcsize(self.fmt)
-        self.owners = []
+        self.sz = struct.calcsize(self.fmt)  # type: int
+        self.owners = []  # type: List[Packet_metaclass]
 
     def register_owner(self, cls):
+        # type: (Packet_metaclass) -> None
         self.owners.append(cls)
 
-    def i2len(self, pkt, x):
+    def i2len(self,
+              pkt,  # type: BasePacket
+              x,  # type: Any
+              ):
+        # type: (...) -> int
         """Convert internal value to a length usable by a FieldLenField"""
         return self.sz
 
     def i2count(self, pkt, x):
+        # type: (Optional[BasePacket], I) -> int
         """Convert internal value to a number of elements usable by a FieldLenField.
         Always 1 except for list fields"""
         return 1
 
     def h2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> I
         """Convert human value to internal value"""
-        return x
+        return cast(I, x)
 
     def i2h(self, pkt, x):
+        # type: (Optional[BasePacket], I) -> Any
         """Convert internal value to human value"""
         return x
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], M) -> I
         """Convert machine value to internal value"""
-        return x
+        return cast(I, x)
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[I]) -> M
         """Convert internal value to machine value"""
         if x is None:
-            x = 0
+            return cast(M, 0)
         elif isinstance(x, str):
-            return bytes_encode(x)
-        return x
+            return cast(M, bytes_encode(x))
+        return cast(M, x)
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> Optional[I]
         """Try to understand the most input values possible and make an internal value from them"""  # noqa: E501
         return self.h2i(pkt, x)
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], I) -> str
         """Convert internal value to a nice representation"""
         return repr(self.i2h(pkt, x))
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[I]) -> bytes
         """Add an internal value to a string
 
         Copy the network representation of field `val` (belonging to layer
@@ -154,6 +194,7 @@ class Field(six.with_metaclass(Field_metaclass, object)):
         return s + self.struct.pack(self.i2m(pkt, val))
 
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, I]
         """Extract an internal value from a string
 
         Extract from the raw packet `s` the field value belonging to layer
@@ -166,22 +207,26 @@ class Field(six.with_metaclass(Field_metaclass, object)):
         return s[self.sz:], self.m2i(pkt, self.struct.unpack(s[:self.sz])[0])
 
     def do_copy(self, x):
+        # type: (I) -> I
         if hasattr(x, "copy"):
-            return x.copy()
+            return x.copy()  # type: ignore
         if isinstance(x, list):
-            x = x[:]
+            x = x[:]  # type: ignore
             for i in range(len(x)):
                 if isinstance(x[i], BasePacket):
                     x[i] = x[i].copy()
         return x
 
     def __repr__(self):
+        # type: () -> str
         return "<Field (%s).%s>" % (",".join(x.__name__ for x in self.owners), self.name)  # noqa: E501
 
     def copy(self):
+        # type: () -> Field[I, M]
         return copy.copy(self)
 
     def randval(self):
+        # type: () -> VolatileValue
         """Return a volatile object whose value is both random and suitable for this field"""  # noqa: E501
         fmtt = self.fmt[-1]
         if fmtt in "BbHhIiQq":
@@ -204,60 +249,76 @@ class Emph(object):
     __slots__ = ["fld"]
 
     def __init__(self, fld):
+        # type: (Any) -> None
         self.fld = fld
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         return getattr(self.fld, attr)
 
     def __eq__(self, other):
-        return self.fld == other
+        # type: (Any) -> bool
+        return bool(self.fld == other)
 
     def __ne__(self, other):
+        # type: (Any) -> bool
         # Python 2.7 compat
         return not self == other
 
-    __hash__ = None
+    # mypy doesn't support __hash__ = None
+    __hash__ = None  # type: ignore
 
 
 class ActionField(object):
     __slots__ = ["_fld", "_action_method", "_privdata"]
 
     def __init__(self, fld, action_method, **kargs):
+        # type: (Field[Any, Any], str, **Any) -> None
         self._fld = fld
         self._action_method = action_method
         self._privdata = kargs
 
     def any2i(self, pkt, val):
+        # type: (Optional[BasePacket], int) -> Any
         getattr(pkt, self._action_method)(val, self._fld, **self._privdata)
         return getattr(self._fld, "any2i")(pkt, val)
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         return getattr(self._fld, attr)
 
 
 class ConditionalField(object):
     __slots__ = ["fld", "cond"]
 
-    def __init__(self, fld, cond):
+    def __init__(self,
+                 fld,  # type: Field[Any, Any]
+                 cond  # type: Callable[[Optional[BasePacket]], bool]
+                 ):
+        # type: (...) -> None
         self.fld = fld
         self.cond = cond
 
     def _evalcond(self, pkt):
-        return self.cond(pkt)
+        # type: (BasePacket) -> bool
+        return bool(self.cond(pkt))
 
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, Any]
         if self._evalcond(pkt):
             return self.fld.getfield(pkt, s)
         else:
             return s, None
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Any) -> bytes
         if self._evalcond(pkt):
             return self.fld.addfield(pkt, s, val)
         else:
             return s
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         return getattr(self.fld, attr)
 
 
@@ -291,13 +352,18 @@ use.
 
     __slots__ = ["flds", "dflt", "name", "default"]
 
-    def __init__(self, flds, dflt):
+    def __init__(self,
+                 flds,  # type: List[Tuple[Field[Any, Any], Any]]
+                 dflt  # type: Field[Any, Any]
+                 ):
+        # type: (...) -> None
         self.flds = flds
         self.dflt = dflt
         self.default = None  # So that we can detect changes in defaults
         self.name = self.dflt.name
 
     def _iterate_fields_cond(self, pkt, val, use_val):
+        # type: (BasePacket, Any, bool) -> Field[Any, Any]
         """Internal function used by _find_fld_pkt & _find_fld_pkt_val"""
         # Iterate through the fields
         for fld, cond in self.flds:
@@ -315,6 +381,7 @@ use.
         return self.dflt
 
     def _find_fld_pkt(self, pkt):
+        # type: (BasePacket) -> Field[Any, Any]
         """Given a Packet instance `pkt`, returns the Field subclass to be
 used. If you know the value to be set (e.g., in .addfield()), use
 ._find_fld_pkt_val() instead.
@@ -322,7 +389,11 @@ used. If you know the value to be set (e.g., in .addfield()), use
         """
         return self._iterate_fields_cond(pkt, None, False)
 
-    def _find_fld_pkt_val(self, pkt, val):
+    def _find_fld_pkt_val(self,
+                          pkt,  # type: BasePacket
+                          val,  # type: Any
+                          ):
+        # type: (...) -> Tuple[Field[Any, Any], Any]
         """Given a Packet instance `pkt` and the value `val` to be set,
 returns the Field subclass to be used, and the updated `val` if necessary.
 
@@ -333,6 +404,7 @@ returns the Field subclass to be used, and the updated `val` if necessary.
         return fld, val
 
     def _find_fld(self):
+        # type: () -> Field[Any, Any]
         """Returns the Field subclass to be used, depending on the Packet
 instance, or the default subclass.
 
@@ -346,7 +418,7 @@ the value to set is also known) of ._find_fld_pkt() instead.
         """
         # Hack to preserve current Scapy API
         # See https://stackoverflow.com/a/7272464/3223422
-        frame = inspect.currentframe().f_back.f_back
+        frame = inspect.currentframe().f_back.f_back  # type: ignore
         while frame is not None:
             try:
                 pkt = frame.f_locals['self']
@@ -361,43 +433,59 @@ the value to set is also known) of ._find_fld_pkt() instead.
             frame = frame.f_back
         return self.dflt
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, Any]
         return self._find_fld_pkt(pkt).getfield(pkt, s)
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Any) -> bytes
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.addfield(pkt, s, val)
 
     def any2i(self, pkt, val):
+        # type: (BasePacket, Any) -> Any
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.any2i(pkt, val)
 
     def h2i(self, pkt, val):
+        # type: (BasePacket, Any) -> Any
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.h2i(pkt, val)
 
-    def i2h(self, pkt, val):
+    def i2h(self,
+            pkt,  # type: BasePacket
+            val,  # type: Any
+            ):
+        # type: (...) -> Any
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.i2h(pkt, val)
 
     def i2m(self, pkt, val):
+        # type: (BasePacket, Optional[Any]) -> Any
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.i2m(pkt, val)
 
     def i2len(self, pkt, val):
+        # type: (BasePacket, Any) -> int
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.i2len(pkt, val)
 
     def i2repr(self, pkt, val):
+        # type: (BasePacket, Any) -> str
         fld, val = self._find_fld_pkt_val(pkt, val)
         return fld.i2repr(pkt, val)
 
     def register_owner(self, cls):
+        # type: (Packet_metaclass) -> None
         for fld, _ in self.flds:
             fld.owners.append(cls)
         self.dflt.owners.append(cls)
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         return getattr(self._find_fld(), attr)
 
 
@@ -407,23 +495,40 @@ class PadField(object):
     __slots__ = ["_fld", "_align", "_padwith"]
 
     def __init__(self, fld, align, padwith=None):
+        # type: (Field[Any, Any], int, Optional[bytes]) -> None
         self._fld = fld
         self._align = align
         self._padwith = padwith or b"\x00"
 
     def padlen(self, flen):
+        # type: (int) -> int
         return -flen % self._align
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, Any]
         remain, val = self._fld.getfield(pkt, s)
         padlen = self.padlen(len(s) - len(remain))
         return remain[padlen:], val
 
-    def addfield(self, pkt, s, val):
+    def addfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 val,  # type: Any
+                 ):
+        # type: (...) -> bytes
         sval = self._fld.addfield(pkt, b"", val)
-        return s + sval + struct.pack("%is" % (self.padlen(len(sval))), self._padwith)  # noqa: E501
+        return s + sval + struct.pack(
+            "%is" % (
+                self.padlen(len(sval))
+            ),
+            self._padwith
+        )
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         return getattr(self._fld, attr)
 
 
@@ -431,114 +536,141 @@ class ReversePadField(PadField):
     """Add bytes BEFORE the proxified field so that it starts at the specified
        alignment from its beginning"""
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, Any]
         # We need to get the length that has already been dissected
         padlen = self.padlen(len(pkt.original) - len(s))
         remain, val = self._fld.getfield(pkt, s[padlen:])
         return remain, val
 
-    def addfield(self, pkt, s, val):
+    def addfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 val,  # type: Any
+                 ):
+        # type: (...) -> bytes
         sval = self._fld.addfield(pkt, b"", val)
-        return s + struct.pack("%is" % (self.padlen(len(s))), self._padwith) + sval  # noqa: E501
+        return s + struct.pack("%is" % (
+            self.padlen(len(s))
+        ), self._padwith) + sval
 
 
-class FCSField(Field):
+class FCSField(Field[int, int]):
     """Special Field that gets its value from the end of the *packet*
     (Note: not layer, but packet).
 
     Mostly used for FCS
     """
+
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, int]
         previous_post_dissect = pkt.post_dissect
         val = self.m2i(pkt, struct.unpack(self.fmt, s[-self.sz:])[0])
 
         def _post_dissect(self, s):
+            # type: (BasePacket, bytes) -> bytes
             # Reset packet to allow post_build
             self.raw_packet_cache = None
             self.post_dissect = previous_post_dissect
-            return previous_post_dissect(s)
+            return previous_post_dissect(s)  # type: ignore
         pkt.post_dissect = MethodType(_post_dissect, pkt)
         return s[:-self.sz], val
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[int]) -> bytes
         previous_post_build = pkt.post_build
         value = struct.pack(self.fmt, self.i2m(pkt, val))
 
         def _post_build(self, p, pay):
+            # type: (BasePacket, bytes, bytes) -> bytes
             pay += value
             self.post_build = previous_post_build
-            return previous_post_build(p, pay)
+            return previous_post_build(p, pay)  # type: ignore
         pkt.post_build = MethodType(_post_build, pkt)
         return s
 
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (BasePacket, int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
-class DestField(Field):
+class DestField(Field[str, bytes]):
     __slots__ = ["defaultdst"]
     # Each subclass must have its own bindings attribute
-    # bindings = {}
+    bindings = {}  # type: Dict[Packet_metaclass, Tuple[str, Any]]
 
     def __init__(self, name, default):
+        # type: (str, str) -> None
         self.defaultdst = default
 
     def dst_from_pkt(self, pkt):
+        # type: (BasePacket) -> str
         for addr, condition in self.bindings.get(pkt.payload.__class__, []):
             try:
                 if all(pkt.payload.getfieldval(field) == value
                        for field, value in six.iteritems(condition)):
-                    return addr
+                    return addr  # type: ignore
             except AttributeError:
                 pass
         return self.defaultdst
 
     @classmethod
     def bind_addr(cls, layer, addr, **condition):
-        cls.bindings.setdefault(layer, []).append((addr, condition))
+        # type: (Packet_metaclass, str, **Any) -> None
+        cls.bindings.setdefault(layer, []).append(  # type: ignore
+            (addr, condition)
+        )
 
 
-class MACField(Field):
+class MACField(Field[str, bytes]):
     def __init__(self, name, default):
+        # type: (str, Optional[Any]) -> None
         Field.__init__(self, name, default, "6s")
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> bytes
         if x is None:
             return b"\0\0\0\0\0\0"
         try:
-            x = mac2str(x)
+            y = mac2str(x)
         except (struct.error, OverflowError):
-            x = bytes_encode(x)
-
-        return x
+            y = bytes_encode(x)
+        return y  # type: ignore
 
     def m2i(self, pkt, x):
-        return str2mac(x)
+        # type: (Optional[BasePacket], bytes) -> str
+        return str2mac(x)  # type: ignore
 
     def any2i(self, pkt, x):
+        # type: (BasePacket, Any) -> str
         if isinstance(x, bytes) and len(x) == 6:
-            x = self.m2i(pkt, x)
-        return x
+            return self.m2i(pkt, x)
+        return cast(str, x)
 
     def i2repr(self, pkt, x):
+        # type: (BasePacket, str) -> str
         x = self.i2h(pkt, x)
         if self in conf.resolve:
             x = conf.manufdb._resolve_MAC(x)
         return x
 
     def randval(self):
+        # type: () -> RandMAC
         return RandMAC()
 
 
-class IPField(Field):
-    slots = []
-
+class IPField(Field[str, bytes]):
     def __init__(self, name, default):
+        # type: (str, Optional[str]) -> None
         Field.__init__(self, name, default, "4s")
 
     def h2i(self, pkt, x):
+        # type: (BasePacket, Union[AnyStr, List[AnyStr]]) -> Any
         if isinstance(x, bytes):
-            x = plain_str(x)
+            x = plain_str(x)  # type: ignore
         if isinstance(x, str):
             try:
                 inet_aton(x)
@@ -548,7 +680,12 @@ class IPField(Field):
             x = [self.h2i(pkt, n) for n in x]
         return x
 
+    def i2h(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
+        return cast(str, x)
+
     def resolve(self, x):
+        # type: (str) -> str
         if self in conf.resolve:
             try:
                 ret = socket.gethostbyaddr(x)[0]
@@ -560,21 +697,26 @@ class IPField(Field):
         return x
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> bytes
         if x is None:
             return b'\x00\x00\x00\x00'
-        return inet_aton(plain_str(x))
+        return inet_aton(plain_str(x))  # type: ignore
 
     def m2i(self, pkt, x):
-        return inet_ntoa(x)
+        # type: (Optional[BasePacket], bytes) -> str
+        return inet_ntoa(x)  # type: ignore
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> Any
         return self.h2i(pkt, x)
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], str) -> str
         r = self.resolve(self.i2h(pkt, x))
         return r if isinstance(r, str) else repr(r)
 
     def randval(self):
+        # type: () -> RandIP
         return RandIP()
 
 
@@ -582,38 +724,47 @@ class SourceIPField(IPField):
     __slots__ = ["dstname"]
 
     def __init__(self, name, dstname):
+        # type: (str, Optional[str]) -> None
         IPField.__init__(self, name, None)
         self.dstname = dstname
 
     def __findaddr(self, pkt):
+        # type: (BasePacket) -> str
         if conf.route is None:
             # unused import, only to initialize conf.route
             import scapy.route  # noqa: F401
         dst = ("0.0.0.0" if self.dstname is None
                else getattr(pkt, self.dstname) or "0.0.0.0")
         if isinstance(dst, (Gen, list)):
-            r = {conf.route.route(str(daddr)) for daddr in dst}
+            r = {
+                conf.route.route(str(daddr))  # type: ignore
+                for daddr in dst
+            }  # type:  Set[Tuple[str, str, str]]
             if len(r) > 1:
                 warning("More than one possible route for %r" % (dst,))
             return min(r)[1]
-        return conf.route.route(dst)[1]
+        return conf.route.route(dst)[1]  # type: ignore
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> bytes
         if x is None:
             x = self.__findaddr(pkt)
-        return IPField.i2m(self, pkt, x)
+        return super(SourceIPField, self).i2m(pkt, x)
 
     def i2h(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
         if x is None:
             x = self.__findaddr(pkt)
-        return IPField.i2h(self, pkt, x)
+        return super(SourceIPField, self).i2h(pkt, x)
 
 
-class IP6Field(Field):
+class IP6Field(Field[Optional[str], bytes]):
     def __init__(self, name, default):
+        # type: (str, Optional[str]) -> None
         Field.__init__(self, name, default, "16s")
 
     def h2i(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
         if isinstance(x, bytes):
             x = plain_str(x)
         if isinstance(x, str):
@@ -623,20 +774,28 @@ class IP6Field(Field):
                 x = Net6(x)
         elif isinstance(x, list):
             x = [self.h2i(pkt, n) for n in x]
-        return x
+        return x  # type: ignore
+
+    def i2h(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
+        return cast(str, x)
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> bytes
         if x is None:
             x = "::"
-        return inet_pton(socket.AF_INET6, plain_str(x))
+        return inet_pton(socket.AF_INET6, plain_str(x))  # type: ignore
 
     def m2i(self, pkt, x):
-        return inet_ntop(socket.AF_INET6, x)
+        # type: (Optional[BasePacket], bytes) -> str
+        return inet_ntop(socket.AF_INET6, x)  # type: ignore
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> str
         return self.h2i(pkt, x)
 
     def i2repr(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
         if x is None:
             return self.i2h(pkt, x)
         elif not isinstance(x, Net6) and not isinstance(x, list):
@@ -650,6 +809,7 @@ class IP6Field(Field):
         return r if isinstance(r, str) else repr(r)
 
     def randval(self):
+        # type: () -> RandIP6
         return RandIP6()
 
 
@@ -657,102 +817,125 @@ class SourceIP6Field(IP6Field):
     __slots__ = ["dstname"]
 
     def __init__(self, name, dstname):
+        # type: (str, str) -> None
         IP6Field.__init__(self, name, None)
         self.dstname = dstname
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> bytes
         if x is None:
             dst = ("::" if self.dstname is None else
                    getattr(pkt, self.dstname) or "::")
             iff, x, nh = conf.route6.route(dst)
-        return IP6Field.i2m(self, pkt, x)
+        return super(SourceIP6Field, self).i2m(pkt, x)
 
     def i2h(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
         if x is None:
             if conf.route6 is None:
                 # unused import, only to initialize conf.route6
                 import scapy.route6  # noqa: F401
             dst = ("::" if self.dstname is None else getattr(pkt, self.dstname))  # noqa: E501
             if isinstance(dst, (Gen, list)):
-                r = {conf.route6.route(str(daddr)) for daddr in dst}
+                r = {conf.route6.route(str(daddr))  # type: ignore
+                     for daddr in dst}
                 if len(r) > 1:
                     warning("More than one possible route for %r" % (dst,))
                 x = min(r)[1]
             else:
                 x = conf.route6.route(dst)[1]
-        return IP6Field.i2h(self, pkt, x)
+        return super(SourceIP6Field, self).i2h(pkt, x)
 
 
 class DestIP6Field(IP6Field, DestField):
-    bindings = {}
+    bindings = {}  # type: Dict[Packet_metaclass, Tuple[str, Any]]
 
     def __init__(self, name, default):
+        # type: (str, str) -> None
         IP6Field.__init__(self, name, None)
         DestField.__init__(self, name, default)
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> bytes
         if x is None:
             x = self.dst_from_pkt(pkt)
         return IP6Field.i2m(self, pkt, x)
 
     def i2h(self, pkt, x):
+        # type: (BasePacket, Optional[str]) -> str
         if x is None:
             x = self.dst_from_pkt(pkt)
-        return IP6Field.i2h(self, pkt, x)
+        return super(DestIP6Field, self).i2h(pkt, x)
 
 
-class ByteField(Field):
+class ByteField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "B")
 
 
 class XByteField(ByteField):
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (Optional[BasePacket], int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
+# XXX Unused field: at least add some tests
 class OByteField(ByteField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return "%03o" % self.i2h(pkt, x)
 
 
 class ThreeBytesField(ByteField):
     def __init__(self, name, default):
-        Field.__init__(self, name, default, "!I")
+        # type: (Optional[BasePacket], str, Optional[int]) -> None
+        Field.__init__(self, name, default, "!I")  # type: ignore
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[int]) -> bytes
         return s + struct.pack(self.fmt, self.i2m(pkt, val))[1:4]
 
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, int]
         return s[3:], self.m2i(pkt, struct.unpack(self.fmt, b"\x00" + s[:3])[0])  # noqa: E501
 
 
 class X3BytesField(ThreeBytesField, XByteField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return XByteField.i2repr(self, pkt, x)
 
 
 class LEThreeBytesField(ByteField):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<I")
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[int]) -> bytes
         return s + struct.pack(self.fmt, self.i2m(pkt, val))[:3]
 
     def getfield(self, pkt, s):
+        # type: (Optional[BasePacket], bytes) -> Tuple[bytes, int]
         return s[3:], self.m2i(pkt, struct.unpack(self.fmt, s[:3] + b"\x00")[0])  # noqa: E501
 
 
 class LEX3BytesField(LEThreeBytesField, XByteField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return XByteField.i2repr(self, pkt, x)
 
 
-class NBytesField(ByteField, Field):
+class NBytesField(Field[int, List[int]]):
     def __init__(self, name, default, sz):
+        # type: (str, Optional[int], int) -> None
         Field.__init__(self, name, default, "<" + "B" * sz)
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[int]) -> List[int]
+        if x is None:
+            return []
         x2m = list()
         for _ in range(self.sz):
             x2m.append(x % 256)
@@ -760,26 +943,33 @@ class NBytesField(ByteField, Field):
         return x2m[::-1]
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], Union[List[int], int]) -> int
         if isinstance(x, int):
             return x
         # x can be a tuple when coming from struct.unpack  (from getfield)
         if isinstance(x, (list, tuple)):
             return sum(d * (256 ** i) for i, d in enumerate(x))
+        return 0
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         if isinstance(x, integer_types):
             return '%i' % x
         return super(NBytesField, self).i2repr(pkt, x)
 
     def addfield(self, pkt, s, val):
+        # type: (Optional[BasePacket], bytes, Optional[int]) -> bytes
         return s + self.struct.pack(*self.i2m(pkt, val))
 
     def getfield(self, pkt, s):
-        return s[self.sz:], self.m2i(pkt, self.struct.unpack(s[:self.sz]))
+        # type: (Optional[BasePacket], bytes) -> Tuple[bytes, int]
+        return (s[self.sz:],
+                self.m2i(pkt, self.struct.unpack(s[:self.sz])))  # type: ignore
 
 
 class XNBytesField(NBytesField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         if isinstance(x, integer_types):
             return '0x%x' % x
         # x can be a tuple when coming from struct.unpack (from getfield)
@@ -788,8 +978,9 @@ class XNBytesField(NBytesField):
         return super(XNBytesField, self).i2repr(pkt, x)
 
 
-class SignedByteField(Field):
+class SignedByteField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "b")
 
 
@@ -858,6 +1049,7 @@ class YesNoByteField(ByteField):
     __slots__ = ['eval_fn']
 
     def _build_config_representation(self, config):
+        # type: (Dict[str, Any]) -> None
         assoc_table = dict()
         for key in config:
             value_spec = config[key]
@@ -899,141 +1091,168 @@ class YesNoByteField(ByteField):
 
         self.eval_fn = lambda x: assoc_table[x] if x in assoc_table else x
 
-    def __init__(self, name, default, config=None, *args, **kargs):
+    def __init__(self, name, default, config=None):
+        # type: (str, int, Optional[Dict[str, Any]]) -> None
 
         if not config:
             # this represents the common use case and therefore it is kept small  # noqa: E501
             self.eval_fn = lambda x: 'no' if x == 0 else 'yes'
         else:
             self._build_config_representation(config)
-        ByteField.__init__(self, name, default, *args, **kargs)
+        ByteField.__init__(self, name, default)
 
     def i2repr(self, pkt, x):
-        return self.eval_fn(x)
+        # type: (Optional[BasePacket], int) -> str
+        return self.eval_fn(x)  # type: ignore
 
 
-class ShortField(Field):
+class ShortField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "H")
 
 
-class SignedShortField(Field):
+class SignedShortField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "h")
 
 
-class LEShortField(Field):
+class LEShortField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<H")
 
 
-class LESignedShortField(Field):
+class LESignedShortField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<h")
 
 
 class XShortField(ShortField):
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (Optional[BasePacket], int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
-class IntField(Field):
+class IntField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "I")
 
 
-class SignedIntField(Field):
+class SignedIntField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, int) -> None
         Field.__init__(self, name, default, "i")
 
 
-class LEIntField(Field):
+class LEIntField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<I")
 
 
-class LESignedIntField(Field):
+class LESignedIntField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, int) -> None
         Field.__init__(self, name, default, "<i")
 
 
 class XIntField(IntField):
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (Optional[BasePacket], int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
 class XLEIntField(LEIntField, XIntField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return XIntField.i2repr(self, pkt, x)
 
 
 class XLEShortField(LEShortField, XShortField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return XShortField.i2repr(self, pkt, x)
 
 
-class LongField(Field):
+class LongField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, int) -> None
         Field.__init__(self, name, default, "Q")
 
 
-class SignedLongField(Field):
+class SignedLongField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "q")
 
 
 class LELongField(LongField):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<Q")
 
 
-class LESignedLongField(Field):
+class LESignedLongField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[Any]) -> None
         Field.__init__(self, name, default, "<q")
 
 
 class XLongField(LongField):
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (Optional[BasePacket], int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
 class XLELongField(LELongField, XLongField):
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         return XLongField.i2repr(self, pkt, x)
 
 
-class IEEEFloatField(Field):
+class IEEEFloatField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "f")
 
 
-class IEEEDoubleField(Field):
+class IEEEDoubleField(Field[int, int]):
     def __init__(self, name, default):
+        # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "d")
 
 
-class StrField(Field):
+class _StrField(Field[I, bytes]):
     __slots__ = ["remain"]
 
     def __init__(self, name, default, fmt="H", remain=0):
+        # type: (str, Optional[I], str, int) -> None
         Field.__init__(self, name, default, fmt)
         self.remain = remain
 
     def i2len(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> int
         return len(x)
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> I
         if isinstance(x, six.text_type):
             x = bytes_encode(x)
-        return super(StrField, self).any2i(pkt, x)
+        return super(_StrField, self).any2i(pkt, x)  # type: ignore
 
     def i2repr(self, pkt, x):
-        val = super(StrField, self).i2repr(pkt, x)
+        # type: (Optional[BasePacket], I) -> str
+        val = super(_StrField, self).i2repr(pkt, x)
         if val[:2] in ['b"', "b'"]:
             return val[1:]
         return val
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[I]) -> bytes
         if x is None:
             return b""
         if not isinstance(x, bytes):
@@ -1041,51 +1260,80 @@ class StrField(Field):
         return x
 
     def addfield(self, pkt, s, val):
+        # type: (Optional[BasePacket], bytes, Optional[I]) -> bytes
         return s + self.i2m(pkt, val)
 
     def getfield(self, pkt, s):
+        # type: (Optional[BasePacket], bytes) -> Tuple[bytes, I]
         if self.remain == 0:
             return b"", self.m2i(pkt, s)
         else:
             return s[-self.remain:], self.m2i(pkt, s[:-self.remain])
 
     def randval(self):
+        # type: () -> RandBin
         return RandBin(RandNum(0, 1200))
+
+
+class StrField(_StrField[bytes]):
+    pass
 
 
 class StrFieldUtf16(StrField):
     def h2i(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> bytes
         return plain_str(x).encode('utf-16')[2:]
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> bytes
         if isinstance(x, six.text_type):
             return self.h2i(pkt, x)
         return super(StrFieldUtf16, self).any2i(pkt, x)
 
     def i2repr(self, pkt, x):
-        return x
+        # type: (Optional[BasePacket], bytes) -> str
+        return plain_str(x)
 
     def i2h(self, pkt, x):
+        # type: (Optional[BasePacket], bytes) -> str
         return bytes_encode(x).decode('utf-16')
 
 
-class PacketField(StrField):
+K = TypeVar('K', List[BasePacket], BasePacket)
+
+
+class _PacketField(_StrField[K]):
     __slots__ = ["cls"]
     holds_packets = 1
 
-    def __init__(self, name, default, cls, remain=0):
-        StrField.__init__(self, name, default, remain=remain)
-        self.cls = cls
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[K]
+                 pkt_cls,  # type: Union[Callable[[bytes], BasePacket], Packet_metaclass]  # noqa: E501
+                 remain=0,  # type: int
+                 ):
+        # type: (...) -> None
+        super(_PacketField, self).__init__(name, default, remain=remain)
+        self.cls = pkt_cls
 
-    def i2m(self, pkt, i):
+    def i2m(self,
+            pkt,  # type: BasePacket
+            i,  # type: Any
+            ):
+        # type: (...) -> bytes
         if i is None:
             return b""
         return raw(i)
 
     def m2i(self, pkt, m):
+        # type: (Optional[BasePacket], bytes) -> BasePacket
         return self.cls(m)
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, K]
         i = self.m2i(pkt, s)
         remain = b""
         if conf.padding_layer in i:
@@ -1095,18 +1343,33 @@ class PacketField(StrField):
         return remain, i
 
     def randval(self):
+        # type: () -> K
         from scapy.packet import fuzz
-        return fuzz(self.cls())
+        return fuzz(self.cls())  # type: ignore
+
+
+class PacketField(_PacketField[BasePacket]):
+    pass
 
 
 class PacketLenField(PacketField):
     __slots__ = ["length_from"]
 
-    def __init__(self, name, default, cls, length_from=None):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: BasePacket
+                 cls,  # type: Union[Callable[[bytes], BasePacket], Packet_metaclass]  # noqa: E501
+                 length_from=None  # type: Optional[Callable[[BasePacket], int]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         PacketField.__init__(self, name, default, cls)
-        self.length_from = length_from
+        self.length_from = length_from or (lambda x: 0)
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, BasePacket]
         len_pkt = self.length_from(pkt)
         try:
             i = self.m2i(pkt, s[:len_pkt])
@@ -1117,7 +1380,7 @@ class PacketLenField(PacketField):
         return s[len_pkt:], i
 
 
-class PacketListField(PacketField):
+class PacketListField(_PacketField[List[BasePacket]]):
     """PacketListField represents a series of Packet instances that might
     occur right in the middle of another Packet field list.
     This field type may also be used to indicate that a series of Packet
@@ -1127,7 +1390,16 @@ class PacketListField(PacketField):
     __slots__ = ["count_from", "length_from", "next_cls_cb"]
     islist = 1
 
-    def __init__(self, name, default, cls=None, count_from=None, length_from=None, next_cls_cb=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Optional[List[BasePacket]]
+            pkt_cls=None,  # type: Optional[Union[Callable[[bytes], BasePacket], Packet_metaclass]]  # noqa: E501
+            count_from=None,  # type: Optional[Callable[[BasePacket], int]]
+            length_from=None,  # type: Optional[Callable[[BasePacket], int]]
+            next_cls_cb=None,  # type: Optional[Callable[[BasePacket, List[BasePacket], Optional[BasePacket], bytes], Packet_metaclass]]  # noqa: E501
+    ):
+        # type: (...) -> None
         """
         The number of Packet instances that are dissected by this field can
         be parametrized using one of three different mechanisms/parameters:
@@ -1135,12 +1407,12 @@ class PacketListField(PacketField):
             * count_from: a callback that returns the number of Packet
               instances to dissect. The callback prototype is::
 
-                count_from(pkt:Packet) -> int
+                count_from(pkt:BasePacket) -> int
 
             * length_from: a callback that returns the number of bytes that
               must be dissected by this field. The callback prototype is::
 
-                length_from(pkt:Packet) -> int
+                length_from(pkt:BasePacket) -> int
 
             * next_cls_cb: a callback that enables a Scapy developer to
               dynamically discover if another Packet instance should be
@@ -1156,20 +1428,20 @@ class PacketListField(PacketField):
         The type of the Packet instances that are dissected with this field is
         specified or discovered using one of the following mechanism:
 
-            * the cls parameter may contain a callable that returns an
+            * the pkt_cls parameter may contain a callable that returns an
               instance of the dissected Packet. This may either be a
               reference of a Packet subclass (e.g. DNSRROPT in layers/dns.py)
               to generate an homogeneous PacketListField or a function
               deciding the type of the Packet instance
               (e.g. _CDPGuessAddrRecord in contrib/cdp.py)
 
-            * the cls parameter may contain a class object with a defined
+            * the pkt_cls parameter may contain a class object with a defined
               ``dispatch_hook`` classmethod. That method must return a Packet
               instance. The ``dispatch_hook`` callmethod must implement the
                 following prototype::
 
                 dispatch_hook(cls,
-                              _pkt:Optional[Packet],
+                              _pkt:Optional[BasePacket],
                               *args, **kargs
                 ) -> Packet_metaclass
 
@@ -1192,7 +1464,7 @@ class PacketListField(PacketField):
               previously parsed during the current ``PacketListField``
               dissection, saved for the very last Packet instance.
               The cur argument contains a reference to that very last parsed
-              ``Packet`` instance. The remain argument contains the bytes
+              ``BasePacket`` instance. The remain argument contains the bytes
               that may still be consumed by the current PacketListField
               dissection operation.
 
@@ -1208,8 +1480,8 @@ class PacketListField(PacketField):
               continuation based on a look-ahead on the bytes to be
               dissected...
 
-        The cls and next_cls_cb parameters are semantically exclusive,
-        although one could specify both. If both are specified, cls is
+        The pkt_cls and next_cls_cb parameters are semantically exclusive,
+        although one could specify both. If both are specified, pkt_cls is
         silently ignored. The same is true for count_from and next_cls_cb.
 
         length_from and next_cls_cb are compatible and the dissection will
@@ -1218,8 +1490,8 @@ class PacketListField(PacketField):
         :param name: the name of the field
         :param default: the default value of this field; generally an empty
             Python list
-        @param cls: either a callable returning a Packet instance or a class
-            object defining a ``dispatch_hook`` class method
+        :param pkt_cls: either a callable returning a Packet instance or a
+            class object defining a ``dispatch_hook`` class method
         :param count_from: a callback returning the number of Packet
             instances to dissect.
         :param length_from: a callback returning the number of bytes to dissect
@@ -1228,32 +1500,36 @@ class PacketListField(PacketField):
         """
         if default is None:
             default = []  # Create a new list for each instance
-        PacketField.__init__(self, name, default, cls)
+        super(PacketListField, self).__init__(name, default, pkt_cls)
         self.count_from = count_from
         self.length_from = length_from
         self.next_cls_cb = next_cls_cb
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> List[BasePacket]
         if not isinstance(x, list):
             return [x]
         else:
             return x
 
-    def i2count(self, pkt, val):
+    def i2count(self,
+                pkt,  # type: BasePacket
+                val,  # type: List[BasePacket]
+                ):
+        # type: (...) -> int
         if isinstance(val, list):
             return len(val)
         return 1
 
-    def i2len(self, pkt, val):
+    def i2len(self,
+              pkt,  # type: BasePacket
+              val,  # type: List[BasePacket]
+              ):
+        # type: (...) -> int
         return sum(len(p) for p in val)
 
-    def do_copy(self, x):
-        if x is None:
-            return None
-        else:
-            return [p if isinstance(p, (str, bytes)) else p.copy() for p in x]
-
     def getfield(self, pkt, s):
+        # type: (Optional[BasePacket], bytes) -> Tuple[bytes, List[BasePacket]]
         c = len_pkt = cls = None
         if self.length_from is not None:
             len_pkt = self.length_from(pkt)
@@ -1265,7 +1541,7 @@ class PacketListField(PacketField):
             if cls is None:
                 c = 0
 
-        lst = []
+        lst = []  # type: BasePacket
         ret = b""
         remain = s
         if len_pkt is not None:
@@ -1301,34 +1577,49 @@ class PacketListField(PacketField):
         return remain + ret, lst
 
     def addfield(self, pkt, s, val):
+        # type: (Optional[BasePacket], bytes, Any) -> bytes
         return s + b"".join(bytes_encode(v) for v in val)
 
 
 class StrFixedLenField(StrField):
     __slots__ = ["length_from"]
 
-    def __init__(self, name, default, length=None, length_from=None):
-        StrField.__init__(self, name, default)
-        self.length_from = length_from
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: bytes
+            length=None,  # type: Optional[int]
+            length_from=None,  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
+        super(StrFixedLenField, self).__init__(name, default)
+        self.length_from = length_from or (lambda x: 0)
         if length is not None:
-            self.length_from = lambda pkt, length=length: length
+            self.length_from = lambda x, length=length: length  # type: ignore
 
-    def i2repr(self, pkt, v):
+    def i2repr(self,
+               pkt,  # type: Optional[BasePacket]
+               v,  # type: bytes
+               ):
+        # type: (...) -> str
         if isinstance(v, bytes):
             v = v.rstrip(b"\0")
         return super(StrFixedLenField, self).i2repr(pkt, v)
 
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, bytes]
         len_pkt = self.length_from(pkt)
         return s[len_pkt:], self.m2i(pkt, s[:len_pkt])
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[bytes]) -> bytes
         len_pkt = self.length_from(pkt)
         if len_pkt is None:
             return s + self.i2m(pkt, val)
         return s + struct.pack("%is" % len_pkt, self.i2m(pkt, val))
 
     def randval(self):
+        # type: () -> RandBin
         try:
             len_pkt = self.length_from(None)
         except Exception:
@@ -1339,53 +1630,83 @@ class StrFixedLenField(StrField):
 class StrFixedLenEnumField(StrFixedLenField):
     __slots__ = ["enum"]
 
-    def __init__(self, name, default, length=None, enum=None, length_from=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: bytes
+            length=None,  # type: Optional[int]
+            enum=None,  # type: Optional[Dict[str, str]]
+            length_from=None  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
         StrFixedLenField.__init__(self, name, default, length=length, length_from=length_from)  # noqa: E501
         self.enum = enum
 
-    def i2repr(self, pkt, v):
-        r = v.rstrip("\0" if isinstance(v, str) else b"\0")
+    def i2repr(self, pkt, w):
+        # type: (BasePacket, bytes) -> str
+        v = plain_str(w)
+        r = v.rstrip("\0")
         rr = repr(r)
-        if v in self.enum:
-            rr = "%s (%s)" % (rr, self.enum[v])
-        elif r in self.enum:
-            rr = "%s (%s)" % (rr, self.enum[r])
+        if self.enum:
+            if v in self.enum:
+                rr = "%s (%s)" % (rr, self.enum[v])
+            elif r in self.enum:
+                rr = "%s (%s)" % (rr, self.enum[r])
         return rr
 
 
 class NetBIOSNameField(StrFixedLenField):
     def __init__(self, name, default, length=31):
+        # type: (str, bytes, int) -> None
         StrFixedLenField.__init__(self, name, default, length)
 
-    def i2m(self, pkt, x):
+    def i2m(self, pkt, y):
+        # type: (Optional[BasePacket], Optional[bytes]) -> bytes
         len_pkt = self.length_from(pkt) // 2
-        x = bytes_encode(x)
-        if x is None:
-            x = b""
+        x = bytes_encode(y or b"")  # type: bytes
         x += b" " * len_pkt
         x = x[:len_pkt]
-        x = b"".join(chb(0x41 + (orb(b) >> 4)) + chb(0x41 + (orb(b) & 0xf)) for b in x)  # noqa: E501
-        x = b" " + x
-        return x
+        x = b"".join(
+            chb(0x41 + (orb(b) >> 4)) +
+            chb(0x41 + (orb(b) & 0xf))
+            for b in x
+        )  # noqa: E501
+        return b" " + x
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], bytes) -> bytes
         x = x.strip(b"\x00").strip(b" ")
-        return b"".join(map(lambda x, y: chb((((orb(x) - 1) & 0xf) << 4) + ((orb(y) - 1) & 0xf)), x[::2], x[1::2]))  # noqa: E501
+        return b"".join(map(
+            lambda x, y: chb(
+                (((orb(x) - 1) & 0xf) << 4) + ((orb(y) - 1) & 0xf)
+            ),
+            x[::2], x[1::2]
+        ))
 
 
 class StrLenField(StrField):
     __slots__ = ["length_from", "max_length"]
 
-    def __init__(self, name, default, fld=None, length_from=None, max_length=None):  # noqa: E501
-        StrField.__init__(self, name, default)
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: bytes
+            fld=None,  # type: Optional[str]
+            length_from=None,  # type: Optional[Callable[[BasePacket], int]]
+            max_length=None,  # type: Optional[Any]
+    ):
+        # type: (...) -> None
+        super(StrLenField, self).__init__(name, default)
         self.length_from = length_from
         self.max_length = max_length
 
     def getfield(self, pkt, s):
-        len_pkt = self.length_from(pkt)
+        # type: (Any, bytes) -> Tuple[bytes, bytes]
+        len_pkt = (self.length_from or (lambda x: 0))(pkt)
         return s[len_pkt:], self.m2i(pkt, s[:len_pkt])
 
     def randval(self):
+        # type: () -> RandBin
         return RandBin(RandNum(0, self.max_length or 1200))
 
 
@@ -1395,6 +1716,7 @@ class XStrField(StrField):
     """
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], bytes) -> str
         if x is None:
             return repr(x)
         return bytes_hex(x).decode()
@@ -1402,9 +1724,12 @@ class XStrField(StrField):
 
 class _XStrLenField:
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], bytes) -> str
         if not x:
             return repr(x)
-        return bytes_hex(x[:self.length_from(pkt)]).decode()
+        return bytes_hex(
+            x[:(self.length_from or (lambda x: 0))(pkt)]  # type: ignore
+        ).decode()
 
 
 class XStrLenField(_XStrLenField, StrLenField):
@@ -1421,45 +1746,74 @@ class XStrFixedLenField(_XStrLenField, StrFixedLenField):
 
 class XLEStrLenField(XStrLenField):
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[bytes]) -> bytes
+        if not x:
+            return b""
         return x[:: -1]
 
     def m2i(self, pkt, x):
+        # type: (BasePacket, bytes) -> bytes
         return x[:: -1]
 
 
 class StrLenFieldUtf16(StrLenField):
     def h2i(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[str]) -> bytes
         return plain_str(x).encode('utf-16')[2:]
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> bytes
         if isinstance(x, six.text_type):
             return self.h2i(pkt, x)
         return super(StrLenFieldUtf16, self).any2i(pkt, x)
 
     def i2repr(self, pkt, x):
-        return x
+        # type: (Optional[BasePacket], bytes) -> str
+        return plain_str(x)
 
-    def i2h(self, pkt, x):
+    def i2h(self,
+            pkt,  # type: Optional[BasePacket]
+            x,  # type: bytes
+            ):
+        # type: (...) -> str
         return bytes_encode(x).decode('utf-16')
 
 
 class BoundStrLenField(StrLenField):
     __slots__ = ["minlen", "maxlen"]
 
-    def __init__(self, name, default, minlen=0, maxlen=255, fld=None, length_from=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: bytes
+            minlen=0,  # type: int
+            maxlen=255,  # type: int
+            fld=None,  # type: Optional[Field_metaclass]
+            length_from=None  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
         StrLenField.__init__(self, name, default, fld, length_from)
         self.minlen = minlen
         self.maxlen = maxlen
 
     def randval(self):
+        # type: () -> RandBin
         return RandBin(RandNum(self.minlen, self.maxlen))
 
 
-class FieldListField(Field):
+class FieldListField(Field[List[Any], List[Any]]):
     __slots__ = ["field", "count_from", "length_from"]
     islist = 1
 
-    def __init__(self, name, default, field, length_from=None, count_from=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Optional[List[Field[Any, Any]]]
+            field,  # type: Field_metaclass
+            length_from=None,  # type: Optional[Callable[[BasePacket], int]]
+            count_from=None,  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
         if default is None:
             default = []  # Create a new list for each instance
         self.field = field
@@ -1468,34 +1822,54 @@ class FieldListField(Field):
         self.length_from = length_from
 
     def i2count(self, pkt, val):
+        # type: (BasePacket, List[Any]) -> int
         if isinstance(val, list):
             return len(val)
         return 1
 
     def i2len(self, pkt, val):
+        # type: (BasePacket, List[Any]) -> int
         return int(sum(self.field.i2len(pkt, v) for v in val))
 
-    def i2m(self, pkt, val):
+    def i2m(self,
+            pkt,  # type: BasePacket
+            val,  # type: Optional[List[Any]]
+            ):
+        # type: (...) -> List[Any]
         if val is None:
             val = []
         return val
 
     def any2i(self, pkt, x):
+        # type: (BasePacket, List[Any]) -> List[Any]
         if not isinstance(x, list):
             return [self.field.any2i(pkt, x)]
         else:
             return [self.field.any2i(pkt, e) for e in x]
 
-    def i2repr(self, pkt, x):
+    def i2repr(self,
+               pkt,  # type: BasePacket
+               x,  # type: List[Any]
+               ):
+        # type: (...) -> str
         return "[%s]" % ", ".join(self.field.i2repr(pkt, v) for v in x)
 
-    def addfield(self, pkt, s, val):
+    def addfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 val,  # type: Optional[List[Any]]
+                 ):
+        # type: (...) -> bytes
         val = self.i2m(pkt, val)
         for v in val:
             s = self.field.addfield(pkt, s, v)
         return s
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Any
         c = len_pkt = None
         if self.length_from is not None:
             len_pkt = self.length_from(pkt)
@@ -1517,10 +1891,20 @@ class FieldListField(Field):
         return s + ret, val
 
 
-class FieldLenField(Field):
+class FieldLenField(Field[int, int]):
     __slots__ = ["length_of", "count_of", "adjust"]
 
-    def __init__(self, name, default, length_of=None, fmt="H", count_of=None, adjust=lambda pkt, x: x, fld=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Optional[Any]
+            length_of=None,  # type: Optional[str]
+            fmt="H",  # type: str
+            count_of=None,  # type: Optional[str]
+            adjust=lambda pkt, x: x,  # type: Callable[[BasePacket, int], int]
+            fld=None,  # type: Optional[Any]
+    ):
+        # type: (...) -> None
         Field.__init__(self, name, default, fmt)
         self.length_of = length_of
         self.count_of = count_of
@@ -1530,6 +1914,7 @@ class FieldLenField(Field):
             self.length_of = fld
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[int]) -> int
         if x is None:
             if self.length_of is not None:
                 fld, fval = pkt.getfield_and_val(self.length_of)
@@ -1543,9 +1928,14 @@ class FieldLenField(Field):
 
 class StrNullField(StrField):
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[bytes]) -> bytes
         return s + self.i2m(pkt, val) + b"\x00"
 
-    def getfield(self, pkt, s):
+    def getfield(self,
+                 pkt,  # type: BasePacket
+                 s,  # type: bytes
+                 ):
+        # type: (...) -> Tuple[bytes, bytes]
         len_str = s.find(b"\x00")
         if len_str < 0:
             # \x00 not found: return empty
@@ -1553,6 +1943,7 @@ class StrNullField(StrField):
         return s[len_str + 1:], self.m2i(pkt, s[:len_str])
 
     def randval(self):
+        # type: () -> RandTermString
         return RandTermString(RandNum(0, 1200), b"\x00")
 
 
@@ -1560,11 +1951,13 @@ class StrStopField(StrField):
     __slots__ = ["stop", "additional"]
 
     def __init__(self, name, default, stop, additional=0):
+        # type: (str, str, bytes, int) -> None
         Field.__init__(self, name, default)
         self.stop = stop
         self.additional = additional
 
     def getfield(self, pkt, s):
+        # type: (Optional[BasePacket], bytes) -> Tuple[bytes, bytes]
         len_str = s.find(self.stop)
         if len_str < 0:
             return b"", s
@@ -1573,34 +1966,44 @@ class StrStopField(StrField):
         return s[len_str:], s[:len_str]
 
     def randval(self):
+        # type: () -> RandTermString
         return RandTermString(RandNum(0, 1200), self.stop)
 
 
-class LenField(Field):
+class LenField(Field[int, int]):
     """
     If None, will be filled with the size of the payload
     """
     __slots__ = ["adjust"]
 
     def __init__(self, name, default, fmt="H", adjust=lambda x: x):
+        # type: (str, Optional[Any], str, Callable[[int], int]) -> None
         Field.__init__(self, name, default, fmt)
         self.adjust = adjust
 
-    def i2m(self, pkt, x):
+    def i2m(self,
+            pkt,  # type: BasePacket
+            x,  # type: Optional[int]
+            ):
+        # type: (...) -> int
         if x is None:
             x = self.adjust(len(pkt.payload))
         return x
 
 
-class BCDFloatField(Field):
+class BCDFloatField(Field[float, int]):
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[float]) -> int
+        if x is None:
+            return 0
         return int(256 * x)
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> float
         return x / 256.0
 
 
-class BitField(Field):
+class _BitField(Field[I, int]):
     """
     Field to handle bits.
 
@@ -1650,6 +2053,7 @@ class BitField(Field):
 
     def __init__(self, name, default, size,
                  tot_size=0, end_tot_size=0):
+        # type: (str, I, int, int, int) -> None
         Field.__init__(self, name, default)
         self.rev = size < 0 or tot_size < 0 or end_tot_size < 0
         self.size = abs(size)
@@ -1659,10 +2063,19 @@ class BitField(Field):
         if not end_tot_size:
             end_tot_size = self.size // 8
         self.end_tot_size = abs(end_tot_size)
-        self.sz = self.size / 8.
+        # Fields always have a round sz except BitField
+        # so to keep it simple, we'll ignore it here.
+        self.sz = self.size / 8.  # type: ignore
 
-    def addfield(self, pkt, s, val):
-        val = self.i2m(pkt, val)
+    # We need to # type: ignore a few things because of how special
+    # BitField is
+    def addfield(self,  # type: ignore
+                 pkt,  # type: BasePacket
+                 s,  # type: Union[Tuple[bytes, int, int], bytes]
+                 ival,  # type: I
+                 ):
+        # type: (...) -> Union[Tuple[bytes, int, int], bytes]
+        val = self.i2m(pkt, ival)
         if isinstance(s, tuple):
             s, bitsdone, v = s
         else:
@@ -1683,7 +2096,11 @@ class BitField(Field):
                 s = s[:-self.end_tot_size] + s[-self.end_tot_size:][::-1]
             return s
 
-    def getfield(self, pkt, s):
+    def getfield(self,  # type: ignore
+                 pkt,  # type: BasePacket
+                 s,  # type: Union[Tuple[bytes, int], bytes]
+                 ):
+        # type: (...) -> Union[Tuple[Tuple[bytes, int], I], Tuple[bytes, I]]  # noqa: E501
         if isinstance(s, tuple):
             s, bn = s
         else:
@@ -1712,17 +2129,23 @@ class BitField(Field):
         bn += self.size
         s = s[bn // 8:]
         bn = bn % 8
-        b = self.m2i(pkt, b)
+        b2 = self.m2i(pkt, b)
         if bn:
-            return (s, bn), b
+            return (s, bn), b2
         else:
-            return s, b
+            return s, b2
 
     def randval(self):
+        # type: () -> RandNum
         return RandNum(0, 2**self.size - 1)
 
-    def i2len(self, pkt, x):
+    def i2len(self, pkt, x):  # type: ignore
+        # type: (Optional[BasePacket], Optional[float]) -> float
         return float(self.size) / 8
+
+
+class BitField(_BitField[int]):
+    __doc__ = _BitField.__doc__
 
 
 class BitFixedLenField(BitField):
@@ -1744,23 +2167,43 @@ class BitFixedLenField(BitField):
 class BitFieldLenField(BitField):
     __slots__ = ["length_of", "count_of", "adjust"]
 
-    def __init__(self, name, default, size, length_of=None, count_of=None, adjust=lambda pkt, x: x):  # noqa: E501
-        BitField.__init__(self, name, default, size)
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: int
+                 size,  # type: int
+                 length_of=None,  # type: Optional[Union[Callable[[Optional[BasePacket]], int], str]]  # noqa: E501
+                 count_of=None,  # type: Optional[str]
+                 adjust=lambda pkt, x: x,  # type: Callable[[Optional[BasePacket], int], int]  # noqa: E501
+                 ):
+        # type: (...) -> None
+        super(BitFieldLenField, self).__init__(name, default, size)
         self.length_of = length_of
         self.count_of = count_of
         self.adjust = adjust
 
     def i2m(self, pkt, x):
-        return (FieldLenField.i2m.__func__ if six.PY2 else FieldLenField.i2m)(self, pkt, x)  # noqa: E501
+        # type: (Optional[BasePacket], Optional[Any]) -> int
+        if six.PY2:
+            func = FieldLenField.i2m.__func__
+        else:
+            func = FieldLenField.i2m
+        return func(self, pkt, x)  # type: ignore
 
 
 class XBitField(BitField):
     def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
+        # type: (Optional[BasePacket], int) -> str
+        return lhex(self.i2h(pkt, x))  # type: ignore
 
 
-class _EnumField(Field):
-    def __init__(self, name, default, enum, fmt="H"):
+class _EnumField(Field[Union[List[I], I], I]):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[I]
+                 enum,  # type: Union[Dict[I, str], List[str], DADict, Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 fmt="H",  # type: str
+                 ):
+        # type: (...) -> None
         """ Initializes enum fields.
 
         @param name:    name of this field
@@ -1780,10 +2223,10 @@ class _EnumField(Field):
             enum.observe(self)
 
         if isinstance(enum, tuple):
-            self.i2s_cb = enum[0]
-            self.s2i_cb = enum[1]
-            self.i2s = None
-            self.s2i = None
+            self.i2s_cb = enum[0]  # type: Optional[Callable[[I], str]]
+            self.s2i_cb = enum[1]  # type: Optional[Callable[[str], I]]
+            self.i2s = None  # type: Optional[Dict[I, str]]
+            self.s2i = None  # type: Optional[Dict[str, I]]
         else:
             i2s = self.i2s = {}
             s2i = self.s2i = {}
@@ -1796,62 +2239,84 @@ class _EnumField(Field):
             else:
                 keys = list(enum)
                 if any(isinstance(x, str) for x in keys):
-                    i2s, s2i = s2i, i2s
+                    i2s, s2i = s2i, i2s  # type: ignore
             for k in keys:
                 i2s[k] = enum[k]
                 s2i[enum[k]] = k
         Field.__init__(self, name, default, fmt)
 
     def any2i_one(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> I
         if isinstance(x, str):
-            try:
-                x = self.s2i[x]
-            except TypeError:
+            if self.s2i:
+                try:
+                    x = self.s2i[x]
+                except KeyError:
+                    pass
+            elif self.s2i_cb:
                 x = self.s2i_cb(x)
-        return x
+        return cast(I, x)
 
     def i2repr_one(self, pkt, x):
+        # type: (Optional[BasePacket], I) -> str
         if self not in conf.noenum and not isinstance(x, VolatileValue):
-            try:
-                return self.i2s[x]
-            except KeyError:
-                pass
-            except TypeError:
+            if self.i2s:
+                try:
+                    return self.i2s[x]
+                except KeyError:
+                    pass
+            elif self.i2s_cb:
                 ret = self.i2s_cb(x)
                 if ret is not None:
                     return ret
         return repr(x)
 
     def any2i(self, pkt, x):
+        # type: (BasePacket, Any) -> Union[I, List[I]]
         if isinstance(x, list):
             return [self.any2i_one(pkt, z) for z in x]
         else:
             return self.any2i_one(pkt, x)
 
-    def i2repr(self, pkt, x):
+    def i2repr(self, pkt, x):  # type: ignore
+        # type: (Optional[BasePacket], Any) -> Union[List[str], str]
         if isinstance(x, list):
             return [self.i2repr_one(pkt, z) for z in x]
         else:
             return self.i2repr_one(pkt, x)
 
     def notify_set(self, enum, key, value):
-        log_runtime.debug("At %s: Change to %s at 0x%x" % (self, value, key))
-        self.i2s[key] = value
-        self.s2i[value] = key
+        # type: (ObservableDict, I, str) -> None
+        ks = "0x%x" if isinstance(key, int) else "%s"
+        log_runtime.debug(
+            ("At %s: Change to %s at " + ks) % (self, value, key)
+        )
+        if self.i2s and self.s2i:
+            self.i2s[key] = value
+            self.s2i[value] = key
 
     def notify_del(self, enum, key):
-        log_runtime.debug("At %s: Delete value at 0x%x" % (self, key))
-        value = self.i2s[key]
-        del self.i2s[key]
-        del self.s2i[value]
+        # type: (ObservableDict, I) -> None
+        ks = "0x%x" if isinstance(key, int) else "%s"
+        log_runtime.debug(("At %s: Delete value at " + ks) % (self, key))
+        if self.i2s and self.s2i:
+            value = self.i2s[key]
+            del self.i2s[key]
+            del self.s2i[value]
 
 
-class EnumField(_EnumField):
+class EnumField(_EnumField[I]):
     __slots__ = ["i2s", "s2i", "s2i_cb", "i2s_cb"]
 
 
-class CharEnumField(EnumField):
-    def __init__(self, name, default, enum, fmt="1s"):
+class CharEnumField(EnumField[str]):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: str
+                 enum,  # type: Union[Dict[str, str], Tuple[Callable[[BasePacket], str], ...]]  # noqa: E501
+                 fmt="1s",  # type: str
+                 ):
+        # type: (...) -> None
         EnumField.__init__(self, name, default, enum, fmt)
         if self.i2s is not None:
             k = list(self.i2s)
@@ -1859,105 +2324,135 @@ class CharEnumField(EnumField):
                 self.i2s, self.s2i = self.s2i, self.i2s
 
     def any2i_one(self, pkt, x):
+        # type: (Optional[BasePacket], str) -> str
         if len(x) != 1:
-            if self.s2i is None:
-                x = self.s2i_cb(x)
-            else:
+            if self.s2i:
                 x = self.s2i[x]
+            elif self.s2i_cb:
+                x = self.s2i_cb(x)
         return x
 
 
-class BitEnumField(BitField, _EnumField):
+class BitEnumField(_BitField[Union[List[int], int]], _EnumField[int]):
     __slots__ = EnumField.__slots__
 
     def __init__(self, name, default, size, enum):
+        # type: (str, Optional[int], int, Dict[int, str]) -> None
         _EnumField.__init__(self, name, default, enum)
         self.rev = size < 0
         self.size = abs(size)
-        self.sz = self.size / 8.
+        self.sz = self.size / 8.  # type: ignore
 
     def any2i(self, pkt, x):
+        # type: (BasePacket, Any) -> Union[List[int], int]
         return _EnumField.any2i(self, pkt, x)
 
-    def i2repr(self, pkt, x):
+    def i2repr(self,
+               pkt,  # type: Optional[BasePacket]
+               x,  # type: Union[List[int], int]
+               ):
+        # type: (...) -> Any
         return _EnumField.i2repr(self, pkt, x)
 
 
-class ShortEnumField(EnumField):
+class ShortEnumField(EnumField[int]):
     __slots__ = EnumField.__slots__
 
-    def __init__(self, name, default, enum):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: int
+                 enum,  # type: Union[Dict[int, str], Tuple[Callable[[BasePacket], int], ...], DADict]  # noqa: E501
+                 ):
+        # type: (...) -> None
         EnumField.__init__(self, name, default, enum, "H")
 
 
-class LEShortEnumField(EnumField):
+class LEShortEnumField(EnumField[int]):
     def __init__(self, name, default, enum):
+        # type: (str, int, Union[Dict[int, str], List[str]]) -> None
         EnumField.__init__(self, name, default, enum, "<H")
 
 
-class ByteEnumField(EnumField):
+class ByteEnumField(EnumField[int]):
     def __init__(self, name, default, enum):
+        # type: (str, Optional[int], Dict[int, str]) -> None
         EnumField.__init__(self, name, default, enum, "B")
 
 
 class XByteEnumField(ByteEnumField):
     def i2repr_one(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         if self not in conf.noenum and not isinstance(x, VolatileValue):
-            try:
-                return self.i2s[x]
-            except KeyError:
-                pass
-            except TypeError:
+            if self.i2s:
+                try:
+                    return self.i2s[x]
+                except KeyError:
+                    pass
+            elif self.i2s_cb:
                 ret = self.i2s_cb(x)
                 if ret is not None:
                     return ret
-        return lhex(x)
+        return lhex(x)  # type: ignore
 
 
-class IntEnumField(EnumField):
+class IntEnumField(EnumField[int]):
     def __init__(self, name, default, enum):
+        # type: (str, Optional[int], Dict[int, str]) -> None
         EnumField.__init__(self, name, default, enum, "I")
 
 
-class SignedIntEnumField(EnumField):
+class SignedIntEnumField(EnumField[int]):
     def __init__(self, name, default, enum):
+        # type: (str, Optional[int], Dict[int, str]) -> None
         EnumField.__init__(self, name, default, enum, "i")
 
 
-class LEIntEnumField(EnumField):
+class LEIntEnumField(EnumField[int]):
     def __init__(self, name, default, enum):
+        # type: (str, int, Dict[int, str]) -> None
         EnumField.__init__(self, name, default, enum, "<I")
 
 
 class XShortEnumField(ShortEnumField):
     def i2repr_one(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> str
         if self not in conf.noenum and not isinstance(x, VolatileValue):
-            try:
-                return self.i2s[x]
-            except KeyError:
-                pass
-            except TypeError:
+            if self.i2s is not None:
+                try:
+                    return self.i2s[x]
+                except KeyError:
+                    pass
+            elif self.i2s_cb:
                 ret = self.i2s_cb(x)
                 if ret is not None:
                     return ret
-        return lhex(x)
+        return lhex(x)  # type: ignore
 
 
-class _MultiEnumField(_EnumField):
-    def __init__(self, name, default, enum, depends_on, fmt="H"):
+class _MultiEnumField(_EnumField[I]):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: int
+                 enum,  # type: Dict[I, Dict[I, str]]
+                 depends_on,  # type: Callable[[BasePacket], I]
+                 fmt="H"  # type: str
+                 ):
+        # type: (...) -> None
 
         self.depends_on = depends_on
         self.i2s_multi = enum
-        self.s2i_multi = {}
-        self.s2i_all = {}
+        self.s2i_multi = {}  # type: Dict[I, Dict[str, I]]
+        self.s2i_all = {}  # type: Dict[str, I]
         for m in enum:
-            self.s2i_multi[m] = s2i = {}
+            s2i = {}  # type: Dict[str, I]
+            self.s2i_multi[m] = s2i
             for k, v in six.iteritems(enum[m]):
                 s2i[v] = k
                 self.s2i_all[v] = k
         Field.__init__(self, name, default, fmt)
 
     def any2i_one(self, pkt, x):
+        # type: (BasePacket, Any) -> I
         if isinstance(x, str):
             v = self.depends_on(pkt)
             if v in self.s2i_multi:
@@ -1965,34 +2460,50 @@ class _MultiEnumField(_EnumField):
                 if x in s2i:
                     return s2i[x]
             return self.s2i_all[x]
-        return x
+        return cast(I, x)
 
     def i2repr_one(self, pkt, x):
+        # type: (BasePacket, I) -> str
         v = self.depends_on(pkt)
         if isinstance(v, VolatileValue):
             return repr(v)
         if v in self.i2s_multi:
-            return self.i2s_multi[v].get(x, x)
-        return x
+            return str(self.i2s_multi[v].get(x, x))
+        return str(x)
 
 
-class MultiEnumField(_MultiEnumField, EnumField):
+class MultiEnumField(_MultiEnumField[int], EnumField[int]):
     __slots__ = ["depends_on", "i2s_multi", "s2i_multi", "s2i_all"]
 
 
-class BitMultiEnumField(BitField, _MultiEnumField):
+class BitMultiEnumField(_BitField[Union[List[int], int]],
+                        _MultiEnumField[int]):
     __slots__ = EnumField.__slots__ + MultiEnumField.__slots__
 
-    def __init__(self, name, default, size, enum, depends_on):
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: int
+            size,  # type: int
+            enum,  # type: Dict[int, Dict[int, str]]
+            depends_on  # type: Callable[[BasePacket], int]
+    ):
+        # type: (...) -> None
         _MultiEnumField.__init__(self, name, default, enum, depends_on)
         self.rev = size < 0
         self.size = abs(size)
-        self.sz = self.size / 8.
+        self.sz = self.size / 8.  # type: ignore
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> Union[List[int], int]
         return _MultiEnumField.any2i(self, pkt, x)
 
-    def i2repr(self, pkt, x):
+    def i2repr(  # type: ignore
+            self,
+            pkt,  # type: Optional[BasePacket]
+            x  # type: Union[List[int], int]
+    ):
+        # type: (...) -> Union[str, List[str]]
         return _MultiEnumField.i2repr(self, pkt, x)
 
 
@@ -2000,6 +2511,7 @@ class ByteEnumKeysField(ByteEnumField):
     """ByteEnumField that picks valid values when fuzzed. """
 
     def randval(self):
+        # type: () -> RandEnumKeys
         return RandEnumKeys(self.i2s)
 
 
@@ -2007,6 +2519,7 @@ class ShortEnumKeysField(ShortEnumField):
     """ShortEnumField that picks valid values when fuzzed. """
 
     def randval(self):
+        # type: () -> RandEnumKeys
         return RandEnumKeys(self.i2s)
 
 
@@ -2014,6 +2527,7 @@ class IntEnumKeysField(IntEnumField):
     """IntEnumField that picks valid values when fuzzed. """
 
     def randval(self):
+        # type: () -> RandEnumKeys
         return RandEnumKeys(self.i2s)
 
 
@@ -2021,22 +2535,35 @@ class IntEnumKeysField(IntEnumField):
 
 
 class LEFieldLenField(FieldLenField):
-    def __init__(self, name, default, length_of=None, fmt="<H", count_of=None, adjust=lambda pkt, x: x, fld=None):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: int
+            length_of=None,  # type: Optional[str]
+            fmt="<H",  # type: str
+            count_of=None,  # type: Optional[str]
+            adjust=lambda pkt, x: x,  # type: Callable[[BasePacket, int], int]
+            fld=None,  # type: Optional[Any]
+    ):
+        # type: (...) -> None
         FieldLenField.__init__(self, name, default, length_of=length_of, fmt=fmt, count_of=count_of, fld=fld, adjust=adjust)  # noqa: E501
 
 
 class FlagValueIter(object):
 
-    slots = ["flagvalue", "cursor"]
+    __slots__ = ["flagvalue", "cursor"]
 
     def __init__(self, flagvalue):
+        # type: (FlagValue) -> None
         self.flagvalue = flagvalue
         self.cursor = 0
 
     def __iter__(self):
+        # type: () -> FlagValueIter
         return self
 
     def __next__(self):
+        # type: () -> str
         x = int(self.flagvalue)
         x >>= self.cursor
         while x:
@@ -2053,6 +2580,7 @@ class FlagValue(object):
     __slots__ = ["value", "names", "multi"]
 
     def _fixvalue(self, value):
+        # type: (Any) -> int
         if not value:
             return 0
         if isinstance(value, six.string_types):
@@ -2065,53 +2593,68 @@ class FlagValue(object):
         return int(value)
 
     def __init__(self, value, names):
+        # type: (Union[List[str], int, str], Union[List[str], str]) -> None
         self.multi = isinstance(names, list)
         self.names = names
         self.value = self._fixvalue(value)
 
     def __hash__(self):
+        # type: () -> int
         return hash(self.value)
 
     def __int__(self):
+        # type: () -> int
         return self.value
 
     def __eq__(self, other):
+        # type: (Any) -> bool
         return self.value == self._fixvalue(other)
 
     def __lt__(self, other):
+        # type: (Any) -> bool
         return self.value < self._fixvalue(other)
 
     def __le__(self, other):
+        # type: (Any) -> bool
         return self.value <= self._fixvalue(other)
 
     def __gt__(self, other):
+        # type: (Any) -> bool
         return self.value > self._fixvalue(other)
 
     def __ge__(self, other):
+        # type: (Any) -> bool
         return self.value >= self._fixvalue(other)
 
     def __ne__(self, other):
+        # type: (Any) -> bool
         return self.value != self._fixvalue(other)
 
     def __and__(self, other):
+        # type: (int) -> FlagValue
         return self.__class__(self.value & self._fixvalue(other), self.names)
     __rand__ = __and__
 
     def __or__(self, other):
+        # type: (int) -> FlagValue
         return self.__class__(self.value | self._fixvalue(other), self.names)
     __ror__ = __or__
 
     def __lshift__(self, other):
+        # type: (int) -> int
         return self.value << self._fixvalue(other)
 
     def __rshift__(self, other):
+        # type: (int) -> int
         return self.value >> self._fixvalue(other)
 
     def __nonzero__(self):
+        # type: () -> bool
         return bool(self.value)
     __bool__ = __nonzero__
 
     def flagrepr(self):
+        # type: () -> str
         warnings.warn(
             "obj.flagrepr() is obsolete. Use str(obj) instead.",
             DeprecationWarning
@@ -2119,6 +2662,7 @@ class FlagValue(object):
         return str(self)
 
     def __str__(self):
+        # type: () -> str
         i = 0
         r = []
         x = int(self)
@@ -2134,17 +2678,21 @@ class FlagValue(object):
         return ("+" if self.multi else "").join(r)
 
     def __iter__(self):
+        # type: () -> FlagValueIter
         return FlagValueIter(self)
 
     def __repr__(self):
+        # type: () -> str
         return "<Flag %d (%s)>" % (self, self)
 
     def __deepcopy__(self, memo):
+        # type: (Dict[Any, Any]) -> FlagValue
         return self.__class__(int(self), self.names)
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         if attr in self.__slots__:
-            return super(FlagValue, self).__getattr__(attr)
+            return super(FlagValue, self).__getattribute__(attr)
         try:
             if self.multi:
                 return bool((2 ** self.names.index(attr)) & int(self))
@@ -2156,9 +2704,10 @@ class FlagValue(object):
                     return self.__getattr__(attr.replace('_', '-'))
                 except AttributeError:
                     pass
-            return super(FlagValue, self).__getattr__(attr)
+            return super(FlagValue, self).__getattribute__(attr)
 
     def __setattr__(self, attr, value):
+        # type: (str, Union[List[str], int, str]) -> None
         if attr == "value" and not isinstance(value, six.integer_types):
             raise ValueError(value)
         if attr in self.__slots__:
@@ -2172,17 +2721,18 @@ class FlagValue(object):
             return super(FlagValue, self).__setattr__(attr, value)
 
     def copy(self):
+        # type: () -> FlagValue
         return self.__class__(self.value, self.names)
 
 
-class FlagsField(BitField):
+class FlagsField(_BitField[Optional[Union[int, FlagValue]]]):
     """ Handle Flag type field
 
    Make sure all your flags have a label
 
    Example (list):
        >>> from scapy.packet import Packet
-       >>> class FlagsTest(Packet):
+       >>> class FlagsTest(BasePacket):
                fields_desc = [FlagsField("flags", 0, 8, ["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7"])]  # noqa: E501
        >>> FlagsTest(flags=9).show2()
        ###[ FlagsTest ]###
@@ -2220,7 +2770,13 @@ class FlagsField(BitField):
     ismutable = True
     __slots__ = ["names"]
 
-    def __init__(self, name, default, size, names):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[Union[int, FlagValue]]
+                 size,  # type: int
+                 names  # type: Union[List[str], str, Dict[int, str]]
+                 ):
+        # type: (...) -> None
         # Convert the dict to a list
         if isinstance(names, dict):
             tmp = ["bit_%d" % i for i in range(size)]
@@ -2229,55 +2785,70 @@ class FlagsField(BitField):
             names = tmp
         # Store the names as str or list
         self.names = names
-        BitField.__init__(self, name, default, size)
+        super(FlagsField, self).__init__(name, default, size)
 
     def _fixup_val(self, x):
+        # type: (Any) -> Optional[FlagValue]
         """Returns a FlagValue instance when needed. Internal method, to be
 used in *2i() and i2*() methods.
 
         """
-        if isinstance(x, FlagValue):
-            return x
+        if isinstance(x, (FlagValue, VolatileValue)):
+            return x  # type: ignore
         if x is None:
             return None
         return FlagValue(x, self.names)
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> Optional[FlagValue]
         return self._fixup_val(super(FlagsField, self).any2i(pkt, x))
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], int) -> Optional[FlagValue]
         return self._fixup_val(super(FlagsField, self).m2i(pkt, x))
 
     def i2h(self, pkt, x):
-        if isinstance(x, VolatileValue):
-            return super(FlagsField, self).i2h(pkt, x)
+        # type: (Optional[BasePacket], Any) -> Optional[FlagValue]
         return self._fixup_val(super(FlagsField, self).i2h(pkt, x))
 
-    def i2repr(self, pkt, x):
+    def i2repr(self,
+               pkt,  # type: Optional[BasePacket]
+               x,  # type: Any
+               ):
+        # type: (...) -> str
         if isinstance(x, (list, tuple)):
             return repr(type(x)(
-                None if v is None else str(self._fixup_val(v)) for v in x
+                "None" if v is None else str(self._fixup_val(v)) for v in x
             ))
-        return None if x is None else str(self._fixup_val(x))
+        return "None" if x is None else str(self._fixup_val(x))
 
 
 MultiFlagsEntry = collections.namedtuple('MultiFlagEntry', ['short', 'long'])
 
 
-class MultiFlagsField(BitField):
+class MultiFlagsField(_BitField[Set[str]]):
     __slots__ = FlagsField.__slots__ + ["depends_on"]
 
-    def __init__(self, name, default, size, names, depends_on):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Set[str]
+                 size,  # type: int
+                 names,  # type: Dict[int, Dict[int, MultiFlagsEntry]]
+                 depends_on,  # type: Callable[[BasePacket], int]
+                 ):
+        # type: (...) -> None
         self.names = names
         self.depends_on = depends_on
         super(MultiFlagsField, self).__init__(name, default, size)
 
     def any2i(self, pkt, x):
-        assert isinstance(x, six.integer_types + (set,)), 'set expected'
+        # type: (Optional[BasePacket], Any) -> Set[str]
+        if not isinstance(x, (set, int)):
+            raise ValueError('set expected')
 
         if pkt is not None:
-            if isinstance(x, six.integer_types):
-                x = self.m2i(pkt, x)
+            if isinstance(x, int):
+                return self.m2i(pkt, x)
             else:
                 v = self.depends_on(pkt)
                 if v is not None:
@@ -2292,14 +2863,19 @@ class MultiFlagsField(BitField):
                         else:
                             assert False, 'Unknown flag "{}" with this dependency'.format(i)  # noqa: E501
                             continue
-                    x = s
+                    return s
+        if isinstance(x, int):
+            return set()
         return x
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[Set[str]]) -> int
         v = self.depends_on(pkt)
         these_names = self.names.get(v, {})
 
         r = 0
+        if x is None:
+            return r
         for flag_set in x:
             for i, val in six.iteritems(these_names):
                 if val.short == flag_set:
@@ -2310,6 +2886,7 @@ class MultiFlagsField(BitField):
         return r
 
     def m2i(self, pkt, x):
+        # type: (BasePacket, int) -> Set[str]
         v = self.depends_on(pkt)
         these_names = self.names.get(v, {})
 
@@ -2326,6 +2903,7 @@ class MultiFlagsField(BitField):
         return r
 
     def i2repr(self, pkt, x):
+        # type: (BasePacket, Set[str]) -> str
         v = self.depends_on(pkt)
         these_names = self.names.get(v, {})
 
@@ -2344,10 +2922,12 @@ class FixedPointField(BitField):
     __slots__ = ['frac_bits']
 
     def __init__(self, name, default, size, frac_bits=16):
+        # type: (str, int, int, int) -> None
         self.frac_bits = frac_bits
-        BitField.__init__(self, name, default, size)
+        super(FixedPointField, self).__init__(name, default, size)
 
     def any2i(self, pkt, val):
+        # type: (Optional[BasePacket], Optional[float]) -> Optional[int]
         if val is None:
             return val
         ival = int(val)
@@ -2355,50 +2935,72 @@ class FixedPointField(BitField):
         return (ival << self.frac_bits) | fract
 
     def i2h(self, pkt, val):
+        # type: (Optional[BasePacket], int) -> float
         int_part = val >> self.frac_bits
-        frac_part = val & (1 << self.frac_bits) - 1
+        frac_part = float(val & (1 << self.frac_bits) - 1)
         frac_part /= 2.0**self.frac_bits
         return int_part + frac_part
 
     def i2repr(self, pkt, val):
-        return self.i2h(pkt, val)
+        # type: (Optional[BasePacket], int) -> str
+        return str(self.i2h(pkt, val))
 
 
 # Base class for IPv4 and IPv6 Prefixes inspired by IPField and IP6Field.
 # Machine values are encoded in a multiple of wordbytes bytes.
-class _IPPrefixFieldBase(Field):
+class _IPPrefixFieldBase(Field[Tuple[str, int], Tuple[bytes, int]]):
     __slots__ = ["wordbytes", "maxbytes", "aton", "ntoa", "length_from"]
 
-    def __init__(self, name, default, wordbytes, maxbytes, aton, ntoa, length_from):  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Tuple[str, int]
+            wordbytes,  # type: int
+            maxbytes,  # type: int
+            aton,  # type: Callable[..., Any]
+            ntoa,  # type: Callable[..., Any]
+            length_from=None  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
         self.wordbytes = wordbytes
         self.maxbytes = maxbytes
         self.aton = aton
         self.ntoa = ntoa
         Field.__init__(self, name, default, "%is" % self.maxbytes)
+        if length_from is None:
+            length_from = lambda x: 0
         self.length_from = length_from
 
     def _numbytes(self, pfxlen):
+        # type: (int) -> int
         wbits = self.wordbytes * 8
         return ((pfxlen + (wbits - 1)) // wbits) * self.wordbytes
 
     def h2i(self, pkt, x):
+        # type: (BasePacket, str) -> Tuple[str, int]
         # "fc00:1::1/64" -> ("fc00:1::1", 64)
         [pfx, pfxlen] = x.split('/')
         self.aton(pfx)  # check for validity
         return (pfx, int(pfxlen))
 
     def i2h(self, pkt, x):
+        # type: (BasePacket, Tuple[str, int]) -> str
         # ("fc00:1::1", 64) -> "fc00:1::1/64"
         (pfx, pfxlen) = x
         return "%s/%i" % (pfx, pfxlen)
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[Tuple[str, int]]) -> Tuple[bytes, int]
         # ("fc00:1::1", 64) -> (b"\xfc\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 64)  # noqa: E501
-        (pfx, pfxlen) = x
+        if x is None:
+            pfx, pfxlen = "", 0
+        else:
+            (pfx, pfxlen) = x
         s = self.aton(pfx)
         return (s[:self._numbytes(pfxlen)], pfxlen)
 
     def m2i(self, pkt, x):
+        # type: (BasePacket, Tuple[bytes, int]) -> Tuple[str, int]
         # (b"\xfc\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 64) -> ("fc00:1::1", 64)  # noqa: E501
         (s, pfxlen) = x
 
@@ -2407,21 +3009,25 @@ class _IPPrefixFieldBase(Field):
         return (self.ntoa(s), pfxlen)
 
     def any2i(self, pkt, x):
+        # type: (BasePacket, Optional[Any]) -> Tuple[str, int]
         if x is None:
             return (self.ntoa(b"\0" * self.maxbytes), 1)
 
         return self.h2i(pkt, x)
 
     def i2len(self, pkt, x):
+        # type: (BasePacket, Tuple[str, int]) -> int
         (_, pfxlen) = x
         return pfxlen
 
     def addfield(self, pkt, s, val):
+        # type: (BasePacket, bytes, Optional[Tuple[str, int]]) -> bytes
         (rawpfx, pfxlen) = self.i2m(pkt, val)
         fmt = "!%is" % self._numbytes(pfxlen)
         return s + struct.pack(fmt, rawpfx)
 
     def getfield(self, pkt, s):
+        # type: (BasePacket, bytes) -> Tuple[bytes, Tuple[str, int]]
         pfxlen = self.length_from(pkt)
         numbytes = self._numbytes(pfxlen)
         fmt = "!%is" % numbytes
@@ -2429,28 +3035,63 @@ class _IPPrefixFieldBase(Field):
 
 
 class IPPrefixField(_IPPrefixFieldBase):
-    def __init__(self, name, default, wordbytes=1, length_from=None):
-        _IPPrefixFieldBase.__init__(self, name, default, wordbytes, 4, inet_aton, inet_ntoa, length_from)  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Tuple[str, int]
+            wordbytes=1,  # type: int
+            length_from=None  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        _IPPrefixFieldBase.__init__(
+            self,
+            name,
+            default,
+            wordbytes,
+            4,
+            inet_aton,
+            inet_ntoa,
+            length_from
+        )
 
 
 class IP6PrefixField(_IPPrefixFieldBase):
-    def __init__(self, name, default, wordbytes=1, length_from=None):
-        _IPPrefixFieldBase.__init__(self, name, default, wordbytes, 16, lambda a: inet_pton(socket.AF_INET6, a), lambda n: inet_ntop(socket.AF_INET6, n), length_from)  # noqa: E501
+    def __init__(
+            self,
+            name,  # type: str
+            default,  # type: Tuple[str, int]
+            wordbytes=1,  # type: int
+            length_from=None  # type: Optional[Callable[[BasePacket], int]]
+    ):
+        # type: (...) -> None
+        _IPPrefixFieldBase.__init__(
+            self,
+            name,
+            default,
+            wordbytes,
+            16,
+            lambda a: inet_pton(socket.AF_INET6, a),
+            lambda n: inet_ntop(socket.AF_INET6, n),
+            length_from
+        )
 
 
-class UTCTimeField(IntField):
+class UTCTimeField(Field[float, int]):
     __slots__ = ["epoch", "delta", "strf",
                  "use_msec", "use_micro", "use_nano"]
 
     # Do not change the order of the keywords in here
     # Netflow heavily rely on this
-    def __init__(self, name, default,
-                 use_msec=False,
-                 use_micro=False,
-                 use_nano=False,
-                 epoch=None,
-                 strf="%a, %d %b %Y %H:%M:%S %z"):
-        IntField.__init__(self, name, default)
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: int
+                 use_msec=False,  # type: bool
+                 use_micro=False,  # type: bool
+                 use_nano=False,  # type: bool
+                 epoch=None,  # type: Optional[Tuple[int, int, int, int, int, int, int, int, int]]  # noqa: E501
+                 strf="%a, %d %b %Y %H:%M:%S %z",  # type: str
+                 ):
+        # type: (...) -> None
+        Field.__init__(self, name, default, "I")
         mk_epoch = EPOCH if epoch is None else calendar.timegm(epoch)
         self.epoch = mk_epoch
         self.delta = mk_epoch - EPOCH
@@ -2460,6 +3101,7 @@ class UTCTimeField(IntField):
         self.use_nano = use_nano
 
     def i2repr(self, pkt, x):
+        # type: (BasePacket, float) -> str
         if x is None:
             x = 0
         elif self.use_msec:
@@ -2473,10 +3115,11 @@ class UTCTimeField(IntField):
         return "%s (%d)" % (t, x)
 
     def i2m(self, pkt, x):
+        # type: (BasePacket, Optional[float]) -> int
         return int(x) if x is not None else 0
 
 
-class SecondsIntField(IntField):
+class SecondsIntField(Field[float, int]):
     __slots__ = ["use_msec", "use_micro", "use_nano"]
 
     # Do not change the order of the keywords in here
@@ -2485,33 +3128,49 @@ class SecondsIntField(IntField):
                  use_msec=False,
                  use_micro=False,
                  use_nano=False):
-        IntField.__init__(self, name, default)
+        # type: (str, int, bool, bool, bool) -> None
+        Field.__init__(self, name, default, "I")
         self.use_msec = use_msec
         self.use_micro = use_micro
         self.use_nano = use_nano
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[float]) -> str
         if x is None:
-            x = 0
+            y = 0  # type: Union[int, float]
         elif self.use_msec:
-            x = x / 1e3
+            y = x / 1e3
         elif self.use_micro:
-            x = x / 1e6
+            y = x / 1e6
         elif self.use_nano:
-            x = x / 1e9
-        return "%s sec" % x
+            y = x / 1e9
+        else:
+            y = x
+        return "%s sec" % y
 
 
 class _ScalingField(object):
-    def __init__(self, name, default, scaling=1, unit="",
-                 offset=0, ndigits=3, fmt="B"):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: float
+                 scaling=1,  # type: int
+                 unit="",  # type: str
+                 offset=0,  # type: int
+                 ndigits=3,  # type: int
+                 fmt="B",  # type: str
+                 ):
+        # type: (...) -> None
         self.scaling = scaling
         self.unit = unit
         self.offset = offset
         self.ndigits = ndigits
         Field.__init__(self, name, default, fmt)
 
-    def i2m(self, pkt, x):
+    def i2m(self,
+            pkt,  # type: Optional[BasePacket]
+            x  # type: Optional[Union[int, float]]
+            ):
+        # type: (...) -> Union[int, float]
         if x is None:
             x = 0
         x = (x - self.offset) / self.scaling
@@ -2520,22 +3179,28 @@ class _ScalingField(object):
         return x
 
     def m2i(self, pkt, x):
+        # type: (Optional[BasePacket], Union[int, float]) -> Union[int, float]
         x = x * self.scaling + self.offset
         if isinstance(x, float) and self.fmt[-1] != "f":
             x = round(x, self.ndigits)
         return x
 
     def any2i(self, pkt, x):
+        # type: (Optional[BasePacket], Any) -> Union[int, float]
         if isinstance(x, (str, bytes)):
             x = struct.unpack(self.fmt, bytes_encode(x))[0]
             x = self.m2i(pkt, x)
+        if not isinstance(x, (int, float)):
+            raise ValueError("Unknown type")
         return x
 
     def i2repr(self, pkt, x):
+        # type: (Optional[BasePacket], Union[int, float]) -> str
         return "%s %s" % (self.i2h(pkt, x), self.unit)
 
     def randval(self):
-        value = super(_ScalingField, self).randval()
+        # type: () -> RandFloat
+        value = super(ScalingField, self).randval()
         if value is not None:
             min_val = round(value.min * self.scaling + self.offset,
                             self.ndigits)
@@ -2545,12 +3210,13 @@ class _ScalingField(object):
             return RandFloat(min(min_val, max_val), max(min_val, max_val))
 
 
-class ScalingField(_ScalingField, Field):
+class ScalingField(_ScalingField,
+                   Field[Union[int, float], Union[int, float]]):
     """ Handle physical values which are scaled and/or offset for communication
 
        Example:
            >>> from scapy.packet import Packet
-           >>> class ScalingFieldTest(Packet):
+           >>> class ScalingFieldTest(BasePacket):
                    fields_desc = [ScalingField('data', 0, scaling=0.1, offset=-1, unit='mV')]  # noqa: E501
            >>> ScalingFieldTest(data=10).show2()
            ###[ ScalingFieldTest ]###
@@ -2586,7 +3252,6 @@ class ScalingField(_ScalingField, Field):
        :param fmt: struct.pack format used to parse and serialize the internal value from and to machine representation # noqa: E501
        """
 
-
 class BitScalingField(_ScalingField, BitField):
     """
     A ScalingField that is a BitField
@@ -2596,7 +3261,7 @@ class BitScalingField(_ScalingField, BitField):
         BitField.__init__(self, name, default, size)
 
 
-class UUIDField(Field):
+class UUIDField(Field[UUID, bytes]):
     """Field for UUID storage, wrapping Python's uuid.UUID type.
 
     The internal storage format of this field is ``uuid.UUID`` from the Python
@@ -2660,17 +3325,20 @@ class UUIDField(Field):
     FORMATS = (FORMAT_BE, FORMAT_LE, FORMAT_REV)
 
     def __init__(self, name, default, uuid_fmt=FORMAT_BE):
+        # type: (str, Optional[int], int) -> None
         self.uuid_fmt = uuid_fmt
         self._check_uuid_fmt()
         Field.__init__(self, name, default, "16s")
 
     def _check_uuid_fmt(self):
+        # type: () -> None
         """Checks .uuid_fmt, and raises an exception if it is not valid."""
         if self.uuid_fmt not in UUIDField.FORMATS:
             raise FieldValueRangeException(
                 "Unsupported uuid_fmt ({})".format(self.uuid_fmt))
 
     def i2m(self, pkt, x):
+        # type: (Optional[BasePacket], Optional[UUID]) -> bytes
         self._check_uuid_fmt()
         if x is None:
             return b'\0' * 16
@@ -2680,8 +3348,14 @@ class UUIDField(Field):
             return x.bytes_le
         elif self.uuid_fmt == UUIDField.FORMAT_REV:
             return x.bytes[::-1]
+        else:
+            raise FieldAttributeException("Unknown fmt")
 
-    def m2i(self, pkt, x):
+    def m2i(self,
+            pkt,  # type: Optional[BasePacket]
+            x,  # type: bytes
+            ):
+        # type: (...) -> UUID
         self._check_uuid_fmt()
         if self.uuid_fmt == UUIDField.FORMAT_BE:
             return UUID(bytes=x)
@@ -2689,15 +3363,21 @@ class UUIDField(Field):
             return UUID(bytes_le=x)
         elif self.uuid_fmt == UUIDField.FORMAT_REV:
             return UUID(bytes=x[::-1])
+        else:
+            raise FieldAttributeException("Unknown fmt")
 
-    def any2i(self, pkt, x):
+    def any2i(self,
+              pkt,  # type: Optional[BasePacket]
+              x  # type: Any  # noqa: E501
+              ):
+        # type: (...) -> Optional[UUID]
         # Python's uuid doesn't handle bytearray, so convert to an immutable
         # type first.
         if isinstance(x, bytearray):
-            x = bytes(x)
+            x = bytes_encode(x)
 
-        if isinstance(x, six.integer_types):
-            x = UUID(int=x)
+        if isinstance(x, int):
+            u = UUID(int=x)
         elif isinstance(x, tuple):
             if len(x) == 11:
                 # For compatibility with dce_rpc: this packs into a tuple where
@@ -2708,21 +3388,26 @@ class UUIDField(Field):
 
                 x = (x[0], x[1], x[2], x[3], x[4], node)
 
-            x = UUID(fields=x)
-        elif isinstance(x, (six.binary_type, six.text_type)):
+            u = UUID(fields=x)
+        elif isinstance(x, (str, bytes)):
             if len(x) == 16:
                 # Raw bytes
-                x = self.m2i(pkt, x)
+                u = self.m2i(pkt, bytes_encode(x))
             else:
-                x = UUID(plain_str(x))
-        return x
+                u = UUID(plain_str(x))
+        elif isinstance(x, UUID):
+            u = x
+        else:
+            return None
+        return u
 
     @staticmethod
     def randval():
+        # type: () -> RandUUID
         return RandUUID()
 
 
-class BitExtendedField(Field):
+class BitExtendedField(Field[Optional[int], bytes]):
     """
     Bit Extended Field
 
@@ -2741,6 +3426,7 @@ class BitExtendedField(Field):
     __slots__ = ["extension_bit"]
 
     def prepare_byte(self, x):
+        # type: (int) -> int
         # Moves the forwarding bit to the LSB
         x = int(x)
         fx_bit = (x & 2**self.extension_bit) >> self.extension_bit
@@ -2749,7 +3435,8 @@ class BitExtendedField(Field):
         x = (msb_bits << (self.extension_bit + 1)) + (lsb_bits << 1) + fx_bit
         return x
 
-    def str2extended(self, x=""):
+    def str2extended(self, x=b""):
+        # type: (bytes) -> Tuple[bytes, Optional[int]]
         # For convenience, we reorder the byte so that the forwarding
         # bit is always the LSB. We then apply the same algorithm
         # whatever the real forwarding bit position
@@ -2771,11 +3458,14 @@ class BitExtendedField(Field):
         if end is None:
             # We reached the end of the data but there was no
             # "ending bit". This is not normal.
-            return None, None
+            return b"", None
         else:
             return end, bits
 
     def extended2str(self, x):
+        # type: (Optional[int]) -> bytes
+        if x is None:
+            return b""
         x = int(x)
         s = []
         LSByte = True
@@ -2811,29 +3501,36 @@ class BitExtendedField(Field):
         return result
 
     def __init__(self, name, default, extension_bit):
+        # type: (str, Optional[Any], int) -> None
         Field.__init__(self, name, default, "B")
         self.extension_bit = extension_bit
 
     def i2m(self, pkt, x):
+        # type: (Optional[Any], Optional[int]) -> bytes
         return self.extended2str(x)
 
     def m2i(self, pkt, x):
+        # type: (Optional[Any], bytes) -> Optional[int]
         return self.str2extended(x)[1]
 
     def addfield(self, pkt, s, val):
+        # type: (Optional[BasePacket], bytes, Optional[int]) -> bytes
         return s + self.i2m(pkt, val)
 
     def getfield(self, pkt, s):
+        # type: (Optional[Any], bytes) -> Tuple[bytes, Optional[int]]
         return self.str2extended(s)
 
 
 class LSBExtendedField(BitExtendedField):
     # This is a BitExtendedField with the extension bit on LSB
     def __init__(self, name, default):
+        # type: (str, Optional[Any]) -> None
         BitExtendedField.__init__(self, name, default, extension_bit=0)
 
 
 class MSBExtendedField(BitExtendedField):
     # This is a BitExtendedField with the extension bit on MSB
     def __init__(self, name, default):
+        # type: (str, Optional[Any]) -> None
         BitExtendedField.__init__(self, name, default, extension_bit=7)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2151,15 +2151,29 @@ class BitField(_BitField[int]):
 class BitFixedLenField(BitField):
     __slots__ = ["length_from"]
 
-    def __init__(self, name, default, length_from):
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: int
+                 length_from  # type: Callable[[BasePacket], int]
+                 ):
+        # type: (...) -> None
         self.length_from = length_from
         super(BitFixedLenField, self).__init__(name, default, 0)
 
-    def getfield(self, pkt, s):
+    def getfield(self,  # type: ignore
+                 pkt,  # type: BasePacket
+                 s,  # type: Union[Tuple[bytes, int], bytes]
+                 ):
+        # type: (...) -> Union[Tuple[Tuple[bytes, int], int], Tuple[bytes, int]]  # noqa: E501
         self.size = self.length_from(pkt)
         return super(BitFixedLenField, self).getfield(pkt, s)
 
-    def addfield(self, pkt, s, val):
+    def addfield(self,  # type: ignore
+                 pkt,  # type: BasePacket
+                 s,  # type: Union[Tuple[bytes, int, int], bytes]
+                 val  # type: int
+                 ):
+        # type: (...) -> Union[Tuple[bytes, int, int], bytes]
         self.size = self.length_from(pkt)
         return super(BitFixedLenField, self).addfield(pkt, s, val)
 
@@ -3164,7 +3178,7 @@ class _ScalingField(object):
         self.unit = unit
         self.offset = offset
         self.ndigits = ndigits
-        Field.__init__(self, name, default, fmt)
+        Field.__init__(self, name, default, fmt)  # type: ignore
 
     def i2m(self,
             pkt,  # type: Optional[BasePacket]
@@ -3174,21 +3188,21 @@ class _ScalingField(object):
         if x is None:
             x = 0
         x = (x - self.offset) / self.scaling
-        if isinstance(x, float) and self.fmt[-1] != "f":
+        if isinstance(x, float) and self.fmt[-1] != "f":  # type: ignore
             x = int(round(x))
         return x
 
     def m2i(self, pkt, x):
         # type: (Optional[BasePacket], Union[int, float]) -> Union[int, float]
         x = x * self.scaling + self.offset
-        if isinstance(x, float) and self.fmt[-1] != "f":
+        if isinstance(x, float) and self.fmt[-1] != "f":  # type: ignore
             x = round(x, self.ndigits)
         return x
 
     def any2i(self, pkt, x):
         # type: (Optional[BasePacket], Any) -> Union[int, float]
         if isinstance(x, (str, bytes)):
-            x = struct.unpack(self.fmt, bytes_encode(x))[0]
+            x = struct.unpack(self.fmt, bytes_encode(x))[0]  # type: ignore
             x = self.m2i(pkt, x)
         if not isinstance(x, (int, float)):
             raise ValueError("Unknown type")
@@ -3196,11 +3210,14 @@ class _ScalingField(object):
 
     def i2repr(self, pkt, x):
         # type: (Optional[BasePacket], Union[int, float]) -> str
-        return "%s %s" % (self.i2h(pkt, x), self.unit)
+        return "%s %s" % (
+            self.i2h(pkt, x),  # type: ignore
+            self.unit
+        )
 
     def randval(self):
         # type: () -> RandFloat
-        value = super(ScalingField, self).randval()
+        value = Field.randval(self)  # type: ignore
         if value is not None:
             min_val = round(value.min * self.scaling + self.offset,
                             self.ndigits)
@@ -3252,13 +3269,15 @@ class ScalingField(_ScalingField,
        :param fmt: struct.pack format used to parse and serialize the internal value from and to machine representation # noqa: E501
        """
 
-class BitScalingField(_ScalingField, BitField):
+
+class BitScalingField(_ScalingField, BitField):  # type: ignore
     """
     A ScalingField that is a BitField
     """
     def __init__(self, name, default, size, *args, **kwargs):
+        # type: (str, int, int, *Any, **Any) -> None
         _ScalingField.__init__(self, name, default, *args, **kwargs)
-        BitField.__init__(self, name, default, size)
+        BitField.__init__(self, name, default, size)  # type: ignore
 
 
 class UUIDField(Field[UUID, bytes]):

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -63,7 +63,6 @@ from scapy.fields import (
     X3BytesField,
     XByteField,
     XStrFixedLenField,
-    _BitField,
 )
 from scapy.ansmachine import AnsweringMachine
 from scapy.plist import PacketList

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -63,6 +63,7 @@ from scapy.fields import (
     X3BytesField,
     XByteField,
     XStrFixedLenField,
+    _BitField,
 )
 from scapy.ansmachine import AnsweringMachine
 from scapy.plist import PacketList

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -36,7 +36,7 @@ from scapy.fields import ConditionalField, IPField, BitField, BitEnumField, \
 from scapy.packet import Packet, bind_layers, bind_bottom_up, NoPayload
 from scapy.volatile import RandShort, RandInt, RandBin, RandNum, VolatileValue
 from scapy.sendrecv import sr, sr1
-from scapy.plist import PacketList, SndRcvList
+from scapy.plist import _PacketList, PacketList, SndRcvList
 from scapy.automaton import Automaton, ATMT
 from scapy.error import log_runtime, warning
 from scapy.pton_ntop import inet_pton
@@ -1205,7 +1205,7 @@ def _packetlist_timeskew_graph(self, ip, **kargs):
     return lines
 
 
-PacketList.timeskew_graph = _packetlist_timeskew_graph
+_PacketList.timeskew_graph = _packetlist_timeskew_graph
 
 
 # Create a new packet list

--- a/scapy/layers/sixlowpan.py
+++ b/scapy/layers/sixlowpan.py
@@ -967,7 +967,7 @@ class LoWPAN_NHC(Packet):
     name = "LOWPAN_NHC"
     fields_desc = [
         PacketListField(
-            "exts", [], cls=LoWPAN_NHC_Hdr,
+            "exts", [], pkt_cls=LoWPAN_NHC_Hdr,
             next_cls_cb=lambda *s: LoWPAN_NHC_Hdr.get_next_cls(s[3])
         )
     ]

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -76,7 +76,7 @@ class _TLSMsgListField(PacketListField):
     def __init__(self, name, default, length_from=None):
         if not length_from:
             length_from = self._get_length
-        super(_TLSMsgListField, self).__init__(name, default, cls=None,
+        super(_TLSMsgListField, self).__init__(name, default, None,
                                                length_from=length_from)
 
     def _get_length(self, pkt):

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -34,7 +34,15 @@ import scapy.modules.six as six
 from scapy.themes import DefaultTheme, BlackAndWhite, apply_ipython_style
 from scapy.consts import WINDOWS
 
-from scapy.compat import cast, Any, Dict, List, Optional, Tuple, Union
+from scapy.compat import (
+    cast,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union
+)
 
 IGNORED = list(six.moves.builtins.__dict__)
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -15,8 +15,8 @@ from collections import defaultdict
 
 from scapy.compat import lambda_tuple_converter
 from scapy.config import conf
-from scapy.base_classes import BasePacket, BasePacketList, _CanvasDumpExtended
-from scapy.fields import IPField, ShortEnumField, PacketField
+from scapy.base_classes import BasePacket, BasePacketList, \
+    _CanvasDumpExtended, Packet_metaclass, PacketList_metaclass
 from scapy.utils import do_graph, hexdump, make_table, make_lined_table, \
     make_tex_table, issubtype
 from scapy.extlib import plt, Line2D, \
@@ -24,17 +24,41 @@ from scapy.extlib import plt, Line2D, \
 from functools import reduce
 import scapy.modules.six as six
 from scapy.modules.six.moves import range, zip
-from scapy.compat import Optional, List, Union, Tuple, Dict, Any, Callable
+
+# typings
+from scapy.compat import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from scapy.packet import Packet
+
+
 #############
 #  Results  #
 #############
 
+_Inner = TypeVar("_Inner", Packet, Tuple[Packet, Packet])
 
-class PacketList(BasePacketList, _CanvasDumpExtended):
+
+@six.add_metaclass(PacketList_metaclass)
+class _PacketList(Generic[_Inner]):
     __slots__ = ["stats", "res", "listname"]
 
-    def __init__(self, res=None, name="PacketList", stats=None):
+    def __init__(self,
+                 res=None,  # type: Optional[Union[_PacketList[_Inner], List[_Inner]]]  # noqa: E501
+                 name="PacketList",  # type: str
+                 stats=None  # type: Optional[List[Packet_metaclass]]
+                 ):
+        # type: (...) -> None
         """create a packet list from a list of packets
            res: the list of packets
            stats: a list of classes that will appear in the stats (defaults to [TCP,UDP,ICMP])"""  # noqa: E501
@@ -42,10 +66,11 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
             stats = conf.stats_classic_protocols
         self.stats = stats
         if res is None:
-            res = []
-        elif isinstance(res, PacketList):
-            res = res.res
-        self.res = res
+            self.res = []  # type: List[_Inner]
+        elif isinstance(res, _PacketList):
+            self.res = res.res
+        else:
+            self.res = res
         self.listname = name
 
     def __len__(self):
@@ -53,15 +78,15 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         return len(self.res)
 
     def _elt2pkt(self, elt):
-        # type: (Packet) -> Packet
-        return elt
+        # type: (_Inner) -> Packet
+        return elt  # type: ignore
 
     def _elt2sum(self, elt):
-        # type: (Packet) -> str
-        return elt.summary()
+        # type: (_Inner) -> str
+        return elt.summary()  # type: ignore
 
     def _elt2show(self, elt):
-        # type: (Packet) -> str
+        # type: (_Inner) -> str
         return self._elt2sum(elt)
 
     def __repr__(self):
@@ -93,7 +118,7 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                                ct.punct(">"))
 
     def __getstate__(self):
-        # type: () -> Dict[str, Union[List[PacketField], List[Packet], str]]
+        # type: () -> Dict[str, Any]
         """
         Creates a basic representation of the instance, used in
         conjunction with __setstate__() e.g. by pickle
@@ -108,7 +133,7 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         return state
 
     def __setstate__(self, state):
-        # type: (Dict[str, Union[List[PacketField], List[Packet], str]]) -> None  # noqa: E501
+        # type: (Dict[str, Any]) -> None
         """
         Sets instance attributes to values given by state, used in
         conjunction with __getstate__() e.g. by pickle
@@ -119,11 +144,16 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         self.stats = state['stats']
         self.listname = state['listname']
 
+    def __iter__(self):
+        # type: () -> Iterator[_Inner]
+        return self.res.__iter__()
+
     def __getattr__(self, attr):
         # type: (str) -> Any
         return getattr(self.res, attr)
 
     def __getitem__(self, item):
+        # type: (Any) -> Any
         if issubtype(item, BasePacket):
             return self.__class__([x for x in self.res if item in self._elt2pkt(x)],  # noqa: E501
                                   name="%s from %s" % (item.__name__, self.listname))  # noqa: E501
@@ -133,12 +163,15 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         return self.res.__getitem__(item)
 
     def __add__(self, other):
-        # type: (PacketList) -> PacketList
+        # type: (_PacketList[_Inner]) -> _PacketList[_Inner]
         return self.__class__(self.res + other.res,
                               name="%s+%s" % (self.listname, other.listname))
 
-    def summary(self, prn=None, lfilter=None):
-        # type: (Optional[Callable], Optional[Callable]) -> None
+    def summary(self,
+                prn=None,  # type: Optional[Callable[..., Any]]
+                lfilter=None  # type: Optional[Callable[..., bool]]
+                ):
+        # type: (...) -> None
         """prints a summary of each packet
 
         :param prn: function to apply to each packet instead of
@@ -159,8 +192,11 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
             else:
                 print(prn(*r))
 
-    def nsummary(self, prn=None, lfilter=None):
-        # type: (Optional[Callable], Optional[Callable]) -> None
+    def nsummary(self,
+                 prn=None,  # type: Optional[Callable[..., Any]]
+                 lfilter=None  # type: Optional[Callable[..., bool]]
+                 ):
+        # type: (...) -> None
         """prints a summary of each packet with the packet's number
 
         :param prn: function to apply to each packet instead of
@@ -183,14 +219,16 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                 print(prn(*res))
 
     def show(self, *args, **kargs):
-        # type: (Any, Any) -> None
+        # type: (*Any, **Any) -> None
         """Best way to display the packet list. Defaults to nsummary() method"""  # noqa: E501
         return self.nsummary(*args, **kargs)
 
     def filter(self, func):
-        # type: (Callable) -> PacketList
+        # type: (Callable[..., bool]) -> _PacketList[_Inner]
         """Returns a packet list filtered by a truth function. This truth
-        function has to take a packet as the only argument and return a boolean value."""  # noqa: E501
+        function has to take a packet as the only argument and return
+        a boolean value.
+        """
         # Python 2 backward compatibility
         func = lambda_tuple_converter(func)
 
@@ -198,23 +236,28 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                               name="filtered %s" % self.listname)
 
     def make_table(self, *args, **kargs):
-        # type: (Any, Any) -> None
+        # type: (Any, Any) -> Optional[str]
         """Prints a table using a function that returns for each packet its head column value, head row value and displayed value  # noqa: E501
         ex: p.make_table(lambda x:(x[IP].dst, x[TCP].dport, x[TCP].sprintf("%flags%")) """  # noqa: E501
-        return make_table(self.res, *args, **kargs)
+        return make_table(self.res, *args, **kargs)  # type: ignore
 
     def make_lined_table(self, *args, **kargs):
-        # type: (Any, Any) -> None
+        # type: (Any, Any) -> Optional[str]
         """Same as make_table, but print a table with lines"""
-        return make_lined_table(self.res, *args, **kargs)
+        return make_lined_table(self.res, *args, **kargs)  # type: ignore
 
     def make_tex_table(self, *args, **kargs):
-        # type: (Any, Any) -> None
+        # type: (Any, Any) -> Optional[str]
         """Same as make_table, but print a table with LaTeX syntax"""
-        return make_tex_table(self.res, *args, **kargs)
+        return make_tex_table(self.res, *args, **kargs)  # type: ignore
 
-    def plot(self, f, lfilter=None, plot_xy=False, **kargs):
-        # type: (Callable, Optional[Callable], bool, Any) -> Line2D
+    def plot(self,
+             f,  # type: Callable[..., Any]
+             lfilter=None,  # type: Optional[Callable[..., bool]]
+             plot_xy=False,  # type: bool
+             **kargs  # type: Any
+             ):
+        # type: (...) -> Line2D
         """Applies a function to each packet to get a value that will be plotted
         with matplotlib. A list of matplotlib.lines.Line2D is returned.
 
@@ -245,8 +288,13 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
 
         return lines
 
-    def diffplot(self, f, delay=1, lfilter=None, **kargs):
-        # type: (Callable, int, Optional[Callable], Any) -> Line2D
+    def diffplot(self,
+                 f,  # type: Callable[..., Any]
+                 delay=1,  # type: int
+                 lfilter=None,  # type: Optional[Callable[..., bool]]
+                 **kargs  # type: Any
+                 ):
+        # type: (...) -> Line2D
         """diffplot(f, delay=1, lfilter=None)
         Applies a function to couples (l[i],l[i+delay])
 
@@ -273,8 +321,13 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
 
         return lines
 
-    def multiplot(self, f, lfilter=None, plot_xy=False, **kargs):
-        # type: (Callable, Optional[Callable], bool, Any) -> Line2D
+    def multiplot(self,
+                  f,  # type: Callable[..., Any]
+                  lfilter=None,  # type: Optional[Callable[..., Any]]
+                  plot_xy=False,  # type: bool
+                  **kargs  # type: Any
+                  ):
+        # type: (...) -> Line2D
         """Uses a function that returns a label and a value for this label, then
         plots all the values label by label.
 
@@ -315,13 +368,13 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         return lines
 
     def rawhexdump(self):
-        # type: (Optional[Callable]) -> None
+        # type: () -> None
         """Prints an hexadecimal dump of each packet in the list"""
         for p in self:
             hexdump(self._elt2pkt(p))
 
     def hexraw(self, lfilter=None):
-        # type: (Optional[Callable]) -> None
+        # type: (Optional[Callable[..., bool]]) -> None
         """Same as nsummary(), except that if a packet has a Raw layer, it will be hexdumped  # noqa: E501
         lfilter: a truth function that decides whether a packet must be displayed"""  # noqa: E501
         for i, res in enumerate(self.res):
@@ -332,10 +385,10 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                                 p.sprintf("%.time%"),
                                 self._elt2sum(res)))
             if p.haslayer(conf.raw_layer):
-                hexdump(p.getlayer(conf.raw_layer).load)
+                hexdump(p.getlayer(conf.raw_layer).load)  # type: ignore
 
     def hexdump(self, lfilter=None):
-        # type: (Optional[Callable]) -> None
+        # type: (Optional[Callable[..., bool]]) -> None
         """Same as nsummary(), except that packets are also hexdumped
         lfilter: a truth function that decides whether a packet must be displayed"""  # noqa: E501
         for i, res in enumerate(self.res):
@@ -348,7 +401,7 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
             hexdump(p)
 
     def padding(self, lfilter=None):
-        # type: (Optional[Callable]) -> None
+        # type: (Optional[Callable[..., bool]]) -> None
         """Same as hexraw(), for Padding layer"""
         for i, res in enumerate(self.res):
             p = self._elt2pkt(res)
@@ -357,24 +410,32 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                     print("%s %s %s" % (conf.color_theme.id(i, fmt="%04i"),
                                         p.sprintf("%.time%"),
                                         self._elt2sum(res)))
-                    hexdump(p.getlayer(conf.padding_layer).load)
+                    hexdump(
+                        p.getlayer(conf.padding_layer).load  # type: ignore
+                    )
 
     def nzpadding(self, lfilter=None):
-        # type: (Optional[Callable]) -> None
+        # type: (Optional[Callable[..., bool]]) -> None
         """Same as padding() but only non null padding"""
         for i, res in enumerate(self.res):
             p = self._elt2pkt(res)
             if p.haslayer(conf.padding_layer):
-                pad = p.getlayer(conf.padding_layer).load
+                pad = p.getlayer(conf.padding_layer).load  # type: ignore
                 if pad == pad[0] * len(pad):
                     continue
                 if lfilter is None or lfilter(p):
                     print("%s %s %s" % (conf.color_theme.id(i, fmt="%04i"),
                                         p.sprintf("%.time%"),
                                         self._elt2sum(res)))
-                    hexdump(p.getlayer(conf.padding_layer).load)
+                    hexdump(
+                        p.getlayer(conf.padding_layer).load  # type: ignore
+                    )
 
-    def conversations(self, getsrcdst=None, **kargs):
+    def conversations(self,
+                      getsrcdst=None,  # type: Optional[Callable[[Packet], Tuple[Any, ...]]]  # noqa: E501
+                      **kargs  # type: Any
+                      ):
+        # type: (...) -> Any
         """Graphes a conversations between sources and destinations and display it
         (using graphviz and imagemagick)
 
@@ -389,7 +450,8 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         :param prog: which graphviz program to use
         """
         if getsrcdst is None:
-            def getsrcdst(pkt):
+            def _getsrcdst(pkt):
+                # type: (Packet) -> Tuple[str, str]
                 """Extract src and dst addresses"""
                 if 'IP' in pkt:
                     return (pkt['IP'].src, pkt['IP'].dst)
@@ -398,7 +460,8 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                 if 'ARP' in pkt:
                     return (pkt['ARP'].psrc, pkt['ARP'].pdst)
                 raise TypeError()
-        conv = {}
+            getsrcdst = _getsrcdst
+        conv = {}  # type: Dict[Tuple[Any, ...], Any]
         for p in self.res:
             p = self._elt2pkt(p)
             try:
@@ -422,20 +485,25 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         gr += "}\n"
         return do_graph(gr, **kargs)
 
-    def afterglow(self, src=None, event=None, dst=None, **kargs):
-        # type: (Optional[Callable], Optional[Callable], Optional[Callable], Any) -> None  # noqa: E501
+    def afterglow(self,
+                  src=None,  # type: Optional[Callable[[_Inner], Any]]
+                  event=None,  # type: Optional[Callable[[_Inner], Any]]
+                  dst=None,  # type: Optional[Callable[[_Inner], Any]]
+                  **kargs  # type: Any
+                  ):
+        # type: (...) -> Any
         """Experimental clone attempt of http://sourceforge.net/projects/afterglow
         each datum is reduced as src -> event -> dst and the data are graphed.
         by default we have IP.src -> IP.dport -> IP.dst"""
         if src is None:
-            src = lambda x: x['IP'].src
+            src = lambda *x: x[0]['IP'].src
         if event is None:
-            event = lambda x: x['IP'].dport
+            event = lambda *x: x[0]['IP'].dport
         if dst is None:
-            dst = lambda x: x['IP'].dst
-        sl = {}  # type: Dict[IPField, Tuple[int, List[ShortEnumField]]]
-        el = {}  # type: Dict[ShortEnumField, Tuple[int, List[IPField]]]
-        dl = {}  # type: Dict[IPField, ShortEnumField]
+            dst = lambda *x: x[0]['IP'].dst
+        sl = {}  # type: Dict[Any, Tuple[Union[float, int], List[Any]]]
+        el = {}  # type: Dict[Any, Tuple[Union[float, int], List[Any]]]
+        dl = {}  # type: Dict[Any, int]
         for i in self.res:
             try:
                 s, e, d = src(i), event(i), dst(i)
@@ -460,6 +528,7 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                 continue
 
         def minmax(x):
+            # type: (Any) -> Tuple[int, int]
             m, M = reduce(lambda a, b: (min(a[0], b[0]), max(a[1], b[1])),
                           ((a, a) for a in x))
             if m == M:
@@ -491,12 +560,12 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
 
         gr += "###\n"
         for s in sl:
-            n, lst = sl[s]
-            for e in lst:
+            n, lst1 = sl[s]
+            for e in lst1:
                 gr += ' "src.%s" -> "evt.%s";\n' % (repr(s), repr(e))
         for e in el:
-            n, lst = el[e]
-            for d in lst:
+            n, lst2 = el[e]
+            for d in lst2:
                 gr += ' "evt.%s" -> "dst.%s";\n' % (repr(e), repr(d))
 
         gr += "}"
@@ -518,37 +587,14 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                                        fittosize=1))
         return d
 
-    def sr(self, multi=0):
-        # type: (int) -> Tuple[SndRcvList, PacketList]
-        """sr([multi=1]) -> (SndRcvList, PacketList)
-        Matches packets in the list and return ( (matched couples), (unmatched packets) )"""  # noqa: E501
-        remain = self.res[:]
-        sr = []
-        i = 0
-        while i < len(remain):
-            s = remain[i]
-            j = i
-            while j < len(remain) - 1:
-                j += 1
-                r = remain[j]
-                if r.answers(s):
-                    sr.append((s, r))
-                    if multi:
-                        remain[i]._answered = 1
-                        remain[j]._answered = 2
-                        continue
-                    del(remain[j])
-                    del(remain[i])
-                    i -= 1
-                    break
-            i += 1
-        if multi:
-            remain = [x for x in remain if not hasattr(x, "_answered")]
-        return SndRcvList(sr), PacketList(remain)
-
-    def sessions(self, session_extractor=None):
+    def sessions(
+            self,
+            session_extractor=None  # type: Optional[Callable[[Packet], str]]
+    ):
+        # type: (...) -> Dict[str, _PacketList[_Inner]]
         if session_extractor is None:
-            def session_extractor(p):
+            def _session_extractor(p):
+                # type: (Packet) -> str
                 """Extract sessions from packets"""
                 if 'Ether' in p:
                     if 'IP' in p or 'IPv6' in p:
@@ -575,9 +621,12 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
                     else:
                         return p.sprintf("Ethernet type=%04xr,Ether.type%")
                 return "Other"
-        sessions = defaultdict(self.__class__)
+            session_extractor = _session_extractor
+        sessions = defaultdict(self.__class__)  # type: DefaultDict[str, _PacketList[_Inner]]  # noqa: E501
         for p in self.res:
-            sess = session_extractor(self._elt2pkt(p))
+            sess = session_extractor(
+                self._elt2pkt(p)
+            )
             sessions[sess].append(p)
         return dict(sessions)
 
@@ -596,8 +645,8 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
         x = PacketList(name="Replaced %s" % self.listname)
         if not isinstance(args[0], tuple):
             args = (args,)
-        for p in self.res:
-            p = self._elt2pkt(p)
+        for _p in self.res:
+            p = self._elt2pkt(_p)
             copied = False
             for scheme in args:
                 fld = scheme[0]
@@ -657,8 +706,9 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
 
         # Only return non-None getlayer results
         return PacketList([
-            pc for pc in (p.getlayer(**getlayer_arg) for p in self.res)
-            if pc is not None],
+            pc for pc in (
+                self._elt2pkt(p).getlayer(**getlayer_arg) for p in self.res
+            ) if pc is not None],
             name, stats
         )
 
@@ -687,21 +737,55 @@ class PacketList(BasePacketList, _CanvasDumpExtended):
             stats = self.stats
 
         return PacketList(
-            [p.convert_to(other_cls) for p in self.res],
+            [self._elt2pkt(p).convert_to(other_cls) for p in self.res],
             name, stats
         )
 
 
-class SndRcvList(PacketList):
+class PacketList(_PacketList[Packet],
+                 BasePacketList,
+                 _CanvasDumpExtended):
+    def sr(self, multi=0):
+        # type: (int) -> Tuple[SndRcvList, PacketList]
+        """sr([multi=1]) -> (SndRcvList, PacketList)
+        Matches packets in the list and return ( (matched couples), (unmatched packets) )"""  # noqa: E501
+        remain = self.res[:]
+        sr = []
+        i = 0
+        while i < len(remain):
+            s = remain[i]
+            j = i
+            while j < len(remain) - 1:
+                j += 1
+                r = remain[j]
+                if r.answers(s):
+                    sr.append((s, r))
+                    if multi:
+                        remain[i]._answered = 1
+                        remain[j]._answered = 2
+                        continue
+                    del(remain[j])
+                    del(remain[i])
+                    i -= 1
+                    break
+            i += 1
+        if multi:
+            remain = [x for x in remain if not hasattr(x, "_answered")]
+        return SndRcvList(sr), PacketList(remain)
+
+
+class SndRcvList(_PacketList[Tuple[Packet, Packet]],
+                 BasePacketList,
+                 _CanvasDumpExtended):
     __slots__ = []  # type: List[str]
 
     def __init__(self,
-                 res=None,  # type: Optional[Union[List[Packet], PacketList]]
+                 res=None,  # type: Optional[Union[PacketList, List[Tuple[Packet, Packet]]]]  # noqa: E501
                  name="Results",  # type: str
                  stats=None  # type: Optional[List[Packet]]
                  ):
         # type: (...) -> None
-        PacketList.__init__(self, res, name, stats)
+        super(SndRcvList, self).__init__(res, name, stats)
 
     def _elt2pkt(self, elt):
         # type: (Tuple[Packet, Packet]) -> Packet

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -37,6 +37,10 @@ from scapy.compat import orb, raw, plain_str, chb, bytes_base64,\
 from scapy.error import log_runtime, Scapy_Exception, warning
 from scapy.pton_ntop import inet_pton
 
+from scapy.compat import (
+    Any,
+)
+
 ###########
 #  Tools  #
 ###########
@@ -190,6 +194,7 @@ def restart():
 
 
 def lhex(x):
+    # type: (Any) -> str
     from scapy.volatile import VolatileValue
     if isinstance(x, VolatileValue):
         return repr(x)
@@ -200,7 +205,7 @@ def lhex(x):
     elif isinstance(x, list):
         return "[%s]" % ", ".join(map(lhex, x))
     else:
-        return x
+        return str(x)
 
 
 @conf.commands.register

--- a/test/dnssecRR.uts
+++ b/test/dnssecRR.uts
@@ -141,6 +141,6 @@ raw(t) == b"\nSAMPLE-ALG\x07EXAMPLE\x00\x00\xfa\x00\x01\x00\x00\x00\x00\x00\x1b\
 = TimeField methods
 
 packed_data = b"\x00\x002\xe4\x07\x00"
-assert(TimeSignedField("", 0).h2i("", 853804800) == packed_data)
-assert(TimeSignedField("", 0).i2h("", packed_data) == 853804800)
-assert(TimeSignedField("", 0).i2repr("", packed_data) == "Tue Jan 21 00:00:00 1997")
+assert(TimeSignedField("", 0).i2m("", 853804800) == packed_data)
+assert(TimeSignedField("", 0).m2i("", packed_data) == 853804800)
+assert(TimeSignedField("", 0).i2repr("", 853804800) == "Tue Jan 21 00:00:00 1997")


### PR DESCRIPTION
Kick off Hinty (https://github.com/secdev/scapy/issues/2158):
- turn on Mypy strict mode (see [this](https://github.com/secdev/scapy/blob/2a914cf2e29e98adea88ed447e524a9970b2e451/.config/mypy/mypy_check.py#L39))
- add typings to 
  - packet.py
  - fields.py
  - config.py
  - main.py (strict)
  - \_\_init\_\_.py (strict)

**Implementations notes:**
- this tries to be as clean and extensible as possible: we use `Generic` classes to make clean `Field`s. This means any other field that inherits from `Field` will be able to mark what `Internal` and `Machine` types it uses.
- this PR fixes a few type errors that mypy triggered. For instance a function that would crash in `SndRcvList` and was moved to a parent class.
- I refactored `TimeSignedField` because it was easier than cleaning it up.
- This is fully compatible except one single thing: the use of `Generic` makes it impossible to use the keyword `cls=` as a key parameter. This keyword was only used in `PacketListField` (in other places, it was only used as an argument which is fine). Therefore I had to rename it to `pkt_cls`, but it's use was not that widespread because you would typically use it as an argument instead of a key argument.

To reproduce the issue with `Generic`:
```python
from typing import Generic, TypeVar
I = TypeVar("I")
class A(Generic[I]):
    def __init__(self, cls=1):
        pass

A(cls=1)  # Error
```

- **This is a big PR, but had to be done in one go because those files just keep referring to each other.** Making them one by one would mean adding a gazillion temporary `# type: ignore`. I hesitated to also do `utils.py`, but it's honnestly to big on its own and will need a separate PR.
- python 2 compatibility was added, but it's quite a nightmare. See the code. I sometimes wish we had drop it. In any case, when will want to drop it (likely in a few years), we'll have the great [`com2ann`](https://github.com/ilevkivskyi/com2ann) module to do it for us.