### PR TITLE
Disable xcpscanner tests on PyPy

### DIFF
--- a/test/tools/xcpscanner.uts
+++ b/test/tools/xcpscanner.uts
@@ -1,5 +1,5 @@
 % Regression tests for the XCP_CAN
-~ needs_root
+~ needs_root not_pypy
 
 # More information at http://www.secdev.org/projects/UTscapy/
 


### PR DESCRIPTION
```
Regression tests for the XCP_CAN
-- Run at 13:42:55 from [test/tools/xcpscanner.uts] by UTscapy in 5.74445080757
 -> Passed=4
 -> Failed=1

######
## Tests XCPonCAN Scanner
######


###(002)=[failed] xcp can scanner broadcast ID-Range

>>> id_range = range(50, 53)
>>> slave_id_1 = 10
>>> response_id_1 = 11
>>> slave_id_2 = 20
>>> response_id_2 = 21
>>> 
>>> slave_1_response = XCPOnCAN(identifier=response_id_1) / CTOResponse(packet_code=0xFF) / TransportLayerCmdGetSlaveIdResponse(can_identifier=slave_id_1)
>>> slave_2_response = XCPOnCAN(identifier=response_id_2) / CTOResponse(packet_code=0xFF) / TransportLayerCmdGetSlaveIdResponse(can_identifier=slave_id_2)
>>> 
>>> random_xcp_response_1 = XCPOnCAN(identifier=30) / CTOResponse(packet_code=0xFF) / GenericResponse(b"\x00\x00")
>>> random_xcp_response_2 = XCPOnCAN(identifier=40) / CTOResponse(packet_code=0xFF) / GenericResponse(b"\x00\x00")
>>> 
>>> sock1 = new_can_socket0()
>>> sock1.basecls = XCPOnCAN
>>> 
>>> sock2 = new_can_socket0()
>>> sock2.basecls = XCPOnCAN
>>> 
>>> 
>>> def ecu():
...     for i in range(50, 53):
...         sock1.sniff(count=1, store=False, timeout=2)
...         if i == 50:
...             sock1.send(CAN(identifier=0x90, data=b'\x01\x02\x03'))
...             sock1.send(CAN(identifier=0x90, data=b'\x05\x02\x03'))
...             sock1.send(CAN(identifier=0x90, data=b'\xff\x05\x03'))
...         if i == 51:
...             sock1.send(random_xcp_response_1)
...             sock1.send(random_xcp_response_2)
...         if i == 52:
...             sock1.send(slave_1_response)
...             sock1.send(slave_2_response)
... 
>>> 
>>> thread = threading.Thread(target=ecu)
>>> thread.start()
>>> 
>>> scanner = XCPOnCANScanner(sock2, id_range=id_range, sniff_time=0.5)
>>> result = scanner.scan_with_get_slave_id()
>>> thread.join(timeout=3)
>>> sock1.close()
>>> sock2.close()
>>> assert len(result) == 2
Traceback (most recent call last):
  File "<input>", line 2, in <module>
AssertionError



UTscapy ended with error code 1
ERROR: InvocationError for command /usr/bin/sudo -E .tox/pypy2-linux_root/bin/python -m coverage run -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -K tshark -K icmp_firewall -K not_pypy (exited with code 1)
```