### PR TITLE
add BGP LARGE_COMMUNITY Path Attribute

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1054,6 +1054,7 @@ path_attributes = {
     27: "PE Distinguisher Labels",  # RFC 6514
     28: "BGP Entropy Label Capability Attribute (deprecated)",  # RFC 6790, RFC 7447  # noqa: E501
     29: "BGP-LS Attribute",  # RFC 7752
+    32: "LARGE_COMMUNITY", #RFC 8092, RFC 8195
     40: "BGP Prefix-SID",  # (TEMPORARY - registered 2015-09-30, expires 2016-09-30)  # noqa: E501
     # draft-ietf-idr-bgp-prefix-sid
     128: "ATTR_SET",  # RFC 6368
@@ -1091,6 +1092,7 @@ attributes_flags = {
     27: 0xc0,   # PE Distinguisher Labels (RFC 6514)
     28: 0xc0,   # BGP Entropy Label Capability Attribute
     29: 0x80,   # BGP-LS Attribute
+    32: 0xc0,   # LARGE_COMMUNITY
     40: 0xc0,   # BGP Prefix-SID
     128: 0xc0   # ATTR_SET (RFC 6368)
 }
@@ -2005,6 +2007,31 @@ class BGPPAAS4Path(Packet):
 
 
 #
+# LARGE_COMMUNITY
+#
+
+class BGPPALargeCommunity(Packet):
+    """
+    Provides an implementation of the LARGE_COMMUNITY attribute.
+    References: RFC 8092, RFC 8195
+    """
+
+    class LargeCommunitySegment(Packet):
+        """
+        Provides an implementation for LARGE_COMMUNITY segments with 3*4 bytes integers.
+        """
+
+        fields_desc = [
+            IntField("global_administrator", None),
+            IntField("local_data_part1", None),
+            IntField("local_data_part2", None)
+        ]
+
+
+    name = "LARGE_COMMUNITY"
+    fields_desc = [PacketListField("segments",[],LargeCommunitySegment)]
+
+#
 # AS4_AGGREGATOR
 #
 
@@ -2035,7 +2062,8 @@ _path_attr_objects = {
     0x0F: "BGPPAMPUnreachNLRI",
     0x10: "BGPPAExtComms",
     0x11: "BGPPAAS4Path",
-    0x19: "BGPPAIPv6AddressSpecificExtComm"
+    0x19: "BGPPAIPv6AddressSpecificExtComm",
+    0x20: "BGPPALargeCommunity"
 }
 
 

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1054,7 +1054,7 @@ path_attributes = {
     27: "PE Distinguisher Labels",  # RFC 6514
     28: "BGP Entropy Label Capability Attribute (deprecated)",  # RFC 6790, RFC 7447  # noqa: E501
     29: "BGP-LS Attribute",  # RFC 7752
-    32: "LARGE_COMMUNITY", #RFC 8092, RFC 8195
+    32: "LARGE_COMMUNITY",  # RFC 8092, RFC 8195
     40: "BGP Prefix-SID",  # (TEMPORARY - registered 2015-09-30, expires 2016-09-30)  # noqa: E501
     # draft-ietf-idr-bgp-prefix-sid
     128: "ATTR_SET",  # RFC 6368
@@ -2010,30 +2010,32 @@ class BGPPAAS4Path(Packet):
 # LARGE_COMMUNITY
 #
 
+class BGPLargeCommunitySegment(Packet):
+    """
+    Provides an implementation for LARGE_COMMUNITY segments
+    which holds 3*4 bytes integers.
+    """
+
+    fields_desc = [
+        IntField("global_administrator", None),
+        IntField("local_data_part1", None),
+        IntField("local_data_part2", None)
+    ]
+
+
 class BGPPALargeCommunity(Packet):
     """
     Provides an implementation of the LARGE_COMMUNITY attribute.
     References: RFC 8092, RFC 8195
     """
 
-    class LargeCommunitySegment(Packet):
-        """
-        Provides an implementation for LARGE_COMMUNITY segments with 3*4 bytes integers.
-        """
-
-        fields_desc = [
-            IntField("global_administrator", None),
-            IntField("local_data_part1", None),
-            IntField("local_data_part2", None)
-        ]
-
-
     name = "LARGE_COMMUNITY"
-    fields_desc = [PacketListField("segments",[],LargeCommunitySegment)]
+    fields_desc = [PacketListField("segments", [], BGPLargeCommunitySegment)]
 
 #
 # AS4_AGGREGATOR
 #
+
 
 class BGPPAAS4Aggregator(Packet):
     """
@@ -2089,7 +2091,7 @@ class _PathAttrPacketField(PacketField):
             if type_code == 0x02 and not bgp_module_conf.use_2_bytes_asn:
                 ret = BGPPAAS4BytesPath(m)
             elif type_code == 0x20:
-                ret=BGPPALargeCommunity(m)
+                ret = BGPPALargeCommunity(m)
             else:
                 ret = _get_cls(
                     _path_attr_objects.get(type_code, conf.raw_layer))(m)

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -2080,7 +2080,7 @@ class _PathAttrPacketField(PacketField):
         if type_code == 0 or type_code == 255:
             ret = conf.raw_layer(m)
         # Unassigned
-        elif (type_code >= 30 and type_code <= 39) or\
+        elif (type_code >= 33 and type_code <= 39) or\
             (type_code >= 41 and type_code <= 127) or\
                 (type_code >= 129 and type_code <= 254):
             ret = conf.raw_layer(m)
@@ -2088,6 +2088,8 @@ class _PathAttrPacketField(PacketField):
         else:
             if type_code == 0x02 and not bgp_module_conf.use_2_bytes_asn:
                 ret = BGPPAAS4BytesPath(m)
+            elif type_code == 0x20:
+                ret=BGPPALargeCommunity(m)
             else:
                 ret = _get_cls(
                     _path_attr_objects.get(type_code, conf.raw_layer))(m)

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -597,6 +597,20 @@ a = BGPPAAS4Aggregator(b'&kN%\xc0\x00\x02\x01')
 a.aggregator_asn == 644566565 and a.speaker_address == "192.0.2.1"
 
 
+############################# BGPPALargeCommunity ############################
++ BGPPALargeCommunity class tests
+
+= BGPPALargeCommunity - Instantiation
+raw(BGPPALargeCommunity()) == b''
+
+= BGPPALargeCommunity - Instantiation with specific values
+raw(BGPPALargeCommunity(segments=BGPPALargeCommunity.LargeCommunitySegment(global_administrator=161,local_data_part1=0,local_data_part2=0))) == b'\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00'
+
+= BGPPALargeCommunity - Dissection
+a = BGPPALargeCommunity(b'\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00')
+a.segments[0].global_administrator == 161 and a.segments[0].local_data_part1 == 0 and a.segments[0].local_data_part2 == 0
+
+
 ################################ BGPPathAttr #################################
 + BGPPathAttr class tests
 

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -604,7 +604,7 @@ a.aggregator_asn == 644566565 and a.speaker_address == "192.0.2.1"
 raw(BGPPALargeCommunity()) == b''
 
 = BGPPALargeCommunity - Instantiation with specific values
-raw(BGPPALargeCommunity(segments=BGPPALargeCommunity.LargeCommunitySegment(global_administrator=161,local_data_part1=0,local_data_part2=0))) == b'\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00'
+raw(BGPPALargeCommunity(segments=BGPLargeCommunitySegment(global_administrator=161,local_data_part1=0,local_data_part2=0))) == b'\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00'
 
 = BGPPALargeCommunity - Dissection
 a = BGPPALargeCommunity(b'\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00')


### PR DESCRIPTION
<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
add support for BGP protocol's LARGE_COMMUNITY Path Attribute, introduced with RFC 8092 and RFC 8195

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->
