### PR TITLE
SCTPChunkParamHearbeatInfo corrected to SCTPChunkParamHeartbeatInfo

### DIFF
--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -184,7 +184,7 @@ sctpchunktypes = {
 }
 
 sctpchunkparamtypescls = {
-    1: "SCTPChunkParamHearbeatInfo",
+    1: "SCTPChunkParamHeartbeatInfo",
     5: "SCTPChunkParamIPv4Addr",
     6: "SCTPChunkParamIPv6Addr",
     7: "SCTPChunkParamStateCookie",
@@ -287,7 +287,7 @@ class _SCTPChunkParam:
         return b"", s[:]
 
 
-class SCTPChunkParamHearbeatInfo(_SCTPChunkParam, Packet):
+class SCTPChunkParamHeartbeatInfo(_SCTPChunkParam, Packet):
     fields_desc = [ShortEnumField("type", 1, sctpchunkparamtypes),
                    FieldLenField("len", None, length_of="data",
                                  adjust=lambda pkt, x:x + 4),


### PR DESCRIPTION
Simple typo fix, shouldn't have implications for other code.

Spent longer than I would like to admit trying to use SCTPChunkParamHeartbeatInfo before I spotted the typo.