### PR TITLE
contrib/pnio: Fix tests for PNIO Alarms

### DIFF
--- a/test/contrib/pnio_rpc.uts
+++ b/test/contrib/pnio_rpc.uts
@@ -3,6 +3,7 @@
 + Syntax check
 = Import the PNIO RPC layer
 from scapy.contrib.dce_rpc import *
+from scapy.contrib.pnio import *
 from scapy.contrib.pnio_rpc import *
 from scapy.modules.six import itervalues
 


### PR DESCRIPTION
The PNIO Alarms tests use ProfinetIO but this is defined in
scapy.contrib.pnio which wasn't being imported. Import it now
so the test run instead of erroring out.

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>

