### PR TITLE
Fix deprecated code examples in usage.rst

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -384,7 +384,7 @@ The above will send a single SYN packet to Google's port 80 and will quit after 
 
 From the above output, we can see Google returned “SA” or SYN-ACK flags indicating an open port.
 
-Use either notations to scan ports 400 through 443 on the system:
+Use either notations to scan ports 440 through 443 on the system:
 
     >>> sr(IP(dst="192.168.1.1")/TCP(sport=666,dport=(440,443),flags="S"))
 
@@ -403,11 +403,13 @@ In order to quickly review responses simply request a summary of collected packe
 
 The above will display stimulus/response pairs for answered probes. We can display only the information we are interested in by using a simple loop:
 
-    >>> ans.summary( lambda s,r: r.sprintf("%TCP.sport% \t %TCP.flags%") )
+    >>> ans.summary( lambda sar: sar[1].sprintf("%TCP.sport% \t %TCP.flags%") )
     440      RA
     441      RA
     442      RA
     https    SA
+
+Note: "sar" stands for "sent and received", sar[0] is the sent packet, and sar[1] is the received packet.  
 
 Even better, a table can be built using the ``make_table()`` function to display information about multiple targets::
 
@@ -417,8 +419,8 @@ Even better, a table can be built using the ``make_table()`` function to display
     **.*.*..*..................
     Received 362 packets, got 8 answers, remaining 1 packets
     >>> ans.make_table(
-    ...    lambda s,r: (s.dst, s.dport,
-    ...    r.sprintf("{TCP:%TCP.flags%}{ICMP:%IP.src% - %ICMP.type%}")))
+    ...    lambda sar: (sar[0].dst, sar[0].dport,
+    ...    sar[1].sprintf("{TCP:%TCP.flags%}{ICMP:%IP.src% - %ICMP.type%}")))
         66.35.250.150                192.168.1.1 216.109.112.135 
     22  66.35.250.150 - dest-unreach RA          -               
     80  SA                           RA          SA              
@@ -428,18 +430,18 @@ The above example will even print the ICMP error type if the ICMP packet was rec
 
 For larger scans, we could be interested in displaying only certain responses. The example below will only display packets with the “SA” flag set::
 
-    >>> ans.nsummary(lfilter = lambda s,r: r.sprintf("%TCP.flags%") == "SA")
+    >>> ans.nsummary(lfilter = lambda sar: sar[1].sprintf("%TCP.flags%") == "SA")
     0003 IP / TCP 192.168.1.100:ftp_data > 192.168.1.1:https S ======> IP / TCP 192.168.1.1:https > 192.168.1.100:ftp_data SA
 
 In case we want to do some expert analysis of responses, we can use the following command to indicate which ports are open::
 
-    >>> ans.summary(lfilter = lambda s,r: r.sprintf("%TCP.flags%") == "SA",prn=lambda s,r: r.sprintf("%TCP.sport% is open"))
+    >>> ans.summary(lfilter = lambda sar: r[1].sprintf("%TCP.flags%") == "SA",prn=lambda sar: sar[1].sprintf("%TCP.sport% is open"))
     https is open
 
 Again, for larger scans we can build a table of open ports::
 
-    >>> ans.filter(lambda s,r: TCP in r and r[TCP].flags&2).make_table(lambda s,r:
-    ...             (s.dst, s.dport, "X"))
+    >>> ans.filter(lambda sar: TCP in sar[1] and sar[1][TCP].flags&2).make_table(lambda sar:
+    ...             (sar[0].dst, sar[0].dport, "X"))
         66.35.250.150 192.168.1.1 216.109.112.135 
     80  X             -           X               
     443 X             X           X
@@ -980,7 +982,7 @@ Here we can see a multi-parallel traceroute (Scapy already has a multi TCP trace
 
     >>> ans, unans = sr(IP(dst="www.test.fr/30", ttl=(1,6))/TCP())
     Received 49 packets, got 24 answers, remaining 0 packets
-    >>> ans.make_table( lambda s,r: (s.dst, s.ttl, r.src) )
+    >>> ans.make_table( lambda sar: (sar[0].dst, sar[0].ttl, sar[1].src) )
       216.15.189.192  216.15.189.193  216.15.189.194  216.15.189.195  
     1 192.168.8.1     192.168.8.1     192.168.8.1     192.168.8.1     
     2 81.57.239.254   81.57.239.254   81.57.239.254   81.57.239.254   
@@ -995,7 +997,7 @@ Here is a more complex example to distinguish machines or their IP stacks from t
 
     >>> ans, unans = sr(IP(dst="172.20.80.192/28")/TCP(dport=[20,21,22,25,53,80]))
     Received 142 packets, got 25 answers, remaining 71 packets
-    >>> ans.make_table(lambda s,r: (s.dst, s.dport, r.sprintf("%IP.id%")))
+    >>> ans.make_table(lambda sar: (sar[0].dst, sar[0].dport, sar[1].sprintf("%IP.id%")))
        172.20.80.196 172.20.80.197 172.20.80.198 172.20.80.200 172.20.80.201 
     20 0             4203          7021          -             11562             
     21 0             4204          7022          -             11563             
@@ -1254,7 +1256,7 @@ The fastest way to discover hosts on a local ethernet network is to use the ARP 
 
 Answers can be reviewed with the following command::
 
-    >>> ans.summary(lambda s,r: r.sprintf("%Ether.src% %ARP.psrc%") )
+    >>> ans.summary(lambda sar: sar[1].sprintf("%Ether.src% %ARP.psrc%") )
 
 Scapy also includes a built-in arping() function which performs similar to the above two commands:
 
@@ -1270,7 +1272,7 @@ Classical ICMP Ping can be emulated using the following command::
 
 Information on live hosts can be collected with the following request::
 
-    >>> ans.summary(lambda s,r: r.sprintf("%IP.src% is alive") )
+    >>> ans.summary(lambda sar: sar[1].sprintf("%IP.src% is alive") )
 
 
 TCP Ping
@@ -1282,7 +1284,7 @@ In cases where ICMP echo requests are blocked, we can still use various TCP Ping
 
 Any response to our probes will indicate a live host. We can collect results with the following command::
 
-    >>> ans.summary( lambda s,r : r.sprintf("%IP.src% is alive") )
+    >>> ans.summary( lambda sar : sar[1].sprintf("%IP.src% is alive") )
 
 
 UDP Ping
@@ -1294,7 +1296,7 @@ If all else fails there is always UDP Ping which will produce ICMP Port unreacha
 
 Once again, results can be collected with this command::
 
-    >>> ans.summary( lambda s,r : r.sprintf("%IP.src% is alive") )
+    >>> ans.summary( lambda sar: sar[1].sprintf("%IP.src% is alive") )
 
 
 DNS Requests
@@ -1377,7 +1379,7 @@ Possible result visualization: open ports
 
 ::
 
-    >>> res.nsummary( lfilter=lambda s,r: (r.haslayer(TCP) and (r.getlayer(TCP).flags & 2)) )
+    >>> res.nsummary( lfilter=lambda sar: (sar[1].haslayer(TCP) and (sar[1].getlayer(TCP).flags & 2)) )
     
     
 IKE Scanning
@@ -1393,7 +1395,7 @@ and receiving the answers::
 
 Visualizing the results in a list::
 
-    >>> res.nsummary(prn=lambda s,r: r.src, lfilter=lambda s,r: r.haslayer(ISAKMP) ) 
+    >>> res.nsummary(prn=lambda sar: sar[1].src, lfilter=lambda sar: sar[1].haslayer(ISAKMP) ) 
     
   
 
@@ -1409,7 +1411,7 @@ TCP SYN traceroute
 
 Results would be::
 
-    >>> ans.summary( lambda s,r: r.sprintf("%IP.src%\t{ICMP:%ICMP.type%}\t{TCP:%TCP.flags%}"))
+    >>> ans.summary( lambda sar: sar[1].sprintf("%IP.src%\t{ICMP:%ICMP.type%}\t{TCP:%TCP.flags%}"))
     192.168.1.1     time-exceeded
     68.86.90.162    time-exceeded
     4.79.43.134     time-exceeded
@@ -1431,7 +1433,7 @@ NTP, etc.) to deserve an answer::
 
 We can visualize the results as a list of routers::
 
-    >>> res.make_table(lambda s,r: (s.dst, s.ttl, r.src))
+    >>> res.make_table(lambda sar: (sar[0].dst, sar[0].ttl, sar[1].src))
 
 
 DNS traceroute


### PR DESCRIPTION
The previous code examples in the documentation resolves in: "TypeError: <lambda>() missing 1 required positional argument: 'r'".

This is because "PEP 3113 -- Removal of Tuple Parameter Unpacking". for more info see [https://www.python.org/dev/peps/pep-3113/](https://www.python.org/dev/peps/pep-3113/).

This pull request updates the docs to resolve this issue.

Additionally, it fixes a minor mistake found at line 387.

Also, I didn't understand if the "Removal of Tuple Parameter Unpacking" affects the rule in CONTRIBUTING.md:

> "lambdas must be written using a single argument when using tuples: use lambda x, y: x + f(y) instead of lambda (x, y): x + f(y)".

So I didn't change CONTRIBUTING.md file, but I'll be happy for more explanation :)