### PR TITLE
Core typing: base_classes/extlib/error

### DIFF
--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -7,10 +7,13 @@
 # CORE
 scapy/__init__.py
 scapy/asn1/mib.py
+scapy/base_classes.py
 scapy/compat.py
 scapy/config.py
 scapy/dadict.py
 scapy/data.py
+scapy/error.py
+scapy/extlib.py
 scapy/fields.py
 scapy/main.py
 scapy/packet.py

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -23,26 +23,50 @@ import subprocess
 import types
 import warnings
 
+import scapy
 from scapy.consts import WINDOWS
+import scapy.modules.six as six
 
 from scapy.modules.six.moves import range
 
 from scapy.compat import (
+    Any,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
     _Generic_metaclass,
+    cast,
 )
 
+try:
+    import pyx
+except ImportError:
+    pass
 
-class Gen(object):
-    __slots__ = []
+_T = TypeVar("_T")
+
+
+@six.add_metaclass(_Generic_metaclass)
+class Gen(Generic[_T]):
+    __slots__ = []  # type: List[str]
 
     def __iter__(self):
+        # type: () -> Iterator[_T]
         return iter([])
 
     def __iterlen__(self):
+        # type: () -> int
         return sum(1 for _ in iter(self))
 
 
 def _get_values(value):
+    # type: (Any) -> Any
     """Generate a range object from (start, stop[, step]) tuples, or
     return value.
 
@@ -56,18 +80,17 @@ def _get_values(value):
     return value
 
 
-class SetGen(Gen):
+class SetGen(Gen[_T]):
     def __init__(self, values, _iterpacket=1):
+        # type: (Any, int) -> None
         self._iterpacket = _iterpacket
         if isinstance(values, (list, BasePacketList)):
             self.values = [_get_values(val) for val in values]
         else:
             self.values = [_get_values(values)]
 
-    def transf(self, element):
-        return element
-
     def __iter__(self):
+        # type: () -> Iterator[Any]
         for i in self.values:
             if (isinstance(i, Gen) and
                 (self._iterpacket or not isinstance(i, BasePacket))) or (
@@ -78,30 +101,32 @@ class SetGen(Gen):
                 yield i
 
     def __repr__(self):
+        # type: () -> str
         return "<SetGen %r>" % self.values
 
 
-class Net(Gen):
+class Net(Gen[str]):
     """Generate a list of IPs from a network address or a name"""
     name = "ip"
     ip_regex = re.compile(r"^(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)\.(\*|[0-2]?[0-9]?[0-9](-[0-2]?[0-9]?[0-9])?)(/[0-3]?[0-9])?$")  # noqa: E501
 
     @staticmethod
     def _parse_digit(a, netmask):
+        # type: (str, int) -> Tuple[int, int]
         netmask = min(8, max(netmask, 0))
         if a == "*":
-            a = (0, 256)
+            return (0, 256)
         elif a.find("-") >= 0:
             x, y = [int(d) for d in a.split('-')]
             if x > y:
                 y = x
-            a = (x & (0xff << netmask), max(y, (x | (0xff >> (8 - netmask)))) + 1)  # noqa: E501
+            return (x & (0xff << netmask), max(y, (x | (0xff >> (8 - netmask)))) + 1)  # noqa: E501
         else:
-            a = (int(a) & (0xff << netmask), (int(a) | (0xff >> (8 - netmask))) + 1)  # noqa: E501
-        return a
+            return (int(a) & (0xff << netmask), (int(a) | (0xff >> (8 - netmask))) + 1)  # noqa: E501
 
     @classmethod
     def _parse_net(cls, net):
+        # type: (str) -> Tuple[List[Tuple[int, int]], int]
         tmp = net.split('/') + ["32"]
         if not cls.ip_regex.match(net):
             tmp[0] = socket.gethostbyname(tmp[0])
@@ -110,13 +135,16 @@ class Net(Gen):
         return ret_list, netmask
 
     def __init__(self, net):
+        # type: (str) -> None
         self.repr = net
         self.parsed, self.netmask = self._parse_net(net)
 
     def __str__(self):
-        return next(self.__iter__(), None)
+        # type: () -> str
+        return next(self.__iter__(), "")
 
     def __iter__(self):
+        # type: () -> Iterator[str]
         for d in range(*self.parsed[3]):
             for c in range(*self.parsed[2]):
                 for b in range(*self.parsed[1]):
@@ -124,44 +152,52 @@ class Net(Gen):
                         yield "%i.%i.%i.%i" % (a, b, c, d)
 
     def __iterlen__(self):
+        # type: () -> int
         return reduce(operator.mul, ((y - x) for (x, y) in self.parsed), 1)
 
     def choice(self):
+        # type: () -> str
         return ".".join(str(random.randint(v[0], v[1] - 1)) for v in self.parsed)  # noqa: E501
 
     def __repr__(self):
+        # type: () -> str
         return "Net(%r)" % self.repr
 
     def __eq__(self, other):
+        # type: (Any) -> bool
         if not other:
             return False
         if hasattr(other, "parsed"):
             p2 = other.parsed
         else:
             p2, nm2 = self._parse_net(other)
-        return self.parsed == p2
+        return bool(self.parsed == p2)
 
     def __ne__(self, other):
+        # type: (Any) -> bool
         # Python 2.7 compat
         return not self == other
 
-    __hash__ = None
+    __hash__ = None  # type: ignore
 
     def __contains__(self, other):
+        # type: (Union[str, Net]) -> bool
         if hasattr(other, "parsed"):
-            p2 = other.parsed
+            p2 = cast(Net, other).parsed
         else:
-            p2, nm2 = self._parse_net(other)
+            p2, _ = self._parse_net(cast(str, other))
         return all(a1 <= a2 and b1 >= b2 for (a1, b1), (a2, b2) in zip(self.parsed, p2))  # noqa: E501
 
     def __rcontains__(self, other):
+        # type: (str) -> bool
         return self in self.__class__(other)
 
 
-class OID(Gen):
+class OID(Gen[str]):
     name = "OID"
 
     def __init__(self, oid):
+        # type: (str) -> None
         self.oid = oid
         self.cmpt = []
         fmt = []
@@ -174,9 +210,11 @@ class OID(Gen):
         self.fmt = ".".join(fmt)
 
     def __repr__(self):
+        # type: () -> str
         return "OID(%r)" % self.oid
 
     def __iter__(self):
+        # type: () -> Iterator[str]
         ii = [k[0] for k in self.cmpt]
         while True:
             yield self.fmt % tuple(ii)
@@ -192,6 +230,7 @@ class OID(Gen):
                 i += 1
 
     def __iterlen__(self):
+        # type: () -> int
         return reduce(operator.mul, (max(y - x, 0) + 1 for (x, y) in self.cmpt), 1)  # noqa: E501
 
 
@@ -199,26 +238,32 @@ class OID(Gen):
 #  Packet abstract and base classes  #
 ######################################
 
-class Packet_metaclass(type):
-    def __new__(cls, name, bases, dct):
+class Packet_metaclass(_Generic_metaclass):
+    def __new__(cls,  # type: ignore
+                name,  # type: str
+                bases,  # type: Tuple[type, ...]
+                dct  # type: Dict[str, Any]
+                ):
+        # type: (...) -> Type['scapy.packet.Packet']
         if "fields_desc" in dct:  # perform resolution of references to other packets  # noqa: E501
-            current_fld = dct["fields_desc"]
-            resolved_fld = []
-            for f in current_fld:
-                if isinstance(f, Packet_metaclass):  # reference to another fields_desc  # noqa: E501
-                    for f2 in f.fields_desc:
-                        resolved_fld.append(f2)
+            current_fld = dct["fields_desc"]  # type: List[Union['scapy.fields.Field'[Any, Any], Packet_metaclass]]  # noqa: E501
+            resolved_fld = []  # type: List['scapy.fields.Field'[Any, Any]]
+            for fld_or_pkt in current_fld:
+                if isinstance(fld_or_pkt, Packet_metaclass):
+                    # reference to another fields_desc
+                    for pkt_fld in fld_or_pkt.fields_desc:  # type: ignore
+                        resolved_fld.append(pkt_fld)
                 else:
-                    resolved_fld.append(f)
+                    resolved_fld.append(fld_or_pkt)
         else:  # look for a fields_desc in parent classes
-            resolved_fld = None
+            resolved_fld = []
             for b in bases:
                 if hasattr(b, "fields_desc"):
-                    resolved_fld = b.fields_desc
+                    resolved_fld = b.fields_desc  # type: ignore
                     break
 
         if resolved_fld:  # perform default value replacements
-            final_fld = []
+            final_fld = []  # type: List['scapy.fields.Field'[Any, Any]]
             names = []
             for f in resolved_fld:
                 if f.name in names:
@@ -247,18 +292,22 @@ class Packet_metaclass(type):
                 dct["_%s" % attr] = dct.pop(attr)
             except KeyError:
                 pass
-        newcls = super(Packet_metaclass, cls).__new__(cls, name, bases, dct)
-        newcls.__all_slots__ = set(
+        newcls = type.__new__(cls, name, bases, dct)
+        # Note: below can't be typed because we use attributes
+        # created dynamically..
+        newcls.__all_slots__ = set(  # type: ignore
             attr
             for cls in newcls.__mro__ if hasattr(cls, "__slots__")
             for attr in cls.__slots__
         )
 
-        newcls.aliastypes = [newcls] + getattr(newcls, "aliastypes", [])
+        newcls.aliastypes = (  # type: ignore
+            [newcls] + getattr(newcls, "aliastypes", [])
+        )
 
         if hasattr(newcls, "register_variant"):
-            newcls.register_variant()
-        for f in newcls.fields_desc:
+            newcls.register_variant()  # type: ignore
+        for f in newcls.fields_desc:  # type: ignore
             if hasattr(f, "register_owner"):
                 f.register_owner(newcls)
         if newcls.__name__[0] != "_":
@@ -267,29 +316,44 @@ class Packet_metaclass(type):
         return newcls
 
     def __getattr__(self, attr):
-        for k in self.fields_desc:
+        # type: (str) -> 'scapy.fields.Field'[Any, Any]
+        for k in self.fields_desc:  # type: ignore
             if k.name == attr:
-                return k
+                return k  # type: ignore
         raise AttributeError(attr)
 
-    def __call__(cls, *args, **kargs):
+    def __call__(cls,
+                 *args,  # type: Any
+                 **kargs  # type: Any
+                 ):
+        # type: (...) -> 'scapy.packet.Packet'
         if "dispatch_hook" in cls.__dict__:
             try:
-                cls = cls.dispatch_hook(*args, **kargs)
+                cls = cls.dispatch_hook(*args, **kargs)  # type: ignore
             except Exception:
                 from scapy import config
                 if config.conf.debug_dissector:
                     raise
-                cls = config.conf.raw_layer
-        i = cls.__new__(cls, cls.__name__, cls.__bases__, cls.__dict__)
+                cls = config.conf.raw_layer  # type: ignore
+        i = cls.__new__(
+            cls,  # type: ignore
+            cls.__name__,
+            cls.__bases__,
+            cls.__dict__
+        )
         i.__init__(*args, **kargs)
-        return i
+        return i  # type: ignore
 
 
 # Note: see compat.py for an explanation
 
 class Field_metaclass(_Generic_metaclass):
-    def __new__(cls, name, bases, dct):
+    def __new__(cls,  # type: ignore
+                name,  # type: str
+                bases,  # type: Tuple[type, ...]
+                dct  # type: Dict[str, Any]
+                ):
+        # type: (...) -> Type['scapy.fields.Field'[Any, Any]]
         dct.setdefault("__slots__", [])
         newcls = super(Field_metaclass, cls).__new__(cls, name, bases, dct)
         return newcls
@@ -298,20 +362,25 @@ class Field_metaclass(_Generic_metaclass):
 PacketList_metaclass = Field_metaclass
 
 
-class BasePacket(Gen):
-    __slots__ = []
+class BasePacket(Gen['scapy.packet.Packet']):
+    __slots__ = []  # type: List[str]
 
 
 #############################
 #  Packet list base class   #
 #############################
 
-class BasePacketList(object):
-    __slots__ = []
+class BasePacketList(Gen[_T]):
+    __slots__ = []  # type: List[str]
 
 
 class _CanvasDumpExtended(object):
+    def canvas_dump(self, **kwargs):
+        # type: (**Any) -> 'pyx.canvas.canvas'
+        pass
+
     def psdump(self, filename=None, **kargs):
+        # type: (Optional[str], **Any) -> None
         """
         psdump(filename=None, layer_shift=0, rebuild=1)
 
@@ -324,7 +393,9 @@ class _CanvasDumpExtended(object):
         from scapy.utils import get_temp_file, ContextManagerSubprocess
         canvas = self.canvas_dump(**kargs)
         if filename is None:
-            fname = get_temp_file(autoext=kargs.get("suffix", ".eps"))
+            fname = cast(str, get_temp_file(
+                autoext=kargs.get("suffix", ".eps")
+            ))
             canvas.writeEPSfile(fname)
             if WINDOWS and conf.prog.psreader is None:
                 os.startfile(fname)
@@ -336,6 +407,7 @@ class _CanvasDumpExtended(object):
         print()
 
     def pdfdump(self, filename=None, **kargs):
+        # type: (Optional[str], **Any) -> None
         """
         pdfdump(filename=None, layer_shift=0, rebuild=1)
 
@@ -348,7 +420,9 @@ class _CanvasDumpExtended(object):
         from scapy.utils import get_temp_file, ContextManagerSubprocess
         canvas = self.canvas_dump(**kargs)
         if filename is None:
-            fname = get_temp_file(autoext=kargs.get("suffix", ".pdf"))
+            fname = cast(str, get_temp_file(
+                autoext=kargs.get("suffix", ".pdf")
+            ))
             canvas.writePDFfile(fname)
             if WINDOWS and conf.prog.pdfreader is None:
                 os.startfile(fname)
@@ -360,6 +434,7 @@ class _CanvasDumpExtended(object):
         print()
 
     def svgdump(self, filename=None, **kargs):
+        # type: (Optional[str], **Any) -> None
         """
         svgdump(filename=None, layer_shift=0, rebuild=1)
 
@@ -372,7 +447,9 @@ class _CanvasDumpExtended(object):
         from scapy.utils import get_temp_file, ContextManagerSubprocess
         canvas = self.canvas_dump(**kargs)
         if filename is None:
-            fname = get_temp_file(autoext=kargs.get("suffix", ".svg"))
+            fname = cast(str, get_temp_file(
+                autoext=kargs.get("suffix", ".svg")
+            ))
             canvas.writeSVGfile(fname)
             if WINDOWS and conf.prog.svgreader is None:
                 os.startfile(fname)

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -18,6 +18,14 @@ import time
 
 from scapy.consts import WINDOWS
 
+# Typing imports
+from logging import LogRecord
+from scapy.compat import (
+    Any,
+    Dict,
+    Tuple,
+)
+
 
 class Scapy_Exception(Exception):
     pass
@@ -33,10 +41,12 @@ class ScapyNoDstMacException(Scapy_Exception):
 
 class ScapyFreqFilter(logging.Filter):
     def __init__(self):
+        # type: () -> None
         logging.Filter.__init__(self)
-        self.warning_table = {}
+        self.warning_table = {}  # type: Dict[int, Tuple[float, int]]  # noqa: E501
 
     def filter(self, record):
+        # type: (LogRecord) -> bool
         from scapy.config import conf
         # Levels below INFO are not covered
         if record.levelno <= logging.INFO:
@@ -44,8 +54,8 @@ class ScapyFreqFilter(logging.Filter):
         wt = conf.warning_threshold
         if wt > 0:
             stk = traceback.extract_stack()
-            caller = None
-            for f, l, n, c in stk:
+            caller = 0  # type: int
+            for _, l, n, _ in stk:
                 if n == 'warning':
                     break
                 caller = l
@@ -76,6 +86,7 @@ class ScapyColoredFormatter(logging.Formatter):
     }
 
     def format(self, record):
+        # type: (LogRecord) -> str
         message = super(ScapyColoredFormatter, self).format(record)
         from scapy.config import conf
         message = conf.color_theme.format(
@@ -119,6 +130,7 @@ log_loading = logging.getLogger("scapy.loading")
 
 
 def warning(x, *args, **kargs):
+    # type: (str, *Any, **Any) -> None
     """
     Prints a warning during runtime.
     """

--- a/scapy/extlib.py
+++ b/scapy/extlib.py
@@ -40,6 +40,7 @@ except (ImportError, RuntimeError):
 
 
 def _test_pyx():
+    # type: () -> bool
     """Returns if PyX is correctly installed or not"""
     try:
         with open(os.devnull, 'wb') as devnull:

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -23,7 +23,7 @@ from scapy.data import DLT_CAN_SOCKETCAN, MTU
 from scapy.fields import FieldLenField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ScalingField, ConditionalField, LenField
 from scapy.volatile import RandFloat, RandBinFloat
-from scapy.packet import Packet, bind_layers, BasePacket
+from scapy.packet import Packet, bind_layers
 from scapy.layers.l2 import CookedLinux
 from scapy.error import Scapy_Exception
 from scapy.plist import PacketList
@@ -167,7 +167,7 @@ class SignalField(ScalingField):
         return self.fmt[-1] == "f"
 
     def addfield(self, pkt, s, val):
-        # type: (BasePacket, bytes, Optional[Union[int, float]]) -> bytes
+        # type: (Packet, bytes, Optional[Union[int, float]]) -> bytes
         if not isinstance(pkt, SignalPacket):
             raise Scapy_Exception("Only use SignalFields in a SignalPacket")
 
@@ -202,7 +202,7 @@ class SignalField(ScalingField):
         return tmp_s[:len(s)]
 
     def getfield(self, pkt, s):
-        # type: (BasePacket, bytes) -> Tuple[bytes, Union[int, float]]
+        # type: (Packet, bytes) -> Tuple[bytes, Union[int, float]]
         if not isinstance(pkt, SignalPacket):
             raise Scapy_Exception("Only use SignalFields in a SignalPacket")
 
@@ -256,7 +256,7 @@ class SignalField(ScalingField):
         return RandFloat(min(min_val, max_val), max(min_val, max_val))
 
     def i2len(self, pkt, x):
-        # type: (BasePacket, Any) -> int
+        # type: (Packet, Any) -> int
         return int(float(self.size) / 8)
 
 
@@ -397,7 +397,7 @@ class CandumpReader:
         return cast(str, filename), fdesc
 
     def next(self):
-        # type: () -> BasePacket
+        # type: () -> Packet
         """implement the iterator protocol on a set of packets
         """
         try:
@@ -411,7 +411,7 @@ class CandumpReader:
     __next__ = next
 
     def read_packet(self, size=MTU):
-        # type: (int) -> Optional[BasePacket]
+        # type: (int) -> Optional[Packet]
         """return a single packet read from the file or None if filters apply
 
         raise EOFError when no more packets are available
@@ -482,7 +482,7 @@ class CandumpReader:
         return PacketList(res, name=os.path.basename(self.filename))
 
     def recv(self, size=MTU):
-        # type: (int) -> Optional[BasePacket]
+        # type: (int) -> Optional[Packet]
         """ Emulate a socket
         """
         return self.read_packet(size=size)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1948,9 +1948,9 @@ class DomainNameListField(StrLenField):
     islist = 1
     padded_unit = 8
 
-    def __init__(self, name, default, fld=None, length_from=None, padded=False):  # noqa: E501
+    def __init__(self, name, default, length_from=None, padded=False):  # noqa: E501
         self.padded = padded
-        StrLenField.__init__(self, name, default, fld, length_from)
+        StrLenField.__init__(self, name, default, length_from=length_from)
 
     def i2len(self, pkt, x):
         return len(self.i2m(pkt, x))

--- a/scapy/layers/tls/record_sslv2.py
+++ b/scapy/layers/tls/record_sslv2.py
@@ -29,7 +29,8 @@ class _SSLv2MsgListField(_TLSMsgListField):
             length_from = lambda pkt: ((pkt.len & 0x7fff) -
                                        (pkt.padlen or 0) -
                                        len(pkt.mac))
-        super(_SSLv2MsgListField, self).__init__(name, default, length_from)
+        super(_SSLv2MsgListField, self).__init__(name, default,
+                                                 length_from=length_from)
 
     def m2i(self, pkt, m):
         cls = Raw

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -28,7 +28,7 @@ from scapy.fields import StrField, ConditionalField, Emph, PacketListField, \
 from scapy.config import conf, _version_checker
 from scapy.compat import raw, orb, bytes_encode
 from scapy.base_classes import BasePacket, Gen, SetGen, Packet_metaclass, \
-    _CanvasDumpExtended, Field_metaclass
+    _CanvasDumpExtended
 from scapy.volatile import RandField, VolatileValue
 from scapy.utils import import_hexcap, tex_escape, colgen, issubtype, \
     pretty_list, EDecimal
@@ -36,6 +36,7 @@ from scapy.error import Scapy_Exception, log_runtime, warning
 from scapy.extlib import PYX
 import scapy.modules.six as six
 
+# Typing imports
 from scapy.compat import (
     Any,
     Callable,
@@ -46,11 +47,11 @@ from scapy.compat import (
     Optional,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
 )
-
 try:
     import pyx
 except ImportError:
@@ -101,21 +102,21 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     name = None
     fields_desc = []  # type: List[Field[Any, Any]]
     deprecated_fields = {}  # type: Dict[str, Tuple[str, str]]
-    overload_fields = {}  # type: Dict[Packet_metaclass, Dict[str, Any]]
-    payload_guess = []  # type: List[Tuple[Dict[str, Any], Packet_metaclass]]
+    overload_fields = {}  # type: Dict[Type[Packet], Dict[str, Any]]
+    payload_guess = []  # type: List[Tuple[Dict[str, Any], Type[Packet]]]
     show_indent = 1
     show_summary = True
     match_subclass = False
-    class_dont_cache = {}  # type: Dict[Packet_metaclass, bool]
-    class_packetfields = {}  # type: Dict[Packet_metaclass, Any]
-    class_default_fields = {}  # type: Dict[Packet_metaclass, Dict[str, Any]]
-    class_default_fields_ref = {}  # type: Dict[Packet_metaclass, List[str]]
-    class_fieldtype = {}  # type: Dict[Packet_metaclass, Dict[str, Field[Any, Any]]]  # noqa: E501
+    class_dont_cache = {}  # type: Dict[Type[Packet], bool]
+    class_packetfields = {}  # type: Dict[Type[Packet], Any]
+    class_default_fields = {}  # type: Dict[Type[Packet], Dict[str, Any]]
+    class_default_fields_ref = {}  # type: Dict[Type[Packet], List[str]]
+    class_fieldtype = {}  # type: Dict[Type[Packet], Dict[str, Field[Any, Any]]]  # noqa: E501
 
     @classmethod
     def from_hexcap(cls):
-        # type: (Packet_metaclass) -> Packet
-        return cls(import_hexcap())  # type: ignore
+        # type: (Type[Packet]) -> Packet
+        return cls(import_hexcap())
 
     @classmethod
     def upper_bonds(self):
@@ -198,7 +199,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     ]
 
     def __reduce__(self):
-        # type: () -> Tuple[Packet_metaclass, Tuple[()], Packet._PickleType]
+        # type: () -> Tuple[Type[Packet], Tuple[()], Packet._PickleType]
         """Used by pickling methods"""
         return (self.__class__, (), (
             self.build(),
@@ -422,7 +423,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         return self.payload.getfieldval(attr)
 
     def getfield_and_val(self, attr):
-        # type: (str) -> Optional[Tuple[Any, Any]]
+        # type: (str) -> Tuple[Any, Any]
         if self.deprecated_fields and attr in self.deprecated_fields:
             attr = self._resolve_alias(attr)
         if attr in self.fields:
@@ -431,13 +432,13 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             return self.get_field(attr), self.overloaded_fields[attr]
         if attr in self.default_fields:
             return self.get_field(attr), self.default_fields[attr]
-        return None
+        raise ValueError
 
     def __getattr__(self, attr):
         # type: (str) -> Any
         try:
-            fld, v = self.getfield_and_val(attr)  # type: ignore
-        except TypeError:
+            fld, v = self.getfield_and_val(attr)
+        except ValueError:
             return self.payload.__getattr__(attr)
         if fld is not None:
             return fld.i2h(self, v)
@@ -582,7 +583,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             cloneA.add_payload(cloneB)
             return cloneA
         elif isinstance(other, (bytes, str)):
-            return self / conf.raw_layer(load=other)  # type: ignore
+            return self / conf.raw_layer(load=other)
         else:
             return other.__rdiv__(self)  # type: ignore
     __truediv__ = __div__
@@ -590,7 +591,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     def __rdiv__(self, other):
         # type: (Any) -> Packet
         if isinstance(other, (bytes, str)):
-            return conf.raw_layer(load=other) / self  # type: ignore
+            return conf.raw_layer(load=other) / self
         else:
             raise TypeError
     __rtruediv__ = __rdiv__
@@ -1012,7 +1013,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             self.add_payload(conf.padding_layer(pad))
 
     def guess_payload_class(self, payload):
-        # type: (bytes) -> Packet_metaclass
+        # type: (bytes) -> Type[Packet]
         """
         DEV: Guesses the next payload class from layer bonds.
         Can be overloaded to use a different mechanism.
@@ -1025,13 +1026,13 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                 try:
                     if all(v == self.getfieldval(k)
                            for k, v in six.iteritems(fval)):
-                        return cls
+                        return cls  # type: ignore
                 except AttributeError:
                     pass
         return self.default_payload_class(payload)
 
     def default_payload_class(self, payload):
-        # type: (bytes) -> Packet_metaclass
+        # type: (bytes) -> Type[Packet]
         """
         DEV: Returns the default payload class if nothing has been found by the
         guess_payload_class() method.
@@ -1102,7 +1103,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                         yield x
             else:
                 if isinstance(self.payload, NoPayload):
-                    payloads = SetGen([None])
+                    payloads = SetGen([None])  # type: SetGen[Packet]
                 else:
                     payloads = self.payload
                 share_time = False
@@ -1145,7 +1146,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             return len(x) == 2 and all(isinstance(z, int) for z in x)
 
         for field in fields:
-            fld, val = self.getfield_and_val(field)  # type: ignore
+            fld, val = self.getfield_and_val(field)
             if hasattr(val, "__iterlen__"):
                 length *= val.__iterlen__()
             elif is_valid_gen_tuple(val):
@@ -1230,7 +1231,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         return 0
 
     def layers(self):
-        # type: () -> List[Packet_metaclass]
+        # type: () -> List[Type[Packet]]
         """returns a list of layer classes (including subclasses) in this packet"""  # noqa: E501
         layers = []
         lyr = self  # type: Optional[Packet]
@@ -1240,7 +1241,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         return layers
 
     def haslayer(self, cls, _subclass=None):
-        # type: (Union[Packet_metaclass, str], Optional[bool]) -> int
+        # type: (Union[Type[Packet], str], Optional[bool]) -> int
         """
         true if self has a layer that is an instance of cls.
         Superseded by "cls in self" syntax.
@@ -1268,7 +1269,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         return self.payload.haslayer(cls, _subclass=_subclass)
 
     def getlayer(self,
-                 cls,  # type: Union[int, Packet_metaclass]
+                 cls,  # type: Union[int, Type[Packet], str]
                  nb=1,  # type: int
                  _track=None,  # type: Optional[List[int]]
                  _subclass=None,  # type: Optional[bool]
@@ -1284,17 +1285,23 @@ values.
             match = issubtype
         else:
             match = lambda cls1, cls2: bool(cls1 == cls2)
+        # Note:
+        # cls can be int, packet, str
+        # string_class_name can be packet, str (packet or packet+field)
+        # class_name can be packet, str (packet only)
         if isinstance(cls, int):
             nb = cls + 1
-            cls = None
-        ccls = None  # type: Union[None, str]
-        fld = None  # type: Union[None, str]
-        if isinstance(cls, str) and "." in cls:
-            ccls, fld = cls.split(".", 1)
+            string_class_name = ""  # type: Union[Type[Packet], str]
         else:
-            ccls, fld = cls, None
-        if cls is None or match(self.__class__, cls) \
-           or ccls in [self.__class__.__name__, self._name]:
+            string_class_name = cls
+        class_name = ""  # type: Union[Type[Packet], str]
+        fld = None  # type: Optional[str]
+        if isinstance(string_class_name, str) and "." in string_class_name:
+            class_name, fld = string_class_name.split(".", 1)
+        else:
+            class_name, fld = string_class_name, None
+        if not class_name or match(self.__class__, class_name) \
+           or class_name in [self.__class__.__name__, self._name]:
             if all(self.getfieldval(fldname) == fldvalue
                    for fldname, fldvalue in six.iteritems(flt)):
                 if nb == 1:
@@ -1313,12 +1320,12 @@ values.
             for fvalue in fvalue_gen:
                 if isinstance(fvalue, Packet):
                     track = []  # type: List[int]
-                    ret = fvalue.getlayer(cls, nb=nb, _track=track,
+                    ret = fvalue.getlayer(class_name, nb=nb, _track=track,
                                           _subclass=_subclass, **flt)
                     if ret is not None:
                         return ret
                     nb = track[0]
-        return self.payload.getlayer(cls, nb=nb, _track=_track,
+        return self.payload.getlayer(class_name, nb=nb, _track=_track,
                                      _subclass=_subclass, **flt)
 
     def firstlayer(self):
@@ -1329,7 +1336,7 @@ values.
         return q
 
     def __getitem__(self, cls):
-        # type: (Packet_metaclass) -> Any
+        # type: (Union[Type[Packet], str]) -> Any
         if isinstance(cls, slice):
             lname = cls.start
             if cls.stop:
@@ -1340,23 +1347,25 @@ values.
             lname = cls
             ret = self.getlayer(cls)
         if ret is None:
-            if isinstance(lname, Packet_metaclass):
-                lname = lname.__name__
+            if isinstance(lname, type):
+                name = lname.__name__
             elif not isinstance(lname, bytes):
-                lname = repr(lname)
-            raise IndexError("Layer [%s] not found" % lname)
+                name = repr(lname)
+            else:
+                name = cast(str, lname)
+            raise IndexError("Layer [%s] not found" % name)
         return ret
 
     def __delitem__(self, cls):
-        # type: (Packet_metaclass) -> None
+        # type: (Type[Packet]) -> None
         del(self[cls].underlayer.payload)
 
     def __setitem__(self, cls, val):
-        # type: (Packet_metaclass, Packet) -> None
+        # type: (Type[Packet], Packet) -> None
         self[cls].underlayer.payload = val
 
     def __contains__(self, cls):
-        # type: (Packet_metaclass) -> int
+        # type: (Union[Type[Packet], str]) -> int
         """
         "cls in self" returns true if self has a layer which is an
         instance of cls.
@@ -1417,7 +1426,10 @@ values.
             fvalue = self.getfieldval(f.name)
             if isinstance(fvalue, Packet) or (f.islist and f.holds_packets and isinstance(fvalue, list)):  # noqa: E501
                 s += "%s  \\%-10s\\\n" % (label_lvl + lvl, ncol(f.name))
-                fvalue_gen = SetGen(fvalue, _iterpacket=0)
+                fvalue_gen = SetGen(
+                    fvalue,
+                    _iterpacket=0
+                )  # type: SetGen[Packet]
                 for fvalue in fvalue_gen:
                     s += fvalue._show_or_dump(dump=dump, indent=indent, label_lvl=label_lvl + lvl + "   |", first_call=False)  # noqa: E501
             else:
@@ -1637,7 +1649,7 @@ values.
         return self.payload.lastlayer(self)
 
     def decode_payload_as(self, cls):
-        # type: (Packet_metaclass) -> None
+        # type: (Type[Packet]) -> None
         """Reassembles the payload and decode it using another packet class"""
         s = raw(self.payload)
         self.payload = cls(s, _internal=1, _underlayer=self)
@@ -1675,7 +1687,7 @@ values.
         return c
 
     def convert_to(self, other_cls, **kwargs):
-        # type: (Packet_metaclass, **Any) -> Packet
+        # type: (Type[Packet], **Any) -> Packet
         """Converts this Packet to another type.
 
         This is not guaranteed to be a lossless process.
@@ -1695,7 +1707,7 @@ values.
             return Raw(raw(self))
 
         if "_internal" not in kwargs:
-            return other_cls.convert_packet(self, _internal=True, **kwargs)  # type: ignore  # noqa: E501
+            return other_cls.convert_packet(self, _internal=True, **kwargs)
 
         raise TypeError("Cannot convert {} to {}".format(
             type(self).__name__, other_cls.__name__))
@@ -1740,7 +1752,7 @@ values.
 
 class NoPayload(Packet):
     def __new__(cls, *args, **kargs):
-        # type: (Packet_metaclass, *Any, **Any) -> Packet
+        # type: (Type[Packet], *Any, **Any) -> Packet
         singl = cls.__dict__.get("__singl__")
         if singl is None:
             cls.__singl__ = singl = Packet.__new__(cls)
@@ -1855,11 +1867,11 @@ class NoPayload(Packet):
         return isinstance(other, NoPayload) or isinstance(other, conf.padding_layer)  # noqa: E501
 
     def haslayer(self, cls, _subclass=None):
-        # type: (Union[Packet_metaclass, str], Optional[bool]) -> int
+        # type: (Union[Type[Packet], str], Optional[bool]) -> int
         return 0
 
     def getlayer(self,
-                 cls,  # type: Union[int, Packet_metaclass]
+                 cls,  # type: Union[int, Type[Packet], str]
                  nb=1,  # type: int
                  _track=None,  # type: Optional[List[int]]
                  _subclass=None,  # type: Optional[bool]
@@ -1890,7 +1902,7 @@ class NoPayload(Packet):
         return 0, "", []
 
     def layers(self):
-        # type: () -> List[Packet_metaclass]
+        # type: () -> List[Type[Packet]]
         return []
 
     def lastlayer(self, layer=None):
@@ -1966,8 +1978,8 @@ if conf.default_l2 is None:
 #################
 
 
-def bind_bottom_up(lower,  # type: Packet_metaclass
-                   upper,  # type: Packet_metaclass
+def bind_bottom_up(lower,  # type: Type[Packet]
+                   upper,  # type: Type[Packet]
                    __fval=None,  # type: Optional[Any]
                    **fval  # type: Any
                    ):
@@ -1988,8 +2000,8 @@ def bind_bottom_up(lower,  # type: Packet_metaclass
     lower.payload_guess.append((fval, upper))
 
 
-def bind_top_down(lower,  # type: Packet_metaclass
-                  upper,  # type: Packet_metaclass
+def bind_top_down(lower,  # type: Type[Packet]
+                  upper,  # type: Type[Packet]
                   __fval=None,  # type: Optional[Any]
                   **fval  # type: Any
                   ):
@@ -2010,8 +2022,8 @@ def bind_top_down(lower,  # type: Packet_metaclass
 
 
 @conf.commands.register
-def bind_layers(lower,  # type: Packet_metaclass
-                upper,  # type: Packet_metaclass
+def bind_layers(lower,  # type: Type[Packet]
+                upper,  # type: Type[Packet]
                 __fval=None,  # type: Optional[Dict[str, int]]
                 **fval  # type: Any
                 ):
@@ -2034,8 +2046,8 @@ def bind_layers(lower,  # type: Packet_metaclass
     bind_bottom_up(lower, upper, **fval)
 
 
-def split_bottom_up(lower,  # type: Packet_metaclass
-                    upper,  # type: Packet_metaclass
+def split_bottom_up(lower,  # type: Type[Packet]
+                    upper,  # type: Type[Packet]
                     __fval=None,  # type: Optional[Any]
                     **fval  # type: Any
                     ):
@@ -2047,7 +2059,7 @@ def split_bottom_up(lower,  # type: Packet_metaclass
         fval.update(__fval)
 
     def do_filter(params, cls):
-        # type: (Dict[str, int], Packet_metaclass) -> bool
+        # type: (Dict[str, int], Type[Packet]) -> bool
         params_is_invalid = any(
             k not in params or params[k] != v for k, v in six.iteritems(fval)
         )
@@ -2055,8 +2067,8 @@ def split_bottom_up(lower,  # type: Packet_metaclass
     lower.payload_guess = [x for x in lower.payload_guess if do_filter(*x)]
 
 
-def split_top_down(lower,  # type: Packet_metaclass
-                   upper,  # type: Packet_metaclass
+def split_top_down(lower,  # type: Type[Packet]
+                   upper,  # type: Type[Packet]
                    __fval=None,  # type: Optional[Any]
                    **fval  # type: Any
                    ):
@@ -2075,8 +2087,8 @@ def split_top_down(lower,  # type: Packet_metaclass
 
 
 @conf.commands.register
-def split_layers(lower,  # type: Packet_metaclass
-                 upper,  # type: Packet_metaclass
+def split_layers(lower,  # type: Type[Packet]
+                 upper,  # type: Type[Packet]
                  __fval=None,  # type: Optional[Any]
                  **fval  # type: Any
                  ):
@@ -2292,10 +2304,10 @@ def explore(layer=None):
     print(pretty_list(rtlst, [("Class", "Name")], borders=True))
 
 
-def _pkt_ls(obj,  # type: Union[Packet, Packet_metaclass]
+def _pkt_ls(obj,  # type: Union[Packet, Type[Packet]]
             verbose=False,  # type: bool
             ):
-    # type: (...) -> List[Tuple[str, Field_metaclass, str, str, List[str]]]
+    # type: (...) -> List[Tuple[str, Type[Field[Any, Any]], str, str, List[str]]]  # noqa: E501
     """Internal function used to resolve `fields_desc` to display it.
 
     :param obj: a packet object or class
@@ -2312,8 +2324,8 @@ def _pkt_ls(obj,  # type: Union[Packet, Packet_metaclass]
         long_attrs = []  # type: List[str]
         while isinstance(cur_fld, (Emph, ConditionalField)):
             if isinstance(cur_fld, ConditionalField):
-                attrs.append(cur_fld.__class__.__name__[:4])
-            cur_fld = cur_fld.fld
+                attrs.append(cur_fld.__class__.__name__[:4])  # type: ignore
+            cur_fld = cur_fld.fld  # type: ignore
         if verbose and isinstance(cur_fld, EnumField) \
            and hasattr(cur_fld, "i2s"):
             if len(cur_fld.i2s or []) < 50:
@@ -2323,12 +2335,15 @@ def _pkt_ls(obj,  # type: Union[Packet, Packet_metaclass]
                     sorted(six.iteritems(cur_fld.i2s))
                 )
         elif isinstance(cur_fld, MultiEnumField):
-            fld_depend = cur_fld.depends_on(obj.__class__
-                                            if is_pkt else obj)
+            fld_depend = cur_fld.depends_on(
+                cast(Packet, obj if is_pkt else obj())
+            )
             attrs.append("Depends on %s" % fld_depend)
             if verbose:
                 cur_i2s = cur_fld.i2s_multi.get(
-                    cur_fld.depends_on(obj if is_pkt else obj()), {}
+                    cur_fld.depends_on(
+                        cast(Packet, obj if is_pkt else obj())
+                    ), {}
                 )
                 if len(cur_i2s) < 50:
                     long_attrs.extend(
@@ -2359,7 +2374,7 @@ def _pkt_ls(obj,  # type: Union[Packet, Packet_metaclass]
 
 
 @conf.commands.register
-def ls(obj=None,  # type: Union[str, Packet, Packet_metaclass]
+def ls(obj=None,  # type: Optional[Union[str, Packet, Type[Packet]]]
        case_sensitive=False,  # type: bool
        verbose=False  # type: bool
        ):
@@ -2378,7 +2393,10 @@ def ls(obj=None,  # type: Union[str, Packet, Packet_metaclass]
             tip = True
             all_layers = sorted(conf.layers, key=lambda x: x.__name__)
         else:
-            pattern = re.compile(obj, 0 if case_sensitive else re.I)
+            pattern = re.compile(
+                cast(str, obj),
+                0 if case_sensitive else re.I
+            )
             # We first order by accuracy, then length
             if case_sensitive:
                 sorter = lambda x: (x.__name__.index(obj), len(x.__name__))
@@ -2399,12 +2417,15 @@ def ls(obj=None,  # type: Union[str, Packet, Packet_metaclass]
                   "layers using a clear GUI")
     else:
         try:
-            fields = _pkt_ls(obj, verbose=verbose)
+            fields = _pkt_ls(
+                obj,  # type: ignore
+                verbose=verbose
+            )
             is_pkt = isinstance(obj, Packet)
             # Print
             for fname, cls, clsne, dflt, long_attrs in fields:
-                cls = cls.__name__ + " " + clsne
-                print("%-10s : %-35s =" % (fname, cls), end=' ')
+                clsinfo = cls.__name__ + " " + clsne
+                print("%-10s : %-35s =" % (fname, clsinfo), end=' ')
                 if is_pkt:
                     print("%-15r" % (getattr(obj, fname),), end=' ')
                 print("(%r)" % (dflt,))
@@ -2423,7 +2444,7 @@ def ls(obj=None,  # type: Union[str, Packet, Packet_metaclass]
 
 @conf.commands.register
 def rfc(cls, ret=False, legend=True):
-    # type: (Packet_metaclass, bool, bool) -> Optional[str]
+    # type: (Type[Packet], bool, bool) -> Optional[str]
     """
     Generate an RFC-like representation of a packet def.
 

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from scapy.compat import lambda_tuple_converter
 from scapy.config import conf
 from scapy.base_classes import BasePacket, BasePacketList, \
-    _CanvasDumpExtended, Packet_metaclass, PacketList_metaclass
+    _CanvasDumpExtended, PacketList_metaclass
 from scapy.utils import do_graph, hexdump, make_table, make_lined_table, \
     make_tex_table, issubtype
 from scapy.extlib import plt, Line2D, \
@@ -36,6 +36,7 @@ from scapy.compat import (
     List,
     Optional,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -56,7 +57,7 @@ class _PacketList(Generic[_Inner]):
     def __init__(self,
                  res=None,  # type: Optional[Union[_PacketList[_Inner], List[_Inner]]]  # noqa: E501
                  name="PacketList",  # type: str
-                 stats=None  # type: Optional[List[Packet_metaclass]]
+                 stats=None  # type: Optional[List[Type[Packet]]]
                  ):
         # type: (...) -> None
         """create a packet list from a list of packets
@@ -674,7 +675,7 @@ class _PacketList(Generic[_Inner]):
                  nb=None,  # type: Optional[int]
                  flt=None,  # type: Optional[Dict[str, Any]]
                  name=None,  # type: Optional[str]
-                 stats=None  # type: Optional[List[Packet]]
+                 stats=None  # type: Optional[List[Type[Packet]]]
                  ):
         # type: (...) -> PacketList
         """Returns the packet list from a given layer.
@@ -718,8 +719,12 @@ class _PacketList(Generic[_Inner]):
             name, stats
         )
 
-    def convert_to(self, other_cls, name=None, stats=None):
-        # type: (Packet, Optional[str], Optional[List[Packet]]) -> PacketList
+    def convert_to(self,
+                   other_cls,  # type: Type[Packet]
+                   name=None,  # type: Optional[str]
+                   stats=None  # type: Optional[List[Type[Packet]]]
+                   ):
+        # type: (...) -> PacketList
         """Converts all packets to another type.
 
         See ``Packet.convert_to`` for more info.
@@ -749,7 +754,7 @@ class _PacketList(Generic[_Inner]):
 
 
 class PacketList(_PacketList[Packet],
-                 BasePacketList,
+                 BasePacketList[Packet],
                  _CanvasDumpExtended):
     def sr(self, multi=False, lookahead=None):
         # type: (bool, Optional[int]) -> Tuple[SndRcvList, PacketList]
@@ -790,14 +795,14 @@ class PacketList(_PacketList[Packet],
 
 
 class SndRcvList(_PacketList[Tuple[Packet, Packet]],
-                 BasePacketList,
+                 BasePacketList[Tuple[Packet, Packet]],
                  _CanvasDumpExtended):
     __slots__ = []  # type: List[str]
 
     def __init__(self,
-                 res=None,  # type: Optional[Union[PacketList, List[Tuple[Packet, Packet]]]]  # noqa: E501
+                 res=None,  # type: Optional[Union[_PacketList[Tuple[Packet, Packet]], List[Tuple[Packet, Packet]]]]  # noqa: E501
                  name="Results",  # type: str
-                 stats=None  # type: Optional[List[Packet]]
+                 stats=None  # type: Optional[List[Type[Packet]]]
                  ):
         # type: (...) -> None
         super(SndRcvList, self).__init__(res, name, stats)

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -13,6 +13,13 @@ Color themes for the interactive console.
 
 import sys
 
+from scapy.compat import (
+    Any,
+    Callable,
+    Optional,
+    Union,
+)
+
 
 class ColorTable:
     colors = {  # Format: (ansi, pygments)
@@ -52,6 +59,7 @@ class ColorTable:
         return self.colors.get(attr, [""])[0]
 
     def ansi_to_pygments(self, x):  # Transform ansi encoded text to Pygments text  # noqa: E501
+        # type: (str) -> str
         for k, v in self.inv_map.items():
             x = x.replace(k, " " + v)
         return x.strip()
@@ -61,7 +69,9 @@ Color = ColorTable()
 
 
 def create_styler(fmt=None, before="", after="", fmt2="%s"):
+    # type: (Optional[Any], str, str, str) -> Callable
     def do_style(val, fmt=fmt, before=before, after=after, fmt2=fmt2):
+        # type: (Union[int, str], Optional[Any], str, str, str) -> str
         if fmt is None:
             if not isinstance(val, str):
                 val = str(val)
@@ -73,12 +83,14 @@ def create_styler(fmt=None, before="", after="", fmt2="%s"):
 
 class ColorTheme:
     def __repr__(self):
+        # type: () -> str
         return "<%s>" % self.__class__.__name__
 
     def __reduce__(self):
         return (self.__class__, (), ())
 
     def __getattr__(self, attr):
+        # type: (str) -> Callable
         if attr in ["__getstate__", "__setstate__", "__getinitargs__",
                     "__reduce_ex__"]:
             raise AttributeError()
@@ -96,6 +108,7 @@ class NoTheme(ColorTheme):
 
 class AnsiColorTheme(ColorTheme):
     def __getattr__(self, attr):
+        # type: (str) -> Callable
         if attr.startswith("__"):
             raise AttributeError(attr)
         s = "style_%s" % attr
@@ -238,6 +251,7 @@ class ColorOnBlackTheme(AnsiColorTheme):
 
 class FormatTheme(ColorTheme):
     def __getattr__(self, attr):
+        # type: (str) -> Callable
         if attr.startswith("__"):
             raise AttributeError(attr)
         colfmt = self.__class__.__dict__.get("style_%s" % attr, "%s")
@@ -323,6 +337,7 @@ class HTMLTheme2(HTMLTheme):
 
 
 def apply_ipython_style(shell):
+    # type: (Any) -> None
     """Updates the specified IPython console shell with
     the conf.color_theme scapy theme."""
     try:


### PR DESCRIPTION
I realize now that we should have done this one MUCH earlier.

- add typing to `base_classes`. **Disclaimer:** metaclasses are really poorly supported in Mypy. They have been heavily ignored. Especially for instance when accessing fields that have not been defined yet `dct[..]`, where they simply cannot be typed yet.
- `Packet_metaclass` shouldn't be used as the type for `Packet` (as it was done) because even though `Type[Packet]` inherits `Packet_metaclass`, `Packet_metaclass` doesn't provide `name` and `fields_desc` attributes. So this PR leads to changing all `Packet_metaclass` to `Type[Packet]` where it made sense. Same for `Field_metaclass`
- add typing to `extlib` and `error`
- there are quite a lot of small bugs fixed but I didn't note them down.
- ~~**requires https://github.com/secdev/scapy/pull/2865**~~