### PR TITLE
TLS1.3 SignatureAlgorithmsCert Fix

### DIFF
--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -657,7 +657,7 @@ class TLS_Ext_PostHandshakeAuth(TLS_Ext_Unknown):                   # RFC 8446
 
 class TLS_Ext_SignatureAlgorithmsCert(TLS_Ext_Unknown):    # RFC 8446
     name = "TLS Extension - Signature Algorithms Cert"
-    fields_desc = [ShortEnumField("type", 0x31, _tls_ext),
+    fields_desc = [ShortEnumField("type", 0x32, _tls_ext),
                    ShortField("len", None),
                    SigAndHashAlgsLenField("sig_algs_len", None,
                                           length_of="sig_algs"),


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
**Description**
Just changes the "Type" field for the 1.3 SignatureAlgorithmsCert extension to the right type
It's a super small change, but I was playing around with TLS extensions when I noticed it.

fixes #2930 <!-- (add issue number here if appropriate, else remove this line) -->