### PR TITLE
Unit tests: allow TLS<1.2 in openssl config

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Install on osx
 if [ "$OSTYPE" = "darwin"* ] || [ "$TRAVIS_OS_NAME" = "osx" ]
 then

--- a/.config/ci/openssl.py
+++ b/.config/ci/openssl.py
@@ -1,0 +1,48 @@
+# This file is part of Scapy
+# Copyright (C) Gabriel Potter
+
+"""
+Create a duplicate of the OpenSSL config to be able to use TLS < 1.2
+This returns the path to this new config file.
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+
+# Get OpenSSL config file
+OPENSSL_DIR = re.search(
+    b"OPENSSLDIR: \"(.*)\"",
+    subprocess.Popen(
+        ["openssl", "version", "-d"],
+        stdout=subprocess.PIPE
+    ).communicate()[0]
+).group(1).decode()
+OPENSSL_CONFIG = os.path.join(OPENSSL_DIR, 'openssl.cnf')
+
+# https://askubuntu.com/a/1233456
+HEADER = b"openssl_conf = default_conf\n"
+FOOTER = b"""
+[ default_conf ]
+
+ssl_conf = ssl_sect
+
+[ssl_sect]
+
+system_default = system_default_sect
+
+[system_default_sect]
+MinProtocol = TLSv1.2
+CipherString = DEFAULT:@SECLEVEL=1
+"""
+
+# Copy and edit
+with open(OPENSSL_CONFIG, 'rb') as fd:
+    DATA = fd.read()
+
+DATA = HEADER + DATA + FOOTER
+
+with tempfile.NamedTemporaryFile(suffix=".cnf", delete=False) as fd:
+    fd.write(DATA)
+    print(fd.name)

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -75,6 +75,9 @@ then
   esac
 fi
 
+# Configure OpenSSL
+export OPENSSL_CONF=$(python `dirname $BASH_SOURCE`/openssl.py)
+
 # Dump vars (the others were already dumped in install.sh)
 echo UT_FLAGS=$UT_FLAGS
 echo TOXENV=$TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ minversion = 2.9
 [testenv]
 description = "Scapy unit tests"
 whitelist_externals = sudo
-passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT
+passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT OPENSSL_CONF
           # Used by scapy
           SCAPY_USE_LIBPCAP
 deps = mock


### PR DESCRIPTION
This PR is an attempt at fixing the unit tests. We need openssl to support <TLS1.2 because we use it to test our TLS 1.0 and 1.1 implementations