### PR TITLE
Disable GMLAN tests

### DIFF
--- a/test/contrib/automotive/gm/gmlan.uts
+++ b/test/contrib/automotive/gm/gmlan.uts
@@ -5,6 +5,8 @@
 
 % gmlan unit tests
 
+~ disabled
+
 + Configuration of scapy
 = Load gmlan layer
 ~ conf


### PR DESCRIPTION
- disable gmlan tests.

They tend to freeze on PyPy2.