### PR TITLE
Fix p0f impersonation: MSS value too low

### DIFF
--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -854,7 +854,7 @@ def p0f_impersonate(pkt, osgenre=None, osdetails=None, signature=None,
                 if mss_hint and 0 <= mss_hint <= maxmss:
                     options.append(("MSS", mss_hint))
                 else:  # invalid hint, generate new value
-                    options.append(("MSS", random.randint(1, maxmss)))
+                    options.append(("MSS", random.randint(100, maxmss)))
             else:
                 options.append(("MSS", sig.mss))
 

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -1069,7 +1069,6 @@ def main():
     try:
         if NON_ROOT or os.getuid() != 0:  # Non root
             # Discard root tests
-            KW_KO.append("netaccess")
             KW_KO.append("needs_root")
             if VERB > 2:
                 print(" " + arrow + " Non-root mode")

--- a/test/nmap.uts
+++ b/test/nmap.uts
@@ -41,21 +41,21 @@ print(conf.nmap_kdb.base, conf.nmap_kdb.filename, len(conf.nmap_kdb.get_base()))
 assert len(conf.nmap_kdb.get_base()) > 100
 
 = fingerprint test: www.secdev.org
-~ netaccess
+~ netaccess needs_root
 score, fprint = nmap_fp('www.secdev.org')
 print(score, fprint)
 assert score > 0.5
 assert fprint
 
 = fingerprint test: gateway
-~ netaccess
+~ netaccess needs_root
 score, fprint = nmap_fp(conf.route.route('0.0.0.0')[2])
 print(score, fprint)
 assert score > 0.5
 assert fprint
 
 = fingerprint test: to text
-~  netaccess
+~  netaccess needs_root
 
 import re as re_
 
@@ -65,7 +65,7 @@ for x in nmap_sig2txt(a).split("\n"):
     assert re_.match(r"\w{2,4}\(.*\)", x)
 
 = nmap_udppacket_sig test: www.google.com
-~ netaccess
+~ netaccess needs_root
 
 a = nmap_sig("www.google.com", ucport=80)
 assert len(a) > 3

--- a/test/p0f.uts
+++ b/test/p0f.uts
@@ -78,6 +78,16 @@ assert fingerprint_mtu(pkt) == "Ethernet or modem"
 pkt = p0f_impersonate(IP()/TCP(), osgenre="Linux", osdetails="3.11 and newer")
 assert p0f(pkt) == (("s", "unix", "Linux", "3.11 and newer"), 0, False)
 
+= Check incidence of MSS value on linux version detection
+~ netaccess
+
+pkt = IP(ttl=64, flags=2)/TCP(options=[('MSS', 14), ('SAckOK', ''), ('Timestamp', (2638474259, 0)), ('NOP', None), ('WScale', 7)], window=280, seq=3964706621, flags=2)
+assert p0f(pkt) == (('g', 'unix', 'Linux', '2.2.x-3.x'), 0, False)
+
+pkt[TCP].options = [('MSS', 100), ('SAckOK', ''), ('Timestamp', (2638474259, 0)), ('NOP', None), ('WScale', 7)]
+pkt[TCP].window = 100*20
+assert p0f(pkt) == (("s", "unix", "Linux", "3.11 and newer"), 0, False)
+
 = Impersonate when window size must be multiple of some integer
 sig = "*:64:0:1460:%8192,0:mss,nop,ws::0"
 pkt = p0f_impersonate(IP()/TCP(), signature=sig)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1351,7 +1351,7 @@ assert ssid == "ROUTE-821E295"
 * Those tests need network access
 
 = Sending and receiving an ICMP
-~ netaccess IP ICMP icmp_firewall
+~ netaccess needs_root IP ICMP icmp_firewall
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
@@ -1365,7 +1365,7 @@ def _test():
 retry_test(_test)
 
 = Sending a TCP syn message at layer 2 and layer 3
-~ netaccess IP
+~ netaccess needs_root IP
 def _test():
     tmp = send(IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), return_packets=True, realtime=True)
     assert(len(tmp) == 1)
@@ -1382,7 +1382,7 @@ def _test():
 retry_test(_test)
 
 = Latency check: localhost ICMP
-~ netaccess linux latency
+~ netaccess needs_root linux latency
 
 sock = conf.L3socket
 conf.L3socket = L3RawSocket
@@ -1425,7 +1425,7 @@ for pkt in sniffer.results:
     assert pkt.sniffed_on == iface
 
 = Sending a TCP syn 'forever' at layer 2 and layer 3
-~ netaccess IP
+~ netaccess needs_root IP
 def _test():
     tmp = srloop(IP(dst="8.8.8.8")/TCP(sport=RandShort(), dport=53, flags="S"), count=1, timeout=3)
     assert(type(tmp) == tuple and len(tmp[0]) == 1)
@@ -1436,7 +1436,7 @@ def _test():
 retry_test(_test)
 
 = Sending and receiving an TCP syn with flooding methods
-~ netaccess IP flood
+~ netaccess needs_root IP flood
 from functools import partial
 # flooding methods do not support timeout. Packing the test for security
 def _test_flood(ip, flood_function, add_ether=False):
@@ -1603,7 +1603,7 @@ assert a.sent_time is None
 + Real usages
 
 = Port scan
-~ netaccess IP TCP
+~ netaccess needs_root IP TCP
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
@@ -1620,7 +1620,7 @@ def _test():
 retry_test(_test)
 
 = Send & receive with debug_match
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     old_debug_match = conf.debug_match
     conf.debug_match = True
@@ -1636,7 +1636,7 @@ def _test():
 retry_test(_test)
 
 = Send & receive with retry
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
@@ -1647,7 +1647,7 @@ def _test():
 retry_test(_test)
 
 = Send & receive with multi
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     old_debug_dissector = conf.debug_dissector
     conf.debug_dissector = False
@@ -1658,16 +1658,19 @@ def _test():
 retry_test(_test)
 
 = Traceroute function
-~ netaccess tcpdump
+~ netaccess needs_root tcpdump
 * Let's test traceroute
-ans, unans = traceroute("www.slashdot.org")
-ans.nsummary()
-s,r=ans[0]
-s.show()
-s.show(2)
+def _test():
+    ans, unans = traceroute("www.slashdot.org")
+    ans.nsummary()
+    s,r=ans[0]
+    s.show()
+    s.show(2)
+
+retry_test(_test)
 
 = send() and sniff()
-~ netaccess
+~ netaccess needs_root
 
 def _test():
     sendp(Ether()/IP(src="9.0.0.0")/UDP(), count=3, iface=conf.iface)
@@ -1680,7 +1683,7 @@ r = sniff(timeout=3, count=1,
 assert r
 
 = GH issue 3306
-~ netaccess
+~ netaccess needs_root
 
 send(fuzz(ARP()))
 
@@ -1725,7 +1728,7 @@ assert _test_select()
 True
 
 = Test set of sent_time by sr
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     packet = IP(dst="8.8.8.8")/ICMP()
     r = sr(packet, timeout=2)
@@ -1734,7 +1737,7 @@ def _test():
 retry_test(_test)
 
 = Test set of sent_time by sr (multiple packets)
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     packet1 = IP(dst="8.8.8.8")/ICMP()
     packet2 = IP(dst="8.8.4.4")/ICMP()
@@ -1745,7 +1748,7 @@ def _test():
 retry_test(_test)
 
 = Test set of sent_time by srflood
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     packet = IP(dst="8.8.8.8")/ICMP()
     r = srflood(packet, timeout=2)
@@ -1754,7 +1757,7 @@ def _test():
 retry_test(_test)
 
 = Test set of sent_time by srflood (multiple packets)
-~ netaccess IP ICMP
+~ netaccess needs_root IP ICMP
 def _test():
     packet1 = IP(dst="8.8.8.8")/ICMP()
     packet2 = IP(dst="8.8.4.4")/ICMP()
@@ -2260,7 +2263,7 @@ assert len(conf.temp_files) == tempfile_count
 
 
 = Run scapy's tshark command
-~ netaccess
+~ needs_root
 tshark(count=1, timeout=3)
 
 = Check wireshark()

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -4,7 +4,7 @@
 ~dns
 
 = DNS request
-~ netaccess IP UDP DNS
+~ netaccess needs_root IP UDP DNS
 * A possible cause of failure could be that the open DNS (resolver1.opendns.com)
 * is not reachable or down.
 def _test():
@@ -18,7 +18,7 @@ def _test():
 dns_ans = retry_test(_test)
 
 = DNS packet manipulation
-~ netaccess IP UDP DNS
+~ netaccess needs_root IP UDP DNS
 dns_ans.show()
 dns_ans.show2()
 dns_ans[DNS].an.show()

--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -61,7 +61,7 @@ tlv = EDNS0TLV(optcode=2, optdata="")
 raw(tlv) == b'\x00\x02\x00\x00'
 
 = NSID - Live test
-~ netaccess
+~ netaccess needs_root
 
 def _test():
     old_debug_dissector = conf.debug_dissector

--- a/test/scapy/layers/l2.uts
+++ b/test/scapy/layers/l2.uts
@@ -8,7 +8,7 @@
 + Layer 2 Unit Tests
 
 = Arping
-~ netaccess tcpdump
+~ netaccess needs_root tcpdump
 * This test assumes the local network is a /24. This is bad.
 def _test():
     ip_address = conf.route.route("0.0.0.0")[2]

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -1,6 +1,6 @@
 % send, sniff, sr* tests for Scapy
 
-~ netaccess
+~ needs_root
 
 ############
 ############

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -26,7 +26,7 @@ assert isinstance(p.payload, IPv6)
 #######
 + Test tun device
 
-~ tun netaccess not_libpcap
+~ tun needs_root not_libpcap
 
 = Create a tun interface
 
@@ -71,7 +71,7 @@ tun0.close()
 #######
 + Test strip_packet_info=False on Linux
 
-~ tun linux netaccess not_libpcap
+~ tun linux needs_root not_libpcap
 
 = Create a tun interface
 
@@ -122,7 +122,7 @@ tun0.close()
 
 + Test strip_packet_info=True and IPv6
 
-~ tun netaccess ipv6 not_libpcap
+~ tun needs_root ipv6 not_libpcap
 
 = Create a tun interface with IPv4 + IPv6
 
@@ -188,7 +188,7 @@ tun0.close()
 
 + Test tap interfaces
 
-~ tap netaccess not_libpcap
+~ tap needs_root not_libpcap
 
 = Create a tap interface with IPv4
 


### PR DESCRIPTION
The issue was that `p0f_impersonation` could set a MSS value too low (<100) that would afterwards get rejected

fixes https://github.com/secdev/scapy/issues/3353
closes https://github.com/secdev/scapy/pull/3364