### PR TITLE
Replace GLOBKEYS by session

### DIFF
--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -27,8 +27,8 @@ __all__ = [
     'DefaultDict',
     'Dict',
     'Generic',
-    'Iterable',
     'IO',
+    'Iterable',
     'Iterable',
     'Iterator',
     'List',
@@ -124,9 +124,9 @@ if not FAKE_TYPING:
         DefaultDict,
         Dict,
         Generic,
+        IO,
         Iterable,
         Iterator,
-        IO,
         List,
         NewType,
         NoReturn,
@@ -154,17 +154,17 @@ else:
                             collections.defaultdict)
     Dict = _FakeType("Dict", dict)  # type: ignore
     Generic = _FakeType("Generic")
+    IO = _FakeType("IO")  # type: ignore
     Iterable = _FakeType("Iterable")  # type: ignore
     Iterator = _FakeType("Iterator")  # type: ignore
-    IO = _FakeType("IO")  # type: ignore
     List = _FakeType("List", list)  # type: ignore
     NewType = _FakeType("NewType")
     NoReturn = _FakeType("NoReturn")  # type: ignore
     Optional = _FakeType("Optional")
     Pattern = _FakeType("Pattern")  # type: ignore
     Sequence = _FakeType("Sequence")  # type: ignore
-    Set = _FakeType("Set", set)  # type: ignore
     Sequence = _FakeType("Sequence", list)  # type: ignore
+    Set = _FakeType("Set", set)  # type: ignore
     Tuple = _FakeType("Tuple")
     Type = _FakeType("Type", type)
     TypeVar = _FakeType("TypeVar")  # type: ignore

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -304,7 +304,7 @@ def _scapy_builtins():
     """Load scapy and return all builtins"""
     return {k: v
             for k, v in six.iteritems(
-                importlib.import_module(".all", "scapy").__dict__
+                importlib.import_module(".all", "scapy").__dict__.copy()
             )
             if _validate_local(k)}
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -35,16 +35,12 @@ from scapy.themes import DefaultTheme, BlackAndWhite, apply_ipython_style
 from scapy.consts import WINDOWS
 
 from scapy.compat import (
-    cast,
     Any,
     Dict,
     List,
     Optional,
-    Tuple,
-    Union
+    Union,
 )
-
-IGNORED = list(six.moves.builtins.__dict__)
 
 LAYER_ALIASES = {
     "tls": "tls.all"
@@ -119,11 +115,8 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(),
 
 def _validate_local(x):
     # type: (str) -> bool
-    """Returns whether or not a variable should be imported.
-    Will return False for any default modules (sys), or if
-    they are detected as private vars (starting with a _)"""
-    global IGNORED
-    return x[0] != "_" and x not in IGNORED
+    """Returns whether or not a variable should be imported."""
+    return x[0] != "_"
 
 
 DEFAULT_PRESTART_FILE = _probe_config_file(".scapy_prestart.py")
@@ -296,11 +289,24 @@ def list_contrib(name=None,  # type: Optional[str]
 def update_ipython_session(session):
     # type: (Dict[str, Any]) -> None
     """Updates IPython session with a custom one"""
+    if "_oh" not in session:
+        session["_oh"] = session["Out"] = {}
+        session["In"] = {}
     try:
         from IPython import get_ipython
         get_ipython().user_ns.update(session)
     except Exception:
         pass
+
+
+def _scapy_builtins():
+    # type: () -> Dict[str, Any]
+    """Load scapy and return all builtins"""
+    return {k: v
+            for k, v in six.iteritems(
+                importlib.import_module(".all", "scapy").__dict__
+            )
+            if _validate_local(k)}
 
 
 def save_session(fname="", session=None, pickleProto=-1):
@@ -317,7 +323,7 @@ def save_session(fname="", session=None, pickleProto=-1):
         fname = conf.session
         if not fname:
             conf.session = fname = utils.get_temp_file(keep=True)
-    log_interactive.info("Use [%s] as session file", fname)
+    log_interactive.info("Saving session into [%s]", fname)
 
     if not session:
         try:
@@ -326,21 +332,28 @@ def save_session(fname="", session=None, pickleProto=-1):
         except Exception:
             session = six.moves.builtins.__dict__["scapy_session"]
 
-    to_be_saved = cast(Dict[str, Any], session).copy()
-    if "__builtins__" in to_be_saved:
-        del(to_be_saved["__builtins__"])
+    if not session:
+        log_interactive.error("No session found ?!")
+        return
+
+    ignore = session.get("_scpybuiltins", [])
+    hard_ignore = ["scapy_session", "In", "Out"]
+    to_be_saved = session.copy()
 
     for k in list(to_be_saved):
         i = to_be_saved[k]
-        if hasattr(i, "__module__") and (k[0] == "_" or
-                                         i.__module__.startswith("IPython")):
+        if k[0] == "_":
             del(to_be_saved[k])
-        if isinstance(i, ConfClass):
+        elif hasattr(i, "__module__") and i.__module__.startswith("IPython"):
             del(to_be_saved[k])
-        elif isinstance(i, (type, type, types.ModuleType)):
+        elif isinstance(i, ConfClass):
+            del(to_be_saved[k])
+        elif k in ignore or k in hard_ignore:
+            del(to_be_saved[k])
+        elif isinstance(i, (type, types.ModuleType)):
             if k[0] != "_":
-                log_interactive.error("[%s] (%s) can't be saved.", k,
-                                      type(to_be_saved[k]))
+                log_interactive.warning("[%s] (%s) can't be saved.", k,
+                                        type(to_be_saved[k]))
             del(to_be_saved[k])
 
     try:
@@ -373,6 +386,7 @@ def load_session(fname=None):
             raise
 
     scapy_session = six.moves.builtins.__dict__["scapy_session"]
+    s.update({k: scapy_session[k] for k in scapy_session["_scpybuiltins"]})
     scapy_session.clear()
     scapy_session.update(s)
     update_ipython_session(scapy_session)
@@ -399,21 +413,12 @@ def update_session(fname=None):
 
 
 def init_session(session_name,  # type: Optional[Union[str, None]]
-                 mydict=None  # type: Optional[Union[Dict[str, Any], None]]
+                 mydict=None,  # type: Optional[Union[Dict[str, Any], None]]
+                 ret=False,  # type: bool
                  ):
-    # type: (...) -> Tuple[Dict[str, Any], List[str]]
+    # type: (...) -> Optional[Dict[str, Any]]
     from scapy.config import conf
-    SESSION = {}  # type: Dict[str, Any]
-    GLOBKEYS = []  # type: List[str]
-
-    scapy_builtins = {k: v
-                      for k, v in six.iteritems(
-                          importlib.import_module(".all", "scapy").__dict__
-                      )
-                      if _validate_local(k)}
-    six.moves.builtins.__dict__.update(scapy_builtins)
-    GLOBKEYS.extend(scapy_builtins)
-    GLOBKEYS.append("scapy_session")
+    SESSION = {}  # type: Optional[Dict[str, Any]]
 
     if session_name:
         try:
@@ -427,7 +432,7 @@ def init_session(session_name,  # type: Optional[Union[str, None]]
                                                                "rb"))
                 except IOError:
                     SESSION = six.moves.cPickle.load(open(session_name, "rb"))
-                log_loading.info("Using session [%s]", session_name)
+                log_loading.info("Using existing session [%s]", session_name)
             except ValueError:
                 msg = "Error opening Python3 pickled session on Python2 [%s]"
                 log_loading.error(msg, session_name)
@@ -450,13 +455,19 @@ def init_session(session_name,  # type: Optional[Union[str, None]]
     else:
         SESSION = {"conf": conf}
 
+    # Load scapy
+    scapy_builtins = _scapy_builtins()
+
+    SESSION.update(scapy_builtins)
+    SESSION["_scpybuiltins"] = scapy_builtins.keys()
     six.moves.builtins.__dict__["scapy_session"] = SESSION
 
     if mydict is not None:
         six.moves.builtins.__dict__["scapy_session"].update(mydict)
         update_ipython_session(mydict)
-        GLOBKEYS.extend(mydict)
-    return SESSION, GLOBKEYS
+    if ret:
+        return SESSION
+    return None
 
 ################
 #     Main     #
@@ -547,7 +558,7 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
     # Reset sys.argv, otherwise IPython thinks it is for him
     sys.argv = sys.argv[:1]
 
-    SESSION, GLOBKEYS = init_session(session_name, mydict)
+    SESSION = init_session(session_name, mydict=mydict, ret=True)
 
     if STARTUP_FILE:
         _read_config_file(STARTUP_FILE, interactive=True)
@@ -699,12 +710,6 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
 
     if conf.session:
         save_session(conf.session, SESSION)
-
-    for k in GLOBKEYS:
-        try:
-            del(six.moves.builtins.__dict__[k])
-        except Exception:
-            pass
 
 
 if __name__ == "__main__":

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -301,7 +301,7 @@ def update_ipython_session(session):
 
 def _scapy_builtins():
     # type: () -> Dict[str, Any]
-    """Load scapy and return all builtins"""
+    """Load Scapy and return all builtins"""
     return {k: v
             for k, v in six.iteritems(
                 importlib.import_module(".all", "scapy").__dict__.copy()
@@ -455,7 +455,7 @@ def init_session(session_name,  # type: Optional[Union[str, None]]
     else:
         SESSION = {"conf": conf}
 
-    # Load scapy
+    # Load Scapy
     scapy_builtins = _scapy_builtins()
 
     SESSION.update(scapy_builtins)

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -24,7 +24,6 @@ from scapy.error import warning, Scapy_Exception, log_runtime
 from scapy.volatile import RandInt, RandByte, RandNum, RandShort, RandString
 from scapy.sendrecv import sniff
 from scapy.modules import six
-from scapy.modules.six.moves import map, range
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route  # noqa: F401

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -36,7 +36,6 @@ from scapy.plist import (
 from scapy.error import log_runtime, log_interactive, Scapy_Exception
 from scapy.base_classes import Gen, SetGen
 from scapy.modules import six
-from scapy.modules.six.moves import map
 from scapy.sessions import DefaultSession
 from scapy.supersocket import SuperSocket, IterSocket
 

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -519,10 +519,10 @@ def remove_empty_testsets(test_campaign):
 # RUN TEST #
 
 def run_test(test, get_interactive_session, theme, verb=3,
-             ignore_globals=None, my_globals=None):
+             my_globals=None):
     """An internal UTScapy function to run a single test"""
     start_time = time.time()
-    test.output, res = get_interactive_session(test.test.strip(), ignore_globals=ignore_globals, verb=verb, my_globals=my_globals)
+    test.output, res = get_interactive_session(test.test.strip(), verb=verb, my_globals=my_globals)
     test.result = "failed"
     try:
         if res is None or res:
@@ -568,12 +568,13 @@ def import_UTscapy_tools(ses):
 
 def run_campaign(test_campaign, get_interactive_session, theme,
                  drop_to_interpreter=False, verb=3,
-                 ignore_globals=None, scapy_ses=None):
+                 scapy_ses=None):
     passed = failed = 0
     if test_campaign.preexec:
         test_campaign.preexec_output = get_interactive_session(
-            test_campaign.preexec.strip(), ignore_globals=ignore_globals,
-            my_globals=scapy_ses)[0]
+            test_campaign.preexec.strip(),
+            my_globals=scapy_ses
+        )[0]
 
     # Drop
     def drop(scapy_ses):
@@ -853,7 +854,7 @@ def usage():
 def execute_campaign(TESTFILE, OUTPUTFILE, PREEXEC, NUM, KW_OK, KW_KO, DUMP, DOCS,
                      FORMAT, VERB, ONLYFAILED, CRC, INTERPRETER,
                      autorun_func, theme, pos_begin=0,
-                     ignore_globals=None, scapy_ses=None):  # noqa: E501
+                     scapy_ses=None):  # noqa: E501
     # Parse test file
     try:
         test_campaign = parse_campaign_file(TESTFILE)
@@ -897,7 +898,6 @@ def execute_campaign(TESTFILE, OUTPUTFILE, PREEXEC, NUM, KW_OK, KW_KO, DUMP, DOC
         test_campaign, autorun_func[FORMAT], theme,
         drop_to_interpreter=INTERPRETER,
         verb=VERB,
-        ignore_globals=None,
         scapy_ses=scapy_ses
     )
 
@@ -939,7 +939,6 @@ def main():
     argv = sys.argv[1:]
     logger = logging.getLogger("scapy")
     logger.addHandler(logging.StreamHandler())
-    ignore_globals = list(six.moves.builtins.__dict__)
 
     import scapy
     print(dash + " UTScapy - Scapy %s - %s" % (
@@ -1161,7 +1160,6 @@ def main():
                 FORMAT, VERB, ONLYFAILED, CRC, INTERPRETER,
                 autorun_func, theme,
                 pos_begin=pos_begin,
-                ignore_globals=ignore_globals,
                 scapy_ses=copy.copy(scapy_ses)
             )
         runned_campaigns.append(campaign)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -817,14 +817,18 @@ scapy_delete_temp_files()
 atol("www.secdev.org") == 3642339845
 
 = Test autorun functions
+~ autorun
 
 ret = autorun_get_text_interactive_session("IP().src")
+ret
 assert(ret == (">>> IP().src\n'127.0.0.1'\n", '127.0.0.1'))
 
 ret = autorun_get_html_interactive_session("IP().src")
+ret
 assert(ret == ("<span class=prompt>&gt;&gt;&gt; </span>IP().src\n'127.0.0.1'\n", '127.0.0.1'))
 
 ret = autorun_get_latex_interactive_session("IP().src")
+ret
 assert(ret == ("\\textcolor{blue}{{\\tt\\char62}{\\tt\\char62}{\\tt\\char62} }IP().src\n'127.0.0.1'\n", '127.0.0.1'))
 
 ret = autorun_get_text_interactive_session("scapy_undefined")
@@ -872,8 +876,14 @@ conf.netcache
 
 = Test pyx detection functions
 
-from scapy.extlib import _test_pyx
-assert _test_pyx() == False
+from mock import patch
+
+def _r(*args, **kwargs):
+    raise OSError
+
+with patch("scapy.extlib.subprocess.check_call", _r):
+    from scapy.extlib import _test_pyx
+    assert _test_pyx() == False
 
 = Test matplotlib detection functions
 


### PR DESCRIPTION
This PR should have little impact, and is mostly code cleanups.

- remove global variables in `interact()`. I suspect this could lead to issues
- cleanup `autorun` code to handle better multiple session overlap
- simplify how we handle sessions. less environment polution when using `interact()`