### PR TITLE
Update utils.corrupt_bits() and corrupt_bytes() docs

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -891,7 +891,7 @@ def load_object(fname):
 
 @conf.commands.register
 def corrupt_bytes(s, p=0.01, n=None):
-    """Corrupt a given percentage or number of bytes from a string"""
+    """Corrupt a given percentage (at least one byte) or number of bytes from a string"""
     s = array.array("B", bytes_encode(s))
     s_len = len(s)
     if n is None:
@@ -903,7 +903,7 @@ def corrupt_bytes(s, p=0.01, n=None):
 
 @conf.commands.register
 def corrupt_bits(s, p=0.01, n=None):
-    """Flip a given percentage or number of bits from a string"""
+    """Flip a given percentage (at least one bit) or number of bits from a string"""
     s = array.array("B", bytes_encode(s))
     s_len = len(s) * 8
     if n is None:


### PR DESCRIPTION
fixes #2721

Documents a corner case for `utils.corrupt_bits()` and `utils.corrupt_bytes()`. Both functions will corrupt at least one bit or byte on a given percentage even when the percentage implies a much lower corruption rate.

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->


