### PR TITLE
Remove duplicated fields from GTP

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -574,13 +574,13 @@ class QoS_Profile(IE_Base):
     name = "QoS profile"
     fields_desc = [ByteField("qos_ei", 0),
                    ByteField("length", None),
-                   XBitField("spare", 0x00, 2),
+                   XBitField("qos_spare1", 0x00, 2),
                    XBitField("delay_class", 0x000, 3),
                    XBitField("reliability_class", 0x000, 3),
                    XBitField("peak_troughput", 0x0000, 4),
                    BitField("spare", 0, 1),
                    XBitField("precedence_class", 0x000, 3),
-                   XBitField("spare", 0x000, 3),
+                   XBitField("qos_spare2", 0x000, 3),
                    XBitField("mean_troughput", 0x00000, 5),
                    XBitField("traffic_class", 0x000, 3),
                    XBitField("delivery_order", 0x00, 2),
@@ -602,7 +602,7 @@ class IE_QoS(IE_Base):
                    ShortField("length", None),
                    ByteField("allocation_retention_prioiry", 1),
 
-                   ConditionalField(XBitField("spare", 0x00, 2),
+                   ConditionalField(XBitField("ie_qos_spare1", 0x00, 2),
                                     lambda p: p.length and p.length > 1),
                    ConditionalField(XBitField("delay_class", 0x000, 3),
                                     lambda p: p.length and p.length > 1),
@@ -611,12 +611,12 @@ class IE_QoS(IE_Base):
 
                    ConditionalField(XBitField("peak_troughput", 0x0000, 4),
                                     lambda p: p.length and p.length > 2),
-                   ConditionalField(BitField("spare", 0, 1),
+                   ConditionalField(BitField("ie_qos_spare2", 0, 1),
                                     lambda p: p.length and p.length > 2),
                    ConditionalField(XBitField("precedence_class", 0x000, 3),
                                     lambda p: p.length and p.length > 2),
 
-                   ConditionalField(XBitField("spare", 0x000, 3),
+                   ConditionalField(XBitField("ie_qos_spare3", 0x000, 3),
                                     lambda p: p.length and p.length > 3),
                    ConditionalField(XBitField("mean_troughput", 0x00000, 5),
                                     lambda p: p.length and p.length > 3),
@@ -727,12 +727,12 @@ class IE_MSTimeZone(IE_Base):
     fields_desc = [ByteEnumField("ietype", 153, IEType),
                    ShortField("length", None),
                    ByteField("timezone", 0),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
+                   BitField("ie_mstz_spare1", 0, 1),
+                   BitField("ie_mstz_spare2", 0, 1),
+                   BitField("ie_mstz_spare3", 0, 1),
+                   BitField("ie_mstz_spare4", 0, 1),
+                   BitField("ie_mstz_spare5", 0, 1),
+                   BitField("ie_mstz_spare6", 0, 1),
                    XBitField("daylight_saving_time", 0x00, 2)]
 
 
@@ -754,11 +754,11 @@ class IE_DirectTunnelFlags(IE_Base):
     name = "Direct Tunnel Flags"
     fields_desc = [ByteEnumField("ietype", 182, IEType),
                    ShortField("length", 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
-                   BitField("Spare", 0, 1),
+                   BitField("ie_dtf_spare1", 0, 1),
+                   BitField("ie_dtf_spare2", 0, 1),
+                   BitField("ie_dtf_spare3", 0, 1),
+                   BitField("ie_dtf_spare4", 0, 1),
+                   BitField("ie_dtf_spare5", 0, 1),
                    BitField("EI", 0, 1),
                    BitField("GCSI", 0, 1),
                    BitField("DTI", 0, 1)]
@@ -775,10 +775,10 @@ class IE_EvolvedAllocationRetentionPriority(IE_Base):
     name = "Evolved Allocation/Retention Priority"
     fields_desc = [ByteEnumField("ietype", 191, IEType),
                    ShortField("length", 1),
-                   BitField("Spare", 0, 1),
+                   BitField("ie_earp_spare1", 0, 1),
                    BitField("PCI", 0, 1),
                    XBitField("PL", 0x0000, 4),
-                   BitField("Spare", 0, 1),
+                   BitField("ie_earp_spare2", 0, 1),
                    BitField("PVI", 0, 1)]
 
 


### PR DESCRIPTION
This PR removes the duplicated fields of the GTP protocol as described in https://github.com/secdev/scapy/issues/2862.

Tested via the CLI and no warnings seen when `load_contrib("gtp")` is run.

