### PR TITLE
Adding support for version 5.0 of the MQTT protocol.

### DIFF
--- a/scapy/contrib/mqtt5.py
+++ b/scapy/contrib/mqtt5.py
@@ -1,0 +1,606 @@
+# This file is part of Scapy
+# See http://www.secdev.org/projects/scapy for more information
+# Copyright (C) Santiago Hernandez Ramos <shramos@protonmail.com>
+# This program is published under GPLv2 license
+
+# scapy.contrib.description = Message Queuing Telemetry Transport (MQTT) version 5.0
+# scapy.contrib.status = loads
+
+from scapy.packet import Packet, bind_layers
+from scapy.fields import FieldLenField, BitEnumField, StrLenField, \
+    ShortField, ConditionalField, ByteEnumField, ByteField, PacketListField
+from scapy.layers.inet import TCP
+from scapy.error import Scapy_Exception
+from scapy.compat import orb, chb
+from scapy.volatile import RandNum
+from scapy.config import conf
+
+
+# CUSTOM FIELDS
+# source: http://stackoverflow.com/a/43717630
+class VariableFieldLenField(FieldLenField):
+    def addfield(self, pkt, s, val):
+        val = self.i2m(pkt, val)
+        data = []
+        while val:
+            if val > 127:
+                data.append(val & 127)
+                val //= 128
+            else:
+                data.append(val)
+                lastoffset = len(data) - 1
+                data = b"".join(chb(val | (0 if i == lastoffset else 128))
+                                for i, val in enumerate(data))
+                return s + data
+            if len(data) > 3:
+                raise Scapy_Exception("%s: malformed length field" %
+                                      self.__class__.__name__)
+        # If val is None / 0
+        return s + b"\x00"
+
+    def getfield(self, pkt, s):
+        value = 0
+        for offset, curbyte in enumerate(s):
+            curbyte = orb(curbyte)
+            value += (curbyte & 127) * (128 ** offset)
+            if curbyte & 128 == 0:
+                return s[offset + 1:], value
+            if offset > 2:
+                raise Scapy_Exception("%s: malformed length field" %
+                                      self.__class__.__name__)
+
+    def randval(self):
+        return RandVariableFieldLen()
+
+
+class RandVariableFieldLen(RandNum):
+    def __init__(self):
+        RandNum.__init__(self, 0, 268435455)
+
+
+# LAYERS
+CONTROL_PACKET_TYPE = {
+    1: 'CONNECT',
+    2: 'CONNACK',
+    3: 'PUBLISH',
+    4: 'PUBACK',
+    5: 'PUBREC',
+    6: 'PUBREL',
+    7: 'PUBCOMP',
+    8: 'SUBSCRIBE',
+    9: 'SUBACK',
+    10: 'UNSUBSCRIBE',
+    11: 'UNSUBACK',
+    12: 'PINGREQ',
+    13: 'PINGRESP',
+    14: 'DISCONNECT',
+    15: 'AUTH'  # Added in v5.0
+}
+
+
+QOS_LEVEL = {
+    0: 'At most once delivery',
+    1: 'At least once delivery',
+    2: 'Exactly once delivery'
+}
+
+PROPERTY = {
+        1: 'Payload Format Indicator', #Byte
+        2: 'Message Expiry Interval', #Four Byte Integer
+        3: 'Content Type', #UTF-8 Encoded String
+        8: 'Response Topic', #UTF-8 Encoded String
+        9: 'Correlation Data', #Binary Data
+        11: 'Subscription Identifier', #Variable Byte Integer
+        17: 'Session Expiry Interval', #Four Byte Integer
+        18: 'Assigned Client Identifier', #UTF-8 Encoded String
+        19: 'Server Keep Alive', #Two Byte Integer
+        21: 'Authentication Method', #UTF-8 Encoded String
+        22: 'Authentication Data', #Binary Data
+        23: 'Request Problem Information', #Byte
+        24: 'Will Delay Interval', #Four Byte Integer
+        25: 'Request Response Information', #Byte
+        26: 'Response Information', #UTF-8 Encoded String
+        28: 'Server Reference', #UTF-8 Encoded String
+        31: 'Reason String', #UTF-8 Encoded String
+        33: 'Receive Maximum', #Two Byte Integer
+        34: 'Topic Alias Maximum', #Two Byte Integer
+        35: 'Topic Alias', #Two Byte Integer
+        36: 'Maximum QoS', #Byte
+        37: 'Retain Available', #Byte
+        38: 'User Property', #UTF-8 String Pair
+        39: 'Maximum Packet Size', #Four Byte Integer
+        40: 'Wildcard Subscription Available', #Byte
+        41: 'Subscription Identifier Available', #Byte
+        42: 'Shared Subscription Available', #Byte
+}
+
+
+# source: http://stackoverflow.com/a/43722441
+class MQTT(Packet):
+    name = "MQTT fixed header"
+    fields_desc = [
+        BitEnumField("type", 1, 4, CONTROL_PACKET_TYPE),
+        BitEnumField("DUP", 0, 1, {0: 'Disabled',
+                                   1: 'Enabled'}),
+        BitEnumField("QOS", 0, 2, QOS_LEVEL),
+        BitEnumField("RETAIN", 0, 1, {0: 'Disabled',
+                                      1: 'Enabled'}),
+        # Since the size of the len field depends on the next layer, we need
+        # to "cheat" with the length_of parameter and use adjust parameter to
+        # calculate the value.
+        VariableFieldLenField("len", None, length_of="len",
+                              adjust=lambda pkt, x: len(pkt.payload),),
+    ]
+
+
+PROTOCOL_LEVEL = {
+    #3: 'v3.1',
+    #4: 'v3.1.1',
+    5: 'v5.0'
+}
+
+class UTF8EncodedString(Packet):
+    fields_desc = [
+        FieldLenField("length", None, length_of="value"),
+        StrLenField("value", "", length_from=lambda pkt:pkt.length)
+    ]
+
+class UTF8StringPair(Packet):
+    fields_desc = [
+                   FieldLenField("keylen", None, length_of="key"),
+                   StrLenField("key", "", length_from=lambda pkt:pkt.keylen),
+                   FieldLenField("valuelen", None, length_of="value"),
+                   StrLenField("value", "", length_from=lambda pkt:pkt.valuelen)
+                  ]
+
+class MQTTProperty(Packet):
+    name = "Property"
+    fields_desc = [
+            ByteEnumField("propid", None, PROPERTY),
+            MultipleTypeField(
+            [
+                #2 BYTE INTEGER FIELDS
+                (ShortField("propvalue", 0),
+                            lambda pkt: (pkt.propid == 19 or 
+                                         pkt.propid == 33 or 
+                                         pkt.propid == 34 or 
+                                         pkt.propid == 35)),
+
+                #4 BYTE INTEGER FIELDS
+                (IntField("propvalue", 0),
+                          lambda pkt: (pkt.propid == 2 or
+                                       pkt.propid == 11 or 
+                                       pkt.propid == 17 or 
+                                       pkt.propid == 24 or 
+                                       pkt.propid == 39)),
+
+                #1 BYTE FIELD
+                (ByteEnumField("propvalue", 0, {0: 'Disabled',
+                                                1: 'Enabled'}),
+                               lambda pkt: (pkt.propid == 1 or
+                                            pkt.propid == 23 or 
+                                            pkt.propid == 25 or 
+                                            pkt.propid == 36 or 
+                                            pkt.propid == 37 or
+                                            pkt.propid == 40 or
+                                            pkt.propid == 41 or
+                                            pkt.propid == 42)),
+
+                #UTF8 STRING PAIR
+                (PacketField("propvalue", None, pkt_cls=UTF8StringPair),
+                                 lambda pkt: pkt.propid == 38),
+
+                #UTF8 ENCODED STRING
+                (PacketField("propvalue", None, pkt_cls=UTF8EncodedString),
+                                 lambda pkt: (pkt.propid == 3 or
+                                              pkt.propid == 8 or
+                                              pkt.propid == 9 or
+                                              pkt.propid == 18 or
+                                              pkt.propid == 21 or
+                                              pkt.propid == 22 or
+                                              pkt.propid == 26 or
+                                              pkt.propid == 28 or
+                                              pkt.propid == 31)),
+            ],
+
+            #None
+            StrLenField("propvalue", None)
+        ),
+
+    ] 
+
+class MQTTWillProperty(MQTTProperty):
+    name = "Will Properties"
+
+class MQTTConnect(Packet):
+    name = "MQTT connect"
+    fields_desc = [
+        FieldLenField("length", None, length_of="protoname"),
+        StrLenField("protoname", "",
+                    length_from=lambda pkt: pkt.length),
+        ByteEnumField("protolevel", 5, PROTOCOL_LEVEL),
+        BitEnumField("usernameflag", 0, 1, {0: 'Disabled',
+                                            1: 'Enabled'}),
+        BitEnumField("passwordflag", 0, 1, {0: 'Disabled',
+                                            1: 'Enabled'}),
+        BitEnumField("willretainflag", 0, 1, {0: 'Disabled',
+                                              1: 'Enabled'}),
+        BitEnumField("willQOSflag", 0, 2, QOS_LEVEL),
+        BitEnumField("willflag", 0, 1, {0: 'Disabled',
+                                        1: 'Enabled'}),
+        BitEnumField("cleansess", 0, 1, {0: 'Disabled',
+                                         1: 'Enabled'}),
+        BitEnumField("reserved", 0, 1, {0: 'Disabled',
+                                        1: 'Enabled'}),
+        ShortField("klive", 0),
+
+        #CONNECT PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        FieldLenField("clientIdlen", None, length_of="clientId"),
+        StrLenField("clientId", "",
+                    length_from=lambda pkt: pkt.clientIdlen),
+        # Payload with optional fields depending on the flags
+
+        # WILL PROPERTIES
+        ConditionalField(FieldLenField("willproplen", None, fmt='B', length_of="willproperties"),
+                          lambda pkt: pkt.willflag == 1),
+        ConditionalField(PacketListField("willproperties", [], pkt_cls=MQTTWillProperty, length_from=lambda pkt: pkt.willproplen),
+                          lambda pkt: pkt.willflag == 1),
+
+        ConditionalField(FieldLenField("wtoplen", None, length_of="willtopic"),
+                         lambda pkt: pkt.willflag == 1),
+        ConditionalField(StrLenField("willtopic", "",
+                                     length_from=lambda pkt: pkt.wtoplen),
+                         lambda pkt: pkt.willflag == 1),
+        ConditionalField(FieldLenField("wmsglen", None, length_of="willmsg"),
+                         lambda pkt: pkt.willflag == 1),
+        ConditionalField(StrLenField("willmsg", "",
+                                     length_from=lambda pkt: pkt.wmsglen),
+                         lambda pkt: pkt.willflag == 1),
+        ConditionalField(FieldLenField("userlen", None, length_of="username"),
+                         lambda pkt: pkt.usernameflag == 1),
+        ConditionalField(StrLenField("username", "",
+                                     length_from=lambda pkt: pkt.userlen),
+                         lambda pkt: pkt.usernameflag == 1),
+        ConditionalField(FieldLenField("passlen", None, length_of="password"),
+                         lambda pkt: pkt.passwordflag == 1),
+        ConditionalField(StrLenField("password", "",
+                                     length_from=lambda pkt: pkt.passlen),
+                         lambda pkt: pkt.passwordflag == 1),
+
+    ]
+
+
+DISCONNECT_REASON_CODE = {
+        0: 'Normal disconnection',
+        4: 'Disconnect with Will Message',
+        128: 'Unspecified error',
+        129: 'Malformed Packet',
+        130: 'Protocol Error',
+        131: 'Implementation specific error',
+        135: 'Not authorized',
+        137: 'Server busy',
+        139: 'Server shutting down',
+        141: 'Keep Alive timeout',
+        142: 'Session taken over',
+        143: 'Topic Filter invalid',
+        144: 'Topic Name invalid',
+        147: 'Receive Maximum exceeded',
+        148: 'Topic Alias invalid',
+        149: 'Packet too large',
+        150: 'Message rate too high',
+        151: 'Quota exceeded',
+        152: 'Administrative action',
+        153: 'Payload format invalid',
+        154: 'Retain not supported',
+        155: 'QoS not supported',
+        156: 'Use another server',
+        157: 'Server moved',
+        158: 'Shared Subscriptions not supported',
+        159: 'Connection rate exceeded',
+        160: 'Maximum connect time',
+        161: 'Subscription identifiers not supported',
+        162: 'Wildcard Subscriptions not supported'
+}
+
+class MQTTDisconnect(Packet):
+    name = "MQTT disconnect"
+    fields_desc = [
+            ByteEnumField('reasoncode', 0, DISCONNECT_REASON_CODE),
+            
+            #DISCONNECT PROPERTIES
+            FieldLenField("proplen", None, fmt='B', length_of="properties"),
+            ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                             lambda pkt: pkt.proplen != 0),
+            ]
+
+
+RETURN_CODE = {
+    0: 'Connection Accepted',
+    128: 'Unspecified Error',
+    129: 'Malformed Packet',
+    130: 'Protocol Error',
+    131: 'Implementation Specific Error',
+    132: 'Unsupported Protocol Version',
+    133: 'Client Identifier not valid',
+    134: 'Bad User Name or Password',
+    135: 'Not Authorized',
+    136: 'Server Unavailable',
+    137: 'Server Busy',
+    138: 'Banned',
+    140: 'Bad Authentication Method',
+    144: 'Topic Name Invalid',
+    149: 'Packet Too Large',
+    151: 'Quota Exceeded',
+    153: 'Payload Format Invalid',
+    154: 'Retain Not Supported',
+    155: 'QOS Not Supported',
+    156: 'Use Another Server',
+    157: 'Server Moved',
+    159: 'Connection Rate Exceeded',
+           
+}
+
+
+class MQTTConnack(Packet):
+    name = "MQTT connack"
+    fields_desc = [
+        ByteField("sessPresentFlag", 0),
+        ByteEnumField("retcode", 0, RETURN_CODE),
+        
+        #CONNACK PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+    ]
+
+
+class MQTTPublish(Packet):
+    name = "MQTT publish"
+    fields_desc = [
+        FieldLenField("length", None, length_of="topic"),
+        StrLenField("topic", "",
+                    length_from=lambda pkt: pkt.length),
+        ConditionalField(ShortField("msgid", None),
+                         lambda pkt: (pkt.underlayer.QOS == 1 or
+                                      pkt.underlayer.QOS == 2)),
+
+        #PUBLISH PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        StrLenField("value", "",
+                    length_from=lambda pkt: (pkt.underlayer.len -
+                                             pkt.length - 2)),
+    ]
+
+PUBLISH_QOS1_REASON_CODE = {
+        0: 'Success',
+        16: 'No matching subscribers',
+        128: 'Unspecified error',
+        131: 'Implementation specific error',
+        135: 'Not authorized',
+        144: 'Topic Name invalid',
+        145: 'Packet identifier in use',
+        151: 'Quota exceeded',
+        153: 'Payload format invalid',
+}
+
+
+class MQTTPuback(Packet):
+    name = "MQTT puback"
+    fields_desc = [
+        ShortField("msgid", None),
+        ByteEnumField("reasoncode", 0, PUBLISH_QOS1_REASON_CODE),
+
+        #PUBACK PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+    ]
+
+
+class MQTTPubrec(Packet):
+    name = "MQTT pubrec"
+    fields_desc = [
+        ShortField("msgid", None),
+        ByteEnumField("reasoncode", 0, PUBLISH_QOS1_REASON_CODE),
+
+        #PUBREC PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+    ]
+
+PUBLISH_QOS2_REASON_CODE = {
+        0: 'Success',
+        146: 'Packet Identifier not found',
+}
+
+class MQTTPubrel(Packet):
+    name = "MQTT pubrel"
+    fields_desc = [
+        ShortField("msgid", None),
+        ByteEnumField("reasoncode", 0, PUBLISH_QOS2_REASON_CODE),
+
+        #PUBREL PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+    ]
+
+
+class MQTTPubcomp(Packet):
+    name = "MQTT pubcomp"
+    fields_desc = [
+        ShortField("msgid", None),
+        ByteEnumField("reasoncode", 0, PUBLISH_QOS2_REASON_CODE),
+
+        #PUBCOMP PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+    ]
+
+RETAIN_VALUE = {
+        0: 'Send retained messages at the time of subscribe',
+        1: 'Send retained messages at subscribe only if the subscription does not currently exist',
+        2: 'Do not send retained messages at the time of the subscribe'
+}
+
+class MQTTTopic(Packet):
+    name = "MQTT topic"
+    fields_desc = [
+        FieldLenField("length", None, length_of="topic"),
+        StrLenField("topic", "", length_from=lambda pkt:pkt.length)
+    ]
+
+    def guess_payload_class(self, payload):
+        return conf.padding_layer
+
+
+class MQTTTopicOptions(MQTTTopic):
+    fields_desc = MQTTTopic.fields_desc + [
+                                            BitEnumField("reserved", 0, 2, {0: 'Disabled',
+                                                                            1: 'Enabled'}),
+                                            BitEnumField("retainhandle", 0, 2, RETAIN_VALUE),
+                                            BitEnumField("RAP", 0, 1, {0: 'Disabled',
+                                                                       1: 'Enabled'}),
+                                            BitEnumField("NL", 0, 1, {0: 'Disabled',
+                                                                      1: 'Enabled'}),
+                                            BitEnumField("QOS", 0, 2, QOS_LEVEL)
+                                          ]
+
+class MQTTSubscribe(Packet):
+    name = "MQTT subscribe"
+    fields_desc = [
+        ShortField("msgid", None),
+
+        #SUBSCRIBE PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        PacketListField("topics", [], pkt_cls=MQTTTopicOptions),
+    ]
+
+
+SUBACK_REASON_CODE = {
+        0: 'Granted QoS 0',
+        1: 'Granted QoS 1',
+        2: 'Granted QoS 2',
+        128: 'Unspecified error',
+        131: 'Implementation specific error',
+        135: 'Not authorized',
+        143: 'Topic Filter invalid',
+        145: 'Packet Identifier in use',
+        151: 'Quota exceeded',
+        158: 'Shared Subscriptions not supported',
+        161: 'Subscription identifiers not supported',
+        162: 'Wildcard Subscriptions not supported'
+}
+
+
+class MQTTSuback(Packet):
+    name = "MQTT suback"
+    fields_desc = [
+        ShortField("msgid", None),
+
+        #SUBACK PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        ByteEnumField("reasoncode", None, SUBACK_REASON_CODE)
+    ]
+
+
+class MQTTUnsubscribe(Packet):
+    name = "MQTT unsubscribe"
+    fields_desc = [
+        ShortField("msgid", None),
+
+        #UNSUBSCRIBE PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        PacketListField("topics", [], pkt_cls=MQTTTopic)
+    ]
+
+UNSUBACK_REASON_CODE = {
+        0: 'Sucess',
+        17: 'No subscription existed',
+        128: 'Unspecified error',
+        131: 'Implementation specific error',
+        135: 'Not authorized',
+        143: 'Topic Filter invalid',
+        145: 'Packet Identifier in use'
+}
+
+
+class MQTTUnsuback(Packet):
+    name = "MQTT unsuback"
+    fields_desc = [
+        ShortField("msgid", None),
+
+        #UNSUBACK PROPERTIES
+        FieldLenField("proplen", None, fmt='B', length_of="properties"),
+        ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+
+        ByteEnumField('reasoncode', 0, UNSUBACK_REASON_CODE)
+    ]
+
+AUTHENTICATE_REASON_CODE = {
+        0: 'Success',
+        24: 'Continue authentication',
+        25: 'Re-authenticate'
+}
+
+class MQTTAuth(Packet):
+    fields_desc = [
+            ByteEnumField('reasoncode', 0, AUTHENTICATE_REASON_CODE),
+
+            #AUTH PROPERTIES
+            FieldLenField("proplen", None, fmt='B', length_of="properties"),
+            ConditionalField(PacketListField("properties", [], pkt_cls=MQTTProperty, length_from=lambda pkt: pkt.proplen),
+                         lambda pkt: pkt.proplen != 0),
+            ]
+
+
+# LAYERS BINDINGS
+
+bind_layers(TCP, MQTT, sport=1883)
+bind_layers(TCP, MQTT, dport=1883)
+bind_layers(MQTT, MQTTConnect, type=1)
+bind_layers(MQTT, MQTTConnack, type=2)
+bind_layers(MQTT, MQTTPublish, type=3)
+bind_layers(MQTT, MQTTPuback, type=4)
+bind_layers(MQTT, MQTTPubrec, type=5)
+bind_layers(MQTT, MQTTPubrel, type=6)
+bind_layers(MQTT, MQTTPubcomp, type=7)
+bind_layers(MQTT, MQTTSubscribe, type=8)
+bind_layers(MQTT, MQTTSuback, type=9)
+bind_layers(MQTT, MQTTUnsubscribe, type=10)
+bind_layers(MQTT, MQTTUnsuback, type=11)
+bind_layers(MQTT, MQTTDisconnect, type=14)
+bind_layers(MQTT, MQTTAuth, type=15)
+bind_layers(MQTTConnect, MQTT)
+bind_layers(MQTTConnack, MQTT)
+bind_layers(MQTTPublish, MQTT)
+bind_layers(MQTTPuback, MQTT)
+bind_layers(MQTTPubrec, MQTT)
+bind_layers(MQTTPubrel, MQTT)
+bind_layers(MQTTPubcomp, MQTT)
+bind_layers(MQTTSubscribe, MQTT)
+bind_layers(MQTTSuback, MQTT)
+bind_layers(MQTTUnsubscribe, MQTT)
+bind_layers(MQTTUnsuback, MQTT)
+bind_layers(MQTTDisconnect, MQTT)
+bind_layers(MQTTAuth, MQTT)

--- a/test/contrib/mqtt5.uts
+++ b/test/contrib/mqtt5.uts
@@ -1,0 +1,669 @@
+# MQTT layer unit tests
+# Copyright (C) Santiago Hernandez Ramos <shramos@protonmail.com>
+#
+# Type the following command to launch start the tests:
+# $ test/run_tests -P "load_contrib('mqtt5')" -t test/contrib/mqtt5.uts
+
++ Syntax check
+= Import the MQTT layer
+from scapy.contrib.mqtt5 import *
+
+
++ MQTT protocol test
+
+= MQTTConnect, packet instantiation, no mqtt property, no will property
+c = MQTT()/MQTTConnect(clientIdlen=5, clientId='newid') 
+assert(c.type == 1)
+assert(c.proplen == None)
+assert(c.clientIdlen == 5)
+assert(c.clientId == b'newid')
+assert(c.willproplen == None)
+ 
+= MQTTConnect, packet dissection, no mqtt property, no will property
+s = b'\x10\x12\x00\x04MQTT\x05\x02\x00<\x00\x00\x05newid'
+connect = MQTT(s)
+assert(connect.length == 4)
+assert(connect.protoname == b'MQTT')
+assert(connect.protolevel == 5)
+assert(connect.usernameflag == 0)
+assert(connect.passwordflag == 0)
+assert(connect.willretainflag == 0)
+assert(connect.willQOSflag == 0)
+assert(connect.willflag == 0)
+assert(connect.cleansess == 1)
+assert(connect.reserved == 0)
+assert(connect.klive == 60)
+assert(connect.proplen == 0)
+assert(connect.clientIdlen == 5)
+assert(connect.clientId == b'newid')
+
+= MQTTConnect, packet instantiation, with mqtt property, no will property
+c = MQTT()/MQTTConnect(properties=[MQTTProperty(propid=21, propvalue=UTF8EncodedString(value='test'))], clientIdlen=5, clientId='newid') 
+assert(c.type == 1)
+assert(c.properties[0].propid == 21)
+assert(c.properties[0].propvalue.value == b'test')
+assert(c.clientIdlen == 5)
+assert(c.clientId == b'newid')
+
+= MQTTConnect, packet dissection, with mqtt property, no will property
+s = b'\x10\x19\x00\x04MQTT\x05\x00\x00\x00\x07\x15\x00\x04test\x00\x05newid' 
+connect = MQTT(s)
+assert(connect.length == 4)
+assert(connect.protoname == b'MQTT')
+assert(connect.protolevel == 5)
+assert(connect.usernameflag == 0)
+assert(connect.passwordflag == 0)
+assert(connect.willretainflag == 0)
+assert(connect.willQOSflag == 0)
+assert(connect.willflag == 0)
+assert(connect.cleansess == 0)
+assert(connect.reserved == 0)
+assert(connect.klive == 0)
+assert(connect.proplen == 7)
+assert(connect.properties[0].propid == 21)
+assert(connect.properties[0].propvalue.value == b'test')
+assert(connect.clientIdlen == 5)
+assert(connect.clientId == b'newid')
+
+= MQTTConnect, packet instantiation, with mqtt property, with will property
+c = MQTT()/MQTTConnect(properties=[MQTTProperty(propid=21, propvalue=UTF8EncodedString(value='test'))], clientIdlen=5, clientId='newid', willflag=1, willproperties=[MQTTWillProperty(propid=1, propvalue=1)]) 
+assert(c.type == 1)
+assert(c.properties[0].propid == 21)
+assert(c.properties[0].propvalue.value == b'test')
+assert(c.clientIdlen == 5)
+assert(c.clientId == b'newid')
+assert(c.willflag == 1)
+assert(c.willproperties[0].propid == 1)
+assert(c.willproperties[0].propvalue == 1)
+
+= MQTTConnect, packet dissection, with mqtt property, with will property
+s = b'\x10\x34\x00\x04MQTT\x05\x04\x00\x00\x07\x15\x00\x04test\x00\x05newid\x02\x01\x01\x00\x09willtopic\x00\x0bwillmessage'
+connect = MQTT(s)
+assert(connect.length == 4)
+assert(connect.protoname == b'MQTT')
+assert(connect.protolevel == 5)
+assert(connect.usernameflag == 0)
+assert(connect.passwordflag == 0)
+assert(connect.willretainflag == 0)
+assert(connect.willQOSflag == 0)
+assert(connect.willflag == 1)
+assert(connect.cleansess == 0)
+assert(connect.reserved == 0)
+assert(connect.klive == 0)
+assert(connect.proplen == 7)
+assert(connect.properties[0].propid == 21)
+assert(connect.properties[0].propvalue.value == b'test')
+assert(connect.clientIdlen == 5)
+assert(connect.clientId == b'newid')
+assert(connect.willproplen == 2)
+assert(connect.willproperties[0].propid == 1)
+assert(connect.willproperties[0].propvalue == 1)
+assert(connect.wtoplen == 9)
+assert(connect.willtopic == b'willtopic')
+assert(connect.wmsglen == 11)
+assert(connect.willmsg == b'willmessage')
+
+= MQTTPublish, packet instantiation, no mqtt property
+p = MQTT()/MQTTPublish(topic='test1',value='test2')
+assert(p.type == 3)
+assert(p.topic == b'test1')
+assert(p.value == b'test2')
+assert(p.len == None)
+assert(p.length == None)
+assert(p.proplen == None)
+
+= Fixed header and MQTTPublish, packet dissection, no mqtt property
+p = b'0\r\x00\x05test1\x00test2'                                                                                                                                            
+publish = MQTT(p)
+assert(publish.type == 3)
+assert(publish.QOS == 0)
+assert(publish.DUP == 0)
+assert(publish.RETAIN == 0)
+assert(publish.len == 13)
+assert(publish[MQTTPublish].length == 5)
+assert(publish[MQTTPublish].topic == b'test1')
+assert(publish.proplen == 0)
+assert(publish[MQTTPublish].value == b'test2')
+
+= MQTTPublish, packet instantiation, with mqtt property
+p = MQTT()/MQTTPublish(topic='test1',value='test2', properties=[MQTTProperty(propid=35, propvalue=33333)])
+assert(p.type == 3)
+assert(p.topic == b'test1')
+assert(p.value == b'test2')
+assert(p.len == None)
+assert(p.length == None)
+assert(p.proplen == None)
+assert(p.properties[0].propid == 35)
+assert(p.properties[0].propvalue == 33333)
+
+= Fixed header and MQTTPublish, packet dissection, with mqtt property
+p = b'0\x10\x00\x05test1\x03#\x825test2'
+publish = MQTT(p)
+assert(publish.type == 3)
+assert(publish.DUP == 0)
+assert(publish.QOS == 0)
+assert(publish.RETAIN == 0)
+assert(publish.len == 16)
+assert(publish.length == 5)
+assert(publish.topic == b'test1')
+assert(publish.proplen == 3)
+assert(publish.properties[0].propid == 35)
+assert(publish.properties[0].propvalue == 33333)
+assert(publish.value == b'test2')
+
+= MQTTDisconnect, packet instantiation, no mqtt property
+d = MQTT()/MQTTDisconnect(reasoncode=148)
+assert(d.type == 14)
+assert(d.len == None)
+assert(d.reasoncode == 148)
+assert(d.proplen == None)
+
+= MQTTDisconnect, packet dissection, no mqtt property
+dc = b'\xe0\x02\x94\x00'                                                                                                                                                    
+disconnect = MQTT(dc)
+assert(disconnect.type == 14)
+assert(disconnect.DUP == 0)
+assert(disconnect.QOS == 0)
+assert(disconnect.RETAIN == 0)
+assert(disconnect.len == 2)
+assert(disconnect.reasoncode == 148)
+assert(disconnect.proplen == 0)
+
+
+= MQTTDisconnect, packet instantiation, with mqtt property
+d = MQTT()/MQTTDisconnect(reasoncode=148, properties=[MQTTProperty(propid=38, propvalue=UTF8StringPair(key='1', value='test'))])
+assert(d.type == 14)
+assert(d.len == None)
+assert(d.reasoncode == 148)
+assert(d.proplen == None)
+assert(d.properties[0].propid == 38)
+assert(d.properties[0].propvalue.key == b'1')
+assert(d.properties[0].propvalue.value == b'test')
+
+= MQTTDisconnect, packet dissection, with mqtt property
+dc = b'\xe0\x0c\x94\n&\x00\x011\x00\x04test'
+disconnect = MQTT(dc)
+assert(disconnect.type == 14)
+assert(disconnect.DUP == 0)
+assert(disconnect.QOS == 0)
+assert(disconnect.RETAIN == 0)
+assert(disconnect.len == 12)
+assert(disconnect.reasoncode == 148)
+assert(disconnect.proplen == 10)
+assert(disconnect.properties[0].propid == 38)
+assert(disconnect.properties[0].propvalue.keylen == 1)
+assert(disconnect.properties[0].propvalue.key == b'1')
+assert(disconnect.properties[0].propvalue.valuelen == 4)
+assert(disconnect.properties[0].propvalue.value == b'test')
+
+=MQTTConnack, packet instantiation, no mqtt property
+ck = MQTT()/MQTTConnack(sessPresentFlag=1,retcode=0)
+assert(ck.type == 2)
+assert(ck.sessPresentFlag == 1)
+assert(ck.retcode == 0)
+assert(ck.proplen == None)
+
+= MQTTConnack, packet dissection, no mqtt property
+s = b' \x02\x01\x00' 
+connack = MQTT(s)
+assert(connack.type == 2)
+assert(connack.DUP == 0)
+assert(connack.QOS == 0)
+assert(connack.RETAIN == 0)
+assert(connack.len == 2)
+assert(connack.sessPresentFlag == 1)
+assert(connack.retcode == 0)
+assert(connack.proplen == None)
+
+=MQTTConnack, packet instantiation, with mqtt property
+ck = MQTT()/MQTTConnack(sessPresentFlag=1,retcode=0, properties=[MQTTProperty(propid=34, propvalue=10)])
+assert(ck.type == 2)
+assert(ck.sessPresentFlag == 1)
+assert(ck.retcode == 0)
+assert(ck.proplen == None)
+assert(ck.properties[0].propid == 34)
+assert(ck.properties[0].propvalue == 10)
+
+= MQTTConnack, packet dissection, no mqtt property
+s = b' \x06\x01\x00\x03"\x00\n'                                                                                                                                             
+connack = MQTT(s) 
+assert(connack.type == 2)
+assert(connack.DUP == 0)
+assert(connack.QOS == 0)
+assert(connack.RETAIN == 0)
+assert(connack.len == 6)
+assert(connack.sessPresentFlag == 1)
+assert(connack.retcode == 0)
+assert(connack.proplen == 3)
+assert(connack.properties[0].propid == 34)
+assert(connack.properties[0].propvalue == 10)
+
+= MQTTSubscribe, packet instantiation, no mqtt property
+sb = MQTT()/MQTTSubscribe(msgid=1, topics=[MQTTTopicOptions(topic='newtopic', retainhandle=1, RAP=1, NL=1, QOS=1, length=0)])
+assert(sb.type == 8)
+assert(sb.msgid == 1)
+assert(sb.proplen == None)
+assert(sb.topics[0].topic == b'newtopic')
+assert(sb.topics[0].length == 0)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].retainhandle == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].RAP == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].NL == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].QOS == 1)
+
+= MQTTSubscribe, packet dissection, no mqtt property
+s = b'\x82\t\x00\x01\x00\x00\x04test\x1d'
+subscribe = MQTT(s)
+assert(subscribe.type == 8)
+assert(subscribe.DUP == 0)
+assert(subscribe.QOS == 1)
+assert(subscribe.RETAIN == 0)
+assert(subscribe.len == 9)
+assert(subscribe.msgid == 1)
+assert(subscribe.proplen == 0)
+assert(subscribe.topics[0].length == 4)
+assert(subscribe.topics[0].topic == b'test')
+assert(subscribe.topics[0].retainhandle == 1)
+assert(subscribe.topics[0].RAP == 1)
+assert(subscribe.topics[0].NL == 1)
+assert(subscribe.topics[0].QOS == 1)
+
+= MQTTSubscribe, packet instantiation, with mqtt property
+sb = MQTT()/MQTTSubscribe(msgid=1, properties=[MQTTProperty(propid=11, propvalue=55)], topics=[MQTTTopicOptions(topic='newtopic', retainhandle=1, RAP=1, NL=1, QOS=1, length=8)])
+assert(sb.type == 8)
+assert(sb.msgid == 1)
+assert(sb.proplen == None)
+assert(sb.properties[0].propid == 11)
+assert(sb.properties[0].propvalue == 55)
+assert(sb.topics[0].topic == b'newtopic')
+assert(sb.topics[0].length == 8)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].retainhandle == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].RAP == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].NL == 1)
+assert(sb[MQTTSubscribe][MQTTTopicOptions].QOS == 1)
+
+= MQTTSubscribe, packet dissection, with mqtt property
+s = b'\x80\x13\x00\x01\x05\x0b\x00\x00\x007\x00\x08newtopic\x1d'                                                                                                            
+subscribe = MQTT(s)
+assert(subscribe.type == 8)
+assert(subscribe.DUP == 0)
+assert(subscribe.QOS == 0)
+assert(subscribe.RETAIN == 0)
+assert(subscribe.len == 19)
+assert(subscribe.msgid == 1)
+assert(subscribe.proplen == 5)
+assert(subscribe.properties[0].propid == 11)
+assert(subscribe.properties[0].propvalue == 55)
+assert(subscribe.topics[0].length == 8)
+assert(subscribe.topics[0].topic == b'newtopic')
+assert(subscribe.topics[0].retainhandle == 1)
+assert(subscribe.topics[0].RAP == 1)
+assert(subscribe.topics[0].NL == 1)
+assert(subscribe.topics[0].QOS == 1)
+
+= MQTTSuback, packet instantiation, no mqtt property
+sk = MQTT()/MQTTSuback(msgid=1, reasoncode=0) 
+assert(sk.type == 9) 
+assert(sk.msgid == 1) 
+assert(sk.reasoncode == 0) 
+
+= MQTTSuback, packet dissection, no mqtt property
+s = b'\x90\x04\x00\x01\x00\x00'                                                                                                                                             
+suback = MQTT(s)
+assert(suback.type == 9)
+assert(suback.DUP == 0)
+assert(suback.QOS == 0)
+assert(suback.RETAIN == 0)
+assert(suback.len == 4)
+assert(suback.msgid == 1)
+assert(suback.proplen == 0)
+assert(suback.reasoncode == 0) 
+
+= MQTTSuback, packet instantiation, with mqtt property
+sk = MQTT()/MQTTSuback(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=0) 
+assert(sk.type == 9) 
+assert(sk.msgid == 1) 
+assert(sk.proplen == None) 
+assert(sk.properties[0].propid == 31) 
+assert(sk.properties[0].propvalue.value == b'test') 
+assert(sk.reasoncode == 0) 
+
+= MQTTSuback, packet dissection, with mqtt property
+s = b'\x90\x0b\x00\x01\x07\x1f\x00\x04test\x00'                                                                                                                             
+suback = MQTT(s)
+assert(suback.type == 9)
+assert(suback.DUP == 0)
+assert(suback.QOS == 0)
+assert(suback.RETAIN == 0)
+assert(suback.len == 11)
+assert(suback.msgid == 1)
+assert(suback.proplen == 7)
+assert(suback.properties[0].propid == 31)     
+assert(suback.properties[0].propvalue.value == b'test')
+assert(suback.reasoncode == 0)
+
+= MQTTUnsubscribe, packet instantiation, no mqtt property
+unsb = MQTT()/MQTTUnsubscribe(msgid=1, topics=[MQTTTopic(topic='a/b',length=3)])
+assert(unsb.type == 10)
+assert(unsb.msgid == 1)
+assert(unsb.proplen == None) 
+assert(unsb.topics[0].topic == b'a/b')
+assert(unsb.topics[0].length == 3)
+
+= MQTTUnsubscribe, packet dissection, no mqtt property
+u = b'\xa0\x08\x00\x01\x00\x00\x03a/b'
+unsubscribe = MQTT(u)
+assert(unsubscribe.type == 10)
+assert(unsubscribe.DUP == 0)
+assert(unsubscribe.QOS == 0)
+assert(unsubscribe.RETAIN == 0)
+assert(unsubscribe.len == 8)
+assert(unsubscribe.msgid == 1)
+assert(unsubscribe.proplen == 0)
+assert(unsubscribe.topics[0].length == 3)
+assert(unsubscribe.topics[0].topic == b'a/b')
+
+= MQTTUnsubscribe, packet instantiation, with mqtt property
+unsb = MQTT()/MQTTUnsubscribe(msgid=1, properties=[MQTTProperty(propid=38, propvalue=UTF8StringPair(key='1', value='test'))], topics=[MQTTTopic(topic='a/b',length=3)])
+assert(unsb.type == 10)
+assert(unsb.msgid == 1)
+assert(unsb.proplen == None) 
+assert(unsb.properties[0].propid == 38)
+assert(unsb.properties[0].propvalue.key == b'1')
+assert(unsb.properties[0].propvalue.value == b'test')
+assert(unsb.topics[0].length == 3)
+assert(unsb.topics[0].topic == b'a/b')
+
+= MQTTUnsubscribe, packet dissection, with mqtt property
+u = b'\xa0\x12\x00\x01\n&\x00\x011\x00\x04test\x00\x03a/b'                                                                                                                  
+unsubscribe = MQTT(u)
+assert(unsubscribe.type == 10)
+assert(unsubscribe.DUP == 0)
+assert(unsubscribe.QOS == 0)
+assert(unsubscribe.RETAIN == 0)
+assert(unsubscribe.len == 18)
+assert(unsubscribe.msgid == 1)
+assert(unsubscribe.proplen == 10)
+assert(unsubscribe.properties[0].propid == 38)
+assert(unsubscribe.properties[0].propvalue.keylen == 1)
+assert(unsubscribe.properties[0].propvalue.key == b'1')
+assert(unsubscribe.properties[0].propvalue.valuelen == 4)
+assert(unsubscribe.properties[0].propvalue.value == b'test')
+assert(unsubscribe.topics[0].length == 3)
+assert(unsubscribe.topics[0].topic == b'a/b')
+
+= MQTTUnsuback, packet instantiation, no mqtt property
+unsk = MQTT()/MQTTUnsuback(msgid=1, reasoncode=17) 
+assert(unsk.type == 11) 
+assert(unsk.msgid == 1) 
+assert(unsk.proplen == None) 
+assert(unsk.reasoncode == 17) 
+
+= MQTTUnsuback, packet dissection, no mqtt property
+s = b'\xb0\x04\x00\x01\x00\x11'                                                                                                                                             
+unsuback = MQTT(s)
+assert(unsuback.type == 11)
+assert(unsuback.DUP == 0)
+assert(unsuback.QOS == 0)
+assert(unsuback.RETAIN == 0)
+assert(unsuback.len == 4)
+assert(unsuback.msgid == 1)
+assert(unsuback.proplen == 0)
+assert(unsuback.reasoncode == 17)
+
+
+= MQTTUnsuback, packet instantiation, with mqtt property
+unsk = MQTT()/MQTTUnsuback(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=17) 
+assert(unsk.type == 11) 
+assert(unsk.msgid == 1) 
+assert(unsk.properties[0].propid == 31) 
+assert(unsk.properties[0].propvalue.value == b'test') 
+assert(unsk.reasoncode == 17) 
+
+
+= MQTTUnsuback, packet dissection, with mqtt property
+s = b'\xb0\x0b\x00\x01\x07\x1f\x00\x04test\x11'                                                                                                                             
+unsuback = MQTT(s)
+assert(unsuback.type == 11)
+assert(unsuback.DUP == 0)
+assert(unsuback.QOS == 0)
+assert(unsuback.RETAIN == 0)
+assert(unsuback.len == 11)
+assert(unsuback.msgid == 1)
+assert(unsuback.proplen == 7)
+assert(unsuback.properties[0].propid == 31) 
+assert(unsuback.properties[0].propvalue.length == 4) 
+assert(unsuback.properties[0].propvalue.value == b'test') 
+assert(unsuback.reasoncode == 17)
+
+= MQTTPuback, packet instantiation, no mqtt property
+pa = MQTT()/MQTTPuback(msgid=1, reasoncode=0)
+assert(pa.type == 4)
+assert(pa.msgid == 1)
+assert(pa.reasoncode == 0)
+assert(pa.proplen == None)
+
+= MQTTPuback, packet dissection, no mqtt property
+s = b'@\x04\x00\x01\x00\x00'
+puback = MQTT(s)
+assert(puback.type == 4)
+assert(puback.DUP == 0)
+assert(puback.QOS == 0)
+assert(puback.RETAIN == 0)
+assert(puback.len == 4)
+assert(puback.msgid == 1)
+assert(puback.reasoncode == 0)
+assert(puback.proplen == 0)
+
+= MQTTPuback, packet instantiation, with mqtt property
+pa = MQTT()/MQTTPuback(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=0)
+assert(pa.type == 4)
+assert(pa.msgid == 1)
+assert(pa.reasoncode == 0) 
+assert(pa.properties[0].propid == 31) 
+assert(pa.properties[0].propvalue.value == b'test') 
+
+= MQTTPuback packet dissection , with mqtt property
+s = b'@\x0b\x00\x01\x00\x07\x1f\x00\x04test'
+puback = MQTT(s)
+assert(puback.type == 4)
+assert(puback.DUP == 0)
+assert(puback.QOS == 0)
+assert(puback.RETAIN == 0)
+assert(puback.len == 11)
+assert(puback.msgid == 1)
+assert(puback.reasoncode == 0)
+assert(puback.proplen == 7)
+assert(puback.properties[0].propid == 31) 
+assert(puback.properties[0].propvalue.length == 4) 
+assert(puback.properties[0].propvalue.value == b'test') 
+
+= MQTTPubrec, packet instantiation, no mqtt property
+pc = MQTT()/MQTTPubrec(msgid=1, reasoncode=0)
+assert(pc.type == 5)
+assert(pc.msgid == 1)
+assert(pc.reasoncode == 0)
+assert(pc.proplen == None)
+
+= MQTTPubrec, packet dissection, no mqtt property
+s = b'P\x04\x00\x01\x00\x00'                                                                                                                                                
+pubrec = MQTT(s)
+assert(pubrec.type == 5)
+assert(pubrec.DUP == 0)
+assert(pubrec.QOS == 0)
+assert(pubrec.RETAIN == 0)
+assert(pubrec.len == 4)
+assert(pubrec.msgid == 1)
+assert(pubrec.reasoncode == 0)
+assert(pubrec.proplen == 0)
+
+= MQTTPubrec, packet instantiation, with mqtt property
+pc = MQTT()/MQTTPubrec(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=0)
+assert(pc.type == 5)
+assert(pc.msgid == 1)
+assert(pc.reasoncode == 0) 
+assert(pc.properties[0].propid == 31) 
+assert(pc.properties[0].propvalue.value == b'test') 
+
+= MQTTPubrec packet dissection , with mqtt property
+s = b'P\x0b\x00\x01\x00\x07\x1f\x00\x04test'                                                                                                                                
+pubrec = MQTT(s)
+assert(pubrec.type == 5)
+assert(pubrec.DUP == 0)
+assert(pubrec.QOS == 0)
+assert(pubrec.RETAIN == 0)
+assert(pubrec.len == 11)
+assert(pubrec.msgid == 1)
+assert(pubrec.reasoncode == 0)
+assert(pubrec.proplen == 7)
+assert(pubrec.properties[0].propid == 31) 
+assert(pubrec.properties[0].propvalue.length == 4) 
+assert(pubrec.properties[0].propvalue.value == b'test') 
+
+= MQTTPubrel, packet instantiation, no mqtt property
+pl = MQTT()/MQTTPubrel(msgid=1, reasoncode=0)
+assert(pl.type == 6)
+assert(pl.msgid == 1)
+assert(pl.reasoncode == 0)
+assert(pl.proplen == None)
+
+= MQTTPubrel, packet dissection, no mqtt property
+s = b'`\x04\x00\x01\x00\x00'
+pubrel = MQTT(s)
+assert(pubrel.type == 6)
+assert(pubrel.DUP == 0)
+assert(pubrel.QOS == 0)
+assert(pubrel.RETAIN == 0)
+assert(pubrel.len == 4)
+assert(pubrel.msgid == 1)
+assert(pubrel.reasoncode == 0)
+assert(pubrel.proplen == 0)
+
+= MQTTPubrel, packet instantiation, with mqtt property
+pl = MQTT()/MQTTPubrel(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=0)
+assert(pl.type == 6)
+assert(pl.msgid == 1)
+assert(pl.reasoncode == 0) 
+assert(pl.properties[0].propid == 31) 
+assert(pl.properties[0].propvalue.value == b'test') 
+
+= MQTTPubrel packet dissection , with mqtt property
+s = b'`\x0b\x00\x01\x00\x07\x1f\x00\x04test'
+pubrel = MQTT(s)
+assert(pubrel.type == 6)
+assert(pubrel.DUP == 0)
+assert(pubrel.QOS == 0)
+assert(pubrel.RETAIN == 0)
+assert(pubrel.len == 11)
+assert(pubrel.msgid == 1)
+assert(pubrel.reasoncode == 0)
+assert(pubrel.proplen == 7)
+assert(pubrel.properties[0].propid == 31) 
+assert(pubrel.properties[0].propvalue.length == 4) 
+assert(pubrel.properties[0].propvalue.value == b'test') 
+
+= MQTTPubcomp, packet instantiation, no mqtt property
+pp = MQTT()/MQTTPubcomp(msgid=1, reasoncode=0)
+assert(pp.type == 7)
+assert(pp.msgid == 1)
+assert(pp.reasoncode == 0)
+assert(pp.proplen == None)
+
+= MQTTPubcomp, packet dissection, no mqtt property
+s = b'p\x04\x00\x01\x00\x00'
+pubcomp = MQTT(s)
+assert(pubcomp.type == 7)
+assert(pubcomp.DUP == 0)
+assert(pubcomp.QOS == 0)
+assert(pubcomp.RETAIN == 0)
+assert(pubcomp.len == 4)
+assert(pubcomp.msgid == 1)
+assert(pubcomp.reasoncode == 0)
+assert(pubcomp.proplen == 0)
+
+= MQTTPubcomp, packet instantiation, with mqtt property
+pp = MQTT()/MQTTPubcomp(msgid=1, properties=[MQTTProperty(propid=31, propvalue=UTF8EncodedString(value='test'))], reasoncode=0)
+assert(pp.type == 7)
+assert(pp.msgid == 1)
+assert(pp.reasoncode == 0) 
+assert(pp.properties[0].propid == 31) 
+assert(pp.properties[0].propvalue.value == b'test') 
+
+= MQTTPubcomp packet dissection , with mqtt property
+s = b'p\x0b\x00\x01\x00\x07\x1f\x00\x04test'
+pubcomp = MQTT(s)
+assert(pubcomp.type == 7)
+assert(pubcomp.DUP == 0)
+assert(pubcomp.QOS == 0)
+assert(pubcomp.RETAIN == 0)
+assert(pubcomp.len == 11)
+assert(pubcomp.msgid == 1)
+assert(pubcomp.reasoncode == 0)
+assert(pubcomp.proplen == 7)
+assert(pubcomp.properties[0].propid == 31) 
+assert(pubcomp.properties[0].propvalue.length == 4) 
+assert(pubcomp.properties[0].propvalue.value == b'test') 
+
+= MQTTAuth, packet instantiation, no mqtt property
+a = MQTT()/MQTTAuth(reasoncode=0)
+assert(a.type == 15)
+assert(a.reasoncode == 0)
+assert(a.proplen == None)
+
+= MQTTAuth, packet dissection, no mqtt property
+s = b'\xf0\x02\x00\x00'                                                                                                                                                     
+auth = MQTT(s)
+assert(auth.type == 15)
+assert(auth.DUP == 0)
+assert(auth.QOS == 0)
+assert(auth.RETAIN == 0)
+assert(auth.len == 2)
+assert(auth.reasoncode == 0)
+assert(auth.proplen == 0)
+
+= MQTTAuth, packet instantiation, with mqtt property
+a = MQTT()/MQTTAuth(reasoncode=0, properties=[MQTTProperty(propid=22, propvalue=UTF8EncodedString(value='test'))])
+assert(a.type == 15)
+assert(a.reasoncode == 0)
+assert(a.properties[0].propid == 22)
+assert(a.properties[0].propvalue.value == b'test')
+
+= MQTTAuth, packet dissection, with mqtt property
+s = b'\xf0\t\x00\x07\x16\x00\x04test'                                                                                                                                       
+auth = MQTT(s)
+assert(auth.type == 15)
+assert(auth.DUP == 0)
+assert(auth.QOS == 0)
+assert(auth.RETAIN == 0)
+assert(auth.len == 9)
+assert(auth.reasoncode == 0)
+assert(auth.proplen == 7)
+assert(auth.properties[0].propid == 22)
+assert(auth.properties[0].propvalue.length == 4)
+assert(auth.properties[0].propvalue.value == b'test')
+
+= MQTTPublish, long value
+p = MQTT()/MQTTPublish(topic='test1', properties=[MQTTProperty(propid=3, propvalue=UTF8EncodedString(value='a'*200))], value='a'*200)
+assert(bytes(p))
+assert(p.type == 3)
+assert(p.topic == b'test1')
+assert(p.properties[0].propid == 3)
+assert(p.properties[0].propvalue.value == b'a'*200)
+assert(p.value == b'a'*200)
+assert(p.len == None)
+assert(p.length == None)
+
+= MQTT without payload
+p = MQTT()
+assert(bytes(p) == b'\x10\x00')
+
+= MQTT RandVariableFieldLen
+assert(type(MQTT().fieldtype['len'].randval()) == RandVariableFieldLen)
+assert(type(MQTT().fieldtype['len'].randval() + 0) == int)
+
+= MQTTUnsubscribe, multiple topics
+u = MQTT(b'\xA2\x0C\x00\x01\x00\x00\x03\x61\x2F\x62\x00\x03\x63\x2F\x64')
+assert MQTTUnsubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/d"
+
+= MQTTSubscribe, multiple topics
+u = MQTT(b'\x82\x10\x00\x01\x00\x00\x03\x61\x2F\x62\x02\x00\x03\x63\x2F\x64\x00')
+assert MQTTSubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/d"


### PR DESCRIPTION
Currently the MQTT module of Scapy (contrib/mqtt.py) only supports version 3.1.1 of the MQTT protocol. Thus, a new module was developed (contrib/mqtt5.py) that supports version 5.0. Version 5.0 contains many changes compared to Version 3.1.1, and thus we had to develop a library specifically for MQTT 5.

It is worth noting that we worked on top of the MQTT 3.1.1 module (contrib/mqtt.py), thus many fields, classes or dictionaries are still roughly the same in this new version. Main differences compared to the MQTT 3.1.1 (contrib/mqtt.py) are :

1. Added Class MQTTProperty : New to version 5.0, most MQTT packets allow users to define properties. Depending on the property, the fields may be either ShortField, IntField, or StrLenField. This is the reason why we defined a MultipleTypeField in the class.

2. Added a dictionary called Property that contains the values and names of the MQTT properties.

3. Class UTF8EncodedString and UTF8String Pair were defined since some properties may have more than 1 field. 

4. Each MQTT Packet has fields for users to define these MQTT Properties. We've highlighted where these fields are located (example: "#CONNECT Properties"). This is one of the reasons why we had to develop  a module specifically for MQTT 5, since we had to modify fields_desc for each packet.

5. Added reason/return/retain codes for the following packets : Disconnect, Connack, Puback, Pubrec, Pubrel, Pubcomp, Subscribe, Suback, and Unsuback (feature specific to MQTT 5.0).

6. Added Bitfields (reserved, retainhandle, RAP, NL, QoS) for topics in MQTT subscribe packets (feature specific to MQTT 5.0). Version 3.1.1 of the MQTT protocol only had 1 field (QoS).

7. Added class MQTTAuth, to support the new MQTT Auth Packet in MQTT 5.0.

8. Added authenticate reason codes for MQTT Auth packets.

9. Added unit tests. The unit tests evaluate when packets have or do not have properties.