### PR TITLE
rpl_metrics.py - resolved duplicates

### DIFF
--- a/scapy/contrib/rpl_metrics.py
+++ b/scapy/contrib/rpl_metrics.py
@@ -123,8 +123,8 @@ class RPLDAGMCNSA(DAGMCObj):
                    # NSA Object Body Format
                    ByteField("res", 0),
                    BitField("flags", 0, 6),
-                   BitField("A", 0, 1),
-                   BitField("O", 0, 1)]
+                   BitField("A2", 0, 1),
+                   BitField("O2", 0, 1)]
 
 
 class RPLDAGMCNodeEnergy(DAGMCObj):


### PR DESCRIPTION
-   [X] If you are new to Scapy: I have checked [CONTRIBUTING.md]

Fixed duplicates names for the rpl_metrics.py file. #2862 

I followed the steps outlined in the issues to find the duplicates and changed the names to follow the res1, res2 format.  One note, rather than renaming A1, A2, and O1, O2 - I simply renamed the second A - A2 and the second O - O2, because when reading the code it looked much cleaner like that.  Please advise if additional changes are needed or wanted!  Glad to help out!

fixes #2862 for rpl_metrics.py
