### PR TITLE
Only import tuntap layer on platforms that support it

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -74,6 +74,9 @@ elif WINDOWS:
 
 _set_conf_sockets()  # Apply config
 
+if LINUX or BSD:
+    conf.load_layers.append("tuntap")
+
 
 def get_if_addr6(iff):
     """

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -798,14 +798,50 @@ class Conf(ConfClass):
     temp_files = []  # type: List[str]
     netcache = NetCache()
     geoip_city = None
-    # can, tls, http are not loaded by default
-    load_layers = ['bluetooth', 'bluetooth4LE', 'dhcp', 'dhcp6', 'dns',
-                   'dot11', 'dot15d4', 'eap', 'gprs', 'hsrp', 'inet',
-                   'inet6', 'ipsec', 'ir', 'isakmp', 'l2', 'l2tp',
-                   'llmnr', 'lltd', 'mgcp', 'mobileip', 'netbios',
-                   'netflow', 'ntp', 'ppi', 'ppp', 'pptp', 'radius', 'rip',
-                   'rtp', 'sctp', 'sixlowpan', 'skinny', 'smb', 'smb2', 'snmp',
-                   'tftp', 'tuntap', 'vrrp', 'vxlan', 'x509', 'zigbee']
+    # can, tls, http and a few others are not loaded by default
+    load_layers = [
+        'bluetooth',
+        'bluetooth4LE',
+        'dhcp',
+        'dhcp6',
+        'dns',
+        'dot11',
+        'dot15d4',
+        'eap',
+        'gprs',
+        'hsrp',
+        'inet',
+        'inet6',
+        'ipsec',
+        'ir',
+        'isakmp',
+        'l2',
+        'l2tp',
+        'llmnr',
+        'lltd',
+        'mgcp',
+        'mobileip',
+        'netbios',
+        'netflow',
+        'ntp',
+        'ppi',
+        'ppp',
+        'pptp',
+        'radius',
+        'rip',
+        'rtp',
+        'sctp',
+        'sixlowpan',
+        'skinny',
+        'smb',
+        'smb2',
+        'snmp',
+        'tftp',
+        'vrrp',
+        'vxlan',
+        'x509',
+        'zigbee'
+    ]
     #: a dict which can be used by contrib layers to store local
     #: configuration
     contribs = dict()  # type: Dict[str, Any]

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -8,9 +8,12 @@ All layers. Configurable with conf.load_layers.
 """
 
 from __future__ import absolute_import
-from scapy.config import conf
+
+# We import conf from arch to make sure arch specific layers are populated
+from scapy.arch import conf
 from scapy.error import log_loading
 from scapy.main import load_layer
+
 import logging
 import scapy.modules.six as six
 


### PR DESCRIPTION
- minor fix to make sure we don't try to load `tuntap` on windows.
- also took that occasion to reformat `conf.load_layers` so that we don't have to update all 4 lines each time we do a change