### PR TITLE
RawVal: fix, document, cleanup

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -270,6 +270,19 @@ The function fuzz() is able to change any default value that is not to be calcul
     ................^C
     Sent 16 packets.
 
+Injecting bytes
+---------------
+
+.. index::
+   single: RawVal
+
+In a packet, each field has a specific type. For instance, the length field of the IP packet ``len`` expects an integer. More on that later. If you're developping a PoC, there are times where you'll want to inject some value that doesn't fit that type. This is possible using ``RawVal``
+
+.. code::
+
+    >>> pkt = IP(len=RawVal(b"NotAnInteger"), src="127.0.0.1")
+    >>> bytes(pkt)
+    b'H\x00NotAnInt\x0f\xb3er\x00\x01\x00\x00@\x00\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01\x00\x00'
 
 Send and receive packets (sr)
 -----------------------------

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -211,7 +211,7 @@ def lambda_tuple_converter(func):
 # This is ugly, but we don't want to move raw() out of compat.py
 # and it makes it much clearer
 if TYPE_CHECKING:
-    from scapy.packet import Packet, RawVal
+    from scapy.packet import Packet
 
 
 if six.PY2:
@@ -225,7 +225,7 @@ if six.PY2:
         return chr(x)
 
     def raw(x):
-        # type: (Union[Packet, RawVal]) -> bytes
+        # type: (Union[Packet]) -> bytes
         """
         Builds a packet and returns its bytes representation.
         This function is and will always be cross-version compatible
@@ -235,7 +235,7 @@ if six.PY2:
         return bytes(x)
 else:
     def raw(x):
-        # type: (Union[Packet, RawVal]) -> bytes
+        # type: (Union[Packet]) -> bytes
         """
         Builds a packet and returns its bytes representation.
         This function is and will always be cross-version compatible

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -1324,14 +1324,14 @@ class HPackHdrString(packet.Packet):
         # underlayer packet
         return config.conf.padding_layer
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self, **kwargs):
         # type: (Any) -> str
         """self_build is overridden because type and len are determined at
         build time, based on the "data" field internal type
         """
         if self.getfieldval('type') is None:
             self.type = 1 if isinstance(self.getfieldval('data'), HPackZString) else 0  # noqa: E501
-        return super(HPackHdrString, self).self_build(field_pos_list)
+        return super(HPackHdrString, self).self_build(**kwargs)
 
 
 class HPackHeaders(packet.Packet):

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -161,7 +161,7 @@ class ICMPExtensionInterfaceInformation(ICMPExtensionObject):
         IntField('mtu', None),
         lambda pkt: pkt.has_mtu == 1)]
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self, **kwargs):
         if self.afi is None:
             if self.ip4 is not None:
                 self.afi = 1
@@ -179,7 +179,7 @@ class ICMPExtensionInterfaceInformation(ICMPExtensionObject):
         if self.has_mtu and self.mtu is None:
             warning('has_mtu set but mtu is not set.')
 
-        return ICMPExtensionObject.self_build(self, field_pos_list=field_pos_list)  # noqa: E501
+        return ICMPExtensionObject.self_build(self, **kwargs)
 
 
 # Add the post_dissection() method to the existing ICMPv4 and

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -375,7 +375,7 @@ class _HTTPContent(Packet):
                 )
         return pkt + pay
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self, **kwargs):
         ''' Takes an HTTPRequest or HTTPResponse object, and creates its
         string representation.'''
         if not isinstance(self.underlayer, HTTP):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -34,6 +34,7 @@ from scapy.fields import (
     MultiEnumField,
     MultipleTypeField,
     PacketListField,
+    RawVal,
     StrField,
 )
 from scapy.config import conf, _version_checker
@@ -67,24 +68,6 @@ try:
     import pyx
 except ImportError:
     pass
-
-
-class RawVal:
-    def __init__(self, val=""):
-        # type: (str) -> None
-        self.val = val
-
-    def __str__(self):
-        # type: () -> str
-        return str(self.val)
-
-    def __bytes__(self):
-        # type: () -> bytes
-        return bytes_encode(self.val)
-
-    def __repr__(self):
-        # type: () -> str
-        return "<RawVal [%r]>" % self.val
 
 
 _T = TypeVar("_T", Dict[str, Any], Optional[Dict[str, Any]])
@@ -652,8 +635,8 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                         fsubval.clear_cache()
         self.payload.clear_cache()
 
-    def self_build(self, field_pos_list=None):
-        # type: (Optional[Any])-> bytes
+    def self_build(self):
+        # type: () -> bytes
         """
         Create the default layer regarding fields_desc dict
 
@@ -672,10 +655,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         for f in self.fields_desc:
             val = self.getfieldval(f.name)
             if isinstance(val, RawVal):
-                sval = raw(val)
-                p += sval
-                if field_pos_list is not None:
-                    field_pos_list.append((f.name, sval, len(p), len(sval)))
+                p += bytes(val)
             else:
                 p = f.addfield(self, p, val)
         return p

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2686,6 +2686,11 @@ p = IP(raw(p))
 
 assert p.len == 0
 
+= IP with RawVal
+
+pkt = IP(src="127.0.0.1", dst="127.0.0.1", ttl=RawVal(b"\x01\x02\x03\x04"))
+assert raw(pkt) == b'F\x00\x00\x18\x00\x01\x00\x00\x01\x02\xb2\xe2\x00\x00\x00\x7f\x00\x00\x01\x7f\x00\x00\x01\x00'
+
 = TCP payload with IP Total Length 0
 data = b'1234567890abcdef123456789ABCDEF'
 pkt = IP()/TCP()/data
@@ -4629,6 +4634,10 @@ assert isinstance(p.payload, NoPayload)
 p = ARP(pdst='192.168.178.0/24')
 assert "Net" in repr(p)
 
+= Test RawVal on ARP
+
+pkt = ARP(psrc="1.1.1.1", hwtype=RawVal(b"test"))
+assert bytes(pkt) == b'test\x08\x00\x00\x04\x00\x01\x01\x01\x01\x01\x00\x00\x00\x00'
 
 ############
 ############


### PR DESCRIPTION
Another approach: keep `RawVal`

- cleanup `RawVal` and where it's used.
- add documentation about it
- remove unused/broken `field_pos_list`
- make struct type errors display an advice to use `RawVal` 

```python
>>> raw(IP(len=b"wrong"))
~/scapy/scapy/fields.py in addfield(self, pkt, s, val)
    203             return s + self.struct.pack(self.i2m(pkt, val))
    204         except struct.error as ex:
--> 205             raise ValueError(
    206                 "Incorrect type of value for field %s:\n" % self.name +
    207                 "struct.error('%s')\n" % ex +

ValueError: Incorrect type of value for field len:
struct.error('required argument is not an integer')
To inject bytes into the field regardless of the type, use RawVal. See help(RawVal)
```

closes https://github.com/secdev/scapy/issues/2917