### PR TITLE
Corrected to use `packet_list` function argument

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -882,7 +882,7 @@ class AsyncSniffer(object):
                 # Write Scapy Packet objects to a pcap file
                 def _write_to_pcap(packets_list):
                     filename = get_temp_file(autoext=".pcap")
-                    wrpcap(filename, offline)
+                    wrpcap(filename, packets_list)
                     return filename, filename
 
                 if isinstance(offline, Packet):


### PR DESCRIPTION
Minor correction so that the internal `_write_to_pcap` function uses its argument `packet_list` when calling `wrpcap(filename, packets_list)` as opposed to the outer scope `offline` variable.