### PR TITLE
Revert part of 2629

### DIFF
--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -9,11 +9,30 @@ SMB (Server Message Block), also known as CIFS - version 2
 
 from scapy.config import conf
 from scapy.packet import Packet, bind_layers
-from scapy.fields import StrFixedLenField, LEIntField, LEShortEnumField, \
-    ShortEnumField, XLEIntField, LEShortField, FlagsField, LELongField, \
-    XLELongField, XNBytesField, FieldLenField, IntField, FieldListField, \
-    XStrLenField, ShortField, IntEnumField, StrFieldUtf16, XLEShortField, \
-    UUIDField, XLongField, PacketListField, PadField
+from scapy.fields import (
+    FieldLenField,
+    FieldListField,
+    FlagsField,
+    IntEnumField,
+    IntField,
+    LEIntField,
+    LELongField,
+    LEShortEnumField,
+    LEShortField,
+    PacketListField,
+    PadField,
+    ShortEnumField,
+    ShortField,
+    StrFieldUtf16,
+    StrFixedLenField,
+    UUIDField,
+    XLEIntField,
+    XLELongField,
+    XLEShortField,
+    XLongField,
+    XNBytesField,
+    XStrLenField,
+)
 
 
 # EnumField
@@ -35,13 +54,13 @@ SMB2_NEGOCIATE_CONTEXT_TYPES = {
 
 # FlagField
 SMB2_CAPABILITIES = {
-    30: "CapabilitiesEncryption",
-    29: "CapabilitiesDirectoryLeasing",
-    28: "CapabilitiesPersistentHandles",
-    27: "CapabilitiesMultiChannel",
-    26: "CapabilitiesLargeMTU",
-    25: "CapabilitiesLeasing",
-    24: "CapabilitiesDFS",
+    30: "Encryption",
+    29: "DirectoryLeasing",
+    28: "PersistentHandles",
+    27: "MultiChannel",
+    26: "LargeMTU",
+    25: "Leasing",
+    24: "DFS",
 }
 
 # EnumField
@@ -75,6 +94,13 @@ class SMB2_Header(Packet):
         XLELongField("SessionID", 0),
         XNBytesField("Signature", 0, 16),
     ]
+
+    def guess_payload_class(self, payload):
+        if self.Command == 0x0000:
+            if self.Flags.SMB2_FLAGS_SERVER_TO_REDIR:
+                return SMB2_Negociate_Protocol_Response_Header
+            return SMB2_Negociate_Protocol_Request_Header
+        return super(SMB2_Header, self).guess_payload_class(payload)
 
 
 class SMB2_Compression_Transform_Header(Packet):
@@ -270,18 +296,6 @@ bind_layers(SMB2_Preauth_Integrity_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Encryption_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Compression_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Netname_Negociate_Context_ID, conf.padding_layer)
-bind_layers(
-    SMB2_Header,
-    SMB2_Negociate_Protocol_Request_Header,
-    Command=0x0000,
-    Flags=lambda f: (f >> 24) & 1 == 0
-)
-bind_layers(
-    SMB2_Header,
-    SMB2_Negociate_Protocol_Response_Header,
-    Command=0x0000,
-    Flags=lambda f: (f >> 24) & 1 == 1
-)
 bind_layers(
     SMB2_Negociate_Context,
     SMB2_Preauth_Integrity_Capabilities,

--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -8,7 +8,7 @@ SMB (Server Message Block), also known as CIFS - version 2
 """
 
 from scapy.config import conf
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_layers, bind_top_down
 from scapy.fields import (
     FieldLenField,
     FieldListField,
@@ -296,6 +296,18 @@ bind_layers(SMB2_Preauth_Integrity_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Encryption_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Compression_Capabilities, conf.padding_layer)
 bind_layers(SMB2_Netname_Negociate_Context_ID, conf.padding_layer)
+bind_top_down(
+    SMB2_Header,
+    SMB2_Negociate_Protocol_Request_Header,
+    Command=0x0000,
+    Flags=0
+)
+bind_top_down(
+    SMB2_Header,
+    SMB2_Negociate_Protocol_Response_Header,
+    Command=0x0000,
+    Flags=2 ** 24  # SMB2_FLAGS_SERVER_TO_REDIR
+)
 bind_layers(
     SMB2_Negociate_Context,
     SMB2_Preauth_Integrity_Capabilities,

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -886,14 +886,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         for t in self.aliastypes:
             for fval, cls in t.payload_guess:
                 try:
-                    for k, v in six.iteritems(fval):
-                        # case where v is a function
-                        if callable(v):
-                            if not v(self.getfieldval(k)):
-                                break
-                        elif v != self.getfieldval(k):
-                            break
-                    else:
+                    if all(v == self.getfieldval(k)
+                           for k, v in six.iteritems(fval)):
                         return cls
                 except AttributeError:
                     pass

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1487,6 +1487,35 @@ assert "f2" in flags
 assert "f4" in flags
 assert "f0" in flags
 
+= FlagsField with str
+
+class TCPTest(Packet):
+    fields_desc = [
+        BitField("reserved", 0, 7),
+        FlagsField("flags", 0x2, 9, "FSRPAUECN")
+    ]
+
+a = TCPTest(flags=3)
+assert a.flags.F
+assert a.flags.S
+assert a.sprintf("%flags%") == "FS"
+
+= FlagsField with dict
+
+class FlagsTest2(Packet):
+    fields_desc = [
+        FlagsField("flags", 0x2, 16, {
+            0: "A",  # 0 bit
+            7: "B"   # 7 bit
+        })
+    ]
+
+a = FlagsTest2(flags=255)
+a.sprintf("%flags%")
+assert a.flags.A
+assert a.flags.B
+assert a.sprintf("%flags%") == "A+bit_1+bit_2+bit_3+bit_4+bit_5+bit_6+B"
+
 
 ########
 ########

--- a/test/smb2.uts
+++ b/test/smb2.uts
@@ -1,7 +1,3 @@
-############
-############
-~ SMB2
-
 + SMB2 Header
 
 = SMB2 Header dissecting
@@ -58,15 +54,6 @@ pkt = IP() / TCP() / NBTSession() / SMB2_Header()
 assert pkt[NBTSession].TYPE == 0x00         # session message
 smb2 = pkt[SMB2_Header]
 assert smb2.Start == b'\xfeSMB'
-
-
-
-
-
-
-
-
-
 
 + SMB2 Negociate Procotol Request Header dissecting
 
@@ -146,28 +133,6 @@ assert netname.DataLength == 28
 assert netname.NetName == '192.168.178.21'
 
 
-
-
-
-
-
-
-
-
-+ test SMB2 Negociate Protocol Request Header - assembling
-
-pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Request_Header()
-assert SMB2_Negociate_Protocol_Request_Header in pkt
-
-
-
-
-
-
-
-
-
-
 + SMB2 Negociate Protocol Response Header dissecting
 
 = Common fields in header
@@ -229,16 +194,3 @@ assert comp.CompressionAlgorithmCount == 1
 assert len(comp.CompressionAlgorithms) == 1
 assert comp.CompressionAlgorithms[0] == 1
 
-
-
-
-
-
-
-
-
-
-+ SMB2 Negociate Protocol Response Header assembling
-
-pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Response_Header()
-assert SMB2_Negociate_Protocol_Response_Header in pkt

--- a/test/smb2.uts
+++ b/test/smb2.uts
@@ -132,6 +132,11 @@ assert netname.ContextType == 0x5
 assert netname.DataLength == 28
 assert netname.NetName == '192.168.178.21'
 
+= test SMB2 Negociate Protocol Request Header - assembling
+
+pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Request_Header()
+pkt = IP(raw(pkt))
+assert SMB2_Negociate_Protocol_Request_Header in pkt
 
 + SMB2 Negociate Protocol Response Header dissecting
 
@@ -194,3 +199,8 @@ assert comp.CompressionAlgorithmCount == 1
 assert len(comp.CompressionAlgorithms) == 1
 assert comp.CompressionAlgorithms[0] == 1
 
+= SMB2 Negociate Protocol Response Header assembling
+
+pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Response_Header()
+pkt = IP(raw(pkt))
+assert SMB2_Negociate_Protocol_Response_Header in pkt


### PR DESCRIPTION
Revert a small part of https://github.com/secdev/scapy/pull/2629

~~I really don't like this addition: it slows `guess_payload_class` for a marginal use case. `bind_layers` should NOT allow callables.
The proper way has always been to add a custom `guess_payload_class` function when the bindings don't fit a `bind_layers` call.~~

It also seems that SMB2 is currently completly broken, mostly because of how it uses the FlagsFields. This fixes it