### PR TITLE
TLS client: support STOP event

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -987,6 +987,12 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
                 self.state = state_req
                 yield state_req
 
+    def __repr__(self):
+        return "<Automaton %s [%s]>" % (
+            self.__class__.__name__,
+            ["HALTED", "RUNNING"][self.started.locked()]
+        )
+
     # Public API
     def add_interception_points(self, *ipts):
         for ipt in ipts:


### PR DESCRIPTION
- very minor fix so that `TLSClientAutomaton` supports `.stop()` gracefully.