### PR TITLE
Add timeouts to thread.join(), sr, sr1 and sniff on all unit tests

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -594,12 +594,6 @@ def run_campaign(test_campaign, get_interactive_session, theme,
                     if drop_to_interpreter:
                         drop(scapy_ses)
                 test_campaign.duration += t.duration
-                # Check active threads
-                if verb > 2:
-                    import threading
-                    if threading.active_count() > 1:
-                        print("\nWARNING: UNFINISHED THREADS")
-                        print(threading.enumerate())
     except KeyboardInterrupt:
         failed += 1
         testset.trunc(j + 1)
@@ -1194,6 +1188,13 @@ def main():
             print(theme.green("UTscapy ended successfully"))
         else:
             print(theme.red("UTscapy ended with error code %s" % glob_result))
+
+    # Check active threads
+    if VERB > 2:
+        import threading
+        if threading.active_count() > 1:
+            print("\nWARNING: UNFINISHED THREADS")
+            print(threading.enumerate())
 
     # Return state
     return glob_result

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -594,6 +594,12 @@ def run_campaign(test_campaign, get_interactive_session, theme,
                     if drop_to_interpreter:
                         drop(scapy_ses)
                 test_campaign.duration += t.duration
+                # Check active threads
+                if verb > 2:
+                    import threading
+                    if threading.active_count() > 1:
+                        print("\nWARNING: UNFINISHED THREADS")
+                        print(threading.enumerate())
     except KeyboardInterrupt:
         failed += 1
         testset.trunc(j + 1)
@@ -1188,13 +1194,6 @@ def main():
             print(theme.green("UTscapy ended successfully"))
         else:
             print(theme.red("UTscapy ended with error code %s" % glob_result))
-
-    # Check active threads
-    if VERB > 2:
-        import threading
-        if threading.active_count() > 1:
-            print("\nWARNING: UNFINISHED THREADS")
-            print(threading.enumerate())
 
     # Return state
     return glob_result

--- a/test/contrib/automotive/ecu.uts
+++ b/test/contrib/automotive/ecu.uts
@@ -60,7 +60,6 @@ msgs = [UDS(service=16) / UDS_DSC(diagnosticSessionType=3),  # no_docs
 
 ecu = Ecu(verbose=False, store_supported_responses=False)
 ecu.update(PacketList(msgs))
-print(ecu.log)
 assert len(ecu.log["DiagnosticSessionControl"]) == 5  # no_docs
 timestamp, value = ecu.log["DiagnosticSessionControl"][0]
 assert timestamp > 0  # no_docs
@@ -80,7 +79,6 @@ msgs = [UDS(service=16) / UDS_DSC(diagnosticSessionType=3),  # no_docs
 
 ecu = Ecu(verbose=True, logging=False, store_supported_responses=False)
 ecu.update(PacketList(msgs))
-print(ecu.current_session)
 assert ecu.current_session == 3  # no_docs
 assert ecu.current_security_level == 0  # no_docs
 assert ecu.communication_control == 0  # no_docs
@@ -98,8 +96,6 @@ ecu = Ecu(verbose=False, logging=False, store_supported_responses=True)
 ecu.update(PacketList(msgs))
 supported_responses = ecu.supported_responses
 unanswered_packets = ecu.unanswered_packets
-print(supported_responses)
-print(unanswered_packets)
 assert ecu.current_session == 3  # no_docs
 assert ecu.current_security_level == 0  # no_docs
 assert ecu.communication_control == 0  # no_docs
@@ -127,8 +123,6 @@ assert len(udsmsgs) == 50  # no_docs
 
 ecu = Ecu()
 ecu.update(udsmsgs)
-print(ecu.log)
-print(ecu.supported_responses)
 response = ecu.supported_responses[0]  # no_docs
 assert response.in_correct_session(1)  # no_docs
 assert response.has_security_access(0)  # no_docs
@@ -162,8 +156,6 @@ with PcapReader("test/contrib/automotive/ecu_trace.pcap.gz") as sock:
 assert len(udsmsgs) == 50  # no_docs
 
 ecu = session.ecu
-print(ecu.log)
-print(ecu.supported_responses)
 response = ecu.supported_responses[0]  # no_docs
 assert response.in_correct_session(1)  # no_docs
 assert response.has_security_access(0)  # no_docs

--- a/test/contrib/automotive/ecu.uts
+++ b/test/contrib/automotive/ecu.uts
@@ -216,8 +216,10 @@ with CandumpReader("test/contrib/automotive/gmlan_trace.candump") as sock:
 
 session = EcuSession(verbose=False, store_supported_responses=False)
 
+conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = 4
+
 with CandumpReader("test/contrib/automotive/gmlan_trace.candump") as sock:
-     gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=200, opened_socket=sock, timeout=3)
+     gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=200, opened_socket=sock, timeout=6)
 
 ecu = session.ecu
 assert len(ecu.supported_responses) == 0

--- a/test/contrib/automotive/ecu.uts
+++ b/test/contrib/automotive/ecu.uts
@@ -121,7 +121,7 @@ assert unanswered_packets[0].diagnosticSessionType == 4  # no_docs
 * which are then casted to ``UDS`` objects through the ``basecls`` parameter
 
 with PcapReader("test/contrib/automotive/ecu_trace.pcap.gz") as sock:
-     udsmsgs = sniff(session=ISOTPSession, session_kwargs={"use_ext_addr":False, "basecls":UDS}, count=50, opened_socket=sock)
+     udsmsgs = sniff(session=ISOTPSession, session_kwargs={"use_ext_addr":False, "basecls":UDS}, count=50, opened_socket=sock, timeout=3)
 
 assert len(udsmsgs) == 50  # no_docs
 
@@ -157,7 +157,7 @@ assert len(ecu.log["TransferData"]) == 2
 session = EcuSession()
 
 with PcapReader("test/contrib/automotive/ecu_trace.pcap.gz") as sock:
-     udsmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "use_ext_addr":False, "basecls":UDS}, count=50, opened_socket=sock)
+     udsmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "use_ext_addr":False, "basecls":UDS}, count=50, opened_socket=sock, timeout=3)
 
 assert len(udsmsgs) == 50  # no_docs
 
@@ -187,25 +187,25 @@ assert len(ecu.log["TransferData"]) == 2  # no_docs
 session = EcuSession()
 
 with CandumpReader("test/contrib/automotive/gmlan_trace.candump") as sock:
-    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=2, opened_socket=sock)
+    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=2, opened_socket=sock, timeout=3)
     ecu = session.ecu
     print("Check 1 after change to diagnostic mode")
     assert len(ecu.supported_responses) == 1
     assert ecu.current_session == 3
     assert ecu.current_security_level == 0
-    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=8, opened_socket=sock)
+    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=8, opened_socket=sock, timeout=3)
     ecu = session.ecu
     print("Check 2 after some more messages were read")
     assert len(ecu.supported_responses) == 4
     assert ecu.current_session == 3
     assert ecu.current_security_level == 0
-    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=10, opened_socket=sock)
+    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=10, opened_socket=sock, timeout=3)
     ecu = session.ecu
     print("Check 3 after change to programming mode (bootloader)")
     assert len(ecu.supported_responses) == 5
     assert ecu.current_session == 2
     assert ecu.current_security_level == 0
-    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=16, opened_socket=sock)
+    gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=16, opened_socket=sock, timeout=3)
     ecu = session.ecu
     print("Check 4 after gaining security access")
     assert len(ecu.supported_responses) == 7
@@ -217,7 +217,7 @@ with CandumpReader("test/contrib/automotive/gmlan_trace.candump") as sock:
 session = EcuSession(verbose=False, store_supported_responses=False)
 
 with CandumpReader("test/contrib/automotive/gmlan_trace.candump") as sock:
-     gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=200, opened_socket=sock)
+     gmlanmsgs = sniff(session=ISOTPSession, session_kwargs={"supersession": session, "did":[0x241, 0x641, 0x101], "basecls":GMLAN}, count=200, opened_socket=sock, timeout=3)
 
 ecu = session.ecu
 assert len(ecu.supported_responses) == 0

--- a/test/contrib/automotive/interface_mockup.py
+++ b/test/contrib/automotive/interface_mockup.py
@@ -98,6 +98,12 @@ def cleanup_interfaces():
 
     :return: True on success
     """
+    import threading
+    from scapy.contrib.isotp import CANReceiverThread
+    for t in threading.enumerate():
+        if isinstance(t, CANReceiverThread):
+            t.join(10)
+
     if LINUX and _not_pypy and _root:
         if 0 != subprocess.call(["sudo", "ip", "link", "delete", iface0]):
             raise Exception("%s could not be deleted" % iface0)

--- a/test/contrib/automotive/interface_mockup.py
+++ b/test/contrib/automotive/interface_mockup.py
@@ -98,6 +98,10 @@ def cleanup_interfaces():
 
     :return: True on success
     """
+    import threading
+    if threading.active_count() > 1:
+        raise Exception(str(threading.enumerate()))
+
     if LINUX and _not_pypy and _root:
         if 0 != subprocess.call(["sudo", "ip", "link", "delete", iface0]):
             raise Exception("%s could not be deleted" % iface0)

--- a/test/contrib/automotive/interface_mockup.py
+++ b/test/contrib/automotive/interface_mockup.py
@@ -98,10 +98,6 @@ def cleanup_interfaces():
 
     :return: True on success
     """
-    import threading
-    if threading.active_count() > 1:
-        raise Exception(str(threading.enumerate()))
-
     if LINUX and _not_pypy and _root:
         if 0 != subprocess.call(["sudo", "ip", "link", "delete", iface0]):
             raise Exception("%s could not be deleted" % iface0)

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -41,7 +41,7 @@ with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, ba
     threadSniffer = threading.Thread(target=sniffer)
     threadSniffer.start()
     sessions = UDS_SessionEnumerator(sendSock, session_range=range(3))
-    threadSniffer.join()
+    threadSniffer.join(timeout=3)
 
 assert sniffed == 3*2
 assert succ
@@ -70,7 +70,7 @@ with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, ba
     threadSniffer = threading.Thread(target=sniffer)
     threadSniffer.start()
     services = UDS_ServiceEnumerator(sendSock)
-    threadSniffer.join()
+    threadSniffer.join(timeout=3)
 
 assert sniffed == 128
 assert succ

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -85,9 +85,6 @@ res_a = getTableEntry(a)
 res_b = getTableEntry(b)
 res_c = getTableEntry(c)
 
-print(res_a)
-print(res_b)
-print(res_c)
 #make_lined_table([a, b, c], getTableEntry)
 
 assert res_a == ('DefaultSession', '0x27: SecurityAccess', 'PositiveResponse')

--- a/test/contrib/automotive/uds_utils.uts
+++ b/test/contrib/automotive/uds_utils.uts
@@ -41,7 +41,7 @@ with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, ba
     threadSniffer = threading.Thread(target=sniffer)
     threadSniffer.start()
     sessions = UDS_SessionEnumerator(sendSock, session_range=range(3))
-    threadSniffer.join(timeout=3)
+    threadSniffer.join(timeout=30)
 
 assert sniffed == 3*2
 assert succ
@@ -70,7 +70,7 @@ with new_can_socket0() as isocan1, ISOTPSocket(isocan1, sid=0x241, did=0x641, ba
     threadSniffer = threading.Thread(target=sniffer)
     threadSniffer.start()
     services = UDS_ServiceEnumerator(sendSock)
-    threadSniffer.join(timeout=3)
+    threadSniffer.join(timeout=30)
 
 assert sniffed == 128
 assert succ

--- a/test/contrib/automotive/xcp/xcp.uts
+++ b/test/contrib/automotive/xcp/xcp.uts
@@ -671,7 +671,7 @@ thread.start()
 time.sleep(0.1)
 pkt = XCPOnCAN(identifier=0x700) / CTORequest() / Connect()
 ans = sock1.sr1(pkt, timeout=3)
-thread.join()
+thread.join(timeout=3)
 sock1.close()
 sock2.close()
 

--- a/test/contrib/automotive/xcp/xcp.uts
+++ b/test/contrib/automotive/xcp/xcp.uts
@@ -770,7 +770,6 @@ assert cto_request.ctr == 0
 assert cto_request.pid == 0xFF
 assert cto_request.connection_mode == 0
 assert bytes(cto_request).endswith(b'\x00\x02\x00\x00\xff\x00')
-print(XCPOnUDP(ctr=0, sport=1, dport=1))
 xcp_on_udp = XCPOnUDP(b'\x00\x01\x00\x01\x00\x0c\x00\x00\x00\x08\x00\x01\xff\x15\xC0\x08\x08\x00\x10\x10')
 assert xcp_on_udp.length == 8
 assert xcp_on_udp.ctr == 1

--- a/test/contrib/cansocket.uts
+++ b/test/contrib/cansocket.uts
@@ -237,8 +237,8 @@ assert len(packetsVCan1) == 6
 sock1.close()
 sock0.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 = PythonCANSocket bridge and sniff setup vcan1 package forwarding
 
@@ -281,8 +281,8 @@ assert len(packetsVCan1) == 6
 sock1.close()
 sock0.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 
 + Cleanup

--- a/test/contrib/cansocket_native.uts
+++ b/test/contrib/cansocket_native.uts
@@ -94,7 +94,7 @@ def sender():
 thread = threading.Thread(target=sender)
 thread.start()
 rx = None
-rx = sock1.sr1(tx, verbose=False)
+rx = sock1.sr1(tx, verbose=False, timeout=3)
 rx == tx
 
 sock1.close()
@@ -298,7 +298,7 @@ sock1.close()
 sock1 = CANSocket(channel="vcan0", receive_own_messages=True)
 tx = CAN(identifier=0x7ff,length=8,data=b'\x01\x02\x03\x04\x05\x06\x07\x08')
 rx = None
-rx = sock1.sr1(tx, verbose=False)
+rx = sock1.sr1(tx, verbose=False, timeout=3)
 tx == rx
 tx.sent_time < rx.time and tx == rx and rx.time > 0
 

--- a/test/contrib/cansocket_python_can.uts
+++ b/test/contrib/cansocket_python_can.uts
@@ -296,8 +296,8 @@ assert len(packetsVCan1) == 6
 sock1.close()
 sock0.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 = bridge and sniff setup vcan0 package forwarding
 
@@ -334,8 +334,8 @@ len(packetsVCan0) == 4
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan0 vcan1 package forwarding both directions
 
@@ -381,8 +381,8 @@ len(packetsVCan1) == 6
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan1 package change
 
@@ -423,8 +423,8 @@ len(packetsVCan1) == 6
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan0 package change
 
@@ -463,8 +463,8 @@ len(packetsVCan0) == 4
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan0 and vcan1 package change in both directions
 
@@ -511,8 +511,8 @@ len(packetsVCan1) == 6
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan0 package remove
 
@@ -556,8 +556,8 @@ len(packetsVCan1) == 5
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 =bridge and sniff setup vcan1 package remove
 
@@ -599,8 +599,8 @@ len(packetsVCan0) == 3
 sock0.close()
 sock1.close()
 
-threadBridge.join()
-threadSender.join()
+threadBridge.join(timeout=3)
+threadSender.join(timeout=3)
 
 
 =bridge and sniff setup vcan0 and vcan1 package remove both directions

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -5,7 +5,7 @@
 
 = Imports
 
-from six.moves.queue import Queue
+from scapy.modules.six.moves.queue import Queue
 from io import BytesIO
 from scapy.contrib.isotp import get_isotp_packet
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1294,7 +1294,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s
     except Scapy_Exception as ex:
         exception = ex
 
-print(exception)
 assert(str(exception) == "TX state was reset due to timeout" or str(exception) == "ISOTP send not completed in 30s")
 
 = Check if not sending the second FC will make the socket timeout
@@ -1351,7 +1350,7 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241) as s
 thread.join(timeout=5)
 
 assert(exception is not None)
-print(exception)
+
 assert(str(exception) == "Overflow happened at the receiver side")
 
 = Close the Socket
@@ -1541,8 +1540,6 @@ with new_can_socket0() as can0_0, \
     sender = threading.Thread(target=sendpkts)
     packetsVCan1 = isoTpSocket1.sniff(timeout=T, count=N, started_callback=sender.start)
     sender.join(timeout=5)
-    print("forwarded: %d" % forwarded)
-    print("len(packetsVCan1): %d" % len(packetsVCan1))
     threadBridge.join(timeout=5)
 
 assert forwarded == N
@@ -1691,8 +1688,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x641, did=0x241, padd
         cans.send(CAN(identifier=0x241, data=dhex("21 07 08 09 00 00 00 00")))
         res = s.recv()
         res.show()
-        print(res.data)
-        print(raw(res))
         assert(res.data == dhex("01 02 03 04 05 06 07 08 09"))
 
 
@@ -1708,7 +1703,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x642, did=0x242) as s
     p = subprocess.Popen(["isotpsend", "-s", "242", "-d", "642", iface0], stdin=subprocess.PIPE, universal_newlines=True)
     p.communicate(message)
     r = p.returncode
-    print("returncode is %d" % r)
     assert(r == 0)
     isotp = s.recv()
     assert(isotp.data == dhex(message))
@@ -1722,7 +1716,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x644, did=0x244, exte
     p = subprocess.Popen(["isotpsend", "-s", "244", "-d", "644", "-x", "ee:aa", iface0], stdin=subprocess.PIPE, universal_newlines=True)
     p.communicate(message)
     r = p.returncode
-    print("returncode is %d" % r)
     assert(r == 0)
     isotp = s.recv()
     assert(isotp.data == dhex(message))
@@ -1733,7 +1726,6 @@ exit_if_no_isotp_module()
 
 isotp = ISOTP(data=bytearray(range(1,20)))
 cmd = ["isotprecv", "-s", "243", "-d", "643", "-b", "3", iface0]
-print(" ".join(cmd))
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 time.sleep(0.1)
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x643, did=0x243) as s:
@@ -1741,7 +1733,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x643, did=0x243) as s
 
 threading.Timer(1, lambda: p.terminate() if p.poll() else p.wait()).start()  # Timeout the receiver after 1 second
 r = p.wait()
-print("returncode is %d" % r)
 assert(0 == r)
 
 result = None
@@ -1752,7 +1743,6 @@ for i in range(10):
         break
 
 assert(result is not None)
-print(result)
 result_data = dhex(result)
 assert(result_data == isotp.data)
 
@@ -1761,7 +1751,6 @@ assert(result_data == isotp.data)
 exit_if_no_isotp_module()
 isotp = ISOTP(data=bytearray(range(1,20)))
 cmd = ["isotprecv", "-s245", "-d645", "-b3", "-x", "ee:aa", iface0]
-print(" ".join(cmd))
 p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 time.sleep(0.1)  # Give some time for starting reception
 with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x645, did=0x245, extended_addr=0xaa, extended_rx_addr=0xee) as s:
@@ -1769,7 +1758,6 @@ with new_can_socket0() as isocan, ISOTPSocket(isocan, sid=0x645, did=0x245, exte
 
 threading.Timer(1, lambda: p.terminate() if p.poll() else p.wait()).start()  # Timeout the receiver after 1 second
 r = p.wait()
-print("returncode is %d" % r)
 assert(0 == r)
 
 result = None
@@ -1780,7 +1768,6 @@ for i in range(10):
         break
 
 assert(result is not None)
-print(result)
 result_data = dhex(result)
 assert(result_data == isotp.data)
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1404,7 +1404,7 @@ with new_can_socket0() as isocan, ISOTPSoftSocket(isocan, 0x123, 0x321) as txSoc
         global rx2, sent
         with new_can_socket0() as isocan, ISOTPSoftSocket(isocan, 0x321, 0x123) as rxSock:
             evt.set()
-            rx2 = rxSock.sniff(count=1)
+            rx2 = rxSock.sniff(count=1, timeout=3)
             rxSock.send(msg)
             sent = True
     rxThread = threading.Thread(target=receiver, name="receiver")

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -294,9 +294,10 @@ test_read_routes()
 ~ linux needs_root
 
 from scapy.arch.linux import L3PacketSocket
+import scapy.modules.six as six
 
 if six.PY3:
-    import mock, six, socket
+    import mock, socket
     @mock.patch("scapy.arch.linux.socket.socket.sendto")
     def test_L3PacketSocket_sendto_python3(mock_sendto):
         mock_sendto.side_effect = OSError(22, 2807)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -187,7 +187,8 @@ try:
                             store=True,
                             count=2,
                             lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
-                            started_callback=_sniffer_started)
+                            started_callback=_sniffer_started,
+                            timeout=3)
             global frm_count
             frm_count = 2
         t_sniffer = Thread(target=_sniffer, name="linux.uts sniff veth_scapy_1")
@@ -244,7 +245,8 @@ def _sniffer():
                     store=True,
                     count=2,
                     lfilter=lambda p: Ether in p and p[Ether].type == 0xbeef,
-                    started_callback=_sniffer_started)
+                    started_callback=_sniffer_started,
+                    timeout=3)
     global frm_count
     frm_count = 2
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1375,7 +1375,7 @@ conf.L3socket = L3RawSocket
 
 def _test():
     req = IP(dst="127.0.0.1")/ICMP()
-    ans = sr1(req)
+    ans = sr1(req, timeout=3)
     assert (ans.time - req.sent_time) >= 0
     assert (ans.time - req.sent_time) <= 1e-3
 
@@ -1565,7 +1565,7 @@ assert a.sent_time is None
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    ans,unans=sr(IP(dst="www.google.com/30")/TCP(dport=[80,443]),timeout=2)
+    ans,unans=sr(IP(dst="www.google.com/30")/TCP(dport=[80,443]), timeout=2)
     conf.debug_dissector = old_debug_dissector
     
     # Backward compatibility: Python 2 only
@@ -1653,7 +1653,7 @@ def _send_or_sniff(pkt, timeout, flt, pid, fork, t_other=None, opened_socket=Non
         if fork:
             os.waitpid(pid, 0)
         else:
-            t_other.join()
+            t_other.join(timeout=3)
     assert raw(pkt) in (raw(p[pkt.__class__]) for p in pkts if pkt.__class__ in p)
 
 def send_and_sniff(pkt, timeout=2, flt=None, opened_socket=None):
@@ -1670,8 +1670,8 @@ def send_and_sniff(pkt, timeout=2, flt=None, opened_socket=None):
         t_child = Thread(target=run_function, args=(pkt, timeout, flt, 1, t_parent, results, opened_socket), name="send_and_sniff 2")
         t_parent.start()
         t_child.start()
-        t_parent.join()
-        t_child.join()
+        t_parent.join(timeout=3)
+        t_child.join(timeout=3)
         assert results.qsize() >= 2
         while not results.empty():
             assert results.get()
@@ -3103,7 +3103,7 @@ class DNSTCP(Packet):
 ssck = StreamSocket(sck)
 ssck.basecls = DNSTCP
 
-r = ssck.sr1(DNSTCP(dns=DNS(rd=1, qd=DNSQR(qname="www.example.com"))))
+r = ssck.sr1(DNSTCP(dns=DNS(rd=1, qd=DNSQR(qname="www.example.com"))), timeout=3)
 sck.close()
 assert(DNSTCP in r and len(r.dns.an))
 

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -63,10 +63,6 @@ returncode = result.wait()
 expected_output = plain_str(b'Start scan')
 std_out, std_err = result.communicate()
 
-print(std_out)
-print("%s" % std_err)
-print(expected_output)
-
 assert returncode == 0
 assert expected_output in plain_str(std_out)
 
@@ -74,12 +70,8 @@ assert expected_output in plain_str(std_out)
 
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "-a", "bitrate=500000", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
-print(returncode)
 expected_output = plain_str(b'Start scan')
 std_out, std_err = result.communicate()
-print(std_out)
-print("%s" % std_err)
-print(expected_output)
 
 assert returncode == 0
 assert expected_output in plain_str(std_out)
@@ -89,12 +81,8 @@ assert expected_output in plain_str(std_out)
 
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "-a", "bitrate=500000 receive_own_messages=True", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
-print(returncode)
 expected_output = plain_str(b'Start scan')
 std_out, std_err = result.communicate()
-print(std_out)
-print("%s" % std_err)
-print(expected_output)
 
 assert returncode == 0
 assert expected_output in plain_str(std_out)
@@ -103,12 +91,8 @@ assert expected_output in plain_str(std_out)
 
 result = subprocess.Popen([sys.executable, "scapy/tools/automotive/isotpscanner.py", "-i", "socketcan", "-c", iface0, "--python-can_args", "bitrate=500000 receive_own_messages=True", "-s", "0x600", "-e", "0x600", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 returncode = result.wait()
-print(returncode)
 expected_output = plain_str(b'Start scan')
 std_out, std_err = result.communicate()
-print(std_out)
-print("%s" % std_err)
-print(expected_output)
 
 assert returncode == 0
 assert expected_output in plain_str(std_out)
@@ -143,10 +127,6 @@ assert 0 == send_returncode
 assert returncode1 == 0
 assert returncode2 == 0
 
-print(std_out1)
-print(std_err1)
-print(std_out2)
-print(std_err2)
 expected_output = [b'0x600', b'0x700']
 for out in expected_output:
     assert plain_str(out) in plain_str(std_out1 + std_out2)

--- a/test/tools/xcpscanner.uts
+++ b/test/tools/xcpscanner.uts
@@ -65,7 +65,7 @@ thread.start()
 
 scanner = XCPOnCANScanner(sock2, id_range=id_range, sniff_time=0.5)
 result = scanner.scan_with_get_slave_id()
-thread.join()
+thread.join(timeout=3)
 sock1.close()
 sock2.close()
 assert len(result) == 2
@@ -112,7 +112,7 @@ thread.start()
 
 scanner = XCPOnCANScanner(sock2, id_range=id_range, sniff_time=0.5)
 result = scanner.scan_with_connect()
-thread.join()
+thread.join(timeout=3)
 sock1.close()
 sock2.close()
 

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -62,7 +62,7 @@ assert subprocess.check_call(["ping", "-c3", "192.0.2.2"]) == 0
 
 = Cleanup
 
-t_am.join()
+t_am.join(timeout=3)
 
 tun0.close()
 if not conf.use_pypy:


### PR DESCRIPTION
I've seeing pypy and pypy3 CI builds often failing. I couldn't debug this errors, but it looks like something is blocking in the background. 
This PR adds timeouts to blocking functions to ensure they get canceled on errors.