### PR TITLE
Fix bug in ClientHello random_bytes. Those start at byte 6, not 10

### DIFF
--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -455,7 +455,7 @@ class TLS13ClientHello(_TLSHandshake):
             s.sid = self.sid
             s.middlebox_compatibility = True
 
-        self.random_bytes = msg_str[10:38]
+        self.random_bytes = msg_str[6:38]
         s.client_random = self.random_bytes
         if self.ext:
             for e in self.ext:


### PR DESCRIPTION
While implementing an option to dump TLSv1.3 keys in NSS Keylog Format from scapy (are you interested in this feature and should I create a PR?), I realized that in the random_bytes field is wrongly parsed.

I assume this is a copy-paste issue from TLSv1.2, where 4 bytes of the client_random were gmt_unix_time.