### PR TITLE
fix naddr field of CDPMsgAddr

### DIFF
--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -189,7 +189,7 @@ class CDPMsgAddr(CDPMsgGeneric):
     name = "Addresses"
     fields_desc = [XShortEnumField("type", 0x0002, _cdp_tlv_types),
                    ShortField("len", None),
-                   FieldLenField("naddr", None, "addr", "!I"),
+                   FieldLenField("naddr", None, fmt="!I", count_of="addr"),
                    PacketListField("addr", [], _CDPGuessAddrRecord,
                                    length_from=lambda x:x.len - 8)]
 

--- a/test/contrib/cdp.uts
+++ b/test/contrib/cdp.uts
@@ -86,6 +86,6 @@ assert len(pkt) == 7
 cdp_msg_addr = CDPMsgAddr(addr=[CDPAddrRecordIPv4(), CDPAddrRecordIPv6()])
 assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv4))
 assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv6))
-assert(len(cdp_msg_addr.addr) == 2))
+assert(len(cdp_msg_addr.addr) == 2)
 
 assert raw(cdp_msg_addr)[4:8] == b'\x00\x00\x00\x02'

--- a/test/contrib/cdp.uts
+++ b/test/contrib/cdp.uts
@@ -81,3 +81,11 @@ assert CDPMsgPortID in p and CDPMsgIPPrefix in p
 
 pkt = CDPv2_HDR(vers=2, ttl=180, msg='123')
 assert len(pkt) == 7
+
+= CDPv2 - CDPMsgAddr Packet
+cdp_msg_addr = CDPMsgAddr(addr=[CDPAddrRecordIPv4(), CDPAddrRecordIPv6())
+assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv4))
+assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv6))
+assert(len(cdp_msg_addr.addr) == 2))
+
+assert raw(cdp_msg_addr)[4:8] == b'\x00\x00\x00\x02'

--- a/test/contrib/cdp.uts
+++ b/test/contrib/cdp.uts
@@ -83,7 +83,7 @@ pkt = CDPv2_HDR(vers=2, ttl=180, msg='123')
 assert len(pkt) == 7
 
 = CDPv2 - CDPMsgAddr Packet
-cdp_msg_addr = CDPMsgAddr(addr=[CDPAddrRecordIPv4(), CDPAddrRecordIPv6())
+cdp_msg_addr = CDPMsgAddr(addr=[CDPAddrRecordIPv4(), CDPAddrRecordIPv6()])
 assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv4))
 assert(cdp_msg_addr.haslayer(CDPAddrRecordIPv6))
 assert(len(cdp_msg_addr.addr) == 2))


### PR DESCRIPTION
The `naddr` filed is the count of how many `CDPAddrRecord` contained in the `addr` field, not its total length. So use `count_of` instead.
