### PR TITLE
Relax a constraint in TLS Hello Extension handling.

### DIFF
--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -727,13 +727,12 @@ class _ExtensionsLenField(FieldLenField):
     def getfield(self, pkt, s):
         """
         We try to compute a length, usually from a msglen parsed earlier.
-        If this length is 0, we consider 'selection_present' (from RFC 5246)
-        to be False. This means that there should not be any length field.
-        However, with TLS 1.3, zero lengths are always explicit.
+        If we can not find any length, we consider 'extensions_present'
+        (from RFC 5246) to be False.
         """
         ext = pkt.get_field(self.length_of)
         tmp_len = ext.length_from(pkt)
-        if tmp_len is None or tmp_len <= 0:
+        if tmp_len is None:
             v = pkt.tls_session.tls_version
             if v is None or v < 0x0304:
                 return s, None


### PR DESCRIPTION
The removed comment suggests that RFC 5246 forbids explicitly empty
extensions. However, RFC5246 describes the field, when present, to
be of the following type:

    Extension extensions<0..2^16-1>;

Which means that the variable length can be 0.

When scapy/tls speaks to some stacks (such as the Erlang one), we
can encounter a case where the ServerHello emitted by such stacks
will contain an extensions field with just 00 00, which can lead to
a handshake failure or strange behaviour from the automaton.

It stills seems to be a good idea not to emit the length field in
the build phase, when the actual extension list is empty.