### PR TITLE
Fix DialectCount default value in SMB2_Negociate_Protocol_Request_Header

### DIFF
--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -134,7 +134,7 @@ class SMB2_Negociate_Protocol_Request_Header(Packet):
     fields_desc = [
         XLEShortField("StructureSize", 0),
         FieldLenField(
-            "DialectCount", 0,
+            "DialectCount", None,
             fmt="<H",
             count_of="Dialects"
         ),

--- a/test/scapy/layers/smb2.uts
+++ b/test/scapy/layers/smb2.uts
@@ -275,3 +275,10 @@ netname = nego_req.NegociateContexts[3]
 assert netname.ContextType == 0x5
 assert netname.DataLength == 28
 assert netname.NetName == '192.168.178.21'
+
++ SMB2 Negociate Protocol Request Header default values
+
+= Default DialectCount
+
+pkt = SMB2_Negociate_Protocol_Request_Header()
+assert len(pkt.Dialects) == pkt.__class__(raw(pkt)).DialectCount


### PR DESCRIPTION
Set DialectCount's default value to None so that it is automatically deduced from Dialects' length when crafting a packet, and doesn't conflict with Dialects' default value anymore