### PR TITLE
Pass pcap file objects through to tcpdump's stdin

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1794,6 +1794,9 @@ def tcpdump(pktlist=None, dump=False, getfd=False, args=None, flt=None,
         if prog[0] == conf.prog.wireshark:
             # Start capturing immediately (-k) from stdin (-i -)
             read_stdin_opts = ["-ki", "-"]
+        elif prog[0] == conf.prog.tcpdump:
+            # Capture in packet-buffered mode (-U) from stdin (-r -)
+            read_stdin_opts = ["-U", "-r", "-"]
         else:
             read_stdin_opts = ["-r", "-"]
     else:
@@ -1831,26 +1834,41 @@ def tcpdump(pktlist=None, dump=False, getfd=False, args=None, flt=None,
                 stderr=stderr,
             )
     else:
-        # pass the packet stream
-        with ContextManagerSubprocess(prog[0], suppress=_suppress):
-            proc = subprocess.Popen(
-                prog + read_stdin_opts + args,
-                stdin=subprocess.PIPE,
-                stdout=stdout,
-                stderr=stderr,
-            )
-            if proc is None:
-                # An error has occurred
-                return
         try:
-            proc.stdin.writelines(iter(lambda: pktlist.read(1048576), b""))
-        except AttributeError:
-            wrpcap(proc.stdin, pktlist, linktype=linktype)
-        except UnboundLocalError:
-            # The error was handled by ContextManagerSubprocess
-            pass
+            pktlist.fileno()
+            pipe = True
+        except Exception:
+            pipe = False
+        if pipe:
+            # pass the packet stream
+            with ContextManagerSubprocess(prog[0], suppress=_suppress):
+                proc = subprocess.Popen(
+                    prog + read_stdin_opts + args,
+                    stdin=pktlist,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
         else:
-            proc.stdin.close()
+            # write the packet stream to stdin
+            with ContextManagerSubprocess(prog[0], suppress=_suppress):
+                proc = subprocess.Popen(
+                    prog + read_stdin_opts + args,
+                    stdin=subprocess.PIPE,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+                if proc is None:
+                    # An error has occurred
+                    return
+            try:
+                proc.stdin.writelines(iter(lambda: pktlist.read(1048576), b""))
+            except AttributeError:
+                wrpcap(proc.stdin, pktlist, linktype=linktype)
+            except UnboundLocalError:
+                # The error was handled by ContextManagerSubprocess
+                pass
+            else:
+                proc.stdin.close()
     if proc is None:
         # An error has occurred
         return

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1836,10 +1836,6 @@ def tcpdump(pktlist=None, dump=False, getfd=False, args=None, flt=None,
     else:
         try:
             pktlist.fileno()
-            pipe = True
-        except Exception:
-            pipe = False
-        if pipe:
             # pass the packet stream
             with ContextManagerSubprocess(prog[0], suppress=_suppress):
                 proc = subprocess.Popen(
@@ -1848,7 +1844,7 @@ def tcpdump(pktlist=None, dump=False, getfd=False, args=None, flt=None,
                     stdout=stdout,
                     stderr=stderr,
                 )
-        else:
+        except (AttributeError, ValueError):
             # write the packet stream to stdin
             with ContextManagerSubprocess(prog[0], suppress=_suppress):
                 proc = subprocess.Popen(
@@ -1857,9 +1853,9 @@ def tcpdump(pktlist=None, dump=False, getfd=False, args=None, flt=None,
                     stdout=stdout,
                     stderr=stderr,
                 )
-                if proc is None:
-                    # An error has occurred
-                    return
+            if proc is None:
+                # An error has occurred
+                return
             try:
                 proc.stdin.writelines(iter(lambda: pktlist.read(1048576), b""))
             except AttributeError:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7366,7 +7366,7 @@ with mock.patch('subprocess.Popen', return_value=Bunch(
         tcpdump([pkt], linktype="DLT_EN3MB", use_tempfile=False)
 
 popen.assert_called_once_with(
-    [conf.prog.tcpdump, '-y', 'EN3MB', '-r', '-'],
+    [conf.prog.tcpdump, '-y', 'EN3MB', '-U', '-r', '-'],
     stdin=subprocess.PIPE, stdout=None, stderr=None)
 
 print(bytes_hex(f.getvalue()))
@@ -7387,7 +7387,7 @@ with mock.patch('subprocess.Popen', return_value=Bunch(
         tcpdump([pkt], linktype=scapy.data.DLT_EN10MB, use_tempfile=False)
 
 popen.assert_called_once_with(
-    [conf.prog.tcpdump, '-y', 'EN10MB', '-r', '-'],
+    [conf.prog.tcpdump, '-y', 'EN10MB', '-U', '-r', '-'],
     stdin=subprocess.PIPE, stdout=None, stderr=None)
 
 print(bytes_hex(f.getvalue()))


### PR DESCRIPTION
This PR prevents sniff from blocking when handed a file-like object and a pcap filter. Instead of attempting to pipe the entire input file into tcpdump, we just pass the file through to the stdin of the subprocess.

fixes #2780
