### PR TITLE
MQTTSubscribe now supports multiple topic subscriptions in the payload.

### DIFF
--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -236,7 +236,7 @@ class MQTTSubscribe(Packet):
     name = "MQTT subscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], cls=MQTTTopicQOS)
+        PacketListField("topics", [], MQTTTopicQOS)
     ]
 
 ALLOWED_RETURN_CODE = {
@@ -258,7 +258,7 @@ class MQTTUnsubscribe(Packet):
     name = "MQTT unsubscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], cls=MQTTTopic)
+        PacketListField("topics", [], MQTTTopic)
     ]
 
 

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -239,7 +239,7 @@ class MQTTSubscribe(Packet):
     name = "MQTT subscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], MQTTTopicQOS)
+        PacketListField("topics", [], cls=MQTTTopicQOS)
     ]
 
 
@@ -263,7 +263,7 @@ class MQTTUnsubscribe(Packet):
     name = "MQTT unsubscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], MQTTTopic)
+        PacketListField("topics", [], cls=MQTTTopic)
     ]
 
 

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -232,22 +232,12 @@ class MQTTTopic(Packet):
 class MQTTTopicQOS(MQTTTopic):
     fields_desc = MQTTTopic.fields_desc + [ByteEnumField("QOS", 0, QOS_LEVEL)]
 
-def cb_topic_qos(pkt, lst, cur, remain):
-    """
-    Decode the remaining bytes as a MQTT topic
-    """
-    if len(remain) > 3:
-        return MQTTTopicQOS
-    else:
-        return conf.raw_layer
-
 class MQTTSubscribe(Packet):
     name = "MQTT subscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], next_cls_cb=cb_topic_qos)
+        PacketListField("topics", [], cls=MQTTTopicQOS)
     ]
-
 
 ALLOWED_RETURN_CODE = {
     0: 'Success',
@@ -264,22 +254,11 @@ class MQTTSuback(Packet):
         ByteEnumField("retcode", None, ALLOWED_RETURN_CODE)
     ]
 
-
-def cb_topic(pkt, lst, cur, remain):
-    """
-    Decode the remaining bytes as a MQTT topic
-    """
-    if len(remain) > 3:
-        return MQTTTopic
-    else:
-        return conf.raw_layer
-
-
 class MQTTUnsubscribe(Packet):
     name = "MQTT unsubscribe"
     fields_desc = [
         ShortField("msgid", None),
-        PacketListField("topics", [], next_cls_cb=cb_topic)
+        PacketListField("topics", [], cls=MQTTTopic)
     ]
 
 

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -222,8 +222,8 @@ class MQTTPubcomp(Packet):
 class MQTTTopic(Packet):
     name = "MQTT topic"
     fields_desc = [
-        FieldLenField("len", None, length_of="topic"),
-        StrLenField("topic", "", length_from=lambda pkt:pkt.len)
+        FieldLenField("length", None, length_of="topic"),
+        StrLenField("topic", "", length_from=lambda pkt:pkt.length)
     ]
 
     def guess_payload_class(self, payload):

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -219,6 +219,7 @@ class MQTTPubcomp(Packet):
         ShortField("msgid", None),
     ]
 
+
 class MQTTTopic(Packet):
     name = "MQTT topic"
     fields_desc = [
@@ -229,8 +230,10 @@ class MQTTTopic(Packet):
     def guess_payload_class(self, payload):
         return conf.padding_layer
 
+
 class MQTTTopicQOS(MQTTTopic):
     fields_desc = MQTTTopic.fields_desc + [ByteEnumField("QOS", 0, QOS_LEVEL)]
+
 
 class MQTTSubscribe(Packet):
     name = "MQTT subscribe"
@@ -238,6 +241,7 @@ class MQTTSubscribe(Packet):
         ShortField("msgid", None),
         PacketListField("topics", [], MQTTTopicQOS)
     ]
+
 
 ALLOWED_RETURN_CODE = {
     0: 'Success',
@@ -253,6 +257,7 @@ class MQTTSuback(Packet):
         ShortField("msgid", None),
         ByteEnumField("retcode", None, ALLOWED_RETURN_CODE)
     ]
+
 
 class MQTTUnsubscribe(Packet):
     name = "MQTT unsubscribe"

--- a/test/contrib/mqtt.uts
+++ b/test/contrib/mqtt.uts
@@ -70,20 +70,20 @@ assert(connack.retcode == 0)
 
 
 = MQTTSubscribe, packet instantiation
-sb = MQTT()/MQTTSubscribe(msgid=1,topic='newtopic',QOS=0,length=0)
+sb = MQTT()/MQTTSubscribe(msgid=1, topics=[MQTTTopicQOS(topic='newtopic', QOS=0, length=0)])
 assert(sb.type == 8)
 assert(sb.msgid == 1)
-assert(sb.topic == b'newtopic')
-assert(sb.length == 0)
-assert(sb[MQTTSubscribe].QOS == 0)
+assert(sb.topics[0].topic == b'newtopic')
+assert(sb.topics[0].length == 0)
+assert(sb[MQTTSubscribe][MQTTTopicQOS].QOS == 0)
 
 = MQTTSubscribe, packet dissection
 s = b'\x82\t\x00\x01\x00\x04test\x00'
 subscribe = MQTT(s)
 assert(subscribe.msgid == 1)
-assert(subscribe.length == 4)
-assert(subscribe.topic == b'test')
-assert(subscribe.QOS == 1)
+assert(subscribe.topics[0].length == 4)
+assert(subscribe.topics[0].topic == b'test')
+assert(subscribe.topics[0].QOS == 0)
 
 
 = MQTTSuback, packet instantiation
@@ -129,3 +129,7 @@ assert(type(MQTT().fieldtype['len'].randval() + 0) == int)
 = MQTTUnsubscribe
 u = MQTT(b'\xA2\x0C\x00\x01\x00\x03\x61\x2F\x62\x00\x03\x63\x2F\x64')
 assert MQTTUnsubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/d"
+
+= MQTTSubscribe
+u = MQTT(b'\x82\x10\x00\x01\x00\x03\x61\x2F\x62\x02\x00\x03\x63\x2F\x64\x00')
+assert MQTTSubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/d"

--- a/test/contrib/mqtt.uts
+++ b/test/contrib/mqtt.uts
@@ -70,20 +70,20 @@ assert(connack.retcode == 0)
 
 
 = MQTTSubscribe, packet instantiation
-sb = MQTT()/MQTTSubscribe(msgid=1, topics=[MQTTTopicQOS(topic='newtopic', QOS=0, length=0)])
+sb = MQTT()/MQTTSubscribe(msgid=1, topics=[MQTTTopicQOS(topic='newtopic', QOS=1, length=0)])
 assert(sb.type == 8)
 assert(sb.msgid == 1)
 assert(sb.topics[0].topic == b'newtopic')
 assert(sb.topics[0].length == 0)
-assert(sb[MQTTSubscribe][MQTTTopicQOS].QOS == 0)
+assert(sb[MQTTSubscribe][MQTTTopicQOS].QOS == 1)
 
 = MQTTSubscribe, packet dissection
-s = b'\x82\t\x00\x01\x00\x04test\x00'
+s = b'\x82\t\x00\x01\x00\x04test\x01'
 subscribe = MQTT(s)
 assert(subscribe.msgid == 1)
 assert(subscribe.topics[0].length == 4)
 assert(subscribe.topics[0].topic == b'test')
-assert(subscribe.topics[0].QOS == 0)
+assert(subscribe.topics[0].QOS == 1)
 
 
 = MQTTSuback, packet instantiation
@@ -98,6 +98,30 @@ suback = MQTT(s)
 assert(suback.msgid == 1)
 assert(suback.retcode == 0)
 
+= MQTTUnsubscribe, packet instantiation
+unsb = MQTT()/MQTTUnsubscribe(msgid=1, topics=[MQTTTopic(topic='newtopic',length=0)])
+assert(unsb.type == 10)
+assert(unsb.msgid == 1)
+assert(unsb.topics[0].topic == b'newtopic')
+assert(unsb.topics[0].length == 0)
+
+= MQTTUnsubscribe, packet dissection
+u = b'\xA2\x09\x00\x01\x00\x03\x61\x2F\x62'
+unsubscribe = MQTT(u)
+assert(unsubscribe.msgid == 1)
+assert(unsubscribe.topics[0].length == 3)
+assert(unsubscribe.topics[0].topic == b'a/b')
+
+= MQTTUnsuback, packet instantiation
+unsk = MQTT()/MQTTUnsuback(msgid=1)
+assert(unsk.type == 11)
+assert(unsk.msgid == 1)
+
+= MQTTUnsuback, packet dissection
+u = b'\xb0\x02\x00\x01'
+unsuback = MQTT(u)
+assert(unsuback.type == 11)
+assert(unsuback.msgid == 1)
 
 = MQTTPubrec, packet instantiation
 pc = MQTT()/MQTTPubrec(msgid=1)


### PR DESCRIPTION
Fixes issue where multiple topic subscriptions were not recognized using MQTTSubscribe.
Although a previous pull request addressed the issue in which multiple topics were not recognized in MQTTUnsubscribe packets, the problem still remained for MQTTSubscribe.

Now, MQTTSubscribe allows users to create a packet with single or multiple topics for subscriptions. 

The specification states that the SUBSCRIBE packet must have the Topic Length, Topic Name, and the QoS for each topic. Thus, a class was written that inherits attributes of the class MQTTTopic, while adding the QoS for each topic.

Any suggestions to improve the changes are welcome.

