### PR TITLE
Move standard root unit tests to Github Actions

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -11,6 +11,12 @@ then
   # Linux
   OSTOX="linux"
   UT_FLAGS+=" -K tshark"
+  if [ ! -z "$GITHUB_ACTIONS" ]
+  then
+    # Due to a security policy, the firewall of the Azure runner
+    # (Standard_DS2_v2) that runs Github Actions on Linux blocks ICMP.
+    UT_FLAGS+=" -K icmp_firewall"
+  fi
   if [ -z "$SIMPLE_TESTS" ]
   then
     # check vcan

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -55,16 +55,27 @@ jobs:
       - name: Run mypy
         run: tox -e mypy
 
-  # Github Actions block ICMP. We can still use it for non root tests
   utscapy:
     name: ${{ matrix.os }} ${{ matrix.python }} ${{ matrix.mode }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [2.7, pypy2, pypy3, 3.5, 3.6, 3.7, 3.8, 3.9]
-        mode: [non_root]
+        python: [2.7, pypy2, pypy3, 3.9]
+        mode: [both]
         include:
+          # Linux non-root only tests
+          - os: ubuntu-latest
+            python: 3.6
+            mode: non_root
+          - os: ubuntu-latest
+            python: 3.7
+            mode: non_root
+          - os: ubuntu-latest
+            python: 3.8
+            mode: non_root
+          # MacOS tests
           - os: macos-latest
             python: 2.7
             mode: both

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,28 +7,6 @@ cache:
 
 jobs:
     include:
-        # Run linux as root on linux.
-        # Non-root on linux and root/non_root on OSX are tested via GitHub CI
-        - os: linux
-          python: 2.7
-          env:
-            - TOXENV=py27-linux_root,codecov
-
-        - os: linux
-          python: pypy2
-          env:
-            - TOXENV=pypy-linux_root,codecov
-
-        - os: linux
-          python: pypy3
-          env:
-            - TOXENV=pypy3-linux_root,codecov
-
-        - os: linux
-          python: 3.8
-          env:
-            - TOXENV=py38-linux_root,codecov
-
         # run custom root tests
         # isotp
         - os: linux

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -67,15 +67,6 @@ _DOC_SNDRCV_PARAMS = """
     :param timeout: how much time to wait after the last packet has been sent
     :param verbose: set verbosity level
     :param multi: whether to accept multiple answers for the same stimulus
-    :param store_unanswered: whether to store not-answered packets or not.
-        setting it to False will increase speed, and will return
-        None as the unans list.
-    :param process: if specified, only result from process(pkt) will be stored.
-        the function should follow the following format:
-        ``lambda sent, received: (func(sent), func2(received))``
-        if the packet is unanswered, `received` will be None.
-        if `store_unanswered` is False, the function won't be called on
-        un-answered packets.
     :param prebuild: pre-build the packets before starting to send them.
         Automatically enabled when a generator is passed as the packet
     """
@@ -681,7 +672,7 @@ def sndrcvflood(pks, pkt, inter=0, verbose=None, chainCC=False, timeout=None):
     return sndrcv(
         pks, infinite_gen,
         inter=inter, verbose=verbose,
-        chainCC=chainCC, timeout=None,
+        chainCC=chainCC, timeout=timeout,
         _flood=_flood
     )
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -9,19 +9,18 @@
 + Linux only test
 
 = L3RawSocket
-~ netaccess IP ICMP linux needs_root
+~ netaccess IP TCP linux needs_root
 
 old_l3socket = conf.L3socket
 old_debug_dissector = conf.debug_dissector
 conf.debug_dissector = False
 conf.L3socket = L3RawSocket
-x = sr1(IP(dst="www.google.com")/ICMP(),timeout=3)
+x = sr1(IP(dst="www.google.com")/TCP(sport=RandShort(), dport=80, flags="S"),timeout=3)
 conf.debug_dissector = old_debug_dissector
 conf.L3socket = old_l3socket
 x
 assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
-x is not None and ICMP in x and x[ICMP].type == 0
 
 # TODO: fix this test (randomly stuck)
 # ex: https://travis-ci.org/secdev/scapy/jobs/247473497

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1388,16 +1388,16 @@ def _test():
 
 retry_test(_test)
 
-= Sending an ICMP message at layer 2 and layer 3
-~ netaccess IP ICMP
+= Sending a TCP syn message at layer 2 and layer 3
+~ netaccess IP
 def _test():
-    tmp = send(IP(dst="8.8.8.8")/ICMP(), return_packets=True, realtime=True)
+    tmp = send(IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), return_packets=True, realtime=True)
     assert(len(tmp) == 1)
     
-    tmp = sendp(Ether()/IP(dst="8.8.8.8")/ICMP(), return_packets=True, realtime=True)
+    tmp = sendp(Ether()/IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), return_packets=True, realtime=True)
     assert(len(tmp) == 1)
     
-    p = Ether()/IP(dst="8.8.8.8")/ICMP()
+    p = Ether()/IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S")
     from decimal import Decimal
     p.time = Decimal(p.time)
     tmp = sendp(p, return_packets=True, realtime=True)
@@ -1421,25 +1421,25 @@ retry_test(_test)
 
 conf.L3socket = sock
 
-= Sending an ICMP message 'forever' at layer 2 and layer 3
-~ netaccess IP ICMP icmp_firewall
+= Sending a TCP syn 'forever' at layer 2 and layer 3
+~ netaccess IP
 def _test():
-    tmp = srloop(IP(dst="8.8.8.8")/ICMP(), count=1, timeout=3)
+    tmp = srloop(IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), count=1, timeout=3)
     assert(type(tmp) == tuple and len(tmp[0]) == 1)
     
-    tmp = srploop(Ether()/IP(dst="8.8.8.8")/ICMP(), count=1, timeout=3)
+    tmp = srploop(Ether()/IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), count=1, timeout=3)
     assert(type(tmp) == tuple and len(tmp[0]) == 1)
 
 retry_test(_test)
 
-= Sending and receiving an ICMP with flooding methods
-~ netaccess IP ICMP icmp_firewall
+= Sending and receiving an TCP syn with flooding methods
+~ netaccess IP
 from functools import partial
 # flooding methods do not support timeout. Packing the test for security
 def _test_flood(flood_function, add_ether=False):
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    p = IP(dst="www.google.com")/ICMP()
+    p = IP(dst="www.google.com")/TCP(sport=RandShort(), dport=80, flags="S")
     if add_ether:
         p = Ether()/p
     x = flood_function(p, timeout=2)
@@ -1449,7 +1449,6 @@ def _test_flood(flood_function, add_ether=False):
     x
     assert x[IP].ottl() in [32, 64, 128, 255]
     assert 0 <= x[IP].hops() <= 126
-    x is not None and ICMP in x and x[ICMP].type == 0
 
 _test_srflood = partial(_test_flood, srflood)
 retry_test(_test_srflood)
@@ -1623,7 +1622,7 @@ def _test():
     conf.debug_match = True
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    ans, unans = sr(IP(dst="www.google.fr") / ICMP(), timeout=2)
+    ans, unans = sr(IP(dst="www.google.fr") / TCP(sport=RandShort(), dport=80, flags="S"), timeout=2)
     assert ans[0].query == ans[0][0]
     assert ans[0].answer == ans[0][1]
     conf.debug_match = old_debug_match
@@ -1637,9 +1636,9 @@ retry_test(_test)
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / ICMP(), timeout=2, retry=1)
+    ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / TCP(sport=RandShort(), dport=53, flags="S"), timeout=2, retry=1)
     conf.debug_dissector = old_debug_dissector
-    len(ans) == 1 and len(unans) == 1
+    assert len(ans) == 1 and len(unans) == 1
 
 retry_test(_test)
 
@@ -1648,9 +1647,9 @@ retry_test(_test)
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / ICMP(), timeout=2, multi=1)
+    ans, unans = sr(IP(dst=["8.8.8.8", "1.2.3.4"]) / TCP(sport=RandShort(), dport=53, flags="S"), timeout=2, multi=1)
     conf.debug_dissector = old_debug_dissector
-    len(ans) == 1 and len(unans) == 1
+    assert len(ans) >= 1 and len(unans) == 1
 
 retry_test(_test)
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1375,7 +1375,7 @@ assert ssid == "ROUTE-821E295"
 * Those tests need network access
 
 = Sending and receiving an ICMP
-~ netaccess IP ICMP
+~ netaccess IP ICMP icmp_firewall
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
@@ -1422,18 +1422,18 @@ retry_test(_test)
 conf.L3socket = sock
 
 = Sending an ICMP message 'forever' at layer 2 and layer 3
-~ netaccess IP ICMP
+~ netaccess IP ICMP icmp_firewall
 def _test():
-    tmp = srloop(IP(dst="8.8.8.8")/ICMP(), count=1)
+    tmp = srloop(IP(dst="8.8.8.8")/ICMP(), count=1, timeout=3)
     assert(type(tmp) == tuple and len(tmp[0]) == 1)
     
-    tmp = srploop(Ether()/IP(dst="8.8.8.8")/ICMP(), count=1)
+    tmp = srploop(Ether()/IP(dst="8.8.8.8")/ICMP(), count=1, timeout=3)
     assert(type(tmp) == tuple and len(tmp[0]) == 1)
 
 retry_test(_test)
 
 = Sending and receiving an ICMP with flooding methods
-~ netaccess IP ICMP
+~ netaccess IP ICMP icmp_firewall
 from functools import partial
 # flooding methods do not support timeout. Packing the test for security
 def _test_flood(flood_function, add_ether=False):


### PR DESCRIPTION
ICMP is blocked by a firewall policy on the Azure runners they use for Github Actions. We can't change that, so we need to work around it.

This PR:
- changes ICMP for TCP/Syn in tests that use those packets to test the send/receive features (rather than ICMP itself)
- move default (not libpcap, isotp or warnings) root jobs over to Github Actions
- disable the now single that test ICMP send/receive on Github CI. This test is still enabled on Windows (AppVeyor), Travis builds, and MacOS builds on GithubCI.
- minor fix in `sendrecv` discovered while trying to fix the tests for Github CI.

**Notes**
- I do not want to encourage triggering too much builds, not only to show respect to the providers that freely give us builds but also to try being future-proof and not run out of credits again. In this regard, I have purposely not enabled root builds for Python 3.6, 3.7 and 3.8 (we had already dropped those on Travis but I don't want to enable them on Github), because it is simply not necessary. We already test 2.7 and 3.9 (and the two pypys) as root. Root builds take more than double the time, I don't want to have too many.
- I am going to restrict the isotp build on Travis to ONLY isotp tests (vcan?...) in a future PR. The full list of tests that will be executed still needs to be established. Indeed, apart from a few tests, it executes the same way as a normal 3.8 root build;
- I am looking into migrating the libpcap test. Will be for a future PR