### PR TITLE
Make sure that a DNS query contains a DNSQR

### DIFF
--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -38,10 +38,10 @@ class LLMNRQuery(Packet):
                    DNSRRCountField("ancount", None, "an"),
                    DNSRRCountField("nscount", None, "ns"),
                    DNSRRCountField("arcount", None, "ar"),
-                   DNSQRField("qd", "qdcount"),
-                   DNSRRField("an", "ancount"),
-                   DNSRRField("ns", "nscount"),
-                   DNSRRField("ar", "arcount", 0)]
+                   DNSQRField("qd", "qdcount", None),
+                   DNSRRField("an", "ancount", None),
+                   DNSRRField("ns", "nscount", None),
+                   DNSRRField("ar", "arcount", None, 0)]
     overload_fields = {UDP: {"sport": 5355, "dport": 5355}}
 
     def hashret(self):

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -218,3 +218,7 @@ assert p.ar.rrname == b'.'
 assert dns_encode(b"www.google.com") == b'\x03www\x06google\x03com\x00'
 assert dns_encode(b"*") == b'\x01*\x00'
 assert dns_encode(dns_encode(b"*")) == b'\x03\x01*\x00'
+
+= DNS - simple request
+
+assert raw(DNS()) == b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x03www\x07example\x03com\x00\x00\x01\x00\x01'


### PR DESCRIPTION
This PR simplifies sending DNS packets with Scapy by using a better default value for the `qr` field.

Before this PR:
```
sr1(IP(dst="1.1.1.1")/UDP()/DNS(qd=DNSQR()))
```

After this PR:
```
sr1(IP(dst="1.1.1.1")/UDP()/DNS())
```