### PR TITLE
Remove duplicated packet fields in opc_da.py

### DIFF
--- a/scapy/contrib/opc_da.py
+++ b/scapy/contrib/opc_da.py
@@ -272,10 +272,10 @@ class LenStringPacket(Packet):
     name = "len string packet"
     fields_desc = [
         FieldLenField('length', 0, length_of='data', fmt="H"),
-        ConditionalField(StrLenField('data', None,
+        ConditionalField(StrLenField('data1', None,
                          length_from=lambda pkt:pkt.length + 2),
                          lambda pkt:pkt.length == 0),
-        ConditionalField(StrLenField('data', '',
+        ConditionalField(StrLenField('data2', '',
                          length_from=lambda pkt:pkt.length),
                          lambda pkt:pkt.length != 0),
     ]
@@ -288,10 +288,10 @@ class LenStringPacketLE(Packet):
     name = "len string packet"
     fields_desc = [
         LEFieldLenField('length', 0, length_of='data', fmt="<H"),
-        ConditionalField(StrLenField('data', None,
+        ConditionalField(StrLenField('data1', None,
                          length_from=lambda pkt:pkt.length + 2),
                          lambda pkt:pkt.length == 0),
-        ConditionalField(StrLenField('data', '',
+        ConditionalField(StrLenField('data2', '',
                          length_from=lambda pkt:pkt.length),
                          lambda pkt:pkt.length != 0),
     ]
@@ -741,18 +741,18 @@ class NTLMSSP(Packet):
         StrFixedLenField('Z', '', 6),
         LongField('timestamp', 0),  # Time in nanoseconde
         StrFixedLenField('clientChallenge', '', 8),
-        IntField('Z', 0),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        PacketField('attributeNTLMV2', None, AttributeName),
-        IntField('Z', 0),
+        IntField('Z1', 0),
+        PacketField('attributeNTLMV2_1', None, AttributeName),
+        PacketField('attributeNTLMV2_2', None, AttributeName),
+        PacketField('attributeNTLMV2_3', None, AttributeName),
+        PacketField('attributeNTLMV2_4', None, AttributeName),
+        PacketField('attributeNTLMV2_5', None, AttributeName),
+        PacketField('attributeNTLMV2_6', None, AttributeName),
+        PacketField('attributeNTLMV2_7', None, AttributeName),
+        PacketField('attributeNTLMV2_8', None, AttributeName),
+        PacketField('attributeNTLMV2_9', None, AttributeName),
+        PacketField('attributeNTLMV2_10', None, AttributeName),
+        IntField('Z2', 0),
         IntField('padding', 0),
         StrLenField('sessionKey', '',
                     length_from=lambda pkt: pkt.sessionKeyLen),
@@ -805,7 +805,7 @@ class NTLMSSPLE(Packet):
         StrFixedLenField('Z', '', 6),
         LELongField('timestamp', 0),  # Time in nanosecond
         StrFixedLenField('clientChallenge', '', 8),
-        LEIntField('Z', 0),
+        LEIntField('Z1', 0),
         PacketField('attribute1', None, AttributeNameLE),
         PacketField('attribute2', None, AttributeNameLE),
         PacketField('attribute3', None, AttributeNameLE),
@@ -816,7 +816,7 @@ class NTLMSSPLE(Packet):
         PacketField('attribute8', None, AttributeNameLE),
         PacketField('attribute9', None, AttributeNameLE),
         PacketField('attribute10', None, AttributeNameLE),
-        LEIntField('Z', 0),
+        LEIntField('Z2', 0),
         LEIntField('padding', 0),
         StrLenField('sessionKey', '',
                     length_from=lambda pkt: pkt.sessionKeyLen),
@@ -1470,8 +1470,8 @@ class OpcDaHeaderMessage(Packet):
                      {0: "ascii", 1: "ebcdic"}),
         ByteEnumField('floatingPointRepresentation', 0,
                       {0: "ieee", 1: "vax", 2: "cray", 3: "ibm"}),
-        ByteField('reservedForFutur', 0),
-        ByteField('reservedForFutur', 0),
+        ByteField('reservedForFutur1', 0),
+        ByteField('reservedForFutur2', 0),
     ]
 
     def guess_payload_class(self, payload):


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
This PR contributes to #2862 by removing duplicate packet fields in opc_da.py. 

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->
Changes were tested by using 'load_contrib("opc_da.py")' and no syntax errors were thrown. No new functionality was introduced so no new unit tests are required.

<!-- if required - outline impacts on other parts of the library -->

