### PR TITLE
p0fv3 support - tcp/http/mtu passive fingerprinting

### DIFF
--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -444,7 +444,7 @@ def packet2tcpsig(pkt):
     if ip_ver == 4:
         ttl = pkt.ttl
         ip_opt_len = (pkt.ihl * 4) - 20
-        if (pkt.tos & 0x3) in (0x1, 0x2, 0x3):
+        if pkt.tos & (0x01 | 0x02):
             addq("ecn")
         if pkt.flags.evil:
             addq("0+")
@@ -459,7 +459,7 @@ def packet2tcpsig(pkt):
         ip_opt_len = 0
         if pkt.fl:
             addq("flow")
-        if (pkt.tc & 0x3) in (0x1, 0x2, 0x3):
+        if pkt.tc & (0x01 | 0x02):
             addq("ecn")
 
     # TCP parsing

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -394,7 +394,7 @@ def detect_win_multi(tcpsig):
         options.append((mss + MIN_TCP6, True))
 
     for div, use_mtu in options:
-        if not (win % div):
+        if not win % div:
             return win / div, use_mtu
     return -1, False
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -25,34 +25,301 @@ WIN_TYPE_MOD = 2  # Modulo check
 WIN_TYPE_MSS = 3  # Window size MSS multiplier
 WIN_TYPE_MTU = 4  # Window size MTU multiplier
 
-quirks_p0f = {
-    "df": 0,  # don't fragment flag
-    "id+": 1,  # df set but IPID non-zero
-    "id-": 2,  # df not set but IPID zero
-    "ecn": 3,  # explicit confestion notification support
-    "0+": 4,  # 'must be zero' field not zero
-    "flow": 5,  # non-zero IPv6 flow ID
-    "seq-": 6,  # sequence number is zero
-    "ack+": 7,  # ACK number is non-zero but ACK flag is not set
-    "ack-": 8,  # ACK number is zero but ACK flag is set
-    "uptr+": 9,  # URG pointer is non-zero but URG flag not set
-    "urgf+": 10,  # URG flag used
-    "pushf+": 11,  # PUSH flag used
-    "ts1-": 12,  # own timestamp specified as zero
-    "ts2+": 13,  # non-zero peer timestamp on initial SYN
-    "opt+": 14,  # trailing non-zero data in options segment
-    "exws": 15,  # excessive window scaling factor ( > 14)
-    "bad": 16  # malformed tcp options
-}
-
-options_p0f = {
-    1: "nop",  # no-op option
+# Convert TCP option num to p0f (nop is handeled seperately)
+tcp_options_p0f = {
     2: "mss",  # maximum segment size
     3: "ws",  # window scaling
     4: "sok",  # selective ACK permitted
     5: "sack",  # selective ACK (should not be seen)
     8: "ts",  # timestamp
 }
+
+
+# Signatures
+class TCP_Signature(object):
+    __slots__ = ["olayout", "quirks", "ip_opt_len", "ip_ver", "ttl",
+                 "mss", "win", "win_type", "wscale", "pay_class", "ts1"]
+
+    def __init__(self, olayout, quirks, ip_opt_len, ip_ver, ttl,
+                 mss, win, win_type, wscale, pay_class, ts1):
+        self.olayout = olayout
+        self.quirks = quirks
+        self.ip_opt_len = ip_opt_len
+        self.ip_ver = ip_ver
+        self.ttl = ttl
+        self.mss = mss
+        self.win = win
+        self.win_type = win_type  # None for packet signatures
+        self.wscale = wscale
+        self.pay_class = pay_class
+        self.ts1 = ts1  # None for base signatures
+
+    @classmethod
+    def from_packet(cls, pkt):
+        """
+        Receives a TCP packet (assuming it's valid), and returns
+        a TCP_Signature object
+        """
+        ip_ver = pkt.version
+        quirks = set()
+
+        def addq(name):
+            quirks.add(name)
+
+        # IPv4/IPv6 parsing
+        if ip_ver == 4:
+            ttl = pkt.ttl
+            ip_opt_len = (pkt.ihl * 4) - 20
+            if pkt.tos & (0x01 | 0x02):
+                addq("ecn")
+            if pkt.flags.evil:
+                addq("0+")
+            if pkt.flags.DF:
+                addq("df")
+                if pkt.id:
+                    addq("id+")
+            elif pkt.id == 0:
+                addq("id-")
+        else:
+            ttl = pkt.hlim
+            ip_opt_len = 0
+            if pkt.fl:
+                addq("flow")
+            if pkt.tc & (0x01 | 0x02):
+                addq("ecn")
+
+        # TCP parsing
+        tcp = pkt[TCP]
+        win = tcp.window
+        if tcp.flags & (0x40 | 0x80 | 0x01):
+            addq("ecn")
+        if tcp.seq == 0:
+            addq("seq-")
+        if tcp.flags.A:
+            if tcp.ack == 0:
+                addq("ack-")
+        elif tcp.ack:
+            addq("ack+")
+        if tcp.flags.U:
+            addq("urgf+")
+        elif tcp.urgptr:
+            addq("uptr+")
+        if tcp.flags.P:
+            addq("pushf+")
+
+        pay_class = 1 if tcp.payload else 0
+
+        # Manual TCP options parsing
+        mss = 0
+        wscale = 0
+        ts1 = 0
+        olayout = ""
+        optlen = (tcp.dataofs << 2) - 20
+        x = raw(tcp)[-optlen:]  # raw bytes of TCP options
+        while x:
+            onum = orb(x[0])
+            if onum == 0:
+                x = x[1:]
+                olayout += "eol+%i," % len(x)
+                if x.strip(b"\x00"):  # non-zero past EOL
+                    addq("opt+")
+                break
+            if onum == 1:
+                x = x[1:]
+                olayout += "nop,"
+                continue
+            try:
+                olen = orb(x[1])
+            except IndexError:  # no room for length field
+                addq("bad")
+                break
+            oval = x[2:olen]
+            if onum in tcp_options_p0f:
+                ofmt = TCPOptions[0][onum][1]
+                olayout += "%s," % tcp_options_p0f[onum]
+                optsize = 2 + struct.calcsize(ofmt) if ofmt else 2  # total len
+                if len(x) < optsize:  # option would end past end of header
+                    addq("bad")
+                    break
+
+                if onum == 5:
+                    if olen < 10 or olen > 34:  # SACK length out of range
+                        addq("bad")
+                        break
+                else:
+                    if olen != optsize:  # length field doesn't fit option type
+                        addq("bad")
+                        break
+                    if ofmt:
+                        oval = struct.unpack(ofmt, oval)
+                        if len(oval) == 1:
+                            oval = oval[0]
+                    if onum == 2:
+                        mss = oval
+                    elif onum == 3:
+                        wscale = oval
+                        if wscale > 14:
+                            addq("exws")
+                    elif onum == 8:
+                        ts1 = oval[0]
+                        if not ts1:
+                            addq("ts1-")
+                        if oval[1] and (tcp.flags.S and not tcp.flags.A):
+                            addq("ts2+")
+            else:  # Unknown option, presumably with specified size
+                if olen < 2 or olen > 40 or olen > len(x):
+                    addq("bad")
+                    break
+            x = x[olen:]
+        olayout = olayout[:-1]
+
+        return cls(olayout, quirks, ip_opt_len, ip_ver, ttl, mss, win, None, wscale, pay_class, ts1)  # noqa: E501
+
+    @classmethod
+    def from_raw_sig(cls, sig_line):
+        """
+        Parses a TCP sig line and returns a tuple consisting of a
+        TCP_Signature object and bad_ttl as bool
+        """
+        ver, ttl, olen, mss, wsize, olayout, quirks, pclass = lparse(sig_line, 8)  # noqa: E501
+        wsize, _, scale = wsize.partition(",")
+
+        ip_ver = -1 if ver == "*" else int(ver)
+        ttl, bad_ttl = (int(ttl[:-1]), True) if ttl[-1] == "-" else (int(ttl), False)  # noqa: E501
+        ip_opt_len = int(olen)
+        mss = -1 if mss == "*" else int(mss)
+        if wsize == "*":
+            win, win_type = (0, WIN_TYPE_ANY)
+        elif wsize[:3] == "mss":
+            win, win_type = (int(wsize[4:]), WIN_TYPE_MSS)
+        elif wsize[0] == "%":
+            win, win_type = (int(wsize[1:]), WIN_TYPE_MOD)
+        elif wsize[:3] == "mtu":
+            win, win_type = (int(wsize[4:]), WIN_TYPE_MTU)
+        else:
+            win, win_type = (int(wsize), WIN_TYPE_NORMAL)
+        wscale = -1 if scale == "*" else int(scale)
+        if quirks:
+            quirks = frozenset(q for q in quirks.split(","))
+        else:
+            quirks = frozenset()
+        pay_class = -1 if pclass == "*" else int(pclass == "+")
+
+        sig = cls(olayout, quirks, ip_opt_len, ip_ver, ttl, mss, win, win_type, wscale, pay_class, None)  # noqa: E501
+        return sig, bad_ttl
+
+    def __str__(self):
+        quirks = ",".join(q for q in self.quirks)
+        fmt = "%i:%i+%i:%i:%i:%i,%i:%s:%s:%i"
+        s = fmt % (self.ip_ver, self.ttl, guess_dist(self.ttl),
+                   self.ip_opt_len, self.mss, self.win, self.wscale,
+                   self.olayout, quirks, self.pay_class)
+        return s
+
+
+class HTTP_Signature(object):
+    __slots__ = ["http_ver", "hdr", "hdr_set", "habsent", "sw"]
+
+    def __init__(self, http_ver, hdr, hdr_set, habsent, sw):
+        self.http_ver = http_ver
+        self.hdr = hdr
+        self.hdr_set = hdr_set
+        self.habsent = habsent  # None for packet signatures
+        self.sw = sw
+
+    @classmethod
+    def from_packet(cls, pkt):
+        """
+        Receives an HTTP packet (assuming it's valid), and returns
+        a HTTP_Signature object
+        """
+        http_payload = raw(pkt[TCP].payload)
+
+        crlfcrlf = b"\r\n\r\n"
+        crlfcrlfIndex = http_payload.find(crlfcrlf)
+        if crlfcrlfIndex != -1:
+            headers = http_payload[:crlfcrlfIndex + len(crlfcrlf)]
+        else:
+            headers = http_payload
+        headers = headers.decode()  # XXX: Check if this could fail
+        first_line, headers = headers.split("\r\n", 1)
+
+        if "1.0" in first_line:
+            http_ver = 0
+        elif "1.1" in first_line:
+            http_ver = 1
+        else:
+            raise ValueError("HTTP version is not 1.0/1.1")
+
+        sw = ""
+        headers_found = []
+        hdr_set = set()
+        for header_line in headers.split("\r\n"):
+            name, _, value = header_line.partition(":")
+            if value:
+                value = value.strip()
+                headers_found.append((name, value))
+                hdr_set.add(name)
+                if name in ("User-Agent", "Server"):
+                    sw = value
+        hdr = tuple(headers_found)
+        return cls(http_ver, hdr, hdr_set, None, sw)
+
+    @classmethod
+    def from_raw_sig(cls, sig_line):
+        """
+        Parses an HTTP sig line and returns a HTTP_Signature object
+        """
+        ver, horder, habsent, expsw = lparse(sig_line, 4)
+        http_ver = -1 if ver == "*" else int(ver)
+
+        # horder parsing - split by commas that aren't in []
+        new_horder = []
+        for header in re.split(r",(?![^\[]*\])", horder):
+            name, _, value = header.partition("=")
+            if name[0] == "?":  # Optional header
+                new_horder.append((name[1:], value[1:-1], True))
+            else:
+                new_horder.append((name, value[1:-1], False))
+        hdr = tuple(new_horder)
+        hdr_set = frozenset(header[0] for header in hdr if not header[2])
+        habsent = frozenset(habsent.split(","))
+        return cls(http_ver, hdr, hdr_set, habsent, expsw)
+
+    def __str__(self):
+        # values that depend on the context are not included in the string
+        skipval = ("Host", "User-Agent", "Date", "Content-Type", "Server")
+        hdr = ",".join(n if n in skipval else "%s=[%s]" % (n, v) for n, v in self.hdr)  # noqa: E501
+        fmt = "%i:%s::%s"
+        s = fmt % (self.http_ver, hdr, self.sw)
+        return s
+
+
+# Records
+class MTU_Record(object):
+    __slots__ = ["label_id", "mtu"]
+
+    def __init__(self, label_id, sig_line):
+        self.label_id = label_id
+        self.mtu = int(sig_line)
+
+
+class TCP_Record(object):
+    __slots__ = ["label_id", "bad_ttl", "sig"]
+
+    def __init__(self, label_id, sig_line):
+        self.label_id = label_id
+        sig, bad_ttl = TCP_Signature.from_raw_sig(sig_line)
+        self.bad_ttl = bad_ttl
+        self.sig = sig
+
+
+class HTTP_Record(object):
+    __slots__ = ["label_id", "sig"]
+
+    def __init__(self, label_id, sig_line):
+        self.label_id = label_id
+        self.sig = HTTP_Signature.from_raw_sig(sig_line)
 
 
 class p0fKnowledgeBase(KnowledgeBase):
@@ -106,13 +373,12 @@ class p0fKnowledgeBase(KnowledgeBase):
 
                 if param == "sig":
                     if section == "mtu":
-                        curr_records.append((label_id, int(val)))
+                        record_class = MTU_Record
                     elif section == "tcp":
-                        sig = self.tcp_register_sig(val)
-                        curr_records.append((label_id, sig))
+                        record_class = TCP_Record
                     elif section == "http":
-                        sig = self.http_register_sig(val)
-                        curr_records.append((label_id, sig))
+                        record_class = HTTP_Record
+                    curr_records.append(record_class(label_id, val))
 
                 elif param == "label":
                     label_id += 1
@@ -127,59 +393,7 @@ class p0fKnowledgeBase(KnowledgeBase):
                     sys_names = tuple(name for name in val.split(","))
                     self.labels[label_id] += (sys_names,)
 
-    def tcp_register_sig(self, line):
-        """
-        Parses a TCP sig line and returns the signature as a tuple
-        """
-        ver, ttl, olen, mss, wsize, olayout, quirks, pclass = lparse(line, 8)
-        wsize, _, scale = wsize.partition(",")
-
-        ip_ver = -1 if ver == "*" else int(ver)
-        ttl, bad_ttl = (int(ttl[:-1]), True) if ttl[-1] == "-" else (int(ttl), False)  # noqa: E501
-        ip_opt_len = int(olen)
-        mss = -1 if mss == "*" else int(mss)
-        if wsize == "*":
-            win, win_type = (0, WIN_TYPE_ANY)
-        elif wsize[:3] == "mss":
-            win, win_type = (int(wsize[4:]), WIN_TYPE_MSS)
-        elif wsize[0] == "%":
-            win, win_type = (int(wsize[1:]), WIN_TYPE_MOD)
-        elif wsize[:3] == "mtu":
-            win, win_type = (int(wsize[4:]), WIN_TYPE_MTU)
-        else:
-            win, win_type = (int(wsize), WIN_TYPE_NORMAL)
-        wscale = -1 if scale == "*" else int(scale)
-        if quirks:
-            quirks = frozenset(quirks_p0f[q] for q in quirks.split(","))
-        else:
-            quirks = frozenset()
-        pay_class = -1 if pclass == "*" else int(pclass == "+")
-
-        sig = (ip_ver, ttl, bad_ttl, ip_opt_len, mss, win, win_type, wscale, olayout, quirks, pay_class)  # noqa: E501
-        return sig
-
-    def http_register_sig(self, val):
-        """
-        Parses an HTTP sig line and returns the signature as a tuple
-        """
-        ver, horder, habsent, expsw = lparse(val, 4)
-        http_ver = -1 if ver == "*" else int(ver)
-
-        # horder parsing - split by commas that aren't in []
-        new_horder = []
-        for header in re.split(r",(?![^\[]*\])", horder):
-            name, _, value = header.partition("=")
-            if name[0] == "?":  # Optional header
-                new_horder.append((name[1:], value[1:-1], True))
-            else:
-                new_horder.append((name, value[1:-1], False))
-        hdr = tuple(new_horder)
-        hdr_set = frozenset(header[0] for header in hdr if not header[2])
-        habsent = frozenset(habsent.split(","))
-
-        return (http_ver, hdr, hdr_set, habsent, expsw)
-
-    def tcp_find_match(self, tcpsig, direction):
+    def tcp_find_match(self, ts, direction):
         """
         Finds the best match for the given signature and direction.
         If a match is found, returns a tuple consisting of:
@@ -188,67 +402,67 @@ class p0fKnowledgeBase(KnowledgeBase):
         - fuzzy: whether the match is fuzzy
         Returns None if no match was found
         """
-        ver, ttl, olen, mss, win, wscale, olayout, quirks, pclass = tcpsig
-        win_multi, use_mtu = detect_win_multi(tcpsig)
+        win_multi, use_mtu = detect_win_multi(ts)
 
         gmatch = None  # generic match
         fmatch = None  # fuzzy match
-        for label_id, sig in self.base["tcp"][direction]:
-            ver2, ttl2, bad_ttl, olen2, mss2, win2, win_type, wscale2, olayout2, quirks2, pclass2 = sig  # noqa: E501
+        for tcp_record in self.base["tcp"][direction]:
+            rs = tcp_record.sig
 
             fuzzy = False
-            if olayout2 != olayout:
+            ref_quirks = rs.quirks
+
+            if rs.olayout != ts.olayout:
                 continue
 
-            if ver2 == -1:
-                if ver == 4:
-                    quirks2 -= {quirks_p0f["flow"]}
-                else:
-                    quirks2 -= {quirks_p0f[q] for q in ("df", "id+", "id-")}
-            if quirks2 != quirks:
-                deleted = (quirks2 ^ quirks) & quirks2
-                added = (quirks2 ^ quirks) & quirks
+            if rs.ip_ver == -1:
+                ref_quirks -= {"flow"} if ts.ip_ver == 4 else {"df", "id+", "id-"}  # noqa: E501
 
-                if (fmatch or (deleted - {quirks_p0f["df"], quirks_p0f["id+"]}) or  # noqa:E501
-                   (added - {quirks_p0f["id-"], quirks_p0f["ecn"]})):
+            if ref_quirks != ts.quirks:
+                deleted = (ref_quirks ^ ts.quirks) & ref_quirks
+                added = (ref_quirks ^ ts.quirks) & ts.quirks
+
+                if (fmatch or (deleted - {"df", "id+"}) or (added - {"id-", "ecn"})):  # noqa: E501
                     continue
                 fuzzy = True
 
-            if olen2 != olen:
+            if rs.ip_opt_len != ts.ip_opt_len:
                 continue
-            if bad_ttl:
-                if ttl2 < ttl:
+            if tcp_record.bad_ttl:
+                if rs.ttl < ts.ttl:
                     continue
             else:
-                if ttl2 < ttl or ttl2 - ttl > MAX_DIST:
+                if rs.ttl < ts.ttl or rs.ttl - ts.ttl > MAX_DIST:
                     fuzzy = True
 
-            if ((mss2 != -1 and mss2 != mss) or
-               (wscale2 != -1 and wscale2 != wscale) or
-               (pclass2 != -1 and pclass2 != pclass)):
+            if ((rs.mss != -1 and rs.mss != ts.mss) or
+               (rs.wscale != -1 and rs.wscale != ts.wscale) or
+               (rs.pay_class != -1 and rs.pay_class != ts.pay_class)):
                 continue
 
-            if win_type == WIN_TYPE_NORMAL:
-                if win2 != win:
+            if rs.win_type == WIN_TYPE_NORMAL:
+                if rs.win != ts.win:
                     continue
-            elif win_type == WIN_TYPE_MOD:
-                if win % win2:
+            elif rs.win_type == WIN_TYPE_MOD:
+                if ts.win % rs.win:
                     continue
-            elif win_type == WIN_TYPE_MSS:
-                if (use_mtu or win2 != win_multi):
+            elif rs.win_type == WIN_TYPE_MSS:
+                if (use_mtu or rs.win != win_multi):
                     continue
-            elif win_type == WIN_TYPE_MTU:
-                if (not use_mtu or win2 != win_multi):
+            elif rs.win_type == WIN_TYPE_MTU:
+                if (not use_mtu or rs.win != win_multi):
                     continue
 
-            label = self.labels[label_id]
+            # Got a match? If not fuzzy, return. If fuzzy, keep looking.
+            label = self.labels[tcp_record.label_id]
+            match = (label, rs.ttl - ts.ttl, fuzzy)
             if not fuzzy:
                 if label[0] == "s":
-                    return (label, ttl2 - ttl, fuzzy)
+                    return match
                 elif not gmatch:
-                    gmatch = (label, ttl2 - ttl, fuzzy)
+                    gmatch = match
             elif not fmatch:
-                fmatch = (label, ttl2 - ttl, fuzzy)
+                fmatch = match
 
         if gmatch:
             return gmatch
@@ -256,7 +470,7 @@ class p0fKnowledgeBase(KnowledgeBase):
             return fmatch
         return None
 
-    def http_find_match(self, httpsig, direction):
+    def http_find_match(self, ts, direction):
         """
         Finds the best match for the given signature and direction.
         If a match is found, returns a tuple consisting of:
@@ -264,48 +478,46 @@ class p0fKnowledgeBase(KnowledgeBase):
         - dishonest: whether the software was detected as dishonest
         Returns None if no match was found
         """
-        ver, hdr, hdr_set, sw = httpsig
-
         gmatch = None  # generic match
-        for label_id, sig in self.base["http"][direction]:
-            ver2, hdr2, hdr_set2, habsent, expsw = sig
+        for http_record in self.base["http"][direction]:
+            rs = http_record.sig
 
-            if ver2 != -1 and ver2 != ver:
+            if rs.http_ver != -1 and rs.http_ver != ts.http_ver:
                 continue
 
             # Check that all non-optional headers appear in the packet
-            if not (hdr_set & hdr_set2) == hdr_set2:
+            if not (ts.hdr_set & rs.hdr_set) == rs.hdr_set:
                 continue
 
             # Check that no forbidden headers appear in the packet.
-            if len(habsent & hdr_set) > 0:
+            if len(rs.habsent & ts.hdr_set) > 0:
                 continue
 
             def headers_correl():
                 phi = 0  # Packet HTTP header index
-                hdr_len = len(hdr)
+                hdr_len = len(ts.hdr)
 
                 # Confirm the ordering and values of headers
                 # (this is relatively slow, hence the if statements above).
                 # The algorithm is derived from the original p0f/fp_http.c
-                for kh in hdr2:  # kh - KnowledgeBase HTTP header
+                for kh in rs.hdr:
                     orig_phi = phi
                     while (phi < hdr_len and
-                           kh[0] != hdr[phi][0]):
+                           kh[0] != ts.hdr[phi][0]):
                         phi += 1
 
                     if phi == hdr_len:
                         if not kh[2]:
                             return False
 
-                        for ph in hdr:
+                        for ph in ts.hdr:
                             if kh[0] == ph[0]:
                                 return False
 
                         phi = orig_phi
                         continue
 
-                    if kh[1] not in hdr[phi][1]:
+                    if kh[1] not in ts.hdr[phi][1]:
                         return False
                     phi += 1
                 return True
@@ -313,13 +525,14 @@ class p0fKnowledgeBase(KnowledgeBase):
             if not headers_correl():
                 continue
 
-            label = self.labels[label_id]
-            dishonest = expsw and sw and expsw not in sw
-
+            # Got a match
+            label = self.labels[http_record.label_id]
+            dishonest = rs.sw and ts.sw and rs.sw not in ts.sw
+            match = (label, dishonest)
             if label[0] == "s":
-                return label, dishonest
+                return match
             elif not gmatch:
-                gmatch = (label, dishonest)
+                gmatch = match
         return gmatch if gmatch else None
 
     def mtu_find_match(self, mtu):
@@ -328,13 +541,19 @@ class p0fKnowledgeBase(KnowledgeBase):
         If a match is found, returns the label string.
         Returns None if no match was found
         """
-        for label_id, mtu_record in self.base["mtu"]:
-            if mtu == mtu_record:
-                return self.labels[label_id]
+        for mtu_record in self.base["mtu"]:
+            if mtu == mtu_record.mtu:
+                return self.labels[mtu_record.label_id]
         return None
 
 
 p0fdb = p0fKnowledgeBase(conf.p0f_base)
+
+
+def guess_dist(ttl):
+    for ottl in (32, 64, 128, 255):
+        if ttl <= ottl:
+            return ottl - ttl
 
 
 def lparse(line, n, delimiter=":", default=""):
@@ -368,17 +587,17 @@ def preprocess_packet(pkt):
     return pkt
 
 
-def detect_win_multi(tcpsig):
+def detect_win_multi(ts):
     """
     Figure out if window size is a multiplier of MSS or MTU.
-    Returns the multiplier and whether mtu should be used
+    Receives a TCP signature and returns the multiplier and
+    whether mtu should be used
     """
-    mss, win = tcpsig[3], tcpsig[4]
+    mss = ts.mss
+    win = ts.win
     if not win or mss < 100:
         return -1, False
 
-    ip_ver, olayout, quirks = tcpsig[0], tcpsig[6], tcpsig[7]
-    ts1 = "ts" in olayout and quirks_p0f["ts1-"] not in quirks
     options = [
         (mss, False),
         (1500 - MIN_TCP4, False),
@@ -386,9 +605,9 @@ def detect_win_multi(tcpsig):
         (mss + MIN_TCP4, True),
         (1500, True)
     ]
-    if ts1:
+    if ts.ts1:
         options.append((mss - 12, False))
-    if ip_ver == 6:
+    if ts.ip_ver == 6:
         options.append((1500 - MIN_TCP6, False))
         options.append((1500 - MIN_TCP6 - 12, False))
         options.append((mss + MIN_TCP6, True))
@@ -411,7 +630,7 @@ def packet2p0f(pkt):
             direction = "response"
         else:
             direction = "request"
-        sig = packet2tcpsig(pkt)
+        sig = TCP_Signature.from_packet(pkt)
 
     elif pkt[TCP].payload:
         # XXX: guess_payload_class doesn't use any class related attributes
@@ -422,194 +641,10 @@ def packet2p0f(pkt):
             direction = "response"
         else:
             raise TypeError("Not an HTTP payload")
-        sig = packet2httpsig(pkt)
+        sig = HTTP_Signature.from_packet(pkt)
     else:
         raise TypeError("Not a SYN, SYN/ACK, or HTTP packet")
     return sig, direction
-
-
-def packet2tcpsig(pkt):
-    """
-    Receives a TCP packet (assuming it's valid), and returns
-    a TCP signature as a tuple containing:
-    (ip_ver, ttl, ip_opt_len, mss, win, wscale, opt_layout, quirks, pay_class)
-    """
-    ip_ver = pkt.version
-    quirks = set()
-
-    def addq(name):
-        quirks.add(quirks_p0f[name])
-
-    # IPv4/IPv6 parsing
-    if ip_ver == 4:
-        ttl = pkt.ttl
-        ip_opt_len = (pkt.ihl * 4) - 20
-        if pkt.tos & (0x01 | 0x02):
-            addq("ecn")
-        if pkt.flags.evil:
-            addq("0+")
-        if pkt.flags.DF:
-            addq("df")
-            if pkt.id:
-                addq("id+")
-        elif pkt.id == 0:
-            addq("id-")
-    else:
-        ttl = pkt.hlim
-        ip_opt_len = 0
-        if pkt.fl:
-            addq("flow")
-        if pkt.tc & (0x01 | 0x02):
-            addq("ecn")
-
-    # TCP parsing
-    tcp = pkt[TCP]
-    win = tcp.window
-    if tcp.flags & (0x40 | 0x80 | 0x01):
-        addq("ecn")
-    if tcp.seq == 0:
-        addq("seq-")
-    if tcp.flags.A:
-        if tcp.ack == 0:
-            addq("ack-")
-    elif tcp.ack:
-        addq("ack+")
-    if tcp.flags.U:
-        addq("urgf+")
-    elif tcp.urgptr:
-        addq("uptr+")
-    if tcp.flags.P:
-        addq("pushf+")
-
-    pay_class = 1 if tcp.payload else 0
-
-    # Manual TCP options parsing
-    mss = 0
-    wscale = 0
-    olayout = ""
-    optlen = (tcp.dataofs << 2) - 20
-    x = raw(tcp)[-optlen:]  # raw bytes of TCP options
-    while x:
-        onum = orb(x[0])
-        if onum == 0:
-            x = x[1:]
-            olayout += "eol+%i," % len(x)
-            if x.strip(b"\x00"):  # non-zero past EOL
-                addq("opt+")
-            break
-        if onum == 1:
-            x = x[1:]
-            olayout += "nop,"
-            continue
-        try:
-            olen = orb(x[1])
-        except IndexError:  # no room for length field
-            addq("bad")
-            break
-        oval = x[2:olen]
-        if onum in options_p0f:
-            ofmt = TCPOptions[0][onum][1]
-            olayout += "%s," % options_p0f[onum]
-            optsize = 2 + struct.calcsize(ofmt) if ofmt else 2  # total size
-            if len(x) < optsize:  # option would end past end of header
-                addq("bad")
-                break
-
-            if onum == 5:
-                if olen < 10 or olen > 34:  # SACK length out of range
-                    addq("bad")
-                    break
-            else:
-                if olen != optsize:  # length field doesn't fit option type
-                    addq("bad")
-                    break
-                if ofmt:
-                    oval = struct.unpack(ofmt, oval)
-                    if len(oval) == 1:
-                        oval = oval[0]
-                if onum == 2:
-                    mss = oval
-                elif onum == 3:
-                    wscale = oval
-                    if wscale > 14:
-                        addq("exws")
-                elif onum == 8:
-                    if not oval[0]:
-                        addq("ts1-")
-                    if oval[1] and (tcp.flags.S and not tcp.flags.A):
-                        addq("ts2+")
-        else:  # Unknown option, presumably with specified size
-            if olen < 2 or olen > 40 or olen > len(x):
-                addq("bad")
-                break
-        x = x[olen:]
-    olayout = olayout[:-1]
-
-    return (ip_ver, ttl, ip_opt_len, mss, win, wscale, olayout, quirks, pay_class)  # noqa: E501
-
-
-def packet2httpsig(pkt):
-    """
-    Receives an HTTP packet (assuming it's valid), and returns
-    an HTTP signature as a tuple containing:
-    (http_ver, hdr, hdr_set, sw)
-    """
-    http_payload = raw(pkt[TCP].payload)
-
-    crlfcrlf = b"\r\n\r\n"
-    crlfcrlfIndex = http_payload.find(crlfcrlf)
-    if crlfcrlfIndex != -1:
-        headers = http_payload[:crlfcrlfIndex + len(crlfcrlf)]
-    else:
-        headers = http_payload
-    headers = headers.decode()
-    first_line, headers = headers.split("\r\n", 1)
-
-    if "1.0" in first_line:
-        http_ver = 0
-    elif "1.1" in first_line:
-        http_ver = 1
-    else:
-        raise ValueError("HTTP version is not 1.0/1.1")
-
-    sw = ""
-    headers_found = []
-    hdr_set = set()
-    for header_line in headers.split("\r\n"):
-        name, _, value = header_line.partition(":")
-        if value:
-            value = value.strip()
-            headers_found.append((name, value))
-            hdr_set.add(name)
-            if name in ("User-Agent", "Server"):
-                sw = value
-    hdr = tuple(headers_found)
-    return (http_ver, hdr, hdr_set, sw)
-
-
-def sig2str(sig):
-    """
-    Receives a packet TCP/HTTP signature as a tuple and returns
-    a string representation of it
-    """
-    s = ""
-    if len(sig) == 9:  # TCP signature
-        def guess_dist(ttl):
-            for opt in (32, 64, 128):
-                if ttl <= opt:
-                    return opt - ttl
-            return 255 - ttl
-
-        fmt = "%i:%i+%i:%i:%i:%i,%i:%s:%s:%i"
-        s += fmt % (sig[0], sig[1], guess_dist(sig[1]), sig[2],
-                    sig[3], sig[4], sig[5], sig[6], sig[7], sig[8])
-    else:
-        # values that depend on the context are not included in the string
-        skipval = ("Host", "User-Agent", "Date", "Content-Type", "Server")
-        fmt = "%i:%s::%s"
-        hdr = ",".join(n if n in skipval else "%s=[%s]" % (n, v) for n, v in sig[1])  # noqa: E501
-        s += fmt % (sig[0], hdr, sig[3])
-    return s
 
 
 def fingerprint_mtu(pkt):
@@ -642,25 +677,27 @@ def p0f(pkt):
         warning("p0f base empty.")
         return None
 
-    if len(sig) == 9:  # TCP signature
+    if isinstance(sig, TCP_Signature):
         return p0fdb.tcp_find_match(sig, direction)
     else:
         return p0fdb.http_find_match(sig, direction)
 
 
 def prnp0f(pkt):
-    """Calls p0f and returns a user-friendly output"""
+    """Calls p0f and prints a user-friendly output"""
     try:
         r = p0f(pkt)
     except Exception:
         return
 
     sig, direction = packet2p0f(pkt)
-    tcp_sig = len(sig) == 9
-    if tcp_sig:
-        pkt_type = "SYN" if direction == "request" else "SYN+ACK"
+    is_tcp_sig = isinstance(sig, TCP_Signature)
+    to_server = direction == "request"
+
+    if is_tcp_sig:
+        pkt_type = "SYN" if to_server else "SYN+ACK"
     else:
-        pkt_type = "HTTP Request" if direction == "request" else "HTTP Response"  # noqa: E501
+        pkt_type = "HTTP Request" if to_server else "HTTP Response"
 
     res = pkt.sprintf(".-[ %IP.src%:%TCP.sport% -> %IP.dst%:%TCP.dport% (" + pkt_type + ") ]-\n|\n")  # noqa: E501
     fields = []
@@ -668,7 +705,7 @@ def prnp0f(pkt):
     def add_field(name, value):
         fields.append("| %-8s = %s\n" % (name, value))
 
-    cli_or_svr = "Client" if direction == "request" else "Server"
+    cli_or_svr = "Client" if to_server else "Server"
     add_field(cli_or_svr, pkt.sprintf("%IP.src%:%TCP.sport%"))
 
     if r:
@@ -677,13 +714,13 @@ def prnp0f(pkt):
         add_field(app_or_os, label[2] + " " + label[3])
         if len(label) == 5:  # label includes sys
             add_field("Sys", ", ".join(name for name in label[4]))
-        if tcp_sig:
+        if is_tcp_sig:
             add_field("Distance", r[1])
     else:
-        app_or_os = "OS" if tcp_sig else "App"
+        app_or_os = "OS" if is_tcp_sig else "App"
         add_field(app_or_os, "UNKNOWN")
 
-    add_field("Raw sig", sig2str(sig))
+    add_field("Raw sig", str(sig))
 
     res += "".join(fields)
     res += "`____\n"

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -465,7 +465,7 @@ def packet2tcpsig(pkt):
     # TCP parsing
     tcp = pkt[TCP]
     win = tcp.window
-    if tcp.flags.C or tcp.flags.E:
+    if tcp.flags & (0x40 | 0x80 | 0x01):
         addq("ecn")
     if tcp.seq == 0:
         addq("seq-")

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -616,6 +616,9 @@ def fingerprint_mtu(pkt):
     """
     Fingerprints the MTU based on the maximum segment size specified
     in TCP options.
+    Returns a tuple consisting of:
+    - label: the matched label, None if no match
+    - raw_mtu: the calculated raw MTU
     """
     pkt = preprocess_packet(pkt)
     mss = 0
@@ -632,7 +635,7 @@ def fingerprint_mtu(pkt):
         warning("p0f base empty.")
         return None
 
-    return p0fdb.mtu_find_match(mtu)
+    return p0fdb.mtu_find_match(mtu), mtu
 
 
 def p0f(pkt):
@@ -681,6 +684,12 @@ def prnp0f(pkt):
     else:
         app_or_os = "OS" if tcp_sig else "App"
         add_field(app_or_os, "UNKNOWN")
+
+    if tcp_sig:
+        mtu_label, raw_mtu = fingerprint_mtu(pkt)
+        if mtu_label:
+            add_field("Link", mtu_label)
+            add_field("Raw MTU", raw_mtu)
 
     add_field("Raw sig", sig2str(sig))
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -1,127 +1,367 @@
-# This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
-"""
-Clone of p0f passive OS fingerprinting
-"""
-
 from __future__ import absolute_import
 from __future__ import print_function
-import time
+import re
 import struct
-import os
-import socket
-import random
 
 from scapy.data import KnowledgeBase, select_path
 from scapy.config import conf
-from scapy.compat import raw
+from scapy.compat import raw, orb
 from scapy.layers.inet import IP, TCP, TCPOptions
-from scapy.packet import NoPayload, Packet
-from scapy.error import warning, Scapy_Exception, log_runtime
-from scapy.volatile import RandInt, RandByte, RandNum, RandShort, RandString
-from scapy.sendrecv import sniff
-from scapy.modules import six
-if conf.route is None:
-    # unused import, only to initialize conf.route
-    import scapy.route  # noqa: F401
+from scapy.layers.http import HTTP, HTTPRequest, HTTPResponse
+from scapy.layers.inet6 import IPv6
+from scapy.error import warning
+from scapy.modules.six.moves import range
 
 _p0fpaths = ["/etc/p0f", "/usr/share/p0f", "/opt/local"]
-
 conf.p0f_base = select_path(_p0fpaths, "p0f.fp")
-conf.p0fa_base = select_path(_p0fpaths, "p0fa.fp")
-conf.p0fr_base = select_path(_p0fpaths, "p0fr.fp")
-conf.p0fo_base = select_path(_p0fpaths, "p0fo.fp")
 
+MIN_TCP4 = 40  # Min size of IPv4/TCP headers
+MIN_TCP6 = 60  # Min size of IPv6/TCP headers
+MAX_DIST = 35  # Maximum TTL distance for non-fuzzy signature matching
 
-###############
-#  p0f stuff  #
-###############
+WIN_TYPE_NORMAL = 0  # Literal value
+WIN_TYPE_ANY = 1  # Wildcard
+WIN_TYPE_MOD = 2  # Modulo check
+WIN_TYPE_MSS = 3  # Window size MSS multiplier
+WIN_TYPE_MTU = 4  # Window size MTU multiplier
 
-# File format (according to p0f.fp) :
-#
-# wwww:ttt:D:ss:OOO...:QQ:OS:Details
-#
-# wwww    - window size
-# ttt     - initial TTL
-# D       - don't fragment bit  (0=unset, 1=set)
-# ss      - overall SYN packet size
-# OOO     - option value and order specification
-# QQ      - quirks list
-# OS      - OS genre
-# details - OS description
+quirks_p0f = {
+    "df": 0,  # don't fragment flag
+    "id+": 1,  # df set but IPID non-zero
+    "id-": 2,  # df not set but IPID zero
+    "ecn": 3,  # explicit confestion notification support
+    "0+": 4,  # 'must be zero' field not zero
+    "flow": 5,  # non-zero IPv6 flow ID
+    "seq-": 6,  # sequence number is zero
+    "ack+": 7,  # ACK number is non-zero but ACK flag is not set
+    "ack-": 8,  # ACK number is zero but ACK flag is set
+    "uptr+": 9,  # URG pointer is non-zero but URG flag not set
+    "urgf+": 10,  # URG flag used
+    "pushf+": 11,  # PUSH flag used
+    "ts1-": 12,  # own timestamp specified as zero
+    "ts2+": 13,  # non-zero peer timestamp on initial SYN
+    "opt+": 14,  # trailing non-zero data in options segment
+    "exws": 15,  # excessive window scaling factor ( > 14)
+    "bad": 16  # malformed tcp options
+}
+
+options_p0f = {
+    1: "nop",  # no-op option
+    2: "mss",  # maximum segment size
+    3: "ws",  # window scaling
+    4: "sok",  # selective ACK permitted
+    5: "sack",  # selective ACK (should not be seen)
+    8: "ts",  # timestamp
+}
+
 
 class p0fKnowledgeBase(KnowledgeBase):
-    def __init__(self, filename):
-        KnowledgeBase.__init__(self, filename)
-        # self.ttl_range=[255]
+    """
+    self.base = {
+        "mtu" (str): { sig (int): labelnum (int) }
 
+        "tcp"/"http" (str): {
+            direction (str): { sig (tuple): labelnum (int) }
+            }
+    }
+
+    # TODO: parse "sys" lines with labels
+    self.labels = ((generic(str), class(str), name(str), flavor(str), ...)
+    """
     def lazy_init(self):
         try:
             f = open(self.filename)
-        except IOError:
+        except Exception:
             warning("Can't open base %s", self.filename)
             return
-        try:
-            self.base = []
-            for line in f:
-                if line[0] in ["#", "\n"]:
-                    continue
-                line = tuple(line.split(":"))
-                if len(line) < 8:
-                    continue
 
-                def a2i(x):
-                    if x.isdigit():
-                        return int(x)
-                    return x
-                li = [a2i(e) for e in line[1:4]]
-                # if li[0] not in self.ttl_range:
-                #    self.ttl_range.append(li[0])
-                #    self.ttl_range.sort()
-                self.base.append((line[0], li[0], li[1], li[2], line[4],
-                                  line[5], line[6], line[7][:-1]))
-        except Exception:
-            warning("Can't parse p0f database (new p0f version ?)")
-            self.base = None
+        self.base = {}
+        self.labels = []
+        self._parse_file(f)
+        self.labels = tuple(self.labels)
+
+        # Parse mtu, tcp, and http bases
+        self.base["mtu"] = {int(s): l for s, l in self.base["mtu"].items()}
+        self._parse_tcp_base()
+        self._parse_http_base()
         f.close()
 
+    def _parse_file(self, file):
+        """
+        Does actual parsing of the file and stores the data with described
+        structures.
+        TODO: parse "sys" lines to associate labels with user applications
+        """
+        label_id = -1
 
-p0f_kdb, p0fa_kdb, p0fr_kdb, p0fo_kdb = None, None, None, None
+        for line in file:
+            line = line.strip()
 
+            if not line or line[0] == ";":
+                continue
+            if line[0] == "[":
+                section, direction = lparse(line[1:-1], 2)
+                if section == "mtu":
+                    self.base[section] = {}
+                    currsec = self.base[section]
+                else:
+                    if section not in self.base:
+                        self.base[section] = {direction: {}}
+                    elif direction not in self.base[section]:
+                        self.base[section][direction] = {}
+                    currsec = self.base[section][direction]
+            else:
+                param, _, value = line.partition(" = ")
+                param = param.strip()
 
-def p0f_load_knowledgebases():
-    global p0f_kdb, p0fa_kdb, p0fr_kdb, p0fo_kdb
-    p0f_kdb = p0fKnowledgeBase(conf.p0f_base)
-    p0fa_kdb = p0fKnowledgeBase(conf.p0fa_base)
-    p0fr_kdb = p0fKnowledgeBase(conf.p0fr_base)
-    p0fo_kdb = p0fKnowledgeBase(conf.p0fo_base)
+                if param == "sig":
+                    currsec[value] = label_id
 
+                elif param == "label":
+                    label_id += 1
+                    if section == "mtu":
+                        self.labels.append(value)
+                    else:
+                        # label = type:class:name:flavor
+                        t, c, name, flavor = lparse(value, 4)
+                        self.labels.append((t, c, name, flavor))
 
-p0f_load_knowledgebases()
+    def _parse_tcp_base(self):
+        """
+        TCP database signature is a tuple containing:
+        - ver: 4, 6, or -1 (any)
+        - tuple(ttl, bad_ttl(bool))
+        - olen: length of IP options
+        - mss: Maximum segment size (-1 = any)
+        - window: tuple(wsize, wtype)
+        - scale: window scale (-1 = any)
+        - olayout(str): TCP option layout
+        - quirks(frozenset): quirks
+        - pclass: -1 = any, 0 = zero, 1 = non-zero
+        """
+        for direction in "request", "response":
+            newsigs = {}
+            for sig, labelnum in self.base["tcp"][direction].items():
+                ver, ttl, olen, mss, wsize, olayout, quirks, pclass = lparse(sig, 8)  # noqa: E501
+                wsize, _, scale = wsize.partition(",")
 
+                ver = -1 if ver == "*" else int(ver)
+                ttl = (int(ttl[:-1]), True) if ttl[-1] == "-" else (int(ttl), False)  # noqa: E501
+                olen = int(olen)
+                mss = -1 if mss == "*" else int(mss)
+                if wsize == "*":
+                    window = (0, WIN_TYPE_ANY)
+                elif wsize[:3] == "mss":
+                    window = (int(wsize[4:]), WIN_TYPE_MSS)
+                elif wsize[0] == "%":
+                    window = (int(wsize[1:]), WIN_TYPE_MOD)
+                elif wsize[:3] == "mtu":
+                    window = (int(wsize[4:]), WIN_TYPE_MTU)
+                else:
+                    window = (int(wsize), WIN_TYPE_NORMAL)
+                scale = -1 if scale == "*" else int(scale)
+                if quirks:
+                    quirks = frozenset(quirks_p0f[q] for q in quirks.split(","))  # noqa: E501
+                else:
+                    quirks = frozenset()
 
-def p0f_selectdb(flags):
-    # tested flags: S, R, A
-    if flags & 0x16 == 0x2:
-        # SYN
-        return p0f_kdb
-    elif flags & 0x16 == 0x12:
-        # SYN/ACK
-        return p0fa_kdb
-    elif flags & 0x16 in [0x4, 0x14]:
-        # RST RST/ACK
-        return p0fr_kdb
-    elif flags & 0x16 == 0x10:
-        # ACK
-        return p0fo_kdb
-    else:
+                pclass = -1 if pclass == "*" else int(pclass == "+")
+
+                newsigs[(ver, ttl, olen, mss, window,
+                         scale, olayout, quirks, pclass)] = labelnum
+
+            self.base["tcp"][direction] = newsigs
+
+    def _parse_http_base(self):
+        """
+        HTTP database signature is a tuple containing:
+        - ver: 0 (1.0), 1 (1.1), or -1 (any)
+        - horder: tuple((name, value(str), optional(bool)), ...)
+        - headers_set(frozenset): all non-optional header names
+        - habsent(frozenset)
+        - expsw(str)
+        """
+        for direction in "request", "response":
+            newsigs = {}
+            for sig, labelnum in self.base["http"][direction].items():
+                ver, horder, habsent, expsw = lparse(sig, 4)
+
+                ver = -1 if ver == "*" else int(ver)
+
+                # horder parsing - split by commas that aren't in []
+                new_horder = []
+                for header in re.split(r",(?![^\[]*\])", horder):
+                    name, _, value = header.partition("=")
+                    if name[0] == "?":  # Optional header
+                        new_horder.append((name[1:], value[1:-1], True))
+                    else:
+                        new_horder.append((name, value[1:-1], False))
+                horder = tuple(new_horder)
+                headers_set = frozenset(hdr[0] for hdr in horder if not hdr[2])
+                habsent = frozenset(habsent.split(","))
+
+                newsigs[(ver, horder, headers_set, habsent, expsw)] = labelnum
+
+            self.base["http"][direction] = newsigs
+
+    def tcp_find_match(self, tcpsig, direction):
+        """
+        Finds the best match for the given signature and direction.
+        Returns a tuple consisting of:
+        - label: the matched label
+        - dist: guessed distance from the packet source
+        - fuzzy: whether the match is fuzzy
+        """
+        ver, ittl, olen, mss, wsize, scale, olayout, quirks, pclass = tcpsig
+        win_multi, use_mtu = detect_win_multi(wsize, mss)
+
+        gmatch = None  # generic match
+        fmatch = None  # fuzzy match
+        for sig, labelnum in self.base["tcp"][direction].items():
+            sver, sittl, solen, smss, swsize, sscale, solayout, squirks, spclass = sig  # noqa: E501
+
+            fuzzy = False
+            if solayout != olayout:
+                continue
+
+            if sver == -1:
+                if ver == 4:
+                    squirks -= {quirks_p0f["flow"]}
+                else:
+                    squirks -= {quirks_p0f[q] for q in ("df", "id+", "id-")}
+            if squirks != quirks:
+                deleted = (squirks ^ quirks) & squirks
+                added = (squirks ^ quirks) & quirks
+
+                if (fmatch or (deleted - {quirks_p0f["df"], quirks_p0f["id+"]})
+                   or (added - {quirks_p0f["id-"], quirks_p0f["ecn"]})):
+                    continue
+                fuzzy = True
+
+            if solen != olen:
+                continue
+            if sittl[1]:
+                if sittl[0] < ittl:
+                    continue
+            else:
+                if sittl[0] < ittl or sittl[0] - ittl > MAX_DIST:
+                    fuzzy = True
+
+            if ((smss != -1 and smss != mss) or
+               (sscale != -1 and sscale != scale) or
+               (spclass != -1 and spclass != pclass)):
+                continue
+
+            if swsize[1] == WIN_TYPE_NORMAL:
+                if swsize[0] != wsize:
+                    continue
+            elif swsize[1] == WIN_TYPE_MOD:
+                if wsize % swsize[0]:
+                    continue
+            elif swsize[1] == WIN_TYPE_MSS:
+                if (use_mtu or swsize[0] != win_multi):
+                    continue
+            elif swsize[1] == WIN_TYPE_MTU:
+                if (not use_mtu or swsize[0] != win_multi):
+                    continue
+
+            label = self.labels[labelnum]
+            if not fuzzy:
+                if label[0] == "s":
+                    return (label, sittl[0] - ittl, fuzzy)
+                elif not gmatch:
+                    gmatch = (label, sittl[0] - ittl, fuzzy)
+            elif not fmatch:
+                fmatch = (label, sittl[0] - ittl, fuzzy)
+
+        if gmatch:
+            return gmatch
+        if fmatch:
+            return fmatch
         return None
 
+    def http_find_match(self, httpsig, direction):
+        """
+        Finds the best match for the given signature and direction.
+        Returns the matched label.
+        """
+        ver, headers, headers_set = httpsig
 
-def packet2p0f(pkt):
+        gmatch = None  # generic match
+        for sig, labelnum in self.base["http"][direction].items():
+            sver, sheaders, sheaders_set, habsent, expsw = sig
+
+            if sver != -1 and sver != ver:
+                continue
+
+            # Check that all non-optional headers appear in the packet
+            if not (headers_set & sheaders_set) == sheaders_set:
+                continue
+
+            # Check that no forbidden headers appear in the packet.
+            if len(habsent & headers_set) > 0:
+                continue
+
+            def headers_correl():
+                d_hdr = 0  # Database hdr index
+                p_hdr = 0  # Packet hdr index
+
+                # Confirm the ordering and values of headers
+                # (this is relatively slow, hence the if statements above).
+                # The algorithm is taken from the original p0f/fp_http.c
+                for d_hdr in range(len(sheaders)):
+                    orig_p = p_hdr
+                    while (p_hdr < len(headers) and
+                           sheaders[d_hdr][0] != headers[p_hdr][0]):
+                        p_hdr += 1
+
+                    if p_hdr == len(headers):
+                        if not sheaders[d_hdr][2]:
+                            return False
+
+                        for p_hdr in range(len(headers)):
+                            if sheaders[d_hdr][0] == headers[p_hdr][0]:
+                                return False
+
+                        p_hdr = orig_p
+                        continue
+
+                    if sheaders[d_hdr][1] not in headers[p_hdr][1]:
+                        return False
+                    p_hdr += 1
+                return True
+
+            if not headers_correl():
+                continue
+
+            label = self.labels[labelnum]
+            # TODO: check dishonest software
+            if label[0] == "s":
+                return label
+            elif not gmatch:
+                gmatch = label
+
+        return gmatch if gmatch else None
+
+
+p0fdb = p0fKnowledgeBase(conf.p0f_base)
+
+
+def lparse(line, n, default="", splitchar=":"):
+    """
+    Parsing of 'a:b:c:d:e' lines
+    """
+    a = line.split(splitchar)[:n]
+    for elt in a:
+        yield elt
+    for _ in range(n - len(a)):
+        yield default
+
+
+def preprocess_packet(pkt):
+    """
+    Makes sure the packet is an IPv4/IPv6 and TCP packet
+    """
     pkt = pkt.copy()
     pkt = pkt.__class__(raw(pkt))
     while pkt.haslayer(IP) and pkt.haslayer(TCP):
@@ -130,493 +370,249 @@ def packet2p0f(pkt):
             break
         pkt = pkt.payload
 
-    if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
+    if ((not isinstance(pkt, IPv6) and not isinstance(pkt, IP))
+       or not isinstance(pkt.payload, TCP)):
         raise TypeError("Not a TCP/IP packet")
-    # if pkt.payload.flags & 0x7 != 0x02: #S,!F,!R
-    #    raise TypeError("Not a SYN or SYN/ACK packet")
-
-    db = p0f_selectdb(pkt.payload.flags)
-
-    # t = p0f_kdb.ttl_range[:]
-    # t += [pkt.ttl]
-    # t.sort()
-    # ttl=t[t.index(pkt.ttl)+1]
-    ttl = pkt.ttl
-
-    ss = len(pkt)
-    # from p0f/config.h : PACKET_BIG = 100
-    if ss > 100:
-        if db == p0fr_kdb:
-            # p0fr.fp: "Packet size may be wildcarded. The meaning of
-            #           wildcard is, however, hardcoded as 'size >
-            #           PACKET_BIG'"
-            ss = '*'
-        else:
-            ss = 0
-    if db == p0fo_kdb:
-        # p0fo.fp: "Packet size MUST be wildcarded."
-        ss = '*'
-
-    ooo = ""
-    mss = -1
-    qqT = False
-    qqP = False
-    # qqBroken = False
-    ilen = (pkt.payload.dataofs << 2) - 20  # from p0f.c
-    for option in pkt.payload.options:
-        ilen -= 1
-        if option[0] == "MSS":
-            ooo += "M" + str(option[1]) + ","
-            mss = option[1]
-            # FIXME: qqBroken
-            ilen -= 3
-        elif option[0] == "WScale":
-            ooo += "W" + str(option[1]) + ","
-            # FIXME: qqBroken
-            ilen -= 2
-        elif option[0] == "Timestamp":
-            if option[1][0] == 0:
-                ooo += "T0,"
-            else:
-                ooo += "T,"
-            if option[1][1] != 0:
-                qqT = True
-            ilen -= 9
-        elif option[0] == "SAckOK":
-            ooo += "S,"
-            ilen -= 1
-        elif option[0] == "NOP":
-            ooo += "N,"
-        elif option[0] == "EOL":
-            ooo += "E,"
-            if ilen > 0:
-                qqP = True
-        else:
-            if isinstance(option[0], str):
-                ooo += "?%i," % TCPOptions[1][option[0]]
-            else:
-                ooo += "?%i," % option[0]
-            # FIXME: ilen
-    ooo = ooo[:-1]
-    if ooo == "":
-        ooo = "."
-
-    win = pkt.payload.window
-    if mss != -1:
-        if mss != 0 and win % mss == 0:
-            win = "S" + str(win / mss)
-        elif win % (mss + 40) == 0:
-            win = "T" + str(win / (mss + 40))
-    win = str(win)
-
-    qq = ""
-
-    if db == p0fr_kdb:
-        if pkt.payload.flags & 0x10 == 0x10:
-            # p0fr.fp: "A new quirk, 'K', is introduced to denote
-            #           RST+ACK packets"
-            qq += "K"
-    # The two next cases should also be only for p0f*r*, but although
-    # it's not documented (or I have not noticed), p0f seems to
-    # support the '0' and 'Q' quirks on any databases (or at the least
-    # "classical" p0f.fp).
-    if pkt.payload.seq == pkt.payload.ack:
-        # p0fr.fp: "A new quirk, 'Q', is used to denote SEQ number
-        #           equal to ACK number."
-        qq += "Q"
-    if pkt.payload.seq == 0:
-        # p0fr.fp: "A new quirk, '0', is used to denote packets
-        #           with SEQ number set to 0."
-        qq += "0"
-    if qqP:
-        qq += "P"
-    if pkt.id == 0:
-        qq += "Z"
-    if pkt.options != []:
-        qq += "I"
-    if pkt.payload.urgptr != 0:
-        qq += "U"
-    if pkt.payload.reserved != 0:
-        qq += "X"
-    if pkt.payload.ack != 0:
-        qq += "A"
-    if qqT:
-        qq += "T"
-    if db == p0fo_kdb:
-        if pkt.payload.flags & 0x20 != 0:
-            # U
-            # p0fo.fp: "PUSH flag is excluded from 'F' quirk checks"
-            qq += "F"
-    else:
-        if pkt.payload.flags & 0x28 != 0:
-            # U or P
-            qq += "F"
-    if db != p0fo_kdb and not isinstance(pkt.payload.payload, NoPayload):
-        # p0fo.fp: "'D' quirk is not checked for."
-        qq += "D"
-    # FIXME : "!" - broken options segment: not handled yet
-
-    if qq == "":
-        qq = "."
-
-    return (db, (win, ttl, pkt.flags.DF, ss, ooo, qq))
-
-
-def p0f_correl(x, y):
-    d = 0
-    # wwww can be "*" or "%nn". "Tnn" and "Snn" should work fine with
-    # the x[0] == y[0] test.
-    d += (x[0] == y[0] or y[0] == "*" or (y[0][0] == "%" and x[0].isdigit() and (int(x[0]) % int(y[0][1:])) == 0))  # noqa: E501
-    # ttl
-    d += (y[1] >= x[1] and y[1] - x[1] < 32)
-    for i in [2, 5]:
-        d += (x[i] == y[i] or y[i] == '*')
-    # '*' has a special meaning for ss
-    d += x[3] == y[3]
-    xopt = x[4].split(",")
-    yopt = y[4].split(",")
-    if len(xopt) == len(yopt):
-        same = True
-        for i in range(len(xopt)):
-            if not (xopt[i] == yopt[i] or
-                    (len(yopt[i]) == 2 and len(xopt[i]) > 1 and
-                     yopt[i][1] == "*" and xopt[i][0] == yopt[i][0]) or
-                    (len(yopt[i]) > 2 and len(xopt[i]) > 1 and
-                     yopt[i][1] == "%" and xopt[i][0] == yopt[i][0] and
-                     int(xopt[i][1:]) % int(yopt[i][2:]) == 0)):
-                same = False
-                break
-        if same:
-            d += len(xopt)
-    return d
-
-
-@conf.commands.register
-def p0f(pkt):
-    """Passive OS fingerprinting: which OS emitted this TCP packet ?
-p0f(packet) -> accuracy, [list of guesses]
-"""
-    db, sig = packet2p0f(pkt)
-    if db:
-        pb = db.get_base()
-    else:
-        pb = []
-    if not pb:
-        warning("p0f base empty.")
-        return []
-    # s = len(pb[0][0])
-    r = []
-    max = len(sig[4].split(",")) + 5
-    for b in pb:
-        d = p0f_correl(sig, b)
-        if d == max:
-            r.append((b[6], b[7], b[1] - pkt[IP].ttl))
-    return r
-
-
-def prnp0f(pkt):
-    """Calls p0f and returns a user-friendly output"""
-    # we should print which DB we use
-    try:
-        r = p0f(pkt)
-    except Exception:
-        return
-    if r == []:
-        r = ("UNKNOWN", "[" + ":".join(map(str, packet2p0f(pkt)[1])) + ":?:?]", None)  # noqa: E501
-    else:
-        r = r[0]
-    uptime = None
-    try:
-        uptime = pkt2uptime(pkt)
-    except Exception:
-        pass
-    if uptime == 0:
-        uptime = None
-    res = pkt.sprintf("%IP.src%:%TCP.sport% - " + r[0] + " " + r[1])
-    if uptime is not None:
-        res += pkt.sprintf(" (up: " + str(uptime / 3600) + " hrs)\n  -> %IP.dst%:%TCP.dport% (%TCP.flags%)")  # noqa: E501
-    else:
-        res += pkt.sprintf("\n  -> %IP.dst%:%TCP.dport% (%TCP.flags%)")
-    if r[2] is not None:
-        res += " (distance " + str(r[2]) + ")"
-    print(res)
-
-
-@conf.commands.register
-def pkt2uptime(pkt, HZ=100):
-    """Calculate the date the machine which emitted the packet booted using TCP timestamp  # noqa: E501
-pkt2uptime(pkt, [HZ=100])"""
-    if not isinstance(pkt, Packet):
-        raise TypeError("Not a TCP packet")
-    if isinstance(pkt, NoPayload):
-        raise TypeError("Not a TCP packet")
-    if not isinstance(pkt, TCP):
-        return pkt2uptime(pkt.payload)
-    for opt in pkt.options:
-        if opt[0] == "Timestamp":
-            # t = pkt.time - opt[1][0] * 1.0/HZ
-            # return time.ctime(t)
-            t = opt[1][0] / HZ
-            return t
-    raise TypeError("No timestamp option")
-
-
-def p0f_impersonate(pkt, osgenre=None, osdetails=None, signature=None,
-                    extrahops=0, mtu=1500, uptime=None):
-    """Modifies pkt so that p0f will think it has been sent by a
-specific OS.  If osdetails is None, then we randomly pick up a
-personality matching osgenre. If osgenre and signature are also None,
-we use a local signature (using p0f_getlocalsigs). If signature is
-specified (as a tuple), we use the signature.
-
-For now, only TCP Syn packets are supported.
-Some specifications of the p0f.fp file are not (yet) implemented."""
-    pkt = pkt.copy()
-    # pkt = pkt.__class__(raw(pkt))
-    while pkt.haslayer(IP) and pkt.haslayer(TCP):
-        pkt = pkt.getlayer(IP)
-        if isinstance(pkt.payload, TCP):
-            break
-        pkt = pkt.payload
-
-    if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
-        raise TypeError("Not a TCP/IP packet")
-
-    db = p0f_selectdb(pkt.payload.flags)
-    if osgenre:
-        pb = db.get_base()
-        if pb is None:
-            pb = []
-        pb = [x for x in pb if x[6] == osgenre]
-        if osdetails:
-            pb = [x for x in pb if x[7] == osdetails]
-    elif signature:
-        pb = [signature]
-    else:
-        pb = p0f_getlocalsigs()[db]
-    if db == p0fr_kdb:
-        # 'K' quirk <=> RST+ACK
-        if pkt.payload.flags & 0x4 == 0x4:
-            pb = [x for x in pb if 'K' in x[5]]
-        else:
-            pb = [x for x in pb if 'K' not in x[5]]
-    if not pb:
-        raise Scapy_Exception("No match in the p0f database")
-    pers = pb[random.randint(0, len(pb) - 1)]
-
-    # options (we start with options because of MSS)
-    # Take the options already set as "hints" to use in the new packet if we
-    # can. MSS, WScale and Timestamp can all be wildcarded in a signature, so
-    # we'll use the already-set values if they're valid integers.
-    orig_opts = dict(pkt.payload.options)
-    int_only = lambda val: val if isinstance(val, six.integer_types) else None
-    mss_hint = int_only(orig_opts.get('MSS'))
-    wscale_hint = int_only(orig_opts.get('WScale'))
-    ts_hint = [int_only(o) for o in orig_opts.get('Timestamp', (None, None))]
-
-    options = []
-    if pers[4] != '.':
-        for opt in pers[4].split(','):
-            if opt[0] == 'M':
-                # MSS might have a maximum size because of window size
-                # specification
-                if pers[0][0] == 'S':
-                    maxmss = (2**16 - 1) // int(pers[0][1:])
-                else:
-                    maxmss = (2**16 - 1)
-                # disregard hint if out of range
-                if mss_hint and not 0 <= mss_hint <= maxmss:
-                    mss_hint = None
-                # If we have to randomly pick up a value, we cannot use
-                # scapy RandXXX() functions, because the value has to be
-                # set in case we need it for the window size value. That's
-                # why we use random.randint()
-                if opt[1:] == '*':
-                    if mss_hint is not None:
-                        options.append(('MSS', mss_hint))
-                    else:
-                        options.append(('MSS', random.randint(1, maxmss)))
-                elif opt[1] == '%':
-                    coef = int(opt[2:])
-                    if mss_hint is not None and mss_hint % coef == 0:
-                        options.append(('MSS', mss_hint))
-                    else:
-                        options.append((
-                            'MSS', coef * random.randint(1, maxmss // coef)))
-                else:
-                    options.append(('MSS', int(opt[1:])))
-            elif opt[0] == 'W':
-                if wscale_hint and not 0 <= wscale_hint < 2**8:
-                    wscale_hint = None
-                if opt[1:] == '*':
-                    if wscale_hint is not None:
-                        options.append(('WScale', wscale_hint))
-                    else:
-                        options.append(('WScale', RandByte()))
-                elif opt[1] == '%':
-                    coef = int(opt[2:])
-                    if wscale_hint is not None and wscale_hint % coef == 0:
-                        options.append(('WScale', wscale_hint))
-                    else:
-                        options.append((
-                            'WScale', coef * RandNum(min=1, max=(2**8 - 1) // coef)))  # noqa: E501
-                else:
-                    options.append(('WScale', int(opt[1:])))
-            elif opt == 'T0':
-                options.append(('Timestamp', (0, 0)))
-            elif opt == 'T':
-                # Determine first timestamp.
-                if uptime is not None:
-                    ts_a = uptime
-                elif ts_hint[0] and 0 < ts_hint[0] < 2**32:
-                    # Note: if first ts is 0, p0f registers it as "T0" not "T",
-                    # hence we don't want to use the hint if it was 0.
-                    ts_a = ts_hint[0]
-                else:
-                    ts_a = random.randint(120, 100 * 60 * 60 * 24 * 365)
-                # Determine second timestamp.
-                if 'T' not in pers[5]:
-                    ts_b = 0
-                elif ts_hint[1] and 0 < ts_hint[1] < 2**32:
-                    ts_b = ts_hint[1]
-                else:
-                    # FIXME: RandInt() here does not work (bug (?) in
-                    # TCPOptionsField.m2i often raises "OverflowError:
-                    # long int too large to convert to int" in:
-                    #    oval = struct.pack(ofmt, *oval)"
-                    # Actually, this is enough to often raise the error:
-                    #    struct.pack('I', RandInt())
-                    ts_b = random.randint(1, 2**32 - 1)
-                options.append(('Timestamp', (ts_a, ts_b)))
-            elif opt == 'S':
-                options.append(('SAckOK', ''))
-            elif opt == 'N':
-                options.append(('NOP', None))
-            elif opt == 'E':
-                options.append(('EOL', None))
-            elif opt[0] == '?':
-                if int(opt[1:]) in TCPOptions[0]:
-                    optname = TCPOptions[0][int(opt[1:])][0]
-                    optstruct = TCPOptions[0][int(opt[1:])][1]
-                    options.append((optname,
-                                    struct.unpack(optstruct,
-                                                  RandString(struct.calcsize(optstruct))._fix())))  # noqa: E501
-                else:
-                    options.append((int(opt[1:]), ''))
-            # FIXME: qqP not handled
-            else:
-                warning("unhandled TCP option %s", opt)
-            pkt.payload.options = options
-
-    # window size
-    if pers[0] == '*':
-        pkt.payload.window = RandShort()
-    elif pers[0].isdigit():
-        pkt.payload.window = int(pers[0])
-    elif pers[0][0] == '%':
-        coef = int(pers[0][1:])
-        pkt.payload.window = coef * RandNum(min=1, max=(2**16 - 1) // coef)
-    elif pers[0][0] == 'T':
-        pkt.payload.window = mtu * int(pers[0][1:])
-    elif pers[0][0] == 'S':
-        # needs MSS set
-        mss = [x for x in options if x[0] == 'MSS']
-        if not mss:
-            raise Scapy_Exception("TCP window value requires MSS, and MSS option not set")  # noqa: E501
-        pkt.payload.window = mss[0][1] * int(pers[0][1:])
-    else:
-        raise Scapy_Exception('Unhandled window size specification')
-
-    # ttl
-    pkt.ttl = pers[1] - extrahops
-    # DF flag
-    pkt.flags |= (2 * pers[2])
-    # FIXME: ss (packet size) not handled (how ? may be with D quirk
-    # if present)
-    # Quirks
-    if pers[5] != '.':
-        for qq in pers[5]:
-            # FIXME: not handled: P, I, X, !
-            # T handled with the Timestamp option
-            if qq == 'Z':
-                pkt.id = 0
-            elif qq == 'U':
-                pkt.payload.urgptr = RandShort()
-            elif qq == 'A':
-                pkt.payload.ack = RandInt()
-            elif qq == 'F':
-                if db == p0fo_kdb:
-                    pkt.payload.flags |= 0x20  # U
-                else:
-                    pkt.payload.flags |= random.choice([8, 32, 40])  # P/U/PU
-            elif qq == 'D' and db != p0fo_kdb:
-                pkt /= conf.raw_layer(load=RandString(random.randint(1, 10)))  # XXX p0fo.fp  # noqa: E501
-            elif qq == 'Q':
-                pkt.payload.seq = pkt.payload.ack
-            # elif qq == '0': pkt.payload.seq = 0
-        # if db == p0fr_kdb:
-        # '0' quirk is actually not only for p0fr.fp (see
-        # packet2p0f())
-    if '0' in pers[5]:
-        pkt.payload.seq = 0
-    elif pkt.payload.seq == 0:
-        pkt.payload.seq = RandInt()
-
-    while pkt.underlayer:
-        pkt = pkt.underlayer
     return pkt
 
 
-def p0f_getlocalsigs():
-    """This function returns a dictionary of signatures indexed by p0f
-db (e.g., p0f_kdb, p0fa_kdb, ...) for the local TCP/IP stack.
+def detect_win_multi(win, mss):
+    """
+    Figure out if window size is a multiplier of MSS or MTU.
+    """
+    default_mtu = False
+    default_multi = -1
+    if win or mss > 100:
+        options = (
+            (mss, False),  # MSS
+            (mss - 12, False),  # MSS - 12
+            (1500 - MIN_TCP4, False),  # MSS (MTU = 1500, IPv4)
+            (1500 - MIN_TCP4 - 12, False),  # MSS (MTU = 1500, IPv4 - 12)
+            (1500 - MIN_TCP6, False),  # MSS (MTU = 1500, IPv6)
+            (1500 - MIN_TCP6 - 12, False),  # MSS (MTU = 1500, IPv6 - 12)
+            (mss + MIN_TCP4, True),  # MTU (IPv4)
+            (mss + MIN_TCP6, True),  # MTU (IPv6)
+            (1500, True)  # MTU (1500)
+        )
+        for div, use_mtu in options:
+            if not (win % div):
+                return win / div, use_mtu
+    return default_multi, default_mtu
 
-You need to have your firewall at least accepting the TCP packets
-from/to a high port (30000 <= x <= 40000) on your loopback interface.
 
-Please note that the generated signatures come from the loopback
-interface and may (are likely to) be different than those generated on
-"normal" interfaces."""
-    pid = os.fork()
-    port = random.randint(30000, 40000)
-    if pid > 0:
-        # parent: sniff
-        result = {}
+def packet2p0f(pkt):
+    """
+    Returns a p0f signature of the packet, and the direction
+    """
+    pkt = preprocess_packet(pkt)
 
-        def addresult(res):
-            # TODO: wildcard window size in some cases? and maybe some
-            # other values?
-            if res[0] not in result:
-                result[res[0]] = [res[1]]
-            else:
-                if res[1] not in result[res[0]]:
-                    result[res[0]].append(res[1])
-        # XXX could we try with a "normal" interface using other hosts
-        iface = conf.route.route('127.0.0.1')[0]
-        # each packet is seen twice: S + RA, S + SA + A + FA + A
-        # XXX are the packets also seen twice on non Linux systems ?
-        count = 14
-        pl = sniff(iface=iface, filter='tcp and port ' + str(port), count=count, timeout=3)  # noqa: E501
-        for pkt in pl:
-            for elt in packet2p0f(pkt):
-                addresult(elt)
-        os.waitpid(pid, 0)
-    elif pid < 0:
-        log_runtime.error("fork error")
+    if pkt[TCP].flags.S:
+        if pkt[TCP].flags.A:
+            direction = "response"
+        else:
+            direction = "request"
+        sig = packet2tcpsig(pkt)
+
+    elif pkt[TCP].payload:
+        # XXX: guess_payload_class doesn't use any class related attributes
+        pclass = HTTP().guess_payload_class(raw(pkt[TCP].payload))
+        if pclass == HTTPRequest:
+            direction = "request"
+        elif pclass == HTTPResponse:
+            direction = "response"
+        else:
+            raise TypeError("Not an HTTP payload")
+        sig = packet2httpsig(pkt)
     else:
-        # child: send
-        # XXX erk
-        time.sleep(1)
-        s1 = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
-        # S & RA
+        raise TypeError("Not a SYN, SYN/ACK, or HTTP packet")
+    return sig, direction
+
+
+def packet2tcpsig(pkt):
+    """
+    TCP packet signature is a tuple containing:
+    (ver(int), ttl(int), ip_opt_len(int), mss(int), wsize(int),
+     scale(int), olayout(str), quirks(set), pclass(int))
+    """
+    ver = pkt.version
+    quirks = set()
+
+    def addq(name):
+        quirks.add(quirks_p0f[name])
+
+    # IPv4/IPv6 parsing
+    if ver == 4:
+        ittl = pkt.ttl
+        ip_opt_len = (pkt.ihl * 4) - 20
+        if (pkt.tos & 0x3) in (0x1, 0x2, 0x3):
+            addq("ecn")
+        if pkt.flags.evil:
+            addq("0+")
+        if pkt.flags.DF:
+            addq("df")
+            if pkt.id:
+                addq("id+")
+        elif pkt.id == 0:
+            addq("id-")
+    else:
+        ittl = pkt.hlim
+        ip_opt_len = 0
+        if pkt.fl:
+            addq("flow")
+        if (pkt.tc & 0x3) in (0x1, 0x2, 0x3):
+            addq("ecn")
+
+    # TCP parsing
+    tcp = pkt[TCP]
+    wsize = tcp.window
+    if tcp.flags.C or tcp.flags.E:
+        addq("ecn")
+    if tcp.seq == 0:
+        addq("seq-")
+    if tcp.flags.A:
+        if tcp.ack == 0:
+            addq("ack-")
+    else:
+        if tcp.ack:
+            addq("ack+")
+    if tcp.flags.U:
+        addq("urgf+")
+    else:
+        if tcp.urgptr:
+            addq("uptr+")
+    if tcp.flags.P:
+        addq("pushf+")
+
+    pclass = 1 if tcp.payload else 0
+
+    # Manual TCP options parsing
+    mss = 0
+    scale = 0
+    olayout = ""
+    optlen = (tcp.dataofs << 2) - 20
+    x = raw(tcp)[-optlen:]  # raw bytes of TCP options
+    while x:
+        onum = orb(x[0])
+        if onum == 0:
+            x = x[1:]
+            olayout += "eol+%i," % len(x)
+            if x.strip(b"\x00"):  # non-zero past EOL
+                addq("opt+")
+            break
+        if onum == 1:
+            x = x[1:]
+            olayout += "nop,"
+            continue
         try:
-            s1.connect(('127.0.0.1', port))
-        except socket.error:
-            pass
-        # S, SA, A, FA, A
-        s1.bind(('127.0.0.1', port))
-        s1.connect(('127.0.0.1', port))
-        # howto: get an RST w/o ACK packet
-        s1.close()
-        os._exit(0)
-    return result
+            olen = orb(x[1])
+        except IndexError:  # no room for length field
+            addq("bad")
+            break
+        oval = x[2:olen]
+        if onum in (2, 3, 4, 5, 8):
+            ofmt = TCPOptions[0][onum][1]
+            olayout += "%s," % options_p0f[onum]
+            optsize = 2 + struct.calcsize(ofmt) if ofmt else 2  # total size
+            if len(x) < optsize:  # option would end past end of header
+                addq("bad")
+                break
+
+            if onum == 5:
+                if olen < 10 or olen > 34:  # SACK length out of range
+                    addq("bad")
+                    break
+            else:
+                if olen != optsize:  # length field doesn't fit option type
+                    addq("bad")
+                    break
+                if ofmt:
+                    oval = struct.unpack(ofmt, oval)
+                    if len(oval) == 1:
+                        oval = oval[0]
+                if onum == 2:
+                    mss = oval
+                elif onum == 3:
+                    scale = oval
+                    if scale > 14:
+                        addq("exws")
+                elif onum == 8:
+                    if not oval[0]:
+                        addq("ts1-")
+                    if oval[1] and (tcp.flags.S and not tcp.flags.A):
+                        addq("ts2+")
+        else:  # Unknown option, presumably with specified size
+            if (olen < 2 or olen > 40) or (olen > len(x)):
+                addq("bad")
+                break
+        x = x[olen:]
+    olayout = olayout[:-1]
+
+    return (ver, ittl, ip_opt_len, mss, wsize, scale, olayout, quirks, pclass)
+
+
+def packet2httpsig(pkt):
+    """
+    HTTP packet signature is a tuple containing:
+    (ver(int), headers(name, value(str), headers_set(set))
+    """
+    http_payload = raw(pkt[TCP].payload)
+
+    crlfcrlf = b"\r\n\r\n"
+    crlfcrlfIndex = http_payload.find(crlfcrlf)
+    if crlfcrlfIndex != -1:
+        headers = http_payload[:crlfcrlfIndex + len(crlfcrlf)]
+    else:
+        headers = http_payload
+    headers = headers.decode()
+    first_line, headers = headers.split("\r\n", 1)
+
+    if "1.0" in first_line:
+        ver = 0
+    elif "1.1" in first_line:
+        ver = 1
+    else:
+        raise ValueError("HTTP version is not 1.0/1.1")
+
+    headers_found = []
+    for header_line in headers.split("\r\n"):
+        name, _, value = header_line.partition(": ")
+        if value:
+            headers_found.append((name, value))
+    headers = tuple(headers_found)
+    headers_set = {hdr[0] for hdr in headers}
+    return (ver, headers, headers_set)
+
+def fingerprint_mtu(pkt):
+    """
+    Fingerprints the MTU based on the maximum segment size specified
+    in TCP options.
+    """
+    pkt = preprocess_packet(pkt)
+    mss = 0
+    for name, value in pkt.payload.options:
+        if name == "MSS":
+            mss = value
+
+    if not mss:
+        return None
+
+    mtu = (mss + MIN_TCP4) if pkt.version == 4 else (mss + MIN_TCP6)
+
+    db = p0fdb.get_base()
+    if db and mtu in db["mtu"]:
+        labelnum = db["mtu"][mtu]
+        return p0fdb.labels[labelnum]
+    return None
+
+def p0f(pkt):
+    sig, direction = packet2p0f(pkt)
+    if not p0fdb.get_base():
+        warning("p0f base empty.")
+        return None
+
+    match = None
+    if len(sig) == 9:  # TCP signature
+        match = p0fdb.tcp_find_match(sig, direction)
+    else:
+        match = p0fdb.http_find_match(sig, direction)
+    return match

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -38,7 +38,7 @@ WIN_TYPE_MOD = 2  # Modulo check
 WIN_TYPE_MSS = 3  # Window size MSS multiplier
 WIN_TYPE_MTU = 4  # Window size MTU multiplier
 
-# Convert TCP option num to p0f (nop is handled seperately)
+# Convert TCP option num to p0f (nop is handled separately)
 tcp_options_p0f = {
     2: "mss",  # maximum segment size
     3: "ws",  # window scaling

--- a/scapy/modules/p0fv2.py
+++ b/scapy/modules/p0fv2.py
@@ -1,0 +1,623 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+# This program is published under a GPLv2 license
+
+"""
+Clone of p0f passive OS fingerprinting
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import time
+import struct
+import os
+import socket
+import random
+
+from scapy.data import KnowledgeBase, select_path
+from scapy.config import conf
+from scapy.compat import raw
+from scapy.layers.inet import IP, TCP, TCPOptions
+from scapy.packet import NoPayload, Packet
+from scapy.error import warning, Scapy_Exception, log_runtime
+from scapy.volatile import RandInt, RandByte, RandNum, RandShort, RandString
+from scapy.sendrecv import sniff
+from scapy.modules import six
+from scapy.modules.six.moves import map, range
+if conf.route is None:
+    # unused import, only to initialize conf.route
+    import scapy.route  # noqa: F401
+
+_p0fpaths = ["/etc/p0f", "/usr/share/p0f", "/opt/local"]
+
+conf.p0f_base = select_path(_p0fpaths, "p0f.fp")
+conf.p0fa_base = select_path(_p0fpaths, "p0fa.fp")
+conf.p0fr_base = select_path(_p0fpaths, "p0fr.fp")
+conf.p0fo_base = select_path(_p0fpaths, "p0fo.fp")
+
+
+###############
+#  p0f stuff  #
+###############
+
+# File format (according to p0f.fp) :
+#
+# wwww:ttt:D:ss:OOO...:QQ:OS:Details
+#
+# wwww    - window size
+# ttt     - initial TTL
+# D       - don't fragment bit  (0=unset, 1=set)
+# ss      - overall SYN packet size
+# OOO     - option value and order specification
+# QQ      - quirks list
+# OS      - OS genre
+# details - OS description
+
+class p0fKnowledgeBase(KnowledgeBase):
+    def __init__(self, filename):
+        KnowledgeBase.__init__(self, filename)
+        # self.ttl_range=[255]
+
+    def lazy_init(self):
+        try:
+            f = open(self.filename)
+        except IOError:
+            warning("Can't open base %s", self.filename)
+            return
+        try:
+            self.base = []
+            for line in f:
+                if line[0] in ["#", "\n"]:
+                    continue
+                line = tuple(line.split(":"))
+                if len(line) < 8:
+                    continue
+
+                def a2i(x):
+                    if x.isdigit():
+                        return int(x)
+                    return x
+                li = [a2i(e) for e in line[1:4]]
+                # if li[0] not in self.ttl_range:
+                #    self.ttl_range.append(li[0])
+                #    self.ttl_range.sort()
+                self.base.append((line[0], li[0], li[1], li[2], line[4],
+                                  line[5], line[6], line[7][:-1]))
+        except Exception:
+            warning("Can't parse p0f database (new p0f version ?)")
+            self.base = None
+        f.close()
+
+
+p0f_kdb, p0fa_kdb, p0fr_kdb, p0fo_kdb = None, None, None, None
+
+
+def p0f_load_knowledgebases():
+    global p0f_kdb, p0fa_kdb, p0fr_kdb, p0fo_kdb
+    p0f_kdb = p0fKnowledgeBase(conf.p0f_base)
+    p0fa_kdb = p0fKnowledgeBase(conf.p0fa_base)
+    p0fr_kdb = p0fKnowledgeBase(conf.p0fr_base)
+    p0fo_kdb = p0fKnowledgeBase(conf.p0fo_base)
+
+
+p0f_load_knowledgebases()
+
+
+def p0f_selectdb(flags):
+    # tested flags: S, R, A
+    if flags & 0x16 == 0x2:
+        # SYN
+        return p0f_kdb
+    elif flags & 0x16 == 0x12:
+        # SYN/ACK
+        return p0fa_kdb
+    elif flags & 0x16 in [0x4, 0x14]:
+        # RST RST/ACK
+        return p0fr_kdb
+    elif flags & 0x16 == 0x10:
+        # ACK
+        return p0fo_kdb
+    else:
+        return None
+
+
+def packet2p0f(pkt):
+    pkt = pkt.copy()
+    pkt = pkt.__class__(raw(pkt))
+    while pkt.haslayer(IP) and pkt.haslayer(TCP):
+        pkt = pkt.getlayer(IP)
+        if isinstance(pkt.payload, TCP):
+            break
+        pkt = pkt.payload
+
+    if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
+        raise TypeError("Not a TCP/IP packet")
+    # if pkt.payload.flags & 0x7 != 0x02: #S,!F,!R
+    #    raise TypeError("Not a SYN or SYN/ACK packet")
+
+    db = p0f_selectdb(pkt.payload.flags)
+
+    # t = p0f_kdb.ttl_range[:]
+    # t += [pkt.ttl]
+    # t.sort()
+    # ttl=t[t.index(pkt.ttl)+1]
+    ttl = pkt.ttl
+
+    ss = len(pkt)
+    # from p0f/config.h : PACKET_BIG = 100
+    if ss > 100:
+        if db == p0fr_kdb:
+            # p0fr.fp: "Packet size may be wildcarded. The meaning of
+            #           wildcard is, however, hardcoded as 'size >
+            #           PACKET_BIG'"
+            ss = '*'
+        else:
+            ss = 0
+    if db == p0fo_kdb:
+        # p0fo.fp: "Packet size MUST be wildcarded."
+        ss = '*'
+
+    ooo = ""
+    mss = -1
+    qqT = False
+    qqP = False
+    # qqBroken = False
+    ilen = (pkt.payload.dataofs << 2) - 20  # from p0f.c
+    for option in pkt.payload.options:
+        ilen -= 1
+        if option[0] == "MSS":
+            ooo += "M" + str(option[1]) + ","
+            mss = option[1]
+            # FIXME: qqBroken
+            ilen -= 3
+        elif option[0] == "WScale":
+            ooo += "W" + str(option[1]) + ","
+            # FIXME: qqBroken
+            ilen -= 2
+        elif option[0] == "Timestamp":
+            if option[1][0] == 0:
+                ooo += "T0,"
+            else:
+                ooo += "T,"
+            if option[1][1] != 0:
+                qqT = True
+            ilen -= 9
+        elif option[0] == "SAckOK":
+            ooo += "S,"
+            ilen -= 1
+        elif option[0] == "NOP":
+            ooo += "N,"
+        elif option[0] == "EOL":
+            ooo += "E,"
+            if ilen > 0:
+                qqP = True
+        else:
+            if isinstance(option[0], str):
+                ooo += "?%i," % TCPOptions[1][option[0]]
+            else:
+                ooo += "?%i," % option[0]
+            # FIXME: ilen
+    ooo = ooo[:-1]
+    if ooo == "":
+        ooo = "."
+
+    win = pkt.payload.window
+    if mss != -1:
+        if mss != 0 and win % mss == 0:
+            win = "S" + str(win / mss)
+        elif win % (mss + 40) == 0:
+            win = "T" + str(win / (mss + 40))
+    win = str(win)
+
+    qq = ""
+
+    if db == p0fr_kdb:
+        if pkt.payload.flags & 0x10 == 0x10:
+            # p0fr.fp: "A new quirk, 'K', is introduced to denote
+            #           RST+ACK packets"
+            qq += "K"
+    # The two next cases should also be only for p0f*r*, but although
+    # it's not documented (or I have not noticed), p0f seems to
+    # support the '0' and 'Q' quirks on any databases (or at the least
+    # "classical" p0f.fp).
+    if pkt.payload.seq == pkt.payload.ack:
+        # p0fr.fp: "A new quirk, 'Q', is used to denote SEQ number
+        #           equal to ACK number."
+        qq += "Q"
+    if pkt.payload.seq == 0:
+        # p0fr.fp: "A new quirk, '0', is used to denote packets
+        #           with SEQ number set to 0."
+        qq += "0"
+    if qqP:
+        qq += "P"
+    if pkt.id == 0:
+        qq += "Z"
+    if pkt.options != []:
+        qq += "I"
+    if pkt.payload.urgptr != 0:
+        qq += "U"
+    if pkt.payload.reserved != 0:
+        qq += "X"
+    if pkt.payload.ack != 0:
+        qq += "A"
+    if qqT:
+        qq += "T"
+    if db == p0fo_kdb:
+        if pkt.payload.flags & 0x20 != 0:
+            # U
+            # p0fo.fp: "PUSH flag is excluded from 'F' quirk checks"
+            qq += "F"
+    else:
+        if pkt.payload.flags & 0x28 != 0:
+            # U or P
+            qq += "F"
+    if db != p0fo_kdb and not isinstance(pkt.payload.payload, NoPayload):
+        # p0fo.fp: "'D' quirk is not checked for."
+        qq += "D"
+    # FIXME : "!" - broken options segment: not handled yet
+
+    if qq == "":
+        qq = "."
+
+    return (db, (win, ttl, pkt.flags.DF, ss, ooo, qq))
+
+
+def p0f_correl(x, y):
+    d = 0
+    # wwww can be "*" or "%nn". "Tnn" and "Snn" should work fine with
+    # the x[0] == y[0] test.
+    d += (x[0] == y[0] or y[0] == "*" or (y[0][0] == "%" and x[0].isdigit() and (int(x[0]) % int(y[0][1:])) == 0))  # noqa: E501
+    # ttl
+    d += (y[1] >= x[1] and y[1] - x[1] < 32)
+    for i in [2, 5]:
+        d += (x[i] == y[i] or y[i] == '*')
+    # '*' has a special meaning for ss
+    d += x[3] == y[3]
+    xopt = x[4].split(",")
+    yopt = y[4].split(",")
+    if len(xopt) == len(yopt):
+        same = True
+        for i in range(len(xopt)):
+            if not (xopt[i] == yopt[i] or
+                    (len(yopt[i]) == 2 and len(xopt[i]) > 1 and
+                     yopt[i][1] == "*" and xopt[i][0] == yopt[i][0]) or
+                    (len(yopt[i]) > 2 and len(xopt[i]) > 1 and
+                     yopt[i][1] == "%" and xopt[i][0] == yopt[i][0] and
+                     int(xopt[i][1:]) % int(yopt[i][2:]) == 0)):
+                same = False
+                break
+        if same:
+            d += len(xopt)
+    return d
+
+
+@conf.commands.register
+def p0f(pkt):
+    """Passive OS fingerprinting: which OS emitted this TCP packet ?
+p0f(packet) -> accuracy, [list of guesses]
+"""
+    db, sig = packet2p0f(pkt)
+    if db:
+        pb = db.get_base()
+    else:
+        pb = []
+    if not pb:
+        warning("p0f base empty.")
+        return []
+    # s = len(pb[0][0])
+    r = []
+    max = len(sig[4].split(",")) + 5
+    for b in pb:
+        d = p0f_correl(sig, b)
+        if d == max:
+            r.append((b[6], b[7], b[1] - pkt[IP].ttl))
+    return r
+
+
+def prnp0f(pkt):
+    """Calls p0f and returns a user-friendly output"""
+    # we should print which DB we use
+    try:
+        r = p0f(pkt)
+    except Exception:
+        return
+    if r == []:
+        r = ("UNKNOWN", "[" + ":".join(map(str, packet2p0f(pkt)[1])) + ":?:?]", None)  # noqa: E501
+    else:
+        r = r[0]
+    uptime = None
+    try:
+        uptime = pkt2uptime(pkt)
+    except Exception:
+        pass
+    if uptime == 0:
+        uptime = None
+    res = pkt.sprintf("%IP.src%:%TCP.sport% - " + r[0] + " " + r[1])
+    if uptime is not None:
+        res += pkt.sprintf(" (up: " + str(uptime / 3600) + " hrs)\n  -> %IP.dst%:%TCP.dport% (%TCP.flags%)")  # noqa: E501
+    else:
+        res += pkt.sprintf("\n  -> %IP.dst%:%TCP.dport% (%TCP.flags%)")
+    if r[2] is not None:
+        res += " (distance " + str(r[2]) + ")"
+    print(res)
+
+
+@conf.commands.register
+def pkt2uptime(pkt, HZ=100):
+    """Calculate the date the machine which emitted the packet booted using TCP timestamp  # noqa: E501
+pkt2uptime(pkt, [HZ=100])"""
+    if not isinstance(pkt, Packet):
+        raise TypeError("Not a TCP packet")
+    if isinstance(pkt, NoPayload):
+        raise TypeError("Not a TCP packet")
+    if not isinstance(pkt, TCP):
+        return pkt2uptime(pkt.payload)
+    for opt in pkt.options:
+        if opt[0] == "Timestamp":
+            # t = pkt.time - opt[1][0] * 1.0/HZ
+            # return time.ctime(t)
+            t = opt[1][0] / HZ
+            return t
+    raise TypeError("No timestamp option")
+
+
+def p0f_impersonate(pkt, osgenre=None, osdetails=None, signature=None,
+                    extrahops=0, mtu=1500, uptime=None):
+    """Modifies pkt so that p0f will think it has been sent by a
+specific OS.  If osdetails is None, then we randomly pick up a
+personality matching osgenre. If osgenre and signature are also None,
+we use a local signature (using p0f_getlocalsigs). If signature is
+specified (as a tuple), we use the signature.
+
+For now, only TCP Syn packets are supported.
+Some specifications of the p0f.fp file are not (yet) implemented."""
+    pkt = pkt.copy()
+    # pkt = pkt.__class__(raw(pkt))
+    while pkt.haslayer(IP) and pkt.haslayer(TCP):
+        pkt = pkt.getlayer(IP)
+        if isinstance(pkt.payload, TCP):
+            break
+        pkt = pkt.payload
+
+    if not isinstance(pkt, IP) or not isinstance(pkt.payload, TCP):
+        raise TypeError("Not a TCP/IP packet")
+
+    db = p0f_selectdb(pkt.payload.flags)
+    if osgenre:
+        pb = db.get_base()
+        if pb is None:
+            pb = []
+        pb = [x for x in pb if x[6] == osgenre]
+        if osdetails:
+            pb = [x for x in pb if x[7] == osdetails]
+    elif signature:
+        pb = [signature]
+    else:
+        pb = p0f_getlocalsigs()[db]
+    if db == p0fr_kdb:
+        # 'K' quirk <=> RST+ACK
+        if pkt.payload.flags & 0x4 == 0x4:
+            pb = [x for x in pb if 'K' in x[5]]
+        else:
+            pb = [x for x in pb if 'K' not in x[5]]
+    if not pb:
+        raise Scapy_Exception("No match in the p0f database")
+    pers = pb[random.randint(0, len(pb) - 1)]
+
+    # options (we start with options because of MSS)
+    # Take the options already set as "hints" to use in the new packet if we
+    # can. MSS, WScale and Timestamp can all be wildcarded in a signature, so
+    # we'll use the already-set values if they're valid integers.
+    orig_opts = dict(pkt.payload.options)
+    int_only = lambda val: val if isinstance(val, six.integer_types) else None
+    mss_hint = int_only(orig_opts.get('MSS'))
+    wscale_hint = int_only(orig_opts.get('WScale'))
+    ts_hint = [int_only(o) for o in orig_opts.get('Timestamp', (None, None))]
+
+    options = []
+    if pers[4] != '.':
+        for opt in pers[4].split(','):
+            if opt[0] == 'M':
+                # MSS might have a maximum size because of window size
+                # specification
+                if pers[0][0] == 'S':
+                    maxmss = (2**16 - 1) // int(pers[0][1:])
+                else:
+                    maxmss = (2**16 - 1)
+                # disregard hint if out of range
+                if mss_hint and not 0 <= mss_hint <= maxmss:
+                    mss_hint = None
+                # If we have to randomly pick up a value, we cannot use
+                # scapy RandXXX() functions, because the value has to be
+                # set in case we need it for the window size value. That's
+                # why we use random.randint()
+                if opt[1:] == '*':
+                    if mss_hint is not None:
+                        options.append(('MSS', mss_hint))
+                    else:
+                        options.append(('MSS', random.randint(1, maxmss)))
+                elif opt[1] == '%':
+                    coef = int(opt[2:])
+                    if mss_hint is not None and mss_hint % coef == 0:
+                        options.append(('MSS', mss_hint))
+                    else:
+                        options.append((
+                            'MSS', coef * random.randint(1, maxmss // coef)))
+                else:
+                    options.append(('MSS', int(opt[1:])))
+            elif opt[0] == 'W':
+                if wscale_hint and not 0 <= wscale_hint < 2**8:
+                    wscale_hint = None
+                if opt[1:] == '*':
+                    if wscale_hint is not None:
+                        options.append(('WScale', wscale_hint))
+                    else:
+                        options.append(('WScale', RandByte()))
+                elif opt[1] == '%':
+                    coef = int(opt[2:])
+                    if wscale_hint is not None and wscale_hint % coef == 0:
+                        options.append(('WScale', wscale_hint))
+                    else:
+                        options.append((
+                            'WScale', coef * RandNum(min=1, max=(2**8 - 1) // coef)))  # noqa: E501
+                else:
+                    options.append(('WScale', int(opt[1:])))
+            elif opt == 'T0':
+                options.append(('Timestamp', (0, 0)))
+            elif opt == 'T':
+                # Determine first timestamp.
+                if uptime is not None:
+                    ts_a = uptime
+                elif ts_hint[0] and 0 < ts_hint[0] < 2**32:
+                    # Note: if first ts is 0, p0f registers it as "T0" not "T",
+                    # hence we don't want to use the hint if it was 0.
+                    ts_a = ts_hint[0]
+                else:
+                    ts_a = random.randint(120, 100 * 60 * 60 * 24 * 365)
+                # Determine second timestamp.
+                if 'T' not in pers[5]:
+                    ts_b = 0
+                elif ts_hint[1] and 0 < ts_hint[1] < 2**32:
+                    ts_b = ts_hint[1]
+                else:
+                    # FIXME: RandInt() here does not work (bug (?) in
+                    # TCPOptionsField.m2i often raises "OverflowError:
+                    # long int too large to convert to int" in:
+                    #    oval = struct.pack(ofmt, *oval)"
+                    # Actually, this is enough to often raise the error:
+                    #    struct.pack('I', RandInt())
+                    ts_b = random.randint(1, 2**32 - 1)
+                options.append(('Timestamp', (ts_a, ts_b)))
+            elif opt == 'S':
+                options.append(('SAckOK', ''))
+            elif opt == 'N':
+                options.append(('NOP', None))
+            elif opt == 'E':
+                options.append(('EOL', None))
+            elif opt[0] == '?':
+                if int(opt[1:]) in TCPOptions[0]:
+                    optname = TCPOptions[0][int(opt[1:])][0]
+                    optstruct = TCPOptions[0][int(opt[1:])][1]
+                    options.append((optname,
+                                    struct.unpack(optstruct,
+                                                  RandString(struct.calcsize(optstruct))._fix())))  # noqa: E501
+                else:
+                    options.append((int(opt[1:]), ''))
+            # FIXME: qqP not handled
+            else:
+                warning("unhandled TCP option %s", opt)
+            pkt.payload.options = options
+
+    # window size
+    if pers[0] == '*':
+        pkt.payload.window = RandShort()
+    elif pers[0].isdigit():
+        pkt.payload.window = int(pers[0])
+    elif pers[0][0] == '%':
+        coef = int(pers[0][1:])
+        pkt.payload.window = coef * RandNum(min=1, max=(2**16 - 1) // coef)
+    elif pers[0][0] == 'T':
+        pkt.payload.window = mtu * int(pers[0][1:])
+    elif pers[0][0] == 'S':
+        # needs MSS set
+        mss = [x for x in options if x[0] == 'MSS']
+        if not mss:
+            raise Scapy_Exception("TCP window value requires MSS, and MSS option not set")  # noqa: E501
+        pkt.payload.window = mss[0][1] * int(pers[0][1:])
+    else:
+        raise Scapy_Exception('Unhandled window size specification')
+
+    # ttl
+    pkt.ttl = pers[1] - extrahops
+    # DF flag
+    pkt.flags |= (2 * pers[2])
+    # FIXME: ss (packet size) not handled (how ? may be with D quirk
+    # if present)
+    # Quirks
+    if pers[5] != '.':
+        for qq in pers[5]:
+            # FIXME: not handled: P, I, X, !
+            # T handled with the Timestamp option
+            if qq == 'Z':
+                pkt.id = 0
+            elif qq == 'U':
+                pkt.payload.urgptr = RandShort()
+            elif qq == 'A':
+                pkt.payload.ack = RandInt()
+            elif qq == 'F':
+                if db == p0fo_kdb:
+                    pkt.payload.flags |= 0x20  # U
+                else:
+                    pkt.payload.flags |= random.choice([8, 32, 40])  # P/U/PU
+            elif qq == 'D' and db != p0fo_kdb:
+                pkt /= conf.raw_layer(load=RandString(random.randint(1, 10)))  # XXX p0fo.fp  # noqa: E501
+            elif qq == 'Q':
+                pkt.payload.seq = pkt.payload.ack
+            # elif qq == '0': pkt.payload.seq = 0
+        # if db == p0fr_kdb:
+        # '0' quirk is actually not only for p0fr.fp (see
+        # packet2p0f())
+    if '0' in pers[5]:
+        pkt.payload.seq = 0
+    elif pkt.payload.seq == 0:
+        pkt.payload.seq = RandInt()
+
+    while pkt.underlayer:
+        pkt = pkt.underlayer
+    return pkt
+
+
+def p0f_getlocalsigs():
+    """This function returns a dictionary of signatures indexed by p0f
+db (e.g., p0f_kdb, p0fa_kdb, ...) for the local TCP/IP stack.
+
+You need to have your firewall at least accepting the TCP packets
+from/to a high port (30000 <= x <= 40000) on your loopback interface.
+
+Please note that the generated signatures come from the loopback
+interface and may (are likely to) be different than those generated on
+"normal" interfaces."""
+    pid = os.fork()
+    port = random.randint(30000, 40000)
+    if pid > 0:
+        # parent: sniff
+        result = {}
+
+        def addresult(res):
+            # TODO: wildcard window size in some cases? and maybe some
+            # other values?
+            if res[0] not in result:
+                result[res[0]] = [res[1]]
+            else:
+                if res[1] not in result[res[0]]:
+                    result[res[0]].append(res[1])
+        # XXX could we try with a "normal" interface using other hosts
+        iface = conf.route.route('127.0.0.1')[0]
+        # each packet is seen twice: S + RA, S + SA + A + FA + A
+        # XXX are the packets also seen twice on non Linux systems ?
+        count = 14
+        pl = sniff(iface=iface, filter='tcp and port ' + str(port), count=count, timeout=3)  # noqa: E501
+        for pkt in pl:
+            for elt in packet2p0f(pkt):
+                addresult(elt)
+        os.waitpid(pid, 0)
+    elif pid < 0:
+        log_runtime.error("fork error")
+    else:
+        # child: send
+        # XXX erk
+        time.sleep(1)
+        s1 = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
+        # S & RA
+        try:
+            s1.connect(('127.0.0.1', port))
+        except socket.error:
+            pass
+        # S, SA, A, FA, A
+        s1.bind(('127.0.0.1', port))
+        s1.connect(('127.0.0.1', port))
+        # howto: get an RST w/o ACK packet
+        s1.close()
+        os._exit(0)
+    return result

--- a/scapy/modules/p0fv2.py
+++ b/scapy/modules/p0fv2.py
@@ -4,7 +4,7 @@
 # This program is published under a GPLv2 license
 
 """
-Clone of p0f passive OS fingerprinting
+Clone of p0f v2 passive OS fingerprinting
 """
 
 from __future__ import absolute_import

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -1,7 +1,9 @@
 % Tests for Scapy's p0f module.
 
+~ p0f
 
 + Basic p0f module tests
+
 = Module loading
 load_module('p0f')
 
@@ -26,29 +28,94 @@ p0fdb.reload(conf.p0f_base)
 + Default tests
 
 = Test TCP p0f, SYN - Windows
+~ netaccess
+
 pkt = IP(b'E\x00\x004Se@\x00\x80\x06\x93?\n\x00\x00\x14\n\x00\x00\x0c\xc3\x08\x01\xbb\xcf\xb4\xbb\\\x00\x00\x00\x00\x80\x02 \x00\xeb\x1b\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
 assert p0f(pkt) == (('s', 'win', 'Windows', '7 or 8'), 0, False)
 
 = Test TCP p0f, SYN - Linux
+~ netaccess
+
 pkt = IP(b"E\x10\x00<A0@\x00@\x06t\xdd\xc0\xa8\x01\x8c\xc0\xa8\x01\xc2\xdd\xb8\x00\x17\xda\xcf!\xd5\x00\x00\x00\x00\xa0\x02\x16\xd0q\x10\x00\x00\x02\x04\x05\xb4\x04\x02\x08\n\x00'`\xe5\x00\x00\x00\x00\x01\x03\x03\x07")
 assert p0f(pkt) == (('s', 'unix', 'Linux', '2.6.x'), 0, False)
 
 = Test TCP p0f, SYN - IPv6 FreeBSD
+~ netaccess
+
 pkt = IPv6(hlim=64) / TCP(seq=1, window=65535, options=[("MSS", 150), ("NOP", None), ("WScale", 6), ("SAckOK", ""), ("Timestamp", (12345, 0))])
 assert p0f(pkt) == (('s', 'unix', 'FreeBSD', '9.x or newer'), 0, False)
 
 = Test TCP p0f, SYN-ACK - Linux
+~ netaccess
+
 pkt = IP(b'E\x00\x00<\x00\x00@\x008\x06N;?t\xf3a\xc0\xa8\x01\x03\x00P\xe5\xc0\xa3\xc4\x80\x9f\xe5\x94=\xab\xa0\x12\x16\xa0N\x07\x00\x00\x02\x04\x05\xb4\x04\x02\x08\n\x8d\x9d\x9d\xfa\x00\x17\x95e\x01\x03\x03\x05')
 assert p0f(pkt) == (('s', 'unix', 'Linux', '2.6.x'), 8, False)
 
 = Test HTTP p0f, request - wget
+~ netaccess
+
 pkt = IP(b'E\x00\x00\xba\xcb]@\x00@\x06(d\xc0\xa8\x01\x8c\xae\x8f\xd5\xb8\xe1N\x00P\x8eP\x19\x02\xc7R\x9d\x89\x80\x18\x00.G)\x00\x00\x01\x01\x08\n\x00!\xd2_1\xc7\xbaHGET /images/layout/logo.png HTTP/1.0\r\nUser-Agent: Wget/1.12 (linux-gnu)\r\nAccept: */*\r\nHost: packetlife.net\r\nConnection: Keep-Alive\r\n\r\n')
 assert p0f(pkt) == (('s', '!', 'wget', '', ('@unix', 'Windows')), False)
 
 = Test HTTP p0f, response - nginx
+~ netaccess
+
 pkt = IP(b"E\x00\x05\xdc'\xde@\x00\xfb\x06\x0b\xc1\xae\x8f\xd5\xb8\xc0\xa8\x01\x8c\x00P\xe1N\xc7R\x9d\x89\x8eP\x19\x88\x80\x10\x00lS\xc4\x00\x00\x01\x01\x08\n1\xc7\xbaT\x00!\xd2_HTTP/1.1 200 OK\r\nServer: nginx/0.8.53\r\nDate: Tue, 01 Mar 2011 20:45:16 GMT\r\nContent-Type: image/png\r\nContent-Length: 21684\r\nLast-Modified: Fri, 21 Jan 2011 03:41:14 GMT\r\nConnection: keep-alive\r\nKeep-Alive: timeout=20\r\nExpires: Wed, 29 Feb 2012 20:45:16 GMT\r\nCache-Control: max-age=31536000\r\nCache-Control: public\r\nVary: Accept-Encoding\r\nAccept-Ranges: bytes\r\n\r\n")
 assert p0f(pkt) == (('s', '!', 'nginx', '1.x', ('@unix',)), False)
 
 = Test MTU p0f
+~ netaccess
+
 pkt = IP(b'E\x00\x004Se@\x00\x80\x06\x93?\n\x00\x00\x14\n\x00\x00\x0c\xc3\x08\x01\xbb\xcf\xb4\xbb\\\x00\x00\x00\x00\x80\x02 \x00\xeb\x1b\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
 assert fingerprint_mtu(pkt) == "Ethernet or modem"
+
+
++ Tests for p0f_impersonate
+
+= Check that the impersonated packet is properly detected by p0f
+~ netaccess
+
+sig = "*:64:0:*:mss*20,10:mss,sok,ts,nop,ws:df,id+:0"
+pkt = p0f_impersonate(IP()/TCP(), signature=sig)
+assert p0f(pkt) == (("s", "unix", "Linux", "3.11 and newer"), 0, False)
+
+= Impersonate when window size must be multiple of some integer
+sig = "*:64:0:1460:%8192,0:mss,nop,ws::0"
+pkt = p0f_impersonate(IP()/TCP(), signature=sig)
+assert pkt[TCP].window % 8192 == 0
+
+= Impersonate when window size must be multiple of mss
+sig = "*:64:0:1024:mss*4,0:mss::0"
+pkt = p0f_impersonate(IP()/TCP(), signature=sig)
+assert (pkt[TCP].window // 4) == 1024
+
+= Impersonate when the following quirks are present: seq-,ack-,pushf+,urgf+
+sig = "*:64:0:1460:8192,0:mss:seq-,ack-,pushf+,urgf+:0"
+pkt = p0f_impersonate(IP()/TCP(seq=1, ack=1, flags="S"), signature=sig)
+tcp = pkt[TCP]
+assert pkt[TCP].seq == pkt[TCP].ack == 0
+assert pkt[TCP].flags.A and pkt[TCP].flags.P and pkt[TCP].flags.U
+
+= Use valid option values from original packet
+sig = "*:64:0:*:8192,*:mss,ws,ts::0"
+opts = [("MSS", 1400), ("WScale", 3), ("Timestamp", (97256, 0))]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt[TCP].options == opts
+
+= Discard invalid options values
+sig = "*:64:0:1000:8192,5:mss,ws::0"
+opts = [("MSS", 1400), ("WScale", 3)]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt[TCP].options[0][1] == 1000
+assert pkt[TCP].options[1][1] == 5
+
++ Clear temp files
+
+= Remove fp files
+def _rem(f):
+    try:
+        os.remove(f)
+    except:
+        pass
+
+_rem("p0f.fp")

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -1,122 +1,36 @@
 % Tests for Scapy's p0f module.
 
-~ p0f
 
-
-############
-############
 + Basic p0f module tests
-
 = Module loading
 load_module('p0f')
 
-= Fetch database
-~ netaccess
-
-from __future__ import print_function
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
-
-def _load_database(file):
-    for i in range(10):
-        try:
-            open(file, 'wb').write(urlopen('https://raw.githubusercontent.com/p0f/p0f/4b4d1f384abebbb9b1b25b8f3c6df5ad7ab365f7/' + file).read())
-            break
-        except:
-            raise
-            pass
-
-_load_database("p0f.fp")
-conf.p0f_base = "p0f.fp"
-_load_database("p0fa.fp")
-conf.p0fa_base = "p0fa.fp"
-_load_database("p0fr.fp")
-conf.p0fr_base = "p0fr.fp"
-_load_database("p0fo.fp")
-conf.p0fo_base = "p0fo.fp"
-
-p0f_load_knowledgebases()
-
-############
-############
 + Default tests
 
-= Test p0f
-~ netaccess
+= Test TCP p0f, SYN - Windows
+pkt = IP(b'E\x00\x004Se@\x00\x80\x06\x93?\n\x00\x00\x14\n\x00\x00\x0c\xc3\x08\x01\xbb\xcf\xb4\xbb\\\x00\x00\x00\x00\x80\x02 \x00\xeb\x1b\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
+assert p0f(pkt) == (('s', 'win', 'Windows', '7 or 8'), 0, False)
 
-pkt = Ether(b'\x14\x0cv\x8f\xfe(\xd0P\x99V\xdd\xf9\x08\x00E\x00\x0045+@\x00\x80\x06\x00\x00\xc0\xa8\x00w(M\xe2\xf9\xda\xcb\x01\xbbcc\xdd\x1e\x00\x00\x00\x00\x80\x02\xfa\xf0\xcc\x8c\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
+= Test TCP p0f, SYN - Linux
+pkt = IP(b"E\x10\x00<A0@\x00@\x06t\xdd\xc0\xa8\x01\x8c\xc0\xa8\x01\xc2\xdd\xb8\x00\x17\xda\xcf!\xd5\x00\x00\x00\x00\xa0\x02\x16\xd0q\x10\x00\x00\x02\x04\x05\xb4\x04\x02\x08\n\x00'`\xe5\x00\x00\x00\x00\x01\x03\x03\x07")
+assert p0f(pkt) == (('s', 'unix', 'Linux', '2.6.x'), 0, False)
 
-assert p0f(pkt) == [('@Windows', 'XP/2000 (RFC1323+, w+, tstamp-)', 0)]
+= Test TCP p0f, SYN - IPv6 FreeBSD
+pkt = IPv6(hlim=64) / TCP(seq=1, window=65535, options=[("MSS", 150), ("NOP", None), ("WScale", 6), ("SAckOK", ""), ("Timestamp", (12345, 0))])
+assert p0f(pkt) == (('s', 'unix', 'FreeBSD', '9.x or newer'), 0, False)
 
-= Test prnp0f
-~ netaccess
+= Test TCP p0f, SYN-ACK - Linux
+pkt = IP(b'E\x00\x00<\x00\x00@\x008\x06N;?t\xf3a\xc0\xa8\x01\x03\x00P\xe5\xc0\xa3\xc4\x80\x9f\xe5\x94=\xab\xa0\x12\x16\xa0N\x07\x00\x00\x02\x04\x05\xb4\x04\x02\x08\n\x8d\x9d\x9d\xfa\x00\x17\x95e\x01\x03\x03\x05')
+assert p0f(pkt) == (('s', 'unix', 'Linux', '2.6.x'), 8, False)
 
-with ContextManagerCaptureOutput() as cmco:
-    prnp0f(pkt)
-    assert cmco.get_output() == '192.168.0.119:56011 - @Windows XP/2000 (RFC1323+, w+, tstamp-)\n  -> 40.77.226.249:https (S) (distance 0)\n'
+= Test HTTP p0f, request - wget
+pkt = IP(b'E\x00\x00\xba\xcb]@\x00@\x06(d\xc0\xa8\x01\x8c\xae\x8f\xd5\xb8\xe1N\x00P\x8eP\x19\x02\xc7R\x9d\x89\x80\x18\x00.G)\x00\x00\x01\x01\x08\n\x00!\xd2_1\xc7\xbaHGET /images/layout/logo.png HTTP/1.0\r\nUser-Agent: Wget/1.12 (linux-gnu)\r\nAccept: */*\r\nHost: packetlife.net\r\nConnection: Keep-Alive\r\n\r\n')
+assert p0f(pkt) == (('s', '!', 'wget', '', ('@unix', 'Windows')), False)
 
-############
-############
-+ Tests for p0f_impersonate
+= Test HTTP p0f, response - nginx
+pkt = IP(b"E\x00\x05\xdc'\xde@\x00\xfb\x06\x0b\xc1\xae\x8f\xd5\xb8\xc0\xa8\x01\x8c\x00P\xe1N\xc7R\x9d\x89\x8eP\x19\x88\x80\x10\x00lS\xc4\x00\x00\x01\x01\x08\n1\xc7\xbaT\x00!\xd2_HTTP/1.1 200 OK\r\nServer: nginx/0.8.53\r\nDate: Tue, 01 Mar 2011 20:45:16 GMT\r\nContent-Type: image/png\r\nContent-Length: 21684\r\nLast-Modified: Fri, 21 Jan 2011 03:41:14 GMT\r\nConnection: keep-alive\r\nKeep-Alive: timeout=20\r\nExpires: Wed, 29 Feb 2012 20:45:16 GMT\r\nCache-Control: max-age=31536000\r\nCache-Control: public\r\nVary: Accept-Encoding\r\nAccept-Ranges: bytes\r\n\r\n")
+assert p0f(pkt) == (('s', '!', 'nginx', '1.x', ('@unix',)), False)
 
-# XXX: a lot of pieces of p0f_impersonate don't have tests yet.
-
-= Impersonate when window size must be multiple of some integer
-sig = ('%467', 64, 1, 60, 'M*,W*', '.', 'Phony Sys', '1.0')
-pkt = p0f_impersonate(IP()/TCP(), signature=sig)
-assert pkt.payload.window % 467 == 0
-
-= Handle unusual flags ("F") quirk
-sig = ('1024', 64, 0, 60, 'W*', 'F', 'Phony Sys', '1.0')
-pkt = p0f_impersonate(IP()/TCP(), signature=sig)
-assert (pkt.payload.flags & 40) in (8, 32, 40)
-
-= Use valid option values from original packet
-sig = ('S4', 64, 1, 60, 'M*,W*,T', '.', 'Phony Sys', '1.0')
-opts = [('MSS', 1400), ('WScale', 3), ('Timestamp', (97256, 0))]
-pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
-assert pkt.payload.options == opts
-
-= Use valid option values when multiples required
-sig = ('S4', 64, 1, 60, 'M%37,W%19', '.', 'Phony Sys', '1.0')
-opts = [('MSS', 37*15), ('WScale', 19*12)]
-pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
-assert pkt.payload.options == opts
-
-= Discard non-multiple option values when multiples required
-sig = ('S4', 64, 1, 60, 'M%37,W%19', '.', 'Phony Sys', '1.0')
-opts = [('MSS', 37*15 + 1), ('WScale', 19*12 + 1)]
-pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
-assert pkt.payload.options[0][1] % 37 == 0
-assert pkt.payload.options[1][1] % 19 == 0
-
-= Discard bad timestamp values
-sig = ('S4', 64, 1, 60, 'M*,T', '.', 'Phony Sys', '1.0')
-opts = [('Timestamp', (0, 1000))]
-pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
-# since option is "T" and not "T0":
-assert pkt.payload.options[1][1][0] > 0
-# since T quirk is not present:
-assert pkt.payload.options[1][1][1] == 0
-
-= Discard 2nd timestamp of 0 if "T" quirk is present
-sig = ('S4', 64, 1, 60, 'M*,T', 'T', 'Phony Sys', '1.0')
-opts = [('Timestamp', (54321, 0))]
-pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
-assert pkt.payload.options[1][1][1] > 0
-
-+ Clear temp files
-
-= Remove fp files
-def _rem(f):
-    try:
-        os.remove(f)
-    except:
-        pass
-
-_rem("p0f.fp")
-_rem("p0fa.fp")
-_rem("p0fr.fp")
-_rem("p0fo.fp")
+= Test MTU p0f
+pkt = IP(b'E\x00\x004Se@\x00\x80\x06\x93?\n\x00\x00\x14\n\x00\x00\x0c\xc3\x08\x01\xbb\xcf\xb4\xbb\\\x00\x00\x00\x00\x80\x02 \x00\xeb\x1b\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
+assert fingerprint_mtu(pkt) == "Ethernet or modem"

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -5,6 +5,24 @@
 = Module loading
 load_module('p0f')
 
+= Fetch database
+~ netaccess
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+for i in range(10):
+    try:
+        open("p0f.fp", 'wb').write(urlopen('https://raw.githubusercontent.com/p0f/p0f/e8b924ae7fa099a3a5fe7def0ce3e397fd9a7137/p0f.fp').read())
+        break
+    except:
+        raise
+
+conf.p0f_base = "p0f.fp"
+p0fdb.reload(conf.p0f_base)
+
 + Default tests
 
 = Test TCP p0f, SYN - Windows

--- a/test/p0fv2.uts
+++ b/test/p0fv2.uts
@@ -1,0 +1,122 @@
+% Tests for Scapy's p0fv2 module.
+
+~ p0f
+
+
+############
+############
++ Basic p0f module tests
+
+= Module loading
+load_module('p0fv2')
+
+= Fetch database
+~ netaccess
+
+from __future__ import print_function
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+def _load_database(file):
+    for i in range(10):
+        try:
+            open(file, 'wb').write(urlopen('https://raw.githubusercontent.com/p0f/p0f/4b4d1f384abebbb9b1b25b8f3c6df5ad7ab365f7/' + file).read())
+            break
+        except:
+            raise
+            pass
+
+_load_database("p0f.fp")
+conf.p0f_base = "p0f.fp"
+_load_database("p0fa.fp")
+conf.p0fa_base = "p0fa.fp"
+_load_database("p0fr.fp")
+conf.p0fr_base = "p0fr.fp"
+_load_database("p0fo.fp")
+conf.p0fo_base = "p0fo.fp"
+
+p0f_load_knowledgebases()
+
+############
+############
++ Default tests
+
+= Test p0f
+~ netaccess
+
+pkt = Ether(b'\x14\x0cv\x8f\xfe(\xd0P\x99V\xdd\xf9\x08\x00E\x00\x0045+@\x00\x80\x06\x00\x00\xc0\xa8\x00w(M\xe2\xf9\xda\xcb\x01\xbbcc\xdd\x1e\x00\x00\x00\x00\x80\x02\xfa\xf0\xcc\x8c\x00\x00\x02\x04\x05\xb4\x01\x03\x03\x08\x01\x01\x04\x02')
+
+assert p0f(pkt) == [('@Windows', 'XP/2000 (RFC1323+, w+, tstamp-)', 0)]
+
+= Test prnp0f
+~ netaccess
+
+with ContextManagerCaptureOutput() as cmco:
+    prnp0f(pkt)
+    assert cmco.get_output() == '192.168.0.119:56011 - @Windows XP/2000 (RFC1323+, w+, tstamp-)\n  -> 40.77.226.249:https (S) (distance 0)\n'
+
+############
+############
++ Tests for p0f_impersonate
+
+# XXX: a lot of pieces of p0f_impersonate don't have tests yet.
+
+= Impersonate when window size must be multiple of some integer
+sig = ('%467', 64, 1, 60, 'M*,W*', '.', 'Phony Sys', '1.0')
+pkt = p0f_impersonate(IP()/TCP(), signature=sig)
+assert pkt.payload.window % 467 == 0
+
+= Handle unusual flags ("F") quirk
+sig = ('1024', 64, 0, 60, 'W*', 'F', 'Phony Sys', '1.0')
+pkt = p0f_impersonate(IP()/TCP(), signature=sig)
+assert (pkt.payload.flags & 40) in (8, 32, 40)
+
+= Use valid option values from original packet
+sig = ('S4', 64, 1, 60, 'M*,W*,T', '.', 'Phony Sys', '1.0')
+opts = [('MSS', 1400), ('WScale', 3), ('Timestamp', (97256, 0))]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt.payload.options == opts
+
+= Use valid option values when multiples required
+sig = ('S4', 64, 1, 60, 'M%37,W%19', '.', 'Phony Sys', '1.0')
+opts = [('MSS', 37*15), ('WScale', 19*12)]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt.payload.options == opts
+
+= Discard non-multiple option values when multiples required
+sig = ('S4', 64, 1, 60, 'M%37,W%19', '.', 'Phony Sys', '1.0')
+opts = [('MSS', 37*15 + 1), ('WScale', 19*12 + 1)]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt.payload.options[0][1] % 37 == 0
+assert pkt.payload.options[1][1] % 19 == 0
+
+= Discard bad timestamp values
+sig = ('S4', 64, 1, 60, 'M*,T', '.', 'Phony Sys', '1.0')
+opts = [('Timestamp', (0, 1000))]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+# since option is "T" and not "T0":
+assert pkt.payload.options[1][1][0] > 0
+# since T quirk is not present:
+assert pkt.payload.options[1][1][1] == 0
+
+= Discard 2nd timestamp of 0 if "T" quirk is present
+sig = ('S4', 64, 1, 60, 'M*,T', 'T', 'Phony Sys', '1.0')
+opts = [('Timestamp', (54321, 0))]
+pkt = p0f_impersonate(IP()/TCP(options=opts), signature=sig)
+assert pkt.payload.options[1][1][1] > 0
+
++ Clear temp files
+
+= Remove fp files
+def _rem(f):
+    try:
+        os.remove(f)
+    except:
+        pass
+
+_rem("p0f.fp")
+_rem("p0fa.fp")
+_rem("p0fr.fp")
+_rem("p0fo.fp")


### PR DESCRIPTION
This adds support to `p0fv3`

Some of the new features and changes:
* Parsing of p0f.fp using the p0fv3 formatting
* Complete IPv4/IPv6/TCP/HTTP parsing
*  TCP/HTTP/MTU passive fingerprinting
* Changed the name of the old `p0f` module to `p0fv2` to allow support for v2

