### PR TITLE
Prevent L2socket from busy spinning reading from the socket on busy hosts

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -445,6 +445,7 @@ class L2Socket(SuperSocket):
             )
         self.ins = socket.socket(
             socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))
+        self.ins.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 0)
         if not nofilter:
             if conf.except_filter:
                 if filter:


### PR DESCRIPTION

Fixes #3006
