### PR TITLE
Add support for Radiotap TLVs

### DIFF
--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -25,9 +25,21 @@ from __future__ import absolute_import
 import struct
 
 from scapy.packet import Packet, bind_layers
-from scapy.fields import ByteEnumField, ByteField, FieldLenField, FlagsField, \
-    IP6Field, IPField, PacketListField, ShortField, StrLenField, \
-    X3BytesField, XByteField, XShortEnumField, XShortField
+from scapy.fields import (
+    ByteEnumField,
+    ByteField,
+    FieldLenField,
+    FlagsField,
+    IP6Field,
+    IPField,
+    OUIField,
+    PacketListField,
+    ShortField,
+    StrLenField,
+    XByteField,
+    XShortEnumField,
+    XShortField,
+)
 from scapy.layers.inet import checksum
 from scapy.layers.l2 import SNAP
 from scapy.compat import orb, chb
@@ -261,7 +273,7 @@ class CDPMsgProtoHello(CDPMsgGeneric):
     type = 0x0008
     fields_desc = [XShortEnumField("type", 0x0008, _cdp_tlv_types),
                    ShortField("len", 32),
-                   X3BytesField("oui", 0x00000c),
+                   OUIField("oui", 0x00000c),
                    XShortField("protocol_id", 0x0),
                    # TLV length (len) - 2 (type) - 2 (len) - 3 (OUI) - 2
                    # (Protocol ID)

--- a/scapy/contrib/homeplugav.py
+++ b/scapy/contrib/homeplugav.py
@@ -19,11 +19,30 @@ from __future__ import absolute_import
 import struct
 
 from scapy.packet import Packet, bind_layers
-from scapy.fields import BitField, ByteEnumField, ByteField, \
-    ConditionalField, EnumField, FieldLenField, IntField, LEIntField, \
-    LELongField, LEShortField, MACField, PacketListField, ShortField, \
-    StrFixedLenField, StrLenField, X3BytesField, XByteField, XIntField, \
-    XLongField, XShortField, LEShortEnumField
+from scapy.fields import (
+    BitField,
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    EnumField,
+    FieldLenField,
+    IntField,
+    LEIntField,
+    LELongField,
+    LEShortEnumField,
+    LEShortField,
+    MACField,
+    OUIField,
+    PacketListField,
+    ShortField,
+    StrFixedLenField,
+    StrLenField,
+    X3BytesField,
+    XByteField,
+    XIntField,
+    XLongField,
+    XShortField,
+)
 from scapy.layers.l2 import Ether
 from scapy.modules.six.moves import range
 
@@ -176,7 +195,7 @@ class MACManagementHeader(Packet):
 
 class VendorMME(Packet):
     name = "VendorMME "
-    fields_desc = [X3BytesField("OUI", 0x00b052)]
+    fields_desc = [OUIField("OUI", 0x00b052)]
 
 
 class GetDeviceVersion(Packet):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -3280,6 +3280,21 @@ class BitScalingField(_ScalingField, BitField):  # type: ignore
         BitField.__init__(self, name, default, size)  # type: ignore
 
 
+class OUIField(X3BytesField):
+    """
+    A field designed to carry a OUI (3 bytes)
+    """
+    def i2repr(self, pkt, val):
+        # type: (Optional[BasePacket], int) -> str
+        by_val = struct.pack("!I", val or 0)[1:]
+        oui = str2mac(by_val + b"\0" * 3)[:8]
+        if conf.manufdb:
+            fancy = conf.manufdb._get_manuf(oui)
+            if fancy != oui:
+                return "%s (%s)" % (fancy, oui)
+        return oui
+
+
 class UUIDField(Field[UUID, bytes]):
     """Field for UUID storage, wrapping Python's uuid.UUID type.
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -25,13 +25,32 @@ from scapy.data import ARPHDR_ETHER, ARPHDR_LOOPBACK, ARPHDR_METRICOM, \
     DLT_NULL, ETHER_ANY, ETHER_BROADCAST, ETHER_TYPES, ETH_P_ARP, \
     ETH_P_MACSEC
 from scapy.error import warning, ScapyNoDstMacException
-from scapy.fields import BCDFloatField, BitField, ByteField, \
-    ConditionalField, FieldLenField, FCSField, \
-    IntEnumField, IntField, IP6Field, IPField, \
-    LenField, MACField, MultipleTypeField, \
-    ShortEnumField, ShortField, SourceIP6Field, SourceIPField, \
-    StrFixedLenField, StrLenField, X3BytesField, XByteField, XIntField, \
-    XShortEnumField, XShortField
+from scapy.fields import (
+    BCDFloatField,
+    BitField,
+    ByteField,
+    ConditionalField,
+    FCSField,
+    FieldLenField,
+    IP6Field,
+    IPField,
+    IntEnumField,
+    IntField,
+    LenField,
+    MACField,
+    MultipleTypeField,
+    OUIField,
+    ShortEnumField,
+    ShortField,
+    SourceIP6Field,
+    SourceIPField,
+    StrFixedLenField,
+    StrLenField,
+    XByteField,
+    XIntField,
+    XShortEnumField,
+    XShortField,
+)
 from scapy.modules.six import viewitems
 from scapy.packet import bind_layers, Packet
 from scapy.plist import PacketList, SndRcvList
@@ -253,7 +272,7 @@ class MPacketPreamble(Packet):
 
 class SNAP(Packet):
     name = "SNAP"
-    fields_desc = [X3BytesField("OUI", 0x000000),
+    fields_desc = [OUIField("OUI", 0x000000),
                    XShortEnumField("code", 0x000, ETHER_TYPES)]
 
 

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -19,10 +19,25 @@ from scapy.layers.eap import EAP
 from scapy.layers.l2 import Ether, CookedLinux, GRE_PPTP
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IPv6
-from scapy.fields import BitField, ByteEnumField, ByteField, \
-    ConditionalField, EnumField, FieldLenField, IntField, IPField, \
-    PacketListField, PacketField, ShortEnumField, ShortField, \
-    StrFixedLenField, StrLenField, XByteField, XShortField, XStrLenField
+from scapy.fields import (
+    BitField,
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    EnumField,
+    FieldLenField,
+    IPField,
+    IntField,
+    OUIField,
+    PacketField,
+    PacketListField,
+    ShortEnumField,
+    ShortField,
+    StrLenField,
+    XByteField,
+    XShortField,
+    XStrLenField,
+)
 from scapy.modules import six
 
 
@@ -449,7 +464,7 @@ class PPP_ECP_Option_OUI(PPP_ECP_Option):
         ByteEnumField("type", 0, _PPP_ecpopttypes),
         FieldLenField("len", None, length_of="data", fmt="B",
                       adjust=lambda _, val: val + 6),
-        StrFixedLenField("oui", "", 3),
+        OUIField("oui", 0),
         ByteField("subtype", 0),
         StrLenField("data", "", length_from=lambda pkt: pkt.len - 6),
     ]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2434,7 +2434,7 @@ assert( q[PPP_IPCP_Option_NBNS2].data == '9.10.11.12' )
 = PPP ECP
 ~ ppp ecp
 
-p = PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui="XYZ")])
+p = PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui=0x58595a)])
 p
 r = raw(p)
 r
@@ -2442,7 +2442,7 @@ assert(r == b'\x80S\x01\x00\x00\n\x00\x06XYZ\x00')
 q = PPP(r)
 q
 assert(raw(p) == raw(q))
-p = PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui="XYZ"),PPP_ECP_Option(type=1,data="ABCDEFG")])
+p = PPP()/PPP_ECP(options=[PPP_ECP_Option_OUI(oui=0x58595a),PPP_ECP_Option(type=1,data="ABCDEFG")])
 p
 r = raw(p)
 r

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -536,6 +536,27 @@ b = RadioTapExtendedPresenceMask(index=1, present="b32+b45+b59+b62")
 pkt = RadioTap(present="Ext", Ext=[a, b])
 assert raw(pkt) == b'\x00\x00\x10\x00\x00\x00\x00\x80\x01\x10\x00\xa0\x01 \x00H'
 
+= RadioTap - dissect & build TLVs
+
+pkt = RadioTap(
+    present="TLV+dBm_TX_Power+TXFlags+Channel+Rate+Flags",
+    tlvs=[
+        RadioTapTLV(type=30, data=b"tes1t"),
+        RadioTapTLV(type=1, data=b"a")
+    ]
+)
+
+assert raw(pkt) == b'\x00\x00,\x00\x0e\x84\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x1e\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00tes1t\x00\x00\x00\x01\x00\x01\x00a\x00\x00\x00'
+
+pkt = RadioTap(raw(pkt))
+assert pkt.present.TLV
+assert pkt.tlvs[0].type == 30
+assert pkt.tlvs[0].data == b"tes1t"
+assert pkt.tlvs[0].pad == b"\0\0\0"
+assert pkt.tlvs[1].type == 1
+assert pkt.tlvs[1].data == b"a"
+assert pkt.notdecoded == b""
+
 = fuzz() calls for Dot11Elt()
 for i in range(10):
     assert isinstance(raw(fuzz(Dot11Elt())), bytes)


### PR DESCRIPTION
- adds support for the TLV field in RadioTap: https://www.radiotap.org/fields/TLV.html
- moves `OUIField` to `fields.py` because it could be used elsewhere (and was used extensively)