### PR TITLE
Typing of Answeringmachine [ready]

### DIFF
--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -10,6 +10,7 @@ scapy/arch/__init__.py
 scapy/arch/common.py
 scapy/arch/linux.py
 scapy/arch/unix.py
+scapy/ansmachine.py
 scapy/asn1/mib.py
 scapy/base_classes.py
 scapy/compat.py

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -25,7 +25,6 @@ import scapy.modules.six as six
 
 from scapy.compat import (
     Any,
-    cast,
     Dict,
     Generic,
     Optional,
@@ -43,11 +42,10 @@ class ReferenceAM(type):
                 bases,  # type: Tuple[type, ...]
                 dct  # type: Dict[str, Any]
                 ):
-        # type: (...) -> Type['AnsweringMachine']
-        obj = cast('AnsweringMachine',
-                   super(ReferenceAM, cls).__new__(cls, name, bases, dct))
-        if obj.function_name:
-            globals()[obj.function_name] = lambda obj=obj, *args, **kargs: obj(*args, **kargs)()  # noqa: E501
+        # type: (...) -> Type['AnsweringMachine[_T]']
+        obj = super(ReferenceAM, cls).__new__(cls, name, bases, dct)
+        if obj.function_name:  # type: ignore
+            globals()[obj.function_name] = lambda obj=obj, *args, **kargs: obj(*args, **kargs)()  # type: ignore  # noqa: E501
         return obj
 
 

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -27,6 +27,7 @@ from scapy.compat import (
     Any,
     Dict,
     Generic,
+    _Generic_metaclass,
     Optional,
     Tuple,
     Type,
@@ -49,6 +50,7 @@ class ReferenceAM(type):
         return obj
 
 
+@six.add_metaclass(_Generic_metaclass)
 @six.add_metaclass(ReferenceAM)
 class AnsweringMachine(Generic[_T]):
     function_name = ""

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -18,51 +18,74 @@ import warnings
 
 from scapy.config import conf
 from scapy.sendrecv import send, sniff
+from scapy.packet import Packet
+from scapy.plist import PacketList
 
 import scapy.modules.six as six
 
+from scapy.compat import (
+    Any,
+    cast,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    Union
+)
+
 
 class ReferenceAM(type):
-    def __new__(cls, name, bases, dct):
-        obj = super(ReferenceAM, cls).__new__(cls, name, bases, dct)
+    def __new__(cls,  # type: ignore
+                name,  # type: str
+                bases,  # type: Tuple[type, ...]
+                dct  # type: Dict[str, Any]
+                ):
+        # type: (...) -> Type['scapy.ansmachine.AnsweringMachine']
+        obj = cast(AnsweringMachine,
+                   super(ReferenceAM, cls).__new__(cls, name, bases, dct))
         if obj.function_name:
             globals()[obj.function_name] = lambda obj=obj, *args, **kargs: obj(*args, **kargs)()  # noqa: E501
         return obj
 
 
-class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
+class AnsweringMachine(six.with_metaclass(ReferenceAM,  # type: ignore
+                                          object)):
     function_name = ""
-    filter = None
-    sniff_options = {"store": 0}
+    filter = None  # type: Optional[str]
+    sniff_options = {"store": 0}  # type: Dict[str, Any]
     sniff_options_list = ["store", "iface", "count", "promisc", "filter",
                           "type", "prn", "stop_filter", "opened_socket"]
-    send_options = {"verbose": 0}
+    send_options = {"verbose": 0}  # type: Dict[str, Any]
     send_options_list = ["iface", "inter", "loop", "verbose", "socket"]
     send_function = staticmethod(send)
 
     def __init__(self, **kargs):
+        # type: (Any) -> None
         self.mode = 0
         self.verbose = kargs.get("verbose", conf.verb >= 0)
         if self.filter:
             kargs.setdefault("filter", self.filter)
         kargs.setdefault("prn", self.reply)
-        self.optam1 = {}
-        self.optam2 = {}
-        self.optam0 = {}
+        self.optam1 = {}  # type: Dict[str, Any]
+        self.optam2 = {}  # type: Dict[str, Any]
+        self.optam0 = {}  # type: Dict[str, Any]
         doptsend, doptsniff = self.parse_all_options(1, kargs)
         self.defoptsend = self.send_options.copy()
         self.defoptsend.update(doptsend)
         self.defoptsniff = self.sniff_options.copy()
         self.defoptsniff.update(doptsniff)
-        self.optsend, self.optsniff = [{}, {}]
+        self.optsend = {}   # type: Dict[str, Any]
+        self.optsniff = {}   # type: Dict[str, Any]
 
     def __getattr__(self, attr):
+        # type: (str) -> Any
         for dct in [self.optam2, self.optam1]:
             if attr in dct:
                 return dct[attr]
         raise AttributeError(attr)
 
     def __setattr__(self, attr, val):
+        # type: (str, Any) -> None
         mode = self.__dict__.get("mode", 0)
         if mode == 0:
             self.__dict__[attr] = val
@@ -70,11 +93,13 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
             [self.optam1, self.optam2][mode - 1][attr] = val
 
     def parse_options(self):
+        # type: () -> None
         pass
 
     def parse_all_options(self, mode, kargs):
-        sniffopt = {}
-        sendopt = {}
+        # type: (int, Any) -> Tuple[Dict[str, Any], Dict[str, Any]]
+        sniffopt = {}  # type: Dict[str, Any]
+        sendopt = {}  # type: Dict[str, Any]
         for k in list(kargs):  # use list(): kargs is modified in the loop
             if k in self.sniff_options_list:
                 sniffopt[k] = kargs[k]
@@ -88,27 +113,36 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
             elif mode == 2 and kargs:
                 k = self.optam0.copy()
                 k.update(kargs)
-                self.parse_options(**k)
+                self.parse_options(**k)  # type: ignore
                 kargs = k
             omode = self.__dict__.get("mode", 0)
             self.__dict__["mode"] = mode
-            self.parse_options(**kargs)
+            self.parse_options(**kargs)  # type: ignore
             self.__dict__["mode"] = omode
         return sendopt, sniffopt
 
     def is_request(self, req):
+        # type: (Packet) -> int
         return 1
 
     def make_reply(self, req):
+        # type: (Packet) -> Union[Packet, PacketList]
         return req
 
     def send_reply(self, reply):
+        # type: (Union[Packet, PacketList]) -> None
         self.send_function(reply, **self.optsend)
 
     def print_reply(self, req, reply):
-        print("%s ==> %s" % (req.summary(), reply.summary()))
+        # type: (Packet, Union[Packet, PacketList]) -> None
+        if isinstance(reply, PacketList):
+            print("%s ==> %s" % (req.summary(),
+                                 [res.summary() for res in reply]))
+        else:
+            print("%s ==> %s" % (req.summary(), reply.summary()))
 
     def reply(self, pkt):
+        # type: (Packet) -> None
         if not self.is_request(pkt):
             return
         reply = self.make_reply(pkt)
@@ -117,6 +151,7 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
             self.print_reply(pkt, reply)
 
     def run(self, *args, **kargs):
+        # type: (Any, Any) -> None
         warnings.warn(
             "run() method deprecated. The instance is now callable",
             DeprecationWarning
@@ -124,6 +159,7 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
         self(*args, **kargs)
 
     def __call__(self, *args, **kargs):
+        # type: (Any, Any) -> None
         optsend, optsniff = self.parse_all_options(2, kargs)
         self.optsend = self.defoptsend.copy()
         self.optsend.update(optsend)
@@ -136,4 +172,5 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM, object)):
             print("Interrupted by user")
 
     def sniff(self):
+        # type: () -> None
         sniff(**self.optsniff)

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -40,7 +40,7 @@ class ReferenceAM(type):
                 bases,  # type: Tuple[type, ...]
                 dct  # type: Dict[str, Any]
                 ):
-        # type: (...) -> Type['scapy.ansmachine.AnsweringMachine']
+        # type: (...) -> Type['AnsweringMachine']
         obj = cast(AnsweringMachine,
                    super(ReferenceAM, cls).__new__(cls, name, bases, dct))
         if obj.function_name:

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -41,7 +41,7 @@ class ReferenceAM(type):
                 dct  # type: Dict[str, Any]
                 ):
         # type: (...) -> Type['AnsweringMachine']
-        obj = cast(AnsweringMachine,
+        obj = cast('AnsweringMachine',
                    super(ReferenceAM, cls).__new__(cls, name, bases, dct))
         if obj.function_name:
             globals()[obj.function_name] = lambda obj=obj, *args, **kargs: obj(*args, **kargs)()  # noqa: E501

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -27,11 +27,14 @@ from scapy.compat import (
     Any,
     cast,
     Dict,
+    Generic,
     Optional,
     Tuple,
     Type,
-    Union
+    TypeVar,
 )
+
+_T = TypeVar("_T", Packet, PacketList)
 
 
 class ReferenceAM(type):
@@ -48,8 +51,8 @@ class ReferenceAM(type):
         return obj
 
 
-class AnsweringMachine(six.with_metaclass(ReferenceAM,  # type: ignore
-                                          object)):
+@six.add_metaclass(ReferenceAM)
+class AnsweringMachine(Generic[_T]):
     function_name = ""
     filter = None  # type: Optional[str]
     sniff_options = {"store": 0}  # type: Dict[str, Any]
@@ -126,15 +129,15 @@ class AnsweringMachine(six.with_metaclass(ReferenceAM,  # type: ignore
         return 1
 
     def make_reply(self, req):
-        # type: (Packet) -> Union[Packet, PacketList]
+        # type: (Packet) -> _T
         return req
 
     def send_reply(self, reply):
-        # type: (Union[Packet, PacketList]) -> None
+        # type: (_T) -> None
         self.send_function(reply, **self.optsend)
 
     def print_reply(self, req, reply):
-        # type: (Packet, Union[Packet, PacketList]) -> None
+        # type: (Packet, _T) -> None
         if isinstance(reply, PacketList):
             print("%s ==> %s" % (req.summary(),
                                  [res.summary() for res in reply]))

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -578,7 +578,7 @@ class EcuAnsweringMachine(AnsweringMachine[PacketList]):
             main_socket=None,  # type: Optional[SuperSocket]
             broadcast_socket=None,  # type: Optional[SuperSocket]
             basecls=Raw,  # type: Type[Packet]
-            timeout=None  # type: Optional[Union[int, float]]
+            timeout=None,  # type: Optional[Union[int, float]]
             initial_ecu_state=None  # type: Optional[EcuState]
     ):
         # type: (...) -> None

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -572,10 +572,16 @@ class EcuAnsweringMachine(AnsweringMachine):
     sniff_options_list = ["store", "opened_socket", "count", "filter", "prn",
                           "stop_filter", "timeout"]
 
-    def parse_options(self, supported_responses=None,
-                      main_socket=None, broadcast_socket=None, basecls=Raw,
-                      timeout=None, initial_ecu_state=None):
-        # type: (Optional[List[EcuResponse]], Optional[SuperSocket], Optional[SuperSocket], Type[Packet], Optional[Union[int, float]], Optional[EcuState]) -> None  # noqa: E501
+    def parse_options(
+            self,
+            supported_responses=None,  # type: Optional[List[EcuResponse]]
+            main_socket=None,  # type: Optional[SuperSocket]
+            broadcast_socket=None,  # type: Optional[SuperSocket]
+            basecls=Raw,  # type: Type[Packet]
+            timeout=None  # type: Optional[Union[int, float]]
+            initial_ecu_state=None  # type: Optional[EcuState]
+    ):
+        # type: (...) -> None
         """
         :param supported_responses: List of ``EcuResponse`` objects to define
                                     the behaviour. The default response is
@@ -615,10 +621,6 @@ class EcuAnsweringMachine(AnsweringMachine):
     def is_request(self, req):
         # type: (Packet) -> bool
         return isinstance(req, self.__basecls)
-
-    def print_reply(self, req, reply):
-        # type: (Packet, PacketList) -> None
-        print("%s ==> %s" % (req.summary(), [res.summary() for res in reply]))
 
     def make_reply(self, req):
         # type: (Packet) -> PacketList

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -556,7 +556,7 @@ class EcuResponse:
 conf.contribs['EcuAnsweringMachine'] = {'send_delay': 0}
 
 
-class EcuAnsweringMachine(AnsweringMachine):
+class EcuAnsweringMachine(AnsweringMachine[PacketList]):
     """AnsweringMachine which emulates the basic behaviour of a real world ECU.
     Provide a list of ``EcuResponse`` objects to configure the behaviour of a
     AnsweringMachine.

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -772,7 +772,7 @@ def promiscping(net, timeout=2, fake_bcast="ff:ff:ff:ff:ff:fe", **kargs):
     return ans, unans
 
 
-class ARP_am(AnsweringMachine):
+class ARP_am(AnsweringMachine[Packet]):
     """Fake ARP Relay Daemon (farpd)
 
     example:
@@ -817,7 +817,7 @@ class ARP_am(AnsweringMachine):
             (self.IP_addr is None or self.IP_addr == arp.pdst)  # noqa: E501
 
     def make_reply(self, req):
-        # type: (Ether) -> Ether
+        # type: (Packet) -> Packet
         ether = req[Ether]
         arp = req[ARP]
 
@@ -842,17 +842,15 @@ class ARP_am(AnsweringMachine):
         return resp
 
     def send_reply(self, reply):
-        # type: (Union[Packet, PacketList]) -> None
-        p = cast(Packet, reply)
+        # type: (Packet) -> None
         if 'iface' in self.optsend:
-            self.send_function(p, **self.optsend)
+            self.send_function(reply, **self.optsend)
         else:
-            self.send_function(p, iface=self.iff, **self.optsend)
+            self.send_function(reply, iface=self.iff, **self.optsend)
 
     def print_reply(self, req, reply):
-        # type: (Packet, Union[Packet, PacketList]) -> None
-        p = cast(Packet, reply)
-        print("%s ==> %s on %s" % (req.summary(), p.summary(), self.iff))
+        # type: (Packet, Packet) -> None
+        print("%s ==> %s on %s" % (req.summary(), reply.summary(), self.iff))
 
 
 @conf.commands.register

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -822,7 +822,7 @@ class ARP_am(AnsweringMachine):
         arp = req[ARP]
 
         if 'iface' in self.optsend:
-            iff = self.optsend.get('iface')
+            iff = cast(Union[NetworkInterface, str], self.optsend.get('iface'))
         else:
             iff, a, gw = conf.route.route(arp.psrc)
         self.iff = iff
@@ -842,15 +842,17 @@ class ARP_am(AnsweringMachine):
         return resp
 
     def send_reply(self, reply):
-        # type: (ARP) -> None
+        # type: (Union[Packet, PacketList]) -> None
+        p = cast(Packet, reply)
         if 'iface' in self.optsend:
-            self.send_function(reply, **self.optsend)
+            self.send_function(p, **self.optsend)
         else:
-            self.send_function(reply, iface=self.iff, **self.optsend)
+            self.send_function(p, iface=self.iff, **self.optsend)
 
     def print_reply(self, req, reply):
-        # type: (Ether, Ether) -> None
-        print("%s ==> %s on %s" % (req.summary(), reply.summary(), self.iff))
+        # type: (Packet, Union[Packet, PacketList]) -> None
+        p = cast(Packet, reply)
+        print("%s ==> %s on %s" % (req.summary(), p.summary(), self.iff))
 
 
 @conf.commands.register


### PR DESCRIPTION
Started with typing of answeringmachine.

I'm not so happy, yet. 
In EcuAnsweringMachines I use PacketLists as reply. If I consider this in the base class, the code gets a little messy. 

@gpotter2 Do you have an idea to fix that?

Unfortunately, I can not overwrite the types of derived classes. 
I tried to apply `_T = TypeVar("_T", Packet, PacketList)` to
```
    def make_reply(self, req):
        # type: (Packet) -> _T
        ...

    def send_reply(self, reply):
        # type: (_T) -> None
        ...

    def print_reply(self, req, reply):
        # type: (Packet, _T) -> None
```
in order to allow both cases, but I couldn't overwrite make_reply in EcuAnsweringMachine.

Maybe you have a idea to improve that.