### PR TITLE
Fix typos in documentation

### DIFF
--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -99,7 +99,7 @@ def _FakeType(name, cls=object):
             # type: (str) -> None
             self.name = name
 
-        # make the objects subscriptable indefinetly
+        # make the objects subscriptable indefinitely
         def __getitem__(self, item):  # type: ignore
             return cls
 

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -74,7 +74,7 @@ class CAN(Packet):
     the wire is given by the length field. To obtain only the CAN frame from
     the wire, this additional padding has to be removed. Nevertheless, for
     corner cases, it might be useful to also get the padding. This can be
-    configuered through the **remove-padding** configuration.
+    configured through the **remove-padding** configuration.
 
     Truncate CAN frame based on length field:
         >>> conf.contribs['CAN']['remove-padding'] = True

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -673,7 +673,7 @@ def http_request(host, path="/", port=80, timeout=3,
     :param path: the path of the request (default /)
     :param port: the port (default 80)
     :param timeout: timeout before None is returned
-    :param display: display the resullt in the default browser (default False)
+    :param display: display the result in the default browser (default False)
     :param raw: opens a raw socket instead of going through the OS's TCP
                 socket. Scapy will then use its own TCP client.
                 Careful, the OS might cancel the TCP connection with RST.

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1303,7 +1303,7 @@ class TracerouteResult(SndRcvList):
             p.join()
 
     def trace3D_notebook(self):
-        """Same than trace3D, used when ran from Jupyther notebooks"""
+        """Same than trace3D, used when ran from Jupyter notebooks"""
         trace = self.get_trace()
         import vpython
 

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -410,7 +410,7 @@ def send(x,  # type: _PacketIterable
 
     :param x: the packets
     :param inter: time (in s) between two packets (default 0)
-    :param loop: send packet indefinetly (default 0)
+    :param loop: send packet indefinitely (default 0)
     :param count: number of packets to send (default None=1)
     :param verbose: verbose mode (default None=conf.verbose)
     :param realtime: check that a packet was sent before sending the next one
@@ -442,7 +442,7 @@ def sendp(x,  # type: _PacketIterable
 
     :param x: the packets
     :param inter: time (in s) between two packets (default 0)
-    :param loop: send packet indefinetly (default 0)
+    :param loop: send packet indefinitely (default 0)
     :param count: number of packets to send (default None=1)
     :param verbose: verbose mode (default None=conf.verbose)
     :param realtime: check that a packet was sent before sending the next one

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2323,7 +2323,7 @@ def pretty_list(rtlst,  # type: List[Tuple[Union[str, List[str]], ...]]
 
     :param rtlst: a list of tuples. each tuple contains a value which can
         be either a string or a list of string.
-    :param sortBy: the column id (starting with 0) which whill be used for
+    :param sortBy: the column id (starting with 0) which will be used for
         ordering
     :param borders: whether to put borders on the table or not
     """


### PR DESCRIPTION
Came across "indefinetly" and quickly fixed some others as well.