### PR TITLE
Lighten up codecov rules

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,7 +16,11 @@ coverage:
   round: down
   status:
     # Only consider changes to the whole project
-    project: true
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        base: auto
     patch: false
     changes: false
 


### PR DESCRIPTION
Scapy's coverage is a bit too random because of network and automotive tests. We have two options:

- Option 1: Mark codecov tests as "informational" => everything as normal but the output of codecov is only for maintainers: even if codecov tests fail (e.g. regress by 0.1%), the Github tests still pass (currently, we as maintainers just ignore codecov failures for the most part)

- Option 2: allow a small threshold of regression (e.g. 0.5%?) but this is hard to quantify. ==> **This PR*