### PR TITLE
Automate alignment of NegociateContexts in SMB2 Negociate Requests and Responses

### DIFF
--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -10,6 +10,7 @@ SMB (Server Message Block), also known as CIFS - version 2
 from scapy.config import conf
 from scapy.packet import Packet, bind_layers, bind_top_down
 from scapy.fields import (
+    ConditionalField,
     FieldLenField,
     FieldListField,
     FlagsField,
@@ -19,7 +20,7 @@ from scapy.fields import (
     LELongField,
     LEShortEnumField,
     LEShortField,
-    PacketListField,
+    PacketField,
     ReversePadField,
     ShortEnumField,
     ShortField,
@@ -149,7 +150,7 @@ class SMB2_Negociate_Protocol_Request_Header(Packet):
         UUIDField("ClientGUID", 0x0, uuid_fmt=UUIDField.FORMAT_LE),
         XLEIntField("NegociateContextOffset", 0x0),
         FieldLenField(
-            "NegociateCount", 0x0,
+            "NegociateCount", None,
             fmt="<H",
             count_of="NegociateContexts"
         ),
@@ -159,12 +160,16 @@ class SMB2_Negociate_Protocol_Request_Header(Packet):
             LEShortEnumField("", 0x0, SMB_DIALECTS),
             count_from=lambda pkt: pkt.DialectCount
         ),
-        # The first negotiate context must be 8-byte aligned
-        ReversePadField(PacketListField(
-            "NegociateContexts", [],
-            SMB2_Negociate_Context,
-            count_from=lambda pkt: pkt.NegociateCount
-        ), 8),
+        # Field only exists if Dialects contains 0x0311
+        # Each negotiate context must be 8-byte aligned
+        ConditionalField(
+            FieldListField(
+                "NegociateContexts", [],
+                ReversePadField(
+                    PacketField("Context", None, SMB2_Negociate_Context), 8
+                ), count_from=lambda pkt: pkt.NegociateCount
+            ), lambda x: 0x0311 in x.Dialects
+        ),
     ]
 
 
@@ -184,12 +189,6 @@ class SMB2_Preauth_Integrity_Capabilities(Packet):
             0x0001: "SHA-512",
         }), count_from=lambda pkt: pkt.HashAlgorithmCount),
         XStrLenField("Salt", "", length_from=lambda pkt: pkt.SaltLength),
-        # Pad the whole packet on 8 bytes
-        XStrLenField(
-            "Padding", "",
-            length_from=lambda pkt:
-                    (8 - (4 + pkt.HashAlgorithmCount * 2 + pkt.SaltLength)) % 8
-        ),
     ]
 
 
@@ -203,11 +202,6 @@ class SMB2_Encryption_Capabilities(Packet):
             0x0001: "AES-128-CCM",
             0x0002: "AES-128-GCM",
         }), count_from=lambda pkt: pkt.CipherCount),
-        # Pad the whole packet on 8 bytes
-        XStrLenField(
-            "Padding", "",
-            length_from=lambda pkt: (8 - (2 + pkt.CipherCount * 2)) % 8
-        ),
     ]
 
 
@@ -230,12 +224,6 @@ class SMB2_Compression_Capabilities(Packet):
             LEShortEnumField("", 0x0, SMB2_COMPRESSION_ALGORITHMS),
             count_from=lambda pkt: pkt.CompressionAlgorithmCount,
         ),
-        # Pad the whole packet on 8 bytes
-        XStrLenField(
-            "Padding2", "",
-            length_from=lambda pkt:
-                    (8 - (2 + 2 + 4 + pkt.CompressionAlgorithmCount * 2)) % 8
-        ),
     ]
 
 
@@ -256,7 +244,7 @@ class SMB2_Negociate_Protocol_Response_Header(Packet):
         }),
         LEShortEnumField("Dialect", 0x0, SMB_DIALECTS),
         FieldLenField(
-            "NegociateCount", 0x0,
+            "NegociateCount", None,
             fmt="<H",
             count_of="NegociateContexts"
         ),
@@ -281,10 +269,15 @@ class SMB2_Negociate_Protocol_Response_Header(Packet):
             "SecurityBuffer", None,
             length_from=lambda pkt: pkt.SecurityBufferLength
         ),
-        PacketListField(
-            "NegociateContexts", [],
-            SMB2_Negociate_Context,
-            count_from=lambda pkt: pkt.NegociateCount
+        # Field only exists if Dialect is 0x0311
+        # Each negotiate context must be 8-byte aligned
+        ConditionalField(
+            FieldListField(
+                "NegociateContexts", [],
+                ReversePadField(
+                    PacketField("Context", None, SMB2_Negociate_Context), 8
+                ), count_from=lambda pkt: pkt.NegociateCount
+            ), lambda x: x.Dialect == 0x0311
         ),
     ]
 

--- a/test/scapy/layers/smb2.uts
+++ b/test/scapy/layers/smb2.uts
@@ -138,6 +138,14 @@ pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Requ
 pkt = IP(raw(pkt))
 assert SMB2_Negociate_Protocol_Request_Header in pkt
 
+= Request with no 0x0311 in dialects
+
+preauth = SMB2_Preauth_Integrity_Capabilities()
+preauth_context = SMB2_Negociate_Context(ContextType = 1, DataLength = len(preauth)) / preauth
+
+pkt = SMB2_Negociate_Protocol_Request_Header(Dialects=[0x0202], NegociateContexts=[preauth_context])
+assert pkt.__class__(raw(pkt)).NegociateContexts is None
+
 + SMB2 Negociate Protocol Response Header dissecting
 
 = Common fields in header
@@ -204,6 +212,14 @@ assert comp.CompressionAlgorithms[0] == 1
 pkt = IP() / TCP() / NBTSession() / SMB2_Header() / SMB2_Negociate_Protocol_Response_Header()
 pkt = IP(raw(pkt))
 assert SMB2_Negociate_Protocol_Response_Header in pkt
+
+= Response with dialect different from 0x0311
+
+preauth = SMB2_Preauth_Integrity_Capabilities()
+preauth_context = SMB2_Negociate_Context(ContextType = 1, DataLength = len(preauth)) / preauth
+
+pkt = SMB2_Negociate_Protocol_Response_Header(Dialect=0x0202, NegociateContexts=[preauth_context])
+assert pkt.__class__(raw(pkt)).NegociateContexts is None
 
 + SMB2 Negociate Procotol Request Header with 1 dialect
 
@@ -282,3 +298,65 @@ assert netname.NetName == '192.168.178.21'
 
 pkt = SMB2_Negociate_Protocol_Request_Header()
 assert len(pkt.Dialects) == pkt.__class__(raw(pkt)).DialectCount
+
+= Default NegociateCount
+
+preauth = SMB2_Preauth_Integrity_Capabilities()
+preauth_context = SMB2_Negociate_Context(ContextType = 1, DataLength = len(preauth)) / preauth
+
+pkt = SMB2_Negociate_Protocol_Request_Header(Dialects=[0x0311], NegociateContexts=[preauth_context], NegociateContextOffset=0x68)
+assert len(pkt.NegociateContexts) == pkt.__class__(raw(pkt)).NegociateCount
+
++ Negociate Request without manual padding of Negociate Contexts
+
+= SMB2 Negociate Context in Request - type PREAUTH - disassemble
+
+preauth = SMB2_Preauth_Integrity_Capabilities()
+preauth_context = SMB2_Negociate_Context(ContextType = 1, DataLength = len(preauth)) / preauth
+
+enc = SMB2_Encryption_Capabilities()
+enc_context = SMB2_Negociate_Context(ContextType = 2, DataLength = len(enc)) / enc
+
+comp = SMB2_Compression_Capabilities()
+comp_context = SMB2_Negociate_Context(ContextType = 3, DataLength = len(comp)) / comp
+
+netname = SMB2_Netname_Negociate_Context_ID("192.168.178.21".encode("utf-16le"))
+netname_context = SMB2_Negociate_Context(ContextType = 5, DataLength = len(netname)) / netname
+
+pkt = SMB2_Header() / SMB2_Negociate_Protocol_Request_Header(Dialects=[0x0311], NegociateContexts=[preauth_context, enc_context, comp_context, netname_context], NegociateContextOffset=0x68)
+
+pkt = SMB2_Header(raw(pkt))
+
+nego_req = pkt[SMB2_Negociate_Protocol_Request_Header]
+
+preauth_dissected = nego_req.NegociateContexts[0]
+assert preauth_dissected.ContextType == preauth_context.ContextType
+assert preauth_dissected.DataLength == preauth_context.DataLength
+assert preauth_dissected.HashAlgorithmCount == preauth_context.HashAlgorithmCount
+assert preauth_dissected.SaltLength == preauth_context.SaltLength
+assert len(preauth_dissected.HashAlgorithms) == len(preauth_context.HashAlgorithms)
+assert preauth_dissected.HashAlgorithms[0] == preauth_context.HashAlgorithms[0]
+
+= SMB2 Negociate Context in Request - type ENCRYPTION disassemble
+
+enc_dissected = nego_req.NegociateContexts[1]
+assert enc_dissected.ContextType == enc_context.ContextType
+assert enc_dissected.DataLength == enc_context.DataLength
+assert enc_dissected.CipherCount == enc_context.CipherCount
+assert len(enc_dissected.Ciphers) == len(enc_context.Ciphers)
+assert enc_dissected.Ciphers[0] == enc_context.Ciphers[0]
+
+= SMB2 Negociate Context in Request - type COMPRESSION
+
+comp_dissected = nego_req.NegociateContexts[2]
+assert comp_dissected.ContextType == comp_context.ContextType
+assert comp_dissected.DataLength == comp_context.DataLength
+assert comp_dissected.CompressionAlgorithmCount == comp_context.CompressionAlgorithmCount
+assert len(comp_dissected.CompressionAlgorithms) == len(comp_context.CompressionAlgorithms)
+
+= SMB2 Negociate Context in Request - type NETNAME NEGOCIATE
+
+netname_dissected = nego_req.NegociateContexts[3]
+assert netname_dissected.ContextType == netname_context.ContextType
+assert netname_dissected.DataLength == netname_context.DataLength
+assert netname_dissected.NetName == netname_context.NetName


### PR DESCRIPTION
The NegociateContexts fields of SMB2_Negociate_Protocol_Request_Header and SMB2_Negociate_Protocol_Response_Header are now a FieldListField of ReversePadFields, so that each element starts on an 8-byte aligned offset from the beginning of the packet.
The whole NegociateContexts field becomes a ConditionalField, which only exists if Dialects contains the value 0x0311, as specified in MS-SMB2 2.2.3 and 2.2.4.
Adds 2 tests ensuring that the field doesn't exist when Dialects doesn't contain 0x0311, and a series of tests checking that a SMB2_Negociate_Protocol_Request_Header crafted without manually adding padding can be correctly dissected.