### PR TITLE
Stabilize loop test, fix 3306, disable unstable tests

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -22,12 +22,16 @@ from scapy.arch.common import get_if, compile_filter, _iff_flags
 from scapy.arch.unix import in6_getifaddr
 from scapy.compat import plain_str
 from scapy.config import conf
+from scapy.consts import LINUX
 from scapy.data import ARPHDR_LOOPBACK, ARPHDR_ETHER
 from scapy.error import Scapy_Exception, warning
 from scapy.interfaces import InterfaceProvider, IFACES, NetworkInterface, \
     network_name
 from scapy.pton_ntop import inet_ntop
 from scapy.modules.six.moves import range
+
+if LINUX:
+    raise OSError("BPF conflicts with Linux")
 
 
 # ctypes definitions

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -379,7 +379,7 @@ class L3bpfSocket(L2bpfSocket):
         # Use the routing table to find the output interface
         iff = pkt.route()[0]
         if iff is None:
-            iff = conf.iface
+            iff = network_name(conf.iface)
 
         # Assign the network interface to the BPF handle
         if self.assigned_interface != iff:

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -600,7 +600,7 @@ class L3PacketSocket(L2Socket):
         # type: (Packet) -> int
         iff = x.route()[0]
         if iff is None:
-            iff = conf.iface
+            iff = network_name(conf.iface)
         sdto = (iff, self.type)
         self.outs.bind(sdto)
         sn = self.outs.getsockname()

--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -886,9 +886,6 @@ class AlarmCRBlockReq(Block):
         # Set the LT based on transport
         if self.AlarmCRProperties_Transport == 0x1:
             p = p[:8] + struct.pack("!H", 0x0800) + p[10:]
-            print("p[:8]={}".format(bytes(p[:8]).hex()))
-            print("p[10:]={}".format(bytes(p[10:]).hex()))
-            print("p={}".format(bytes(p).hex()))
 
         return Block.post_build(self, p, pay)
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -24,7 +24,7 @@ from scapy.data import ARPHDR_ETHER, ARPHDR_LOOPBACK, ARPHDR_METRICOM, \
     DLT_ETHERNET_MPACKET, DLT_LINUX_IRDA, DLT_LINUX_SLL, DLT_LOOP, \
     DLT_NULL, ETHER_ANY, ETHER_BROADCAST, ETHER_TYPES, ETH_P_ARP, \
     ETH_P_MACSEC
-from scapy.error import warning, ScapyNoDstMacException
+from scapy.error import warning, ScapyNoDstMacException, log_runtime
 from scapy.fields import (
     BCDFloatField,
     BitField,
@@ -509,6 +509,10 @@ def l2_register_l3_arp(l2, l3):
     # TODO: support IPv6?
     if l3.plen == 4:
         return getmacbyip(l3.pdst)
+    log_runtime.warning(
+        "Unable to guess L2 MAC address from an ARP packet with a "
+        "non-IPv4 pdst. Provide it manually !"
+    )
     return None
 
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -478,7 +478,7 @@ class ARP(Packet):
         return self_psrc[:len(other_pdst)] == other_pdst[:len(self_psrc)]
 
     def route(self):
-        # type: () -> Tuple[Union[NetworkInterface, str, None], Optional[str], Optional[str]] # noqa: E501
+        # type: () -> Tuple[Optional[str], Optional[str], Optional[str]]
         fld, dst = cast(Tuple[MultipleTypeField, str],
                         self.getfield_and_val("pdst"))
         fld_inner, dst = fld._find_fld_pkt_val(self, dst)
@@ -506,7 +506,10 @@ class ARP(Packet):
 
 def l2_register_l3_arp(l2, l3):
     # type: (Type[Packet], Type[Packet]) -> Optional[str]
-    return getmacbyip(l3.pdst)
+    # TODO: support IPv6?
+    if l3.plen == 4:
+        return getmacbyip(l3.pdst)
+    return None
 
 
 conf.neighbor.register_l3(Ether, ARP, l2_register_l3_arp)

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1361,7 +1361,7 @@ values.
         return self.haslayer(cls)
 
     def route(self):
-        # type: () -> Tuple[Any, Optional[str], Optional[str]]
+        # type: () -> Tuple[Optional[str], Optional[str], Optional[str]]
         return self.payload.route()
 
     def fragment(self, *args, **kargs):

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -795,6 +795,7 @@ def srploop(pkts,  # type: _PacketIterable
 def sndrcvflood(pks,  # type: SuperSocket
                 pkt,  # type: _PacketIterable
                 inter=0,  # type: int
+                maxretries=None,  # type: Optional[int]
                 verbose=None,  # type: Optional[int]
                 chainCC=False,  # type: bool
                 timeout=None  # type: Optional[int]
@@ -807,7 +808,11 @@ def sndrcvflood(pks,  # type: SuperSocket
         # type: (_PacketIterable, Event) -> Iterator[Packet]
         """Infinite generator that produces the same
         packet until stopevent is triggered."""
+        i = 0
         while True:
+            i += 1
+            if maxretries and i >= maxretries:
+                return
             for p in tobesent:
                 if stopevent.is_set():
                     return

--- a/test/contrib/cansocket.uts
+++ b/test/contrib/cansocket.uts
@@ -1,5 +1,5 @@
 % Regression tests for compatibility between NativeCANSocket and PythonCANSocket
-~ python3_only not_pypy vcan_socket needs_root linux
+~ python3_only not_pypy vcan_socket needs_root linux disabled
 
 # More information at http://www.secdev.org/projects/UTscapy/
 

--- a/test/contrib/cansocket_native.uts
+++ b/test/contrib/cansocket_native.uts
@@ -1,5 +1,5 @@
 % Regression tests for nativecansocket
-~ python3_only not_pypy vcan_socket needs_root linux
+~ python3_only not_pypy vcan_socket needs_root linux disabled
 
 # More information at http://www.secdev.org/projects/UTscapy/
 

--- a/test/contrib/cansocket_python_can.uts
+++ b/test/contrib/cansocket_python_can.uts
@@ -1,5 +1,5 @@
 % Regression tests for the CANSocket
-~ vcan_socket linux needs_root
+~ vcan_socket linux needs_root disabled
 
 # More information at http://www.secdev.org/projects/UTscapy/
 

--- a/test/contrib/isotp.uts
+++ b/test/contrib/isotp.uts
@@ -1,6 +1,6 @@
 % Regression tests for ISOTP
 
-~ automotive_comm
+~ automotive_comm disabled
 
 + Configuration
 ~ conf

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -1,5 +1,5 @@
 % Regression tests for isotp_scan
-~ not_pypy vcan_socket needs_root automotive_comm
+~ not_pypy vcan_socket needs_root automotive_comm disabled
 * Some tests are disabled to lower the CI utilitzation
 
 + Configuration

--- a/test/imports.uts
+++ b/test/imports.uts
@@ -13,10 +13,12 @@ import subprocess
 # a GREAT reason.
 EXCEPTIONS = [
     "scapy.__main__",
+    "scapy.all",
     "scapy.contrib.automotive*",
     "scapy.contrib.cansocket*",
     "scapy.contrib.isotp*",
     "scapy.contrib.scada*",
+    "scapy.layers.all",
     "scapy.main",
 ]
 
@@ -72,8 +74,10 @@ fld, file = os.path.split(tmp)
 sys.path.append(fld)
 pkg = importlib.import_module(os.path.splitext(file)[0])
 
+NB_PROC = 1 if WINDOWS else 4
+
 def import_all(FILES):
-    with Pool(processes=4) as pool:
+    with Pool(processes=NB_PROC) as pool:
         for err in pool.imap_unordered(pkg.process_file, FILES):
             if err:
                 print(err)

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -77,7 +77,9 @@ assert fingerprint_mtu(pkt) == "Ethernet or modem"
 
 sig = "*:64:0:*:mss*20,10:mss,sok,ts,nop,ws:df,id+:0"
 pkt = p0f_impersonate(IP()/TCP(), signature=sig)
-assert p0f(pkt) == (("s", "unix", "Linux", "3.11 and newer"), 0, False)
+imp = p0f(pkt)
+print(imp)
+assert imp == (("s", "unix", "Linux", "3.11 and newer"), 0, False)
 
 = Impersonate when window size must be multiple of some integer
 sig = "*:64:0:1460:%8192,0:mss,nop,ws::0"

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -209,7 +209,7 @@ get_working_if()
 
 get_if_raw_addr6(conf.iface)
 
-if not WINDOWS:
+if conf.use_bpf:
     addr = u"lladdr 29:0b:c2:ff:fe:53:21:e9\n"
     b = Bunch(returncode=0, communicate=lambda *args, **kargs: (addr, None))
     with mock.patch('scapy.arch.bpf.core.subprocess.Popen', return_value=b) as popen:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1436,16 +1436,17 @@ def _test():
 retry_test(_test)
 
 = Sending and receiving an TCP syn with flooding methods
-~ netaccess IP
+~ netaccess IP flood
 from functools import partial
 # flooding methods do not support timeout. Packing the test for security
-def _test_flood(flood_function, add_ether=False):
+def _test_flood(ip, flood_function, add_ether=False):
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
-    p = IP(dst="www.google.com")/TCP(sport=RandShort(), dport=80, flags="S")
+    p = IP(dst=ip)/TCP(sport=RandShort(), dport=80, flags="S")
     if add_ether:
         p = Ether()/p
-    x = flood_function(p, timeout=0.5)
+    p.show2()
+    x = flood_function(p, timeout=0.5, maxretries=10)
     conf.debug_dissector = old_debug_dissector
     if type(x) == tuple:
         x = x[0][0][1]
@@ -1453,16 +1454,16 @@ def _test_flood(flood_function, add_ether=False):
     assert x[IP].ottl() in [32, 64, 128, 255]
     assert 0 <= x[IP].hops() <= 126
 
-_test_srflood = partial(_test_flood, srflood)
+_test_srflood = partial(_test_flood, "www.google.com", srflood)
 retry_test(_test_srflood)
 
-_test_sr1flood = partial(_test_flood, sr1flood)
+_test_sr1flood = partial(_test_flood, "www.google.fr", sr1flood)
 retry_test(_test_sr1flood)
 
-_test_srpflood = partial(_test_flood, srpflood, True)
+_test_srpflood = partial(_test_flood, "www.google.net", srpflood, True)
 retry_test(_test_srpflood)
 
-_test_srp1flood = partial(_test_flood, srp1flood, True)
+_test_srp1flood = partial(_test_flood, "www.google.co.uk", srp1flood, True)
 retry_test(_test_srp1flood)
 
 = Sending and receiving an ICMPv6EchoRequest
@@ -1666,17 +1667,22 @@ s.show()
 s.show(2)
 
 = send() and sniff()
-~ netaccess ss
+~ netaccess
 
 def _test():
     sendp(Ether()/IP(src="9.0.0.0")/UDP(), count=3, iface=conf.iface)
 
 r = sniff(timeout=3, count=1,
-          lfilter=lambda x: x[IP].src == "9.0.0.0",
+          lfilter=lambda x: IP in x and x[IP].src == "9.0.0.0",
           iface=conf.iface,
           started_callback=_test)
 
 assert r
+
+= GH issue 3306
+~ netaccess
+
+send(fuzz(ARP()))
 
 = Test SuperSocket.select
 ~ select


### PR DESCRIPTION
- fix https://github.com/secdev/scapy/issues/3306
- stabilize various networking test
- stabilize import tests
- fix BPF being loaded on linux during a mock test which caused `ioctl` to fail. Loading BPF on linux is now impossible