### PR TITLE
Remove duplicate name in pnio_dcp contirb file.

### DIFF
--- a/scapy/contrib/pnio_dcp.py
+++ b/scapy/contrib/pnio_dcp.py
@@ -540,7 +540,7 @@ class ProfinetDCP(Packet):
                          lambda pkt: pkt.service_id == 4 and
                          pkt.service_type == 0),
         # Name Of Station
-        ConditionalField(StrLenField("name_of_station", "et200sp",
+        ConditionalField(StrLenField("name_of_station_set_req", "et200sp",
                          length_from=lambda x: x.dcp_block_length - 2),
                          lambda pkt: pkt.service_id == 4 and
                          pkt.service_type == 0 and pkt.option == 2 and

--- a/scapy/contrib/pnio_dcp.py
+++ b/scapy/contrib/pnio_dcp.py
@@ -567,7 +567,7 @@ class ProfinetDCP(Packet):
 
         # DCP IDENTIFY REQUEST #
         # Name of station
-        ConditionalField(StrLenField("name_of_station", "et200sp",
+        ConditionalField(StrLenField("name_of_station_identify_req", "et200sp",
                                      length_from=lambda x: x.dcp_block_length),
                          lambda pkt: pkt.service_id == 5 and
                          pkt.service_type == 0 and pkt.option == 2 and


### PR DESCRIPTION
I just changed the name for the name_of_station field in DCP Identify and Set Requests.

I thought I might be able to combine the two duplicates but they differ in their length_from lambda function and I didn't see a way for me to combine the two into one conditional field. I had a look at some Profinet resources and I think it makes sense just to just specify this name_of_station field is for DCP identify and set requests. I didn't add any unit tests since I didn't add any functionality.

Partly fixes #2862
