### PR TITLE
Lighter MyPy rules for layers

### DIFF
--- a/.config/mypy/mypy.ini
+++ b/.config/mypy/mypy.ini
@@ -6,6 +6,11 @@
 ignore_errors = True
 ignore_missing_imports = True
 
+# Layers specific config
+
+[mypy-scapy.layers.*,mypy-scapy.contribs.*]
+warn_return_any = False
+
 # External libraries that we ignore
 
 [mypy-IPython]


### PR DESCRIPTION
I'm trying to find a good typing compromise.

For **layers** or **contribs** files, because the type of Packet fields are unknown (doing `src = IP().src` is typed "Any"), we are going to need lighter rules if we don't want the entire codebase to become a mess of `cast()` calls.

This is a first step towards this balance. I might tweak it more later