### PR TITLE
Refactoring of EcuState object

### DIFF
--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -14,7 +14,7 @@ import random
 from collections import defaultdict
 from types import GeneratorType
 
-from scapy.compat import Any, cast
+from scapy.compat import Any, cast, Dict
 from scapy.packet import Raw, Packet
 from scapy.plist import PacketList
 from scapy.error import Scapy_Exception
@@ -33,7 +33,7 @@ class EcuState(object):
     A EcuState supports comparison and serialization (command()).
     """
     def __init__(self, **kwargs):
-        # type: (Any) -> None
+        # type: (Dict[str, Any]) -> None
         for k, v in kwargs.items():
             if isinstance(v, GeneratorType):
                 v = list(v)
@@ -49,27 +49,32 @@ class EcuState(object):
 
     def __repr__(self):
         # type: () -> str
-        return "".join([str(k) + str(v) for k, v in
-                        sorted(self.__dict__.items(), key=lambda t: t[0])])
+        return "".join(str(k) + str(v) for k, v in
+                       sorted(self.__dict__.items(), key=lambda t: t[0]))
 
     def __eq__(self, other):
         # type: (object) -> bool
         other = cast(EcuState, other)
-        if sorted(self.__dict__.keys()) != sorted(other.__dict__.keys()):
+        if len(self.__dict__) != len(other.__dict__):
             return False
-        return all(self.__dict__[k] == other.__dict__[k]
-                   for k in self.__dict__.keys())
+        try:
+            return all(self.__dict__[k] == other.__dict__[k]
+                       for k in self.__dict__.keys())
+        except KeyError:
+            return False
 
     def __contains__(self, item):
         # type: (EcuState) -> bool
         if not isinstance(item, EcuState):
             return False
-        if not sorted(self.__dict__.keys()) == sorted(item.__dict__.keys()):
+        if len(self.__dict__) != len(item.__dict__):
             return False
-        return all(ov[1] == sv[1] or
-                   (hasattr(sv[1], "__iter__") and ov[1] in sv[1])
-                   for sv, ov in
-                   zip(self.__dict__.items(), item.__dict__.items()))
+        try:
+            return all(ov == sv or (hasattr(sv, "__iter__") and ov in sv)
+                       for sv, ov in
+                       zip(self.__dict__.values(), item.__dict__.values()))
+        except (KeyError, TypeError):
+            return False
 
     def __ne__(self, other):
         # type: (object) -> bool
@@ -99,7 +104,7 @@ class EcuState(object):
             if self.__dict__[k] > other.__dict__[k]:
                 return False
 
-        if len(common) < len(self.__dict__.keys()):
+        if len(common) < len(self.__dict__):
             self_diffs = set(self.__dict__.keys()).difference(
                 set(other.__dict__.keys()))
             other_diffs = set(other.__dict__.keys()).difference(

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -12,7 +12,9 @@ import time
 import random
 
 from collections import defaultdict
+from types import GeneratorType
 
+from scapy.compat import Any, cast
 from scapy.packet import Raw, Packet
 from scapy.plist import PacketList
 from scapy.error import Scapy_Exception
@@ -25,46 +27,108 @@ __all__ = ["EcuState", "Ecu", "EcuResponse", "EcuSession",
 
 
 class EcuState(object):
-    def __init__(self, session=1, tester_present=False, security_level=0,
-                 communication_control=0, **kwargs):
-        self.session = session
-        self.security_level = security_level
-        self.communication_control = communication_control
-        self._tp = tester_present
-        self.misc = kwargs
+    """
+    Stores the state of an Ecu. The state is defined by a protocol, for
+    example UDS or GMLAN.
+    A EcuState supports comparison and serialization (command()).
+    """
+    def __init__(self, **kwargs):
+        # type: (Any) -> None
+        for k, v in kwargs.items():
+            if isinstance(v, GeneratorType):
+                v = list(v)
+            self.__setattr__(k, v)
 
-    def reset(self):
-        self.session = 1
-        self.security_level = 0
-        self.communication_control = 0
-        self._tp = False
-        self.misc = dict()
+    def __getitem__(self, item):
+        # type: (str) -> Any
+        return self.__dict__[item]
 
-    @property
-    def tp(self):
-        return self._tp or self.session > 1
+    def __setitem__(self, key, value):
+        # type: (str, Any) -> None
+        self.__dict__[key] = value
+
+    def __repr__(self):
+        # type: () -> str
+        return "".join([str(k) + str(v) for k, v in
+                        sorted(self.__dict__.items(), key=lambda t: t[0])])
 
     def __eq__(self, other):
-        return other.session == self.session and other.tp == self.tp and \
-            other.misc == self.misc and \
-            self.security_level == other.security_level
+        # type: (object) -> bool
+        other = cast(EcuState, other)
+        if sorted(self.__dict__.keys()) != sorted(other.__dict__.keys()):
+            return False
+        return all(self.__dict__[k] == other.__dict__[k]
+                   for k in self.__dict__.keys())
+
+    def __contains__(self, item):
+        # type: (EcuState) -> bool
+        if not isinstance(item, EcuState):
+            return False
+        if not sorted(self.__dict__.keys()) == sorted(item.__dict__.keys()):
+            return False
+        return all(ov[1] == sv[1] or
+                   (hasattr(sv[1], "__iter__") and ov[1] in sv[1])
+                   for sv, ov in
+                   zip(self.__dict__.items(), item.__dict__.items()))
 
     def __ne__(self, other):
+        # type: (object) -> bool
         return not other == self
 
     def __lt__(self, other):
-        if self.session == other.session:
-            return len(self.misc) < len(other.misc)
-        return self.session < other.session
+        # type: (EcuState) -> bool
+        if self == other:
+            return False
+
+        if len(self.__dict__.keys()) < len(other.__dict__.keys()):
+            return True
+
+        if len(self.__dict__.keys()) > len(other.__dict__.keys()):
+            return False
+
+        common = set(self.__dict__.keys()).intersection(
+            set(other.__dict__.keys()))
+
+        for k in sorted(common):
+            if not isinstance(other.__dict__[k], type(self.__dict__[k])):
+                raise TypeError(
+                    "Can't compare %s with %s for the EcuState element %s" %
+                    (type(self.__dict__[k]), type(other.__dict__[k]), k))
+            if self.__dict__[k] < other.__dict__[k]:
+                return True
+            if self.__dict__[k] > other.__dict__[k]:
+                return False
+
+        if len(common) < len(self.__dict__.keys()):
+            self_diffs = set(self.__dict__.keys()).difference(
+                set(other.__dict__.keys()))
+            other_diffs = set(other.__dict__.keys()).difference(
+                set(self.__dict__.keys()))
+
+            for s, o in zip(self_diffs, other_diffs):
+                if s < o:
+                    return True
+
+            return False
+
+        raise TypeError("EcuStates should be identical. Something bad happen. "
+                        "self: %s other: %s" % (self.__dict__, other.__dict__))
 
     def __hash__(self):
+        # type: () -> int
         return hash(repr(self))
 
-    def __repr__(self):
-        tps = "_TP" if self.tp else ""
-        sl = "_SL%d" % self.security_level if self.security_level else ""
-        ks = "_" + "_".join(self.misc.keys()) if len(self.misc) else ""
-        return "%d%s%s%s" % (self.session, tps, sl, ks)
+    def reset(self):
+        # type: () -> None
+        keys = list(self.__dict__.keys())
+        for k in keys:
+            del self.__dict__[k]
+
+    def command(self):
+        # type: () -> str
+        return "EcuState(" + ", ".join(
+            ["%s=%s" % (k, repr(v)) for k, v in sorted(
+                self.__dict__.items(), key=lambda t: t[0])]) + ")"
 
 
 class Ecu(object):
@@ -141,6 +205,9 @@ class Ecu(object):
 
     def reset(self):
         self.state.reset()
+        self.state.session = 1
+        self.state.security_level = 0
+        self.state.communication_control = 0
 
     def update(self, p):
         if isinstance(p, PacketList):

--- a/test/contrib/automotive/ecu.uts
+++ b/test/contrib/automotive/ecu.uts
@@ -9,6 +9,10 @@
 ~ conf command
 
 = Load modules
+
+import copy
+import itertools
+
 load_contrib("isotp", globals_dict=globals())
 load_contrib("automotive.uds", globals_dict=globals())
 load_contrib("automotive.gm.gmlan", globals_dict=globals())
@@ -18,6 +22,293 @@ conf.contribs["CAN"]["swap-bytes"] = True
 = Load Ecu module
 
 load_contrib("automotive.ecu", globals_dict=globals())
+
++ EcuState Basic checks
+
+= Check EcuState basic functionality
+
+state = EcuState()
+state["session"] = 2
+state["securityAccess"] = 4
+print(repr(state))
+assert repr(state) == "securityAccess4session2"
+
+= More complex tests
+
+state = EcuState(ses=4)
+assert state.ses == 4
+state.ses = 5
+assert state.ses == 5
+
+= Even more complex tests
+
+state = EcuState(myinfo="42")
+
+state.ses = 5
+assert state.ses == 5
+
+state["ses"] = None
+assert state.ses is None
+
+state.ses = 5
+assert 5 == state.ses
+
+assert "42" == state.myinfo
+assert repr(state) == "myinfo42ses5"
+
+
+
+= Copy tests
+
+state = EcuState(myinfo="42")
+state.ses = 5
+
+ns = copy.copy(state)
+
+ns.ses = 6
+
+assert ns.ses == 6
+assert state.ses == 5
+assert ns.myinfo == "42"
+
+
+= Move tests
+
+state = EcuState(myinfo="42")
+state.ses = 5
+
+ns = state
+
+ns.ses = 6
+
+assert ns.ses == 6
+assert state.ses == 6
+assert ns.myinfo == "42"
+
+= equal tests
+
+state = EcuState(myinfo="42")
+state.ses = 5
+
+ns = copy.copy(state)
+
+assert state == ns
+assert hash(state) == hash(ns)
+
+ns.ses = 6
+
+assert state != ns
+assert hash(state) != hash(ns)
+
+ns.ses = 5
+
+assert state == ns
+assert hash(state) == hash(ns)
+
+ns.sa = 5
+
+assert state != ns
+assert hash(state) != hash(ns)
+
+
+= hash tests
+
+state = EcuState(myinfo="42")
+state.ses = 5
+
+ns = copy.copy(state)
+
+assert hash(state) == hash(ns)
+
+ns.ses = 6
+
+assert hash(state) != hash(ns)
+
+ns.ses = 5
+
+assert hash(state) == hash(ns)
+
+ns.sa = 5
+
+assert hash(state) != hash(ns)
+
+= command tests
+
+state = EcuState(myinfo="42")
+state.ses = 5
+
+state.command()
+assert "EcuState(myinfo='42', ses=5)" == state.command()
+
+= less than tests
+
+s1 = EcuState()
+s2 = EcuState()
+
+s1.a = 1
+s2.a = 2
+
+assert s1 < s2
+
+s1.b = 4
+
+assert s1 > s2
+
+s2.b = 1
+
+assert s1 < s2
+
+s1.a = 2
+
+assert s1 > s2
+
+= less than tests 2
+
+s1 = EcuState()
+s2 = EcuState()
+
+s1.c = "x"
+s2.c = 4
+exception = False
+
+try:
+    assert s1 < s2
+except TypeError:
+    exception = True
+
+assert exception
+
+= less than tests 3
+
+s1 = EcuState()
+s2 = EcuState()
+
+
+s1.A = 1
+s1.a = 2
+
+s2.A = 2
+s2.a = 1
+
+assert s1 < s2
+
+= less than tests 4
+
+s1 = EcuState()
+s2 = EcuState()
+
+
+s1.A = 1
+s1.a = 2
+
+s2.A = 2
+s2.b = 100
+
+assert s1 < s2
+
+= less than tests 5
+
+s1 = EcuState()
+s2 = EcuState()
+
+
+s1.A = 100
+s1.a = 2
+
+s2.A = 2
+s2.b = 100
+
+assert s1 > s2
+
+= less than tests 6
+
+s1 = EcuState()
+s2 = EcuState()
+
+
+s1.A = 100
+s1.B = 200
+
+s2.a = 2
+s2.b = 1
+
+assert s1 < s2
+
+= contains test
+
+s1 = EcuState(ses=[1,2,3])
+s2 = EcuState(ses=1)
+
+assert s1 != s2
+assert s2 in s1
+assert s1 not in s2
+
+s1 = EcuState(ses=[2,3])
+s2 = EcuState(ses=1)
+
+assert s1 != s2
+assert s2 not in s1
+assert s1 not in s2
+
+
+s1 = EcuState(ses=[1,2,3], security=5)
+s2 = EcuState(ses=1)
+
+assert s1 != s2
+assert s2 not in s1
+assert s1 not in s2
+
+s1 = EcuState(ses=range(3), security=5)
+s2 = EcuState(ses=1, security=5)
+
+assert s1 != s2
+assert s2 in s1
+assert s1 not in s2
+
+s1 = EcuState(ses=range(3), security=(x for x in range(1, 10, 2)))
+s2 = EcuState(ses=1, security=5)
+
+assert s1 != s2
+assert s2 in s1
+assert s1 not in s2
+
+s1 = EcuState(ses=[1,2,3])
+s2 = EcuState(ses=[1,2,3])
+
+assert s1 in s2
+assert s2 in s1
+assert s1 == s2
+
+s1 = EcuState(ses=range(3), security=range(5))
+for ses, sec in itertools.product(range(3), range(5)):
+    s2 = EcuState(ses=ses, security=sec)
+    assert s1 != s2
+    assert s2 in s1
+    assert s1 not in s2
+
+
+s1 = EcuState(ses=[0, 1, 2], security=[43, 44])
+for ses, sec in itertools.product(range(3), range(43, 45)):
+    s2 = EcuState(ses=ses, security=sec)
+    assert s1 != s2
+    assert s2 in s1
+    assert s1 not in s2
+
+s1 = EcuState(ses=[0, 1, 2], security=["a", "b"])
+for ses, sec in itertools.product(range(3), (x for x in "ab")):
+    s2 = EcuState(ses=ses, security=sec)
+    assert s1 != s2
+    assert s2 in s1
+    try:
+        assert s1 not in s2
+    except TypeError:
+        assert True
+
+s1 = [EcuState(ses=1), EcuState(ses=2), EcuState(ses=3)]
+s2 = EcuState(ses=3)
+
+assert s2 in s1
+assert s1 not in s2
 
 + Basic checks
 


### PR DESCRIPTION
Another PR to split up #3054 

This introduces a much more flexible EcuState object. Later, EcuState objects will be stored in a graph to explore all possible system states of an Ecu. This is why this comparison functions are necessary.