### PR TITLE
Fix IKEv2 payload type list

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -384,7 +384,7 @@ IKEv2_payload_type = ["None", "", "Proposal", "Transform"]
 
 IKEv2_payload_type.extend([""] * 29)
 IKEv2_payload_type.extend(["SA", "KE", "IDi", "IDr", "CERT", "CERTREQ", "AUTH", "Nonce", "Notify", "Delete",  # noqa: E501
-                           "VendorID", "TSi", "TSr", "Encrypted", "CP", "EAP", "", "", "", "", "Encrypted Fragment"])  # noqa: E501
+                           "VendorID", "TSi", "TSr", "Encrypted", "CP", "EAP", "", "", "", "", "Encrypted_Fragment"])  # noqa: E501
 
 IKEv2_exchange_type = [""] * 34
 IKEv2_exchange_type.extend(["IKE_SA_INIT", "IKE_AUTH", "CREATE_CHILD_SA",


### PR DESCRIPTION
In `scapy.contrib.ikev2` the packet type `IKEv2 Encrypted Fragment`  was wrongly listed as `Encrypted Fragment` where as the class name is `IKEv2_payload_Encrypted_Fragment` (with underscore).

This bug results in not detecting any `IKEv2_payload_Encrypted_Fragment` when parsing `IKEv2` packets.

Example:
```python
>>> from scapy.contrib.ikev2 import *
>>> p = IKEv2() / IKEv2_payload_Encrypted_Fragment()
>>> p.show()
###[ IKEv2 ]### 
  init_SPI  = ''
  resp_SPI  = ''
  next_payload= Encrypted Fragment
  version   = 0x20
  exch_type = 
  flags     = 
  id        = 0
  length    = None
###[ IKEv2 Encrypted Fragment ]### 
     next_payload= None
     res       = 0
     length    = None
     frag_number= 1
     frag_total= 1
     load      = ''

>>> IKEv2(bytes(p)).show()
###[ IKEv2 ]### 
  init_SPI  = ''
  resp_SPI  = ''
  next_payload= Encrypted Fragment
  version   = 0x20
  exch_type = 
  flags     = 
  id        = 0
  length    = 36
###[ IKEv2 Payload ]### 
     next_payload= None
     flags     = 
     length    = 8
     load      = '\x00\x01\x00\x01'
```