### PR TITLE
Unintended HUGE refactoring of automotive scanners.

### DIFF
--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -50,6 +50,7 @@ scapy/layers/can.py
 scapy/layers/l2.py
 
 # CONTRIB
+#scapy/contrib/http2.py  # needs to be fixed
 scapy/contrib/automotive/bmw/hsfz.py
 scapy/contrib/automotive/doip.py
 scapy/contrib/automotive/ecu.py
@@ -63,6 +64,7 @@ scapy/contrib/automotive/scanner/configuration.py
 scapy/contrib/automotive/scanner/enumerator.py
 scapy/contrib/automotive/scanner/executor.py
 scapy/contrib/automotive/scanner/graph.py
+scapy/contrib/automotive/scanner/profiler.py
 scapy/contrib/automotive/scanner/staged_test_case.py
 scapy/contrib/automotive/scanner/test_case.py
 scapy/contrib/automotive/uds_ecu_states.py
@@ -70,7 +72,6 @@ scapy/contrib/automotive/uds_logging.py
 scapy/contrib/automotive/uds_scan.py
 scapy/contrib/cansocket_native.py
 scapy/contrib/cansocket_python_can.py
-#scapy/contrib/http2.py  # needs to be fixed
 scapy/contrib/isotp/isotp_native_socket.py
 scapy/contrib/isotp/isotp_packet.py
 scapy/contrib/isotp/isotp_scanner.py

--- a/scapy/contrib/automotive/scanner/graph.py
+++ b/scapy/contrib/automotive/scanner/graph.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 from scapy.compat import Union, List, Optional, Dict, Tuple, Set, TYPE_CHECKING
 from scapy.contrib.automotive.ecu import EcuState
+from scapy.contrib.automotive.scanner.profiler import Profiler
 from scapy.error import log_interactive
 
 _Edge = Tuple[EcuState, EcuState]
@@ -44,6 +45,7 @@ class Graph(object):
         :param edge: edge from node to node
         :param transition_function: tuple with enter and cleanup function
         """
+        Profiler.write_milestone(repr(edge[1]))
         self.edges[edge[0]].append(edge[1])
         self.weights[edge] = 1
         self.__transition_functions[edge] = transition_function

--- a/scapy/contrib/automotive/scanner/profiler.py
+++ b/scapy/contrib/automotive/scanner/profiler.py
@@ -1,0 +1,80 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+# Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
+# This program is published under a GPLv2 license
+
+# scapy.contrib.description = Profiler for AutomotiveTestCaseExecutor
+# scapy.contrib.status = library
+
+import time
+import functools
+
+from scapy.compat import Any, Optional, Callable
+
+
+class Profiler:
+    # For the profiling we'll use the unix time
+    # candump is using the same and thus it would be matchable
+
+    # _candump_fmt_date = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    # _filename_milestone = "milestones-%s.csv" % _candump_fmt_date
+    # _filename_profiling = "profiling-%s.csv" % _candump_fmt_date
+    _filename_milestone = "milestones.csv"
+    _filename_profiling = "profiling.csv"
+
+    _first = True
+    enabled = True
+
+    def __init__(self, state, enum=None):
+        # type: (Any, Optional[Any]) -> None
+        # We use the csv format
+        # If len(p) > 1, it would contain a ','
+        # For example: "[1, 2, 3]"
+        # Thus we replace all ',' with a ';' to avoid this
+        self.state = str(state).replace(",", ";")
+        self.enum = str(enum or state).replace(",", ";")
+        self.start_time = time.time()
+
+        if Profiler._first and Profiler.enabled:
+            Profiler._first = False
+            with open(Profiler._filename_profiling, mode="a") as f:  # noqa: E501
+                # Writing header
+                # Not required for milestone file because this is parsed
+                # manually instead of using `read_csv` of plotly
+                f.write("state,enumerator,start,end\n")
+
+    @classmethod
+    def write_milestone(cls, name):
+        # type: (str) -> None
+        if not cls.enabled:
+            return
+        with open(cls._filename_milestone, mode="a") as f:
+            f.write("%s,%f\n" % (name, time.time()))
+
+    def __enter__(self):
+        # type: () -> Profiler
+        self.start_time = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # type: (Any, Any, Any) -> None
+        if not Profiler.enabled:
+            return
+        with open(Profiler._filename_profiling, mode="a") as f:
+            f.write("%s,%s,%f,%f\n" % (
+                self.state, self.enum, self.start_time, time.time()))
+
+
+def profile(state, enum=None):
+    # type: (Any, Optional[Any]) -> Callable[[Callable[..., Any]], Callable[..., Any]]  # noqa: E501
+    def profile_decorator(func):
+        # type: (Callable[..., Any]) -> Callable[..., Any]
+        @functools.wraps(func)
+        def wrapper_profiled(*args, **kwargs):  # type: ignore
+            with Profiler(state, enum):
+                value = func(*args, **kwargs)
+            return value
+
+        return wrapper_profiled
+    return profile_decorator


### PR DESCRIPTION
This PR:
  - changes variable names of automotive utilities to be more compliant
    with python
  - adds typing for various automotive utilities
  - refactors the core of automotive scanners which involve:
	- Ecu objects
	- EcuState objects
	- EcuAnsweringMachines
	- AutomotiveTestCases
	- AutomotiveTestCaseExecutors
  - cleans up UDS Scanner, OBD Scanner and GMLAN Scanner


Sorry that this PR became that big. I hope it is merge-able in some way.