### PR TITLE
ISOTPScan improvement

### DIFF
--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -185,6 +185,14 @@ assert(p.exsrc == 3)
 assert(p.data == b"eee")
 assert(bytes(p) == b"eee")
 
+= ISOTP answers test
+p = ISOTP()
+r = ISOTP()
+assert(p.data == b"")
+assert(p.answers(r))
+assert(not p.answers(Raw()))
+
+
 = Creation of a simple ISOTP packet with src validation error
 ex = False
 try:
@@ -433,6 +441,21 @@ assert(fragment.length == 5)
 assert(fragment.reserved == 0)
 assert(fragment.flags == 4)
 
+= Fragment a 8 bytes long ISOTP message extended
+fragments = ISOTP(b"datadata", dst=0x1fff0000).fragment()
+assert(len(fragments) == 2)
+assert(isinstance(fragments[0], CAN))
+fragment = CAN(bytes(fragments[0]))
+assert(fragment.data == b"\x10\x08datada")
+assert(fragment.length == 8)
+assert(fragment.reserved == 0)
+assert(fragment.flags == 4)
+fragment = CAN(bytes(fragments[1]))
+assert(fragment.data == b"\x21ta")
+assert(fragment.length == 3)
+assert(fragment.reserved == 0)
+assert(fragment.flags == 4)
+
 = Fragment a 7 bytes long ISOTP message
 fragments = ISOTP(b"abcdefg").fragment()
 assert(len(fragments) == 1)
@@ -490,12 +513,27 @@ fragments = [CAN(identifier=0x641, data=b"\xa4test")]
 isotp = ISOTP.defragment(fragments)
 assert isotp is None
 
+= Defragment ISOTP message with warning
+fragments = [CAN(identifier=0x641, data=b"\x04test"), CAN(identifier=0x642, data=b"\x04test")]
+isotp = ISOTP.defragment(fragments)
+assert(isotp.data == b"test")
+assert(isotp.dst == 0x641)
+
 = Defragment exception
 fragments = []
 ex = False
 try:
     isotp = ISOTP.defragment(fragments)
     isotp.show()
+except Scapy_Exception:
+    ex = True
+
+assert ex
+
+= Fragment exception
+ex = False
+try:
+    fragments = ISOTP(b"a" * (1 << 32)).fragment()
 except Scapy_Exception:
     ex = True
 
@@ -1275,6 +1313,13 @@ assert (isotp.dst == 0x541)
 isotp = pkts[0]
 assert(isotp.data == dhex(""))
 assert (isotp.dst == 0x241)
+
+= ISOTPSession tests
+
+ses = ISOTPSession()
+ses.on_packet_received(None)
+ses.on_packet_received([None, None])
+assert True
 
 = Receive a two-frame ISOTP message
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s:

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -300,6 +300,44 @@ def test_isotpscan_text(sniff_time=0.02):
     assert "0x703" in result
     assert "No Padding" in result
 
+def test_isotpscan_text_padding(sniff_time=0.02):
+    semaphore = threading.Semaphore(0)
+    def isotpserver(i):
+        with new_can_socket0() as isocan, \
+                ISOTPSocket(isocan, sid=0x700 + i, did=0x600 + i, padding=True) as isotpsock:
+            isotpsock.sniff(timeout=1500 * sniff_time, count=1,
+                            started_callback=semaphore.release)
+    pkt = CAN(identifier=0x701, length=8,
+              data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    thread_noise = threading.Thread(target=make_noise, args=(pkt, sniff_time,))
+    thread_noise.start()
+    thread1 = threading.Thread(target=isotpserver, args=(2,))
+    thread2 = threading.Thread(target=isotpserver, args=(3,))
+    thread1.start()
+    thread2.start()
+    semaphore.acquire()
+    semaphore.acquire()
+    with new_can_socket0() as scansock:
+        result = ISOTPScan(scansock, range(0x5ff, 0x604 + 1),
+                           output_format="text",
+                           noise_listen_time=sniff_time * 6,
+                           sniff_time=sniff_time,
+                           verbose=True)
+    with new_can_socket0() as cans:
+        cans.send(CAN(identifier=0x601, data=b'\x01\xaaffffff'))
+        cans.send(CAN(identifier=0x602, data=b'\x01\xaaffffff'))
+        cans.send(CAN(identifier=0x603, data=b'\x01\xaaffffff'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
+    text = "\nFound 2 ISOTP-FlowControl Packet(s):"
+    assert text in result
+    assert "0x602" in result
+    assert "0x603" in result
+    assert "0x702" in result
+    assert "0x703" in result
+    assert "Padding enabled" in result
+
 
 def test_isotpscan_text_extended_can_id(sniff_time=0.02):
     semaphore = threading.Semaphore(0)
@@ -385,6 +423,43 @@ def test_isotpscan_code(sniff_time=0.02):
     print(result)
     assert s1 in result
     assert s2 in result
+
+
+def test_isotpscan_code_noise(sniff_time=0.02):
+    semaphore = threading.Semaphore(0)
+    def isotpserver(i):
+        with new_can_socket0() as isocan, \
+                ISOTPSocket(isocan, sid=0x700 + i, did=0x600 + i) as isotpsock:
+            isotpsock.sniff(timeout=1500 * sniff_time, count=1,
+                            started_callback=semaphore.release)
+    pkt = CAN(identifier=0x702, length=8,
+              data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
+    thread_noise = threading.Thread(target=make_noise, args=(pkt, sniff_time,))
+    thread_noise.start()
+    thread1 = threading.Thread(target=isotpserver, args=(2,))
+    thread2 = threading.Thread(target=isotpserver, args=(3,))
+    thread1.start()
+    thread2.start()
+    semaphore.acquire()
+    semaphore.acquire()
+    with new_can_socket0() as scansock:
+        result = ISOTPScan(scansock, range(0x5ff, 0x603 + 1),
+                           output_format="code",
+                           noise_listen_time=sniff_time * 6,
+                           sniff_time=sniff_time,
+                           can_interface="can0",
+                           verbose=True)
+    with new_can_socket0() as cans:
+        cans.send(CAN(identifier=0x601, data=b'\x01\xaa'))
+        cans.send(CAN(identifier=0x603, data=b'\x01\xaa'))
+    thread1.join(timeout=10)
+    thread2.join(timeout=10)
+    thread_noise.join(timeout=10)
+    s2 = "ISOTPSocket(can0, sid=0x603, did=0x703, " \
+         "padding=False, basecls=ISOTP)\n"
+    print(result)
+    assert s2 in result
+
 
 
 def test_extended_isotpscan_code(sniff_time=0.02):
@@ -758,6 +833,10 @@ test_dynamic(test_scan_extended)
 
 test_dynamic(test_isotpscan_text)
 
+= Test ISOTPScan with padding (output_format=text)
+
+test_dynamic(test_isotpscan_text_padding)
+
 = Test ISOTPScan(output_format=text) extended_can_id
 
 test_dynamic(test_isotpscan_text_extended_can_id)
@@ -765,6 +844,10 @@ test_dynamic(test_isotpscan_text_extended_can_id)
 = Test ISOTPScan(output_format=code)
 
 test_dynamic(test_isotpscan_code)
+
+= Test ISOTPScan with noise (output_format=code)
+
+test_dynamic(test_isotpscan_code_noise)
 
 = Test extended ISOTPScan(output_format=code)
 


### PR DESCRIPTION
This PR changes the internal behavior of the ISOTPScan functions.

The captured noise before a scan is executed is now used to suppress probe packets.
On some cars these probe packets caused errors. This change ensures that no packets
which could interfere with the cars internal communication are sent during an ISOTP
scan.

Cleanup of function comments and added type information