### PR TITLE
Fix #3489: test failure on "pcapng file with a Decryption Secrets Block"

### DIFF
--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1586,15 +1586,15 @@ conf = bck_conf
 = pcapng file with a Decryption Secrets Block
 ~ tshark linux
 
-bck_conf = conf
-
-key_log_path = scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.keys.txt")
-pcap_path = scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.pcap")
-pcapng_path = get_temp_file()
-os.system("editcap --inject-secrets tls,%s %s %s" % (key_log_path, pcap_path, pcapng_path))
-
-packets = rdpcap(pcapng_path)
-assert b"GET /secret.txt HTTP/1.0\n" in packets[11].msg[0].data
-assert b"z2|gxarIKOxt,G1d>.Q2MzGY[k@" in packets[13].msg[0].data
-
-conf = bck_conf
+import shutil
+if shutil.which("editcap"):
+    bck_conf = conf
+    key_log_path = scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.keys.txt")
+    pcap_path = scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.pcap")
+    pcapng_path = get_temp_file()
+    exit_status = os.system("editcap --inject-secrets tls,%s %s %s" % (key_log_path, pcap_path, pcapng_path))
+    assert(exit_status == 0)
+    packets = rdpcap(pcapng_path)
+    assert b"GET /secret.txt HTTP/1.0\n" in packets[11].msg[0].data
+    assert b"z2|gxarIKOxt,G1d>.Q2MzGY[k@" in packets[13].msg[0].data
+    conf = bck_conf


### PR DESCRIPTION
Fix failing because os.system returns 0, this means success for a shell
process but failure for utsscapy.

Also check if editcap tool is present first.

Fixes #3489

Signed-off-by: Leonard Crestez <cdleonard@gmail.com>