### PR TITLE
Fix typo in inet6.py

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -676,8 +676,8 @@ class HBHOptUnknown(Packet):  # IPv6 Hop-By-Hop Option
         """
         As specified in section 4.2 of RFC 2460, every options has
         an alignment requirement usually expressed xn+y, meaning
-        the Option Type must appear at an integer multiple of x octest
-        from the start of the header, plus y octet.
+        the Option Type must appear at an integer multiple of x octets
+        from the start of the header, plus y octets.
 
         That function is provided the current position from the
         start of the header and returns required padding length.


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
<!--
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-->


<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

Fixes typo in comments, inet6.py (`"octest"` to `"octets"`).

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->
