### PR TITLE
L2Socket close method to check if ins attr exists before using it

### DIFF
--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -547,7 +547,7 @@ class L2Socket(SuperSocket):
         if self.closed:
             return
         try:
-            if self.promisc and self.ins:
+            if self.promisc and getattr(self, "ins", None):
                 set_promisc(self.ins, self.iface, 0)
         except (AttributeError, OSError):
             pass


### PR DESCRIPTION
`L2Socket` implementation for `arch/linux` uses `self.ins` within `close` method. Which might lead to throwing exception in `SuperSocket.__del__` when `ins` was not setup properly (e.g. when call to `socket.socket` failed). Note that `SuperSocket`'s implementation is quite careful: attributes are only accessed using `getattr`. The PR uses the same approach for overloaded `close` in `L2Socket` class.