### PR TITLE
Minor cleanup and stabilization of UDS_Scanner / UDS_SA_XOR_Enumerator

### DIFF
--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -282,7 +282,7 @@ class ServiceEnumerator(AutomotiveTestCase):
     execute.__doc__ = _supported_kwargs_doc
 
     def sr1_with_retry_on_error(self, req, socket, state, timeout):
-        # type: (Packet, _SocketUnion, EcuState, int) -> Packet
+        # type: (Packet, _SocketUnion, EcuState, int) -> Optional[Packet]
         try:
             res = socket.sr1(req, timeout=timeout, verbose=False)
             if socket.closed:


### PR DESCRIPTION
I discovered a unit-test instability of the `UDS_SA_XOR_Enumerator` which let's the unit tests fail with a probability of 0.22%.

This PR fixes this instability and cleans up the code a little bit.