### PR TITLE
v2.4.5 BSD fixes

### DIFF
--- a/doc/vagrant_ci/Vagrantfile
+++ b/doc/vagrant_ci/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "freebsd" do |bsd|
-    bsd.vm.box = "freebsd/FreeBSD-12.1-STABLE"
+    bsd.vm.box = "freebsd/FreeBSD-13.0-RELEASE"
     bsd.vm.provision "shell", path: "provision_freebsd.sh"
   end
 

--- a/doc/vagrant_ci/provision_netbsd.sh
+++ b/doc/vagrant_ci/provision_netbsd.sh
@@ -12,10 +12,10 @@ unset PROMPT_COMMAND
 export PATH="/sbin:/usr/pkg/sbin:/usr/pkg/bin:$PATH"
 export PKG_PATH="http://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/${RELEASE}/All/"
 pkg_delete curl
-pkg_add git python27 python38 py27-virtualenv py27-sqlite3 py38-sqlite3 py38-expat rust mozilla-rootcerts-openssl
+pkg_add git python27 python38 py38-virtualenv py27-sqlite3 py38-sqlite3 py38-expat rust mozilla-rootcerts-openssl
 git clone https://github.com/secdev/scapy
 cd scapy
-virtualenv-2.7 venv
+virtualenv-3.8 venv
 . venv/bin/activate
 pip install tox
 chown -R vagrant:vagrant ../scapy/

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2154,7 +2154,7 @@ f.close()
 del f, pkt
 
 = Check sniff() offline with linktype & 802.11 filter
-~ tcpdump
+~ tcpdump linux
 
 fd = get_temp_file()
 wrpcap(fd, [RadioTap()/Dot11()/Dot11ProbeReq(), RadioTap()/Dot11()])


### PR DESCRIPTION
This are the last commits before releasing v2.4.5 (see #3158). Please do not merge anything else before the release =)

8b63d73a17266bae2a61513ea97ded5283a7ccd3 is the only important commit. On OpenBSD, `tcpdump` does not recognize `subtype prob-req` as a valid filter.