### PR TITLE
Move libpcap tests to Github Actions

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Usage:
+# ./install.sh [install mode]
+
+# Detect install mode
+if [[ "${1}" == "libpcap" ]]; then
+    export SCAPY_USE_LIBPCAP="yes"
+    if [[ ! -z "$GITHUB_ACTIONS" ]]; then
+      echo "SCAPY_USE_LIBPCAP=yes" >> $GITHUB_ENV
+    fi
+fi
+
 # Install on osx
 if [ "$OSTYPE" = "darwin"* ] || [ "$TRAVIS_OS_NAME" = "osx" ]
 then

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -43,6 +43,11 @@ then
   UT_FLAGS+=" -K not_pypy"
 fi
 
+# libpcap
+if [[ ! -z "$SCAPY_USE_LIBPCAP" ]]; then
+  UT_FLAGS+=" -K veth"
+fi
+
 # Create version tag (github actions)
 PY_VERSION="py${1//./}"
 PY_VERSION=${PY_VERSION/pypypy/pypy}

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -3,8 +3,9 @@
 # test.sh
 # Usage:
 #   ./test.sh [tox version] [both/root/non_root (default root)]
-# Example:
+# Examples:
 #   ./test.sh 3.7 both
+#   ./test.sh 3.9 non_root
 
 if [ "$OSTYPE" = "linux-gnu" ] || [ "$TRAVIS_OS_NAME" = "linux" ]
 then

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -58,7 +58,7 @@ jobs:
   utscapy:
     name: ${{ matrix.os }} ${{ matrix.installmode }} ${{ matrix.python }} ${{ matrix.mode }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -56,14 +56,15 @@ jobs:
         run: tox -e mypy
 
   utscapy:
-    name: ${{ matrix.os }} ${{ matrix.python }} ${{ matrix.mode }}
+    name: ${{ matrix.os }} ${{ matrix.installmode }} ${{ matrix.python }} ${{ matrix.mode }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [2.7, pypy2, pypy3, 3.9]
+        python: [2.7, 3.9]
         mode: [both]
+        installmode: ['']
         include:
           # Linux non-root only tests
           - os: ubuntu-latest
@@ -75,6 +76,18 @@ jobs:
           - os: ubuntu-latest
             python: 3.8
             mode: non_root
+          # PyPy tests: root only
+          - os: ubuntu-latest
+            python: pypy2
+            mode: root
+          - os: ubuntu-latest
+            python: pypy3
+            mode: root
+          # Libpcap test
+          - os: ubuntu-latest
+            python: 3.9
+            mode: root
+            installmode: 'libpcap'
           # MacOS tests
           - os: macos-latest
             python: 2.7
@@ -93,7 +106,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages
-        run: ./.config/ci/install.sh
+        run: ./.config/ci/install.sh ${{ matrix.installmode }}
       - name: Run Tox
         run: ./.config/ci/test.sh ${{ matrix.python }} ${{ matrix.mode }}
       - name: Codecov
@@ -105,20 +118,14 @@ jobs:
   analyze:
     name: CodeQL analysis
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['python']
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-         languages: ${{ matrix.language }}
+         languages: 'python'
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ test/*.html
 .tox
 .ipynb_checkpoints
 .mypy_cache
+.vscode
 doc/scapy/_build
 doc/scapy/api

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ jobs:
           env:
             - TOXENV=py38-isotp_kernel_module,codecov
 
-        # libpcap
-        - os: linux
-          python: 3.8
-          env:
-            - SCAPY_USE_LIBPCAP=yes TOXENV=py38-linux_root,codecov
-
         # warnings/deprecations
         - os: linux
           python: 3.8

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -117,7 +117,9 @@ _arp_cache = conf.netcache.new_cache("arp_cache", 120)
 @conf.commands.register
 def getmacbyip(ip, chainCC=0):
     # type: (str, int) -> Optional[str]
-    """Return MAC address corresponding to a given IP address"""
+    """
+    Returns the MAC address matching the route to reach a given IP address
+    """
     if isinstance(ip, Net):
         ip = next(iter(ip))
     ip = inet_ntoa(inet_aton(ip or "0.0.0.0"))

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -319,7 +319,7 @@ assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == "scapy0"
 exit_status = os.system("ip link del name dev scapy0")
 
 = Test 802.Q sniffing
-~ linux needs_root python3_only
+~ linux needs_root python3_only veth
 
 from threading import Thread, Condition
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1622,7 +1622,7 @@ conf.route
 conf.ifaces
 conf.iface
 conf.route.route("8.8.8.8")
-getmacbyip(conf.route.route(conf.route.route("8.8.8.8")[2]))
+getmacbyip(_[2])
 tshark(timeout=2)
 
 ans, unans = traceroute("www.slashdot.org")

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1618,6 +1618,13 @@ retry_test(_test)
 = Traceroute function
 ~ netaccess tcpdump
 * Let's test traceroute
+conf.route
+conf.ifaces
+conf.iface
+conf.route.route("8.8.8.8")
+getmacbyip(conf.route.route(_[2]))
+tshark(timeout=2)
+
 ans, unans = traceroute("www.slashdot.org")
 ans.nsummary()
 s,r=ans[0]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1622,7 +1622,7 @@ conf.route
 conf.ifaces
 conf.iface
 conf.route.route("8.8.8.8")
-getmacbyip(conf.route.route(_[2]))
+getmacbyip(conf.route.route(conf.route.route("8.8.8.8")[2]))
 tshark(timeout=2)
 
 ans, unans = traceroute("www.slashdot.org")


### PR DESCRIPTION
- Move libpcap tests to Github actions since our travis suite is pretty much dead
- Only test root with PyPy (the only differences we're testing with PyPy are the `attach_filter` functions.. root only + pypy tests already are super long due to the build-on-install)
- Small Github Actions tweaks