### PR TITLE
Ensure command line arguments are passed through run_tests

### DIFF
--- a/test/run_tests
+++ b/test/run_tests
@@ -27,6 +27,8 @@ then
     esac
   done
   PYTHON=${PYTHON:-python3}
+else
+  ARGS="$@"
 fi
 $PYTHON --version > /dev/null 2>&1
 if [ ! $? -eq 0 ]


### PR DESCRIPTION
A pretty trivial patch, relevant if a user is both setting $PYTHON and supplying command line arguments, as I've had occasion to do.