### PR TITLE
Remove duplicate field warnings from gtpv2 modules

### DIFF
--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -31,6 +31,7 @@ from scapy.fields import (
     ConditionalField,
     IPField,
     IntField,
+    MultipleTypeField,
     PacketField,
     PacketListField,
     ShortEnumField,
@@ -268,7 +269,8 @@ class GTPHeader(gtp.GTPHeader):
                                     lambda pkt:pkt.MP == 1),
                    ConditionalField(
                        MultipleTypeField(
-                           [(BitField("SPARE3", 0, 4), lambda pkt: pkt.MP == 1)],
+                           [(BitField("SPARE3", 0, 4),
+                             lambda pkt: pkt.MP == 1)],
                            ByteField("SPARE3", 0)
                        ), lambda pkt: pkt.MP in [0, 1]
                    )

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -266,9 +266,9 @@ class GTPHeader(gtp.GTPHeader):
                    ThreeBytesField("seq", RandShort()),
                    ConditionalField(BitField("msg_priority", 0, 4),
                                     lambda pkt:pkt.MP == 1),
-                   ConditionalField(BitField("SPARE3", 0, 4),
+                   ConditionalField(BitField("SPARE3_MP1", 0, 4),
                                     lambda pkt:pkt.MP == 1),
-                   ConditionalField(ByteField("SPARE3", 0),
+                   ConditionalField(ByteField("SPARE3_MP0", 0),
                                     lambda pkt:pkt.MP == 0)
                    ]
 
@@ -512,10 +512,10 @@ class IE_UCI(gtp.IE_Base):
                    BitField("instance", 0, 4),
                    gtp.TBCDByteField("MCC", "", 2),
                    gtp.TBCDByteField("MNC", "", 1),
-                   BitField("SPARE", 0, 5),
+                   BitField("SPARE1", 0, 5),
                    BitField("CSG_ID", 0, 27),
                    BitField("AccessMode", 0, 2),
-                   BitField("SPARE", 0, 4),
+                   BitField("SPARE2", 0, 4),
                    BitField("LCSG", 0, 1),
                    BitField("CMI", 0, 1)]
 
@@ -904,11 +904,11 @@ class IE_Indication(gtp.IE_Base):
         ConditionalField(
         BitField("TSPCMI", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
-        BitField("Spare", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("Spare1", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("Spare", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("Spare2", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("Spare", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("Spare3", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
         BitField("N5GNMI", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
@@ -1346,10 +1346,10 @@ class IE_Bearer_QoS(gtp.IE_Base):
                    ShortField("length", None),
                    BitField("CR_flag", 0, 4),
                    BitField("instance", 0, 4),
-                   BitField("SPARE", 0, 1),
+                   BitField("SPARE1", 0, 1),
                    BitField("PCI", 0, 1),
                    BitField("PriorityLevel", 0, 4),
-                   BitField("SPARE", 0, 1),
+                   BitField("SPARE2", 0, 1),
                    BitField("PVI", 0, 1),
                    ByteField("QCI", 0),
                    BitField("MaxBitRateForUplink", 0, 40),

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -266,10 +266,12 @@ class GTPHeader(gtp.GTPHeader):
                    ThreeBytesField("seq", RandShort()),
                    ConditionalField(BitField("msg_priority", 0, 4),
                                     lambda pkt:pkt.MP == 1),
-                   ConditionalField(BitField("SPARE3_MP1", 0, 4),
-                                    lambda pkt:pkt.MP == 1),
-                   ConditionalField(ByteField("SPARE3_MP0", 0),
-                                    lambda pkt:pkt.MP == 0)
+                   ConditionalField(
+                       MultipleTypeField(
+                           [(BitField("SPARE3", 0, 4), lambda pkt: pkt.MP == 1)],
+                           ByteField("SPARE3", 0)
+                       ), lambda pkt: pkt.MP in [0, 1]
+                   )
                    ]
 
 
@@ -904,11 +906,11 @@ class IE_Indication(gtp.IE_Base):
         ConditionalField(
         BitField("TSPCMI", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
-        BitField("Spare1", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("SPARE1", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("Spare2", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("SPARE2", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("Spare3", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("SPARE3", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
         BitField("N5GNMI", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -271,10 +271,8 @@ class GTPHeader(gtp.GTPHeader):
                        MultipleTypeField(
                            [(BitField("SPARE3", 0, 4),
                              lambda pkt: pkt.MP == 1)],
-                           ByteField("SPARE3", 0)
-                       ), lambda pkt: pkt.MP in [0, 1]
-                   )
-                   ]
+                           ByteField("SPARE3", 0)),
+                       lambda pkt: pkt.MP in [0, 1])]
 
 
 class IE_IP_Address(gtp.IE_Base):

--- a/test/contrib/gtp_v2.uts
+++ b/test/contrib/gtp_v2.uts
@@ -266,7 +266,7 @@ ie = gtp.IE_list[0]
 ie.CSG_ID == 22 and ie.AccessMode == 0 and ie.LCSG == 1 and ie.CMI == 0 and ie.MCC == b'123' and ie.MNC == b'45'
 
 = IE_UCI, basic instantiation
-ie = IE_UCI(ietype='UCI', length=8, CR_flag=0, instance=0, MCC=b'123', MNC=b'45', SPARE=0, CSG_ID=22, AccessMode=0, LCSG=1, CMI=0)
+ie = IE_UCI(ietype='UCI', length=8, CR_flag=0, instance=0, MCC=b'123', MNC=b'45', SPARE1=0, SPARE2=0, CSG_ID=22, AccessMode=0, LCSG=1, CMI=0)
 ie.ietype == 145 and ie.CSG_ID == 22 and ie.AccessMode == 0 and ie.LCSG == 1 and ie.CMI == 0 and ie.MCC == b'123' and ie.MNC == b'45'
 
 = IE_BearerFlags, dissection


### PR DESCRIPTION
Before:
```
Python 3.6.8 (default, Aug  7 2019, 17:28:10)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from scapy.all import *
>>> from scapy.contrib.gtp_v2 import *
/usr/local/lib/python3.6/site-packages/scapy/base_classes.py:279: SyntaxWarning: Packet 'GTPHeader' has a duplicated 'SPARE3' field ! If you are using several ConditionalFields, have a look at MultipleTypeField instead ! This will become a SyntaxError in a future version of Scapy !
  warnings.warn(war_msg, SyntaxWarning)
/usr/local/lib/python3.6/site-packages/scapy/base_classes.py:279: SyntaxWarning: Packet 'IE_UCI' has a duplicated 'SPARE' field ! If you are using several ConditionalFields, have a look at MultipleTypeField instead ! This will become a SyntaxError in a future version of Scapy !
  warnings.warn(war_msg, SyntaxWarning)
/usr/local/lib/python3.6/site-packages/scapy/base_classes.py:279: SyntaxWarning: Packet 'IE_Indication' has a duplicated 'Spare' field ! If you are using several ConditionalFields, have a look at MultipleTypeField instead ! This will become a SyntaxError in a future version of Scapy !
  warnings.warn(war_msg, SyntaxWarning)
/usr/local/lib/python3.6/site-packages/scapy/base_classes.py:279: SyntaxWarning: Packet 'IE_Bearer_QoS' has a duplicated 'SPARE' field ! If you are using several ConditionalFields, have a look at MultipleTypeField instead ! This will become a SyntaxError in a future version of Scapy !
  warnings.warn(war_msg, SyntaxWarning)
```


After:
```
Python 3.6.8 (default, Aug  7 2019, 17:28:10)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from scapy.all import *
>>> from scapy.contrib.gtp_v2 import *
>>> from scapy.contrib.gtp import *
>>>
```