### PR TITLE
Fix condition for inclusion of group_management_cipher_suite

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1206,7 +1206,7 @@ class Dot11EltRSN(Dot11Elt):
         ConditionalField(
             PacketField("group_management_cipher_suite",
                         RSNCipherSuite(cipher=0x6), RSNCipherSuite),
-            lambda pkt: pkt.mfp_capable == 1
+            lambda pkt: pkt.mfp_capable == 1 and pkt.mfp_required == 1
         )
     ]
 


### PR DESCRIPTION
In all my captures, the RSN tag corrupts the following tags because it uses too many bytes. The culprit is the group_management_cipher_suite, which does not appear in Wireshark. 
I don't have the full 802.11 spec, but a search in internet revealed that, possibly, both these bits must be set for the descriptor to be present.
