### PR TITLE
Stop when all listening sockets have closed

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1167,7 +1167,8 @@ class AsyncSniffer(object):
                 stoptime = time.time() + timeout
             remain = None
 
-            while sniff_sockets and self.continue_sniff:
+            # Loop until no sockets (except possibly the control socket) are left in sniff_sockets, or continue_sniff is False:
+            while any(sock for sock in sniff_sockets if sock is not close_pipe) and self.continue_sniff:
                 if timeout is not None:
                     remain = stoptime - time.time()
                     if remain <= 0:


### PR DESCRIPTION
Otherwise, if select() is blocking, with a control socket (close_pipe) remaining in sniff_sockets, the loop will never terminate.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [X] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [X] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
If select() is blocking, with a control socket (close_pipe) remaining in sniff_sockets, the loop will never terminate. This change fixes that.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
