### PR TITLE
GHCI: set fetch-depth=2 for codecov

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -85,6 +85,9 @@ jobs:
     steps:
       - name: Checkout Scapy
         uses: actions/checkout@v2
+        # Codecov requires a fetch-depth > 1
+        with:
+          fetch-depth: 2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Codecov is displaying this warning. Fix it

```
==> GitHub Actions detected.
->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
    project root: .
    Yaml found at: .github/codecov.yml
    -> Found 1 reports
```