### PR TITLE
Update installation.rst

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -134,7 +134,7 @@ Here are the topics involved and some examples that you can use to try if your i
  
   .. code-block:: python
 
-    >>> p=readpcap("myfile.pcap")
+    >>> p=rdpcap("myfile.pcap")
     >>> p.conversations(type="jpg", target="> test.jpg")
 
   .. note::


### PR DESCRIPTION
Changed `readpcap` method to `rdpcap` as the `readpcap` is no longer available.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
