### PR TITLE
Disable ISOTPSCAN tests

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -990,6 +990,8 @@ def main():
             if VERB > 2:
                 print("### libpcap mode ###")
 
+        KW_KO.append("disabled")
+
         # Process extras
         if six.PY3:
             KW_KO.append("FIXME_py3")

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -1,5 +1,9 @@
 % Regression tests for ISOTPScan
 
+# Currently too unstable
+
+~ disabled
+
 + Configuration
 ~ conf
 


### PR DESCRIPTION
Disable tests that have been making tests fail consistently on both GHCI and Travis

Because a lot of tests are identical, they are likely to be able to fail equally. Disable everything