### PR TITLE
Fix contrib.bfd.BFD summary

### DIFF
--- a/scapy/contrib/bfd.py
+++ b/scapy/contrib/bfd.py
@@ -33,7 +33,8 @@ class BFD(Packet):
     def mysummary(self):
         return self.sprintf(
             "BFD (my_disc=%BFD.my_discriminator%,"
-            "your_disc=%BFD.my_discriminator%)"
+            "your_disc=%BFD.your_discriminator%,"
+            "state=%BFD.sta%)"
         )
 
 


### PR DESCRIPTION
Quick fix of bfd.BFD.mysummary as it displayed twice "my_discrimator".
Also added BFD state as it is a useful info to know the state of the BFD session.