### PR TITLE
Unit tests fixes

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -575,7 +575,7 @@ class _BGPCap_metaclass(type):
         return newclass
 
 
-class _BGPCapability_metaclass(Packet_metaclass, _BGPCap_metaclass):
+class _BGPCapability_metaclass(_BGPCap_metaclass, Packet_metaclass):
     pass
 
 

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -839,7 +839,7 @@ def execute_campaign(TESTFILE, OUTPUTFILE, PREEXEC, NUM, KW_OK, KW_KO, DUMP, DOC
     except ValueError as ex:
         print(theme.red("Error while parsing '%s': '%s'" % (TESTFILE.name, ex)),
               file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
 
     # Report parameters
     if PREEXEC:

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -1,7 +1,9 @@
 #################################### bgp.py ##################################
 % Regression tests for the bgp module
 
-# Default configuration : OLD speaker (see RFC 6793)
++ Default configuration
+
+= OLD speaker (see RFC 6793)
 bgp_module_conf.use_2_bytes_asn  = True
 
 ################################ BGPNLRI_IPv4 ################################

--- a/test/contrib/lldp.uts
+++ b/test/contrib/lldp.uts
@@ -1,4 +1,3 @@
-from enum import test
 % LLDP test campaign
 
 #


### PR DESCRIPTION
While investigating how to reduce unit tests running times, I discovered that LLDP and BGP ones are failing.