### PR TITLE
Fix show() padding on colored themes

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1425,7 +1425,8 @@ values.
                 vcol = ct.field_value
             fvalue = self.getfieldval(f.name)
             if isinstance(fvalue, Packet) or (f.islist and f.holds_packets and isinstance(fvalue, list)):  # noqa: E501
-                s += "%s  \\%-10s\\\n" % (label_lvl + lvl, ncol(f.name))
+                pad = max(0, 10 - len(f.name)) * " "
+                s += "%s  \\%s%s\\\n" % (label_lvl + lvl, ncol(f.name), pad)
                 fvalue_gen = SetGen(
                     fvalue,
                     _iterpacket=0
@@ -1433,9 +1434,11 @@ values.
                 for fvalue in fvalue_gen:
                     s += fvalue._show_or_dump(dump=dump, indent=indent, label_lvl=label_lvl + lvl + "   |", first_call=False)  # noqa: E501
             else:
-                begn = "%s  %-10s%s " % (label_lvl + lvl,
-                                         ncol(f.name),
-                                         ct.punct("="),)
+                pad = max(0, 10 - len(f.name)) * " "
+                begn = "%s  %s%s%s " % (label_lvl + lvl,
+                                        ncol(f.name),
+                                        pad,
+                                        ct.punct("="),)
                 reprval = f.i2repr(self, fvalue)
                 if isinstance(reprval, str):
                     reprval = reprval.replace("\n", "\n" + " " * (len(label_lvl) +  # noqa: E501


### PR DESCRIPTION
The length of the invisible characters used for coloring was taken into account when padding the fields in `show()`. This PR fixes that. This bug is probably as old as scapy itself

On master:
![image](https://user-images.githubusercontent.com/10530980/97093607-b3d05580-164d-11eb-83fa-3f0e8323eda7.png)

This PR:
![image](https://user-images.githubusercontent.com/10530980/97093585-88e60180-164d-11eb-8d0f-0473989af133.png)