### PR TITLE
Implement proper `select()` on Windows

### DIFF
--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -231,7 +231,7 @@ class _L2bpfSocket(SuperSocket):
         the available sockets.
         """
         # sockets, None (means use the socket's recv() )
-        return bpf_select(sockets, remain), None
+        return bpf_select(sockets, remain)
 
 
 class L2bpfListenSocket(_L2bpfSocket):

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -10,7 +10,6 @@ Functions common to different architectures
 import ctypes
 import socket
 import struct
-import time
 from scapy.consts import WINDOWS
 from scapy.config import conf
 from scapy.data import MTU, ARPHDR_ETHER, ARPHRD_TO_DLT
@@ -21,11 +20,8 @@ from scapy.libs.structures import bpf_program
 # Type imports
 import scapy
 from scapy.compat import (
-    Callable,
-    List,
     Optional,
     Tuple,
-    TypeVar,
     Union,
 )
 
@@ -91,30 +87,6 @@ def get_if_raw_hwaddr(iff,  # type: Union[NetworkInterface, str]
         get_if(iff, siocgifhwaddr)
     )
 
-# SOCKET UTILS
-
-
-_T = TypeVar("_T")
-
-
-def _select_nonblock(sockets,  # type: List[_T]
-                     remain=None  # type: Optional[int]
-                     ):
-    # type: (...) -> Tuple[List[_T], Callable[['scapy.supersocket.SuperSocket'], Optional['scapy.packet.Packet']]]  # type: ignore # noqa: E501
-    """This function is called during sendrecv() routine to select
-    the available sockets.
-    """
-    # pcap sockets aren't selectable, so we return all of them
-    # and ask the selecting functions to use nonblock_recv instead of recv
-    def _sleep_nonblock_recv(self  # type: 'scapy.supersocket.SuperSocket'
-                             ):
-        # type: (...) -> 'Optional[scapy.packet.Packet]'
-        res = self.nonblock_recv()  # type: ignore
-        if res is None:
-            time.sleep(conf.recv_poll_rate)
-        return res  # type: ignore
-    # we enforce remain=None: don't wait.
-    return sockets, _sleep_nonblock_recv
 
 # BPF HANDLERS
 

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -49,8 +49,7 @@ import socket
 import subprocess
 import time
 
-from scapy.automaton import SelectableObject
-from scapy.arch.common import _select_nonblock
+from scapy.automaton import SelectableObject, select_objects
 from scapy.arch.windows.structures import GetIcmpStatistics
 from scapy.compat import raw
 from scapy.config import conf
@@ -65,6 +64,7 @@ from scapy.supersocket import SuperSocket
 class L3WinSocket(SuperSocket, SelectableObject):
     desc = "a native Layer 3 (IPv4) raw socket under Windows"
     nonblocking_socket = True
+    __selectable_force_select__ = True
     __slots__ = ["promisc", "cls", "ipv6", "proto"]
 
     def __init__(self, iface=None, proto=socket.IPPROTO_IP,
@@ -186,9 +186,6 @@ class L3WinSocket(SuperSocket, SelectableObject):
         else:
             return IP, data, time.time()
 
-    def check_recv(self):
-        return True
-
     def close(self):
         if not self.closed and self.promisc:
             self.ins.ioctl(socket.SIO_RCVALL, socket.RCVALL_OFF)
@@ -196,7 +193,7 @@ class L3WinSocket(SuperSocket, SelectableObject):
 
     @staticmethod
     def select(sockets, remain=None):
-        return _select_nonblock(sockets, remain=remain)
+        return select_objects(sockets, remain)
 
 
 class L3WinSocket6(L3WinSocket):

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -11,17 +11,18 @@ TODO:
     - add documentation for ioevent, as_supersocket...
 """
 
-import io
+import ctypes
 import itertools
 import logging
 import os
+import random
 import sys
 import threading
 import time
 import traceback
 import types
 
-from select import select
+import select
 from collections import deque
 
 from scapy.config import conf
@@ -34,199 +35,105 @@ from scapy.consts import WINDOWS
 import scapy.modules.six as six
 
 
-""" In Windows, select.select is not available for custom objects. Here's the implementation of scapy to re-create this functionality  # noqa: E501
-# Passive way: using no-ressources locks
-               +---------+             +---------------+      +-------------------------+  # noqa: E501
-               |  Start  +------------->Select_objects +----->+Linux: call select.select|  # noqa: E501
-               +---------+             |(select.select)|      +-------------------------+  # noqa: E501
-                                       +-------+-------+
-                                               |
-                                          +----v----+               +--------+
-                                          | Windows |               |Time Out+----------------------------------+  # noqa: E501
-                                          +----+----+               +----+---+                                  |  # noqa: E501
-                                               |                         ^                                      |  # noqa: E501
-      Event                                    |                         |                                      |  # noqa: E501
-        +                                      |                         |                                      |  # noqa: E501
-        |                              +-------v-------+                 |                                      |  # noqa: E501
-        |                       +------+Selectable Sel.+-----+-----------------+-----------+                    |  # noqa: E501
-        |                       |      +-------+-------+     |           |     |           v              +-----v-----+  # noqa: E501
-+-------v----------+            |              |             |           |     |        Passive lock<-----+release_all<------+  # noqa: E501
-|Data added to list|       +----v-----+  +-----v-----+  +----v-----+     v     v            +             +-----------+      |  # noqa: E501
-+--------+---------+       |Selectable|  |Selectable |  |Selectable|   ............         |                                |  # noqa: E501
-         |                 +----+-----+  +-----------+  +----------+                        |                                |  # noqa: E501
-         |                      v                                                           |                                |  # noqa: E501
-         v                 +----+------+   +------------------+               +-------------v-------------------+            |  # noqa: E501
-   +-----+------+          |wait_return+-->+  check_recv:     |               |                                 |            |  # noqa: E501
-   |call_release|          +----+------+   |If data is in list|               |  END state: selectable returned |        +---+--------+  # noqa: E501
-   +-----+--------              v          +-------+----------+               |                                 |        | exit door  |  # noqa: E501
-         |                    else                 |                          +---------------------------------+        +---+--------+  # noqa: E501
-         |                      +                  |                                                                         |  # noqa: E501
-         |                 +----v-------+          |                                                                         |  # noqa: E501
-         +--------->free -->Passive lock|          |                                                                         |  # noqa: E501
-                           +----+-------+          |                                                                         |  # noqa: E501
-                                |                  |                                                                         |  # noqa: E501
-                                |                  v                                                                         |  # noqa: E501
-                                +------------------Selectable-Selector-is-advertised-that-the-selectable-is-readable---------+
-"""
-
-
 class SelectableObject(object):
-    """DEV: to implement one of those, you need to add 2 things to your object:
-    - add "check_recv" function
-    - call "self.call_release" once you are ready to be read
+    if WINDOWS:
+        def __init__(self):
+            self._fd = ctypes.windll.kernel32.CreateEventA(
+                None, 0, 0,
+                "SelectableObject %s" % random.random()
+            )
 
-    You can set the __selectable_force_select__ to True in the class, if you want to  # noqa: E501
-    force the handler to use fileno(). This may only be usable on sockets created using  # noqa: E501
-    the builtin socket API."""
-    __selectable_force_select__ = False
+        def call_release(self):
+            if ctypes.windll.kernel32.PulseEvent(
+                    ctypes.c_void_p(self._fd)) == 0:
+                warning(ctypes.FormatError())
 
-    def __init__(self):
-        self.hooks = []
+        def _close_fd(self):
+            if self._fd and ctypes.windll.kernel32.CloseHandle(
+                    ctypes.c_void_p(self._fd)) == 0:
+                warning(ctypes.FormatError())
+                self._fd = None
+
+        def __del__(self):
+            if hasattr(self, "_fd"):
+                self._close_fd()
+    else:
+        def call_release(self):
+            pass
+
+        def close(self):
+            pass
 
     def check_recv(self):
-        """DEV: will be called only once (at beginning) to check if the object is ready."""  # noqa: E501
-        raise OSError("This method must be overwritten.")
-
-    def _wait_non_ressources(self, callback):
-        """This get started as a thread, and waits for the data lock to be freed then advertise itself to the SelectableSelector using the callback"""  # noqa: E501
-        self.trigger = threading.Lock()
-        self.was_ended = False
-        self.trigger.acquire()
-        self.trigger.acquire()
-        if not self.was_ended:
-            callback(self)
-
-    def wait_return(self, callback):
-        """Entry point of SelectableObject: register the callback"""
-        if self.check_recv():
-            return callback(self)
-        _t = threading.Thread(
-            target=self._wait_non_ressources,
-            args=(callback,),
-            name="scapy.automaton wait_return"
-        )
-        _t.setDaemon(True)
-        _t.start()
-
-    def register_hook(self, hook):
-        """DEV: When call_release() will be called, the hook will also"""
-        self.hooks.append(hook)
-
-    def call_release(self, aborted=False):
-        """DEV: Must be call when the object becomes ready to read.
-           Relesases the lock of _wait_non_ressources"""
-        self.was_ended = aborted
-        try:
-            self.trigger.release()
-        except (threading.ThreadError, AttributeError):
-            pass
-        # Trigger hooks
-        for hook in self.hooks:
-            hook()
-
-
-class SelectableSelector(object):
-    """
-    Select SelectableObject objects.
-
-    inputs: objects to process
-    remain: timeout. If 0, return [].
-    customTypes: types of the objects that have the check_recv function.
-    """
-
-    def _release_all(self):
-        """Releases all locks to kill all threads"""
-        for i in self.inputs:
-            i.call_release(True)
-        self.available_lock.release()
-
-    def _timeout_thread(self, remain):
-        """Timeout before releasing every thing, if nothing was returned"""
-        time.sleep(remain)
-        if not self._ended:
-            self._ended = True
-            self._release_all()
-
-    def _exit_door(self, _input):
-        """This function is passed to each SelectableObject as a callback
-        The SelectableObjects have to call it once there are ready"""
-        self.results.append(_input)
-        if self._ended:
-            return
-        self._ended = True
-        self._release_all()
-
-    def __init__(self, inputs, remain):
-        self.results = []
-        self.inputs = list(inputs)
-        self.remain = remain
-        self.available_lock = threading.Lock()
-        self.available_lock.acquire()
-        self._ended = False
-
-    def process(self):
-        """Entry point of SelectableSelector"""
-        if WINDOWS:
-            select_inputs = []
-            for i in self.inputs:
-                if not isinstance(i, SelectableObject):
-                    warning("Unknown ignored object type: %s", type(i))
-                elif i.__selectable_force_select__:
-                    # Then use select.select
-                    select_inputs.append(i)
-                elif not self.remain and i.check_recv():
-                    self.results.append(i)
-                elif self.remain:
-                    i.wait_return(self._exit_door)
-            if select_inputs:
-                # Use default select function
-                self.results.extend(select(select_inputs, [], [], self.remain)[0])  # noqa: E501
-            if not self.remain:
-                return self.results
-
-            threading.Thread(
-                target=self._timeout_thread,
-                args=(self.remain,),
-                name="scapy.automaton process"
-            ).start()
-            if not self._ended:
-                self.available_lock.acquire()
-            return self.results
-        else:
-            r, _, _ = select(self.inputs, [], [], self.remain)
-            return r
+        return False
 
 
 def select_objects(inputs, remain):
     """
     Select SelectableObject objects. Same than:
-    ``select.select([inputs], [], [], remain)``
+    ``select.select(inputs, [], [], remain)``
     But also works on Windows, only on SelectableObject.
 
     :param inputs: objects to process
     :param remain: timeout. If 0, return [].
     """
-    handler = SelectableSelector(inputs, remain)
-    return handler.process()
+    if WINDOWS:
+        natives = []
+        events = []
+        results = []
+        for i in inputs:
+            if getattr(i, "__selectable_force_select__", False):
+                natives.append(i)
+            elif isinstance(i, SelectableObject):
+                if i.check_recv():
+                    results.append(i)
+                else:
+                    events.append(i)
+            else:
+                raise TypeError(
+                    "Invalid type: %s (must extend SelectableObject"
+                )
+        if natives:
+            results.extend(select.select(natives, [], [], remain)[0])
+        if events:
+            remainms = int((remain or 0) * 1000)
+            if len(events) == 1:
+                res = ctypes.windll.kernel32.WaitForSingleObject(
+                    ctypes.c_void_p(events[0].fileno()),
+                    remainms
+                )
+            else:
+                res = ctypes.windll.kernel32.WaitForMultipleObjects(
+                    len(events),
+                    (ctypes.c_void_p * len(events))(
+                        *[x.fileno() for x in events]
+                    ),
+                    False,
+                    remainms
+                )
+            if res != 0xFFFFFFFF and res != 0x00000102:  # Failed or Timeout
+                results.append(events[res])
+        return results
+    else:
+        return select.select(inputs, [], [], remain)[0]
 
 
-class ObjectPipe(SelectableObject, io.BufferedIOBase):
-
+class ObjectPipe(SelectableObject):
     def __init__(self):
         self._closed = False
-        self.rd, self.wr = os.pipe()
-        self.queue = deque()
+        self.__rd, self.__wr = os.pipe()
+        self.__queue = deque()
         SelectableObject.__init__(self)
 
     def fileno(self):
-        return self.rd
-
-    def check_recv(self):
-        return len(self.queue) > 0
+        if WINDOWS:
+            return self._fd
+        else:
+            return self.__rd
 
     def send(self, obj):
-        self.queue.append(obj)
-        os.write(self.wr, b"X")
+        self.__queue.append(obj)
+        os.write(self.__wr, b"X")
         self.call_release()
 
     def write(self, obj):
@@ -235,13 +142,16 @@ class ObjectPipe(SelectableObject, io.BufferedIOBase):
     def flush(self):
         pass
 
+    def check_recv(self):
+        return bool(self.__queue)
+
     def recv(self, n=0):
         if self._closed:
             if self.check_recv():
-                return self.queue.popleft()
+                return self.__queue.popleft()
             return None
-        os.read(self.rd, 1)
-        return self.queue.popleft()
+        os.read(self.__rd, 1)
+        return self.__queue.popleft()
 
     def read(self, n=0):
         return self.recv(n)
@@ -249,9 +159,11 @@ class ObjectPipe(SelectableObject, io.BufferedIOBase):
     def close(self):
         if not self._closed:
             self._closed = True
-            os.close(self.rd)
-            os.close(self.wr)
-            self.queue.clear()
+            os.close(self.__rd)
+            os.close(self.__wr)
+            self.__queue.clear()
+            if WINDOWS:
+                self._close_fd()
 
     def __del__(self):
         self.close()
@@ -265,7 +177,7 @@ class ObjectPipe(SelectableObject, io.BufferedIOBase):
                 results.append(s)
         if results:
             return results, None
-        return select_objects(sockets, remain), None
+        return select_objects(sockets, remain)
 
 
 class Message:
@@ -435,29 +347,26 @@ class _ATMT_Command:
 
 class _ATMT_supersocket(SuperSocket, SelectableObject):
     def __init__(self, name, ioevent, automaton, proto, *args, **kargs):
-        SelectableObject.__init__(self)
         self.name = name
         self.ioevent = ioevent
         self.proto = proto
         # write, read
         self.spa, self.spb = ObjectPipe(), ObjectPipe()
-        # Register recv hook
-        self.spb.register_hook(self.call_release)
         kargs["external_fd"] = {ioevent: (self.spa, self.spb)}
         kargs["is_atmt_socket"] = True
         self.atmt = automaton(*args, **kargs)
         self.atmt.runbg()
 
-    def fileno(self):
-        return self.spb.fileno()
-
     def send(self, s):
         if not isinstance(s, bytes):
             s = bytes(s)
-        return self.spa.send(s)
+        self.spa.send(s)
 
     def check_recv(self):
         return self.spb.check_recv()
+
+    def fileno(self):
+        return self.spb.fileno()
 
     def recv(self, n=MTU):
         r = self.spb.recv(n)
@@ -474,7 +383,7 @@ class _ATMT_supersocket(SuperSocket, SelectableObject):
 
     @staticmethod
     def select(sockets, remain=conf.recv_poll_rate):
-        return select_objects(sockets, remain), None
+        return select_objects(sockets, remain)
 
 
 class _ATMT_to_supersocket:
@@ -650,7 +559,6 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
             return os.read(self.rd, n)
 
         def write(self, msg):
-            self.call_release()
             if isinstance(self.wr, ObjectPipe):
                 self.wr.send(msg)
                 return
@@ -683,8 +591,7 @@ class Automaton(six.with_metaclass(Automaton_metaclass)):
             return self.recv(n)
 
         def send(self, msg):
-            self.wr.send(msg)
-            return self.call_release()
+            return self.wr.send(msg)
 
         def write(self, msg):
             return self.send(msg)

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -220,7 +220,7 @@ class PythonCANSocket(SuperSocket):
     def select(sockets, *args, **kwargs):
         SocketsPool().multiplex_rx_packets()
         return [s for s in sockets if isinstance(s, PythonCANSocket) and
-                not s.iface.rx_queue.empty()], PythonCANSocket.recv
+                not s.iface.rx_queue.empty()]
 
     def close(self):
         if self.closed:

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -723,7 +723,7 @@ class ISOTPSoftSocket(SuperSocket):
 
         ready_sockets = find_ready_sockets()
         if len(ready_sockets) > 0 or not blocking:
-            return ready_sockets, None
+            return ready_sockets
 
         exit_select = Event()
 
@@ -746,7 +746,7 @@ class ISOTPSoftSocket(SuperSocket):
                     pass
 
         ready_sockets = find_ready_sockets()
-        return ready_sockets, None
+        return ready_sockets
 
 
 ISOTPSocket = ISOTPSoftSocket

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -522,5 +522,5 @@ class CandumpReader:
     # emulate SuperSocket
     @staticmethod
     def select(sockets, remain=None):
-        # type: (List[SuperSocket], Optional[int]) -> Tuple[List[SuperSocket], None]  # noqa: E501
-        return sockets, None
+        # type: (List[SuperSocket], Optional[int]) -> List[SuperSocket]
+        return sockets

--- a/scapy/layers/usb.py
+++ b/scapy/layers/usb.py
@@ -258,7 +258,7 @@ if WINDOWS:
 
         @staticmethod
         def select(sockets, remain=None):
-            return sockets, None
+            return sockets
 
         def __init__(self, iface=None, *args, **karg):
             _usbpcap_check()

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -247,7 +247,7 @@ class SuperSocket:
 
     @staticmethod
     def select(sockets, remain=conf.recv_poll_rate):
-        # type: (List[SuperSocket], Optional[float]) -> Tuple[List[SuperSocket], None]  # noqa: E501
+        # type: (List[SuperSocket], Optional[float]) -> List[SuperSocket]
         """This function is called during sendrecv() routine to select
         the available sockets.
 
@@ -261,7 +261,7 @@ class SuperSocket:
             # select.error has no .errno attribute
             if not exc.args or exc.args[0] != errno.EINTR:
                 raise
-        return inp, None
+        return inp
 
     def __del__(self):
         # type: () -> None
@@ -370,6 +370,7 @@ class L3RawSocket(SuperSocket):
 
 class SimpleSocket(SuperSocket):
     desc = "wrapper around a classic socket"
+    nonblocking_socket = True
 
     def __init__(self, sock):
         # type: (socket.socket) -> None
@@ -379,7 +380,6 @@ class SimpleSocket(SuperSocket):
 
 class StreamSocket(SimpleSocket):
     desc = "transforms a stream socket into a layer 2"
-    nonblocking_socket = True
 
     def __init__(self, sock, basecls=None):
         # type: (socket.socket, Optional[Type[Packet]]) -> None
@@ -490,9 +490,9 @@ class L2ListenTcpdump(SuperSocket):
 
     @staticmethod
     def select(sockets, remain=None):
-        # type: (List[SuperSocket], Optional[float]) -> Tuple[List[SuperSocket], None]  # noqa: E501
+        # type: (List[SuperSocket], Optional[float]) -> List[SuperSocket]
         if (WINDOWS or DARWIN):
-            return sockets, None
+            return sockets
         return SuperSocket.select(sockets, remain=remain)
 
 
@@ -527,8 +527,8 @@ class IterSocket(SuperSocket):
 
     @staticmethod
     def select(sockets, remain=None):
-        # type: (List[SuperSocket], Any) -> Tuple[List[SuperSocket], None]
-        return sockets, None
+        # type: (List[SuperSocket], Any) -> List[SuperSocket]
+        return sockets
 
     def recv(self, *args):
         # type: (*Any) -> Optional[Packet]

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1314,8 +1314,8 @@ class RawPcapReader:
     def select(sockets,  # type: List[SuperSocket]
                remain=None,  # type: Optional[float]
                ):
-        # type: (...) -> Tuple[List[SuperSocket], None]
-        return sockets, None
+        # type: (...) -> List[SuperSocket]
+        return sockets
 
 
 class PcapReader(RawPcapReader, _SuperSocket):

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -36,7 +36,7 @@ class MockCANSocket(SuperSocket):
         self.sent_queue.put(p)
     @staticmethod
     def select(sockets, remain=None):
-        return sockets, None
+        return sockets
 
 
 # utility function that waits on list l for n elements, timing out if nothing is added for 1 second

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -305,7 +305,7 @@ def _fail():
 
 a = AutoSource()
 a._send = mock.MagicMock(side_effect=_fail)
-a._wake_up()
+a.send("x")
 try:
     a.deliver()
 except:
@@ -665,16 +665,16 @@ assert DNS in res[0] and res[0][UDP].sport == 1234
 
 p.stop()
 
-= FDSourceSink on a Bunch object
+= FDSourceSink on a ObjectPipe object
 
-fd = Bunch(write=lambda x: None, read=lambda: "hello", fileno=lambda: None)
+obj = ObjectPipe()
+obj.send("hello")
 
-s = FDSourceSink(fd)
+s = FDSourceSink(obj)
 d = Drain()
 c = QueueSink()
 s > d > c
 
-assert s.fileno() == None
 s.push("data")
 s.deliver()
 assert c.q.get(timeout=1) == "hello"

--- a/test/scapy/automaton.uts
+++ b/test/scapy/automaton.uts
@@ -100,7 +100,7 @@ class ATMT3(ATMT2):
             raise self.MAIN(s+"da")
 
 
-a=ATMT3(init="a", debug=2, ll=lambda: None, recvsock=lambda: None)
+a=ATMT3(init="a", ll=lambda: None, recvsock=lambda: None)
 r = a.run()
 r
 assert(r == 'cccccacabdacccacabdabda')
@@ -397,7 +397,7 @@ def _tcp_client_test():
         Connection=b'keep-alive',
         Host=b'www.secdev.org',
     )
-    t = TCP_client.tcplink(HTTP, SECDEV_IP4, 80)
+    t = TCP_client.tcplink(HTTP, SECDEV_IP4, 80, debug=4)
     response = t.sr1(req, timeout=3)
     t.close()
     assert response.Http_Version == b'HTTP/1.1'
@@ -405,7 +405,7 @@ def _tcp_client_test():
     assert response.Reason_Phrase == b'OK'
 
 def _http_request_test(_raw=False):
-    response = http_request("www.google.com", path="/", raw=_raw, iptables=LINUX)
+    response = http_request("www.google.com", path="/", raw=_raw, iptables=LINUX, verbose=4)
     assert response.Http_Version == b'HTTP/1.1'
     assert response.Status_Code == b'200'
     assert response.Reason_Phrase == b'OK'

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -367,10 +367,11 @@ load_layer("http")
 
 def _test_connection():
     a = TLSClientAutomaton.tlslink(HTTP, server="www.google.com", dport=443,
-                                   server_name="www.google.com")
+                                   server_name="www.google.com", debug=4)
     pkt = a.sr1(HTTP()/HTTPRequest(Host="www.google.com"),
                 session=TCPSession(app=True), timeout=2, retry=3)
     a.close()
+    assert pkt
     assert HTTPResponse in pkt
     assert b"</html>" in pkt[HTTPResponse].load
 

--- a/test/windows.uts
+++ b/test/windows.uts
@@ -12,14 +12,14 @@ import mock
 ############
 + Mechanics tests
 
-= Automaton - SelectableSelector system timeout
+= Automaton - Test select_objects edge cases
 
-class TimeOutSelector(SelectableObject):
-    def check_recv(self):
-        return False
+assert select_objects([ObjectPipe()], 0) == []
+assert select_objects([ObjectPipe()], 1) == []
 
-assert select_objects([TimeOutSelector()], 0) == []
-assert select_objects([TimeOutSelector()], 1) == []
+a = ObjectPipe()
+a.send("test")
+assert select_objects([a], 0) == [a]
 
 ############
 ############


### PR DESCRIPTION
When I made the `automaton.py` windows alternative, I re-invented the wheel. I knew there was the `WaitForMultipleObjects` but didn't manage to make it work (freezes). With more experience with python C bindings, here's another take at that.

- removes our custom `automaton.py` windows implementation and use a much cleaner `WaitForMultipleObjects` approach
- use this function on Windows to receive packets => **We can now select on windows socket.**
- **make windows socket blocking as on Linux**
- with this, the second parameter of the static `select()` function is unused everywhere. Remove it
- Re-use the `ObjectPipe` (automaton.py) implementation in `Pipetools.AutoSource`. They were extremly similar