### PR TITLE
Typing cleanups

### DIFF
--- a/.config/mypy/mypy_deployment_stats.py
+++ b/.config/mypy/mypy_deployment_stats.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 # Parse config file
 
 localdir = os.path.split(__file__)[0]
+rootpath = os.path.abspath(os.path.join(localdir, '../../'))
 
 with io.open(os.path.join(localdir, "mypy_enabled.txt")) as fd:
     FILES = [l.strip() for l in fd.readlines() if l.strip() and l[0] != "#"]
@@ -22,25 +23,28 @@ with io.open(os.path.join(localdir, "mypy_enabled.txt")) as fd:
 # Scan Scapy
 
 ALL_FILES = [
-     "".join(x.partition("scapy/")[1:]) for x in
-     glob.iglob(os.path.join(localdir, '../../scapy/**/*.py'), recursive=True)
+     "".join(x.partition("scapy/")[2:]) for x in
+     glob.iglob(os.path.join(rootpath, 'scapy/**/*.py'), recursive=True)
 ]
 
 # Process
 
+REMAINING = defaultdict(list)
 MODULES = defaultdict(lambda: (0, 0))
 
 for f in ALL_FILES:
-    with open(os.path.join(localdir, '../../', f)) as fd:
+    with open(os.path.join(rootpath, f)) as fd:
         lines = len(fd.read().split("\n"))
     parts = f.split("/")
     if len(parts) > 2:
         mod = parts[1]
     else:
-        mod = "[main]"
+        mod = "[core]"
     e, l = MODULES[mod]
     if f in FILES:
         e += lines
+    else:
+        REMAINING[mod].append(f)
     l += lines
     MODULES[mod] = (e, l)
 
@@ -51,3 +55,11 @@ print("*The numbers correspond to the amount of lines per files processed*")
 print("**MyPy Support: %.2f%%**" % (ENABLED / TOTAL * 100))
 for mod, dat in MODULES.items():
     print("- `%s`: %.2f%%" % (mod, dat[0] / dat[1] * 100))
+
+print()
+COREMODS = REMAINING["[core]"]
+if COREMODS:
+    print("Core modules still untypes:")
+    for mod in COREMODS:
+        print("- `%s`" % mod)
+

--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -6,15 +6,18 @@
 
 # CORE
 scapy/__init__.py
+scapy/__main__.py
+scapy/all.py
+scapy/ansmachine.py
 scapy/arch/__init__.py
 scapy/arch/common.py
 scapy/arch/linux.py
 scapy/arch/unix.py
-scapy/ansmachine.py
 scapy/asn1/mib.py
 scapy/base_classes.py
 scapy/compat.py
 scapy/config.py
+scapy/consts.py
 scapy/dadict.py
 scapy/data.py
 scapy/error.py
@@ -30,6 +33,7 @@ scapy/route6.py
 scapy/sendrecv.py
 scapy/sessions.py
 scapy/supersocket.py
+scapy/themes.py
 scapy/utils.py
 scapy/utils6.py
 


### PR DESCRIPTION
- Improve the Mypy detection script
- Enable typing for some modules that could but hadn't been already
- fix and restore partially existing typing in `scapy/themes.py`