### PR TITLE
Fix link to documentation about adding new protocols.

### DIFF
--- a/doc/scapy/build_dissect.rst
+++ b/doc/scapy/build_dissect.rst
@@ -2,7 +2,7 @@
 Adding new protocols
 ********************
 
-Adding new protocol (or more correctly: a new *layer*) in Scapy is very easy. All the magic is in the fields. If the 
+Adding a new protocol (or more correctly: a new *layer*) in Scapy is very easy. All the magic is in the fields. If the 
 fields you need are already there and the protocol is not too brain-damaged, 
 this should be a matter of minutes. 
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -139,9 +139,10 @@ M = TypeVar('M')  # Machine storage
 @six.add_metaclass(Field_metaclass)
 class Field(Generic[I, M]):
     """
-    For more information on how this work, please refer to
-    http://www.secdev.org/projects/scapy/files/scapydoc.pdf
-    chapter ``Adding a New Field``
+    For more information on how this works, please refer to the
+    'Adding new protocols' chapter in the online documentation:
+
+    https://scapy.readthedocs.io/en/stable/build_dissect.html
     """
     __slots__ = [
         "name",


### PR DESCRIPTION
This commit updates an outdated documentation link in a doc string, and a grammar nit in the documentation itself.

**Checklist:**

-   [x] I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)

