### PR TITLE
Very minor fixes

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1345,7 +1345,7 @@ class Dot11EltHTCapabilities(Dot11Elt):
                  end_tot_size=-4),
         # ASEL Capabilities: 1B
         FlagsField("ASEL", 0, 8, [
-            "res"
+            "res",
             "Transmit_Sounding_PPDUs",
             "Receive_ASEL",
             "Antenna_Indices_Feedback",

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -770,7 +770,6 @@ class TLSServerAutomaton(_TLSAutomaton):
         if self.cur_session.sid is not None:
             self.add_record(is_tls12=True)
             self.add_msg(TLSChangeCipherSpec())
-        pass
 
     @ATMT.condition(tls13_ADDED_SERVERHELLO)
     def tls13_should_add_EncryptedExtensions(self):

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -18,6 +18,7 @@ import hashlib
 import importlib
 import json
 import logging
+import os
 import os.path
 import sys
 import time
@@ -1180,6 +1181,21 @@ def main():
     # Delete scapy's test environment vars
     del os.environ['SCAPY_ROOT_DIR']
 
+    # Print end message
+    if VERB > 2:
+        if glob_result == 0:
+            print(theme.green("UTscapy ended successfully"), file=sys.stderr)
+        else:
+            print(theme.red("UTscapy ended with error code %s" % glob_result),
+                  file=sys.stderr)
+
+    # Check active threads
+    if VERB > 2:
+        import threading
+        if threading.active_count() > 1:
+            print("\nWARNING: UNFINISHED THREADS", file=sys.stderr)
+            print(threading.enumerate(), file=sys.stderr)
+
     # Return state
     return glob_result
 
@@ -1190,7 +1206,7 @@ if __name__ == "__main__":
             warnings.resetwarnings()
             # Let's discover the garbage waste
             warnings.simplefilter('error')
-            print("### Warning mode enabled ###")
+            print("### Warning mode enabled ###", file=sys.stderr)
             res = main()
             if cw:
                 res = 1

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -368,12 +368,13 @@ assert f.Receive_NDP == 0
 assert f.Transmit_Staggered_Sounding == 1
 assert f.Receive_Staggered_Sounding == 1
 assert f.Implicit_Transmit_Beamforming_Receiving == 0
-assert f.ASEL.resTransmit_Sounding_PPDUs
+assert f.ASEL.res
+assert f.ASEL.Transmit_Sounding_PPDUs
 assert f.ASEL.Receive_ASEL
 assert f.ASEL.Antenna_Indices_Feedback
 assert f.ASEL.Explicit_CSI_Feedback
 assert f.ASEL.Explicit_CSI_Feedback_Based_Transmit_ASEL
-assert f.ASEL.Antenna_Selection
+assert not f.ASEL.Antenna_Selection
 assert f.ASEL == 63
 
 = RadioTap - MCS weird padding


### PR DESCRIPTION
super minor fixes. I'll self merge those
- unnecesseary `pass`
- use `os._exit` instead of `sys` when not using `-W`
- missing coma