### PR TITLE
Remove Python 3.4, 3.5 from supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy) <!-- ignore_ppi -->
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/30ee6772bb264a689a2604f5cdb0437b)](https://www.codacy.com/app/secdev/scapy) <!-- ignore_ppi -->
 [![PyPI Version](https://img.shields.io/pypi/v/scapy.svg)](https://pypi.python.org/pypi/scapy/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/scapy.svg)](https://pypi.python.org/pypi/scapy/)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
+[![Python Versions](https://img.shields.io/pypi/pyversions/scapy.svg)](https://pypi.python.org/pypi/scapy/)
 [![Join the chat at https://gitter.im/secdev/scapy](https://badges.gitter.im/secdev/scapy.svg)](https://gitter.im/secdev/scapy) <!-- ignore_ppi -->
 
 Scapy is a powerful Python-based interactive packet manipulation program and

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 
 
 [tox]
-envlist = py{27,34,35,36,37,38,39,py,py3}-{linux,bsd}_{non_root,root},
-          py{27,34,25,36,37,38,39,py,py3}-windows,
+envlist = py{27,36,37,38,39,py,py3}-{linux,bsd}_{non_root,root},
+          py{27,36,37,38,39,py,py3}-windows,
 skip_missing_interpreters = true
 minversion = 2.9
 


### PR DESCRIPTION
They've both been EOL for a year and, unlike 2.7, no one really use them.