### PR TITLE
Fix cryptography 3.0 test

### DIFF
--- a/test/cert.uts
+++ b/test/cert.uts
@@ -69,9 +69,9 @@ z.pubkey.public_numbers().x == 1047486561747694969523700054215665182527042630001
 
 = PubKeyRSA class : Generate without modulus
 t = PubKeyRSA()
-t.fill_and_store(modulus=None, pubExp=32769, modulusLen=1024)
+t.fill_and_store(modulus=None, pubExp=65537, modulusLen=1024)
 assert t.pubkey.key_size == 1024
-assert t.pubkey.public_numbers().e == 32769
+assert t.pubkey.public_numbers().e == 65537
 
 ########### PrivKey class ###############################################
 


### PR DESCRIPTION
Fix test for cryptography 3.0

```
###(011)=[failed] PubKeyRSA class : Generate without modulus
1966

1967
>>> t = PubKeyRSA()
1968
>>> t.fill_and_store(modulus=None, pubExp=32769, modulusLen=1024)
1969
Traceback (most recent call last):
1970
  File "<input>", line 2, in <module>
1971
  File "scapy/config.py", line 719, in func_in
1972
    return func(*args, **kwargs)
1973
  File "scapy/layers/tls/cert.py", line 266, in fill_and_store
1974
    backend=default_backend())
1975
  File "/home/runner/work/scapy/scapy/.tox/py27-linux_non_root/lib/python2.7/site-packages/cryptography/hazmat/primitives/asymmetric/rsa.py", line 119, in generate_private_key
1976
    _verify_rsa_parameters(public_exponent, key_size)
1977
  File "/home/runner/work/scapy/scapy/.tox/py27-linux_non_root/lib/python2.7/site-packages/cryptography/hazmat/primitives/asymmetric/rsa.py", line 126, in _verify_rsa_parameters
1978
    "public_exponent must be either 3 (for legacy compatibility) or "
1979
ValueError: public_exponent must be either 3 (for legacy compatibility) or 65537. Almost everyone should choose 65537 here!
```