### PR TITLE
Do not test invalid interfaces

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -146,7 +146,7 @@ if not conf.use_pcap:
     conf.use_pcap = True
     assert conf.iface.provider.libpcap
     for iface in conf.ifaces.values():
-        assert iface.provider.libpcap
+        assert iface.provider.libpcap or iface.is_valid() == False
     conf.use_pcap = False
     assert not conf.iface.provider.libpcap
 


### PR DESCRIPTION
This PR discards invalid interfaces from a use_pcap test.

On a Docker image, I have the following interfaces:
```
ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: tunl0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ipip 0.0.0.0 brd 0.0.0.0
3: ip6tnl0@NONE: <NOARP> mtu 1452 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/tunnel6 :: brd ::
6: eth0@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
    link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff link-netnsid 0
```

`tunl0` and `ip6tnl0` are not usable which cause the test to fail.