### PR TITLE
Remove Remain parameter from PacketField.__init__()

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -2310,7 +2310,7 @@ class BGPORFEntry(Packet):
     Provides an implementation of an ORF entry.
     References: RFC 5291
     """
-
+    __slots__ = ["afi", "safi"]
     name = "ORF entry"
     fields_desc = [
         BitEnumField("action", 0, 2, _orf_actions),
@@ -2318,6 +2318,11 @@ class BGPORFEntry(Packet):
         BitField("reserved", 0, 5),
         StrField("value", "")
     ]
+
+    def __init__(self, *args, **kwargs):
+        self.afi = kwargs.pop("afi", 1)
+        self.safi = kwargs.pop("safi", 1)
+        super(BGPORFEntry, self).__init__(*args, **kwargs)
 
 
 class _ORFNLRIPacketField(PacketField):
@@ -2328,11 +2333,11 @@ class _ORFNLRIPacketField(PacketField):
     def m2i(self, pkt, m):
         ret = None
 
-        if _orf_entry_afi == 1:
+        if pkt.afi == 1:
             # IPv4
             ret = BGPNLRI_IPv4(m)
 
-        elif _orf_entry_afi == 2:
+        elif pkt.afi == 2:
             # IPv6
             ret = BGPNLRI_IPv6(m)
 
@@ -2346,7 +2351,6 @@ class BGPORFAddressPrefix(BGPORFEntry):
     """
     Provides an implementation of the Address Prefix ORF (RFC 5292).
     """
-
     name = "Address Prefix ORF"
     fields_desc = [
         BitEnumField("action", 0, 2, _orf_actions),
@@ -2359,11 +2363,10 @@ class BGPORFAddressPrefix(BGPORFEntry):
     ]
 
 
-class BGPORFCoveringPrefix(Packet):
+class BGPORFCoveringPrefix(BGPORFEntry):
     """
     Provides an implementation of the CP-ORF (RFC 7543).
     """
-
     name = "CP-ORF"
     fields_desc = [
         BitEnumField("action", 0, 2, _orf_actions),
@@ -2387,12 +2390,19 @@ class BGPORFEntryPacketListField(PacketListField):
     def m2i(self, pkt, m):
         ret = None
 
+        if isinstance(pkt.underlayer, BGPRouteRefresh):
+            afi = pkt.underlayer.afi
+            safi = pkt.underlayer.safi
+        else:
+            afi = 1
+            safi = 1
+
         # Cisco also uses 128
         if pkt.orf_type == 64 or pkt.orf_type == 128:
-            ret = BGPORFAddressPrefix(m)
+            ret = BGPORFAddressPrefix(m, afi=afi, safi=safi)
 
         elif pkt.orf_type == 65:
-            ret = BGPORFCoveringPrefix(m)
+            ret = BGPORFCoveringPrefix(m, afi=afi, safi=safi)
 
         else:
             ret = conf.raw_layer(m)
@@ -2426,19 +2436,19 @@ class BGPORFEntryPacketListField(PacketListField):
             elif pkt.orf_type == 65:
                 # Covering Prefix ORF
 
-                if _orf_entry_afi == 1:
+                if pkt.afi == 1:
                     # IPv4
                     # sequence (4 bytes) + min_len (1 byte) + max_len (1 byte) +  # noqa: E501
                     # rt (8 bytes) + import_rt (8 bytes) + route_type (1 byte)
                     orf_len = 23 + 4
 
-                elif _orf_entry_afi == 2:
+                elif pkt.afi == 2:
                     # IPv6
                     # sequence (4 bytes) + min_len (1 byte) + max_len (1 byte) +  # noqa: E501
                     # rt (8 bytes) + import_rt (8 bytes) + route_type (1 byte)
                     orf_len = 23 + 16
 
-                elif _orf_entry_afi == 25:
+                elif pkt.afi == 25:
                     # sequence (4 bytes) + min_len (1 byte) + max_len (1 byte) +  # noqa: E501
                     # rt (8 bytes) + import_rt (8 bytes)
                     route_type = orb(remain[22])

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1650,8 +1650,8 @@ class _ExtCommValuePacketField(PacketField):
 
     __slots__ = ["type_from"]
 
-    def __init__(self, name, default, cls, remain=0, type_from=(0, 0)):
-        PacketField.__init__(self, name, default, cls, remain)
+    def __init__(self, name, default, cls, type_from=(0, 0)):
+        PacketField.__init__(self, name, default, cls)
         self.type_from = type_from
 
     def m2i(self, pkt, m):
@@ -2499,11 +2499,7 @@ class BGPRouteRefresh(BGP):
         ShortEnumField("afi", 1, address_family_identifiers),
         ByteEnumField("subtype", 0, rr_message_subtypes),
         ByteEnumField("safi", 1, subsequent_afis),
-        PacketField(
-            'orf_data',
-            "", BGPORF,
-            lambda p: _update_orf_afi_safi(p.afi, p.safi)
-        )
+        PacketField('orf_data', "", BGPORF)
     ]
 
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1392,10 +1392,9 @@ class _PacketField(_StrField[K]):
                  name,  # type: str
                  default,  # type: Optional[K]
                  pkt_cls,  # type: Union[Callable[[bytes], Packet], Type[Packet]]  # noqa: E501
-                 remain=0,  # type: int
                  ):
         # type: (...) -> None
-        super(_PacketField, self).__init__(name, default, remain=remain)
+        super(_PacketField, self).__init__(name, default)
         self.cls = pkt_cls
 
     def i2m(self,

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -1258,9 +1258,9 @@ class _TLSCKExchKeysField(PacketField):
     __slots__ = ["length_from"]
     holds_packet = 1
 
-    def __init__(self, name, length_from=None, remain=0):
+    def __init__(self, name, length_from=None):
         self.length_from = length_from
-        PacketField.__init__(self, name, None, None, remain=remain)
+        PacketField.__init__(self, name, None, None)
 
     def m2i(self, pkt, m):
         """

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -231,9 +231,9 @@ class _TLSSignatureField(PacketField):
     """
     __slots__ = ["length_from"]
 
-    def __init__(self, name, default, length_from=None, remain=0):
+    def __init__(self, name, default, length_from=None):
         self.length_from = length_from
-        PacketField.__init__(self, name, default, _TLSSignature, remain=remain)
+        PacketField.__init__(self, name, default, _TLSSignature)
 
     def m2i(self, pkt, m):
         tmp_len = self.length_from(pkt)
@@ -266,9 +266,9 @@ class _TLSServerParamsField(PacketField):
     """
     __slots__ = ["length_from"]
 
-    def __init__(self, name, default, length_from=None, remain=0):
+    def __init__(self, name, default, length_from=None):
         self.length_from = length_from
-        PacketField.__init__(self, name, default, None, remain=remain)
+        PacketField.__init__(self, name, default, None)
 
     def m2i(self, pkt, m):
         s = pkt.tls_session
@@ -456,10 +456,10 @@ class _ECBasisTypeField(ByteEnumField):
 class _ECBasisField(PacketField):
     __slots__ = ["clsdict", "basis_type_from"]
 
-    def __init__(self, name, default, basis_type_from, clsdict, remain=0):
+    def __init__(self, name, default, basis_type_from, clsdict):
         self.clsdict = clsdict
         self.basis_type_from = basis_type_from
-        PacketField.__init__(self, name, default, None, remain=remain)
+        PacketField.__init__(self, name, default, None)
 
     def m2i(self, pkt, m):
         basis = self.basis_type_from(pkt)


### PR DESCRIPTION
This is just a inconsistency I suggest to be fixed. The remain value is only applicable to the StrField itself but not to the PacketField. This becomes visible as one checks where remain is used inside StrField. It's used only in the method getfield(), which is overwritten by PacketField(). In the overwritten method, the remain is unused. The present remain is a local variable! 

I have to ask for help! The last commit I did modified the class BGPRouteRefresh. Originally, there was given a lambda where actually the remain (int) parameter was expected. The remain is treated by StrField and remains unused in PacketField. Handing over the lambda will not harm, but whom is expected to call the lambda? Also function call executed through the lambda is invoked at no other place.

I kept it for now, but now the design is really broken. I am unsure on how to continue as this is beyond my understanding.

fixes #2902 
