### PR TITLE
Use difflib in hexdiff

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -608,19 +608,63 @@ assert(fletcher16_checkbytes(b"\x28\x07", 1) == b"\xaf(")
 
 = Test hexdiff function
 ~ not_pypy
-def test_hexdiff():
+def test_hexdiff(a, b, autojunk=False):
     conf_color_theme = conf.color_theme
     conf.color_theme = BlackAndWhite()
     with ContextManagerCaptureOutput() as cmco:
-        hexdiff("abcde", "abCde")
+        hexdiff(a, b, autojunk=autojunk)
         result_hexdiff = cmco.get_output()
     conf.interactive = True
     conf.color_theme = conf_color_theme
-    expected  = "0000        61 62 63 64 65                                     abcde\n"
-    expected += "     0000   61 62 43 64 65                                     abCde\n"
-    assert(result_hexdiff == expected)
+    return result_hexdiff
 
-test_hexdiff()
+# Basic string test
+
+result_hexdiff = test_hexdiff("abcde", "abCde")
+expected  = "0000        61 62 63 64 65                                     abcde\n"
+expected += "     0000   61 62 43 64 65                                     abCde\n"
+assert result_hexdiff == expected
+
+# More advanced string test
+
+result_hexdiff = test_hexdiff("add_common_", "_common_removed")
+expected  = "0000        61 64 64 5F 63 6F 6D 6D  6F 6E 5F                  add_common_     \n"
+expected += "     -003            5F 63 6F 6D 6D  6F 6E 5F 72 65 6D 6F 76      _common_remov\n"
+expected += "     000d   65 64                                              ed\n"
+assert result_hexdiff == expected
+
+# Compare packets
+
+result_hexdiff = test_hexdiff(IP(dst="127.0.0.1", src="127.0.0.1"), IP(dst="127.0.0.2", src="127.0.0.1"))
+expected  = "0000        45 00 00 14 00 01 00 00  40 00 7C E7 7F 00 00 01   E.......@.|.....\n"
+expected += "     0000   45 00 00 14 00 01 00 00  40 00 7C E6 7F 00 00 01   E.......@.|.....\n"
+expected += "0010        7F 00 00 01                                        ....\n"
+expected += "     0010   7F 00 00 02                                        ....\n"
+assert result_hexdiff == expected
+
+# Compare using autojunk
+
+a = "A" * 1000 + "findme" + "B" * 1000
+b = "A" * 1000 + "B" * 1000
+ret1 = test_hexdiff(a, b)
+ret2 = test_hexdiff(a, b, autojunk=True)
+
+expected_ret1 = """
+03d0 03d0   41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41   AAAAAAAAAAAAAAAA
+03e0        41 41 41 41 41 41 41 41  66 69 6E 64 6D 65 42 42   AAAAAAAAfindmeBB
+     03e0   41 41 41 41 41 41 41 41                    42 42   AAAAAAAA      BB
+03ea 03ea   42 42 42 42 42 42 42 42  42 42 42 42 42 42 42 42   BBBBBBBBBBBBBBBB
+"""
+expected_ret2 = """
+03d0 03d0   41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41   AAAAAAAAAAAAAAAA
+03e0        41 41 41 41 41 41 41 41  66 69 6E 64 6D 65 42 42   AAAAAAAAfindmeBB
+     03e0   41 41 41 41 41 41 41 41  42 42 42 42 42 42 42 42   AAAAAAAABBBBBBBB
+03f0 03f0   42 42 42 42 42 42 42 42  42 42 42 42 42 42 42 42   BBBBBBBBBBBBBBBB
+"""
+
+assert ret1 != ret2
+assert expected_ret1 in ret1
+assert expected_ret2 in ret2
 
 = Test mysummary functions - Ether
 


### PR DESCRIPTION
The [LCS (wikipedia)](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) solving algorithm that we are using ([same than on wikipedia](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem#Computing_the_length_of_the_LCS)) is actually also implemented in C in the builtin `difflib` library. See [`difflib.SequenceMatcher`](https://docs.python.org/3.8/library/difflib.html#difflib.SequenceMatcher).

This PR:
- use `difflib` instead our own algorithm
    - For small-sized byte strings, this has little effect. However it REALLY makes a difference for long byte strings.
- provides `autojunk` option that is bundled in `difflib`. It marks some lines as junk to detect the most important changes must faster but will in most cases return a partially wrong diff (for instance, insertions missed and seen as replacements). While it is True by default in `difflib`, we'll therefore use `False` as a default.

### Performance: O(n^2)
```python
import time
def test(n):
    x = time.time()
    a = "A" * n + "findme" + "B" * n
    b = "A" * n + "B" * n
    hexdiff(a, b)
    return "%.3gms" % ((time.time() - x) * 1000)
```

| n   | 10      | 100    | 200    | 500    | 1000  | 10000       |
|-----|---------|--------|--------|--------|-------|-------------|
| OLD | 0.842ms | 42.6ms | 175ms  | 1.1s   | 5.56s | MemoryError |
| NEW | 0.446ms | 4.77ms | 19.6ms | 94.7ms | 355ms | 37s         |

When passing `autojunk=True`, it goes crazy fast (`60ms` for n=10000), but has slightly wrong results. For instance in this example, it shows:
![image](https://user-images.githubusercontent.com/10530980/95030046-f20cd180-06ac-11eb-9ed9-8e01a4bf3936.png)
instead of the proper
![image](https://user-images.githubusercontent.com/10530980/95030066-26808d80-06ad-11eb-9335-62b190b49b1b.png)

