### PR TITLE
Fix an error in the PMS derivation for DHE key exchange in TLS.

### DIFF
--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -746,7 +746,7 @@ class ClientDiffieHellmanPublic(_GenericTLSSessionInheritance):
 
         if s.client_kx_privkey and s.server_kx_pubkey:
             pms = s.client_kx_privkey.exchange(s.server_kx_pubkey)
-            s.pre_master_secret = pms
+            s.pre_master_secret = pms.lstrip(b"\x00")
             if not s.extms or s.session_hash:
                 # If extms is set (extended master secret), the key will
                 # need the session hash to be computed. This is provided
@@ -780,7 +780,7 @@ class ClientDiffieHellmanPublic(_GenericTLSSessionInheritance):
 
         if s.server_kx_privkey and s.client_kx_pubkey:
             ZZ = s.server_kx_privkey.exchange(s.client_kx_pubkey)
-            s.pre_master_secret = ZZ
+            s.pre_master_secret = ZZ.lstrip(b"\x00")
             if not s.extms or s.session_hash:
                 s.compute_ms_and_derive_keys()
 


### PR DESCRIPTION
The current version of the TLS layer leads to handshake failure, due to a discrepancy in the key derivation logic in scapy implementation. The problem happens for Diffie Hellman key exchange (only the Finite Field DHE, not the ECDHE variant).

Indeed, the RFC states that the leading zero bytes must be stripped when storing the Pre Master Secret. This is bad practice, since it leads to exploitable timing attacks such as the Raccoon Attack (https://blog.min.io/raccoonattack/, which is CVE-2020-1968 for OpenSSL).