### PR TITLE
Added proper OIDs in defaul issuer, subject and directory name classes

### DIFF
--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -238,11 +238,11 @@ _default_directoryName = [
     X509_RDN(),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.10",
+            type=ASN1_OID("2.5.4.10"),
             value=ASN1_PRINTABLE_STRING("Scapy, Inc."))]),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.3",
+            type=ASN1_OID("2.5.4.3"),
             value=ASN1_PRINTABLE_STRING("Scapy Default Name"))])
 ]
 
@@ -882,11 +882,11 @@ _default_issuer = [
     X509_RDN(),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.10",
+            type=ASN1_OID("2.5.4.10"),
             value=ASN1_PRINTABLE_STRING("Scapy, Inc."))]),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.3",
+            type=ASN1_OID("2.5.4.3"),
             value=ASN1_PRINTABLE_STRING("Scapy Default Issuer"))])
 ]
 
@@ -894,11 +894,11 @@ _default_subject = [
     X509_RDN(),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.10",
+            type=ASN1_OID("2.5.4.10"),
             value=ASN1_PRINTABLE_STRING("Scapy, Inc."))]),
     X509_RDN(
         rdn=[X509_AttributeTypeAndValue(
-            type="2.5.4.3",
+            type=ASN1_OID("2.5.4.3"),
             value=ASN1_PRINTABLE_STRING("Scapy Default Subject"))])
 ]
 


### PR DESCRIPTION
The default constructs for Issuer, Subject and Directory Name in the X.509 layer were missing the proper set of the OID elements and instead used plain strings for the OID.

Before the PR:
```
In [1]: from scapy.layers.x509 import *

In [2]: X509_DirectoryName
Out[2]: scapy.layers.x509.X509_DirectoryName

In [3]: dn = X509_DirectoryName()

In [4]: dn
Out[4]: <X509_DirectoryName  directoryName=[<X509_RDN  rdn=[<X509_AttributeTypeAndValue  |>] |>, <X509_RDN  rdn=[<X509_AttributeTypeAndValue  type='2.5.4.10' value=<ASN1_PRINTABLE_STRING['Scapy, Inc.']> |>] |>, <X509_RDN  rdn=[<X509_AttributeTypeAndValue  type='2.5.4.3' value=<ASN1_PRINTABLE_STRING['Scapy Default Name']> |>] |>] |>

In [5]: dn.show()
###[ X509_DirectoryName ]### 
  \directoryName\
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = <ASN1_OID['countryName']>
   |   |  value     = <ASN1_PRINTABLE_STRING['FR']>
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = '2.5.4.10'
   |   |  value     = <ASN1_PRINTABLE_STRING['Scapy, Inc.']>
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = '2.5.4.3'
   |   |  value     = <ASN1_PRINTABLE_STRING['Scapy Default Name']>
```

After the PR:
```
In [1]: from scapy.layers.x509 import *

In [2]: dn = X509_DirectoryName()

In [3]: dn.show()
###[ X509_DirectoryName ]### 
  \directoryName\
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = <ASN1_OID['countryName']>
   |   |  value     = <ASN1_PRINTABLE_STRING['FR']>
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = <ASN1_OID['organizationName']>
   |   |  value     = <ASN1_PRINTABLE_STRING['Scapy, Inc.']>
   |###[ X509_RDN ]### 
   |  \rdn       \
   |   |###[ X509_AttributeTypeAndValue ]### 
   |   |  type      = <ASN1_OID['commonName']>
   |   |  value     = <ASN1_PRINTABLE_STRING['Scapy Default Name']>
```