### PR TITLE
Implement duck typing for raw payloads

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -356,10 +356,8 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                     if t in payload.overload_fields:
                         self.overloaded_fields = payload.overload_fields[t]
                         break
-            elif isinstance(payload, bytes):
-                self.payload = conf.raw_layer(load=payload)
             else:
-                raise TypeError("payload must be either 'Packet' or 'bytes', not [%s]" % repr(payload))  # noqa: E501
+                self.payload = conf.raw_layer(load=bytes_encode(payload))
 
     def remove_payload(self):
         # type: () -> None
@@ -577,18 +575,17 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             cloneB = other.copy()
             cloneA.add_payload(cloneB)
             return cloneA
-        elif isinstance(other, (bytes, str, bytearray)):
-            return self / conf.raw_layer(load=other)
         else:
+            try:
+                return self / conf.raw_layer(load=bytes_encode(other))
+            except TypeError:
+                pass
             return other.__rdiv__(self)  # type: ignore
     __truediv__ = __div__
 
     def __rdiv__(self, other):
         # type: (Any) -> Packet
-        if isinstance(other, (bytes, str, bytearray)):
-            return conf.raw_layer(load=other) / self
-        else:
-            raise TypeError
+        return conf.raw_layer(load=bytes_encode(other)) / self
     __rtruediv__ = __rdiv__
 
     def __mul__(self, other):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1000,6 +1000,18 @@ a=3
 assert bytes(Raw("sca")/"py") == b"scapy"
 assert bytes(Raw("sca")/b"py") == b"scapy"
 assert bytes(Raw("sca")/bytearray(b"py")) == b"scapy"
+assert bytes("sca"/Raw("py")) == b"scapy"
+assert bytes(b"sca"/Raw("py")) == b"scapy"
+assert bytes(bytearray(b"sca")/Raw("py")) == b"scapy"
+a=Raw("sca")
+a.add_payload("py")
+assert bytes(a) == b"scapy"
+a=Raw("sca")
+a.add_payload(b"py")
+assert bytes(a) == b"scapy"
+a=Raw("sca")
+a.add_payload(bytearray(b"py"))
+assert bytes(a) == b"scapy"
 
 = Checking overloads
 ~ basic IP TCP Ether


### PR DESCRIPTION
Implement duck typing for raw payloads by unconditionally passing anything that isn't a `Packet` instance through `bytes_encode`.  This means anything that can be converted to `bytes` can be used as a payload without explicitly converting to `bytes` first, not limited to `bytearray`s.  This applies to `Packet.__div__`, `Packet.__rdiv__`, and `Packet.add_payload()`.

More complete fix for #3015.