### PR TITLE
Pin brotli version

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -7682,6 +7682,7 @@ assert HTTPResponse in pkts[2]
 assert pkts[2].load == b'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"><html><head><title></title></head><body style="background-color: transparent"><img src=\'https://pixel.mathtag.com/event/img?mt_id=151466&mt_adid=106144&v1=&v2=&v3=&s1=&s2=&s3=&ord=2047279765\' width=\'1\' height=\'1\' /><img src="https://adservice.google.com/ddm/fls/z/src=3656617;type=hpvisit;cat=homep198;u2=;u6=;u5=;u4=;u3=;u9=;u10=;u7=;u13=;u14=;u11=;u17=;u18=unknown;u20=;ord=1956603866265.9536"/></body></html>'
 
 = HTTP decompression (brotli)
+~ brotli
 
 conf.debug_dissector = True
 load_layer("http")

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps = mock
        cryptography
        coverage
        python-can
-       brotli
+       brotli<1.0.8
 platform =
   linux_non_root,linux_root: linux
   bsd_non_root,bsd_root: darwin|freebsd|openbsd|netbsd


### PR DESCRIPTION
Try pinning brotli 1.0.7 to fix the build install on Windows Py2.7