### PR TITLE
Update to enable offline sniff() to use a PacketList

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -887,7 +887,8 @@ class AsyncSniffer(object):
 
                 if isinstance(offline, Packet):
                     tempfile_written, offline = _write_to_pcap([offline])
-                elif isinstance(offline, list) and \
+                elif (isinstance(offline, list) or
+                        isinstance(offline, PacketList)) and \
                         all(isinstance(elt, Packet) for elt in offline):
                     tempfile_written, offline = _write_to_pcap(offline)
 

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -887,8 +887,7 @@ class AsyncSniffer(object):
 
                 if isinstance(offline, Packet):
                     tempfile_written, offline = _write_to_pcap([offline])
-                elif (isinstance(offline, list) or
-                        isinstance(offline, PacketList)) and \
+                elif isinstance(offline, (list, PacketList)) and \
                         all(isinstance(elt, Packet) for elt in offline):
                     tempfile_written, offline = _write_to_pcap(offline)
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1993,6 +1993,11 @@ fdesc = os.fdopen(fdesc, "wb")
 wrpcap(fdesc, pktpcap)
 fdesc.close()
 
+= Check offline sniff() (by PacketList)
+l=sniff(offline=PacketList([IP()/TCP(),IP()/TCP()]))
+assert len(l) == 2
+assert(all(TCP in p for p in l))
+
 = Check offline sniff() (by filename)
 assert list(pktpcap) == list(sniff(offline=filename))
 


### PR DESCRIPTION
This minor patch allows for providing a `PacketList` to`sniff(offline=my_packet_list)`. The existing behaviour is to fail ("AttributeError: 'list' object has no attribute 'read'") when provided with a PacketList.

The test suit runs against it ok.
