### PR TITLE
BFD: handle more variant

### DIFF
--- a/test/contrib/bfd.uts
+++ b/test/contrib/bfd.uts
@@ -2,7 +2,8 @@
 
 = BFD, basic instantiation
 
-a = UDP()/BFD()
+from scapy.contrib.bfd import BFD
+a = UDP(sport=3784, dport=3784)/BFD()
 assert raw(a) == b'\x0e\xc8\x0e\xc8\x00 \x00\x00 \xc0\x03\x18\x11\x11\x11\x11"""";\x9a\xca\x00;\x9a\xca\x00;\x9a\xca\x00'
 
 = BFD - dissection


### PR DESCRIPTION
BFD: handle more variants (micro-BFD, seamless BFD), which have the same wire format but are on different UDP ports.

The flags field was listed in the wrong order, FlagsField expect the flags in LSB first order.

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together (only one commit)
-   [x] I added unit tests or explained why they are not relevant: No new UT, as this is only refining a existing dissector.
-   [x] I executed the regression tests for Python2 and Python3 (using `tox`)
-> looks like last second change messed something up.
