### PR TITLE
fix len calculation for CDPMsgAddr

### DIFF
--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -195,8 +195,7 @@ class CDPMsgAddr(CDPMsgGeneric):
 
     def post_build(self, pkt, pay):
         if self.len is None:
-            tmp_len = 8 + len(self.addr) * 9
-            pkt = pkt[:2] + struct.pack("!H", tmp_len) + pkt[4:]
+            pkt = pkt[:2] + struct.pack("!H", len(pkt)) + pkt[4:]
         p = pkt + pay
         return p
 


### PR DESCRIPTION
The original len calculation uses a constant value `9`, for it only considers `CDPAddrRecordIPv4`. For `CDPAddrRecordIPv6`, it has a length `28`. So update the len calculation using the `plen` and `addrlen` field in `CDPAddrRecord`.

https://github.com/secdev/scapy/blob/c68ee2bc05a0cd3cd2341ad915590260e33487fd/scapy/contrib/cdp.py#L188-L202
