### PR TITLE
improved ASN1_{GENERALIZED,UTC}_TIME implementations

### DIFF
--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import random
 
-from datetime import datetime
+from datetime import datetime, timedelta, tzinfo
 from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP, GeneralizedTime
@@ -20,6 +20,35 @@ from scapy.utils import Enum_metaclass, EnumElement, binrepr
 from scapy.compat import plain_str, chb, orb
 import scapy.modules.six as six
 from scapy.modules.six.moves import range
+
+try:
+    from datetime import timezone
+except ImportError:
+    class UTC(tzinfo):
+        """UTC"""
+        def utcoffset(self, dt):
+            return timedelta(0)
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return None
+
+    class timezone(tzinfo):
+        def __init__(self, delta):
+            self.delta = delta
+
+        def utcoffset(self, dt):
+            return self.delta
+
+        def tzname(self, dt):
+            return None
+
+        def dst(self, dt):
+            return None
+
+    timezone.utc = UTC()
 
 
 class RandASN1Object(RandField):
@@ -433,34 +462,108 @@ class ASN1_IA5_STRING(ASN1_STRING):
     tag = ASN1_Class_UNIVERSAL.IA5_STRING
 
 
-class ASN1_UTC_TIME(ASN1_STRING):
-    tag = ASN1_Class_UNIVERSAL.UTC_TIME
+class ASN1_GENERALIZED_TIME(ASN1_STRING):
+    """
+    Improved version of ASN1_GENERALIZED_TIME, properly handling time zones and
+    all string representation formats defined by ASN.1. These are:
+
+    1. Local time only:                        YYYYMMDDHH[MM[SS[.fff]]]
+    2. Universal time (UTC time) only:         YYYYMMDDHH[MM[SS[.fff]]]Z
+    3. Difference between local and UTC times: YYYYMMDDHH[MM[SS[.fff]]]+-HHMM
+
+    It also handles ASN1_UTC_TIME, which allows:
+
+    1. Universal time (UTC time) only:         YYMMDDHHMM[SS[.fff]]Z
+    2. Difference between local and UTC times: YYMMDDHHMM[SS[.fff]]+-HHMM
+
+    Note the differences: Year is only two digits, minutes are not optional and
+    there is no milliseconds.
+    """
+    tag = ASN1_Class_UNIVERSAL.GENERALIZED_TIME
+    pretty_time = None
 
     def __init__(self, val):
-        ASN1_STRING.__init__(self, val)
+        if isinstance(val, datetime):
+            self.__setattr__("datetime", val)
+        else:
+            ASN1_STRING.__init__(self, val)
 
     def __setattr__(self, name, value):
         if isinstance(value, bytes):
             value = plain_str(value)
+
         if name == "val":
+            formats = {
+                10: "%Y%m%d%H",
+                12: "%Y%m%d%H%M",
+                14: "%Y%m%d%H%M%S"
+            }
+            try:
+                if value[-1] == "Z":
+                    str, ofs = value[:-1], value[-1:]
+                elif value[-5] in ("+", "-"):
+                    str, ofs = value[:-5], value[-5:]
+                elif isinstance(self, ASN1_UTC_TIME):
+                    raise ValueError()
+                else:
+                    str, ofs = value, ""
+
+                if isinstance(self, ASN1_UTC_TIME) and len(str) >= 10:
+                    fmt = "%y" + formats[len(str) + 2][2:]
+                elif str[-4] == ".":
+                    fmt = formats[len(str) - 4] + ".%f"
+                else:
+                    fmt = formats[len(str)]
+
+                dt = datetime.strptime(str, fmt)
+                if ofs == 'Z':
+                    dt = dt.replace(tzinfo=timezone.utc)
+                elif ofs:
+                    sign = -1 if ofs[0] == "-" else 1
+                    ofs = datetime.strptime(ofs[1:], "%H%M")
+                    delta = timedelta(hours=ofs.hour * sign,
+                                      minutes=ofs.minute * sign)
+                    dt = dt.replace(tzinfo=timezone(delta))
+            except Exception:
+                dt = None
+
             pretty_time = None
-            if isinstance(self, ASN1_GENERALIZED_TIME):
-                _len = 15
-                self._format = "%Y%m%d%H%M%S"
-            else:
-                _len = 13
-                self._format = "%y%m%d%H%M%S"
-            _nam = self.tag._asn1_obj.__name__[4:].lower()
-            if (isinstance(value, str) and
-                    len(value) == _len and value[-1] == "Z"):
-                dt = datetime.strptime(value[:-1], self._format)
-                pretty_time = dt.strftime("%b %d %H:%M:%S %Y GMT")
-            else:
+            if dt is None:
+                _nam = self.tag._asn1_obj.__name__[5:]
+                _nam = _nam.lower().replace("_", " ")
                 pretty_time = "%s [invalid %s]" % (value, _nam)
+            else:
+                pretty_time = dt.strftime("%Y-%m-%d %H:%M:%S")
+                if dt.microsecond:
+                    pretty_time += dt.strftime(".%f")[:4]
+                if dt.tzinfo == timezone.utc:
+                    pretty_time += dt.strftime(" UTC")
+                elif dt.tzinfo is not None:
+                    if dt.tzinfo.utcoffset(dt) is not None:
+                        pretty_time += dt.strftime(" %z")
+
             ASN1_STRING.__setattr__(self, "pretty_time", pretty_time)
+            ASN1_STRING.__setattr__(self, "datetime", dt)
             ASN1_STRING.__setattr__(self, name, value)
         elif name == "pretty_time":
             print("Invalid operation: pretty_time rewriting is not supported.")
+        elif name == "datetime":
+            ASN1_STRING.__setattr__(self, name, value)
+            if isinstance(value, datetime):
+                yfmt = "%y" if isinstance(self, ASN1_UTC_TIME) else "%Y"
+                if value.microsecond:
+                    str = value.strftime(yfmt + "%m%d%H%M%S.%f")[:-3]
+                else:
+                    str = value.strftime(yfmt + "%m%d%H%M%S")
+
+                if value.tzinfo == timezone.utc:
+                    str = str + "Z"
+                else:
+                    str = str + value.strftime("%z")  # empty if naive
+
+                ASN1_STRING.__setattr__(self, "val", str)
+            else:
+                ASN1_STRING.__setattr__(self, "val", None)
         else:
             ASN1_STRING.__setattr__(self, name, value)
 
@@ -468,8 +571,8 @@ class ASN1_UTC_TIME(ASN1_STRING):
         return "%s %s" % (self.pretty_time, ASN1_STRING.__repr__(self))
 
 
-class ASN1_GENERALIZED_TIME(ASN1_UTC_TIME):
-    tag = ASN1_Class_UNIVERSAL.GENERALIZED_TIME
+class ASN1_UTC_TIME(ASN1_GENERALIZED_TIME):
+    tag = ASN1_Class_UNIVERSAL.UTC_TIME
 
 
 class ASN1_ISO646_STRING(ASN1_STRING):

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -599,24 +599,16 @@ class Cert(six.with_metaclass(_CertMaker, object)):
         self.authorityKeyID = None
 
         self.notBefore_str = tbsCert.validity.not_before.pretty_time
-        notBefore = tbsCert.validity.not_before.val
-        if notBefore[-1] == "Z":
-            notBefore = notBefore[:-1]
         try:
-            _format = tbsCert.validity.not_before._format
-            self.notBefore = time.strptime(notBefore, _format)
-        except Exception:
+            self.notBefore = tbsCert.validity.not_before.datetime.timetuple()
+        except ValueError:
             raise Exception(error_msg)
         self.notBefore_str_simple = time.strftime("%x", self.notBefore)
 
         self.notAfter_str = tbsCert.validity.not_after.pretty_time
-        notAfter = tbsCert.validity.not_after.val
-        if notAfter[-1] == "Z":
-            notAfter = notAfter[:-1]
         try:
-            _format = tbsCert.validity.not_after._format
-            self.notAfter = time.strptime(notAfter, _format)
-        except Exception:
+            self.notAfter = tbsCert.validity.not_after.datetime.timetuple()
+        except ValueError:
             raise Exception(error_msg)
         self.notAfter_str_simple = time.strftime("%x", self.notAfter)
 

--- a/test/cert.uts
+++ b/test/cert.uts
@@ -377,7 +377,7 @@ awaited = """
 Serial: 15459312981008553731928384953135426796
 Issuer: /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Assured ID Root G3
 Subject: /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Assured ID Root G3
-Validity: Aug 01 12:00:00 2013 GMT to Jan 15 12:00:00 2038 GMT
+Validity: 2013-08-01 12:00:00 UTC to 2038-01-15 12:00:00 UTC
 """
 
 with ContextManagerCaptureOutput() as cmco:
@@ -452,8 +452,8 @@ awaited = """
 Version: 1
 sigAlg: sha1-with-rsa-signature
 Issuer: /C=US/O=VeriSign, Inc./OU=Class 1 Public Primary Certification Authority
-lastUpdate: Nov 02 00:00:00 2006 GMT
-nextUpdate: Feb 17 23:59:59 2007 GMT
+lastUpdate: 2006-11-02 00:00:00 UTC
+nextUpdate: 2007-02-17 23:59:59 UTC
 """
 
 with ContextManagerCaptureOutput() as cmco:

--- a/test/scapy/layers/asn1.uts
+++ b/test/scapy/layers/asn1.uts
@@ -1,0 +1,103 @@
+% Tests for generic ASN.1 encoding
+
+#
+# Try me with:
+# bash test/run_tests -t test/scapy/layers/asn1.uts -F
+
+########### ASN.1 border case #######################################
+
++ ASN.1 Generalized Time
+= short HH
+repr(ASN1_GENERALIZED_TIME("1999123123")).startswith("1999-12-31 23:00:00 <")
+= short HH (invalid)
+"invalid" in repr(ASN1_GENERALIZED_TIME("1999123124"))
+= short HHMM
+repr(ASN1_GENERALIZED_TIME("199912312359")).startswith("1999-12-31 23:59:00 <")
+= short HHMM (invalid)
+"invalid" in repr(ASN1_GENERALIZED_TIME("199912312360"))
+= full
+repr(ASN1_GENERALIZED_TIME("19991231235959")).startswith("1999-12-31 23:59:59 <")
+= full (invalid)
+"invalid" in repr(ASN1_GENERALIZED_TIME("19991231235960"))
+= with microseconds
+repr(ASN1_GENERALIZED_TIME("19991231235959.999")).startswith("1999-12-31 23:59:59.999 <")
+= with microseconds (invalid)
+assert("invalid" in repr(ASN1_GENERALIZED_TIME("1999123125959.99")))
+assert("invalid" in repr(ASN1_GENERALIZED_TIME("1999123125959.99x")))
+assert("invalid" in repr(ASN1_GENERALIZED_TIME("1999123125959.9999")))
+
+
++ ASN.1 Generalized Time (Zulu)
+= Z short HH
+repr(ASN1_GENERALIZED_TIME("1999123123Z")).startswith("1999-12-31 23:00:00 UTC <")
+= Z short HHMM
+repr(ASN1_GENERALIZED_TIME("199912312359Z")).startswith("1999-12-31 23:59:00 UTC <")
+= Z full
+repr(ASN1_GENERALIZED_TIME("19991231235959Z")).startswith("1999-12-31 23:59:59 UTC <")
+= Z with microseconds
+repr(ASN1_GENERALIZED_TIME("19991231235959.999Z")).startswith("1999-12-31 23:59:59.999 UTC <")
+
+
++ ASN.1 Generalized Time (Timezone Offset)
+= offset short HH
+ASN1_GENERALIZED_TIME("1999123123+0100")
+repr(ASN1_GENERALIZED_TIME("1999123123+0100")).startswith("1999-12-31 23:00:00 +0100 <")
+= offset short HHMM
+repr(ASN1_GENERALIZED_TIME("199912312359+0100")).startswith("1999-12-31 23:59:00 +0100 <")
+= offset full
+repr(ASN1_GENERALIZED_TIME("19991231235959+0100")).startswith("1999-12-31 23:59:59 +0100 <")
+= offset with microseconds
+repr(ASN1_GENERALIZED_TIME("19991231235959.999+0100")).startswith("1999-12-31 23:59:59.999 +0100 <")
+= offset negative
+repr(ASN1_GENERALIZED_TIME("19991231235959-2359")).startswith("1999-12-31 23:59:59 -2359 <")
+= offset invalid (offset >= 24h)
+assert("invalid" in repr(ASN1_GENERALIZED_TIME("19991231235959-2400")))
+assert("invalid" in repr(ASN1_GENERALIZED_TIME("19991231235959+2400")))
+
+
++ ASN.1 UTC Time
+= UTC short HHMM
+repr(ASN1_UTC_TIME("9912312359Z")).startswith("1999-12-31 23:59:00 UTC <")
+= UTC short HHMM (no Z)
+"invalid" in repr(ASN1_UTC_TIME("9912312359"))
+= UTC short HHMM (invalid)
+"invalid" in repr(ASN1_UTC_TIME("99123160"))
+= UTC full
+repr(ASN1_UTC_TIME("991231235959Z")).startswith("1999-12-31 23:59:59 UTC <")
+= UTC full (no Z)
+"invalid" in repr(ASN1_UTC_TIME("991231235959"))
+= UTC full (invalid)
+"invalid" in repr(ASN1_UTC_TIME("9912315960"))
+
++ ASN.1 Generalized Time (datetime member)
+= prepare
+class TZ(tzinfo):
+    def __init__(self, delta): self.delta = delta
+    def utcoffset(self, dt): return self.delta
+    def dst(self, dt): return None
+= short HH datetime
+ASN1_GENERALIZED_TIME("1999123123").datetime == datetime(1999, 12, 31, 23)
+= short HHMM datetime
+ASN1_GENERALIZED_TIME("199912312359").datetime == datetime(1999, 12, 31, 23, 59)
+= full datetime
+ASN1_GENERALIZED_TIME("19991231235959").datetime == datetime(1999, 12, 31, 23, 59, 59)
+= datetime assignment
+x = ASN1_GENERALIZED_TIME("19991231235959.999")
+x.datetime = datetime(2020, 12, 31)
+assert(x.val == "20201231000000")
+x.datetime = x.datetime.replace(tzinfo=timezone.utc)
+x.val == "20201231000000Z"
+= datetime construction
+ASN1_GENERALIZED_TIME(datetime(2020, 12, 31)).val == "20201231000000"
+= datetime construction (UTC)
+ASN1_GENERALIZED_TIME(datetime(2020, 12, 31, tzinfo=timezone.utc)).val == "20201231000000Z"
+= datetime construction (offset)
+ASN1_GENERALIZED_TIME(datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-23, minutes=-59)))).val == "20201231000000-2359"
+
++ ASN.1 UTC Time (datetime member)
+= UTC datetime construction
+ASN1_UTC_TIME(datetime(2020, 12, 31)).val == "201231000000"
+= UTC datetime construction (Z)
+ASN1_UTC_TIME(datetime(2020, 12, 31, tzinfo=timezone.utc)).val == "201231000000Z"
+= UTC datetime construction (offset)
+ASN1_UTC_TIME(datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-23, minutes=-59)))).val == "201231000000-2359"


### PR DESCRIPTION
This PR improves the ASN.1 implementations of GENERALIZED TIME and UTC TIME. The current one supports only a subset of the supported formats and doesn't help in converting to/from datetime. This implementation parses into to "datetime" objects and set tzinfo if included in the string.

A minor incompatibility might arise from this when existing implementations rely on the 'pretty_time' format of this field. It used to be hardcoded to "GMT", but that is not appropriate for a full implementation. Instead, iso-style "1999-12-31 23:59:59 UTC" or "1999-12-31 23:59:59.999 +1000" is printed. Two tests in cert.uts had to be adapted to this. On the upper hand, tls/cert.py does no longer need the date's format string.

For python27 compatiblity, a mini implemenation of datetime.timezone is included.