### PR TITLE
support for DHCPv4 option 77

### DIFF
--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -186,6 +186,7 @@ DHCPOptions = {
     74: IPField("IRC_server", "0.0.0.0"),
     75: IPField("StreetTalk_server", "0.0.0.0"),
     76: IPField("StreetTalk_Dir_Assistance", "0.0.0.0"),
+    77: "user_class",
     78: "slp_service_agent",
     79: "slp_service_scope",
     81: "client_FQDN",

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -11,8 +11,8 @@ assert BOOTP().hashret() == b"\x00\x00\x00\x00"
 import random
 random.seed(0x2809)
 o = str(RandDHCPOptions(size=1))
-print("RandDHCPOptions %s" % o)
-assert o in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_keepalive_interval', 3853054080)]"]
+# print("RandDHCPOptions %s" % o)
+assert o in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_keepalive_interval', 3853054080)]", r"[('tcp_keepalive_interval', 3853054080L)]"]
 
 = DHCPOptionsField
 

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -10,7 +10,9 @@ assert BOOTP().hashret() == b"\x00\x00\x00\x00"
 
 import random
 random.seed(0x2809)
-assert str(RandDHCPOptions(size=1)) in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_keepalive_interval', 3853054080)]"]
+o = str(RandDHCPOptions(size=1))
+print("RandDHCPOptions %s" % o)
+assert o in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_keepalive_interval', 3853054080)]"]
 
 = DHCPOptionsField
 

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -10,7 +10,7 @@ assert BOOTP().hashret() == b"\x00\x00\x00\x00"
 
 import random
 random.seed(0x2809)
-assert str(RandDHCPOptions(size=1)) in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_ttl', 229)]"]
+assert str(RandDHCPOptions(size=1)) in [r"[('NIS_server', '0.45.231.69')]", r"[('tcp_keepalive_interval', 3853054080)]"]
 
 = DHCPOptionsField
 


### PR DESCRIPTION
This is very simple change that just adds mapping entry for option 77 for DHCPv4.
When it is added then packets with this option are generated correctly.