### PR TITLE
Fix ResourceWarning in L3RawSocket6

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3364,10 +3364,10 @@ def traceroute6(target, dport=80, minttl=1, maxttl=30, sport=RandShort(),
 
 class L3RawSocket6(L3RawSocket):
     def __init__(self, type=ETH_P_IPV6, filter=None, iface=None, promisc=None, nofilter=0):  # noqa: E501
-        L3RawSocket.__init__(self, type, filter, iface, promisc)
         # NOTE: if fragmentation is needed, it will be done by the kernel (RFC 2292)  # noqa: E501
         self.outs = socket.socket(socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
         self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
+        self.iface = iface
 
 
 def IPv6inIP(dst='203.178.135.36', src=None):


### PR DESCRIPTION
`L3RawSocket6` objects are firing a ResourceWarning on allocation:

```
L3RawSocket6(iface="eth0")
/.../secdev_scapy/scapy/layers/inet6.py:3369: ResourceWarning: unclosed <socket.socket fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_RAW, proto=255, laddr=('0.0.0.0', 255)>
  self.outs = socket.socket(socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/.../secdev_scapy/scapy/layers/inet6.py:3370: ResourceWarning: unclosed <socket.socket fd=15, family=AddressFamily.AF_PACKET, type=SocketKind.SOCK_RAW, proto=56710, laddr=('eth0', 34525, 0, 1, b'T\xe1\xadk\xac\x15')>
  self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```