### PR TITLE
Add new parameter to PacketList.sr() [ready for merge]

### DIFF
--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -745,17 +745,26 @@ class _PacketList(Generic[_Inner]):
 class PacketList(_PacketList[Packet],
                  BasePacketList,
                  _CanvasDumpExtended):
-    def sr(self, multi=0):
-        # type: (int) -> Tuple[SndRcvList, PacketList]
-        """sr([multi=1]) -> (SndRcvList, PacketList)
-        Matches packets in the list and return ( (matched couples), (unmatched packets) )"""  # noqa: E501
+    def sr(self, multi=False, lookahead=None):
+        # type: (bool, Optional[int]) -> Tuple[SndRcvList, PacketList]
+        """
+        Matches packets in the list
+
+        :param multi: True if a packet can have multiple answers
+        :param lookahead: Maximum number of packets between packet and answer.
+                          If 0 or None, full remaining list is
+                          scanned for answers
+        :return: ( (matched couples), (unmatched packets) )
+        """
         remain = self.res[:]
-        sr = []
+        sr = []  # type: List[Tuple[Packet, Packet]]
         i = 0
+        if lookahead is None or lookahead == 0:
+            lookahead = len(remain)
         while i < len(remain):
             s = remain[i]
             j = i
-            while j < len(remain) - 1:
+            while j < min(lookahead + i, len(remain) - 1):
                 j += 1
                 r = remain[j]
                 if r.answers(s):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -11891,6 +11891,62 @@ p[IP]
 ############
 + PacketList methods
 
+= sr()
+
+class Req(Packet):
+    fields_desc = [
+        ByteField("raw", 0)
+    ]
+    def answers(self, other):
+        return False
+
+class Res(Packet):
+    fields_desc = [
+        ByteField("raw", 0)
+    ]
+    def answers(self, other):
+        return other.__class__ == Req and other.raw == self.raw
+
+pl = PacketList([Req(b"1"), Res(b"1"), Req(b"2"), Req(b"3"), Req(b"4"), Res(b"3"), Res(b"1"), Res(b"1"), Res(b"4")])
+
+srl, rl = pl.sr()
+assert len(srl) == 3
+assert len(rl) == 3
+
+srl, rl = pl.sr(lookahead=1)
+assert len(srl) == 1
+assert len(rl) == 7
+
+srl, rl = pl.sr(lookahead=2)
+assert len(srl) == 2
+assert len(rl) == 5
+
+srl, rl = pl.sr(lookahead=3)
+assert len(srl) == 3
+assert len(rl) == 3
+
+pl = PacketList([Req(b"\x05"), Res(b"1"), Res(b"2"), Res(b"3"), Res(b"4"), Res(b"3"), Res(b"1"), Res(b"1"), Res(b"\x05")])
+
+srl, rl = pl.sr(lookahead=3)
+assert len(srl) == 0
+assert len(rl) == 9
+
+srl, rl = pl.sr(lookahead=7)
+assert len(srl) == 0
+assert len(rl) == 9
+
+srl, rl = pl.sr(lookahead=8)
+assert len(srl) == 1
+assert len(rl) == 7
+
+srl, rl = pl.sr(lookahead=0)
+assert len(srl) == 1
+assert len(rl) == 7
+
+srl, rl = pl.sr(lookahead=None)
+assert len(srl) == 1
+assert len(rl) == 7
+
 = plot()
 
 import mock


### PR DESCRIPTION
This parameter limits the lookahead width to search for a answer packet in the remaining list.
With this parameter, the sr() function can be speed up drastically on long PacketLists
