### PR TITLE
Remove duplicated fields from LTP

### DIFF
--- a/scapy/contrib/bp.py
+++ b/scapy/contrib/bp.py
@@ -56,7 +56,7 @@ class BP(Packet):
                        (SDNV2("ADUL", 0), lambda x: (
                            x.ProcFlags & 0x01)),
                    ],
-                   SDNV2("ADUL", 0)),
+                       SDNV2("ADUL", 0)),
                    ]
 
     def mysummary(self):

--- a/scapy/contrib/bp.py
+++ b/scapy/contrib/bp.py
@@ -27,7 +27,7 @@
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers
-from scapy.fields import ByteEnumField, ByteField, MultipleTypeField, \
+from scapy.fields import ByteEnumField, ByteField, ConditionalField, \
     StrLenField
 from scapy.contrib.sdnv import SDNV2FieldLenField, SDNV2LenField, SDNV2
 from scapy.contrib.ltp import LTP, ltp_bind_payload
@@ -50,13 +50,10 @@ class BP(Packet):
                    SDNV2('CTSN', 0),
                    SDNV2('LT', 0),
                    SDNV2('DL', 0),
-                   MultipleTypeField([
-                       (SDNV2("FO", 0), lambda x: (
-                           x.ProcFlags & 0x01)),
-                       (SDNV2("ADUL", 0), lambda x: (
-                           x.ProcFlags & 0x01)),
-                   ],
-                       SDNV2("ADUL", 0)),
+                   ConditionalField(SDNV2("FO", 0), lambda x: (
+                       x.ProcFlags & 0x01)),
+                   ConditionalField(SDNV2("ADUL", 0), lambda x: (
+                       x.ProcFlags & 0x01)),
                    ]
 
     def mysummary(self):

--- a/scapy/contrib/bp.py
+++ b/scapy/contrib/bp.py
@@ -27,7 +27,7 @@
 # scapy.contrib.status = loads
 
 from scapy.packet import Packet, bind_layers
-from scapy.fields import ByteEnumField, ByteField, ConditionalField, \
+from scapy.fields import ByteEnumField, ByteField, MultipleTypeField, \
     StrLenField
 from scapy.contrib.sdnv import SDNV2FieldLenField, SDNV2LenField, SDNV2
 from scapy.contrib.ltp import LTP, ltp_bind_payload
@@ -50,10 +50,13 @@ class BP(Packet):
                    SDNV2('CTSN', 0),
                    SDNV2('LT', 0),
                    SDNV2('DL', 0),
-                   ConditionalField(SDNV2("FO", 0), lambda x: (
-                       x.ProcFlags & 0x01)),
-                   ConditionalField(SDNV2("ADUL", 0), lambda x: (
-                       x.ProcFlags & 0x01)),
+                   MultipleTypeField([
+                       (SDNV2("FO", 0), lambda x: (
+                           x.ProcFlags & 0x01)),
+                       (SDNV2("ADUL", 0), lambda x: (
+                           x.ProcFlags & 0x01)),
+                   ],
+                   SDNV2("ADUL", 0)),
                    ]
 
     def mysummary(self):

--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -144,13 +144,11 @@ class LTP(Packet):
         MultipleTypeField([
             (SDNV2("ReportSerialNo", 0),
                 lambda x: x.flags in _ltp_checkpoint_segment),
-
             #
             # Field for Reception Reports
             #
             (SDNV2("ReportSerialNo", 0),
                 lambda x: x.flags == 8),
-
         ],
             SDNV2("ReportSerialNo", 0)
         ),

--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -143,15 +143,15 @@ class LTP(Packet):
                          lambda x: x.flags in _ltp_checkpoint_segment),
         MultipleTypeField([
             (SDNV2("ReportSerialNo", 0),
-                         lambda x: x.flags in _ltp_checkpoint_segment),
+                lambda x: x.flags in _ltp_checkpoint_segment),
 
             #
             # Field for Reception Reports
             #
             (SDNV2("ReportSerialNo", 0),
-                         lambda x: x.flags == 8),
+                lambda x: x.flags == 8),
 
-            ],
+        ],
             SDNV2("ReportSerialNo", 0)
         ),
         #

--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -29,8 +29,7 @@
 import scapy.modules.six as six
 from scapy.packet import Packet, bind_layers, bind_top_down
 from scapy.fields import BitEnumField, BitField, BitFieldLenField, \
-    ByteEnumField, ConditionalField, PacketListField, StrLenField, \
-    MultipleTypeField
+    ByteEnumField, ConditionalField, PacketListField, StrLenField
 from scapy.layers.inet import UDP
 from scapy.config import conf
 from scapy.contrib.sdnv import SDNV2, SDNV2FieldLenField
@@ -141,17 +140,12 @@ class LTP(Packet):
         #
         ConditionalField(SDNV2("CheckpointSerialNo", 0),
                          lambda x: x.flags in _ltp_checkpoint_segment),
-        MultipleTypeField([
-            (SDNV2("ReportSerialNo", 0),
-                lambda x: x.flags in _ltp_checkpoint_segment),
-            #
-            # Field for Reception Reports
-            #
-            (SDNV2("ReportSerialNo", 0),
-                lambda x: x.flags == 8),
-        ],
-            SDNV2("ReportSerialNo", 0)
-        ),
+        #
+        # For segments that are checkpoints or reception reports.
+        #
+        ConditionalField(SDNV2("ReportSerialNo", 0),
+                         lambda x: x.flags in _ltp_checkpoint_segment \
+                         or x.flags == 8),
         #
         # Then comes the actual payload for data carrying segments.
         #
@@ -164,7 +158,8 @@ class LTP(Packet):
         ConditionalField(SDNV2("RA_ReportSerialNo", 0),
                          lambda x: x.flags == 9),
         #
-        # Reception reports have the following fields.
+        # Reception reports have the following fields,
+        # excluding ReportSerialNo defined above.
         #
         ConditionalField(SDNV2("ReportCheckpointSerialNo", 0),
                          lambda x: x.flags == 8),


### PR DESCRIPTION
I fixed the SyntaxWarnings described in #2862 in the Bundle Protocol. I didn't add any unit tests, since I'm not changing any functionality.