### PR TITLE
[Hinty] data.py / dadict.py / pton_ntop.py / mib.py

### DIFF
--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -6,12 +6,16 @@
 
 # CORE
 scapy/__init__.py
+scapy/asn1/mib.py
 scapy/compat.py
 scapy/config.py
+scapy/dadict.py
+scapy/data.py
 scapy/fields.py
 scapy/main.py
 scapy/packet.py
 scapy/plist.py
+scapy/pton_ntop.py
 scapy/route.py
 scapy/route6.py
 scapy/utils.py

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -23,9 +23,13 @@ import subprocess
 import types
 import warnings
 
-from scapy.compat import FAKE_TYPING
 from scapy.consts import WINDOWS
+
 from scapy.modules.six.moves import range
+
+from scapy.compat import (
+    _Generic_metaclass,
+)
 
 
 class Gen(object):
@@ -284,15 +288,11 @@ class Packet_metaclass(type):
 
 # Note: see compat.py for an explanation
 
-class Field_metaclass(type):
+class Field_metaclass(_Generic_metaclass):
     def __new__(cls, name, bases, dct):
         dct.setdefault("__slots__", [])
         newcls = super(Field_metaclass, cls).__new__(cls, name, bases, dct)
         return newcls
-
-    if FAKE_TYPING:
-        def __getitem__(self, type):
-            return self
 
 
 PacketList_metaclass = Field_metaclass

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -1,6 +1,5 @@
 # This file is part of Scapy
 # See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Gabriel Potter <gabriel@potter.fr>
 # This program is published under a GPLv2 license
 
@@ -13,6 +12,7 @@ import base64
 import binascii
 import collections
 import gzip
+import socket
 import struct
 import sys
 
@@ -45,6 +45,7 @@ __all__ = [
     'FAKE_TYPING',
     'TYPE_CHECKING',
     # compat
+    'AddressFamily',
     'base64_bytes',
     'bytes_base64',
     'bytes_encode',
@@ -166,6 +167,21 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     Literal = _FakeType("Literal")
+
+# Python 3.4
+if sys.version_info >= (3, 4):
+    from socket import AddressFamily
+else:
+    class AddressFamily:
+        AF_INET = socket.AF_INET
+        AF_INET6 = socket.AF_INET6
+
+
+class _Generic_metaclass(type):
+    if FAKE_TYPING:
+        def __getitem__(self, typ):
+            # type: (Any) -> Any
+            return self
 
 
 ###########

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -725,7 +725,8 @@ class Conf(ConfClass):
     BTsocket = None
     USBsocket = None
     min_pkt_size = 60
-    mib = None  #: holds MIB direct access dictionary
+    #: holds MIB direct access dictionary
+    mib = None  # type: 'scapy.asn1.mib.MIBDict'
     bufsize = 2**16
     #: history file
     histfile = os.getenv('SCAPY_HISTFILE',
@@ -754,6 +755,7 @@ class Conf(ConfClass):
     #: holds the Scapy IPv6 routing table and provides methods to
     #: manipulate it
     route6 = None  # type: 'scapy.route6.Route6'
+    manufdb = None  # type: 'scapy.data.ManufDA'
     # 'route6' will be filed by route6.py
     auto_fragment = True
     #: raise exception when a packet dissector raises an exception
@@ -810,7 +812,7 @@ class Conf(ConfClass):
     raise_no_dst_mac = False
     loopback_name = "lo" if LINUX else "lo0"
 
-    def __getattr__(self, attr):
+    def __getattribute__(self, attr):
         # type: (str) -> Any
         # Those are loaded on runtime to avoid import loops
         if attr == "manufdb":

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -13,12 +13,25 @@ from scapy.error import Scapy_Exception
 import scapy.modules.six as six
 from scapy.compat import plain_str
 
+from scapy.compat import (
+    Any,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    TypeVar,
+    Union,
+    cast,
+    _Generic_metaclass,
+)
+
 ###############################
 #  Direct Access dictionary   #
 ###############################
 
 
 def fixname(x):
+    # type: (Union[bytes, str]) -> str
     """
     Modifies a string to make sure it can be used as an attribute name.
     """
@@ -38,7 +51,12 @@ class DADict_Exception(Scapy_Exception):
     pass
 
 
-class DADict(object):
+_K = TypeVar('_K')  # Key type
+_V = TypeVar('_V')  # Value type
+
+
+@six.add_metaclass(_Generic_metaclass)
+class DADict(Generic[_K, _V]):
     """
     Direct Access Dictionary
 
@@ -55,64 +73,84 @@ class DADict(object):
         ETHER_TYPES.IPv4 -> 2048
     """
     def __init__(self, _name="DADict", **kargs):
+        # type: (str, **Any) -> None
         self._name = _name
+        self.d = {}  # type: Dict[_K, _V]
         self.update(kargs)
 
     def ident(self, v):
+        # type: (_V) -> str
         """
         Return value that is used as key for the direct access
         """
-        return fixname(v)
+        if isinstance(v, (str, bytes)):
+            return fixname(v)
+        return "unknown"
 
     def update(self, *args, **kwargs):
+        # type: (*Dict[str, _V], **Dict[str, _V]) -> None
         for k, v in six.iteritems(dict(*args, **kwargs)):
             self[k] = v
 
     def iterkeys(self):
-        for x in six.iterkeys(self.__dict__):
+        # type: () -> Iterator[_K]
+        for x in six.iterkeys(self.d):
             if not isinstance(x, str) or x[0] != "_":
                 yield x
 
     def keys(self):
+        # type: () -> List[_K]
         return list(self.iterkeys())
 
     def __iter__(self):
+        # type: () -> Iterator[_K]
         return self.iterkeys()
 
     def itervalues(self):
-        return six.itervalues(self.__dict__)
+        # type: () -> Iterator[_V]
+        return six.itervalues(self.d)  # type: ignore
 
     def values(self):
+        # type: () -> List[_V]
         return list(self.itervalues())
 
     def _show(self):
+        # type: () -> None
         for k in self.iterkeys():
             print("%10s = %r" % (k, self[k]))
 
     def __repr__(self):
+        # type: () -> str
         return "<%s - %s elements>" % (self._name, len(self))
 
     def __getitem__(self, attr):
-        return self.__dict__[attr]
+        # type: (_K) -> _V
+        return self.d[attr]
 
     def __setitem__(self, attr, val):
-        self.__dict__[attr] = val
+        # type: (_K, _V) -> None
+        self.d[attr] = val
 
     def __len__(self):
-        return len(self.__dict__)
+        # type: () -> int
+        return len(self.d)
 
     def __nonzero__(self):
+        # type: () -> bool
         # Always has at least its name
         return len(self) > 1
     __bool__ = __nonzero__
 
     def __getattr__(self, attr):
+        # type: (str) -> _K
         try:
-            return object.__getattribute__(self, attr)
+            return object.__getattribute__(self, attr)  # type: ignore
         except AttributeError:
-            for k, v in six.iteritems(self.__dict__):
+            for k, v in six.iteritems(self.d):
                 if self.ident(v) == attr:
-                    return k
+                    return cast(_K, k)
+        raise AttributeError
 
     def __dir__(self):
+        # type: () -> List[str]
         return [self.ident(x) for x in self.itervalues()]

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -784,11 +784,11 @@ class IP6Field(Field[Optional[str], bytes]):
         # type: (Optional[BasePacket], Optional[str]) -> bytes
         if x is None:
             x = "::"
-        return inet_pton(socket.AF_INET6, plain_str(x))  # type: ignore
+        return inet_pton(socket.AF_INET6, plain_str(x))
 
     def m2i(self, pkt, x):
         # type: (Optional[BasePacket], bytes) -> str
-        return inet_ntop(socket.AF_INET6, x)  # type: ignore
+        return inet_ntop(socket.AF_INET6, x)
 
     def any2i(self, pkt, x):
         # type: (Optional[BasePacket], Optional[str]) -> str
@@ -2214,7 +2214,7 @@ class _EnumField(Field[Union[List[I], I], I]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[I]
-                 enum,  # type: Union[Dict[I, str], List[str], DADict, Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: Union[Dict[I, str], List[str], DADict[I, str], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
                  fmt="H",  # type: str
                  ):
         # type: (...) -> None
@@ -2234,7 +2234,7 @@ class _EnumField(Field[Union[List[I], I], I]):
                         internal value from and to machine representation.
         """
         if isinstance(enum, ObservableDict):
-            enum.observe(self)
+            cast(ObservableDict, enum).observe(self)
 
         if isinstance(enum, tuple):
             self.i2s_cb = enum[0]  # type: Optional[Callable[[I], str]]
@@ -2327,7 +2327,7 @@ class CharEnumField(EnumField[str]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: str
-                 enum,  # type: Union[Dict[str, str], Tuple[Callable[[BasePacket], str], ...]]  # noqa: E501
+                 enum,  # type: Union[Dict[str, str], Tuple[Callable[[str], str], Callable[[str], str]]]  # noqa: E501
                  fmt="1s",  # type: str
                  ):
         # type: (...) -> None
@@ -2375,7 +2375,7 @@ class ShortEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: int
-                 enum,  # type: Union[Dict[int, str], Tuple[Callable[[BasePacket], int], ...], DADict]  # noqa: E501
+                 enum,  # type: Union[Dict[int, str], Tuple[Callable[[int], str], Callable[[str], int]], DADict[int, str]]  # noqa: E501
                  ):
         # type: (...) -> None
         EnumField.__init__(self, name, default, enum, "H")

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -17,11 +17,17 @@ import binascii
 from scapy.modules.six.moves import range
 from scapy.compat import plain_str, hex_bytes, bytes_encode, bytes_hex
 
+from scapy.compat import (
+    AddressFamily,
+    Union,
+)
+
 _IP6_ZEROS = re.compile('(?::|^)(0(?::0)+)(?::|$)')
 _INET6_PTON_EXC = socket.error("illegal IP address string passed to inet_pton")
 
 
 def _inet6_pton(addr):
+    # type: (str) -> bytes
     """Convert an IPv6 address from text representation into binary form,
 used when socket.inet_pton is not available.
 
@@ -79,6 +85,7 @@ _INET_PTON = {
 
 
 def inet_pton(af, addr):
+    # type: (AddressFamily, Union[bytes, str]) -> bytes
     """Convert an IP address from text representation into binary form."""
     # Will replace Net/Net6 objects
     addr = plain_str(addr)
@@ -93,6 +100,7 @@ def inet_pton(af, addr):
 
 
 def _inet6_ntop(addr):
+    # type: (bytes) -> str
     """Convert an IPv6 address from binary form into text representation,
 used when socket.inet_pton is not available.
 
@@ -125,6 +133,7 @@ _INET_NTOP = {
 
 
 def inet_ntop(af, addr):
+    # type: (AddressFamily, bytes) -> str
     """Convert an IP address from binary form into text representation."""
     # Use inet_ntop if available
     addr = bytes_encode(addr)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -10062,7 +10062,7 @@ os.write(fd, b"-- MIB test\nscapy       OBJECT IDENTIFIER ::= {test 2807}\n")
 os.close(fd)
 
 load_mib(fname)
-assert(sum(1 for k in six.itervalues(conf.mib.__dict__) if "scapy" in k) == 1)
+assert(sum(1 for k in six.itervalues(conf.mib.d) if "scapy" in k) == 1)
 
 assert(sum(1 for oid in conf.mib) > 100)
 


### PR DESCRIPTION
- add typing to `data.py`, `dadict.py`, `pton_ntop.py`, `asn1/mib.py`
- Stop abusing `__dict__` of `DADict` to store data that simply shouldn't be there (`__dict__` are `Dict[str, Any]` and we used it wildly), and messes with mypy.
- ~~**requires https://github.com/secdev/scapy/pull/2864 (route & route6)**~~