### PR TITLE
Add ERF Ethernet Support

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2363,6 +2363,53 @@ with mock.patch("scapy.utils.warning") as warning:
     os.remove(filename)
     assert any("Inconsistent" in arg for arg in warning.call_args[0])
 
+############
+############
++ ERF Ethernet format support 
+
+= Variable creations
+erffile = BytesIO(b'3;!E_9\x92_\x02\x04\x00p\x00\x00\x00P\x00\x00\x00\x0fS?\xca\xc0\x1cjz\x18\x90\xed\x81\x00\x01:\x08\x00E\x00\x00(\xdf\xab@\x00;\x06\xb3s\n\x01]\xdb\n\xfb9\xda\xc3v\x84\xecD\x16\xb9\xab\xda\xa1b\xf9P\x10f\x98\x18\xcb\x00\x00\x00\x00\x90\x9e\xd7\xd2_\x929_\x0f\x9e\xcd\x1f\x01\x88\xb9\x15[/s<\x01\x88\xb9\x15[/\xcd\x1f\x01\x88\xb9\x15[/0\xcd"E_9\x92_\x02\x04\x00p\x00\x00\x00P\x00\x00\x1cjz\x18\x90\xed\x00\x0fS?\xca\xc0\x08\x00E\x00\x00(\xa2\xdd@\x00@\x06\xebA\n\xfb9\xda\n\x01]\xdb\x84\xec\xc3v\xda\xa1b\xf9D\x16\xb9\xacP\x10\x9a\xf0\xe4q\x00\x00\x00\x00\x00\x00\x00\x00o\xbc\xe2{_\x929_\x0f\x9f+3\x01\x88\xb9\x15u\x1e(^\x01\x88\xb9\x15u\x1e+3\x01\x88\xb9\x15u\x1e')
+erffilewithheader = BytesIO(b'4;!E_9\x92_\x82\x00\x00x\x00\x00\x00P\x00\x00\x1a+<M^o\x00\x00\x00\x0fS?\xca\xc0\x1cjz\x18\x90\xed\x81\x00\x01:\x08\x00E\x00\x00(\xdf\xab@\x00;\x06\xb3s\n\x01]\xdb\n\xfb9\xda\xc3v\x84\xecD\x16\xb9\xab\xda\xa1b\xf9P\x10f\x98\x18\xcb\x00\x00\x00\x00\x90\x9e\xd7\xd2_\x929_\x0f\x9e\xcd\x1f\x01\x88\xb9\x15[/s<\x01\x88\xb9\x15[/\xcd\x1f\x01\x88\xb9\x15[/0\xcd"E_9\x92_\x82\x00\x00x\x00\x00\x00P\x00\x00\x1a+<M^o\x00\x00\x1cjz\x18\x90\xed\x00\x0fS?\xca\xc0\x08\x00E\x00\x00(\xa2\xdd@\x00@\x06\xebA\n\xfb9\xda\n\x01]\xdb\x84\xec\xc3v\xda\xa1b\xf9D\x16\xb9\xacP\x10\x9a\xf0\xe4q\x00\x00\x00\x00\x00\x00\x00\x00o\xbc\xe2{_\x929_\x0f\x9f+3\x01\x88\xb9\x15u\x1e(^\x01\x88\xb9\x15u\x1e+3\x01\x88\xb9\x15u\x1e')
+
+= Check reading of ERF Ethernet file
+pkterf = rderf(erffile)
+assert pkterf[0].time == 1603418463.270038318
+assert pkterf[0][IP].src == "10.1.93.219"
+assert pkterf[0][IP].dst == "10.251.57.218"
+assert pkterf[0][Ether].src == "1c:6a:7a:18:90:ed"
+assert pkterf[0][Ether].dst == "00:0f:53:3f:ca:c0"
+
+= Check writing of ERF Ethernet file
+import os, tempfile
+fdesc, filename = tempfile.mkstemp()
+fdesc = os.fdopen(fdesc, "wb")
+wrerf(fdesc, pkterf)
+fdesc.close()
+newpkterf = rderf(filename)
+
+assert pkterf[1][Ether].src == newpkterf[1][Ether].src
+
+assert len(pkterf) == len(newpkterf)
+assert newpkterf[0].time is not None
+assert newpkterf[0].wirelen is not None
+assert newpkterf[0].time == pkterf[0].time
+assert newpkterf[0].wirelen == pkterf[0].wirelen
+assert newpkterf[1].time is not None
+assert newpkterf[1].wirelen is not None
+assert newpkterf[1].time == pkterf[1].time
+assert newpkterf[1].wirelen == pkterf[1].wirelen
+
+_, filename = tempfile.mkstemp()
+wrerf(filename, pkterf, append=True)
+wrerf(filename, pkterf, append=True)
+newdoublepkterf = rderf(filename)
+
+assert len(newpkterf) * 2 == len(newdoublepkterf)
+
+= Check rderf
+pkterf = rderf(erffilewithheader)
+assert pkterf[1].time == 1603418463.270062279
+assert pkterf[1][Ether].src == "00:0f:53:3f:ca:c0"
 
 ############
 ############


### PR DESCRIPTION
This PR adds:
* ERF Ethernet Reader
* ERF Ethernet Writer
* Unit tests for Ethernet Reader and Writer 

Co-authored-by: 
- Daniel Widjaja <dwidjaja@drwholdings.com>
- Tuan Le <tle@drwholdings.com>
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
Previously when we want to read an ERF capture file, we convert the ERF file to pcap using wireshark or tshark and pass the pcap to scapy. This PR enables to read and write ERF Ethernet files directly. We only support ERF files of Type 2 which is used for the ethernet captures. 

We create ERFEthernetReader and ERFEthernetWriter which behave similarly to PcapReader and PcapWriter. The main 2 functions that will be used are `rderf(filename, count)` and `wrerf(filename, pkt, *args, **kargs)` which similar to `rdpcap(filename, count)` and `wrpcap(filename, pkt, *args, **kargs)` but it receive ERF Capture File. 

However, `PcapWriter.write(pkt)` accepts both `Packet` and `bytes` type for `pkt`. But `ERFEthernetWriter.write(pkt)` only accepts `Packet` type for `pkt`. We feel that this feature isn't frequently used to be implemented and we would like to hear your opinion about this. 

### ERF Reader Example usage
```
scapy_erf = rderf("sample.erf") # scapy_erf is a array of Packets
wrerf("output_sample.erf", scapy_erf) # scapy_erf will be written to output_sample.erf file as a ERF Capture file.
```

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

Fix #3276 <!-- (add issue number here if appropriate, else remove this line) -->
