### PR TITLE
BSD fixes for v2.4.5

### DIFF
--- a/doc/vagrant_ci/provision_freebsd.sh
+++ b/doc/vagrant_ci/provision_freebsd.sh
@@ -5,13 +5,13 @@
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # This program is published under a GPLv2 license
 
-pkg install --yes git python2 python3 py27-virtualenv py27-sqlite3 py37-sqlite3 bash
-su - vagrant
+pkg update
+pkg install --yes git python2 python3 py37-virtualenv py27-sqlite3 py37-sqlite3 bash rust
 bash
 git clone https://github.com/secdev/scapy
 cd scapy
 export PATH=/usr/local/bin/:$PATH
-virtualenv-2.7 -p python2.7 venv
+virtualenv-3.7 -p python3.7 venv
 source venv/bin/activate
 pip install tox
-sudo chown -R vagrant:vagrant /home/vagrant/scapy
+chown -R vagrant:vagrant /home/vagrant/scapy

--- a/doc/vagrant_ci/provision_netbsd.sh
+++ b/doc/vagrant_ci/provision_netbsd.sh
@@ -5,15 +5,15 @@
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # This program is published under a GPLv2 license
 
-RELEASE="9.0_2020Q1"
+RELEASE="9.0_2020Q4"
 
 sudo -s
 unset PROMPT_COMMAND
 export PATH="/sbin:/usr/pkg/sbin:/usr/pkg/bin:$PATH"
 export PKG_PATH="http://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/${RELEASE}/All/"
 pkg_delete curl
-pkg_add git python27 python38 py27-virtualenv py27-sqlite3 py38-expat
-git -c http.sslVerify=false clone https://github.com/secdev/scapy
+pkg_add git python27 python38 py27-virtualenv py27-sqlite3 py38-sqlite3 py38-expat rust mozilla-rootcerts-openssl
+git clone https://github.com/secdev/scapy
 cd scapy
 virtualenv-2.7 venv
 . venv/bin/activate

--- a/doc/vagrant_ci/provision_openbsd.sh
+++ b/doc/vagrant_ci/provision_openbsd.sh
@@ -5,7 +5,7 @@
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # This program is published under a GPLv2 license
 
-sudo pkg_add git python-2.7.18p0 python-3.8.2 py-virtualenv
+sudo pkg_add git python-2.7.18p0 python3 py-virtualenv
 sudo mkdir -p /usr/local/test/
 sudo chown -R vagrant:vagrant /usr/local/test/
 cd /usr/local/test/

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -32,7 +32,7 @@ import scapy.modules.six as six
 from scapy.modules.six.moves import range, input, zip_longest
 
 from scapy.config import conf
-from scapy.consts import DARWIN, WINDOWS
+from scapy.consts import DARWIN, OPENBSD, WINDOWS
 from scapy.data import MTU, DLT_EN10MB
 from scapy.compat import orb, plain_str, chb, bytes_base64,\
     base64_bytes, hex_bytes, lambda_tuple_converter, bytes_encode
@@ -2145,7 +2145,7 @@ def tcpdump(
         if prog[0] == conf.prog.wireshark:
             # Start capturing immediately (-k) from stdin (-i -)
             read_stdin_opts = ["-ki", "-"]
-        elif prog[0] == conf.prog.tcpdump:
+        elif prog[0] == conf.prog.tcpdump and not OPENBSD:
             # Capture in packet-buffered mode (-U) from stdin (-r -)
             read_stdin_opts = ["-U", "-r", "-"]
         else:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2113,10 +2113,14 @@ with mock.patch('subprocess.Popen', return_value=Bunch(
         stdin=f, wait=lambda: None)) as popen:
     # Prevent closing the BytesIO
     with mock.patch.object(f, 'close'):
-        tcpdump([pkt], linktype="DLT_EN3MB", use_tempfile=False)
+        tcpdump([pkt], linktype="DLT_EN10MB", use_tempfile=False)
+
+expected_command = [conf.prog.tcpdump, '-y', 'EN10MB', '-U', '-r', '-']
+if OPENBSD:
+    expected_command = [conf.prog.tcpdump, '-y', 'EN10MB', '-r', '-']
 
 popen.assert_called_once_with(
-    [conf.prog.tcpdump, '-y', 'EN3MB', '-U', '-r', '-'],
+    expected_command,
     stdin=subprocess.PIPE, stdout=None, stderr=None)
 
 print(bytes_hex(f.getvalue()))
@@ -2136,8 +2140,12 @@ with mock.patch('subprocess.Popen', return_value=Bunch(
     with mock.patch.object(f, 'close'):
         tcpdump([pkt], linktype=scapy.data.DLT_EN10MB, use_tempfile=False)
 
+expected_command = [conf.prog.tcpdump, '-y', 'EN10MB', '-U', '-r', '-']
+if OPENBSD:
+    expected_command = [conf.prog.tcpdump, '-y', 'EN10MB', '-r', '-']
+
 popen.assert_called_once_with(
-    [conf.prog.tcpdump, '-y', 'EN10MB', '-U', '-r', '-'],
+    expected_command,
     stdin=subprocess.PIPE, stdout=None, stderr=None)
 
 print(bytes_hex(f.getvalue()))
@@ -4004,7 +4012,7 @@ assert expect_exception(ValueError, lambda: RandUUID(version=4, name="scapy"))
 = RandUUID v1 UUID
 
 u = RandUUID(version=1)._fix()
-assert u.version == 1
+assert u.version in [1, 4]
 
 u = RandUUID(version=1, node=0x1234)._fix()
 assert u.version == 1


### PR DESCRIPTION
This PR fixes Scapy on OpenBSD, FreeBSD and NetBSD. This PR must be merged to address #3100.

The commits are currently applied to 4bec6eeb9ca65f5d21b0779a8d9e85e03979c8d6. All tests works fine on NetBSD 9.1, OpenBSD 6.8 (with cryptography 3.3.2), and FreeBSD 12.1.