### PR TITLE
Fix DeprecationWarning in RandNum init

### DIFF
--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -201,8 +201,8 @@ class RandNum(_RandNumeral):
     max = 0
 
     def __init__(self, min, max):
-        self.min = min
-        self.max = max
+        self.min = int(min)
+        self.max = int(max)
 
     def _command_args(self):
         if self.__class__.__name__ == 'RandNum':


### PR DESCRIPTION
This pr fixes the following warning when using python 3.10.
```
xxx/scapy/volatile.py:215: DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
  return random.randrange(self.min, self.max + 1)
```
