### PR TITLE
btle-rf: Define previous RFU flags to create better Wireshark logs

### DIFF
--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -14,9 +14,10 @@ from scapy.data import DLT_BLUETOOTH_LE_LL, DLT_BLUETOOTH_LE_LL_WITH_PHDR, \
     PPI_BTLE
 from scapy.packet import Packet, bind_layers
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
-    Field, FlagsField, LEIntField, LEShortEnumField, LEShortField, \
+    Field, LEIntField, LEShortEnumField, LEShortField, \
     MACField, PacketListField, SignedByteField, X3BytesField, XBitField, \
     XByteField, XIntField, XShortField, XLEIntField, XLEShortField
+from scapy.contrib.ethercat import LEBitEnumField, LEBitField
 
 from scapy.layers.bluetooth import EIR_Hdr, L2CAP_Hdr
 from scapy.layers.ppi import PPI_Element, PPI_Hdr
@@ -53,22 +54,47 @@ class BTLE_PPI(PPI_Element):
 class BTLE_RF(Packet):
     """Cooked BTLE link-layer pseudoheader.
 
-    http://www.whiterocker.com/bt/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
+    https://www.tcpdump.org/linktypes/LINKTYPE_BLUETOOTH_LE_LL_WITH_PHDR.html
     """
     name = "BTLE RF info header"
+
+    _TYPES = {
+        0: "ADV_OR_DATA_UNKNOWN_DIR",
+        1: "AUX_ADV",
+        2: "DATA_M_TO_S",
+        3: "DATA_S_TO_M",
+        4: "CONN_ISO_M_TO_S",
+        5: "CONN_ISO_S_TO_M",
+        6: "BROADCAST_ISO",
+        7: "RFU",
+    }
+
+    _PHY = {
+        0: "1M",
+        1: "2M",
+        2: "Coded",
+        3: "RFU",
+    }
+
     fields_desc = [
         ByteField("rf_channel", 0),
         SignedByteField("signal", -128),
         SignedByteField("noise", -128),
         ByteField("access_address_offenses", 0),
         XLEIntField("reference_access_address", 0),
-        FlagsField("flags", 0, -16, [
-            "dewhitened", "sig_power_valid", "noise_power_valid",
-            "decrypted", "reference_access_address_valid",
-            "access_address_offenses_valid", "channel_aliased",
-            "res1", "res2", "res3", "crc_checked", "crc_valid",
-            "mic_checked", "mic_valid", "res4", "res5"
-        ])
+        LEBitField("dewhitened", 0, 1),
+        LEBitField("sig_power_valid", 0, 1),
+        LEBitField("noise_power_valid", 0, 1),
+        LEBitField("decrypted", 0, 1),
+        LEBitField("reference_access_address_valid", 0, 1),
+        LEBitField("access_address_offenses_valid", 0, 1),
+        LEBitField("channel_aliased", 0, 1),
+        LEBitEnumField("type", 0, 3, _TYPES),
+        LEBitField("crc_checked", 0, 1),
+        LEBitField("crc_valid", 0, 1),
+        LEBitField("mic_checked", 0, 1),
+        LEBitField("mic_valid", 0, 1),
+        LEBitEnumField("phy", 0, 2, _PHY),
     ]
 
 

--- a/test/scapy/layers/bluetooth4LE.uts
+++ b/test/scapy/layers/bluetooth4LE.uts
@@ -65,19 +65,23 @@ assert BTLE_SCAN_RSP in pkt.layers()
 a = BTLE_RF()/BTLE()/BTLE_ADV()/BTLE_SCAN_REQ()
 a.ScanA = "aa:aa:aa:aa:aa:aa"
 a.AdvA = "bb:bb:bb:bb:bb:bb"
-a.flags = 0x10
+a.reference_access_address_valid = 1
 a.reference_access_address = 0x8e89bed6
+a.phy = 3
+a.type = 5
 a.noise = -90
 a.signal = -75
 a.rf_channel = 6
 a.access_address_offenses = 10
-assert raw(a) == b'\x06\xb5\xa6\n\xd6\xbe\x89\x8e\x10\x00\xd6\xbe\x89\x8e\x03\x0c\xaa\xaa\xaa\xaa\xaa\xaa\xbb\xbb\xbb\xbb\xbb\xbb\x07\xb2a'
+assert raw(a) == b'\x06\xb5\xa6\n\xd6\xbe\x89\x8e\x90\xc2\xd6\xbe\x89\x8e\x03\x0c\xaa\xaa\xaa\xaa\xaa\xaa\xbb\xbb\xbb\xbb\xbb\xbb\x07\xb2a'
 
 a = BTLE_RF(raw(a))
 
 assert a.noise == -90
 assert a.signal == -75
-assert a.flags == "reference_access_address_valid"
+assert a.phy == 3
+assert a.type == 5
+assert a.reference_access_address_valid == 1
 assert a[BTLE_SCAN_REQ].ScanA == "aa:aa:aa:aa:aa:aa"
 
 + Specific tests after issue GH#1673


### PR DESCRIPTION
These flags are used to provide more context for the current PDU.
Wireshark can use these to determine the direction of the PDU, the location in an advertising chain etc.
The additional context can be used by the Wireshark dissector to improve the expect info and provide easier-to-read logs.

Notes:
 * This PR imports `LEBitField` and `LEBitEnumField` defined in the Ethercat layer. This PR has the same use case: There a multibit fields that range over byte boundaries. Those fields where not moved to the common `fields.py` as a result from a discussion in https://github.com/secdev/scapy/pull/569. I'm fine with moving them to `fields.py` as part of this PR. 
 * This PR breaks the API of `class BTLE_RF` as `flags` is no longer available. This was necessary as some of the fields are multibit fields. I'm not too familiar with Scapy, so I was not able to find a way to preserve the API. Let me know if you have some suggestion on how to preserve it.

Below is a code snippet creating a Bluetooth LE Wireshark log demonstrating how the logs become easier to read with the additional provided context:

```
access_addr = 0x11111111
adv_addr    = bytes([0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA])
master_addr = bytes([0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE])

adv_ind = BTLE_RF()/BTLE()/BTLE_ADV()/ \
          BTLE_ADV_IND(AdvA=adv_addr, data=EIR_Hdr(type='complete_local_name')/b'MyAdv')
connect_ind = BTLE_RF()/BTLE()/BTLE_ADV(PDU_type='CONNECT_REQ')/ \
              BTLE_CONNECT_REQ(InitA=master_addr, AdvA=adv_addr, AA=access_addr)
m_to_s = BTLE_RF(type=2, rf_channel=1)/BTLE(access_addr=access_addr)/ \
         BTLE_DATA(SN=0, NESN=0, LLID=1)
s_to_m = BTLE_RF(type=3, rf_channel=1)/BTLE(access_addr=access_addr)/ \
         BTLE_DATA(SN=0, NESN=0, LLID=1)

packets = []
packets += adv_ind
packets += connect_ind
packets += m_to_s
packets += s_to_m

scapy.utils.wrpcap("my_log.pcap", packets)
```

Before:
![image](https://user-images.githubusercontent.com/23234783/102872308-d3161400-443f-11eb-9714-34e41f824bcf.png)

After:
![image](https://user-images.githubusercontent.com/23234783/102871897-49664680-443f-11eb-9781-aeaafad0921f.png)

