### PR TITLE
PoC: Fix handling of range and generator functions for field values

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1192,6 +1192,76 @@ answer = IP(src='192.168.48.19', dst='10.128.0.7')/ICMP(type=11)/IPerror(id=4267
 assert answer.answers(query)
 conf.checkIPsrc = conf_checkIPsrc
 
+= check Packet iterators with range
+
+class TestPacket(Packet):
+    name = 'TestPacket'
+    fields_desc = [
+        IntField('data', 0)
+    ]
+
+p = TestPacket(data=range(5))
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+assert len(pks) == 5
+assert pks[0].data == 0
+assert pks[-1].data == 4
+
+p = TestPacket(data=range(1, 11, 2))
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+assert len(pks) == 5
+assert pks[0].data == 1
+assert pks[-1].data == 9
+
+= check Packet iterators with generator
+
+p = TestPacket(data=(x for x in range(5)))
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+print(pks)
+p.show()
+assert len(pks) == 5
+assert pks[0].data == 0
+assert pks[-1].data == 4
+
+p = TestPacket(data=(x for x in range(1, 11, 2)))
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+assert len(pks) == 5
+assert pks[0].data == 1
+assert pks[-1].data == 9
+
+= check Packet iterators with generator function
+
+def gen():
+    for x in range(5):
+        yield x
+
+p = TestPacket(data=gen())
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+print(pks)
+p.show()
+assert len(pks) == 5
+assert pks[0].data == 0
+assert pks[-1].data == 4
+p.show()
+print(repr(p))
+
+def gen():
+    for x in range(1, 11, 2):
+        yield x
+
+p = TestPacket(data=gen())
+assert p.__iterlen__() == 5
+pks = [px for px in p]
+assert len(pks) == 5
+assert pks[0].data == 1
+assert pks[-1].data == 9
+p.show()
+print(repr(p))
+
 
 ############
 ############


### PR DESCRIPTION
Fixes #3380 
This PR would fix the behavior of __iterlen__ to be identical on python2 and python3. Also this PR adds support for generator functions for field values which would provide more flexibility for future use-cases. 

I marked this PR as PoC. So if you don't like the idea of having generators for field values, feel free to ignore this PR and #3380. 