### PR TITLE
Revert "Fix High CPU Windows"

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -95,8 +95,7 @@ def select_objects(inputs, remain):
     if natives:
         results = results.union(set(select.select(natives, [], [], remain)[0]))
     if events:
-        # 0xFFFFFFFF = INFINITE
-        remainms = int(remain * 1000 if remain else 0xFFFFFFFF)
+        remainms = int((remain or 0) * 1000)
         if len(events) == 1:
             res = ctypes.windll.kernel32.WaitForSingleObject(
                 ctypes.c_void_p(events[0].fileno()),


### PR DESCRIPTION
This reverts commit 65089071da1acf54622df0b4fa7fc7673d47d3cd.

Apparently, this commit broke appveyor. I inspected the error a little bit, and select_objects is broken after this commit.