### PR TITLE
preserve rdlen when rdata is not a compressed DNS string

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -128,7 +128,7 @@ def dns_get_str(s, pointer=0, pkt=None, _fullpacket=False):
     if bytes_left is None:
         bytes_left = s[pointer:]
     # name, end_index, remaining
-    return name, pointer, bytes_left
+    return name, pointer, bytes_left, len(processed_pointers) != 0
 
 
 def dns_encode(x, check_built=False):
@@ -161,7 +161,7 @@ def DNSgetstr(*args, **kwargs):
         "DNSgetstr is deprecated. Use dns_get_str instead.",
         DeprecationWarning
     )
-    return dns_get_str(*args, **kwargs)
+    return dns_get_str(*args, **kwargs)[:-1]
 
 
 def dns_compress(pkt):
@@ -265,6 +265,8 @@ class DNSStrField(StrLenField):
     It will also handle DNS decompression.
     (may be StrLenField if a length_from is passed),
     """
+    __slots__ = ["compressed"]
+
     def h2i(self, pkt, x):
         if not x:
             return b"."
@@ -281,7 +283,7 @@ class DNSStrField(StrLenField):
         if self.length_from:
             remain, s = super(DNSStrField, self).getfield(pkt, s)
         # Decode the compressed DNS message
-        decoded, _, left = dns_get_str(s, 0, pkt)
+        decoded, _, left, self.compressed = dns_get_str(s, 0, pkt)
         # returns (remaining, decoded)
         return left + remain, decoded
 
@@ -337,8 +339,10 @@ class DNSRRField(StrField):
         p += 10
         cls = DNSRR_DISPATCHER.get(typ, DNSRR)
         rr = cls(b"\x00" + ret + s[p:p + rdlen], _orig_s=s, _orig_p=p)
-        # Will have changed because of decompression
-        rr.rdlen = None
+        # Reset rdlen if DNS compression was used
+        rdata_object = rr.fieldtype["rdata"]._find_fld_pkt_val(rr, rr.type)[0]
+        if isinstance(rdata_object, DNSStrField) and rdata_object.compressed:
+            del(rr.rdlen)
         rr.rrname = name
 
         p += rdlen
@@ -356,7 +360,7 @@ class DNSRRField(StrField):
             return s, b""
         while c:
             c -= 1
-            name, p, _ = dns_get_str(s, p, _fullpacket=True)
+            name, p, _, _ = dns_get_str(s, p, _fullpacket=True)
             rr, p = self.decodeRR(name, s, p)
             if ret is None:
                 ret = rr

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -222,3 +222,15 @@ assert dns_encode(dns_encode(b"*")) == b'\x03\x01*\x00'
 = DNS - simple request
 
 assert raw(DNS()) == b'\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x03www\x07example\x03com\x00\x00\x01\x00\x01'
+
+= DNS - preserve rdlen when rdata is not a compressed DNS string
+
+# RR type A
+dnsrr1 = Raw(b'\x01a\x01b\x01c\x00\x00\x01\x10\x00\x00\x00\x00\x01\x00\x04\x01\x02\x03\x04')
+# RR type NS & plain rdata
+dnsrr2 = Raw(b'\x02ns\xc0\x0e\x00\x02\x10\x00\x00\x00\x00\x01\x00\x06\x01x\x01y\x01z')
+# RR type NS & compressed rdata
+dnsrr3 = Raw(b'\x02ns\xc0\x0e\x00\x02\x10\x00\x00\x00\x00\x01\x00\x07\x04test\xc0\x0e')
+
+d = DNS(raw(DNS(ancount=3, an=dnsrr1/dnsrr2/dnsrr3)))
+assert d.an[0].rdlen == 4 and d.an[1].rdlen == 6 and d.an[2].rdlen is None


### PR DESCRIPTION
This PR provides a partial answer to #3269. It makes sure that `rdlen` is not set to None when `rdata` is not compressed.