### PR TITLE
Ensure that hashret() returns bytes

### DIFF
--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -111,8 +111,8 @@ class LLTD(Packet):
 
     def hashret(self):
         tos, function = self.tos, self.function
-        return "%c%c" % self.answer_hashret.get((tos, function),
-                                                (tos, function))
+        return b"%c%c" % self.answer_hashret.get((tos, function),
+                                                 (tos, function))
 
     def answers(self, other):
         if not isinstance(other, LLTD):

--- a/test/scapy/layers/lltd.uts
+++ b/test/scapy/layers/lltd.uts
@@ -20,6 +20,7 @@ assert pkt.dst == pkt.real_dst
 assert pkt.src == pkt.real_src
 assert pkt.tos == 0
 assert pkt.function == 0
+assert pkt.hashret() == b'\xd9\x88\x00\x00'
 
 = Attribute build / dissection
 assert isinstance(LLTDAttribute(), LLTDAttribute)


### PR DESCRIPTION
This PR fixes #3133 by returning bytes instead of string.

For the maintainers: I checked `hashret()` methods and they return bytes.