### PR TITLE
inet6: Fix PseudoIPv6 uplen being only 16 bits

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -554,7 +554,7 @@ class PseudoIPv6(Packet):  # IPv6 Pseudo-header for checksum computation
     name = "Pseudo IPv6 Header"
     fields_desc = [IP6Field("src", "::"),
                    IP6Field("dst", "::"),
-                   ShortField("uplen", None),
+                   IntField("uplen", None),
                    BitField("zero", 0, 24),
                    ByteField("nh", 0)]
 

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -55,6 +55,10 @@ IPv6(dst="ff00::1:ff28:9c5a", src="::").hashret() == b';'
 p = PseudoIPv6(src="fd00::abcd", dst="fd00::1234", uplen=64, nh=socket.IPPROTO_UDP)
 raw(p) == b"\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xab\xcd\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12\x34\x00\x00\x00\x40\x00\x00\x00\x11"
 
+= in6_chksum is computed on UDP or TCP build
+p = IPv6(raw(IPv6()/UDP()/Raw(load="somedata")))
+assert p.chksum == 0x45cb
+
 ########### IPv6ExtHdrRouting Class ###########################
 
 = IPv6ExtHdrRouting Class - No address - build

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -51,6 +51,10 @@ GRE in p and p[GRE:1].proto == 0x6558 and p[GRE:2].proto == 0x86DD and IPv6 in p
 = IPv6 ma_addr coverage on hashret
 IPv6(dst="ff00::1:ff28:9c5a", src="::").hashret() == b';'
 
+= PseudoIPv6
+p = PseudoIPv6(src="fd00::abcd", dst="fd00::1234", uplen=64, nh=socket.IPPROTO_UDP)
+raw(p) == b"\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xab\xcd\xfd\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12\x34\x00\x00\x00\x40\x00\x00\x00\x11"
+
 ########### IPv6ExtHdrRouting Class ###########################
 
 = IPv6ExtHdrRouting Class - No address - build


### PR DESCRIPTION
According to RFC2460 the payload length in the ipv6 pseudoheader is 32bits. Nobody noticed so far likely because this is only used for computing 16-bit checksum. When computing alternative checksums this makes a difference.

This was found while working on TCP-MD5 and TCP-AO support, see #3358