### PR TITLE
Improvements to `select_objects` on Windows

### DIFF
--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -13,7 +13,7 @@ import socket
 import struct
 import time
 
-from scapy.automaton import SelectableObject, select_objects
+from scapy.automaton import select_objects
 from scapy.compat import raw, plain_str
 from scapy.config import conf
 from scapy.consts import WINDOWS
@@ -60,9 +60,8 @@ _pcap_if_flags = [
 ]
 
 
-class _L2libpcapSocket(SuperSocket, SelectableObject):
+class _L2libpcapSocket(SuperSocket):
     def __init__(self):
-        SelectableObject.__init__(self)
         self.cls = None
 
     def recv_raw(self, x=MTU):

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -49,7 +49,7 @@ import socket
 import subprocess
 import time
 
-from scapy.automaton import SelectableObject, select_objects
+from scapy.automaton import select_objects
 from scapy.arch.windows.structures import GetIcmpStatistics
 from scapy.compat import raw
 from scapy.config import conf
@@ -61,10 +61,10 @@ from scapy.supersocket import SuperSocket
 # Watch out for import loops (inet...)
 
 
-class L3WinSocket(SuperSocket, SelectableObject):
+class L3WinSocket(SuperSocket):
     desc = "a native Layer 3 (IPv4) raw socket under Windows"
     nonblocking_socket = True
-    __selectable_force_select__ = True
+    __selectable_force_select__ = True  # see automaton.py
     __slots__ = ["promisc", "cls", "ipv6", "proto"]
 
     def __init__(self, iface=None, proto=socket.IPPROTO_IP,

--- a/scapy/contrib/isotp.py
+++ b/scapy/contrib/isotp.py
@@ -31,7 +31,6 @@ from scapy.fields import BitField, FlagsField, StrLenField, \
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN, CAN_MAX_IDENTIFIER, CAN_MTU, CAN_MAX_DLEN
 import scapy.modules.six as six
-import scapy.automaton as automaton
 from scapy.modules.six.moves import queue
 from scapy.error import Scapy_Exception, warning, log_loading, log_runtime
 from scapy.supersocket import SuperSocket
@@ -1175,7 +1174,7 @@ ISOTP_FC_WT = 1  # /* wait */
 ISOTP_FC_OVFLW = 2  # /* overflow */
 
 
-class ISOTPSocketImplementation(automaton.SelectableObject):
+class ISOTPSocketImplementation:
     """
     Implementation of an ISOTP "state machine".
 
@@ -1222,8 +1221,6 @@ class ISOTPSocketImplementation(automaton.SelectableObject):
                  listen_only=False  # type: bool
                  ):
         # type: (...) -> None
-        automaton.SelectableObject.__init__(self)
-
         self.can_socket = can_socket
         self.dst_id = dst_id
         self.src_id = src_id
@@ -1491,7 +1488,6 @@ class ISOTPSocketImplementation(automaton.SelectableObject):
         self.rx_queue.put((msg, ts))
         for cb in self.rx_callbacks:
             cb(msg)
-        self.call_release()
 
     def _recv_ff(self, data, ts):
         # type: (bytes, Union[float, EDecimal]) -> None
@@ -1589,7 +1585,6 @@ class ISOTPSocketImplementation(automaton.SelectableObject):
             self.rx_queue.put((self.rx_buf, self.rx_ts))
             for cb in self.rx_callbacks:
                 cb(self.rx_buf)
-            self.call_release()
             self.rx_buf = None
             return
 
@@ -1679,11 +1674,6 @@ class ISOTPSocketImplementation(automaton.SelectableObject):
             return self.rx_queue.get(timeout is None or timeout > 0, timeout)
         except queue.Empty:
             return None
-
-    def check_recv(self):
-        # type: () -> bool
-        """Implementation for SelectableObject"""
-        return not self.rx_queue.empty()
 
 
 if six.PY3 and LINUX:

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -41,7 +41,7 @@ class PipeEngine(ObjectPipe):
                 print("###### %s" % pn)
 
     def __init__(self, *pipes):
-        ObjectPipe.__init__(self)
+        ObjectPipe.__init__(self, "PipeEngine")
         self.active_pipes = set()
         self.active_sources = set()
         self.active_drains = set()
@@ -108,7 +108,7 @@ class PipeEngine(ObjectPipe):
             RUN = True
             STOP_IF_EXHAUSTED = False
             while RUN and (not STOP_IF_EXHAUSTED or len(sources) > 1):
-                fds = select_objects(sources, 2)
+                fds = select_objects(sources, 0.5)
                 for fd in fds:
                     if fd is self:
                         cmd = self._read_cmd()
@@ -319,7 +319,7 @@ class Pipe(six.with_metaclass(_PipeMeta, _ConnectorLogic)):
 class Source(Pipe, ObjectPipe):
     def __init__(self, name=None):
         Pipe.__init__(self, name=name)
-        ObjectPipe.__init__(self)
+        ObjectPipe.__init__(self, name)
         self.is_exhausted = False
 
     def _read_message(self):

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -57,9 +57,6 @@ class SniffSource(Source):
     def fileno(self):
         return self.s.fileno()
 
-    def check_recv(self):
-        return True
-
     def deliver(self):
         try:
             pkt = self.s.recv()
@@ -95,9 +92,6 @@ class RdpcapSource(Source):
 
     def fileno(self):
         return self.f.fileno()
-
-    def check_recv(self):
-        return True
 
     def deliver(self):
         try:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1305,7 +1305,7 @@ class RawPcapReader:
 
     def fileno(self):
         # type: () -> int
-        return self.f.fileno()
+        return -1 if WINDOWS else self.f.fileno()
 
     def close(self):
         # type: () -> Optional[Any]
@@ -1689,7 +1689,7 @@ class RawPcapWriter:
 
     def fileno(self):
         # type: () -> int
-        return self.f.fileno()
+        return -1 if WINDOWS else self.f.fileno()
 
     def write_header(self, pkt):
         # type: (Optional[Union[Packet, bytes]]) -> None

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -229,12 +229,12 @@ p.wait_and_stop()
 = Test SniffSource
 
 import mock
-r, w = os.pipe()
-os.write(w, b"X")
+fd = ObjectPipe("sniffsource")
+fd.write("test")
 
 @mock.patch("scapy.scapypipes.conf.L2listen")
 def _test(l2listen):
-    l2listen.return_value=Bunch(close=lambda *args: None, fileno=lambda: r, recv=lambda *args: Raw("data"))
+    l2listen.return_value=Bunch(close=lambda *args: None, fileno=lambda: fd.fileno(), recv=lambda *args: Raw("data"))
     p = PipeEngine()
     s = SniffSource()
     assert s.s is None
@@ -251,13 +251,12 @@ def _test(l2listen):
 try:
     _test()
 finally:
-    os.close(r)
-    os.close(w)
+    fd.close()
 
 = Test SniffSource with socket
 
-r, w = os.pipe()
-os.write(w, b"X")
+fd = ObjectPipe("sniffsource_socket")
+fd.write("test")
 
 class FakeSocket(object):
     def __init__(self):
@@ -268,7 +267,7 @@ class FakeSocket(object):
         self.times += 1
         return Raw(b'hello')
     def fileno(self):
-        return r
+        return fd.fileno()
 
 try:
     p = PipeEngine()
@@ -282,8 +281,7 @@ try:
     p.stop()
     assert raw(msg) == b'hello'
 finally:
-    os.close(r)
-    os.close(w)
+    fd.close()
 
 = Test SniffSource with invalid args
 
@@ -322,7 +320,7 @@ except:
 = Test WiresharkSink
 ~ wiresharksink
 
-q = ObjectPipe()
+q = ObjectPipe("wiresharksink")
 pkt = Ether(dst="aa:aa:aa:aa:aa:aa", src="bb:bb:bb:bb:bb:bb")/IP(dst="127.0.0.1", src="127.0.0.1")/ICMP()
 
 import mock
@@ -344,7 +342,7 @@ popen.assert_called_once_with(
 ~ wiresharksink
 
 linktype = scapy.data.DLT_EN3MB
-q = ObjectPipe()
+q = ObjectPipe("wiresharksink_linktype")
 pkt = Ether(dst="aa:aa:aa:aa:aa:aa", src="bb:bb:bb:bb:bb:bb")/IP(dst="127.0.0.1", src="127.0.0.1")/ICMP()
 
 import mock
@@ -362,7 +360,7 @@ assert raw(pkt) in q.recv()
 ~ wiresharksink
 
 linktype = scapy.data.DLT_EN3MB
-q = ObjectPipe()
+q = ObjectPipe("wiresharksink_args")
 pkt = Ether(dst="aa:aa:aa:aa:aa:aa", src="bb:bb:bb:bb:bb:bb")/IP(dst="127.0.0.1", src="127.0.0.1")/ICMP()
 
 import mock
@@ -667,7 +665,7 @@ p.stop()
 
 = FDSourceSink on a ObjectPipe object
 
-obj = ObjectPipe()
+obj = ObjectPipe("fdsourcesink")
 obj.send("hello")
 
 s = FDSourceSink(obj)

--- a/test/run_tests.bat
+++ b/test/run_tests.bat
@@ -34,3 +34,4 @@ IF "%_args%" == "" (
 )
 REM ### Start UTScapy normally ###
 %PYTHON% "%MYDIR%\scapy\tools\UTscapy.py" %_args%
+PAUSE

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -123,7 +123,7 @@ def run_openssl_client(msg, suite="", version="", tls13=False, client_auth=False
     )
     msg += b"\nstop_server\n"
     out = p.communicate(input=msg)[0]
-    print(out.decode())
+    print(plain_str(out))
     if p.returncode != 0:
         raise RuntimeError("OpenSSL returned with error code %s" % p.returncode)
     else:


### PR DESCRIPTION
This PR performs some additional cleanups to `select_objects` on windows:
- remove `SelectableObject`. Merge it into `ObjectPipe`. It was complicated to use + unless people were using it with `ObjectPipe`, it wouldn't use the fancy new system. This will force us to use the new elegant system implemented in `ObjectPipe`.
- fix https://github.com/secdev/scapy/issues/3206 and other various bugs in the implementation