### PR TITLE
More injection of signatures

### DIFF
--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -45,16 +45,20 @@ class ReferenceAM(_Generic_metaclass):
                 ):
         # type: (...) -> Type['AnsweringMachine[_T]']
         obj = super(ReferenceAM, cls).__new__(cls, name, bases, dct)
+        try:
+            import inspect
+            obj.__signature__ = inspect.signature(  # type: ignore
+                obj.parse_options  # type: ignore
+            )
+        except (ImportError, AttributeError):
+            pass
         if obj.function_name:  # type: ignore
             func = lambda obj=obj, *args, **kargs: obj(*args, **kargs)()  # type: ignore  # noqa: E501
             # Inject signature
             func.__qualname__ = obj.function_name  # type: ignore
             try:
-                import inspect
-                func.__signature__ = inspect.signature(  # type: ignore
-                    obj.parse_options  # type: ignore
-                )
-            except (ImportError, AttributeError):
+                func.__signature__ = obj.__signature__  # type: ignore
+            except (AttributeError):
                 pass
             globals()[obj.function_name] = func  # type: ignore
         return obj

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -605,6 +605,14 @@ class Automaton_metaclass(type):
                         ioev.atmt_as_supersocket,
                         ioev.atmt_ioname,
                         cast(Type["Automaton"], cls)))
+
+        # Inject signature
+        try:
+            import inspect
+            cls.__signature__ = inspect.signature(cls.parse_args)  # type: ignore  # noqa: E501
+        except (ImportError, AttributeError):
+            pass
+
         return cast(Type["Automaton"], cls)
 
     def build_graph(self):

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -337,6 +337,20 @@ class Packet_metaclass(_Generic_metaclass):
                 dct["_%s" % attr] = dct.pop(attr)
             except KeyError:
                 pass
+        # Build and inject signature
+        try:
+            # Py3 only
+            import inspect
+            dct["__signature__"] = inspect.Signature([
+                inspect.Parameter("_pkt", inspect.Parameter.POSITIONAL_ONLY),
+            ] + [
+                inspect.Parameter(f.name,
+                                  inspect.Parameter.KEYWORD_ONLY,
+                                  default=f.default)
+                for f in dct["fields_desc"]
+            ])
+        except (ImportError, AttributeError, KeyError):
+            pass
         newcls = type.__new__(cls, name, bases, dct)
         # Note: below can't be typed because we use attributes
         # created dynamically..

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -303,7 +303,7 @@ class CDPMsgVoIPVLANReply(CDPMsgGeneric):
     name = "VoIP VLAN Reply"
     fields_desc = [XShortEnumField("type", 0x000e, _cdp_tlv_types),
                    ShortField("len", 7),
-                   ByteField("status?", 1),
+                   ByteField("status", 1),
                    ShortField("vlan", 1)]
 
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -873,7 +873,7 @@ class IE_PrivateExtension(IE_Base):
     name = "Private Extension"
     fields_desc = [ByteEnumField("ietype", 255, IEType),
                    ShortField("length", 1),
-                   ByteField("extension identifier", 0),
+                   ByteField("extension_identifier", 0),
                    StrLenField("extention_value", "",
                                length_from=lambda x: x.length)]
 

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -890,11 +890,11 @@ class IE_Indication(gtp.IE_Base):
         ConditionalField(
         BitField("WPMSI", 0, 1), lambda pkt: pkt.length > 5),
         ConditionalField(
-        BitField("5GSNN26", 0, 1), lambda pkt: pkt.length > 6),
+        BitField("_5GSNN26", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
         BitField("REPREFI", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
-        BitField("5GSIWKI", 0, 1), lambda pkt: pkt.length > 6),
+        BitField("_5GSIWKI", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
         BitField("EEVRSI", 0, 1), lambda pkt: pkt.length > 6),
         ConditionalField(
@@ -914,11 +914,11 @@ class IE_Indication(gtp.IE_Base):
         ConditionalField(
         BitField("N5GNMI", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("5GCNRS", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("_5GCNRS", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("5GCNRI", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("_5GCNRI", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
-        BitField("5SRHOI", 0, 1), lambda pkt: pkt.length > 7),
+        BitField("_5SRHOI", 0, 1), lambda pkt: pkt.length > 7),
         ConditionalField(
         BitField("ETHPDN", 0, 1), lambda pkt: pkt.length > 7),
 

--- a/scapy/contrib/opc_da.py
+++ b/scapy/contrib/opc_da.py
@@ -721,8 +721,8 @@ _opcDa_auth_classes = {
 class OpcDaAuth3(Packet):
     name = "Auth3"
     fields_desc = [
-        ShortField('code?', 5840),
-        ShortField('code2?', 5840),
+        ShortField('code', 5840),
+        ShortField('code2', 5840),
         ByteField('authType', 10),
         ByteField('authLevel', 2),
         ByteField('authPadLen', 0),

--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -1170,14 +1170,14 @@ class PNIORealTimeAcyclicPDUHeader(Packet):
 class Alarm_Low(Packet):
     fields_desc = [
         PNIORealTimeAcyclicPDUHeader,
-        PacketField("RTA-SDU", None, AlarmNotification_Low),
+        PacketField("RTA_SDU", None, AlarmNotification_Low),
     ]
 
 
 class Alarm_High(Packet):
     fields_desc = [
         PNIORealTimeAcyclicPDUHeader,
-        PacketField("RTA-SDU", None, AlarmNotification_High),
+        PacketField("RTA_SDU", None, AlarmNotification_High),
     ]
 
 

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -137,7 +137,7 @@ class RSVP_Object(Packet):
     name = "RSVP_Object"
     fields_desc = [ShortField("Length", 4),
                    ByteEnumField("Class", 0x01, rsvptypes),
-                   ByteField("C-Type", 1)]
+                   ByteField("C_Type", 1)]
 
     def guess_payload_class(self, payload):
         if self.Class == 0x03:

--- a/scapy/contrib/scada/iec104/iec104_information_elements.py
+++ b/scapy/contrib/scada/iec104/iec104_information_elements.py
@@ -489,7 +489,7 @@ class IEC104_IE_QOC:
     }
 
     informantion_element_fields = [
-        BitEnumField('s/e', 0, 1, SE_FLAGS),
+        BitEnumField('s_or_e', 0, 1, SE_FLAGS),
         BitEnumField('qu', 0, 5, QU_FLAGS)
     ]
 
@@ -613,7 +613,7 @@ class IEC104_IE_CP56TIME2A(IEC104_IE_CommonQualityFlags):
         BitField('reserved_2', 0, 2),
         BitField('hours', 0, 5),
         BitEnumField('weekday', 0, 3, WEEK_DAY_FLAGS),
-        BitField('day-of-month', 0, 5),
+        BitField('day_of_month', 0, 5),
         BitField('reserved_3', 0, 4),
         BitField('month', 0, 4),
         BitField('reserved_4', 0, 1),
@@ -638,7 +638,7 @@ class IEC104_IE_CP56TIME2A_START_TIME(IEC104_IE_CP56TIME2A):
         BitField('start_hours', 0, 5),
         BitEnumField('start_weekday', 0, 3,
                      IEC104_IE_CP56TIME2A.WEEK_DAY_FLAGS),
-        BitField('start_day-of-month', 0, 5),
+        BitField('start_day_of_month', 0, 5),
         BitField('start_reserved_3', 0, 4),
         BitField('start_month', 0, 4),
         BitField('start_reserved_4', 0, 1),
@@ -663,7 +663,7 @@ class IEC104_IE_CP56TIME2A_STOP_TIME(IEC104_IE_CP56TIME2A):
         BitField('stop_hours', 0, 5),
         BitEnumField('stop_weekday', 0, 3,
                      IEC104_IE_CP56TIME2A.WEEK_DAY_FLAGS),
-        BitField('stop_day-of-month', 0, 5),
+        BitField('stop_day_of_month', 0, 5),
         BitField('stop_reserved_3', 0, 4),
         BitField('stop_month', 0, 4),
         BitField('stop_reserved_4', 0, 1),

--- a/scapy/layers/ir.py
+++ b/scapy/layers/ir.py
@@ -25,19 +25,19 @@ class IrLAPHead(Packet):
 class IrLAPCommand(Packet):
     name = "IrDA Link Access Protocol Command"
     fields_desc = [XByteField("Control", 0),
-                   XByteField("Format identifier", 0),
-                   XIntField("Source address", 0),
-                   XIntField("Destination address", 0xffffffff),
-                   XByteField("Discovery flags", 0x1),
-                   ByteEnumField("Slot number", 255, {"final": 255}),
+                   XByteField("Format_identifier", 0),
+                   XIntField("Source_address", 0),
+                   XIntField("Destination_address", 0xffffffff),
+                   XByteField("Discovery_flags", 0x1),
+                   ByteEnumField("Slot_number", 255, {"final": 255}),
                    XByteField("Version", 0)]
 
 
 class IrLMP(Packet):
     name = "IrDA Link Management Protocol"
-    fields_desc = [XShortField("Service hints", 0),
-                   XByteField("Character set", 0),
-                   StrField("Device name", "")]
+    fields_desc = [XShortField("Service_hints", 0),
+                   XByteField("Character_set", 0),
+                   StrField("Device_name", "")]
 
 
 bind_layers(CookedLinux, IrLAPHead, proto=23)

--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -117,7 +117,7 @@ class SMB2_Compression_Transform_Header(Packet):
             0x0000: "SMB2_COMPRESSION_FLAG_NONE",
             0x0001: "SMB2_COMPRESSION_FLAG_CHAINED",
         }),
-        XLEIntField("Offset/Length", 0),
+        XLEIntField("Offset_or_Length", 0),
     ]
 
 


### PR DESCRIPTION
- more signature injection
  - inject signatures in Automatons
  - inject fields signatures in Packet classes 
- this led to all already invalid field names (containing a space, starting with a number...) in scapy's contrib files to raise an error on build, so I had to fix them

This currently works in `help(...)`, ~~but there is sadly a tiny IPython bug preventing the following autocompletions from happening. I have made a PR (over https://github.com/ipython/ipython/pull/13187) . Feel free to upvote it~~. **Works in IPython >= 7.29**

![image](https://user-images.githubusercontent.com/10530980/137351788-5e617134-c02b-4a4a-91b1-07d5b1cc9ed9.png)
![image](https://user-images.githubusercontent.com/10530980/137352011-121eeca8-5a0d-4057-a091-533d0d2e2669.png)

