### PR TITLE
Catch invalid filter: tcpdump()

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -855,12 +855,12 @@ class AsyncSniffer(object):
                     all(isinstance(elt, str) for elt in offline):
                 sniff_sockets.update((PcapReader(
                     fname if flt is None else
-                    tcpdump(fname, args=["-w", "-", flt], getfd=True)
+                    tcpdump(fname, args=["-w", "-"], flt=flt, getfd=True)
                 ), fname) for fname in offline)
             elif isinstance(offline, dict):
                 sniff_sockets.update((PcapReader(
                     fname if flt is None else
-                    tcpdump(fname, args=["-w", "-", flt], getfd=True)
+                    tcpdump(fname, args=["-w", "-"], flt=flt, getfd=True)
                 ), label) for fname, label in six.iteritems(offline))
             else:
                 # Write Scapy Packet objects to a pcap file
@@ -878,7 +878,8 @@ class AsyncSniffer(object):
                 sniff_sockets[PcapReader(
                     offline if flt is None else
                     tcpdump(offline,
-                            args=["-w", "-", flt],
+                            args=["-w", "-"],
+                            flt=flt,
                             getfd=True,
                             quiet=quiet)
                 )] = offline

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7180,6 +7180,16 @@ assert(all(UDP in p for p in l))
 l = sniff(offline=IP()/UDP(sport=(10000, 10001)), filter="tcp")
 assert len(l) == 0
 
+= Check offline sniff() with Packets, tcpdump and a bad filter
+~ tcpdump
+
+try:
+    sniff(offline=IP()/UDP(), filter="bad filter")
+except Scapy_Exception:
+    pass
+else:
+    assert False
+
 = Check offline sniff with lfilter
 assert len(sniff(offline=[IP()/UDP(), IP()/TCP()], lfilter=lambda x: TCP in x)) == 1
 


### PR DESCRIPTION
An alternative to #2205. To discuss

fix #2205 
fix #2172