### PR TITLE
Minor UTscapy tweak (conf.use_pcap is set later on windows)

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -1077,13 +1077,10 @@ def main():
     except AttributeError:
         pass
 
-    if conf.use_pcap:
+    if conf.use_pcap or WINDOWS:
         KW_KO.append("not_libpcap")
         if VERB > 2:
             print(" " + arrow + " libpcap mode")
-    elif WINDOWS and not NON_ROOT:
-        print("ERROR: libpcap is required on Windows for root tests")
-        raise SystemExit
 
     KW_KO.append("disabled")
 


### PR DESCRIPTION
`conf.use_pcap` is set to `True` later on windows so this test would fail