### PR TITLE
Use any brotli version except 1.0.8/1.0.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps = mock
        cryptography
        coverage
        python-can
-       brotli<1.0.8
+       brotli>=1.0.0,!=1.0.8,!=1.0.9
        zstandard==0.14.0
 platform =
   linux_non_root,linux_root: linux


### PR DESCRIPTION
- change the pinned brotli version to allow any version except 1.0.8/1.0.9

I've made a patch in the brotli repo: https://github.com/google/brotli/pull/843 but they still haven't released a version including it, and I don't want to have to check regularly.