### PR TITLE
Improve packet pickling

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -103,18 +103,16 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         for lower, fval in six.iteritems(self._overload_fields):
             print("%-20s  %s" % (lower.__name__, ", ".join("%-12s" % ("%s=%r" % i) for i in six.iteritems(fval))))  # noqa: E501
 
-    def _unpickle(self, dlist):
-        """Used to unpack pickling"""
-        self.__init__(b"".join(dlist))
-        return self
-
     def __reduce__(self):
         """Used by pickling methods"""
-        return (self.__class__, (), (self.build(),))
-
-    def __reduce_ex__(self, proto):
-        """Used by pickling methods"""
-        return self.__reduce__()
+        return (self.__class__, (), (
+            self.build(),
+            self.time,
+            self.sent_time,
+            self.direction,
+            self.sniffed_on,
+            self.wirelen,
+        ))
 
     def __getstate__(self):
         """Mark object as pickable"""
@@ -122,7 +120,13 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
 
     def __setstate__(self, state):
         """Rebuild state using pickable methods"""
-        return self._unpickle(state)
+        self.__init__(state[0])
+        self.time = state[1]
+        self.sent_time = state[2]
+        self.direction = state[3]
+        self.sniffed_on = state[4]
+        self.wirelen = state[5]
+        return self
 
     def __deepcopy__(self, memo):
         """Used by copy.deepcopy"""
@@ -148,6 +152,8 @@ class Packet(six.with_metaclass(Packet_metaclass, BasePacket,
         self.raw_packet_cache = None
         self.raw_packet_cache_fields = None
         self.wirelen = None
+        self.direction = None
+        self.sniffed_on = None
         if _pkt:
             self.dissect(_pkt)
             if not _internal:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -13267,13 +13267,19 @@ if PYX and not six.PY2:
 import pickle
 
 frm = Ether(src='00:11:22:33:44:55', dst='00:22:33:44:55:66')/Raw()
+frm.time = EDecimal(123.45)
+frm.sniffed_on = "iface"
+frm.wirelen = 1
 pl = PacketList(res=[frm, frm], name='WhatAGreatName')
 pickled = pickle.dumps(pl)
 pl = pickle.loads(pickled)
-assert(pl.listname == "WhatAGreatName")
-assert(len(pl) == 2)
-assert(pl[0][Ether].src == '00:11:22:33:44:55')
-assert(pl[1][Ether].dst == '00:22:33:44:55:66')
+assert pl.listname == "WhatAGreatName"
+assert len(pl) == 2
+assert pl[0].time == 123.45
+assert pl[0].sniffed_on == "iface"
+assert pl[0].wirelen == 1
+assert pl[0][Ether].src == '00:11:22:33:44:55'
+assert pl[1][Ether].dst == '00:22:33:44:55:66'
 
 
 ############


### PR DESCRIPTION
- keep packet metadata (time, sent_time...) when using `pickle`
- fix https://github.com/secdev/scapy/issues/2648