### PR TITLE
Introduce 'long_test' keyword in UTscapy

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -516,9 +516,6 @@ def filter_tests_remove_some_long_tests(test_campaign, verb):
                 print("From TestSet '%s' removed Test %03i '%s' because of the keyword 'long_test' assigned" % (ts.name, t.num, t.name))
         ts.tests = tests
 
-        ts.tests = [t for t in ts.tests if "long_test" not in t.keywords or
-                    ("long_test" in t.keywords and random.randint(0, 9) == 5)]
-
 
 def remove_empty_testsets(test_campaign):
     test_campaign.campaign = [ts for ts in test_campaign.campaign if ts.tests]

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -253,7 +253,7 @@ assert len(s.enumerators[7].results) == 1    # 1 PR
 
 
 = Run scanner with real world responses full scan
-
+~ long_test
 exit_if_no_isotp_module()
 
 drain_bus(iface0)

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -130,6 +130,8 @@ else:
 load_contrib("automotive.uds", globals_dict=globals())
 
 = Test Session Enumerator
+~ long_test
+
 drain_bus(iface0)
 drain_bus(iface1)
 
@@ -157,6 +159,8 @@ assert succ
 
 
 = Test Service Enumerator
+~ long_test
+
 drain_bus(iface0)
 drain_bus(iface1)
 

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -1,9 +1,5 @@
 % Regression tests for ISOTPScan
 
-# Currently too unstable
-
-~ disabled
-
 + Configuration
 ~ conf
 
@@ -850,14 +846,17 @@ test_dynamic(test_isotpscan_text_extended_can_id)
 test_dynamic(test_isotpscan_code)
 
 = Test ISOTPScan with noise (output_format=code)
+~ long_test
 
 test_dynamic(test_isotpscan_code_noise)
 
 = Test extended ISOTPScan(output_format=code)
+~ long_test
 
 test_dynamic(test_extended_isotpscan_code)
 
 = Test extended ISOTPScan(output_format=code) extended_can_id
+~ long_test
 
 test_dynamic(test_extended_isotpscan_code_extended_can_id)
 
@@ -870,14 +869,17 @@ test_dynamic(test_isotpscan_none)
 test_dynamic(test_isotpscan_none_2)
 
 = Test extended ISOTPScan(output_format=None)
+~ long_test
 
 test_dynamic(test_extended_isotpscan_none)
 
 = Test ISOTPScan(output_format=None) random IDs
+~ long_test disabled
 
 test_dynamic(test_isotpscan_none_random_ids)
 
 = Test ISOTPScan(output_format=None) random IDs padding
+~ long_test disabled
 
 test_dynamic(test_isotpscan_none_random_ids_padding)
 

--- a/test/contrib/pfcp.uts
+++ b/test/contrib/pfcp.uts
@@ -25,7 +25,7 @@ for name, cls in pfcp_mod.__dict__.items():
 
 = Verify PCAPs
 
-~ pcaps
+~ pcaps long_test
 
 # the following can be useful while adding more IE types
 # (e.g. updating for a newer version of the spec)

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -702,7 +702,7 @@ p.stop()
 srv.stop()
 
 = TCPConnectPipe networking test
-~ networking needs_root
+~ networking needs_root long_test
 
 p = PipeEngine()
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -680,7 +680,7 @@ s.deliver()
 assert c.q.get(timeout=1) == "hello"
 
 = UDPClientPipe and UDPServerPipe
-~ networking needs_root
+~ networking needs_root long_test
 
 p = PipeEngine()
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1502,7 +1502,7 @@ def _test():
 retry_test(_test)
 
 = AS resolvers
-~ netaccess IP as_resolvers
+~ netaccess IP as_resolvers long_test
 * This test retries on failure because it often fails
 
 def _test():

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -121,7 +121,7 @@ else:
 
 print('waiting a bit...')
 import time
-time.sleep(10)
+time.sleep(7)
 
 = Run a sniff thread on the tun1 **interface**
 * It will terminate when 5 IP packets from 192.0.2.1 have been sniffed
@@ -266,6 +266,7 @@ else:
     assert subprocess.check_call(["ifconfig", "tap0", "up"]) == 0
 
 = Check for arpleak
+~ long_test
 
 def answer_arp_leak(pkt):
     mymac = b"\x00\x01\x02\x03\x04\x06"

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -207,6 +207,7 @@ assert expected_output in plain_str(std_out)
 + Scan tests
 
 = Test standard scan
+~ long_test
 
 drain_bus(iface0)
 started = threading.Event()
@@ -243,6 +244,7 @@ for out in expected_output:
 
 
 = Test extended scan
+~ long_test
 
 drain_bus(iface0)
 started = threading.Event()
@@ -274,6 +276,7 @@ for out in expected_output:
     assert plain_str(out) in plain_str(std_out1 + std_out2)
 
 = Test extended only scan
+~ long_test
 
 drain_bus(iface0)
 started = threading.Event()
@@ -306,6 +309,7 @@ for out in expected_output:
 
 
 = Test scan with piso flag
+~ long_test
 
 drain_bus(iface0)
 started = threading.Event()

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -203,6 +203,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
     assert bytes_encode(expected_output) in bytes_encode(std_out1) or bytes_encode(expected_output) in bytes_encode(std_out2) 
 
 = Test supported PIDs scan
+~ long_test
 
 drain_bus(iface0)
 

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -294,6 +294,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, 0x7e8, 0x7e0, basecls=OBD,
 
 
 = Test full scan
+~ long_test
 
 drain_bus(iface0)
 

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -218,6 +218,7 @@ else:
         "arp", "-s", "192.0.2.2", "20:00:00:20:00:00", "temp"]) == 0
 
 = Send ping packets from OS into Scapy
+~ long_test
 
 t = AsyncSniffer(opened_socket=tap0)
 t.start()

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -89,6 +89,7 @@ assert subprocess.check_call([
     "192.0.2.1", "peer", "192.0.2.2", "dev", "tun0"]) == 0
 
 = Send ping packets from Linux into Scapy
+~ long_test
 
 t = AsyncSniffer(opened_socket=tun0)
 t.start()
@@ -150,6 +151,7 @@ else:
     raise NotImplementedError()
 
 = Send ping packets from OS into Scapy
+~ long_test
 
 t = AsyncSniffer(opened_socket=tun0)
 t.start()

--- a/tox.ini
+++ b/tox.ini
@@ -30,11 +30,11 @@ platform =
   bsd_non_root,bsd_root: darwin|freebsd|openbsd|netbsd
   windows: win32
 commands =
-  linux_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -N {posargs}
-  linux_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs}
-  bsd_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -N {posargs}
-  bsd_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark {posargs}
-  windows: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/windows.utsc {posargs}
+  linux_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -N {posargs} -L
+  linux_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs} -L
+  bsd_non_root: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -N {posargs} -L
+  bsd_root: sudo -E {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark {posargs} -L
+  windows: {envpython} {env:SCAPY_PY_OPTS:-m coverage run} -m scapy.tools.UTscapy -c test/configs/windows.utsc {posargs} -L
   coverage combine
 
 # Variants of the main tests
@@ -56,7 +56,7 @@ commands =
   bash -c "cd /tmp/can-isotp; make; sudo make modules_install; sudo modprobe can_isotp || sudo insmod ./net/can/can-isotp.ko" 
   bash -c "rm -rf /tmp/can-utils /tmp/can-isotp"
   lsmod
-  sudo -E {envpython} -m coverage run -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs}
+  sudo -E {envpython} -m coverage run -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs} -L
   coverage combine
 
 # Specific functions or tests


### PR DESCRIPTION
 This PR does two things.

First: It enforces that every test with an execution time longer than 10s need to be marked with the keyword long_test.
Second: Tests with the keyword long_test are only executed with a probability of 10% to save CI credits