### PR TITLE
Stop processing a pcapng file when a block is malformed

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1234,6 +1234,7 @@ class RawPcapNgReader(RawPcapReader):
                 if (blocklen,) != struct.unpack(self.endian + 'I',
                                                 self.f.read(4)):
                     warning("PcapNg: Invalid pcapng block (bad blocklen)")
+                    raise EOFError
             except struct.error:
                 raise EOFError
             res = self.blocktypes.get(blocktype,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7269,6 +7269,12 @@ assert isinstance(pkt, Padding) and pkt.load == b'\xeay$\xf6'
 pkt = pkt.payload
 assert isinstance(pkt, NoPayload)
 
+= Invalid pcapng file
+
+from io import BytesIO
+invalid_pcapngfile = BytesIO(b'\n\r\r\n\r\x00\x00\x00M<+\x1a\xb2<\xb2\xa1\x01\x00\x00\x00\r\x00\x00\x00M<+\x1a\x80\xaa\xb2\x02')
+assert(len(rdpcap(invalid_pcapngfile)) == 0)
+
 = Check PcapWriter on null write
 
 f = BytesIO()


### PR DESCRIPTION
This PR fixes #2787 