### PR TITLE
Fix typo in the documentation of SOME/IP SD

### DIFF
--- a/doc/scapy/layers/automotive.rst
+++ b/doc/scapy/layers/automotive.rst
@@ -963,7 +963,7 @@ Create the entry array input::
 
 Create the options array input::
 
-   oa = SDOption_IP4_Endpoint()
+   oa = SDOption_IP4_EndPoint()
    oa.addr = "192.168.0.13"
    oa.l4_proto = 0x11
    oa.port = 30509


### PR DESCRIPTION
Fixes a typo in the example showing how to create a SOME/IP-SD message
```
>>> oa = SDOption_IP4_Endpoint()                                                                                                                                                                                                                               
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-10-def2c2508e1c> in <module>
----> 1 oa = SDOption_IP4_Endpoint()

NameError: name 'SDOption_IP4_Endpoint' is not defined
>>> oa = SDOption_IP4_EndPoint()                                                                                                                                                                                                                               
>>>  
```