### PR TITLE
Minor HTTP improvements

### DIFF
--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -240,7 +240,7 @@ class TCPSession(IPSession):
         pay = pkt[TCP].payload
         if isinstance(pay, (NoPayload, conf.padding_layer)):
             return pkt
-        new_data = raw(pay)
+        new_data = pay.original
         # Match packets by a uniqute TCP identifier
         seq = pkt[TCP].seq
         ident = pkt.sprintf(self.fmt)
@@ -256,7 +256,7 @@ class TCPSession(IPSession):
             pay_class = metadata["pay_class"]
         # Get a relative sequence number for a storage purpose
         relative_seq = metadata.get("relative_seq", None)
-        if not relative_seq:
+        if relative_seq is None:
             relative_seq = metadata["relative_seq"] = seq - 1
         seq = seq - relative_seq
         # Add the data to the buffer

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7750,6 +7750,18 @@ for i in range(3, 10):
     assert HTTP not in pkts[i]
     assert H2Frame in pkts[i]
 
+= Test chunked with gzip
+
+conf.contribs["http"]["auto_compression"] = False
+z = b'\x1f\x8b\x08\x00S\\-_\x02\xff\xb3\xc9(\xc9\xcd\xb1\xcb\xcd)\xb0\xd1\x07\xb3\x00\xe6\xedpt\x10\x00\x00\x00'
+a = IP(dst="1.1.1.1", src="2.2.2.2")/TCP(seq=1)/HTTP()/HTTPResponse(Content_Encoding="gzip", Transfer_Encoding="chunked")/(b"5\r\n" + z[:5] + b"\r\n")
+b = IP(dst="1.1.1.1", src="2.2.2.2")/TCP(seq=len(a[TCP].payload)+1)/HTTP()/(hex(len(z[5:])).encode()[2:] + b"\r\n" + z[5:] + b"\r\n0\r\n\r\n")
+xa, xb = IP(raw(a)), IP(raw(b))
+conf.contribs["http"]["auto_compression"] = True
+
+c = sniff(offline=[xa, xb], session=TCPSession)[0]
+assert gzip_decompress(z) == c.load
+
 ############
 ############
 + LLMNR protocol


### PR DESCRIPTION
- fix https://github.com/secdev/scapy/issues/2744
- supress brotli warning when not encountered: it's rarely used and the warning is annoying

I won't add unit tests because we have too many HTTP ones already, and they always end up being giant :/