### PR TITLE
Cleanup __class__ comparisons

### DIFF
--- a/scapy/contrib/automotive/bmw/definitions.py
+++ b/scapy/contrib/automotive/bmw/definitions.py
@@ -336,8 +336,8 @@ class DEV_JOB_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == DEV_JOB \
-            and self.identifier == other.identifier
+        return isinstance(other, DEV_JOB) and \
+            self.identifier == other.identifier
 
 
 UDS.services[0xBF] = "DevelopmentJob"

--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -48,12 +48,6 @@ class HSFZ(Packet):
         pay_hash = self.payload.hashret()
         return hdr_hash + pay_hash
 
-    def answers(self, other):
-        # type: (Packet) -> int
-        if other.__class__ == self.__class__:
-            return self.payload.answers(other.payload)
-        return 0
-
     def extract_padding(self, s):
         # type: (bytes) -> Tuple[bytes, bytes]
         return s[:self.length - 2], s[self.length - 2:]

--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -141,7 +141,7 @@ class DoIP(Packet):
     def answers(self, other):
         # type: (Packet) -> int
         """DEV: true if self is an answer from other"""
-        if other.__class__ == self.__class__:
+        if isinstance(other, type(self)):
             if self.payload_type == 0:
                 return 1
 

--- a/scapy/contrib/automotive/gm/gmlan.py
+++ b/scapy/contrib/automotive/gm/gmlan.py
@@ -96,7 +96,7 @@ class GMLAN(ISOTP):
     ]
 
     def answers(self, other):
-        if other.__class__ != self.__class__:
+        if not isinstance(other, type(self)):
             return False
         if self.service == 0x7f:
             return self.payload.answers(other)
@@ -165,7 +165,7 @@ class GMLAN_RFRDPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_RFRD and \
+        return isinstance(other, GMLAN_RFRD) and \
             other.subfunction == self.subfunction
 
 
@@ -301,7 +301,7 @@ class GMLAN_RDBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_RDBI and \
+        return isinstance(other, GMLAN_RDBI) and \
             other.dataIdentifier == self.dataIdentifier
 
 
@@ -333,7 +333,7 @@ class GMLAN_RDBPIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_RDBPI and \
+        return isinstance(other, GMLAN_RDBPI) and \
             self.parameterIdentifier in other.identifiers
 
 
@@ -400,7 +400,7 @@ class GMLAN_RMBAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_RMBA and \
+        return isinstance(other, GMLAN_RMBA) and \
             other.memoryAddress == self.memoryAddress
 
 
@@ -444,7 +444,7 @@ class GMLAN_SAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_SA \
+        return isinstance(other, GMLAN_SA) \
             and other.subfunction == self.subfunction
 
 
@@ -470,7 +470,7 @@ class GMLAN_DDMPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_DDM \
+        return isinstance(other, GMLAN_DDM) \
             and other.DPIDIdentifier == self.DPIDIdentifier
 
 
@@ -506,7 +506,7 @@ class GMLAN_DPBAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_DPBA \
+        return isinstance(other, GMLAN_DPBA) \
             and other.parameterIdentifier == self.parameterIdentifier
 
 
@@ -579,7 +579,7 @@ class GMLAN_WDBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_WDBI \
+        return isinstance(other, GMLAN_WDBI) \
             and other.dataIdentifier == self.dataIdentifier
 
 
@@ -693,7 +693,7 @@ class GMLAN_DCPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == GMLAN_DC \
+        return isinstance(other, GMLAN_DC) \
             and other.CPIDNumber == self.CPIDNumber
 
 

--- a/scapy/contrib/automotive/obd/iid/iids.py
+++ b/scapy/contrib/automotive/obd/iid/iids.py
@@ -30,7 +30,7 @@ class OBD_S09_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S09 \
+        return isinstance(other, OBD_S09) \
             and all(r.iid in other.iid for r in self.data_records)
 
 

--- a/scapy/contrib/automotive/obd/mid/mids.py
+++ b/scapy/contrib/automotive/obd/mid/mids.py
@@ -461,7 +461,7 @@ class OBD_S06_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S06 \
+        return isinstance(other, OBD_S06) \
             and all(r.mid in other.mid for r in self.data_records)
 
 

--- a/scapy/contrib/automotive/obd/pid/pids.py
+++ b/scapy/contrib/automotive/obd/pid/pids.py
@@ -31,7 +31,7 @@ class OBD_S01_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S01 \
+        return isinstance(other, OBD_S01) \
             and all(r.pid in other.pid for r in self.data_records)
 
 
@@ -49,7 +49,7 @@ class OBD_S02_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S02 \
+        return isinstance(other, OBD_S02) \
             and all(r.pid in [o.pid for o in other.requests]
                     for r in self.data_records)
 

--- a/scapy/contrib/automotive/obd/services.py
+++ b/scapy/contrib/automotive/obd/services.py
@@ -88,7 +88,7 @@ class OBD_S03_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S03
+        return isinstance(other, OBD_S03)
 
 
 class OBD_S04(Packet):
@@ -99,7 +99,7 @@ class OBD_S04_PR(Packet):
     name = "S4_ClearDTCsPositiveResponse"
 
     def answers(self, other):
-        return other.__class__ == OBD_S04
+        return isinstance(other, OBD_S04)
 
 
 class OBD_S06(Packet):
@@ -121,7 +121,7 @@ class OBD_S07_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S07
+        return isinstance(other, OBD_S07)
 
 
 class OBD_S08(Packet):
@@ -150,4 +150,4 @@ class OBD_S0A_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S0A
+        return isinstance(other, OBD_S0A)

--- a/scapy/contrib/automotive/obd/tid/tids.py
+++ b/scapy/contrib/automotive/obd/tid/tids.py
@@ -136,7 +136,7 @@ class OBD_S08_PR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == OBD_S08 \
+        return isinstance(other, OBD_S08) \
             and all(r.tid in other.tid for r in self.data_records)
 
 

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -144,7 +144,7 @@ class SOMEIP(Packet):
         return pkt + pay
 
     def answers(self, other):
-        if other.__class__ == self.__class__:
+        if isinstance(other, type(self)):
             if self.msg_type in [SOMEIP.TYPE_REQUEST_NO_RET,
                                  SOMEIP.TYPE_REQUEST_NORET_ACK,
                                  SOMEIP.TYPE_NOTIFICATION,

--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -146,7 +146,7 @@ class UDS_DSCPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_DSC and \
+        return isinstance(other, UDS_DSC) and \
             other.diagnosticSessionType == self.diagnosticSessionType
 
 
@@ -182,7 +182,7 @@ class UDS_ERPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_ER
+        return isinstance(other, UDS_ER)
 
 
 bind_layers(UDS, UDS_ERPR, service=0x51)
@@ -212,7 +212,7 @@ class UDS_SAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_SA \
+        return isinstance(other, UDS_SA) \
             and other.securityAccessType == self.securityAccessType
 
 
@@ -267,7 +267,7 @@ class UDS_CCPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_CC \
+        return isinstance(other, UDS_CC) \
             and other.controlType == self.controlType
 
 
@@ -292,7 +292,7 @@ class UDS_TPPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_TP
+        return isinstance(other, UDS_TP)
 
 
 bind_layers(UDS, UDS_TPPR, service=0x7E)
@@ -329,7 +329,7 @@ class UDS_ATPPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_ATP \
+        return isinstance(other, UDS_ATP) \
             and other.timingParameterAccessType == \
             self.timingParameterAccessType
 
@@ -355,7 +355,7 @@ class UDS_SDTPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_SDT
+        return isinstance(other, UDS_SDT)
 
 
 bind_layers(UDS, UDS_SDTPR, service=0xC4)
@@ -385,7 +385,7 @@ class UDS_CDTCSPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_CDTCS
+        return isinstance(other, UDS_CDTCS)
 
 
 bind_layers(UDS, UDS_CDTCSPR, service=0xC5)
@@ -419,7 +419,7 @@ class UDS_ROEPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_ROE \
+        return isinstance(other, UDS_ROE) \
             and other.eventType == self.eventType
 
 
@@ -458,7 +458,7 @@ class UDS_LCPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_LC \
+        return isinstance(other, UDS_LC) \
             and other.linkControlType == self.linkControlType
 
 
@@ -487,7 +487,7 @@ class UDS_RDBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RDBI \
+        return isinstance(other, UDS_RDBI) \
             and self.dataIdentifier in other.identifiers
 
 
@@ -529,7 +529,7 @@ class UDS_RMBAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RMBA
+        return isinstance(other, UDS_RMBA)
 
 
 bind_layers(UDS, UDS_RMBAPR, service=0x63)
@@ -557,7 +557,7 @@ class UDS_RSDBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RSDBI \
+        return isinstance(other, UDS_RSDBI) \
             and other.dataIdentifier == self.dataIdentifier
 
 
@@ -593,7 +593,7 @@ class UDS_RDBPIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RDBPI \
+        return isinstance(other, UDS_RDBPI) \
             and other.periodicDataIdentifier == self.periodicDataIdentifier
 
 
@@ -625,7 +625,7 @@ class UDS_DDDIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_DDDI \
+        return isinstance(other, UDS_DDDI) \
             and other.subFunction == self.subFunction
 
 
@@ -652,7 +652,7 @@ class UDS_WDBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_WDBI \
+        return isinstance(other, UDS_WDBI) \
             and other.dataIdentifier == self.dataIdentifier
 
 
@@ -713,7 +713,7 @@ class UDS_WMBAPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_WMBA \
+        return isinstance(other, UDS_WMBA) \
             and other.memorySizeLen == self.memorySizeLen \
             and other.memoryAddressLen == self.memoryAddressLen
 
@@ -738,7 +738,7 @@ class UDS_CDTCIPR(Packet):
     name = 'ClearDiagnosticInformationPositiveResponse'
 
     def answers(self, other):
-        return other.__class__ == UDS_CDTCI
+        return isinstance(other, UDS_CDTCI)
 
 
 bind_layers(UDS, UDS_CDTCIPR, service=0x54)
@@ -828,7 +828,7 @@ class UDS_RDTCIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RDTCI \
+        return isinstance(other, UDS_RDTCI) \
             and other.reportType == self.reportType
 
 
@@ -863,7 +863,7 @@ class UDS_RCPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RC \
+        return isinstance(other, UDS_RC) \
             and other.routineControlType == self.routineControlType \
             and other.routineIdentifier == self.routineIdentifier
 
@@ -912,7 +912,7 @@ class UDS_RDPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RD
+        return isinstance(other, UDS_RD)
 
 
 bind_layers(UDS, UDS_RDPR, service=0x74)
@@ -957,7 +957,7 @@ class UDS_RUPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RU
+        return isinstance(other, UDS_RU)
 
 
 bind_layers(UDS, UDS_RUPR, service=0x75)
@@ -983,7 +983,7 @@ class UDS_TDPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_TD \
+        return isinstance(other, UDS_TD) \
             and other.blockSequenceCounter == self.blockSequenceCounter
 
 
@@ -1008,7 +1008,7 @@ class UDS_RTEPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RTE
+        return isinstance(other, UDS_RTE)
 
 
 bind_layers(UDS, UDS_RTEPR, service=0x77)
@@ -1093,7 +1093,7 @@ class UDS_RFTPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_RFT
+        return isinstance(other, UDS_RFT)
 
 
 bind_layers(UDS, UDS_RFTPR, service=0x78)
@@ -1121,7 +1121,7 @@ class UDS_IOCBIPR(Packet):
     ]
 
     def answers(self, other):
-        return other.__class__ == UDS_IOCBI \
+        return isinstance(other, UDS_IOCBI) \
             and other.dataIdentifier == self.dataIdentifier
 
 

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -72,11 +72,6 @@ class ISOTP(Packet):
     ]
     __slots__ = Packet.__slots__ + ["src", "dst", "exsrc", "exdst"]
 
-    def answers(self, other):
-        if other.__class__ == self.__class__:
-            return self.payload.answers(other.payload)
-        return 0
-
     def __init__(self, *args, **kwargs):
         self.src = None
         self.dst = None

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1222,7 +1222,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     def answers(self, other):
         # type: (Packet) -> int
         """DEV: true if self is an answer from other"""
-        if isinstance(other, type(self)):
+        if other.__class__ == self.__class__:
             return self.payload.answers(other.payload)
         return 0
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1222,7 +1222,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     def answers(self, other):
         # type: (Packet) -> int
         """DEV: true if self is an answer from other"""
-        if other.__class__ == self.__class__:
+        if isinstance(other, type(self)):
             return self.payload.answers(other.payload)
         return 0
 


### PR DESCRIPTION
This PR removes all `x.__class__ == Y` comparisons and replaces them with `isinstance(x, Y)`