### PR TITLE
FFDH fix (fixes #3324)

### DIFF
--- a/scapy/layers/tls/crypto/groups.py
+++ b/scapy/layers/tls/crypto/groups.py
@@ -445,7 +445,8 @@ def _tls_named_groups_import(group, pubbytes):
     if group in _tls_named_ffdh_groups:
         params = _ffdh_groups[_tls_named_ffdh_groups[group]][0]
         pn = params.parameter_numbers()
-        public_numbers = dh.DHPublicNumbers(pubbytes, pn)
+        pubint = int.from_bytes(pubbytes, "big")
+        public_numbers = dh.DHPublicNumbers(pubint, pn)
         return public_numbers.public_key(default_backend())
     elif group in _tls_named_curves:
         if _tls_named_curves[group] in ["x25519", "x448"]:

--- a/scapy/layers/tls/keyexchange_tls13.py
+++ b/scapy/layers/tls/keyexchange_tls13.py
@@ -113,7 +113,7 @@ class TLS_Ext_KeyShare_CH(TLS_Ext_Unknown):
             privshares = self.tls_session.tls13_client_privshares
             for kse in self.client_shares:
                 if kse.privkey:
-                    if _tls_named_curves[kse.group] in privshares:
+                    if _tls_named_groups[kse.group] in privshares:
                         pkt_info = pkt.firstlayer().summary()
                         log_runtime.info("TLS: group %s used twice in the same ClientHello [%s]", kse.group, pkt_info)  # noqa: E501
                         break
@@ -125,11 +125,11 @@ class TLS_Ext_KeyShare_CH(TLS_Ext_Unknown):
             for kse in self.client_shares:
                 if kse.pubkey:
                     pubshares = self.tls_session.tls13_client_pubshares
-                    if _tls_named_curves[kse.group] in pubshares:
+                    if _tls_named_groups[kse.group] in pubshares:
                         pkt_info = r.firstlayer().summary()
                         log_runtime.info("TLS: group %s used twice in the same ClientHello [%s]", kse.group, pkt_info)  # noqa: E501
                         break
-                    pubshares[_tls_named_curves[kse.group]] = kse.pubkey
+                    pubshares[_tls_named_groups[kse.group]] = kse.pubkey
         return super(TLS_Ext_KeyShare_CH, self).post_dissection(r)
 
 


### PR DESCRIPTION
Fixes [#3324](https://github.com/secdev/scapy/issues/3324)

From what I have understood, Scapy is correctly parsing the data but encounters 2 problems:
- in `scapy/layers/tls/crypto/groups.py` line 448, `pubbytes` is given to `dh.DHPublicNumbers` without bytes to int conversion (in `DHPublicNumbers` init, an error is then raised).
- in `scapy/layers/tls/keyexchange_tls13.py` lines 128 & 132, `_tls_named_curves` is used instead of `_tls_named_groups`, this last having `_tls_named_curves` AND `_tls_named_ffdh_groups` (in `groups.py`). Usage of `_tls_named_curves` leads to the ffdh group not being found.

