### PR TITLE
Fix scapy init on FreeBSD.

### DIFF
--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -49,7 +49,7 @@ def read_routes():
     if SOLARIS:
         f = os.popen("netstat -rvn -f inet")
     elif FREEBSD:
-        f = os.popen("netstat -rnW")  # -W to handle long interface names
+        f = os.popen("netstat -rnW -f inet")  # -W to show long interface names
     else:
         f = os.popen("netstat -rn -f inet")
     ok = 0
@@ -71,7 +71,7 @@ def read_routes():
                 mtu_present = "mtu" in line
                 prio_present = "prio" in line
                 refs_present = "ref" in line  # There is no s on Solaris
-                use_present = "use" in line
+                use_present = "use" in line or "nhop" in line
             continue
         if not line:
             break


### PR DESCRIPTION
- Read ipv4 table in read_routes() instead of all, fixing IPv6-only setups.
- Address FreeBSD 13 netstat -rnW output change by skipping "nhop" column.

Before (IPv6 only, FreeBSD):
```
17:57 [1] m@devel2 s jexec qqq netstat -rn
Routing tables

Internet6:
Destination                       Gateway                       Flags     Netif Expire
fe80::%epair0a/64                 link#2                        U       epair0a
fe80::ab:6aff:fede:e30a%epair0a   link#1                        UHS         lo0
..
17:58 [1] m@devel2 s jexec qqq /usr/home/melifaro/scapy/run_scapy
INFO: Can't import matplotlib. Won't be able to plot.
INFO: Can't import PyX. Won't be able to use psdump() or pdfdump().
Traceback (most recent call last):
  File "/usr/home/melifaro/scapy/scapy/utils.py", line 534, in atol
    ip = inet_aton(x)
OSError: illegal IP address string passed to inet_aton

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/home/melifaro/scapy/scapy/__main__.py", line 15, in <module>
    interact()
  File "/usr/home/melifaro/scapy/scapy/main.py", line 560, in interact
    SESSION, GLOBKEYS = init_session(session_name, mydict)
  File "/usr/home/melifaro/scapy/scapy/main.py", line 401, in init_session
    importlib.import_module(".all", "scapy").__dict__
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/home/melifaro/scapy/scapy/all.py", line 25, in <module>
    from scapy.route import *
  File "/usr/home/melifaro/scapy/scapy/route.py", line 199, in <module>
    conf.route = Route()
  File "/usr/home/melifaro/scapy/scapy/route.py", line 27, in __init__
    self.resync()
  File "/usr/home/melifaro/scapy/scapy/route.py", line 35, in resync
    self.routes = read_routes()
  File "/usr/home/melifaro/scapy/scapy/arch/unix.py", line 103, in read_routes
    dest = scapy.utils.atol(dest)
  File "/usr/home/melifaro/scapy/scapy/utils.py", line 536, in atol
    ip = inet_aton(socket.gethostbyname(x))
socket.gaierror: [Errno 8] Name does not resolve
```

After:
```
17:59 [1] m@devel2 s jexec qqq /usr/home/melifaro/scapy/run_scapy
INFO: Can't import matplotlib. Won't be able to plot.
INFO: Can't import PyX. Won't be able to use psdump() or pdfdump().
INFO: Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption. (Dot11)
INFO: Can't import python-cryptography v1.7+. Disabled IPsec encryption/authentication.
WARNING: IPython not available. Using standard Python shell instead.
AutoCompletion, History are disabled.
```

Before (nhop change, FreeBSD 13):
```
18:00 [1] m@devel2 (cd test && ./run_tests)
### Non-root mode ###
### Booting scapy...
Failed to execute ifconfig: (ifconfig: interface 1500 does not exist
)
Failed to execute ifconfig: (ifconfig: interface 1500 does not exist
)
more Failed to execute ifconfig: (ifconfig: interface 16384 does not exist
)
### Starting tests...
### Writing output...
```

After:
```
18:01 [1] m@devel2 (cd test && ./run_tests)
### Non-root mode ###
### Booting scapy...
### Starting tests...
### Writing output...
```
