### PR TITLE
Pin cryptography==3.1.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,11 @@ passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT
 deps = mock
        # cryptography requirements
        setuptools>=18.5
-       cryptography
+       cryptography==3.1.1  # See https://github.com/secdev/scapy/issues/2919
        coverage
        python-can
        brotli>=1.0.0,!=1.0.8,!=1.0.9
-       zstandard==0.14.0
+       zstandard
 platform =
   linux_non_root,linux_root: linux
   bsd_non_root,bsd_root: darwin|freebsd|openbsd|netbsd


### PR DESCRIPTION
See https://github.com/secdev/scapy/issues/2919

Builds are failing https://ci.appveyor.com/project/secdev/scapy/builds/35988133