### PR TITLE
Fixes and improves TrafficSelector handling in IKEv2

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -589,9 +589,12 @@ class IKEv2_payload_TSi(IKEv2_class):
         ByteEnumField("next_payload", None, IKEv2_payload_type),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
-        FieldLenField("number_of_TSs", None, fmt="B", count_of="traffic_selector"),
+        FieldLenField("number_of_TSs", None, fmt="B",
+                      count_of="traffic_selector"),
         X3BytesField("res2", 0),
-        PacketListField("traffic_selector", None, TrafficSelector, length_from=lambda x:x.length - 8, count_from=lambda x:x.number_of_TSs),  # noqa: E501
+        PacketListField("traffic_selector", None, TrafficSelector,
+                        length_from=lambda x:x.length - 8,
+                        count_from=lambda x:x.number_of_TSs),
     ]
 
 
@@ -602,9 +605,12 @@ class IKEv2_payload_TSr(IKEv2_class):
         ByteEnumField("next_payload", None, IKEv2_payload_type),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
-        FieldLenField("number_of_TSs", None, fmt="B", count_of="traffic_selector"),
+        FieldLenField("number_of_TSs", None, fmt="B",
+                      count_of="traffic_selector"),
         X3BytesField("res2", 0),
-        PacketListField("traffic_selector", None, TrafficSelector, length_from=lambda x:x.length - 8, count_from=lambda x:x.number_of_TSs),  # noqa: E501
+        PacketListField("traffic_selector", None, TrafficSelector,
+                        length_from=lambda x:x.length - 8,
+                        count_from=lambda x:x.number_of_TSs),
     ]
 
 

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -525,6 +525,9 @@ class TrafficSelector(Packet):
                 return RawTrafficSelector
         return IPv4TrafficSelector
 
+    def extract_padding(self, s):
+        return '', s
+
 
 class IPv4TrafficSelector(TrafficSelector):
     name = "IKEv2 IPv4 Traffic Selector"
@@ -586,7 +589,7 @@ class IKEv2_payload_TSi(IKEv2_class):
         ByteEnumField("next_payload", None, IKEv2_payload_type),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
-        ByteField("number_of_TSs", 0),
+        FieldLenField("number_of_TSs", None, fmt="B", count_of="traffic_selector"),
         X3BytesField("res2", 0),
         PacketListField("traffic_selector", None, TrafficSelector, length_from=lambda x:x.length - 8, count_from=lambda x:x.number_of_TSs),  # noqa: E501
     ]
@@ -599,7 +602,7 @@ class IKEv2_payload_TSr(IKEv2_class):
         ByteEnumField("next_payload", None, IKEv2_payload_type),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
-        ByteField("number_of_TSs", 0),
+        FieldLenField("number_of_TSs", None, fmt="B", count_of="traffic_selector"),
         X3BytesField("res2", 0),
         PacketListField("traffic_selector", None, TrafficSelector, length_from=lambda x:x.length - 8, count_from=lambda x:x.number_of_TSs),  # noqa: E501
     ]

--- a/test/contrib/ikev2.uts
+++ b/test/contrib/ikev2.uts
@@ -115,6 +115,26 @@ assert isinstance(a, IPv4TrafficSelector)
 assert isinstance(b, IPv6TrafficSelector)
 assert isinstance(c, EncryptedTrafficSelector)
 
+= Test TSi with multiple TrafficSelector dissection
+
+a = IKEv2_payload_TSi()
+a.traffic_selector.extend(IPv4TrafficSelector() * 2)
+a.traffic_selector.extend(IPv6TrafficSelector() * 3)
+assert len(a.traffic_selector) == 5
+
+b = IKEv2_payload_TSi(raw(a))
+assert len(b.traffic_selector) == 5
+
+= Test automatic calculation of number_of_TSs field
+
+a = IKEv2_payload_TSi(traffic_selector=IPv4TrafficSelector() * 2)
+b = IKEv2_payload_TSi(raw(a))
+assert b.number_of_TSs == 2
+
+c = IKEv2_payload_TSr(traffic_selector=IPv4TrafficSelector() * 2)
+d = IKEv2_payload_TSr(raw(c))
+assert d.number_of_TSs == 2
+
 = IKEv2_payload_Encrypted_Fragment, simple tests
 
 s = b"\x00\x00\x00\x08\x00\x01\x00\x01"


### PR DESCRIPTION
Corrects dissecting of packets containing multiple TrafficSelectors

Previously, dissecting IKEv2_payload_IDi and IKEv2_payload_IDr with
more than one TrafficSelector would incorrectly result in just one of
the TrafficSelectors being properly identified.

Adds automatic calculation of the number_of_TSs field for TSi and TSr
IKEv2 payloads.

Adds corresponding unit tests
