### PR TITLE
Support bytearray and memoryview as raw payload

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -356,10 +356,10 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                     if t in payload.overload_fields:
                         self.overloaded_fields = payload.overload_fields[t]
                         break
-            elif isinstance(payload, bytes):
-                self.payload = conf.raw_layer(load=payload)
+            elif isinstance(payload, (bytes, str, bytearray, memoryview)):
+                self.payload = conf.raw_layer(load=bytes_encode(payload))
             else:
-                raise TypeError("payload must be either 'Packet' or 'bytes', not [%s]" % repr(payload))  # noqa: E501
+                raise TypeError("payload must be 'Packet', 'bytes', 'str', 'bytearray', or 'memoryview', not [%s]" % repr(payload))  # noqa: E501
 
     def remove_payload(self):
         # type: () -> None
@@ -577,16 +577,16 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             cloneB = other.copy()
             cloneA.add_payload(cloneB)
             return cloneA
-        elif isinstance(other, (bytes, str, bytearray)):
-            return self / conf.raw_layer(load=other)
+        elif isinstance(other, (bytes, str, bytearray, memoryview)):
+            return self / conf.raw_layer(load=bytes_encode(other))
         else:
             return other.__rdiv__(self)  # type: ignore
     __truediv__ = __div__
 
     def __rdiv__(self, other):
         # type: (Any) -> Packet
-        if isinstance(other, (bytes, str, bytearray)):
-            return conf.raw_layer(load=other) / self
+        if isinstance(other, (bytes, str, bytearray, memoryview)):
+            return conf.raw_layer(load=bytes_encode(other)) / self
         else:
             raise TypeError
     __rtruediv__ = __rdiv__

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1000,6 +1000,18 @@ a=3
 assert bytes(Raw("sca")/"py") == b"scapy"
 assert bytes(Raw("sca")/b"py") == b"scapy"
 assert bytes(Raw("sca")/bytearray(b"py")) == b"scapy"
+assert bytes("sca"/Raw("py")) == b"scapy"
+assert bytes(b"sca"/Raw("py")) == b"scapy"
+assert bytes(bytearray(b"sca")/Raw("py")) == b"scapy"
+a=Raw("sca")
+a.add_payload("py")
+assert bytes(a) == b"scapy"
+a=Raw("sca")
+a.add_payload(b"py")
+assert bytes(a) == b"scapy"
+a=Raw("sca")
+a.add_payload(bytearray(b"py"))
+assert bytes(a) == b"scapy"
 
 = Checking overloads
 ~ basic IP TCP Ether


### PR DESCRIPTION
Support all python builtin objects that are interchangeable with bytes (bytearray and memoryview) in payloads.  Ensure that mutable bytearrays are cast to bytes at the same time to prevent unexpected issues.  This applies to `Packet.__div__`, `Packet.__rdiv__`, and `Packet.add_payload()`.

More complete fix for #3015.