### PR TITLE
Fix a typo in the documentation (mpbs -> mbps)

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -489,7 +489,7 @@ def sendpfast(x,  # type: _PacketIterable
     """Send packets at layer 2 using tcpreplay for performance
 
     :param pps:  packets per second
-    :param mpbs: MBits per second
+    :param mbps: MBits per second
     :param realtime: use packet's timestamp, bending time with real-time value
     :param loop: number of times to process the packet list
     :param file_cache: cache packets in RAM instead of reading from


### PR DESCRIPTION
This may be my dyslexic moment, but I believe it should read `mbps`, not `mpbs`.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
This fixes a minor typo in the documentation (to `mbps` from `mpbs`, for MB per seconds).

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->