### PR TITLE
radiotap: add support for fixed order Tx flag

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -212,7 +212,7 @@ _rt_channelflags = ['res1', 'res2', 'res3', 'res4', 'Turbo', 'CCK',
 
 _rt_rxflags = ["res1", "BAD_PLCP", "res2"]
 
-_rt_txflags = ["TX_FAIL", "CTS", "RTS", "NOACK", "NOSEQ"]
+_rt_txflags = ["TX_FAIL", "CTS", "RTS", "NOACK", "NOSEQ", "ORDER"]
 
 _rt_channelflags2 = ['res1', 'res2', 'res3', 'res4', 'Turbo', 'CCK',
                      'OFDM', '2GHz', '5GHz', 'Passive', 'Dynamic_CCK_OFDM',

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1260,7 +1260,7 @@ assert r.MCS_index == 5
 assert r.Ness_LSB == 0
 
 = RadioTap RX/TX Flags dissection
-data = b'\x00\x00\x0c\x00\x00\xc0\x00\x00\x02\x00\x1f\x00'
+data = b'\x00\x00\x0c\x00\x00\xc0\x00\x00\x02\x00\x3f\x00'
 r = RadioTap(data)
 r.show()
 assert r.present.TXFlags
@@ -1269,6 +1269,7 @@ assert r.TXFlags.CTS
 assert r.TXFlags.RTS
 assert r.TXFlags.NOACK
 assert r.TXFlags.NOSEQ
+assert r.TXFlags.ORDER
 assert r.present.RXFlags
 assert r.RXFlags.BAD_PLCP
 


### PR DESCRIPTION
This patch is part of my proposal to add a new bit to the Tx flags of the radiotap header. I consider the patch itself ready, but the code should only be merged if/once this addition has gone through [radiotap's standardization process](https://www.radiotap.org/Standardisation).