### PR TITLE
Fixed an issue with the BPF filter on the M1 mac.

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -38,7 +38,7 @@ if LINUX:
 
 LIBC = cdll.LoadLibrary(find_library("c"))
 
-LIBC.ioctl.argtypes = [c_int, c_ulong, c_char_p]
+LIBC.ioctl.argtypes = [c_int, c_ulong, ]
 LIBC.ioctl.restype = c_int
 
 # The following is implemented as of Python >= 3.3


### PR DESCRIPTION
Fix for Mac computers with Apple silicon (M1). The BPF filter wasn't working, because the definition of the third argument of ioctl was wrong.

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

This fix is useful for m1 mac users.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

The definition of ioctl in the C library is as follows:

  int ioctl(int fildes, unsigned long request, ...);

<!-- if required - outline impacts on other parts of the library -->
