### PR TITLE
Properly save sent_time in pcaps

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1423,7 +1423,13 @@ class RawPcapWriter:
             # Import here to avoid a circular dependency
             from scapy.plist import SndRcvList
             if isinstance(pkt, SndRcvList):
-                pkt = (p for t in pkt for p in t)
+                def _iter(pkt=pkt):
+                    for s, r in pkt:
+                        if s.sent_time:
+                            s.time = s.sent_time
+                        yield s
+                        yield r
+                pkt = _iter()
             else:
                 pkt = pkt.__iter__()
             for p in pkt:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7138,6 +7138,17 @@ assert newpktpcapwirelen[0].wirelen is not None
 assert len(newpktpcapwirelen[0]) < newpktpcapwirelen[0].wirelen
 assert newpktpcapwirelen[0].wirelen == pktpcapwirelen[0].wirelen
 
+= Check wrpcap() then rdpcap() with sent_time on SndRcvList
+f = get_temp_file()
+s = Ether()/IP()
+r = Ether()/IP()
+s.sent_time = 1
+r.time = 2
+wrpcap(f, SndRcvList([(s, r)]))
+pcap = rdpcap(f)
+assert pcap[0].time == 1
+assert pcap[1].time == 2
+
 = Check wrpcap()
 fdesc, filename = tempfile.mkstemp()
 fdesc = os.fdopen(fdesc, "wb")


### PR DESCRIPTION
- use `sent_time` as time when storing a packet in a pcap or when iterating over `SndRcvList`
- fix https://github.com/secdev/scapy/issues/2427