### PR TITLE
Fix HomeplugGP MatchVariableFieldLen

### DIFF
--- a/scapy/contrib/homepluggp.py
+++ b/scapy/contrib/homepluggp.py
@@ -143,7 +143,7 @@ class CM_SLAC_MATCH_REQ(Packet):
     fields_desc = [ByteField("ApplicationType", 0x0),
                    ByteField("SecurityType", 0x0),
                    FieldLenField("MatchVariableFieldLen", None,
-                                 count_of="VariableField", fmt="H"),
+                                 length_of="VariableField", fmt="<H"),
                    PacketField("VariableField",
                                SLAC_varfield(),
                                SLAC_varfield)]
@@ -167,7 +167,7 @@ class CM_SLAC_MATCH_CNF(Packet):
     fields_desc = [ByteField("ApplicationType", 0x0),
                    ByteField("SecurityType", 0x0),
                    FieldLenField("MatchVariableFieldLen", None,
-                                 count_of="VariableField", fmt="H"),
+                                 length_of="VariableField", fmt="<H"),
                    PacketField("VariableField",
                                SLAC_varfield_cnf(),
                                SLAC_varfield_cnf)]


### PR DESCRIPTION
- MatchVariableField is not a list so `count_of` doesn't work, `length_of` is the way to go
- And explicit define byte order, based on homeplugav