### PR TITLE
Fix TLS split_pem

### DIFF
--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -102,7 +102,12 @@ def split_pem(s):
         if start_idx == -1:
             break
         end_idx = s.find(b"-----END")
+        if end_idx == -1:
+            raise Exception("Invalid PEM object (missing END tag)")
         end_idx = s.find(b"\n", end_idx) + 1
+        if end_idx == 0:
+            # There is no final \n
+            end_idx = len(s)
         pem_strings.append(s[start_idx:end_idx])
         s = s[end_idx:]
     return pem_strings

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -384,6 +384,22 @@ with ContextManagerCaptureOutput() as cmco:
     y.show()
     assert cmco.get_output().strip() == awaited.strip()
 
+= Cert: Check split_pem on chained certs with missing end \n
+from scapy.layers.tls.cert import split_pem
+ks = split_pem(b"""
+-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIMiRlFoy6046m1NXu911ukXyjDLVgmOXWCKWdQMd8gCRoAcGBSuBBAAK
+oUQDQgAE55WjbZjS/88K1kYagsO9wtKifw0IKLp4Jd5qtmDF2Zu+xrwrBRT0HBnP
+weDU+RsFxcyU/QxD9WYORzYarqxbcA==
+-----END EC PRIVATE KEY-----
+-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIMiRlFoy6046m1NXu911ukXyjDLVgmOXWCKWdQMd8gCRoAcGBSuBBAAK
+oUQDQgAE55WjbZjS/88K1kYagsO9wtKifw0IKLp4Jd5qtmDF2Zu+xrwrBRT0HBnP
+weDU+RsFxcyU/QxD9WYORzYarqxbcA==
+-----END EC PRIVATE KEY-----""")
+assert ks[0][:-1] == ks[1]
+
+
 ########### CRL class ###############################################
 
 + CRL class tests


### PR DESCRIPTION
- fix issue in split_pem which could result in an infinite loop when parsing a PEM file with a missing final carriage return.

Repro:
```python
load_layer("tls")
ks = split_pem(b"""
-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIMiRlFoy6046m1NXu911ukXyjDLVgmOXWCKWdQMd8gCRoAcGBSuBBAAK
oUQDQgAE55WjbZjS/88K1kYagsO9wtKifw0IKLp4Jd5qtmDF2Zu+xrwrBRT0HBnP
weDU+RsFxcyU/QxD9WYORzYarqxbcA==
-----END EC PRIVATE KEY-----
-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIMiRlFoy6046m1NXu911ukXyjDLVgmOXWCKWdQMd8gCRoAcGBSuBBAAK
oUQDQgAE55WjbZjS/88K1kYagsO9wtKifw0IKLp4Jd5qtmDF2Zu+xrwrBRT0HBnP
weDU+RsFxcyU/QxD9WYORzYarqxbcA==
-----END EC PRIVATE KEY-----""")
```

This function is called during any `PubKey()`, `PrivKey()`. The only call that is done while dissecting a packet is through `Cert()` in `handshake.py`. This SHOULD not be critical considering it's only for PEM and that DER is used on the network, but who knows if it's not possible to craft a packet which certificate looks just like PEM.

In any case, the TLS module is not loaded by default so it should be fine.