### PR TITLE
contrib/pnio: Use correct block types for AlarmNotification_High/Low

### DIFF
--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -37,8 +37,8 @@ from scapy.volatile import RandUUID
 
 # Block Packet
 BLOCK_TYPES_ENUM = {
-    0x0000: "AlarmNotification_High",
-    0x0001: "AlarmNotification_Low",
+    0x0001: "AlarmNotification_High",
+    0x0002: "AlarmNotification_Low",
     0x0008: "IODWriteReqHeader",
     0x0009: "IODReadReqHeader",
     0x0010: "DiagnosisData",


### PR DESCRIPTION
According to table 514 of IEC 61158-6-10 the correct BlockType for
AlarmNotification_High is 0x0001 and AlarmNotification_Low is 0x0002.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>