### PR TITLE
Remove RawVal from Scapy

### DIFF
--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -211,7 +211,7 @@ def lambda_tuple_converter(func):
 # This is ugly, but we don't want to move raw() out of compat.py
 # and it makes it much clearer
 if TYPE_CHECKING:
-    from scapy.packet import Packet, RawVal
+    from scapy.packet import Packet
 
 
 if six.PY2:
@@ -225,7 +225,7 @@ if six.PY2:
         return chr(x)
 
     def raw(x):
-        # type: (Union[Packet, RawVal]) -> bytes
+        # type: (Union[Packet]) -> bytes
         """
         Builds a packet and returns its bytes representation.
         This function is and will always be cross-version compatible
@@ -235,7 +235,7 @@ if six.PY2:
         return bytes(x)
 else:
     def raw(x):
-        # type: (Union[Packet, RawVal]) -> bytes
+        # type: (Union[Packet]) -> bytes
         """
         Builds a packet and returns its bytes representation.
         This function is and will always be cross-version compatible

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -1324,14 +1324,14 @@ class HPackHdrString(packet.Packet):
         # underlayer packet
         return config.conf.padding_layer
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self):
         # type: (Any) -> str
         """self_build is overridden because type and len are determined at
         build time, based on the "data" field internal type
         """
         if self.getfieldval('type') is None:
             self.type = 1 if isinstance(self.getfieldval('data'), HPackZString) else 0  # noqa: E501
-        return super(HPackHdrString, self).self_build(field_pos_list)
+        return super(HPackHdrString, self).self_build()
 
 
 class HPackHeaders(packet.Packet):

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -161,7 +161,7 @@ class ICMPExtensionInterfaceInformation(ICMPExtensionObject):
         IntField('mtu', None),
         lambda pkt: pkt.has_mtu == 1)]
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self):
         if self.afi is None:
             if self.ip4 is not None:
                 self.afi = 1
@@ -179,7 +179,7 @@ class ICMPExtensionInterfaceInformation(ICMPExtensionObject):
         if self.has_mtu and self.mtu is None:
             warning('has_mtu set but mtu is not set.')
 
-        return ICMPExtensionObject.self_build(self, field_pos_list=field_pos_list)  # noqa: E501
+        return ICMPExtensionObject.self_build(self)
 
 
 # Add the post_dissection() method to the existing ICMPv4 and

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -375,7 +375,7 @@ class _HTTPContent(Packet):
                 )
         return pkt + pay
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self):
         ''' Takes an HTTPRequest or HTTPResponse object, and creates its
         string representation.'''
         if not isinstance(self.underlayer, HTTP):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -57,24 +57,6 @@ except ImportError:
     pass
 
 
-class RawVal:
-    def __init__(self, val=""):
-        # type: (str) -> None
-        self.val = val
-
-    def __str__(self):
-        # type: () -> str
-        return str(self.val)
-
-    def __bytes__(self):
-        # type: () -> bytes
-        return bytes_encode(self.val)
-
-    def __repr__(self):
-        # type: () -> str
-        return "<RawVal [%r]>" % self.val
-
-
 _T = TypeVar("_T", Dict[str, Any], Optional[Dict[str, Any]])
 
 
@@ -640,12 +622,10 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                         fsubval.clear_cache()
         self.payload.clear_cache()
 
-    def self_build(self, field_pos_list=None):
-        # type: (Optional[Any])-> bytes
+    def self_build(self):
+        # type: ()-> bytes
         """
         Create the default layer regarding fields_desc dict
-
-        :param field_pos_list:
         """
         if self.raw_packet_cache is not None:
             for fname, fval in six.iteritems(self.raw_packet_cache_fields):
@@ -659,13 +639,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         p = b""
         for f in self.fields_desc:
             val = self.getfieldval(f.name)
-            if isinstance(val, RawVal):
-                sval = raw(val)
-                p += sval
-                if field_pos_list is not None:
-                    field_pos_list.append((f.name, sval, len(p), len(sval)))
-            else:
-                p = f.addfield(self, p, val)
+            p = f.addfield(self, p, val)
         return p
 
     def do_build_payload(self):
@@ -1944,8 +1918,8 @@ class Raw(Packet):
 class Padding(Raw):
     name = "Padding"
 
-    def self_build(self, field_pos_list=None):
-        # type: (Optional[Any]) -> bytes
+    def self_build(self):
+        # type: () -> bytes
         return b""
 
     def build_padding(self):


### PR DESCRIPTION
**Rationale: https://github.com/secdev/scapy/issues/2917**
Those things are clearly legacy leftovers. They have no use in scapy.

fixes https://github.com/secdev/scapy/issues/2917
