### PR TITLE
Add GRH and AETH header support in RoCE dissector

### DIFF
--- a/scapy/contrib/roce.py
+++ b/scapy/contrib/roce.py
@@ -213,8 +213,19 @@ class GRH(Packet):
         XBitField("dgid", 0, 128),
     ]
 
+
+class AETH(Packet):
+    name = "AETH"
+    fields_desc = [
+        XByteField("syndrome", 0),
+        XBitField("msn", 0, 24),
+    ]
+
+
 bind_layers(BTH, CNPPadding, opcode=CNP_OPCODE)
 
 bind_layers(Ether, GRH, type=0x8915)
 bind_layers(GRH, BTH)
+bind_layers(BTH, AETH, opcode=opcode('RC', 'ACKNOWLEDGE')[0])
+bind_layers(BTH, AETH, opcode=opcode('RD', 'ACKNOWLEDGE')[0])
 bind_layers(UDP, BTH, dport=4791)

--- a/scapy/contrib/roce.py
+++ b/scapy/contrib/roce.py
@@ -11,9 +11,10 @@ RoCE: RDMA over Converged Ethernet
 """
 
 from scapy.packet import Packet, bind_layers, Raw
-from scapy.fields import ByteEnumField, XShortField, \
-    XLongField, BitField, FCSField
+from scapy.fields import ByteEnumField, ByteField, XByteField, \
+    ShortField, XShortField, XLongField, BitField, XBitField, FCSField
 from scapy.layers.inet import IP, UDP
+from scapy.layers.l2 import Ether
 from scapy.compat import raw
 from scapy.error import warning
 from zlib import crc32
@@ -199,6 +200,21 @@ def cnp(dqpn):
     return BTH(opcode=CNP_OPCODE, becn=1, dqpn=dqpn) / CNPPadding()
 
 
+class GRH(Packet):
+    name = "GRH"
+    fields_desc = [
+        BitField("ipver", 6, 4),
+        BitField("tclass", 0, 8),
+        BitField("flowlabel", 6, 20),
+        ShortField("paylen", 0),
+        ByteField("nexthdr", 0),
+        ByteField("hoplmt", 0),
+        XBitField("sgid", 0, 128),
+        XBitField("dgid", 0, 128),
+    ]
+
 bind_layers(BTH, CNPPadding, opcode=CNP_OPCODE)
 
+bind_layers(Ether, GRH, type=0x8915)
+bind_layers(GRH, BTH)
 bind_layers(UDP, BTH, dport=4791)

--- a/test/contrib/roce.uts
+++ b/test/contrib/roce.uts
@@ -77,3 +77,50 @@ del pkt.icrc
 pkt = Ether(pkt.build())
 assert pkt.icrc == 0x82fd002a
 
+= RoCE v1 RC RDMA WRITE ONLY
+
+pkt = Ether(import_hexcap('''\
+0x0000   7c fe 90 75 3c d8 7c fe 90 75 3c d8 89 15 60 20
+0x0010   00 00 00 28 1b 40 00 00 00 00 00 00 00 00 00 00
+0x0020   ff ff 0f 00 00 02 00 00 00 00 00 00 00 00 00 00
+0x0030   ff ff 0f 00 00 02 0a 70 ff ff 00 00 01 0a 80 a7
+0x0040   88 bc 00 00 55 d4 c0 72 60 00 00 00 47 b3 00 00
+0x0050   00 05 00 00 00 00 01 00 00 00 e3 d8 56 bb
+'''))
+
+assert GRH in pkt.layers()
+assert BTH in pkt.layers()
+assert pkt[GRH].ipver == 6
+assert pkt[GRH].tclass == 2
+assert pkt[GRH].flowlabel == 0
+assert pkt[GRH].paylen == 40
+assert pkt[BTH].opcode == 0xa
+assert pkt[BTH].padcount == 3
+assert pkt[BTH].dqpn == 0x10a
+assert pkt[BTH].ackreq
+assert pkt.icrc == 0xe3d856bb
+
+= RoCE v1 RC ACKNOWLEDGE
+
+pkt = Ether(import_hexcap('''\
+0000   7c fe 90 75 3c d8 7c fe 90 75 3c d8 89 15 60 20
+0010   00 00 00 14 1b 40 00 00 00 00 00 00 00 00 00 00
+0020   ff ff 0f 00 00 02 00 00 00 00 00 00 00 00 00 00
+0030   ff ff 0f 00 00 02 11 40 ff ff 00 00 01 09 00 a7
+0040   88 c0 00 00 00 05 25 f0 c0 38
+'''))
+
+assert GRH in pkt.layers()
+assert BTH in pkt.layers()
+assert AETH in pkt.layers()
+assert pkt[GRH].ipver == 6
+assert pkt[GRH].tclass == 2
+assert pkt[GRH].flowlabel == 0
+assert pkt[GRH].paylen == 20
+assert pkt[BTH].opcode == 0x11
+assert pkt[BTH].padcount == 0
+assert pkt[BTH].dqpn == 0x109
+assert not pkt[BTH].ackreq
+assert pkt[AETH].syndrome == 0
+assert pkt[AETH].msn == 5
+assert pkt.icrc == 0x25f0c038


### PR DESCRIPTION
This PR adds the GRH packet header used in the version 1 of the RoCE protocol, and the AETH packet header as well.