### PR TITLE
Fix for scapy.contrib.lldp. Add to XStrLenField's length_from lambda if statement to avoid performing substraction on None.

### DIFF
--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -332,7 +332,8 @@ class LLDPDUChassisID(LLDPDU):
                 IPField('id', None),
                 lambda pkt: pkt.subtype == 0x05
             ),
-        ], StrLenField('id', '', length_from=lambda pkt: pkt._length - 1)
+        ], StrLenField('id', '', length_from=lambda pkt: 0 if pkt._length is
+                       None else pkt._length - 1)
         )
     ]
 
@@ -387,7 +388,8 @@ class LLDPDUPortID(LLDPDU):
                 IPField('id', None),
                 lambda pkt: pkt.subtype == 0x04
             ),
-        ], StrLenField('id', '', length_from=lambda pkt: pkt._length - 1)
+        ], StrLenField('id', '', length_from=lambda pkt: 0 if pkt._length is
+                       None else pkt._length - 1)
         )
     ]
 

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -631,7 +631,8 @@ class LLDPDUManagementAddress(LLDPDU):
         ByteEnumField('management_address_subtype', 0x00,
                       IANA_ADDRESS_FAMILY_NUMBERS),
         XStrLenField('management_address', '',
-                     length_from=lambda pkt:
+                     length_from=lambda pkt: 0
+                     if pkt._management_address_string_length is None else
                      pkt._management_address_string_length - 1),
         ByteEnumField('interface_numbering_subtype',
                       SUBTYPE_INTERFACE_NUMBER_UNKNOWN,
@@ -681,7 +682,9 @@ class LLDPDUGenericOrganisationSpecific(LLDPDU):
         BitFieldLenField('_length', None, 9, length_of='data', adjust=lambda pkt, x: len(pkt.data) + 4),  # noqa: E501
         ThreeBytesEnumField('org_code', 0, ORG_UNIQUE_CODES),
         ByteField('subtype', 0x00),
-        XStrLenField('data', '', length_from=lambda pkt: pkt._length - 4)
+        XStrLenField('data', '',
+                     length_from=lambda pkt: 0 if pkt._length is None else
+                     pkt._length - 4)
     ]
 
 

--- a/test/contrib/lldp.uts
+++ b/test/contrib/lldp.uts
@@ -25,6 +25,16 @@ frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/ \
 frm = frm.build()
 frm = Ether(frm)
 
+= build: check length calculation (#GH3107)
+
+frame = Ether(src='aa:bb:cc:dd:ee:ff', dst='11:22:33:44:55:66') / \
+        LLDPDUChassisID(subtype=0x04, id='aa:bb:cc:dd:ee:ff') / \
+        LLDPDUPortID(subtype=0x05, id='1') / \
+        LLDPDUTimeToLive(ttl=5) / \
+        LLDPDUManagementAddress(management_address_subtype=0x01, management_address=socket.inet_aton('192.168.0.10'))
+data = b'\x11"3DUf\xaa\xbb\xcc\xdd\xee\xff\x88\xcc\x02\x07\x04\xaa\xbb\xcc\xdd\xee\xff\x04\x02\x051\x06\x02\x00\x05\x10\x0c\x05\x01\xc0\xa8\x00\n\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+assert bytes(frame) == data
+
 = add padding if required
 
 conf.contribs['LLDP'].strict_mode_disable()


### PR DESCRIPTION
Fix scapy.contrib.lldp. Add to XStrLenFields argument's length_from lambda if statement so in case that other referenced field is None lambda will not try to perform unhandeled operation on None eg. + integer.

<!-- This is just a checklist to guide you. You can remove it safely. -->

I'm new to the scapy and I have read the CONTRIBUTING.md. If I've missed something I apologize and I would be grateful for guidance on how to improve.
I've not created any new unit tests as I don't add new functionality, but simply fix existing one. If maintainers still would like me to add some I would be happy to do so, but I will need a little bit of a help to make sure that they're resiliant to other changes in scapy.

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
XStrLenField calls lambda from argument 'length_from' when running i2repr. It may happen as it is in the scapy.contrib.lldp that lambda consist of taking value from other field and adjusting it by addition/substraction. In such case if the referenced field has value 'None' it will raise exception TypeError.  This change is adding if statement to simply put '0' as the return of lambda in case the referenced field is None, so we won't try to perform unhandled operation like substracting integer from 'None'.

fixes #3107
