### PR TITLE
Implement global & extensible interfaces

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -2,10 +2,10 @@
 # Install on osx
 if [ "$OSTYPE" = "darwin"* ] || [ "$TRAVIS_OS_NAME" = "osx" ]
 then
-  if [ ! -z $SCAPY_USE_PCAPDNET ]
+  if [ ! -z $SCAPY_USE_LIBPCAP ]
   then
     brew update
-    brew install libdnet libpcap
+    brew install libpcap
   fi
 fi
 
@@ -18,7 +18,7 @@ then
 fi
 
 # Make sure libpcap is installed
-if [ ! -z $SCAPY_USE_PCAPDNET ]
+if [ ! -z $SCAPY_USE_LIBPCAP ]
 then
   sudo apt-get -qy install libpcap-dev  || exit 1
 fi

--- a/.config/codespell_ignore.txt
+++ b/.config/codespell_ignore.txt
@@ -12,6 +12,7 @@ fo
 gost
 iff
 inout
+microsof
 mitre
 nd
 negociate

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - os: linux
           python: 3.8
           env:
-            - SCAPY_USE_PCAPDNET=yes TOXENV=py38-linux_root,codecov
+            - SCAPY_USE_LIBPCAP=yes TOXENV=py38-linux_root,codecov
 
         # warnings/deprecations
         - os: linux

--- a/doc/scapy/routing.rst
+++ b/doc/scapy/routing.rst
@@ -20,6 +20,18 @@ Use ``get_if_list()`` to get the interface list
     >>> get_if_list()
     ['lo', 'eth0']
 
+You can also use the :py:attr:`conf.ifaces <scapy.interfaces.NetworkInterfaceDict>` object to get interfaces.
+In this example, the object is first displayed as as column. Then, the :py:attr:`dev_from_index() <scapy.interfaces.NetworkInterfaceDict.dev_from_index>` is used to access the interface at index 2.
+
+.. code-block:: pycon
+
+    >>> conf.ifaces
+    SRC  INDEX  IFACE  IPv4       IPv6                      MAC
+    sys  2      eth0   10.0.0.5   fe80::10a:2bef:dc12:afae  Microsof:12:cb:ef
+    sys  1      lo     127.0.0.1  ::1                       00:00:00:00:00:00
+    >>> conf.ifaces.dev_from_index(2)
+    <NetworkInterface eth0 [UP+BROADCAST+RUNNING+SLAVE]>
+
 IPv4 routes
 -----------
 

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1214,7 +1214,7 @@ Provided that your wireless card and driver are correctly configured for frame i
 
 On Windows, if using Npcap, the equivalent would be to call::
 
-    >>> # Of course, conf.iface can be replaced by any interfaces accessed through IFACES
+    >>> # Of course, conf.iface can be replaced by any interfaces accessed through conf.ifaces
     ... conf.iface.setmonitor(True)
 
 you can have a kind of FakeAP::

--- a/run_scapy.bat
+++ b/run_scapy.bat
@@ -2,10 +2,10 @@
 set PYTHONPATH=%~dp0
 REM shift will not work with %*
 set "_args=%*"
-IF "%1" == "--2" (
+IF "%1" == "-2" (
   set PYTHON=python
   set "_args=%_args:~3%"
-) ELSE IF "%1" == "--3" (
+) ELSE IF "%1" == "-3" (
   set PYTHON=python3
   set "_args=%_args:~3%"
 )

--- a/scapy/all.py
+++ b/scapy/all.py
@@ -14,6 +14,7 @@ from scapy.data import *
 from scapy.error import *
 from scapy.themes import *
 from scapy.arch import *
+from scapy.interfaces import *
 
 from scapy.plist import *
 from scapy.fields import *

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -22,13 +22,8 @@ def str2mac(s):
     return ("%02x:" * 6)[:-1] % tuple(orb(x) for x in s)
 
 
-if not WINDOWS:
-    if not conf.use_pcap:
-        from scapy.arch.bpf.core import get_if_raw_addr
-
-
 def get_if_addr(iff):
-    return inet_ntop(socket.AF_INET, get_if_raw_addr(iff))
+    return inet_ntop(socket.AF_INET, get_if_raw_addr(iff))  # noqa: F405
 
 
 def get_if_hwaddr(iff):
@@ -51,6 +46,8 @@ def get_if_hwaddr(iff):
 # def get_if(iff,cmd):
 # def get_if_index(iff):
 
+from scapy.interfaces import get_working_if # noqa F401
+
 if LINUX:
     from scapy.arch.linux import *  # noqa F403
 elif BSD:
@@ -58,7 +55,7 @@ elif BSD:
     from scapy.arch.bpf.core import *  # noqa F403
     if not conf.use_pcap:
         # Native
-        from scapy.arch.bpf.supersocket import * # noqa F403
+        from scapy.arch.bpf.supersocket import *  # noqa F403
         conf.use_bpf = True
 elif SOLARIS:
     from scapy.arch.solaris import *  # noqa F403
@@ -66,8 +63,6 @@ elif WINDOWS:
     from scapy.arch.windows import *  # noqa F403
     from scapy.arch.windows.native import *  # noqa F403
 
-if conf.iface is None:
-    conf.iface = conf.loopback_name
 
 _set_conf_sockets()  # Apply config
 

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -18,15 +18,23 @@ from scapy.data import ARPHDR_ETHER, ARPHDR_LOOPBACK, IPV6_ADDR_GLOBAL
 from scapy.compat import orb
 
 
+# Duplicated from scapy/utils.py for import reasons
+
 def str2mac(s):
     return ("%02x:" * 6)[:-1] % tuple(orb(x) for x in s)
 
 
 def get_if_addr(iff):
+    """
+    Returns the IPv4 of an interface or "0.0.0.0" if not available
+    """
     return inet_ntop(socket.AF_INET, get_if_raw_addr(iff))  # noqa: F405
 
 
 def get_if_hwaddr(iff):
+    """
+    Returns the MAC (hardware) address of an interface
+    """
     addrfamily, mac = get_if_raw_hwaddr(iff)  # noqa: F405
     if addrfamily in [ARPHDR_ETHER, ARPHDR_LOOPBACK]:
         return str2mac(mac)

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -137,7 +137,10 @@ def get_dev_bpf():
             return (fd, bpf)
         except OSError as ex:
             if ex.errno == 13:  # Permission denied
-                raise Scapy_Exception("Permission denied")
+                raise Scapy_Exception((
+                    "Permission denied: could not open /dev/bpf%i. "
+                    "Make sure to be running Scapy as root ! (sudo)"
+                ) % bpf)
             continue
 
     raise Scapy_Exception("No /dev/bpf handle is available !")

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -7,7 +7,7 @@ Scapy *BSD native support - core
 from __future__ import absolute_import
 
 from ctypes import cdll, cast, pointer
-from ctypes import c_int, c_ulong, c_char_p
+from ctypes import c_int, c_ulong, c_uint, c_char_p, Structure, POINTER
 from ctypes.util import find_library
 import fcntl
 import os
@@ -16,26 +16,52 @@ import socket
 import struct
 import subprocess
 
+import scapy
 from scapy.arch.bpf.consts import BIOCSETF, SIOCGIFFLAGS, BIOCSETIF
-from scapy.arch.common import get_if, compile_filter
+from scapy.arch.common import get_if, compile_filter, _iff_flags
+from scapy.arch.unix import in6_getifaddr
 from scapy.compat import plain_str
 from scapy.config import conf
 from scapy.data import ARPHDR_LOOPBACK, ARPHDR_ETHER
 from scapy.error import Scapy_Exception, warning
+from scapy.interfaces import InterfaceProvider, IFACES, NetworkInterface, \
+    network_name
+from scapy.pton_ntop import inet_ntop
 from scapy.modules.six.moves import range
 
 
 # ctypes definitions
 
 LIBC = cdll.LoadLibrary(find_library("libc"))
+
 LIBC.ioctl.argtypes = [c_int, c_ulong, c_char_p]
 LIBC.ioctl.restype = c_int
 
+# The following is implemented as of Python >= 3.3
+# under socket.*. Remember to use them when dropping Py2.7
+
+# See https://docs.python.org/3/library/socket.html#socket.if_nameindex
+
+
+class if_nameindex(Structure):
+    _fields_ = [("if_index", c_uint),
+                ("if_name", c_char_p)]
+
+
+_ptr_ifnameindex_table = POINTER(if_nameindex * 255)
+
+LIBC.if_nameindex.argtypes = []
+LIBC.if_nameindex.restype = _ptr_ifnameindex_table
+LIBC.if_freenameindex.argtypes = [_ptr_ifnameindex_table]
+LIBC.if_freenameindex.restype = None
 
 # Addresses manipulation functions
 
+
 def get_if_raw_addr(ifname):
     """Returns the IPv4 address configured on 'ifname', packed with inet_pton."""  # noqa: E501
+
+    ifname = network_name(ifname)
 
     # Get ifconfig output
     subproc = subprocess.Popen(
@@ -49,7 +75,7 @@ def get_if_raw_addr(ifname):
     # Get IPv4 addresses
 
     addresses = [
-        line for line in plain_str(stdout).splitlines()
+        line.strip() for line in plain_str(stdout).splitlines()
         if "inet " in line
     ]
 
@@ -69,6 +95,7 @@ def get_if_raw_hwaddr(ifname):
 
     NULL_MAC_ADDRESS = b'\x00' * 6
 
+    ifname = network_name(ifname)
     # Handle the loopback interface separately
     if ifname == conf.loopback_name:
         return (ARPHDR_LOOPBACK, NULL_MAC_ADDRESS)
@@ -85,7 +112,7 @@ def get_if_raw_hwaddr(ifname):
 
     # Get MAC addresses
     addresses = [
-        line for line in plain_str(stdout).splitlines() if (
+        line.strip() for line in plain_str(stdout).splitlines() if (
             "ether" in line or "lladdr" in line or "address" in line
         )
     ]
@@ -108,7 +135,9 @@ def get_dev_bpf():
         try:
             fd = os.open("/dev/bpf%i" % bpf, os.O_RDWR)
             return (fd, bpf)
-        except OSError:
+        except OSError as ex:
+            if ex.errno == 13:  # Permission denied
+                raise Scapy_Exception("Permission denied")
             continue
 
     raise Scapy_Exception("No /dev/bpf handle is available !")
@@ -125,87 +154,87 @@ def attach_filter(fd, bpf_filter, iface):
 
 # Interface manipulation functions
 
-def get_if_list():
-    """Returns a list containing all network interfaces."""
-
-    # Get ifconfig output
-    subproc = subprocess.Popen(
-        [conf.prog.ifconfig],
-        close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    stdout, stderr = subproc.communicate()
-    if subproc.returncode:
-        raise Scapy_Exception("Failed to execute ifconfig: (%s)" %
-                              (plain_str(stderr)))
-
-    interfaces = [
-        line[:line.find(':')] for line in plain_str(stdout).splitlines()
-        if ": flags" in line.lower()
-    ]
-    return interfaces
+def _get_ifindex_list():
+    """
+    Returns a list containing (iface, index)
+    """
+    ptr = LIBC.if_nameindex()
+    ifaces = []
+    for i in range(255):
+        iface = ptr.contents[i]
+        if not iface.if_name:
+            break
+        ifaces.append((plain_str(iface.if_name), iface.if_index))
+    LIBC.if_freenameindex(ptr)
+    return ifaces
 
 
 _IFNUM = re.compile(r"([0-9]*)([ab]?)$")
 
 
-def get_working_ifaces():
-    """
-    Returns an ordered list of interfaces that could be used with BPF.
-    Note: the order mimics pcap_findalldevs() behavior
-    """
+def _get_if_flags(ifname):
+    """Internal function to get interface flags"""
+    # Get interface flags
+    try:
+        result = get_if(ifname, SIOCGIFFLAGS)
+    except IOError:
+        warning("ioctl(SIOCGIFFLAGS) failed on %s !", ifname)
+        return None
 
-    # Only root is allowed to perform the following ioctl() call
-    if os.getuid() != 0:
-        return []
+    # Convert flags
+    ifflags = struct.unpack("16xH14x", result)[0]
+    return ifflags
 
-    # Test all network interfaces
-    interfaces = []
-    for ifname in get_if_list():
 
-        # Unlike pcap_findalldevs(), we do not care of loopback interfaces.
-        if ifname == conf.loopback_name:
-            continue
+class BPFInterfaceProvider(InterfaceProvider):
+    name = "BPF"
 
-        # Get interface flags
+    def _is_valid(self, dev):
+        if not dev.flags & 0x1:  # not IFF_UP
+            return False
+        # Get a BPF handle
         try:
-            result = get_if(ifname, SIOCGIFFLAGS)
-        except IOError:
-            warning("ioctl(SIOCGIFFLAGS) failed on %s !", ifname)
-            continue
-
-        # Convert flags
-        ifflags = struct.unpack("16xH14x", result)[0]
-        if ifflags & 0x1:  # IFF_UP
-
-            # Get a BPF handle
             fd = get_dev_bpf()[0]
-            if fd is None:
-                raise Scapy_Exception("No /dev/bpf are available !")
+        except Scapy_Exception:
+            return True  # Can't check if available (non sudo?)
+        if fd is None:
+            raise Scapy_Exception("No /dev/bpf are available !")
+        # Check if the interface can be used
+        try:
+            fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x",
+                                                   dev.network_name.encode()))
+        except IOError:
+            return False
+        else:
+            return True
+        finally:
+            # Close the file descriptor
+            os.close(fd)
 
-            # Check if the interface can be used
+    def load(self):
+        from scapy.fields import FlagValue
+        data = {}
+        ips = in6_getifaddr()
+        for ifname, index in _get_ifindex_list():
             try:
-                fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x",
-                                                       ifname.encode()))
-            except IOError:
-                pass
-            else:
-                ifnum, ifab = _IFNUM.search(ifname).groups()
-                interfaces.append((ifname, int(ifnum) if ifnum else -1, ifab))
-            finally:
-                # Close the file descriptor
-                os.close(fd)
+                ifflags = _get_if_flags(ifname)
+                mac = scapy.utils.str2mac(get_if_raw_hwaddr(ifname)[1])
+                ip = inet_ntop(socket.AF_INET, get_if_raw_addr(ifname))
+            except Scapy_Exception:
+                continue
+            ifflags = FlagValue(ifflags, _iff_flags)
+            if_data = {
+                "name": ifname,
+                "network_name": ifname,
+                "description": ifname,
+                "flags": ifflags,
+                "index": index,
+                "ip": ip,
+                "ips": [x[0] for x in ips if x[2] == ifname] + [ip],
+                "mac": mac
+            }
+            data[ifname] = NetworkInterface(self, if_data)
+        return data
 
-    # Sort to mimic pcap_findalldevs() order
-    interfaces.sort(key=lambda elt: (elt[1], elt[2], elt[0]))
 
-    return [iface[0] for iface in interfaces]
-
-
-def get_working_if():
-    """Returns the first interface than can be used with BPF"""
-
-    ifaces = get_working_ifaces()
-    if not ifaces:
-        # A better interface will be selected later using the routing table
-        return conf.loopback_name
-    return ifaces[0]
+IFACES.register_provider(BPFInterfaceProvider)

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -21,6 +21,7 @@ from scapy.config import conf
 from scapy.consts import FREEBSD, NETBSD, DARWIN
 from scapy.data import ETH_P_ALL
 from scapy.error import Scapy_Exception, warning
+from scapy.interfaces import network_name
 from scapy.supersocket import SuperSocket
 from scapy.compat import raw
 
@@ -53,10 +54,7 @@ class _L2bpfSocket(SuperSocket):
         else:
             self.promisc = promisc
 
-        if iface is None:
-            self.iface = conf.iface
-        else:
-            self.iface = iface
+        self.iface = network_name(iface or conf.iface)
 
         # Get the BPF handle
         (self.ins, self.dev_bpf) = get_dev_bpf()

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -16,9 +16,34 @@ from scapy.consts import WINDOWS
 from scapy.config import conf
 from scapy.data import MTU, ARPHRD_TO_DLT
 from scapy.error import Scapy_Exception
+from scapy.interfaces import network_name
 
 if not WINDOWS:
     from fcntl import ioctl
+
+# From if.h
+_iff_flags = [
+    "UP",
+    "BROADCAST",
+    "DEBUG",
+    "LOOPBACK",
+    "POINTTOPOINT",
+    "NOTRAILERS",
+    "RUNNING",
+    "NOARP",
+    "PROMISC",
+    "NOTRAILERS",
+    "ALLMULTI",
+    "MASTER",
+    "SLAVE",
+    "MULTICAST",
+    "PORTSEL",
+    "AUTOMEDIA",
+    "DYNAMIC",
+    "LOWER_UP",
+    "DORMANT",
+    "ECHO"
+]
 
 # UTILS
 
@@ -26,6 +51,7 @@ if not WINDOWS:
 def get_if(iff, cmd):
     """Ease SIOCGIF* ioctl calls"""
 
+    iff = network_name(iff)
     sck = socket.socket()
     try:
         return ioctl(sck, cmd, struct.pack("16s16x", iff.encode("utf8")))
@@ -33,7 +59,7 @@ def get_if(iff, cmd):
         sck.close()
 
 
-def get_if_raw_hwaddr(iff):
+def get_if_raw_hwaddr(iff, siocgifhwaddr=None):
     """Get the raw MAC address of a local interface.
 
     This function uses SIOCGIFHWADDR calls, therefore only works
@@ -42,8 +68,10 @@ def get_if_raw_hwaddr(iff):
     :param iff: the network interface name as a string
     :returns: the corresponding raw MAC address
     """
-    from scapy.arch import SIOCGIFHWADDR
-    return struct.unpack("16xh6s8x", get_if(iff, SIOCGIFHWADDR))
+    if siocgifhwaddr is None:
+        from scapy.arch import SIOCGIFHWADDR
+        siocgifhwaddr = SIOCGIFHWADDR
+    return struct.unpack("16xh6s8x", get_if(iff, siocgifhwaddr))
 
 # SOCKET UTILS
 
@@ -96,10 +124,7 @@ def compile_filter(filter_exp, iface=None, linktype=None,
                 raise Scapy_Exception(
                     "Please provide an interface or linktype!"
                 )
-            if WINDOWS:
-                iface = conf.iface.pcap_name
-            else:
-                iface = conf.iface
+            iface = conf.iface
         # Try to guess linktype to avoid requiring root
         try:
             arphd = get_if_raw_hwaddr(iface)[0]
@@ -113,6 +138,7 @@ def compile_filter(filter_exp, iface=None, linktype=None,
         )
     elif iface:
         err = create_string_buffer(PCAP_ERRBUF_SIZE)
+        iface = network_name(iface)
         iface = create_string_buffer(iface.encode("utf8"))
         pcap = pcap_open_live(
             iface, MTU, promisc, 0, err

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -95,6 +95,10 @@ PACKET_FASTROUTE = 6  # Fastrouted frame
 
 
 def get_if_raw_addr(iff):
+    r"""
+    Return the raw IPv4 address of an interface.
+    If unavailable, returns b"\0\0\0\0"
+    """
     try:
         return get_if(iff, SIOCGIFADDR)[20:24]
     except IOError:
@@ -367,6 +371,8 @@ class LinuxInterfaceProvider(InterfaceProvider):
                 get_if_raw_hwaddr(i, siocgifhwaddr=SIOCGIFHWADDR)[1]
             )
             ip = inet_ntop(socket.AF_INET, get_if_raw_addr(i))
+            if ip == "0.0.0.0":
+                ip = None
             ifflags = FlagValue(ifflags, _iff_flags)
             if_data = {
                 "name": i,
@@ -375,7 +381,7 @@ class LinuxInterfaceProvider(InterfaceProvider):
                 "flags": ifflags,
                 "index": index,
                 "ip": ip,
-                "ips": [x[0] for x in ips if x[2] == i] + [ip],
+                "ips": [x[0] for x in ips if x[2] == i] + [ip] if ip else [],
                 "mac": mac
             }
             data[i] = NetworkInterface(self, if_data)

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -28,10 +28,13 @@ from scapy.packet import Packet, Padding
 from scapy.config import conf
 from scapy.data import MTU, ETH_P_ALL, SOL_PACKET, SO_ATTACH_FILTER, \
     SO_TIMESTAMPNS
+from scapy.interfaces import IFACES, InterfaceProvider, NetworkInterface, \
+    network_name
 from scapy.supersocket import SuperSocket
+from scapy.pton_ntop import inet_ntop
 from scapy.error import warning, Scapy_Exception, \
     ScapyInvalidPlatformException, log_runtime
-from scapy.arch.common import get_if, compile_filter
+from scapy.arch.common import get_if, compile_filter, _iff_flags
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
 
@@ -98,7 +101,10 @@ def get_if_raw_addr(iff):
         return b"\0\0\0\0"
 
 
-def get_if_list():
+def _get_if_list():
+    """
+    Function to read the interfaces from /proc/net/dev
+    """
     try:
         f = open("/proc/net/dev", "rb")
     except IOError:
@@ -116,19 +122,6 @@ def get_if_list():
         lst.append(line.split(":")[0].strip())
     f.close()
     return lst
-
-
-def get_working_if():
-    """
-    Return the name of the first network interfcace that is up.
-    """
-    for i in get_if_list():
-        if i == conf.loopback_name:
-            continue
-        ifflags = struct.unpack("16xH14x", get_if(i, SIOCGIFFLAGS))[0]
-        if ifflags & IFF_UP:
-            return i
-    return conf.loopback_name
 
 
 def attach_filter(sock, bpf_filter, iface):
@@ -256,15 +249,12 @@ def read_routes():
         gw_str = scapy.utils.inet_ntoa(struct.pack("I", int(gw, 16)))
         metric = int(metric)
 
+        route = [dst_int, msk_int, gw_str, iff, ifaddr, metric]
         if ifaddr_int & msk_int != dst_int:
             tmp_route = get_alias_address(iff, dst_int, gw_str, metric)
             if tmp_route:
-                routes.append(tmp_route)
-            else:
-                routes.append((dst_int, msk_int, gw_str, iff, ifaddr, metric))
-
-        else:
-            routes.append((dst_int, msk_int, gw_str, iff, ifaddr, metric))
+                route = tmp_route
+        routes.append(tuple(route))
 
     f.close()
     s.close()
@@ -360,6 +350,40 @@ def get_if_index(iff):
     return int(struct.unpack("I", get_if(iff, SIOCGIFINDEX)[16:20])[0])
 
 
+class LinuxInterfaceProvider(InterfaceProvider):
+    name = "sys"
+
+    def _is_valid(self, dev):
+        return bool(dev.flags & IFF_UP)
+
+    def load(self):
+        from scapy.fields import FlagValue
+        data = {}
+        ips = in6_getifaddr()
+        for i in _get_if_list():
+            ifflags = struct.unpack("16xH14x", get_if(i, SIOCGIFFLAGS))[0]
+            index = get_if_index(i)
+            mac = scapy.utils.str2mac(
+                get_if_raw_hwaddr(i, siocgifhwaddr=SIOCGIFHWADDR)[1]
+            )
+            ip = inet_ntop(socket.AF_INET, get_if_raw_addr(i))
+            ifflags = FlagValue(ifflags, _iff_flags)
+            if_data = {
+                "name": i,
+                "network_name": i,
+                "description": i,
+                "flags": ifflags,
+                "index": index,
+                "ip": ip,
+                "ips": [x[0] for x in ips if x[2] == i] + [ip],
+                "mac": mac
+            }
+            data[i] = NetworkInterface(self, if_data)
+        return data
+
+
+IFACES.register_provider(LinuxInterfaceProvider)
+
 if os.uname()[4] in ['x86_64', 'aarch64']:
     def get_last_packet_timestamp(sock):
         ts = ioctl(sock, SIOCGSTAMP, "1234567890123456")
@@ -388,7 +412,7 @@ class L2Socket(SuperSocket):
 
     def __init__(self, iface=None, type=ETH_P_ALL, promisc=None, filter=None,
                  nofilter=0, monitor=None):
-        self.iface = conf.iface if iface is None else iface
+        self.iface = network_name(iface or conf.iface)
         self.type = type
         self.promisc = conf.sniff_promisc if promisc is None else promisc
         if monitor is not None:
@@ -586,7 +610,9 @@ class VEthPair(object):
     def __enter__(self):
         self.setup()
         self.up()
+        conf.ifaces.reload()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.destroy()
+        conf.ifaces.reload()

--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -18,7 +18,7 @@ socket.IPPROTO_GRE = 47
 # From sys/sockio.h and net/if.h
 SIOCGIFHWADDR = 0xc02069b9  # Get hardware address
 
-from scapy.arch.pcapdnet import *  # noqa: F401, F403, E402
+from scapy.arch.libpcap import *  # noqa: F401, F403, E402
 from scapy.arch.unix import *  # noqa: F401, F403, E402
 from scapy.arch.common import get_if_raw_hwaddr  # noqa: F401, F403, E402
 

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -56,6 +56,7 @@ from scapy.compat import raw
 from scapy.config import conf
 from scapy.data import MTU
 from scapy.error import Scapy_Exception, warning
+from scapy.interfaces import resolve_iface
 from scapy.supersocket import SuperSocket
 
 # Watch out for import loops (inet...)
@@ -115,7 +116,7 @@ class L3WinSocket(SuperSocket, SelectableObject):
         self.ins.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, ttl)
         self.outs.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, ttl)
         # Bind on all ports
-        iface = iface or conf.iface
+        iface = resolve_iface(iface) or conf.iface
         host = iface.ip if iface.ip else socket.gethostname()
         self.ins.bind((host, 0))
         self.ins.setblocking(False)

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -110,6 +110,14 @@ def bytes_base64(x):
 
 
 if six.PY2:
+    import cgi
+    html_escape = cgi.escape
+else:
+    import html
+    html_escape = html.escape
+
+
+if six.PY2:
     from StringIO import StringIO
 
     def gzip_decompress(x):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2100,7 +2100,11 @@ class FlagValue(object):
         x = int(self)
         while x:
             if x & 1:
-                r.append(self.names[i])
+                try:
+                    name = self.names[i]
+                except IndexError:
+                    name = "?"
+                r.append(name)
             i += 1
             x >>= 1
         return ("+" if self.multi else "").join(r)

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -181,13 +181,7 @@ class NetworkInterfaceDict(UserDict):
         # Can only be called after conf.route is populated
         if not conf.route:
             raise ValueError("Error: conf.route isn't populated !")
-        iface = conf.route.route(verbose=0)[0]
-        if iface == conf.loopback_name:
-            conf.iface = get_working_if()
-        else:
-            conf.iface = resolve_iface(iface)
-            if not conf.iface.is_valid():
-                conf.iface = get_working_if()
+        conf.iface = get_working_if()
 
     def _reload_provs(self):
         self.clear()
@@ -312,6 +306,11 @@ def get_working_if():
             return iface
     # There is no hope left
     return conf.loopback_name
+
+
+def get_working_ifaces():
+    """Return all interfaces that work"""
+    return [iface for iface in conf.ifaces.values() if iface.is_valid()]
 
 
 def dev_from_networkname(network_name):

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -24,7 +24,7 @@ import scapy.modules.six as six
 class InterfaceProvider(object):
     name = "Unknown"
     headers = ("Index", "Name", "MAC", "IPv4", "IPv6")
-    header_sort = 4
+    header_sort = 1
     libpcap = False
 
     def load(self):
@@ -249,13 +249,18 @@ class NetworkInterfaceDict(UserDict):
         else:
             self.data[ifname] = NetworkInterface(InterfaceProvider(), data)
 
-    def show(self, print_result=True, **kwargs):
+    def show(self, print_result=True, hidden=False, **kwargs):
         """
         Print list of available network interfaces in human readable form
+
+        :param print_result: print the results if True, else return it
+        :param hidden: if True, also displays invalid interfaces
         """
         res = defaultdict(list)
         for iface_name in sorted(self.data):
             dev = self.data[iface_name]
+            if not hidden and not dev.is_valid():
+                continue
             prov = dev.provider
             res[prov].append(
                 (prov.name,) + prov._format(dev, **kwargs)

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -50,7 +50,7 @@ class InterfaceProvider(object):
 
     def _is_valid(self, dev):
         """Returns whether an interface is valid or not"""
-        return bool((self.ip or self.ip6) and self.mac)
+        return bool((dev.ips[4] or dev.ips[6]) and dev.mac)
 
     def _format(self, dev, **kwargs):
         """Returns the elements used by show()
@@ -76,7 +76,6 @@ class NetworkInterface(object):
         self.network_name = ""
         self.index = -1
         self.ip = None
-        self.ip6 = None
         self.ips = defaultdict(list)
         self.mac = None
         self.dummy = False
@@ -92,7 +91,6 @@ class NetworkInterface(object):
         self.network_name = data.get('network_name', "")
         self.index = data.get('index', 0)
         self.ip = data.get('ip', "")
-        self.ip6 = data.get('ip6', "")
         self.mac = data.get('mac', "")
         self.flags = data.get('flags', 0)
         self.dummy = data.get('dummy', False)
@@ -103,14 +101,10 @@ class NetworkInterface(object):
             else:
                 self.ips[4].append(ip)
 
-        # An interface may have multiple IPv4 or IPv6
-        # "ip" and "ip6" should contain the "main" one
+        # An interface often has multiple IPv6 so we don't store
+        # a "main" one, unlike IPv4.
         if self.ips[4] and not self.ip:
             self.ip = self.ips[4][0]
-        if self.ips[6] and not self.ip6:
-            # TODO XXX
-            # What should we consider the main IPv6 ? @guedou
-            self.ip6 = self.ips[6][0]
 
     def __eq__(self, other):
         if isinstance(other, str):

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -1,0 +1,366 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# Copyright (C) Gabriel Potter <gabriel@potter.fr>
+# This program is published under a GPLv2 license
+
+"""
+Interfaces management
+"""
+
+import itertools
+import uuid
+from collections import defaultdict
+
+from scapy.config import conf
+from scapy.consts import WINDOWS
+from scapy.utils import pretty_list
+from scapy.utils6 import in6_isvalid
+
+from scapy.modules.six.moves import UserDict
+import scapy.modules.six as six
+
+
+class InterfaceProvider(object):
+    name = "Unknown"
+    headers = ("Index", "Name", "MAC", "IPv4", "IPv6")
+    header_sort = 4
+    libpcap = False
+
+    def load(self):
+        """Returns a dictionary of the loaded interfaces, by their
+        name."""
+        raise NotImplementedError
+
+    def reload(self):
+        """Same than load() but for reloads. By default calls load"""
+        return self.load()
+
+    def l2socket(self):
+        """Return L2 socket used by interfaces of this provider"""
+        return conf.L2socket
+
+    def l2listen(self):
+        """Return L2listen socket used by interfaces of this provider"""
+        return conf.L2listen
+
+    def l3socket(self):
+        """Return L3 socket used by interfaces of this provider"""
+        return conf.L3socket
+
+    def _is_valid(self, dev):
+        """Returns whether an interface is valid or not"""
+        return dev.valid
+
+    def _format(self, dev, **kwargs):
+        """Returns the elements used by show()
+
+        If a tuple is returned, this consist of the strings that will be
+        inlined along with the interface.
+        If a list of tuples is returned, they will be appended one above the
+        other and should all be part of a single interface.
+        """
+        mac = dev.mac
+        resolve_mac = kwargs.get("resolve_mac", True)
+        if resolve_mac and conf.manufdb:
+            mac = conf.manufdb._resolve_MAC(mac)
+        index = str(dev.index)
+        return (index, dev.description, mac, dev.ips[4], dev.ips[6])
+
+
+class NetworkInterface(object):
+    def __init__(self, provider, data=None):
+        self.provider = provider
+        self.name = ""
+        self.description = ""
+        self.network_name = ""
+        self.index = -1
+        self.ip = None
+        self.ip6 = None
+        self.ips = defaultdict(list)
+        self.mac = None
+        self.valid = True
+        self.dummy = False
+        if data is not None:
+            self.update(data)
+
+    def update(self, data):
+        """Update info about a network interface according
+        to a given dictionary. Such data is provided by providers
+        """
+        self.name = data.get('name', "")
+        self.description = data.get('description', "")
+        self.network_name = data.get('network_name', "")
+        self.index = data.get('index', 0)
+        self.ip = data.get('ip', "")
+        self.ip6 = data.get('ip6', "")
+        self.mac = data.get('mac', "")
+        self.flags = data.get('flags', 0)
+        self.valid = data.get('valid', True)
+        self.dummy = data.get('dummy', False)
+
+        for ip in data.get('ips', []):
+            if in6_isvalid(ip):
+                self.ips[6].append(ip)
+            else:
+                self.ips[4].append(ip)
+
+        # An interface may have multiple IPv4 or IPv6
+        # "ip" and "ip6" should contain the "main" one
+        if self.ips[4] and not self.ip:
+            self.ip = self.ips[4][0]
+        if self.ips[6] and not self.ip6:
+            # TODO XXX
+            # What should we consider the main IPv6 ? @guedou
+            self.ip6 = self.ips[6][0]
+        if (not self.ip and not self.ip6) or not self.mac:
+            self.valid = False
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return other in [self.name, self.network_name, self.description]
+        if isinstance(other, NetworkInterface):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.network_name)
+
+    def is_valid(self):
+        return self.provider._is_valid(self)
+
+    def l2socket(self):
+        return self.provider.l2socket()
+
+    def l2listen(self):
+        return self.provider.l2listen()
+
+    def l3socket(self):
+        return self.provider.l3socket()
+
+    def __repr__(self):
+        return "<%s %s [%s]>" % (self.__class__.__name__,
+                                 self.description,
+                                 self.dummy and "dummy" or (self.flags or ""))
+
+    def __str__(self):
+        return self.network_name
+
+    def __add__(self, other):
+        return self.network_name + other
+
+    def __radd__(self, other):
+        return other + self.network_name
+
+
+class NetworkInterfaceDict(UserDict):
+    """Store information about network interfaces and convert between names"""
+
+    def __init__(self):
+        self.providers = {}
+        UserDict.__init__(self)
+
+    def _load(self, dat, prov):
+        for ifname, iface in six.iteritems(dat):
+            if ifname in self.data:
+                # Handle priorities: keep except if libpcap
+                if prov.libpcap:
+                    self.data[ifname] = iface
+            else:
+                self.data[ifname] = iface
+
+    def register_provider(self, provider):
+        prov = provider()
+        self.providers[provider] = prov
+
+    def load_confiface(self):
+        """
+        Reload conf.iface
+        """
+        # Can only be called after conf.route is populated
+        if not conf.route:
+            raise ValueError("Error: conf.route isn't populated !")
+        iface = conf.route.route(verbose=0)[0]
+        if iface == conf.loopback_name:
+            conf.iface = get_working_if()
+        else:
+            conf.iface = resolve_iface(iface)
+            if not conf.iface.is_valid():
+                conf.iface = get_working_if()
+
+    def _reload_provs(self):
+        self.clear()
+        for prov in self.providers.values():
+            self._load(prov.reload(), prov)
+
+    def reload(self):
+        self._reload_provs()
+        if conf.route:
+            self.load_confiface()
+
+    def dev_from_name(self, name):
+        """Return the first network device name for a given
+        device name.
+        """
+        try:
+            return next(iface for iface in six.itervalues(self)
+                        if (iface.name == name or iface.description == name))
+        except (StopIteration, RuntimeError):
+            raise ValueError("Unknown network interface %r" % name)
+
+    def dev_from_networkname(self, network_name):
+        """Return interface for a given network device name."""
+        try:
+            return next(iface for iface in six.itervalues(self)
+                        if iface.network_name == network_name)
+        except (StopIteration, RuntimeError):
+            raise ValueError(
+                "Unknown network interface %r" %
+                network_name)
+
+    def dev_from_index(self, if_index):
+        """Return interface name from interface index"""
+        try:
+            if_index = int(if_index)  # Backward compatibility
+            return next(iface for iface in six.itervalues(self)
+                        if iface.index == if_index)
+        except (StopIteration, RuntimeError):
+            if str(if_index) == "1":
+                # Test if the loopback interface is set up
+                return self.dev_from_networkname(conf.loopback_name)
+            raise ValueError("Unknown network interface index %r" % if_index)
+
+    def _add_fake_iface(self, ifname):
+        """Internal function used for a testing purpose"""
+        data = {
+            'name': ifname,
+            'description': ifname,
+            'network_name': ifname,
+            'index': -1000,
+            'valid': False,
+            'mac': '00:00:00:00:00:00',
+            'flags': 0,
+            'ips': ["127.0.0.1", "::"],
+            # Windows only
+            'guid': "{%s}" % uuid.uuid1(),
+            'ipv4_metric': 0,
+            'ipv6_metric': 0,
+        }
+        if WINDOWS:
+            from scapy.arch.windows import NetworkInterface_Win, \
+                WindowsInterfacesProvider
+
+            class FakeProv(WindowsInterfacesProvider):
+                name = "fake"
+
+            self.data[ifname] = NetworkInterface_Win(
+                FakeProv(),
+                data
+            )
+        else:
+            self.data[ifname] = NetworkInterface(InterfaceProvider(), data)
+
+    def show(self, print_result=True, **kwargs):
+        """
+        Print list of available network interfaces in human readable form
+        """
+        res = defaultdict(list)
+        for iface_name in sorted(self.data):
+            dev = self.data[iface_name]
+            prov = dev.provider
+            res[prov].append(
+                (prov.name,) + prov._format(dev, **kwargs)
+            )
+        output = ""
+        for provider in res:
+            output += pretty_list(
+                res[provider],
+                [("Source",) + provider.headers],
+                sortBy=provider.header_sort
+            ) + "\n"
+        output = output[:-1]
+        if print_result:
+            print(output)
+        else:
+            return output
+
+    def __repr__(self):
+        return self.show(print_result=False)
+
+
+conf.ifaces = IFACES = ifaces = NetworkInterfaceDict()
+
+
+def get_if_list():
+    """Return a list of interface names"""
+    return list(conf.ifaces.keys())
+
+
+def get_working_if():
+    """Return an interface that works"""
+    # return the interface associated with the route with smallest
+    # mask (route by default if it exists)
+    routes = conf.route.routes[:]
+    routes.sort(key=lambda x: x[1])
+    ifaces = (x[3] for x in routes)
+    # First check the routing ifaces from best to worse,
+    # then check all the available ifaces as backup.
+    for iface in itertools.chain(ifaces, conf.ifaces.values()):
+        iface = resolve_iface(iface)
+        if iface and iface.is_valid():
+            return iface
+    # There is no hope left
+    return conf.loopback_name
+
+
+def dev_from_networkname(network_name):
+    """Return Scapy device name for given network device name"""
+    return conf.ifaces.dev_from_networkname(network_name)
+
+
+def dev_from_index(if_index):
+    """Return interface for a given interface index"""
+    return conf.ifaces.dev_from_index(if_index)
+
+
+def resolve_iface(dev):
+    """
+    Resolve an interface name into the interface
+    """
+    if isinstance(dev, NetworkInterface):
+        return dev
+    try:
+        return conf.ifaces.dev_from_name(dev)
+    except ValueError:
+        try:
+            return dev_from_networkname(dev)
+        except ValueError:
+            pass
+    # Return a dummy interface
+    return NetworkInterface(
+        InterfaceProvider(),
+        data={
+            "name": dev,
+            "description": dev,
+            "network_name": dev,
+            "dummy": True
+        }
+    )
+
+
+def network_name(dev):
+    """
+    Resolves the device network name of a device or Scapy NetworkInterface
+    """
+    iface = resolve_iface(dev)
+    if iface:
+        return iface.network_name
+    return dev
+
+
+def show_interfaces(resolve_mac=True):
+    """Print list of available network interfaces"""
+    return conf.ifaces.show(resolve_mac)

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -12,7 +12,7 @@ from ctypes.util import find_library
 import os
 
 from scapy.libs.structures import bpf_program
-from scapy.consts import WINDOWS
+from scapy.consts import WINDOWS, BSD
 
 if WINDOWS:
     # Try to load Npcap, or Winpcap
@@ -66,23 +66,11 @@ class timeval(Structure):
 # sockaddr is used by pcap_addr.
 # For example if sa_family==socket.AF_INET then we need cast
 # with sockaddr_in
-if WINDOWS:
-    class sockaddr(Structure):
-        _fields_ = [("sa_family", c_ushort),
-                    ("sa_data", c_ubyte * 14)]
 
-    class sockaddr_in(Structure):
-        _fields_ = [("sin_family", c_ushort),
-                    ("sin_port", c_uint16),
-                    ("sin_addr", 4 * c_ubyte)]
-
-    class sockaddr_in6(Structure):
-        _fields_ = [("sin6_family", c_ushort),
-                    ("sin6_port", c_uint16),
-                    ("sin6_flowinfo", c_uint32),
-                    ("sin6_addr", 16 * c_ubyte),
-                    ("sin6_scope", c_uint32)]
-else:
+# sockaddr has a different structure depending on the OS
+if BSD:
+    # https://github.com/freebsd/freebsd/blob/master/sys/sys/socket.h
+    # https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html
     class sockaddr(Structure):
         _fields_ = [("sa_len", c_ubyte),
                     ("sa_family", c_ubyte),
@@ -112,6 +100,26 @@ else:
                     ("sdl_alen", c_ubyte),
                     ("sdl_slen", c_ubyte),
                     ("sdl_data", 46 * c_ubyte)]
+
+else:
+    # https://github.com/torvalds/linux/blob/master/include/linux/socket.h
+    # https://docs.microsoft.com/en-us/windows/win32/winsock/sockaddr-2
+    class sockaddr(Structure):
+        _fields_ = [("sa_family", c_ushort),
+                    ("sa_data", c_ubyte * 14)]
+
+    class sockaddr_in(Structure):
+        _fields_ = [("sin_family", c_ushort),
+                    ("sin_port", c_uint16),
+                    ("sin_addr", 4 * c_ubyte)]
+
+    class sockaddr_in6(Structure):
+        _fields_ = [("sin6_family", c_ushort),
+                    ("sin6_port", c_uint16),
+                    ("sin6_flowinfo", c_uint32),
+                    ("sin6_addr", 16 * c_ubyte),
+                    ("sin6_scope", c_uint32)]
+
 ##
 # END misc
 ##

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -17,6 +17,7 @@ Routing and network interface handling for IPv6.
 from __future__ import absolute_import
 import socket
 from scapy.config import conf
+from scapy.interfaces import resolve_iface
 from scapy.utils6 import in6_ptop, in6_cidr2mask, in6_and, \
     in6_islladdr, in6_ismlladdr, in6_isincluded, in6_isgladdr, \
     in6_isaddr6to4, in6_ismaddr, construct_source_candidate_set, \
@@ -24,7 +25,6 @@ from scapy.utils6 import in6_ptop, in6_cidr2mask, in6_and, \
 from scapy.arch import read_routes6, in6_getifaddr
 from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.error import warning, log_loading
-import scapy.modules.six as six
 from scapy.utils import pretty_list
 
 
@@ -57,11 +57,11 @@ class Route6:
         rtlst = []
 
         for net, msk, gw, iface, cset, metric in self.routes:
+            if_repr = resolve_iface(iface).description
             rtlst.append(('%s/%i' % (net, msk),
                           gw,
-                          (iface if isinstance(iface, six.string_types)
-                           else iface.description),
-                          ", ".join(cset) if len(cset) > 0 else "",
+                          if_repr,
+                          cset,
                           str(metric)))
 
         return pretty_list(rtlst,
@@ -255,7 +255,7 @@ class Route6:
         # Deal with dev-specific request for cache search
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)  # noqa: E501
+            k = dst + "%%" + dev
         if k in self.cache:
             return self.cache[k]
 
@@ -324,7 +324,7 @@ class Route6:
         # Fill the cache (including dev-specific request)
         k = dst
         if dev is not None:
-            k = dst + "%%" + (dev if isinstance(dev, six.string_types) else dev.pcap_name)  # noqa: E501
+            k = dst + "%%" + dev
         self.cache[k] = res[0][2]
 
         return res[0][2]

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -21,6 +21,7 @@ from scapy.consts import LINUX, DARWIN, WINDOWS
 from scapy.data import MTU, ETH_P_IP, SOL_PACKET, SO_TIMESTAMPNS
 from scapy.compat import raw, bytes_encode
 from scapy.error import warning, log_runtime
+from scapy.interfaces import network_name
 import scapy.modules.six as six
 import scapy.packet
 from scapy.utils import PcapReader, tcpdump
@@ -222,7 +223,8 @@ class L3RawSocket(SuperSocket):
         self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
         self.iface = iface
         if iface is not None:
-            self.ins.bind((self.iface, type))
+            iface = network_name(iface)
+            self.ins.bind((iface, type))
         if not six.PY2:
             try:
                 # Receive Auxiliary Data (VLAN tags)
@@ -361,14 +363,9 @@ class L2ListenTcpdump(SuperSocket):
         args = ['-w', '-', '-s', '65535']
         if iface is None and (WINDOWS or DARWIN):
             iface = conf.iface
-        if WINDOWS:
-            try:
-                iface = iface.pcap_name
-            except AttributeError:
-                pass
         self.iface = iface
         if iface is not None:
-            args.extend(['-i', self.iface])
+            args.extend(['-i', network_name(iface)])
         if not promisc:
             args.append('-p')
         if not nofilter:

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -11,7 +11,6 @@ Color themes for the interactive console.
 #  Color themes  #
 ##################
 
-import cgi
 import sys
 
 
@@ -44,6 +43,7 @@ class ColorTable:
         "blink": ("\033[5m", ""),
         "invert": ("\033[7m", ""),
     }
+    inv_map = {v[0]: v[1] for k, v in colors.items()}
 
     def __repr__(self):
         return "<ColorTable>"
@@ -52,8 +52,7 @@ class ColorTable:
         return self.colors.get(attr, [""])[0]
 
     def ansi_to_pygments(self, x):  # Transform ansi encoded text to Pygments text  # noqa: E501
-        inv_map = {v[0]: v[1] for k, v in self.colors.items()}
-        for k, v in inv_map.items():
+        for k, v in self.inv_map.items():
             x = x.replace(k, " " + v)
         return x.strip()
 
@@ -363,7 +362,8 @@ def apply_ipython_style(shell):
         if isinstance(conf.color_theme, (FormatTheme, NoTheme)):
             # Formatable
             if isinstance(conf.color_theme, HTMLTheme):
-                prompt = cgi.escape(conf.prompt)
+                from scapy.compat import html_escape
+                prompt = html_escape(conf.prompt)
             elif isinstance(conf.color_theme, LatexTheme):
                 from scapy.utils import tex_escape
                 prompt = tex_escape(conf.prompt)

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -515,9 +515,9 @@ def import_UTscapy_tools(ses):
     ses["retry_test"] = retry_test
     ses["Bunch"] = Bunch
     if WINDOWS:
-        from scapy.arch.windows import _route_add_loopback, IFACES
+        from scapy.arch.windows import _route_add_loopback
         _route_add_loopback()
-        ses["IFACES"] = IFACES
+        ses["conf"].ifaces = conf.ifaces
         ses["conf"].route.routes = conf.route.routes
         ses["conf"].route6.routes = conf.route6.routes
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -26,7 +26,7 @@ import tempfile
 import threading
 
 import scapy.modules.six as six
-from scapy.modules.six.moves import range, input
+from scapy.modules.six.moves import range, input, zip_longest
 
 from scapy.config import conf
 from scapy.consts import DARWIN, WINDOWS, WINDOWS_XP, OPENBSD
@@ -1926,20 +1926,46 @@ def get_terminal_width():
 
 
 def pretty_list(rtlst, header, sortBy=0, borders=False):
-    """Pretty list to fit the terminal, and add header"""
+    """
+    Pretty list to fit the terminal, and add header.
+
+    :param rtlst: a list of tuples. each tuple contains a value which can
+        be either a string or a list of string.
+    :param sortBy: the column id (starting with 0) which whill be used for
+        ordering
+    :param borders: whether to put borders on the table or not
+    """
     if borders:
         _space = "|"
     else:
         _space = "  "
+    cols = len(header[0])
     # Windows has a fat terminal border
-    _spacelen = len(_space) * (len(header) - 1) + (10 if WINDOWS else 0)
+    _spacelen = len(_space) * (cols - 1) + int(WINDOWS)
     _croped = False
     # Sort correctly
     rtlst.sort(key=lambda x: x[sortBy])
+    # Resolve multi-values
+    for i, line in enumerate(rtlst):
+        ids = []
+        values = []
+        for j, val in enumerate(line):
+            if isinstance(val, list):
+                ids.append(j)
+                values.append(val or " ")
+        if values:
+            del rtlst[i]
+            k = 0
+            for ex_vals in zip_longest(*values, fillvalue=" "):
+                extra_line = ([" "] * cols) if k else list(line)
+                for j, h in enumerate(ids):
+                    extra_line[h] = ex_vals[j]
+                rtlst.insert(i + k, tuple(extra_line))
+                k += 1
     # Append tag
     rtlst = header + rtlst
     # Detect column's width
-    colwidth = [max([len(y) for y in x]) for x in zip(*rtlst)]
+    colwidth = [max(len(y) for y in x) for x in zip(*rtlst)]
     # Make text fit in box (if required)
     width = get_terminal_width()
     if conf.auto_crop_tables and width:
@@ -1968,8 +1994,7 @@ def pretty_list(rtlst, header, sortBy=0, borders=False):
     if borders:
         rtlst.insert(1, tuple("-" * x for x in colwidth))
     # Compile
-    rt = "\n".join(((fmt % x).strip() for x in rtlst))
-    return rt
+    return "\n".join(fmt % x for x in rtlst)
 
 
 def __make_table(yfmtfunc, fmtfunc, endline, data, fxyz, sortx=None, sorty=None, seplinefunc=None, dump=False):  # noqa: E501

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -832,7 +832,7 @@ def in6_isvalid(address):
        otherwise."""
 
     try:
-        socket.inet_pton(socket.AF_INET6, address)
+        inet_pton(socket.AF_INET6, address)
         return True
     except Exception:
         return False

--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -43,43 +43,6 @@ attach_filter(fd, "arp or icmp", conf.iface)
 iflist = get_if_list()
 len(iflist) > 0
 
-
-= Get working network interfaces
-~ needs_root
-
-from scapy.arch.bpf.core import get_working_if, get_working_ifaces
-ifworking = get_working_ifaces()
-assert len(ifworking)
-assert get_working_if() == ifworking[0]
-
-
-= Get working network interfaces order
-
-import mock
-from scapy.arch.bpf.core import get_working_ifaces
-
-@mock.patch("scapy.arch.bpf.core.os.close")
-@mock.patch("scapy.arch.bpf.core.fcntl.ioctl")
-@mock.patch("scapy.arch.bpf.core.get_dev_bpf")
-@mock.patch("scapy.arch.bpf.core.get_if")
-@mock.patch("scapy.arch.bpf.core.get_if_list")
-@mock.patch("scapy.arch.bpf.core.os.getuid")
-def test_get_working_ifaces(mock_getuid, mock_get_if_list, mock_get_if,
-                            mock_get_dev_bpf, mock_ioctl, mock_close):
-    mock_getuid.return_value = 0
-    mock_get_if_list.return_value = ['igb0', 'em0', 'msk0', 'epair0a', 'igb1',
-                                     'vlan20', 'igb10', 'igb2']
-    mock_get_if.return_value = (b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                                b'\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00'
-                                b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
-    mock_get_dev_bpf.return_value = (31337,)
-    mock_ioctl.return_value = 0
-    mock_close.return_value = 0
-    return get_working_ifaces()
-
-assert test_get_working_ifaces() == ['em0', 'igb0', 'msk0', 'epair0a', 'igb1',
-                                     'igb2', 'igb10', 'vlan20']
-
 = Misc functions
 ~ needs_root
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -76,14 +76,6 @@ from mock import patch
 with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo_x'):
     routes = read_routes()
 
-= catch get_working_if only loopback
-~ linux
-
-from mock import patch
-
-with patch('scapy.arch.linux.get_if_list', side_effect=lambda: [conf.loopback_name]):
-    assert get_working_if() == conf.loopback_name
-
 = catch loopback device no address assigned
 ~ linux needs_root
 
@@ -122,6 +114,8 @@ exit_status = os.system("ip link del dev scapy_lo")
 assert(exit_status == 0)
 
 = IPv6 link-local address selection
+
+IFACES._add_fake_iface("scapy0")
 
 from mock import patch
 conf.route6.routes =  [('fe80::', 64, '::', 'scapy0', ['fe80::e039:91ff:fe79:1910'], 256)]
@@ -238,6 +232,7 @@ except subprocess.CalledProcessError:
 except Exception:
     assert False
 
+conf.ifaces.reload()
 if_list = get_if_list()
 assert ('veth_scapy_0' in if_list)
 assert ('veth_scapy_1' in if_list)
@@ -265,6 +260,7 @@ try:
     veth.down()
     veth.destroy()
 
+    conf.ifaces.reload()
     if_list = get_if_list()
     assert ('veth_scapy_0' not in if_list)
     assert ('veth_scapy_1' not in if_list)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -204,7 +204,7 @@ conf.iface = conf.iface.name
 assert conf.iface == old
 
 assert isinstance(conf.iface, NetworkInterface)
-assert conf.iface.valid
+assert conf.iface.is_valid()
 
 import mock
 @mock.patch("scapy.interfaces.conf.route.routes", [])

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -127,15 +127,6 @@ except:
 
 assert not conf.use_bpf
 
-if not conf.use_pcap:
-    a = six.moves.builtins.__dict__
-    conf.interactive = True
-    conf.use_pcap = True
-    assert a["get_if_list"] == scapy.arch.pcapdnet.get_if_list
-    conf.use_pcap = False
-    assert a["get_if_list"] == scapy.arch.linux.get_if_list
-    conf.interactive = False
-
 = Configuration conf.use_* WINDOWS
 ~ windows
 
@@ -146,6 +137,18 @@ except:
     True
 
 assert not conf.use_bpf
+
+= Configuration conf.use_pcap
+~ linux
+
+if not conf.use_pcap:
+    assert not conf.iface.provider.libpcap
+    conf.use_pcap = True
+    assert conf.iface.provider.libpcap
+    for iface in conf.ifaces.values():
+        assert iface.provider.libpcap
+    conf.use_pcap = False
+    assert not conf.iface.provider.libpcap
 
 = Test layer filtering
 ~ filter
@@ -182,22 +185,8 @@ bytes_hex(get_if_raw_addr(conf.iface))
 
 def get_dummy_interface():
     """Returns a dummy network interface"""
-    if WINDOWS:
-        data = {}
-        data["name"] = "dummy0"
-        data["description"] = "Does not exist"
-        data["win_index"] = -1
-        data["guid"] = "{1XX00000-X000-0X0X-X00X-00XXXX000XXX}"
-        data["invalid"] = True
-        data["ipv4_metric"] = 1
-        data["ipv6_metric"] = 1
-        data["mac"] = "00:00:00:00:00:00"
-        data["ips"] = ["127.0.0.1", "::1"]
-        data["pcap_name"] = "\\Device\\NPF_" + data["guid"]
-        data["flags"] = 0
-        return NetworkInterface(data)
-    else:
-        return "dummy0"
+    IFACES._add_fake_iface("dummy0")
+    return "dummy0"
 
 get_if_raw_addr(get_dummy_interface())
 
@@ -206,6 +195,56 @@ get_if_list()
 get_working_if()
 
 get_if_raw_addr6(conf.iface)
+
+= More Interfaces related functions
+
+# Test name resolution
+old = conf.iface
+conf.iface = conf.iface.name
+assert conf.iface == old
+
+assert isinstance(conf.iface, NetworkInterface)
+assert conf.iface.valid
+
+import mock
+@mock.patch("scapy.interfaces.conf.route.routes", [])
+@mock.patch("scapy.interfaces.conf.ifaces", {})
+def _test_get_working_if():
+    assert get_working_if() == conf.loopback_name
+
+assert conf.iface + "a"  # left +
+assert "hey! are you, ready to go ? %s" % conf.iface  # format
+assert "cuz you know the way to go" + conf.iface  # right +
+
+_test_get_working_if()
+
+= Test conf.ifaces
+
+conf.iface
+conf.ifaces
+
+assert conf.iface in conf.ifaces.values()
+assert conf.ifaces.dev_from_index(conf.iface.index) == conf.iface
+assert conf.ifaces.dev_from_networkname(conf.iface.network_name) == conf.iface
+
+conf.ifaces.data = {'a': NetworkInterface(InterfaceProvider(), {"name": 'a', "network_name": 'a', "description": 'a', "ips": ["127.0.0.1", "::1", "::2", "127.0.0.2"], "mac": 'aa:aa:aa:aa:aa:aa'})}
+
+with ContextManagerCaptureOutput() as cmco:
+    conf.ifaces.show()
+    output = cmco.get_output()
+
+data = """
+Source   Index  Name  MAC                IPv4       IPv6
+Unknown  0      a     aa:aa:aa:aa:aa:aa  127.0.0.1  ::1
+                                         127.0.0.2  ::2
+""".strip()
+
+output = [x.strip() for x in output.strip().split("\n")]
+data = [x.strip() for x in data.strip().split("\n")]
+
+assert output == data
+
+conf.ifaces.reload()
 
 = Test read_routes6() - default output
 
@@ -1675,6 +1714,7 @@ asrm = AS_resolver_multi(MockAS_resolver())
 assert len(asrm.resolve(["8.8.8.8", "8.8.4.4"])) == 0
 
 = sendpfast
+~ tcpreplay
 
 old_interactive = conf.interactive
 conf.interactive = False
@@ -4336,6 +4376,11 @@ assert defragment6(pkts).plen == 1508
 ############
 + Test Route6 class
 
+= Fake interfaces
+IFACES._add_fake_iface("eth0")
+IFACES._add_fake_iface("lo")
+IFACES._add_fake_iface("scapy0")
+
 = Route6 - Route6 flushing
 conf_iface = conf.iface
 conf.iface = "eth0"
@@ -4346,6 +4391,7 @@ conf.route6.flush()
 not conf.route6.routes
 
 = Route6 - Route6.route
+
 conf.route6.flush()
 conf.route6.ipv6_ifaces = set(['lo', 'eth0'])
 conf.route6.routes=[
@@ -4356,7 +4402,12 @@ conf.route6.routes=[
 (                 '2001:db8:0:4444::',  64,                       '::', 'eth0', ['2001:db8:0:4444:20f:1fff:feca:4650'], 1), 
 (                                '::',   0, 'fe80::20f:34ff:fe8a:8aa1', 'eth0', ['2001:db8:0:4444:20f:1fff:feca:4650', '2002:db8:0:4444:20f:1fff:feca:4650'], 1)
 ]
-conf.route6.route("2002::1") == ('eth0', '2002:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1') and conf.route6.route("2001::1") == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1') and conf.route6.route("fe80::20f:1fff:feab:4870") == ('eth0', 'fe80::20f:1fff:feca:4650', '::') and conf.route6.route("::1") == ('lo', '::1', '::') and conf.route6.route("::") == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1') and conf.route6.route('ff00::') == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1')
+assert conf.route6.route("2002::1") == ('eth0', '2002:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1')
+assert conf.route6.route("2001::1") == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1')
+assert conf.route6.route("fe80::20f:1fff:feab:4870") == ('eth0', 'fe80::20f:1fff:feca:4650', '::')
+assert conf.route6.route("::1") == ('lo', '::1', '::')
+assert conf.route6.route("::") == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1')
+assert conf.route6.route('ff00::') == ('eth0', '2001:db8:0:4444:20f:1fff:feca:4650', 'fe80::20f:34ff:fe8a:8aa1')
 conf.iface = conf_iface
 conf.route6.resync()
 if not len(conf.route6.routes):
@@ -9095,6 +9146,9 @@ test_netbsd_7_0()
 
 import scapy
 
+IFACES._add_fake_iface("enp3s0")
+IFACES._add_fake_iface("lo")
+
 old_routes = conf.route.routes
 old_iface = conf.iface
 old_loopback = conf.loopback_name
@@ -9124,10 +9178,15 @@ finally:
     conf.iface = old_iface
     conf.route.routes = old_routes
     conf.route.invalidate_cache()
+    IFACES.reload()
 
 
 = Mocked IPv6 routes calls
 
+IFACES._add_fake_iface("enp3s0")
+IFACES._add_fake_iface("lo")
+
+old_routes = conf.route6.routes
 old_iface = conf.iface
 old_loopback = conf.loopback_name
 try:

--- a/test/windows.uts
+++ b/test/windows.uts
@@ -25,31 +25,19 @@ assert select_objects([TimeOutSelector()], 1) == []
 ############
 + Windows arch unit tests
 
-= Test pcapname
+= Test network_name
 
 iface = conf.iface
 
-assert pcapname(iface.name) == iface.pcap_name
-assert pcapname(iface.description) == iface.pcap_name
-assert pcapname(iface.pcap_name) == iface.pcap_name
+assert network_name(iface.name) == iface.network_name
+assert network_name(iface.description) == iface.network_name
+assert network_name(iface.network_name) == iface.network_name
 
-= show_interfaces
-
-from scapy.arch import show_interfaces
-
-with ContextManagerCaptureOutput() as cmco:
-    show_interfaces()
-    lines = cmco.get_output().split("\n")[1:]
-    for l in lines:
-        if not l.strip():
-            continue
-        int(l[:2])
-
-= dev_from_pcapname
+= dev_from_networkname
 
 from scapy.config import conf
 
-assert dev_from_pcapname(conf.iface.pcap_name).guid == conf.iface.guid
+assert dev_from_networkname(conf.iface.network_name).guid == conf.iface.guid
 
 = test pcap_service_status
 
@@ -74,7 +62,7 @@ assert pcap_service_status()[2] == True
 def _test_autostart_ui(mocked_getiflist):
     mocked_getiflist.side_effect = lambda: []
     IFACES.reload()
-    assert all(x.win_index < 0 for x in IFACES.data.values())
+    assert all(x.index < 0 for x in IFACES.data.values())
 
 try:
     old_ifaces = IFACES.data.copy()

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ description = "Scapy unit tests"
 whitelist_externals = sudo
 passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT
           # Used by scapy
-          SCAPY_USE_PCAPDNET
+          SCAPY_USE_LIBPCAP
 deps = mock
        # cryptography requirements
        setuptools>=18.5


### PR DESCRIPTION
A pretty major refactor based on a [very old PR](https://github.com/secdev/scapy/pull/2264), but pretty cool. This:

- unifies how interfaces work on all platforms using a `scapy/interfaces.py` file and introducing `conf.ifaces`
- makes the switch to libpcap work in all cases
- drops the last places where "dnet" was used to make it clear we stopped supporting it (env var, "pcapdnet" file)
- merges `get_if_list` on all platforms
- improves how interfaces are detected on OSX
- gives extra detail about the status of the interfaces using interfaces flags and lists all interfaces in a human friendly way
- allows multiple interfaces providers to cohabitate, in a [wireshark extcap](https://www.wireshark.org/docs/man-pages/extcap.html) style, and for each one to provide it's own sockets. This is very useful for USB sockets for instance, or if the user wants to add its own interfaces/providers to scapy.

It brings the "interfaces" objects to other platforms. Those are cool because they give you the content of the flags and avoid having to re-read the /etc/ files each time you need them.

### Screenshots

e.g.: Linux
![image](https://user-images.githubusercontent.com/10530980/87220442-08341b80-c364-11ea-8e7e-20d044bc70be.png)


e.g.: Usbpcap AND libpcap
![image](https://user-images.githubusercontent.com/10530980/87220411-b55a6400-c363-11ea-90eb-e80556a0083d.png)

This is fully backward compatible: the interfaces objects implement the same functions as strings: `conf.iface + "test" == "eth0test"` so that it doesn't break anything, and all functions use a `network_name` function to get the network name from the object or a string (instead of the current `if WINDOWS:` .... checks)

## Tested

- [x] Windows & Linux (manual + unit tests)
- [x] OS x (manual + unit tests)
- [x] *BSD (manual)

## How to test this

**Mainteners, please test the changes (there are unit tests, but I'd like you all to give some feedback on the features)**: try playing around with `conf.ifaces` and `conf.iface`, then with `conf.use_pcap` to understand what it does.