### PR TITLE
Fix traceroute6() output

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -3351,7 +3351,7 @@ def traceroute6(target, dport=80, minttl=1, maxttl=30, sport=RandShort(),
     a = TracerouteResult6(a.res)
 
     if verbose:
-        a.display()
+        a.show()
 
     return a, b
 


### PR DESCRIPTION
`traceroute6()` output was broken by 9a9853f39f091e781321c92b574ec612e1f62ddb

I wonder if this should be tested in the CI.