### PR TITLE
DHCPv6 cleanups

### DIFF
--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -545,7 +545,6 @@ class ASN1F_CHOICE(ASN1F_field):
             # we don't want to import ASN1_Packet in this module...
             return self.extract_packet(choice, s)
         elif isinstance(choice, type):
-            # XXX find a way not to instantiate the ASN1F_field
             return choice(self.name, b"").m2i(pkt, s)
         else:
             # XXX check properly if this is an ASN1F_PACKET

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1543,7 +1543,7 @@ class StrNullField(StrField):
     def getfield(self, pkt, s):
         len_str = s.find(b"\x00")
         if len_str < 0:
-            # XXX \x00 not found
+            # \x00 not found: return empty
             return b"", s
         return s[len_str + 1:], self.m2i(pkt, s[:len_str])
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -269,7 +269,7 @@ class _IPv6GuessPayload:
 class IPv6(_IPv6GuessPayload, Packet, IPTools):
     name = "IPv6"
     fields_desc = [BitField("version", 6, 4),
-                   BitField("tc", 0, 8),  # TODO: IPv6, ByteField ?
+                   BitField("tc", 0, 8),
                    BitField("fl", 0, 20),
                    ShortField("plen", None),
                    ByteEnumField("nh", 59, ipv6nh),

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -71,7 +71,6 @@ class Route6:
     # Unlike Scapy's Route.make_route() function, we do not have 'host' and 'net'  # noqa: E501
     # parameters. We only have a 'dst' parameter that accepts 'prefix' and
     # 'prefix/prefixlen' values.
-    # WARNING: Providing a specific device will at the moment not work correctly.  # noqa: E501
     def make_route(self, dst, gw=None, dev=None):
         """Internal function : create a route for 'dst' via 'gw'.
         """
@@ -83,8 +82,6 @@ class Route6:
         if dev is None:
             dev, ifaddr, x = self.route(gw)
         else:
-            # TODO: do better than that
-            # replace that unique address by the list of all addresses
             lifaddr = in6_getifaddr()
             devaddrs = [x for x in lifaddr if x[2] == dev]
             ifaddr = construct_source_candidate_set(prefix, plen, devaddrs)

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -513,8 +513,25 @@ class RandRegExp(RandField):
         self._regexp = regexp
         self._lambda = lambda_
 
+    special_sets = {
+        "[:alnum:]": "[a-zA-Z0-9]",
+        "[:alpha:]": "[a-zA-Z]",
+        "[:ascii:]": "[\x00-\x7F]",
+        "[:blank:]": "[ \t]",
+        "[:cntrl:]": "[\x00-\x1F\x7F]",
+        "[:digit:]": "[0-9]",
+        "[:graph:]": "[\x21-\x7E]",
+        "[:lower:]": "[a-z]",
+        "[:print:]": "[\x20-\x7E]",
+        "[:punct:]": "[!\"\\#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_{|}~]",
+        "[:space:]": "[ \t\r\n\v\f]",
+        "[:upper:]": "[A-Z]",
+        "[:word:]": "[A-Za-z0-9_]",
+        "[:xdigit:]": "[A-Fa-f0-9]",
+    }
+
     @staticmethod
-    def choice_expand(s):  # XXX does not support special sets like (ex ':alnum:')  # noqa: E501
+    def choice_expand(s):
         m = ""
         invert = s and s[0] == "^"
         while True:
@@ -580,10 +597,13 @@ class RandRegExp(RandField):
         index = []
         current = stack
         i = 0
-        ln = len(self._regexp)
+        regexp = self._regexp
+        for k, v in self.special_sets.items():
+            regexp = regexp.replace(k, v)
+        ln = len(regexp)
         interp = True
         while i < ln:
-            c = self._regexp[i]
+            c = regexp[i]
             i += 1
 
             if c == '(':
@@ -632,7 +652,7 @@ class RandRegExp(RandField):
                     current.append(e)
                 interp = True
             elif c == '\\':
-                c = self._regexp[i]
+                c = regexp[i]
                 if c == "s":
                     c = RandChoice(" ", "\t")
                 elif c in "0123456789":

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -11521,6 +11521,9 @@ random.seed(0x2807)
 rex = RandRegExp("[g-v]* @? [0-9]{3} . (g|v)")
 bytes(rex) == ('vmuvr @ 906 \x9e g' if six.PY2 else b'irrtv @ 517 \xc2\xb8 v')
 
+rex = RandRegExp("[:digit:][:space:][:word:]")
+assert re.match(b"\\d\\s\\w", bytes(rex))
+
 = Corrupted(Bytes|Bits)
 
 random.seed(0x2807)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4921,7 +4921,7 @@ raw(DHCP6OptIAAddress()) == b'\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x
 
 = DHCP6OptIAAddress - Basic Dissection
 a = DHCP6OptIAAddress(b'\x00\x05\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-a.optcode == 5 and a.optlen == 24 and a.addr == "::" and a.preflft == 0 and a. validlft == 0 and a.iaaddropts == b""
+a.optcode == 5 and a.optlen == 24 and a.addr == "::" and a.preflft == 0 and a. validlft == 0 and a.iaaddropts == []
 
 = DHCP6OptIAAddress - Instantiation with specific values
 raw(DHCP6OptIAAddress(optlen=0x1111, addr="2222:3333::5555", preflft=0x66666666, validlft=0x77777777, iaaddropts="somestring")) == b'\x00\x05\x11\x11""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomestring'
@@ -4931,7 +4931,7 @@ raw(DHCP6OptIAAddress(addr="2222:3333::5555", preflft=0x66666666, validlft=0x777
 
 = DHCP6OptIAAddress - Dissection with specific values 
 a = DHCP6OptIAAddress(b'\x00\x05\x00"""33\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00UUffffwwwwsomerawing')
-a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts == b"somerawing"
+a.optcode == 5 and a.optlen == 34 and a.addr == "2222:3333::5555" and a.preflft == 0x66666666 and a. validlft == 0x77777777 and a.iaaddropts[0].load == b"somerawing"
 
 
 ############
@@ -5426,18 +5426,18 @@ a.optcode == 28 and a.optlen == 32 and len(a.nispservers) == 2 and a.nispservers
 + Test DHCP6 Option - NIS Domain Name
 
 = DHCP6OptNISDomain - Basic Instantiation
-raw(DHCP6OptNISDomain()) == b'\x00\x1d\x00\x00'
+raw(DHCP6OptNISDomain()) == b'\x00\x1d\x00\x01\x00'
 
 = DHCP6OptNISDomain - Basic Dissection
 a = DHCP6OptNISDomain(b'\x00\x1d\x00\x00')
-a.optcode == 29 and a.optlen == 0 and a.nisdomain == b""
+a.optcode == 29 and a.optlen == 0 and a.nisdomain == b"."
 
 = DHCP6OptNISDomain - Instantiation with one domain name
-raw(DHCP6OptNISDomain(nisdomain="toto.example.org")) == b'\x00\x1d\x00\x11\x04toto\x07example\x03org'
+raw(DHCP6OptNISDomain(nisdomain="toto.example.org")) == b'\x00\x1d\x00\x12\x04toto\x07example\x03org\x00'
 
 = DHCP6OptNISDomain - Dissection with one domain name
 a = DHCP6OptNISDomain(b'\x00\x1d\x00\x11\x04toto\x07example\x03org\x00')
-a.optcode == 29 and a.optlen == 17 and a.nisdomain == b"toto.example.org"
+a.optcode == 29 and a.optlen == 17 and a.nisdomain == b"toto.example.org."
 
 = DHCP6OptNISDomain - Instantiation with one domain with trailing dot
 raw(DHCP6OptNISDomain(nisdomain="toto.example.org.")) == b'\x00\x1d\x00\x12\x04toto\x07example\x03org\x00'
@@ -5448,18 +5448,18 @@ raw(DHCP6OptNISDomain(nisdomain="toto.example.org.")) == b'\x00\x1d\x00\x12\x04t
 + Test DHCP6 Option - NIS+ Domain Name
 
 = DHCP6OptNISPDomain - Basic Instantiation
-raw(DHCP6OptNISPDomain()) == b'\x00\x1e\x00\x00'
+raw(DHCP6OptNISPDomain()) == b'\x00\x1e\x00\x01\x00'
 
 = DHCP6OptNISPDomain - Basic Dissection
 a = DHCP6OptNISPDomain(b'\x00\x1e\x00\x00')
-a.optcode == 30 and a.optlen == 0 and a.nispdomain == b""
+a.optcode == 30 and a.optlen == 0 and a.nispdomain == b"."
 
 = DHCP6OptNISPDomain - Instantiation with one domain name
-raw(DHCP6OptNISPDomain(nispdomain="toto.example.org")) == b'\x00\x1e\x00\x11\x04toto\x07example\x03org'
+raw(DHCP6OptNISPDomain(nispdomain="toto.example.org")) == b'\x00\x1e\x00\x12\x04toto\x07example\x03org\x00'
 
 = DHCP6OptNISPDomain - Dissection with one domain name
-a = DHCP6OptNISPDomain(b'\x00\x1e\x00\x11\x04toto\x07example\x03org\x00')
-a.optcode == 30 and a.optlen == 17 and a.nispdomain == b"toto.example.org"
+a = DHCP6OptNISPDomain(b'\x00\x1e\x00\x12\x04toto\x07example\x03org\x00')
+a.optcode == 30 and a.optlen == 18 and a.nispdomain == b"toto.example.org."
 
 = DHCP6OptNISPDomain - Instantiation with one domain with trailing dot
 raw(DHCP6OptNISPDomain(nispdomain="toto.example.org.")) == b'\x00\x1e\x00\x12\x04toto\x07example\x03org\x00'
@@ -5599,21 +5599,21 @@ a.optcode == 38 and a.optlen == 6 and a.subscriberid == b"someid"
 + Test DHCP6 Option - Client FQDN
 
 = DHCP6OptClientFQDN - Basic Instantiation
-raw(DHCP6OptClientFQDN()) == b"\x00'\x00\x01\x00"
+raw(DHCP6OptClientFQDN()) == b"\x00'\x00\x02\x00\x00"
 
 = DHCP6OptClientFQDN - Basic Dissection
 a = DHCP6OptClientFQDN(b"\x00'\x00\x01\x00")
-a.optcode == 39 and a.optlen == 1 and a.res == 0 and a.flags == 0 and a.fqdn == b""
+a.optcode == 39 and a.optlen == 1 and a.res == 0 and a.flags == 0 and a.fqdn == b"."
 
 = DHCP6OptClientFQDN - Instantiation with various flags combinations
-raw(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x01\x01" and raw(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x01\x02" and raw(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x01\x04" and raw(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x01\x07" and raw(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x01\x06"
+raw(DHCP6OptClientFQDN(flags="S")) == b"\x00'\x00\x02\x01\x00" and raw(DHCP6OptClientFQDN(flags="O")) == b"\x00'\x00\x02\x02\x00" and raw(DHCP6OptClientFQDN(flags="N")) == b"\x00'\x00\x02\x04\x00" and raw(DHCP6OptClientFQDN(flags="SON")) == b"\x00'\x00\x02\x07\x00" and raw(DHCP6OptClientFQDN(flags="ON")) == b"\x00'\x00\x02\x06\x00"
 
 = DHCP6OptClientFQDN - Instantiation with one fqdn 
-raw(DHCP6OptClientFQDN(fqdn="toto.example.org")) == b"\x00'\x00\x12\x00\x04toto\x07example\x03org"
+raw(DHCP6OptClientFQDN(fqdn="toto.example.org")) == b"\x00'\x00\x13\x00\x04toto\x07example\x03org\x00"
 
 = DHCP6OptClientFQDN - Dissection with one fqdn 
 a = DHCP6OptClientFQDN(b"\x00'\x00\x12\x00\x04toto\x07example\x03org\x00")
-a.optcode == 39 and a.optlen == 18 and a.res == 0 and a.flags == 0 and a.fqdn == b"toto.example.org"
+a.optcode == 39 and a.optlen == 18 and a.res == 0 and a.flags == 0 and a.fqdn == b"toto.example.org."
 
 
 ############


### PR DESCRIPTION
Some old PR I forgot

- cleanup some obsolete warnings
- fix some DHCP6 incomplete functions based on the revision of the RFC + specify in inline comments which RFC is used if it wasn't already the case.