### PR TITLE
Automaton: Skip immediate tests for CommandMessage

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -885,16 +885,20 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                 elif not isinstance(state_output, list):
                     state_output = state_output,
 
-                # Then check immediate conditions
-                for cond in self.conditions[self.state.state]:
-                    self._run_condition(cond, *state_output)
+                # If there are commandMessage, we should skip immediate
+                # conditions.
+                if not select_objects([self.cmdin], 0):
+                    # Then check immediate conditions
+                    for cond in self.conditions[self.state.state]:
+                        self._run_condition(cond, *state_output)
 
-                # If still there and no conditions left, we are stuck!
-                if (len(self.recv_conditions[self.state.state]) == 0 and
-                    len(self.ioevents[self.state.state]) == 0 and
-                        len(self.timeout[self.state.state]) == 1):
-                    raise self.Stuck("stuck in [%s]" % self.state.state,
-                                     state=self.state.state, result=state_output)  # noqa: E501
+                    # If still there and no conditions left, we are stuck!
+                    if (len(self.recv_conditions[self.state.state]) == 0 and
+                        len(self.ioevents[self.state.state]) == 0 and
+                            len(self.timeout[self.state.state]) == 1):
+                        raise self.Stuck("stuck in [%s]" % self.state.state,
+                                         state=self.state.state,
+                                         result=state_output)
 
                 # Finally listen and pay attention to timeouts
                 expirations = iter(self.timeout[self.state.state])

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -363,6 +363,7 @@ def _test_connection():
                                    server_name="www.google.com")
     pkt = a.sr1(HTTP()/HTTPRequest(Host="www.google.com"),
                 session=TCPSession(app=True), timeout=2, retry=3)
+    a.close()
     assert HTTPResponse in pkt
     assert b"</html>" in pkt[HTTPResponse].load
 


### PR DESCRIPTION
The TLS automatons are built (ab)using the `immediate conditions`.
While this allows to bypass the Automaton's socket to use a custom one, it prevents the CommandMessage from reaching the loop, making it impossible to stop an automaton using `stop()`.
This PR adds a check for those messages.

This allows us to close properly the TLS client and fix https://github.com/secdev/scapy/issues/2812