### PR TITLE
Fix ctypes usage with Python 3.9

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -32,7 +32,7 @@ from scapy.modules.six.moves import range
 
 # ctypes definitions
 
-LIBC = cdll.LoadLibrary(find_library("libc"))
+LIBC = cdll.LoadLibrary(find_library("c"))
 
 LIBC.ioctl.argtypes = [c_int, c_ulong, c_char_p]
 LIBC.ioctl.restype = c_int


### PR DESCRIPTION
There is a regression in Python 3.9 with the `find_library()`
function:

    >>> import ctypes.util
    >>> ctypes.util.find_library("libc")
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File "/usr/lib/python3.9/ctypes/util.py", line 341, in find_library
         _get_soname(_findLib_gcc(name)) or _get_soname(_findLib_ld(name))
       File "/usr/lib/python3.9/ctypes/util.py", line 147, in _findLib_gcc
         if not _is_elf(file):
       File "/usr/lib/python3.9/ctypes/util.py", line 99, in _is_elf
         with open(filename, 'br') as thefile:
     FileNotFoundError: [Errno 2] No such file or directory: b'liblibc.a'

A workaround is to use `find_library("c")` instead. It also works in
older versions of Python and that's already what's used in
`contrib/isotp.py`.

Python issue reported here:
 https://bugs.python.org/issue42580

Signed-off-by: Vincent Bernat <vincent@bernat.ch>