### PR TITLE
MultipleTypeField: add warning on wrong usage

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -371,6 +371,11 @@ use.
         self.dflt = dflt
         self.default = None  # So that we can detect changes in defaults
         self.name = self.dflt.name
+        if any(x[0].name != self.name for x in self.flds):
+            warnings.warn(
+                "All fields should have the same name in a MultipleTypeField",
+                SyntaxWarning
+            )
 
     def _iterate_fields_cond(self, pkt, val, use_val):
         # type: (Optional[Packet], Any, bool) -> Field[Any, Any]

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -1401,6 +1401,22 @@ assert o.subfield == 0xBEEFBEEF
 o = SweetPacket(switch=1, subfield=0x88)
 assert o.subfield == 0x88
 
+= MultipleTypeField - syntax error
+
+import warnings
+
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    class MTFPacket(Packet):
+        fields_desc = [ByteField("a", 0),
+                       MultipleTypeField([
+                           (ByteField("b", 0), lambda pkt: pkt.a == 0),
+                           (ShortField("not_b", 0), lambda: pkt.a != 0),
+                       ], IntField("b", 0))]
+    assert len(w) == 1
+    assert issubclass(w[-1].category, SyntaxWarning)
+
+
 ########
 ########
 + FlagsField


### PR DESCRIPTION
- adds a warning on wrong usage in MultipleTypeField. This technically doesn't break anything but is ugly