### PR TITLE
BSD + macOS: fix send() on loopback and utun devices

### DIFF
--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -390,14 +390,31 @@ class L3bpfSocket(L2bpfSocket):
             self.assigned_interface = iff
 
         # Build the frame
-        if self.guessed_cls == Loopback:
-            # bpf(4) man page (from macOS, but also for BSD):
-            # "A packet can be sent out on the network by writing to a bpf
-            # file descriptor. [...] Currently only writes to Ethernets and
-            # SLIP links are supported"
-            #
-            # Headers are only mentioned for reads, not writes. tuntaposx's tun
-            # device reports as a "loopback" device, but it does IP.
+        #
+        # LINKTYPE_NULL / DLT_NULL (Loopback) is a special case. From the
+        # bpf(4) man page (from macOS/Darwin, but also for BSD):
+        #
+        # "A packet can be sent out on the network by writing to a bpf file
+        # descriptor. [...] Currently only writes to Ethernets and SLIP links
+        # are supported."
+        #
+        # Headers are only mentioned for reads, not writes, and it has the
+        # name "NULL" and id=0.
+        #
+        # The _correct_ behaviour appears to be that one should add a BSD
+        # Loopback header to every sent packet. This is needed by FreeBSD's
+        # if_lo, and Darwin's if_lo & if_utun.
+        #
+        # tuntaposx appears to have interpreted "NULL" as "no headers".
+        # Thankfully its interfaces have a different name (tunX) to Darwin's
+        # if_utun interfaces (utunX).
+        #
+        # There might be other drivers which make the same mistake as
+        # tuntaposx, but these are typically provided with VPN software, and
+        # Apple are breaking these kexts in a future version of macOS... so
+        # the problem will eventually go away. They already don't work on Macs
+        # with Apple Silicon (M1).
+        if DARWIN and iff.startswith('tun') and self.guessed_cls == Loopback:
             frame = raw(pkt)
         else:
             frame = raw(self.guessed_cls() / pkt)

--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -145,3 +145,23 @@ s.send(IP(dst="8.8.8.8")/ICMP())
 s = L3bpfSocket()             
 s.assigned_interface = conf.loopback_name
 s.send(IP(dst="8.8.8.8")/ICMP())
+
+= L3bpfSocket - send and sniff on loopback
+~ needs_root
+
+localhost_ip = conf.ifaces[conf.loopback_name].ips[4][0]
+
+def cb():
+    # Send a ping to the loopback IP.
+    s = L3bpfSocket(iface=conf.loopback_name)
+    s.send(IP(dst=localhost_ip)/ICMP(seq=1001))
+
+t = AsyncSniffer(iface=conf.loopback_name, started_callback=cb)
+t.start()
+time.sleep(1)
+t.stop()
+t.join(timeout=1)
+
+# We expect to see our packet and kernel's response.
+len(t.results.filter(lambda p: (
+    IP in p and ICMP in p and (p[IP].src == localhost_ip or p[IP].dst == localhost_ip) and p[ICMP].seq == 1001))) == 2


### PR DESCRIPTION
This pull request fixes the `send()` function on `loX` (`if_lo`) and Darwin `utunX` (`if_utun`), by including the `Loopback` header unless on Darwin/macOS with a device that looks like tuntaposx's TUN device.

My previous change (#2584) of mine operated under the assumption that a `DLT_NULL` (`Loopback`) device doesn't need any headers on BSD, because `tuntaposx` on Darwin didn't work with it.  At the time, I hadn't tested this on BSD, but the true story seems to be a bit more complicated:

* [Prior to FreeBSD 10.0, `bpf` couldn't send packets to `if_lo` interfaces due to a kernel bug](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198211).
* FreeBSD 13.0's `if_lo` needs the `Loopback` header.
* [FreeBSD 13.0's `if_tuntap` is broken due to a kernel bug](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=256587), but _should_ need the `Loopback` header once that's fixed.
* Darwin's `if_lo` and `if_utun` need the `Loopback` header.
* tuntaposx's `tun` interface needs _no_ headers (per #2584), because they seem to interpret `NULL` as "no headers".

Without this change:

* running Wireshark against a `utun` has missing headers, and the first 4 bytes of the packet are swapped between network and host byte order, and reports an "Unknown" packet type of `0x001c`.
* an application on the far side of the `utun` device gets bad packets (because it's missing the `DLT_NULL` header)

Long term it looks like Apple is pushing userspace applications towards `utun` and away from third-party kernel extensions like `tuntaposx`.  I'm working on another PR which adds `utun` support for `TunTapInterface`, but that's not quite ready yet (#3258).

**Tests:** I've added a test to `bpf.uts` which sends an ICMP ping packet to localhost on IPv4, and tries to sniff for that packet being sent _and_ a response from the kernel.  This seems to work on FreeBSD 13.0-RELEASE and macOS 11.4.
