### PR TITLE
Remove unused read_allowed_exceptions

### DIFF
--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -151,7 +151,10 @@ class L3WinSocket(SuperSocket, SelectableObject):
         self.outs.sendto(data, (dst_ip, 0))
 
     def nonblock_recv(self, x=MTU):
-        return self.recv()
+        try:
+            return self.recv()
+        except IOError:
+            return None
 
     # https://docs.microsoft.com/en-us/windows/desktop/winsock/tcp-ip-raw-sockets-2  # noqa: E501
     # - For IPv4 (address family of AF_INET), an application receives the IP

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -197,8 +197,6 @@ def select_objects(inputs, remain):
 
 
 class ObjectPipe(SelectableObject):
-    read_allowed_exceptions = ()
-
     def __init__(self):
         self.closed = False
         self.rd, self.wr = os.pipe()

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -327,7 +327,6 @@ def rdcandump(filename, count=-1, interface=None):
 class CandumpReader:
     """A stateful candump reader. Each packet is returned as a CAN packet"""
 
-    read_allowed_exceptions = ()  # emulate SuperSocket
     nonblocking_socket = True
 
     def __init__(self, filename, interface=None):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -904,7 +904,6 @@ class AsyncSniffer(object):
 
         # Get select information from the sockets
         _main_socket = next(iter(sniff_sockets))
-        read_allowed_exceptions = _main_socket.read_allowed_exceptions
         select_func = _main_socket.select
         _backup_read_func = _main_socket.__class__.recv
         nonblocking_socket = _main_socket.nonblocking_socket
@@ -913,10 +912,6 @@ class AsyncSniffer(object):
             warning("Warning: inconsistent socket types ! "
                     "The used select function "
                     "will be the one of the first socket")
-
-        # Fill if empty
-        if not read_allowed_exceptions:
-            read_allowed_exceptions = (IOError,)
 
         if nonblocking_socket:
             # select is non blocking
@@ -966,8 +961,6 @@ class AsyncSniffer(object):
                         except Exception:
                             pass
                         dead_sockets.append(s)
-                        continue
-                    except read_allowed_exceptions:
                         continue
                     except Exception as ex:
                         msg = " It was closed."

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -60,7 +60,6 @@ class SuperSocket(six.with_metaclass(_SuperSocket_metaclass)):
     desc = None
     closed = 0
     nonblocking_socket = False
-    read_allowed_exceptions = ()
     auxdata_available = False
 
     def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):  # noqa: E501

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1012,7 +1012,6 @@ class PcapReader_metaclass(type):
 class RawPcapReader(six.with_metaclass(PcapReader_metaclass)):
     """A stateful pcap reader. Each packet is returned as a string"""
 
-    read_allowed_exceptions = ()  # emulate SuperSocket
     nonblocking_socket = True
     PacketMetadata = collections.namedtuple("PacketMetadata",
                                             ["sec", "usec", "wirelen", "caplen"])  # noqa: E501


### PR DESCRIPTION
- remove unused socket parameter (used to be for Windows but we got rid of it thanks to EOFError catching). It's going to be a source of weird bugs because it dismisses `IOError`s by default