### PR TITLE
packet.py: init default_fields with deep-copy cached values (#3024)

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -279,10 +279,10 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
             for fname in Packet.class_default_fields_ref[cls_name]:
                 value = self.default_fields[fname]
                 try:
-                    self.fields[fname] = value.copy()
+                    self.default_fields[fname] = value.copy()
                 except AttributeError:
                     # Python 2.7 - list only
-                    self.fields[fname] = value[:]
+                    self.default_fields[fname] = value[:]
 
     def prepare_cached_fields(self, flist):
         # type: (Sequence[AnyField]) -> None


### PR DESCRIPTION
Providing values to Packet.fields, prevents the ability to provide
overloaded_fields using the standard bind_layers() operation.

When using cached fields for Packet setup (do_init_cached_fields()),
ensure that the deep-copy initializes the lower priority
self.default_fields and not self.fields.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

fixes #3024

**Test Code**
```
#!/usr/bin/env python3

from scapy.all import *

class TestPacket(Packet):
  name = 'TestPacket'
  fields_desc = [
      ByteField('dummy', 1),
  ]

bind_layers(IP, TestPacket,
            options=[IPOption_Router_Alert()],
)

ether = Ether(dst='00:00:00:11:22:33',
              src='00:00:00:11:11:11')
ip = IP(src='192.168.0.1',
        dst='192.168.0.2')
test = TestPacket()

# There should be no 'options', just 'src' and 'dst'
print(ip.fields)
assert('options' not in ip.fields)

frame = ether / ip / test
assert(len(frame[IP].options) == 1)
assert(isinstance(frame[IP].options[0], IPOption_Router_Alert))
frame.show()
```