### PR TITLE
Do not resolve the interface name globally

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -711,6 +711,8 @@ We can sniff and do passive OS fingerprinting::
 
 The number before the OS guess is the accuracy of the guess.
 
+.. note:: When sniffing on several interfaces (e.g. ``iface=["eth0", ...]``), you can check what interface a packet was sniffed on by using the ``sniffed_on`` attribute, as shown in one of the examples above.
+
 Asynchronous Sniffing
 ---------------------
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1379,9 +1379,36 @@ def _test():
     assert (ans.time - req.sent_time) >= 0
     assert (ans.time - req.sent_time) <= 1e-3
 
-retry_test(_test)
+try:
+    retry_test(_test)
+finally:
+    conf.L3socket = sock
 
-conf.L3socket = sock
+= Test sniffing on multiple sockets
+~ netaccess needs_root sniff
+
+# This test sniffs on the same interface twice at the same time, to
+# simulate sniffing on multiple interfaces.
+
+iface = conf.route.route("www.google.com")[0]
+port = int(RandShort())
+pkt = IP(dst="www.google.com")/TCP(sport=port, dport=80, flags="S")
+
+def cb():
+    sr1(pkt, timeout=3)
+
+sniffer = AsyncSniffer(started_callback=cb,
+                       iface=[iface, iface],
+                       lfilter=lambda x: TCP in x and x[TCP].dport == port,
+                       prn=lambda x: x.summary(),
+                       count=2)
+sniffer.start()
+sniffer.join(timeout=3)
+
+assert len(sniffer.results) == 2
+
+for pkt in sniffer.results:
+    assert pkt.sniffed_on == iface
 
 = Sending a TCP syn 'forever' at layer 2 and layer 3
 ~ netaccess IP


### PR DESCRIPTION
- mostly like https://github.com/secdev/scapy/pull/3209 but with a test. (closes https://github.com/secdev/scapy/pull/3209)
- fixes https://github.com/secdev/scapy/issues/3191

See also https://github.com/secdev/scapy/pull/3234