### PR TITLE
Update six to support Python 3.11

### DIFF
--- a/.config/mypy/mypy.ini
+++ b/.config/mypy/mypy.ini
@@ -2,7 +2,7 @@
 
 # Internal Scapy modules that we ignore
 
-[mypy-scapy.modules.six,scapy.modules.six.moves,scapy.libs.winpcapy]
+[mypy-scapy.libs.six,scapy.libs.six.moves,scapy.libs.winpcapy]
 ignore_errors = True
 ignore_missing_imports = True
 

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -21,7 +21,7 @@ from scapy.sendrecv import send, sniff, AsyncSniffer
 from scapy.packet import Packet
 from scapy.plist import PacketList
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -28,7 +28,6 @@ from scapy.error import Scapy_Exception, warning
 from scapy.interfaces import InterfaceProvider, IFACES, NetworkInterface, \
     network_name
 from scapy.pton_ntop import inet_ntop
-from scapy.modules.six.moves import range
 
 if LINUX:
     raise OSError("BPF conflicts with Linux")

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -49,8 +49,7 @@ from scapy.packet import Packet, Padding
 from scapy.pton_ntop import inet_ntop
 from scapy.supersocket import SuperSocket
 
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 
 # Typing imports
 from scapy.compat import (

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -36,8 +36,8 @@ from scapy.pton_ntop import inet_ntop, inet_pton
 from scapy.utils import atol, itom, mac2str, str2mac
 from scapy.utils6 import construct_source_candidate_set, in6_getscope
 from scapy.data import ARPHDR_ETHER, load_manuf
-import scapy.modules.six as six
-from scapy.modules.six.moves import input, winreg
+import scapy.libs.six as six
+from scapy.libs.six.moves import input, winreg
 from scapy.compat import plain_str
 from scapy.supersocket import SuperSocket
 

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -18,7 +18,7 @@ from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP, GeneralizedTime
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
 from scapy.compat import plain_str, bytes_encode, chb, orb
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -28,7 +28,7 @@ from scapy.asn1.asn1 import (
     ASN1_Object,
     _ASN1_ERROR,
 )
-from scapy.modules import six
+from scapy.libs import six
 
 from scapy.compat import (
     Any,

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -14,7 +14,7 @@ from glob import glob
 from scapy.dadict import DADict, fixname
 from scapy.config import conf
 from scapy.utils import do_graph
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import plain_str
 
 from scapy.compat import (

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -40,7 +40,7 @@ from scapy.compat import raw
 from scapy.base_classes import BasePacket
 from scapy import packet
 from functools import reduce
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -12,7 +12,7 @@ Packet holding data in Abstract Syntax Notation (ASN.1).
 from __future__ import absolute_import
 from scapy.base_classes import Packet_metaclass
 from scapy.packet import Packet
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -33,7 +33,7 @@ from scapy.data import MTU
 from scapy.supersocket import SuperSocket
 from scapy.packet import Packet
 from scapy.consts import WINDOWS
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -27,8 +27,8 @@ from scapy.compat import (
     Tuple,
 )
 
-from scapy.modules.six.moves import queue
-import scapy.modules.six as six
+from scapy.libs.six.moves import queue
+import scapy.libs.six as six
 
 
 #########################

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -28,7 +28,7 @@ import scapy
 from scapy.error import Scapy_Exception
 from scapy.consts import WINDOWS
 
-from scapy.modules.six.moves import range
+from scapy.libs.six.moves import range
 
 from scapy.compat import (
     Any,

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -16,7 +16,7 @@ import socket
 import struct
 import sys
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 # Very important: will issue typing errors otherwise
 __all__ = [

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -25,7 +25,7 @@ from scapy import VERSION
 from scapy.base_classes import BasePacket
 from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
 from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
-from scapy.modules import six
+from scapy.libs import six
 from scapy.themes import NoTheme, apply_ipython_style
 
 from scapy.compat import (

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from types import GeneratorType
 from threading import Lock
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import Any, Union, Iterable, Callable, List, Optional, \
     Tuple, Type, cast, Dict, orb, ValuesView
 from scapy.packet import Raw, Packet

--- a/scapy/contrib/automotive/gm/gmlan_scanner.py
+++ b/scapy/contrib/automotive/gm/gmlan_scanner.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from scapy.compat import Optional, List, Type, Any, Tuple, Iterable, Dict, \
     cast, Callable, orb
 from scapy.packet import Packet
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.supersocket import SuperSocket
 from scapy.error import Scapy_Exception, log_interactive, warning

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -17,7 +17,7 @@ from scapy.compat import Any, Union, List, Optional, Iterable, \
     Dict, Tuple, Set, Callable, cast, NamedTuple, orb
 from scapy.error import Scapy_Exception, log_interactive
 from scapy.utils import make_lined_table, EDecimal
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import Packet
 from scapy.contrib.automotive.ecu import EcuState, EcuResponse
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCase, \

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -17,7 +17,7 @@ from scapy.contrib.automotive.scanner.graph import Graph
 from scapy.error import Scapy_Exception, log_interactive
 from scapy.supersocket import SuperSocket
 from scapy.utils import make_lined_table, SingleConversationSocket
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.contrib.automotive.ecu import EcuState, EcuResponse, Ecu
 from scapy.contrib.automotive.scanner.configuration import \
     AutomotiveTestCaseExecutorConfiguration

--- a/scapy/contrib/automotive/scanner/test_case.py
+++ b/scapy/contrib/automotive/scanner/test_case.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from scapy.compat import Any, Union, List, Optional, \
     Dict, Tuple, Set, Callable, TYPE_CHECKING
 from scapy.utils import make_lined_table, SingleConversationSocket
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.supersocket import SuperSocket
 from scapy.contrib.automotive.scanner.graph import _Edge
 from scapy.contrib.automotive.ecu import EcuState, EcuResponse

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -36,7 +36,6 @@ from scapy.layers.inet import TCP, UDP
 from scapy.layers.inet6 import IP6Field
 from scapy.compat import raw, orb
 from scapy.config import conf
-from scapy.modules.six.moves import range
 from scapy.packet import Packet, Raw, bind_top_down, bind_bottom_up
 from scapy.fields import XShortField, BitEnumField, ConditionalField, \
     BitField, XBitField, IntField, XByteField, ByteEnumField, \

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -19,7 +19,7 @@ from typing import Sequence
 from scapy.compat import Dict, Optional, List, Type, Any, Iterable, \
     cast, Union, NamedTuple, orb, Set
 from scapy.packet import Raw, Packet
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.error import Scapy_Exception, log_interactive
 from scapy.contrib.automotive.uds import UDS, UDS_NR, UDS_DSC, UDS_TP, \
     UDS_RDBI, UDS_WDBI, UDS_SA, UDS_RC, UDS_IOCBI, UDS_RMBA, UDS_ER, \

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -38,7 +38,7 @@ from scapy.layers.inet6 import IP6Field
 from scapy.config import conf, ConfClass
 from scapy.compat import orb, chb
 from scapy.error import log_runtime
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 #

--- a/scapy/contrib/cansocket.py
+++ b/scapy/contrib/cansocket.py
@@ -13,7 +13,7 @@ CANSocket.
 from scapy.error import log_loading
 from scapy.consts import LINUX
 from scapy.config import conf
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 PYTHON_CAN = False
 

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -23,7 +23,7 @@ from scapy.layers.can import CAN
 from scapy.packet import Packet
 from scapy.error import warning
 from scapy.compat import List, Type, Tuple, Dict, Any, Optional, cast
-from scapy.modules.six.moves import queue
+from scapy.libs.six.moves import queue
 
 from can import Message as can_Message
 from can import CanError as can_CanError

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -43,7 +43,6 @@ from scapy.fields import (
 from scapy.layers.inet import checksum
 from scapy.layers.l2 import SNAP
 from scapy.compat import orb, chb
-from scapy.modules.six.moves import range
 from scapy.config import conf
 
 

--- a/scapy/contrib/diameter.py
+++ b/scapy/contrib/diameter.py
@@ -32,8 +32,7 @@ from scapy.fields import ConditionalField, EnumField, Field, FieldLenField, \
     XByteField, XIntField
 from scapy.layers.inet import TCP
 from scapy.layers.sctp import SCTPChunkData
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.compat import chb, orb, raw, bytes_hex, plain_str
 from scapy.error import warning
 from scapy.utils import inet_ntoa, inet_aton

--- a/scapy/contrib/eddystone.py
+++ b/scapy/contrib/eddystone.py
@@ -27,7 +27,7 @@ from scapy.fields import IntField, SignedByteField, StrField, BitField, \
     StrFixedLenField, ShortField, FixedPointField, ByteEnumField
 from scapy.layers.bluetooth import EIR_Hdr, EIR_ServiceData16BitUUID, \
     EIR_CompleteList16BitServiceUUIDs, LowEnergyBeaconHelper
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import bind_layers, Packet
 
 EDDYSTONE_UUID = 0xfeaa

--- a/scapy/contrib/ethercat.py
+++ b/scapy/contrib/ethercat.py
@@ -51,7 +51,7 @@ from scapy.error import log_runtime, Scapy_Exception
 from scapy.fields import BitField, ByteField, LEShortField, FieldListField, \
     LEIntField, FieldLenField, _EnumField, EnumField
 from scapy.layers.l2 import Ether, Dot1Q
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import bind_layers, Packet, Padding
 
 '''

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -45,7 +45,6 @@ from scapy.fields import (
 from scapy.layers.inet import IP, UDP
 from scapy.layers.inet6 import IPv6, IP6Field
 from scapy.layers.ppp import PPP
-from scapy.modules.six.moves import range
 from scapy.packet import bind_layers, bind_bottom_up, bind_top_down, \
     Packet, Raw
 from scapy.volatile import RandInt, RandIP, RandNum, RandString

--- a/scapy/contrib/homeplugav.py
+++ b/scapy/contrib/homeplugav.py
@@ -53,7 +53,6 @@ from scapy.fields import (
     XShortField,
 )
 from scapy.layers.l2 import Ether
-from scapy.modules.six.moves import range
 
 HPAVTypeList = {0xA000: "'Get Device/sw version Request'",
                 0xA001: "'Get Device/sw version Confirmation'",

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -33,7 +33,7 @@ import abc
 import re
 from io import BytesIO
 import struct
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import raw, plain_str, hex_bytes, orb, chb, bytes_encode
 
 # Only required if using mypy-lang for static typing

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -28,7 +28,7 @@ from scapy.layers.inet import IP, ICMP, checksum
 from scapy.layers.inet6 import IP6Field
 from scapy.error import warning
 from scapy.contrib.mpls import MPLS
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 
 

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -80,7 +80,6 @@ from scapy.layers.clns import network_layer_protocol_ids, register_cln_protocol
 from scapy.layers.inet6 import IP6ListField, IP6Field
 from scapy.utils import fletcher16_checkbytes
 from scapy.volatile import RandString, RandByte
-from scapy.modules.six.moves import range
 from scapy.compat import orb, hex_bytes
 
 EXT_VERSION = "v0.0.3"

--- a/scapy/contrib/isotp/__init__.py
+++ b/scapy/contrib/isotp/__init__.py
@@ -7,7 +7,7 @@
 # scapy.contrib.status = loads
 
 from scapy.consts import LINUX
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.error import log_loading
 

--- a/scapy/contrib/isotp/isotp_native_socket.py
+++ b/scapy/contrib/isotp/isotp_native_socket.py
@@ -13,7 +13,7 @@ import socket
 
 from scapy.compat import Optional, Union, Tuple, Type, cast
 from scapy.packet import Packet
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.error import Scapy_Exception, warning
 from scapy.supersocket import SuperSocket
 from scapy.data import SO_TIMESTAMPNS

--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -19,7 +19,7 @@ from scapy.compat import Optional, Union, List, Tuple, Any, Type, cast, \
     Callable, TYPE_CHECKING
 from scapy.packet import Packet
 from scapy.layers.can import CAN
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.error import Scapy_Exception, warning, log_runtime
 from scapy.supersocket import SuperSocket
 from scapy.config import conf

--- a/scapy/contrib/isotp/isotp_utils.py
+++ b/scapy/contrib/isotp/isotp_utils.py
@@ -17,7 +17,7 @@ from scapy.packet import Packet
 from scapy.sessions import DefaultSession
 from scapy.contrib.isotp.isotp_packet import ISOTP, N_PCI_CF, N_PCI_SF, \
     N_PCI_FF, N_PCI_FC
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 class ISOTPMessageBuilderIter(object):

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -27,7 +27,6 @@ from scapy.fields import BitField, IPField, IntField, ShortField, StrField, \
     XBitField
 from scapy.layers.inet import UDP
 from scapy.layers.inet import TCP
-from scapy.modules.six.moves import range
 from scapy.config import conf
 from scapy.utils import inet_aton, inet_ntoa
 

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -51,7 +51,6 @@ from scapy.fields import MACField, IPField, BitField, \
     ShortField, XStrLenField, ByteField, ConditionalField, \
     MultipleTypeField
 from scapy.packet import Packet, bind_layers
-from scapy.modules.six.moves import range
 from scapy.data import ETHER_TYPES
 from scapy.compat import orb
 
@@ -106,7 +105,6 @@ class LLDPDU(Packet):
         0x06: 'system description',
         0x07: 'system capabilities',
         0x08: 'management address',
-        range(0x09, 0x7e): 'reserved - future standardization',
         127: 'organisation specific TLV'
     }
 
@@ -302,7 +300,6 @@ class LLDPDUChassisID(LLDPDU):
         0x05: 'network address',
         0x06: 'interface name',
         0x07: 'locally assigned',
-        range(0x08, 0xff): 'reserved'
     }
 
     SUBTYPE_RESERVED = 0x00
@@ -358,7 +355,6 @@ class LLDPDUPortID(LLDPDU):
         0x05: 'interface name',
         0x06: 'agent circuit ID',
         0x07: 'locally assigned',
-        range(0x08, 0xff): 'reserved'
     }
 
     SUBTYPE_RESERVED = 0x00

--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -26,7 +26,7 @@
 # scapy.contrib.description = Licklider Transmission Protocol (LTP)
 # scapy.contrib.status = loads
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import Packet, bind_layers, bind_top_down
 from scapy.fields import BitEnumField, BitField, BitFieldLenField, \
     ByteEnumField, ConditionalField, PacketListField, StrLenField

--- a/scapy/contrib/macsec.py
+++ b/scapy/contrib/macsec.py
@@ -26,7 +26,7 @@ from scapy.layers.inet6 import IPv6
 from scapy.compat import raw
 from scapy.data import ETH_P_MACSEC, ETHER_TYPES, ETH_P_IP, ETH_P_IPV6
 from scapy.error import log_loading
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend

--- a/scapy/contrib/nfs.py
+++ b/scapy/contrib/nfs.py
@@ -12,7 +12,7 @@ from scapy.packet import Packet, bind_layers
 from scapy.fields import IntField, IntEnumField, FieldListField, LongField, \
     XIntField, XLongField, ConditionalField, PacketListField, StrLenField, \
     PacketField
-from scapy.modules.six import integer_types
+from scapy.libs.six import integer_types
 
 nfsstat3 = {
     0: 'NFS3_OK',

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -23,7 +23,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import TCP
 from scapy.packet import Packet, Raw, bind_bottom_up, bind_top_down
 from scapy.utils import binrepr
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 # If prereq_autocomplete is True then match prerequisites will be

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -25,7 +25,7 @@ from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     XIntField, XShortField, PacketLenField
 from scapy.layers.l2 import Ether
 from scapy.packet import Packet, Padding, Raw
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.contrib.openflow import _ofp_header, _ofp_header_item, \
     OFPacketField, OpenFlow, _UnknownOpenFlow

--- a/scapy/contrib/pnio.py
+++ b/scapy/contrib/pnio.py
@@ -30,7 +30,7 @@ from scapy.fields import (
     StrFixedLenField, ShortField,
     FlagsField, ByteField, XIntField, X3BytesField
 )
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 PNIO_FRAME_IDS = {
     0x0020: "PTCP-RTSyncPDU-followup",

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -34,8 +34,7 @@ from scapy.fields import ByteField, ConditionalField, Field, FlagsField, \
     UTCTimeField, XLEIntField, SignedByteField, XLEShortField
 from scapy.layers.ppi import PPI_Hdr, PPI_Element
 from scapy.error import warning
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 
 CURR_GEOTAG_VER = 2  # Major revision of specification
 

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -29,7 +29,6 @@ from scapy.packet import Packet, bind_layers
 from scapy.fields import FlagsField, IPField, LEIntEnumField, LEIntField, \
     StrFixedLenField
 from scapy.layers.inet import TCP
-from scapy.modules.six.moves import range
 from scapy.volatile import RandShort
 from scapy.config import conf
 

--- a/scapy/contrib/tacacs.py
+++ b/scapy/contrib/tacacs.py
@@ -29,7 +29,6 @@ from scapy.fields import FieldLenField, ConditionalField, StrLenField
 from scapy.layers.inet import TCP
 from scapy.compat import chb, orb
 from scapy.config import conf
-from scapy.modules.six.moves import range
 
 SECRET = 'test'
 

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -10,7 +10,7 @@ Direct Access dictionary.
 from __future__ import absolute_import
 from __future__ import print_function
 from scapy.error import Scapy_Exception
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import plain_str
 
 from scapy.compat import (

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -17,7 +17,7 @@ from scapy.dadict import DADict, fixname
 from scapy.consts import FREEBSD, NETBSD, OPENBSD, WINDOWS
 from scapy.error import log_loading
 from scapy.compat import plain_str
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.compat import (
     Any,

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -18,7 +18,7 @@ import time
 import warnings
 
 from scapy.consts import WINDOWS
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 # Typing imports
 from logging import LogRecord

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -38,8 +38,9 @@ from scapy.utils6 import in6_6to4ExtractAddr, in6_isaddr6to4, \
     in6_isaddrTeredo, in6_ptop, Net6, teredoAddrExtractInfo
 from scapy.base_classes import Gen, Net, BasePacket, Field_metaclass
 from scapy.error import warning
-import scapy.modules.six as six
-from scapy.modules.six import integer_types
+
+import scapy.libs.six as six
+from scapy.libs.six import integer_types
 
 # Typing imports
 from scapy.compat import (

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -17,8 +17,8 @@ from scapy.consts import WINDOWS
 from scapy.utils import pretty_list
 from scapy.utils6 import in6_isvalid
 
-from scapy.modules.six.moves import UserDict
-import scapy.modules.six as six
+from scapy.libs.six.moves import UserDict
+import scapy.libs.six as six
 
 # Typing imports
 import scapy

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -15,7 +15,7 @@ from scapy.error import log_loading
 from scapy.main import load_layer
 
 import logging
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 ignored = list(six.moves.builtins.__dict__) + ["sys"]
 log = logging.getLogger("scapy.loading")

--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -50,7 +50,7 @@ from scapy.consts import WINDOWS
 from scapy.error import warning
 from scapy.utils import lhex, mac2str, str2mac
 from scapy.volatile import RandMAC
-from scapy.modules import six
+from scapy.libs import six
 
 
 ##########

--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -39,7 +39,6 @@ from scapy.contrib.ethercat import LEBitEnumField, LEBitField
 from scapy.layers.bluetooth import EIR_Hdr, L2CAP_Hdr
 from scapy.layers.ppi import PPI_Element, PPI_Hdr
 
-from scapy.modules.six.moves import range
 from scapy.utils import mac2str, str2mac
 
 ####################

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -17,7 +17,7 @@ import binascii
 from scapy.compat import Tuple, Optional, Type, List, Union, Callable, IO, \
     Any, cast
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.compat import orb
 from scapy.data import DLT_CAN_SOCKETCAN

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -31,8 +31,7 @@ from scapy.volatile import RandBin, RandField, RandNum, RandNumExpo
 from scapy.arch import get_if_raw_hwaddr
 from scapy.sendrecv import srp1, sendp
 from scapy.error import warning
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.config import conf
 
 dhcpmagic = b"c\x82Sc"

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -35,7 +35,7 @@ from scapy.packet import Packet, bind_bottom_up
 from scapy.pton_ntop import inet_pton
 from scapy.themes import Color
 from scapy.utils6 import in6_addrtovendor, in6_islladdr
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 #############################################################################
 # Helpers                                                                  ##

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -24,8 +24,7 @@ from scapy.sendrecv import sr1
 from scapy.layers.inet import IP, DestIPField, IPField, UDP, TCP
 from scapy.layers.inet6 import DestIP6Field, IP6Field
 from scapy.error import log_runtime, warning, Scapy_Exception
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 
 
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -61,7 +61,7 @@ from scapy.utils import get_temp_file, ContextManagerSubprocess
 
 from scapy.layers.inet import TCP, TCP_client
 
-from scapy.modules import six
+from scapy.libs import six
 
 try:
     import brotli

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -64,8 +64,7 @@ from scapy.pton_ntop import inet_pton
 
 import scapy.as_resolvers
 
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 
 ####################
 #  IP Tools class  #

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -49,7 +49,7 @@ from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
 from scapy.layers.inet import IP, IPTools, TCP, TCPerror, TracerouteResult, \
     UDP, UDPerror
 from scapy.layers.l2 import CookedLinux, Ether, GRE, Loopback, SNAP
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import bind_layers, Packet, Raw
 from scapy.sendrecv import sendp, sniff, sr, srp1
 from scapy.supersocket import SuperSocket, L3RawSocket

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -56,8 +56,7 @@ from scapy.fields import ByteEnumField, ByteField, IntField, PacketField, \
     ShortField, StrField, XIntField, XStrField, XStrLenField
 from scapy.packet import Packet, bind_layers, Raw
 from scapy.layers.inet import IP, UDP
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.layers.inet6 import IPv6, IPv6ExtHdrHopByHop, IPv6ExtHdrDestOpt, \
     IPv6ExtHdrRouting
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -51,7 +51,7 @@ from scapy.fields import (
     XShortEnumField,
     XShortField,
 )
-from scapy.modules.six import viewitems
+from scapy.libs.six import viewitems
 from scapy.packet import bind_layers, Packet
 from scapy.plist import (
     PacketList,

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -22,7 +22,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import IPField
 from scapy.layers.inet6 import IP6Field
 from scapy.data import ETHER_ANY
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import orb, chb
 
 

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -25,8 +25,7 @@ from scapy.layers.inet import UDP
 from scapy.utils import lhex
 from scapy.compat import orb
 from scapy.config import conf
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 
 
 #############################################################################

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -38,7 +38,7 @@ from scapy.fields import (
     XShortField,
     XStrLenField,
 )
-from scapy.modules import six
+from scapy.libs import six
 
 
 class PPPoE(Packet):

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -16,7 +16,6 @@ from scapy.fields import PacketListField, ShortEnumField, ShortField, \
     StrNullField
 from scapy.automaton import ATMT, Automaton
 from scapy.layers.inet import UDP, IP
-from scapy.modules.six.moves import range
 from scapy.config import conf
 from scapy.volatile import RandShort
 

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -71,7 +71,7 @@ from scapy.layers.tls.crypto.suites import _tls_cipher_suites, \
     _tls_cipher_suites_cls
 from scapy.layers.tls.crypto.groups import _tls_named_groups
 from scapy.layers.tls.crypto.hkdf import TLS13_HKDF
-from scapy.modules import six
+from scapy.libs import six
 from scapy.packet import Raw
 from scapy.compat import bytes_encode
 

--- a/scapy/layers/tls/basefields.py
+++ b/scapy/layers/tls/basefields.py
@@ -10,7 +10,7 @@ upon the TLS version or ciphersuite, the packet has to provide a TLS context.
 import struct
 
 from scapy.fields import ByteField, ShortEnumField, ShortField, StrField
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import orb
 
 _tls_type = {20: "change_cipher_spec",

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -33,8 +33,7 @@ import os
 import time
 
 from scapy.config import conf, crypto_validator
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.error import warning
 from scapy.utils import binrepr
 from scapy.asn1.asn1 import ASN1_BIT_STRING

--- a/scapy/layers/tls/crypto/cipher_aead.py
+++ b/scapy/layers/tls/crypto/cipher_aead.py
@@ -19,7 +19,7 @@ from scapy.config import conf
 from scapy.layers.tls.crypto.pkcs1 import pkcs_i2osp, pkcs_os2ip
 from scapy.layers.tls.crypto.common import CipherError
 from scapy.utils import strxor
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes  # noqa: E501

--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -10,7 +10,7 @@ Block ciphers.
 from __future__ import absolute_import
 from scapy.config import conf
 from scapy.layers.tls.crypto.common import CipherError
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.utils import register_interface

--- a/scapy/layers/tls/crypto/cipher_stream.py
+++ b/scapy/layers/tls/crypto/cipher_stream.py
@@ -10,7 +10,7 @@ Stream ciphers.
 from __future__ import absolute_import
 from scapy.config import conf
 from scapy.layers.tls.crypto.common import CipherError
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms

--- a/scapy/layers/tls/crypto/compression.py
+++ b/scapy/layers/tls/crypto/compression.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import zlib
 
 from scapy.error import warning
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 _tls_compression_algs = {}

--- a/scapy/layers/tls/crypto/groups.py
+++ b/scapy/layers/tls/crypto/groups.py
@@ -18,7 +18,7 @@ from scapy.config import conf
 from scapy.compat import bytes_int, int_bytes
 from scapy.error import warning
 from scapy.utils import long_converter
-import scapy.modules.six as six
+import scapy.libs.six as six
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric import dh, ec

--- a/scapy/layers/tls/crypto/h_mac.py
+++ b/scapy/layers/tls/crypto/h_mac.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import hmac
 
 from scapy.layers.tls.crypto.hash import _tls_hash_algs
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.compat import bytes_encode
 
 _SSLv3_PAD1_MD5 = b"\x36" * 48

--- a/scapy/layers/tls/crypto/hash.py
+++ b/scapy/layers/tls/crypto/hash.py
@@ -9,7 +9,7 @@ Hash classes.
 
 from __future__ import absolute_import
 from hashlib import md5, sha1, sha224, sha256, sha384, sha512
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 _tls_hash_algs = {}

--- a/scapy/layers/tls/crypto/kx_algs.py
+++ b/scapy/layers/tls/crypto/kx_algs.py
@@ -16,7 +16,7 @@ from scapy.layers.tls.keyexchange import (ServerDHParams,
                                           ClientECDiffieHellmanPublic,
                                           _tls_server_ecdh_cls_guess,
                                           EncryptedPreMasterSecret)
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 _tls_kx_algs = {}

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -13,7 +13,7 @@ Ubuntu or OSX. This is why we reluctantly keep some legacy crypto here.
 
 from __future__ import absolute_import
 from scapy.compat import bytes_encode, hex_bytes, bytes_hex
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 from scapy.config import conf, crypto_validator
 from scapy.error import warning

--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -13,7 +13,6 @@ from scapy.utils import strxor
 
 from scapy.layers.tls.crypto.hash import _tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import _tls_hmac_algs
-from scapy.modules.six.moves import range
 from scapy.compat import bytes_encode
 
 

--- a/scapy/layers/tls/crypto/suites.py
+++ b/scapy/layers/tls/crypto/suites.py
@@ -15,7 +15,7 @@ from scapy.layers.tls.crypto.kx_algs import _tls_kx_algs
 from scapy.layers.tls.crypto.hash import _tls_hash_algs
 from scapy.layers.tls.crypto.h_mac import _tls_hmac_algs
 from scapy.layers.tls.crypto.ciphers import _tls_cipher_algs
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 def get_algs_from_ciphersuite_name(ciphersuite_name):

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -36,7 +36,7 @@ from scapy.fields import (
 
 from scapy.compat import hex_bytes, orb, raw
 from scapy.config import conf
-from scapy.modules import six
+from scapy.libs import six
 from scapy.packet import Packet, Raw, Padding
 from scapy.utils import randstring, repr_hex
 from scapy.layers.x509 import OCSP_Response

--- a/scapy/layers/tls/keyexchange_tls13.py
+++ b/scapy/layers/tls/keyexchange_tls13.py
@@ -32,7 +32,7 @@ from scapy.layers.tls.crypto.groups import (
     _tls_named_groups_import,
     _tls_named_groups_pubbytes,
 )
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.hazmat.primitives.asymmetric import ec

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -36,7 +36,7 @@ from scapy.layers.tls.crypto.cipher_aead import AEADTagError
 from scapy.layers.tls.crypto.cipher_stream import Cipher_NULL
 from scapy.layers.tls.crypto.common import CipherError
 from scapy.layers.tls.crypto.h_mac import HMACError
-import scapy.modules.six as six
+import scapy.libs.six as six
 if conf.crypto_valid_advanced:
     from scapy.layers.tls.crypto.cipher_aead import Cipher_CHACHA20_POLY1305
 

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -14,7 +14,7 @@ import struct
 
 from scapy.config import conf
 from scapy.compat import raw
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.error import log_runtime, warning
 from scapy.packet import Packet
 from scapy.pton_ntop import inet_pton

--- a/scapy/layers/tuntap.py
+++ b/scapy/layers/tuntap.py
@@ -31,7 +31,7 @@ from scapy.layers.l2 import Ether
 from scapy.packet import Packet
 from scapy.supersocket import SimpleSocket
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 # Linux-specific defines (/usr/include/linux/if_tun.h)
 LINUX_TUNSETIFF = 0x400454ca

--- a/scapy/libs/six.py
+++ b/scapy/libs/six.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2017 Benjamin Peterson
+# Copyright (c) 2010-2020 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -7,7 +7,7 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all  # noqa: E501
+# The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -18,10 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-## This file is part of Scapy
-## See http://www.secdev.org/projects/scapy for more information
-## Copyright (C) Philippe Biondi <phil@secdev.org>
-## This program is published under a GPLv2 license
+# This file is published as part of Scapy under GPLv2 or later
 
 """Utilities for writing code that runs on Python 2 and 3"""
 
@@ -34,7 +31,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.10.0"
+__version__ = "1.16.0"
 
 
 # Useful for very coarse version differentiation.
@@ -75,6 +72,11 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 
 def _add_doc(func, doc):
@@ -169,7 +171,7 @@ class MovedAttribute(_LazyDescr):
 class _SixMetaPathImporter(object):
 
     """
-    A meta path importer to import scapy.modules.six.moves and its submodules.
+    A meta path importer to import six.moves and its submodules.
 
     This class implements a PEP302 finder and loader. It should be compatible
     with Python 2.5 and all existing versions of Python3
@@ -189,6 +191,11 @@ class _SixMetaPathImporter(object):
     def find_module(self, fullname, path=None):
         if fullname in self.known_modules:
             return self
+        return None
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
         return None
 
     def __get_module(self, fullname):
@@ -228,6 +235,12 @@ class _SixMetaPathImporter(object):
         return None
     get_source = get_code  # same as get_code
 
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
+
 _importer = _SixMetaPathImporter(__name__)
 
 
@@ -240,30 +253,31 @@ class _MovedItems(_LazyModule):
 _moved_attributes = [
     MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
     MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
-    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),  # noqa: E501
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
     MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
     MovedAttribute("intern", "__builtin__", "sys"),
     MovedAttribute("map", "itertools", "builtins", "imap", "map"),
     MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
     MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
-    MovedAttribute("getstatusoutput", "commands", "subprocess"),
     MovedAttribute("getoutput", "commands", "subprocess"),
     MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
-    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),  # noqa: E501
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
     MovedAttribute("reduce", "__builtin__", "functools"),
     MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
     MovedAttribute("StringIO", "StringIO", "io"),
-    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserDict", "UserDict", "collections", "IterableUserDict", "UserDict"),
     MovedAttribute("UserList", "UserList", "collections"),
     MovedAttribute("UserString", "UserString", "collections"),
     MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
     MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
-    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),  # noqa: E501
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
     MovedModule("builtins", "__builtin__"),
     MovedModule("configparser", "ConfigParser"),
+    MovedModule("collections_abc", "collections", "collections.abc" if sys.version_info >= (3, 3) else "collections"),
     MovedModule("copyreg", "copy_reg"),
     MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
-    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("dbm_ndbm", "dbm", "dbm.ndbm"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread" if sys.version_info < (3, 9) else "_thread"),
     MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
     MovedModule("http_cookies", "Cookie", "http.cookies"),
     MovedModule("html_entities", "htmlentitydefs", "html.entities"),
@@ -271,8 +285,8 @@ _moved_attributes = [
     MovedModule("http_client", "httplib", "http.client"),
     MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
     MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
-    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),  # noqa: E501
-    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),  # noqa: E501
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
     MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
     MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
     MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
@@ -285,8 +299,8 @@ _moved_attributes = [
     MovedModule("tkinter", "Tkinter"),
     MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
     MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
-    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),  # noqa: E501
-    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),  # noqa: E501
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
     MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
     MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
     MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
@@ -300,9 +314,9 @@ _moved_attributes = [
     MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
     MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
                 "tkinter.simpledialog"),
-    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),  # noqa: E501
-    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),  # noqa: E501
-    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),  # noqa: E501
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
     MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
     MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
     MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
@@ -327,7 +341,7 @@ _importer._add_module(moves, "moves")
 
 class Module_six_moves_urllib_parse(_LazyModule):
 
-    """Lazy loading of moved objects in scapy.modules.six.urllib_parse"""
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
 
 
 _urllib_parse_moved_attributes = [
@@ -345,7 +359,7 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("quote_plus", "urllib", "urllib.parse"),
     MovedAttribute("unquote", "urllib", "urllib.parse"),
     MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
-    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),  # noqa: E501
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
     MovedAttribute("urlencode", "urllib", "urllib.parse"),
     MovedAttribute("splitquery", "urllib", "urllib.parse"),
     MovedAttribute("splittag", "urllib", "urllib.parse"),
@@ -361,15 +375,15 @@ for attr in _urllib_parse_moved_attributes:
     setattr(Module_six_moves_urllib_parse, attr.name, attr)
 del attr
 
-Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes  # noqa: E501
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
 
-_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),  # noqa: E501
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
                       "moves.urllib_parse", "moves.urllib.parse")
 
 
 class Module_six_moves_urllib_error(_LazyModule):
 
-    """Lazy loading of moved objects in scapy.modules.six.urllib_error"""
+    """Lazy loading of moved objects in six.moves.urllib_error"""
 
 
 _urllib_error_moved_attributes = [
@@ -381,15 +395,15 @@ for attr in _urllib_error_moved_attributes:
     setattr(Module_six_moves_urllib_error, attr.name, attr)
 del attr
 
-Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes  # noqa: E501
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
 
-_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),  # noqa: E501
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
                       "moves.urllib_error", "moves.urllib.error")
 
 
 class Module_six_moves_urllib_request(_LazyModule):
 
-    """Lazy loading of moved objects in scapy.modules.six.urllib_request"""
+    """Lazy loading of moved objects in six.moves.urllib_request"""
 
 
 _urllib_request_moved_attributes = [
@@ -407,7 +421,7 @@ _urllib_request_moved_attributes = [
     MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
     MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
     MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
-    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),  # noqa: E501
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
     MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
     MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
     MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
@@ -426,20 +440,22 @@ _urllib_request_moved_attributes = [
     MovedAttribute("URLopener", "urllib", "urllib.request"),
     MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
     MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
 ]
 for attr in _urllib_request_moved_attributes:
     setattr(Module_six_moves_urllib_request, attr.name, attr)
 del attr
 
-Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes  # noqa: E501
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
 
-_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),  # noqa: E501
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
                       "moves.urllib_request", "moves.urllib.request")
 
 
 class Module_six_moves_urllib_response(_LazyModule):
 
-    """Lazy loading of moved objects in scapy.modules.six.urllib_response"""
+    """Lazy loading of moved objects in six.moves.urllib_response"""
 
 
 _urllib_response_moved_attributes = [
@@ -452,15 +468,15 @@ for attr in _urllib_response_moved_attributes:
     setattr(Module_six_moves_urllib_response, attr.name, attr)
 del attr
 
-Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes  # noqa: E501
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
 
-_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),  # noqa: E501
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
                       "moves.urllib_response", "moves.urllib.response")
 
 
 class Module_six_moves_urllib_robotparser(_LazyModule):
 
-    """Lazy loading of moved objects in scapy.modules.six.urllib_robotparser"""
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
 
 
 _urllib_robotparser_moved_attributes = [
@@ -470,15 +486,15 @@ for attr in _urllib_robotparser_moved_attributes:
     setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
 del attr
 
-Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes  # noqa: E501
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
 
-_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),  # noqa: E501
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
                       "moves.urllib_robotparser", "moves.urllib.robotparser")
 
 
 class Module_six_moves_urllib(types.ModuleType):
 
-    """Create a scapy.modules.six.urllib namespace that resembles the Python 3 namespace"""  # noqa: E501
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
     __path__ = []  # mark as package
     parse = _importer._get_module("moves.urllib_parse")
     error = _importer._get_module("moves.urllib_error")
@@ -494,12 +510,12 @@ _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
 
 
 def add_move(move):
-    """Add an item to scapy.modules.six."""
+    """Add an item to six.moves."""
     setattr(_MovedItems, move.name, move)
 
 
 def remove_move(name):
-    """Remove item from scapy.modules.six."""
+    """Remove item from six.moves."""
     try:
         delattr(_MovedItems, name)
     except AttributeError:
@@ -641,13 +657,16 @@ if PY3:
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
+    del io
     _assertCountEqual = "assertCountEqual"
     if sys.version_info[1] <= 1:
         _assertRaisesRegex = "assertRaisesRegexp"
         _assertRegex = "assertRegexpMatches"
+        _assertNotRegex = "assertNotRegexpMatches"
     else:
         _assertRaisesRegex = "assertRaisesRegex"
         _assertRegex = "assertRegex"
+        _assertNotRegex = "assertNotRegex"
 else:
     def b(s):
         return s
@@ -669,6 +688,7 @@ else:
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
     _assertRegex = "assertRegexpMatches"
+    _assertNotRegex = "assertNotRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
 
@@ -683,6 +703,10 @@ def assertRaisesRegex(self, *args, **kwargs):
 
 def assertRegex(self, *args, **kwargs):
     return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+def assertNotRegex(self, *args, **kwargs):
+    return getattr(self, _assertNotRegex)(*args, **kwargs)
 
 
 if PY3:
@@ -720,16 +744,7 @@ else:
 """)
 
 
-if sys.version_info[:2] == (3, 2):
-    exec_("""def raise_from(value, from_value):
-    try:
-        if from_value is None:
-            raise value
-        raise value from from_value
-    finally:
-        value = None
-""")
-elif sys.version_info[:2] > (3, 2):
+if sys.version_info[:2] > (3,):
     exec_("""def raise_from(value, from_value):
     try:
         raise value from from_value
@@ -809,13 +824,33 @@ if sys.version_info[:2] < (3, 3):
 _add_doc(reraise, """Reraise an exception.""")
 
 if sys.version_info[0:2] < (3, 4):
+    # This does exactly the same what the :func:`py3:functools.update_wrapper`
+    # function does on Python versions after 3.2. It sets the ``__wrapped__``
+    # attribute on ``wrapper`` object and it doesn't raise an error if any of
+    # the attributes mentioned in ``assigned`` and ``updated`` are missing on
+    # ``wrapped`` object.
+    def _update_wrapper(wrapper, wrapped,
+                        assigned=functools.WRAPPER_ASSIGNMENTS,
+                        updated=functools.WRAPPER_UPDATES):
+        for attr in assigned:
+            try:
+                value = getattr(wrapped, attr)
+            except AttributeError:
+                continue
+            else:
+                setattr(wrapper, attr, value)
+        for attr in updated:
+            getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
+        wrapper.__wrapped__ = wrapped
+        return wrapper
+    _update_wrapper.__doc__ = functools.update_wrapper.__doc__
+
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
               updated=functools.WRAPPER_UPDATES):
-        def wrapper(f):
-            f = functools.wraps(wrapped, assigned, updated)(f)
-            f.__wrapped__ = wrapped
-            return f
-        return wrapper
+        return functools.partial(_update_wrapper, wrapped=wrapped,
+                                 assigned=assigned, updated=updated)
+    wraps.__doc__ = functools.wraps.__doc__
+
 else:
     wraps = functools.wraps
 
@@ -825,10 +860,22 @@ def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
-    class metaclass(meta):
+    class metaclass(type):
 
         def __new__(cls, name, this_bases, d):
-            return meta(name, bases, d)
+            if sys.version_info[:2] >= (3, 7):
+                # This version introduced PEP 560 that requires a bit
+                # of extra care (we mimic what is done by __build_class__).
+                resolved_bases = types.resolve_bases(bases)
+                if resolved_bases is not bases:
+                    d['__orig_bases__'] = bases
+            else:
+                resolved_bases = bases
+            return meta(name, resolved_bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 
@@ -844,13 +891,75 @@ def add_metaclass(metaclass):
                 orig_vars.pop(slots_var)
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
 
 
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, binary_type):
+        return s
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    # Optimization: Fast return for the common case.
+    if type(s) is str:
+        return s
+    if PY2 and isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
 def python_2_unicode_compatible(klass):
     """
-    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    A class decorator that defines __unicode__ and __str__ methods under Python 2.
     Under Python 3 it does nothing.
 
     To support Python 2 and 3 with a single code base, define a __str__ method
@@ -878,7 +987,7 @@ if globals().get("__spec__") is not None:
 # this for some reason.)
 if sys.meta_path:
     for i, importer in enumerate(sys.meta_path):
-        # Here's some real nastiness: Another "instance" of the six module might  # noqa: E501
+        # Here's some real nastiness: Another "instance" of the six module might
         # be floating around. Therefore, we can't use isinstance() to check for
         # the six meta path importer, since the other six instance will have
         # inserted an importer with different class.

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -30,7 +30,7 @@ from scapy.error import (
     log_loading,
     Scapy_Exception,
 )
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.themes import DefaultTheme, BlackAndWhite, apply_ipython_style
 from scapy.consts import WINDOWS
 

--- a/scapy/modules/krack/crypto.py
+++ b/scapy/modules/krack/crypto.py
@@ -6,8 +6,7 @@ from zlib import crc32
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
 
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.compat import orb, chb
 from scapy.layers.dot11 import Dot11TKIP
 from scapy.utils import mac2str

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -28,7 +28,7 @@ from scapy.layers.inet import IP, TCP, UDP, ICMP, UDPerror, IPerror
 from scapy.packet import NoPayload
 from scapy.sendrecv import sr
 from scapy.compat import plain_str, raw
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 
 if WINDOWS:

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -22,8 +22,7 @@ from scapy.layers.http import HTTP, HTTPRequest, HTTPResponse
 from scapy.layers.inet6 import IPv6
 from scapy.volatile import RandByte, RandShort, RandString
 from scapy.error import warning
-from scapy.modules.six import integer_types, string_types
-from scapy.modules.six.moves import range
+from scapy.libs.six import integer_types, string_types
 
 _p0fpaths = ["/etc/p0f", "/usr/share/p0f", "/opt/local"]
 conf.p0f_base = select_path(_p0fpaths, "p0f.fp")

--- a/scapy/modules/p0fv2.py
+++ b/scapy/modules/p0fv2.py
@@ -23,8 +23,7 @@ from scapy.packet import NoPayload, Packet
 from scapy.error import warning, Scapy_Exception, log_runtime
 from scapy.volatile import RandInt, RandByte, RandNum, RandShort, RandString
 from scapy.sendrecv import sniff
-from scapy.modules import six
-from scapy.modules.six.moves import map, range
+from scapy.libs import six
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route  # noqa: F401

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -18,7 +18,6 @@ from scapy.layers.inet import IP, UDP
 from scapy.layers.rtp import RTP
 from scapy.consts import WINDOWS
 from scapy.config import conf
-from scapy.modules.six.moves import range
 
 
 sox_base = (["sox", "-t", ".ul"], ["-", "-t", "ossdsp", "/dev/dsp"])

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -47,7 +47,7 @@ from scapy.utils import import_hexcap, tex_escape, colgen, issubtype, \
     pretty_list, EDecimal
 from scapy.error import Scapy_Exception, log_runtime, warning
 from scapy.extlib import PYX
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 # Typing imports
 from scapy.compat import (

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import os
 import subprocess
 import time
-import scapy.modules.six as six
+import scapy.libs.six as six
 from threading import Lock, Thread
 
 from scapy.automaton import (

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -27,8 +27,7 @@ from scapy.utils import do_graph, hexdump, make_table, make_lined_table, \
 from scapy.extlib import plt, Line2D, \
     MATPLOTLIB_INLINED, MATPLOTLIB_DEFAULT_PLOT_KARGS
 from functools import reduce
-import scapy.modules.six as six
-from scapy.modules.six.moves import range, zip
+import scapy.libs.six as six
 
 # typings
 from scapy.compat import (

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 import socket
 import re
 import binascii
-from scapy.modules.six.moves import range
 from scapy.compat import plain_str, hex_bytes, bytes_encode, bytes_hex
 
 from scapy.compat import (

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import socket
 import subprocess
 
-from scapy.modules.six.moves.queue import Queue, Empty
+from scapy.libs.six.moves.queue import Queue, Empty
 from scapy.automaton import ObjectPipe
 from scapy.config import conf
 from scapy.compat import raw

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -34,7 +34,7 @@ from scapy.plist import (
 )
 from scapy.error import log_runtime, log_interactive, Scapy_Exception
 from scapy.base_classes import Gen, SetGen
-from scapy.modules import six
+from scapy.libs import six
 from scapy.sessions import DefaultSession
 from scapy.supersocket import SuperSocket, IterSocket
 

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -21,7 +21,7 @@ from scapy.data import MTU, ETH_P_IP, SOL_PACKET, SO_TIMESTAMPNS
 from scapy.compat import raw
 from scapy.error import warning, log_runtime
 from scapy.interfaces import network_name
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.packet import Packet
 import scapy.packet
 from scapy.plist import (

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -28,8 +28,7 @@ import warnings
 import zlib
 
 from scapy.consts import WINDOWS
-import scapy.modules.six as six
-from scapy.modules.six.moves import range
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.compat import base64_bytes, bytes_hex, plain_str
 from scapy.themes import DefaultTheme, BlackAndWhite
@@ -71,7 +70,7 @@ class Bunch:
 def retry_test(func):
     """Retries the passed function 3 times before failing"""
     success = False
-    for _ in six.moves.range(3):
+    for _ in range(3):
         try:
             result = func()
         except Exception:

--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -13,7 +13,7 @@ import re
 
 from ast import literal_eval
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.consts import LINUX
 

--- a/scapy/tools/automotive/obdscanner.py
+++ b/scapy/tools/automotive/obdscanner.py
@@ -17,7 +17,7 @@ import traceback
 
 from ast import literal_eval
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.config import conf
 from scapy.consts import LINUX
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -29,8 +29,8 @@ import threading
 import time
 import warnings
 
-import scapy.modules.six as six
-from scapy.modules.six.moves import range, input, zip_longest
+import scapy.libs.six as six
+from scapy.libs.six.moves import range, input, zip_longest
 
 from scapy.config import conf
 from scapy.consts import DARWIN, OPENBSD, WINDOWS

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -22,7 +22,7 @@ import string
 from scapy.base_classes import Net
 from scapy.compat import bytes_encode, chb, plain_str
 from scapy.utils import corrupt_bits, corrupt_bytes
-from scapy.modules.six.moves import zip_longest
+from scapy.libs.six.moves import zip_longest
 
 from scapy.compat import (
     List,

--- a/test/contrib/automotive/interface_mockup.py
+++ b/test/contrib/automotive/interface_mockup.py
@@ -15,7 +15,7 @@ from platform import python_implementation
 from scapy.main import load_layer, load_contrib
 from scapy.config import conf
 from scapy.error import log_runtime, Scapy_Exception
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.consts import LINUX
 
 load_layer("can", globals_dict=globals())

--- a/test/contrib/automotive/scanner/enumerator.uts
+++ b/test/contrib/automotive/scanner/enumerator.uts
@@ -182,7 +182,7 @@ assert e._retry_pkt[EcuState(session=1)] is not None
 
 = ServiceEnumerator execute
 
-from scapy.modules.six.moves.queue import Queue
+from scapy.libs.six.moves.queue import Queue
 from scapy.supersocket import SuperSocket
 
 class MockISOTPSocket(SuperSocket):

--- a/test/contrib/isotp_soft_socket.uts
+++ b/test/contrib/isotp_soft_socket.uts
@@ -7,7 +7,7 @@
 = Imports
 import time
 from io import BytesIO
-import scapy.modules.six as six
+import scapy.libs.six as six
 from scapy.layers.can import *
 from scapy.contrib.isotp import *
 from scapy.contrib.isotp.isotp_soft_socket import TimeoutScheduler

--- a/test/contrib/pnio_rpc.uts
+++ b/test/contrib/pnio_rpc.uts
@@ -4,7 +4,7 @@
 = Import the PNIO RPC layer
 from scapy.contrib.dce_rpc import *
 from scapy.contrib.pnio_rpc import *
-from scapy.modules.six import itervalues
+from scapy.libs.six import itervalues
 
 = Check that we have UUIDs
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -294,7 +294,7 @@ test_read_routes()
 ~ linux needs_root
 
 from scapy.arch.linux import L3PacketSocket
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 if six.PY3:
     import mock, socket

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -395,7 +395,7 @@ assert chb(1) == b"\x01"
 
 = Pickle and unpickle a packet
 
-import scapy.modules.six as six
+import scapy.libs.six as six
 
 a = IP(dst="192.168.0.1")/UDP()
 

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1332,7 +1332,7 @@ assert not TLSHelloRequest().tls_session_update(None)
 
 
 = Cryptography module is unavailable
-import scapy.modules.six as six
+import scapy.libs.six as six
 import mock
 
 @mock.patch("scapy.layers.tls.crypto.suites.get_algs_from_ciphersuite_name")

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import sys, os, re, time, subprocess
-from scapy.modules.six.moves.queue import Queue
+from scapy.libs.six.moves.queue import Queue
 import threading
 
 from ast import literal_eval
@@ -24,7 +24,7 @@ import sys
 from contextlib import contextmanager
 from scapy.autorun import StringWriter
 
-from scapy.modules import six
+from scapy.libs import six
 
 from scapy.config import conf
 from scapy.layers.tls.automaton_srv import TLSServerAutomaton
@@ -211,7 +211,7 @@ import sys, os, time, threading
 from scapy.layers.tls.automaton_cli import TLSClientAutomaton
 from scapy.layers.tls.handshake import TLSClientHello, TLS13ClientHello
 
-from scapy.modules.six.moves.queue import Queue
+from scapy.libs.six.moves.queue import Queue
 
 send_data = cipher_suite_code = version = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -155,5 +155,5 @@ per-file-ignores =
     scapy/layers/tls/crypto/all.py:F403
     scapy/libs/winpcapy.py:F405,F403,E501
     scapy/tools/UTscapy.py:E501
-exclude = scapy/modules/six.py,
+exclude = scapy/libs/six.py,
           scapy/libs/ethertypes.py


### PR DESCRIPTION
- Updates `six` to support `Python 3.10` & `Python 3.11`
- moves `six` to `libs/`. It made no sense for it to be in `modules`
- remove some six imports when not needed

fixes https://github.com/secdev/scapy/issues/3502