### PR TITLE
Generalize FCSField into TrailerField

### DIFF
--- a/scapy/contrib/scada/iec104/__init__.py
+++ b/scapy/contrib/scada/iec104/__init__.py
@@ -427,17 +427,13 @@ class IEC104_I_Message(IEC104_APDU):
 
     fields_desc = []
 
-    def __init__(self, _pkt=b"", post_transform=None, _internal=0,
-                 _underlayer=None, **fields):
+    def __init__(self, _pkt=b"", **kwargs):
 
         super(IEC104_I_Message, self).__init__(_pkt=_pkt,
-                                               post_transform=post_transform,
-                                               _internal=_internal,
-                                               _underlayer=_underlayer,
-                                               **fields)
+                                               **kwargs)
 
-        if 'io' in fields and fields['io']:
-            self._information_object_update(fields['io'])
+        if 'io' in kwargs and kwargs['io']:
+            self._information_object_update(kwargs['io'])
 
     def _information_object_update(self, io_instances):
         """

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -804,16 +804,13 @@ class Dot11(Packet):
 class Dot11FCS(Dot11):
     name = "802.11-FCS"
     match_subclass = True
-    fields_desc = Dot11.fields_desc + [FCSField("fcs", None, fmt="<I")]
 
-    def compute_fcs(self, s):
+    def compute_fcs(_, s):
         return struct.pack("!I", crc32(s) & 0xffffffff)[::-1]
 
-    def post_build(self, p, pay):
-        p += pay
-        if self.fcs is None:
-            p = p[:-4] + self.compute_fcs(p[:-4])
-        return p
+    fields_desc = Dot11.fields_desc + [
+        FCSField("fcs", None, compute_fcs, fmt="<I")
+    ]
 
 
 class Dot11QoS(Packet):

--- a/scapy/layers/dot15d4.py
+++ b/scapy/layers/dot15d4.py
@@ -161,9 +161,8 @@ class Dot15d4FCS(Dot15d4):
     '''
     name = "802.15.4 - FCS"
     match_subclass = True
-    fields_desc = Dot15d4.fields_desc + [FCSField("fcs", None, fmt="<H")]
 
-    def compute_fcs(self, data):
+    def compute_fcs(_, data):
         # Do a CRC-CCITT Kermit 16bit on the data given
         # Returns a CRC that is the FCS for the frame
         #  Implemented using pseudocode from: June 1986, Kermit Protocol Manual
@@ -178,13 +177,9 @@ class Dot15d4FCS(Dot15d4):
             crc = (crc // 16) ^ (q * 4225)
         return struct.pack('<H', crc)  # return as bytes in little endian order
 
-    def post_build(self, p, pay):
-        # construct the packet with the FCS at the end
-        p = Dot15d4.post_build(self, p, pay)
-        if self.fcs is None:
-            p = p[:-2]
-            p = p + self.compute_fcs(p)
-        return p
+    fields_desc = Dot15d4.fields_desc + [
+        FCSField("fcs", None, compute_fcs, fmt="<H")
+    ]
 
 
 class Dot15d4Ack(Packet):

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -30,7 +30,6 @@ from scapy.fields import (
     BitField,
     ByteField,
     ConditionalField,
-    FCSField,
     FieldLenField,
     IP6Field,
     IPField,
@@ -46,6 +45,7 @@ from scapy.fields import (
     SourceIPField,
     StrFixedLenField,
     StrLenField,
+    TrailerField,
     XByteField,
     XIntField,
     XShortEnumField,
@@ -310,7 +310,7 @@ class MPacketPreamble(Packet):
     # IEEE 802.3br Figure 99-3
     name = "MPacket Preamble"
     fields_desc = [StrFixedLenField("preamble", b"", length=8),
-                   FCSField("fcs", 0, fmt="!I")]
+                   TrailerField(IntField("fcs", 0))]
 
 
 class SNAP(Packet):

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -279,13 +279,10 @@ class _SpecificRadiusAttr(RadiusAttribute):
     __slots__ = ["val"]
     match_subclass = True
 
-    def __init__(self, _pkt="", post_transform=None, _internal=0, _underlayer=None, **fields):  # noqa: E501
+    def __init__(self, _pkt="", **kwargs):  # noqa: E501
         super(_SpecificRadiusAttr, self).__init__(
             _pkt,
-            post_transform,
-            _internal,
-            _underlayer,
-            **fields
+            **kwargs
         )
         self.fields["type"] = self.val
         name_parts = self.__class__.__name__.split('RadiusAttr_')
@@ -494,13 +491,10 @@ class _RadiusAttrHexStringVal(_SpecificRadiusAttr):
 
     __slots__ = ["val"]
 
-    def __init__(self, _pkt="", post_transform=None, _internal=0, _underlayer=None, **fields):  # noqa: E501
+    def __init__(self, _pkt="", **kwargs):
         super(_RadiusAttrHexStringVal, self).__init__(
             _pkt,
-            post_transform,
-            _internal,
-            _underlayer,
-            **fields
+            **kwargs
         )
         self.fields["type"] = self.val
         name_parts = self.__class__.__name__.split('RadiusAttr_')

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -867,8 +867,7 @@ class _GenericTLSSessionInheritance(Packet):
     name = "Dummy Generic TLS Packet"
     fields_desc = []
 
-    def __init__(self, _pkt="", post_transform=None, _internal=0,
-                 _underlayer=None, tls_session=None, **fields):
+    def __init__(self, _pkt="", _underlayer=None, tls_session=None, **kwargs):
         try:
             setme = self.tls_session is None
         except Exception:
@@ -910,9 +909,7 @@ class _GenericTLSSessionInheritance(Packet):
                         srk:
                     self.tls_session.server_rsa_key = srk
 
-        Packet.__init__(self, _pkt=_pkt, post_transform=post_transform,
-                        _internal=_internal, _underlayer=_underlayer,
-                        **fields)
+        Packet.__init__(self, _pkt=_pkt, **kwargs)
 
     def __getattr__(self, attr):
         """

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -2041,7 +2041,7 @@ class TestPacket(Packet):
         ByteField("a", 0),
         LEShortField("b", 15),
         LEIntField("c", 7),
-        FCSField("fcs", None),
+        FCSField("fcs", None, None, fmt="H"),
         IntField("bottom", 0)
     ]
 
@@ -2056,6 +2056,28 @@ assert raw(pkt) == b'\x0c\x0f\x00\x07\x00\x00\x00\x00\x00\x00{\xbb\xbb\xbb\xbb\x
 pkt = TestPacket(raw(pkt))
 assert pkt.fcs == 0xbeef
 
+assert raw(pkt) == b'\x0c\x0f\x00\x07\x00\x00\x00\x00\x00\x00{\xbb\xbb\xbb\xbb\xbb\xbb\xaa\xaa\xaa\xaa\xaa\xaa\x08\x00E\x00\x00\x14\x00\x01\x00\x00@\x00|\xe7\x7f\x00\x00\x01\x7f\x00\x00\x01\xbe\xef'
+
+= TrailerField
+
+class TestPacket(Packet):
+    fields_desc = [
+        ByteField("a", 0),
+        LEShortField("b", 15),
+        LEIntField("c", 7),
+        TrailerField(MACField("mac", None)),
+        TrailerField(MACField("mac2", None)),
+        IntField("bottom", 0)
+    ]
+
+bind_layers(TestPacket, Ether)
+pkt = TestPacket(a=12, mac="11:11:11:11:11:11", mac2="dd:dd:dd:dd:dd:dd", bottom=123)/Ether(src="aa:aa:aa:aa:aa:aa", dst="bb:bb:bb:bb:bb:bb")/IP(src="127.0.0.1", dst="127.0.0.1")
+
+assert raw(pkt) == b'\x0c\x0f\x00\x07\x00\x00\x00\x00\x00\x00{\xbb\xbb\xbb\xbb\xbb\xbb\xaa\xaa\xaa\xaa\xaa\xaa\x08\x00E\x00\x00\x14\x00\x01\x00\x00@\x00|\xe7\x7f\x00\x00\x01\x7f\x00\x00\x01\xdd\xdd\xdd\xdd\xdd\xdd\x11\x11\x11\x11\x11\x11'
+
+pkt = TestPacket(raw(pkt))
+
+assert raw(pkt) == b'\x0c\x0f\x00\x07\x00\x00\x00\x00\x00\x00{\xbb\xbb\xbb\xbb\xbb\xbb\xaa\xaa\xaa\xaa\xaa\xaa\x08\x00E\x00\x00\x14\x00\x01\x00\x00@\x00|\xe7\x7f\x00\x00\x01\x7f\x00\x00\x01\xdd\xdd\xdd\xdd\xdd\xdd\x11\x11\x11\x11\x11\x11'
 
 ############
 ############


### PR DESCRIPTION
- fix https://github.com/secdev/scapy/issues/3251
- create a generic trailerfield like mentioned in https://github.com/secdev/scapy/pull/2360 (but contrary to https://github.com/secdev/scapy/pull/2360, also support build)
- rewrite how `FCSField` (now `TrailerField`) adds its field by re-purposing `post_transform` (undocumented) into `build_dones`. This is much cleaner than the previous hack and allows for further similar special fields