### PR TITLE
Retrieve the optimized BPF filter

### DIFF
--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -137,7 +137,7 @@ def compile_filter(filter_exp,  # type: str
             linktype = ARPHDR_ETHER
     if linktype is not None:
         ret = pcap_compile_nopcap(
-            MTU, linktype, ctypes.byref(bpf), bpf_filter, 0, -1
+            MTU, linktype, ctypes.byref(bpf), bpf_filter, 1, -1
         )
     elif iface:
         err = create_string_buffer(PCAP_ERRBUF_SIZE)
@@ -149,7 +149,7 @@ def compile_filter(filter_exp,  # type: str
         if error:
             raise OSError(error)
         ret = pcap_compile(
-            pcap, ctypes.byref(bpf), bpf_filter, 0, -1
+            pcap, ctypes.byref(bpf), bpf_filter, 1, -1
         )
         pcap_close(pcap)
     if ret == -1:

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -293,7 +293,7 @@ if conf.use_pcap:
 
         def setfilter(self, f):
             filter_exp = create_string_buffer(f.encode("utf8"))
-            if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 0, -1) == -1:  # noqa: E501
+            if pcap_compile(self.pcap, byref(self.bpf_program), filter_exp, 1, -1) == -1:  # noqa: E501
                 log_runtime.error("Could not compile filter expression %s", f)
                 return False
             else:


### PR DESCRIPTION
This PR fixes #3445. It turns out that Scapy currently injects raw BPF filter that are not optimized by libpcap. That is why the filter used by @janus1345 hits the memory limit while tcpcpdump does not.