### PR TITLE
Preventing problems with segments out of order

### DIFF
--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -308,6 +308,9 @@ class TCPSession(IPSession):
         if relative_seq is None:
             relative_seq = metadata["relative_seq"] = seq - 1
         seq = seq - relative_seq
+        # If the seq < 0 means the segment is out of order
+        if seq < 0:
+            return None
         # Add the data to the buffer
         # Note that this take care of retransmission packets.
         data.append(new_data, seq)


### PR DESCRIPTION
<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
## Brief description
I detected an "out-of-order" TCP segment in the trace, could make the TCPSession stop inmediatly.

![out_of_order_segment](https://user-images.githubusercontent.com/444620/154520481-07c565d1-0767-4946-82fd-072551042b31.png)

The fix is pretty simple, some out of order segments could generate a sequence number < 0, that make the StringBuffer used to collect all the data from the segments raises an error. To prevent it, we just check the seq number is > 0 before to continue with the append of the data.
