### PR TITLE
gtp: fix GTPPDUSessionContainer layer implementation

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -18,15 +18,30 @@ Some IEs: 3GPP TS 24.008
 
 from __future__ import absolute_import
 import struct
-import math
 
 from scapy.compat import chb, orb, bytes_encode
 from scapy.config import conf
 from scapy.error import warning
-from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
-    ConditionalField, FieldLenField, FieldListField, FlagsField, IntField, \
-    IPField, PacketListField, ShortField, StrFixedLenField, StrLenField, \
-    XBitField, XByteField, XIntField
+from scapy.fields import (
+    BitEnumField,
+    BitField,
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    FieldLenField,
+    FieldListField,
+    FlagsField,
+    IPField,
+    IntField,
+    PacketListField,
+    ShortField,
+    StrFixedLenField,
+    StrLenField,
+    X3BytesField,
+    XBitField,
+    XByteField,
+    XIntField,
+)
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IPv6, IP6Field
 from scapy.layers.ppp import PPP
@@ -312,62 +327,64 @@ GTPforcedTypes = {
 }
 
 
-def get_hdr_len(pkt):
-    """
-    helper function to return the GTPPDUSessionContainer padding length
-    """
-    length = 0
-    for field in pkt.fields_desc[:-1]:
-        if isinstance(field, ConditionalField) and not field.cond(pkt):
-            continue
-        length += field.i2len(None, None)
-
-    return int(length)
-
-
 class GTPPDUSessionContainer(Packet):
+    # TS 38.415-g30 sect 5
     name = "GTP PDU Session Container"
+    deprecated_fields = {
+        "qmp": ("QMP", "2.4.5"),
+        "P": ("PPP", "2.4.5"),
+        "R": ("RQI", "2.4.5"),
+        "extraPadding": ("padding", "2.4.5"),
+    }
     fields_desc = [ByteField("ExtHdrLen", None),
-                   BitField("type", 0, 4),
-                   BitField("qmp", 0, 1),
+                   BitEnumField("type", 0, 4,
+                                {0: "DL PDU SESSION INFORMATION",
+                                 1: "UL PDU SESSION INFORMATION"}),
+                   BitField("QMP", 0, 1),
+                   # UL (type 1)
                    ConditionalField(BitField("dlDelayInd", 0, 1),
                                     lambda pkt: pkt.type == 1),
                    ConditionalField(BitField("ulDelayInd", 0, 1),
                                     lambda pkt: pkt.type == 1),
-                   ConditionalField(BitField("spareUl1", 0, 1),
+                   # Common
+                   BitField("SNP", 0, 1),
+                   # UL (type 1)
+                   ConditionalField(BitField("N3N9DelayInd", 0, 1),
                                     lambda pkt: pkt.type == 1),
-                   ConditionalField(BitField("SNP", 0, 1),
-                                    lambda pkt: pkt.type == 0),
+                   ConditionalField(XBitField("spareUl1", 0, 1),
+                                    lambda pkt: pkt.type == 1),
+                   # DL (type 0)
                    ConditionalField(XBitField("spareDl1", 0, 2),
                                     lambda pkt: pkt.type == 0),
-                   ConditionalField(BitField("P", 0, 1),
+                   ConditionalField(BitField("PPP", 0, 1),
                                     lambda pkt: pkt.type == 0),
-                   ConditionalField(BitField("R", 0, 1),
+                   ConditionalField(BitField("RQI", 0, 1),
                                     lambda pkt: pkt.type == 0),
-                   ConditionalField(XBitField("spareUl2", 0, 2),
-                                    lambda pkt: pkt.type == 1),
-                   BitField("QFI", 0, 6),
+                   # Common
+                   BitField("QFI", 0, 6),  # QoS Flow Identifier
+                   # DL (type 0)
                    ConditionalField(XBitField("PPI", 0, 3),
                                     lambda pkt: pkt.type == 0 and
-                                    pkt.P == 1),
+                                    pkt.PPP == 1),
                    ConditionalField(XBitField("spareDl2", 0, 5),
                                     lambda pkt: pkt.type == 0 and
-                                    pkt.P == 1),
+                                    pkt.PPP == 1),
                    ConditionalField(XBitField("dlSendTime", 0, 64),
                                     lambda pkt: pkt.type == 0 and
-                                    pkt.qmp == 1),
-                   ConditionalField(XBitField("dlQFISeqNum", 0, 24),
+                                    pkt.QMP == 1),
+                   ConditionalField(X3BytesField("dlQFISeqNum", 0),
                                     lambda pkt: pkt.type == 0 and
                                     pkt.SNP == 1),
+                   # UL (type 1)
                    ConditionalField(XBitField("dlSendTimeRpt", 0, 64),
                                     lambda pkt: pkt.type == 1 and
-                                    pkt.qmp == 1),
+                                    pkt.QMP == 1),
                    ConditionalField(XBitField("dlRecvTime", 0, 64),
                                     lambda pkt: pkt.type == 1 and
-                                    pkt.qmp == 1),
+                                    pkt.QMP == 1),
                    ConditionalField(XBitField("ulSendTime", 0, 64),
                                     lambda pkt: pkt.type == 1 and
-                                    pkt.qmp == 1),
+                                    pkt.QMP == 1),
                    ConditionalField(XBitField("dlDelayRslt", 0, 32),
                                     lambda pkt: pkt.type == 1 and
                                     pkt.dlDelayInd == 1),
@@ -376,17 +393,15 @@ class GTPPDUSessionContainer(Packet):
                                     pkt.ulDelayInd == 1),
                    ConditionalField(XBitField("UlQFISeqNum", 0, 24),
                                     lambda pkt: pkt.type == 1 and
-                                    pkt.spareUl1 == 1),
+                                    pkt.SNP == 1),
                    ConditionalField(XBitField("N3N9DelayRslt", 0, 32),
                                     lambda pkt: pkt.type == 1 and
-                                    (pkt.spareUl2 >> 1) == 1),
+                                    pkt.N3N9DelayInd == 1),
+                   # Common
                    ByteEnumField("NextExtHdr", 0, ExtensionHeadersTypes),
-                   ConditionalField(StrLenField(
-                       "extraPadding",
-                       "", length_from=lambda pkt:
-                       pkt.ExtHdrLen * 4 - get_hdr_len(pkt),
-                       max_length=12),
-                       lambda pkt: pkt.ExtHdrLen is not None), ]
+                   ConditionalField(
+                       StrLenField("padding", b"", length_from=lambda p: 0),
+                       lambda pkt: pkt.NextExtHdr == 0)]
 
     def guess_payload_class(self, payload):
         if self.NextExtHdr == 0:
@@ -399,18 +414,24 @@ class GTPPDUSessionContainer(Packet):
                 return PPP
         return GTPHeader.guess_payload_class(self, payload)
 
+    def post_dissect(self, s):
+        if self.NextExtHdr == 0:
+            # Padding is handled in this layer
+            length = len(self.original) - len(s)
+            pad_length = (- length) % 4
+            self.padding = s[:pad_length]
+            return s[pad_length:]
+        return s
+
     def post_build(self, p, pay):
-        p += pay
-        ext_hdr_len = self.ExtHdrLen
-        hdr_len = get_hdr_len(self)
-        if ext_hdr_len is None:
-            ext_hdr_len = math.ceil(hdr_len / 4.0)
-            p = struct.pack("!B", ext_hdr_len) + p[1:]
-
-        if not self.extraPadding and hdr_len * 4 != len(p) - len(pay):
-            p += bytes(b'0' * int((ext_hdr_len * 4 - hdr_len)))
-
-        return p
+        # Length
+        if self.NextExtHdr == 0:
+            p += b"\x00" * ((-len(p)) % 4)
+        else:
+            pay += b"\x00" * ((-len(p + pay)) % 4)
+        if self.ExtHdrLen is None:
+            p = struct.pack("!B", len(p) // 4) + p[1:]
+        return p + pay
 
 
 class GTPEchoRequest(Packet):

--- a/test/contrib/gtp.uts
+++ b/test/contrib/gtp.uts
@@ -55,7 +55,12 @@ assert isinstance(a[GTP_U_Header].payload, PPP)
 = GTPPDUSessionContainer(), dissect
 h = 'fa163ed6de7bfa163ed82b9408004500008400000000fe114b560a0a2e010a0a2efe086808680070000034ff006000000001fa163e850200ff800000000045000054074d00004001fb490a0a31fe0a0a32010000325600930001c444ca5f00000000759e0a0000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637'
 gtp = Ether(hex_bytes(h))
-gtp[GTP_U_Header].ExtHdrLen == 2 and gtp[GTP_U_Header].extraPadding == b'\x00\x00\x00' and gtp[GTP_U_Header][IP].src == '10.10.49.254' and gtp[GTP_U_Header][IP][ICMP].type == 0 and gtp[GTP_U_Header].type == 0 and gtp[GTP_U_Header].qmp == 0 and gtp[GTP_U_Header].P == 1 and gtp[GTP_U_Header].R == 1 and gtp[GTP_U_Header].QFI == 63 and gtp[GTP_U_Header].PPI == 4
+gtp[GTP_U_Header].ExtHdrLen == 2 and gtp[GTP_U_Header].padding == b'\x00\x00\x00' and gtp[GTP_U_Header][IP].src == '10.10.49.254' and gtp[GTP_U_Header][IP][ICMP].type == 0 and gtp[GTP_U_Header].type == 0 and gtp[GTP_U_Header].qmp == 0 and gtp[GTP_U_Header].P == 1 and gtp[GTP_U_Header].R == 1 and gtp[GTP_U_Header].QFI == 63 and gtp[GTP_U_Header].PPI == 4
+
+= GTPPDUSessionContainer with padding
+data = b'\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x08\x00E\x00\x00^\x00\x01\x00\x00@\x11|\x8c\x7f\x00\x00\x01\x7f\x00\x00\x01\x08h\x08h\x00J\xed^4\xff\x00:\x00\x00\x00\x00\x00\x00\x00\x85\x04\x08\xbf\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00E\x00\x00&\x00\x01\x00\x00@\x11|\xc4\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x12\x01^ffffffffff000'
+gtp = Ether(data)
+assert IP in gtp
 
 = GTPEchoResponse matches GTPEchoRequest by seq
 req = GTPHeader(seq=12345)/GTPEchoRequest()


### PR DESCRIPTION
This reflects the rfc 38415-f20 with the following
example frame format:

Bits	                Number of Octets
7  6  5  4  3  2  1  0
 Field 1  |  Field 2          1          Octet 1
 Field 3  |  Field 4          2          Octet 2
 Field 4 Cont | Spare	                 Octet 3
          Field 6             2          Octet 4
 Field 6 Cont | Padding bits             Octet 5
      Future Extension        0-m
      Padding                 0-3

Signed-off-by: Raslan Darawsheh <rasland@nvidia.com>

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [ ] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
