### PR TITLE
Pin MyPy v0.782

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands =
 [testenv:mypy]
 description = "Check Scapy compliance against static typing"
 skip_install = true
-deps = mypy
+deps = mypy==0.782
        typing
 commands = python .config/mypy/mypy_check.py
 


### PR DESCRIPTION
MyPy released 0.790 and it's buggy https://github.com/python/mypy/issues/9122#issuecomment-656918736. Pin 0.782

wtf
```
scapy/main.py:284: error: Argument "key" to "sort" of "list" has incompatible type "Callable[[Dict[str, Optional[str]]], Optional[str]]"; expected "Callable[[Dict[str, Optional[str]]], _SupportsLessThan]"
scapy/main.py:284: error: Incompatible return value type (got "Optional[str]", expected "_SupportsLessThan")
```