### PR TITLE
Detect long tests UTscapy

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -58,7 +58,7 @@ jobs:
   utscapy:
     name: ${{ matrix.os }} ${{ matrix.python }} ${{ matrix.mode }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -618,12 +618,24 @@ def run_campaign(test_campaign, get_interactive_session, theme,
 
 #    INFO LINES    #
 
-def info_line(test_campaign):
+def info_line(test_campaign, theme):
     filename = test_campaign.filename
+    duration = test_campaign.duration
+    if duration > 10:
+        duration = theme.format(duration, "bg_red+white")
+    elif duration > 5:
+        duration = theme.format(duration, "red")
     if filename is None:
-        return "Run %s by UTscapy" % time.ctime()
+        return "Run at %s by UTscapy in %s" % (
+            time.strftime("%H:%M:%S"),
+            duration
+        )
     else:
-        return "Run %s from [%s] by UTscapy" % (time.ctime(), filename)
+        return "Run at %s from [%s] by UTscapy in %s" % (
+            time.strftime("%H:%M:%S"),
+            filename,
+            duration
+        )
 
 
 def html_info_line(test_campaign):
@@ -641,7 +653,7 @@ def campaign_to_TEXT(test_campaign, theme):
     ftheme = [lambda x: x, theme.fail][bool(test_campaign.failed)]
 
     output = theme.green("\n%(title)s\n" % test_campaign)
-    output += dash + " " + info_line(test_campaign) + "\n"
+    output += dash + " " + info_line(test_campaign, theme) + "\n"
     output += ptheme(" " + arrow + " Passed=%(passed)i\n" % test_campaign)
     output += ftheme(" " + arrow + " Failed=%(failed)i\n" % test_campaign)
     output += "%(headcomments)s\n" % test_campaign

--- a/test/contrib/automotive/gm/gmlan.uts
+++ b/test/contrib/automotive/gm/gmlan.uts
@@ -5,8 +5,6 @@
 
 % gmlan unit tests
 
-~ disabled
-
 + Configuration of scapy
 = Load gmlan layer
 ~ conf


### PR DESCRIPTION
- re-enable gmlan tests
- show the duration of each campaign with colors