### PR TITLE
Fix pypy2 ci-test

### DIFF
--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -797,7 +797,7 @@ result = tc1.show(dump=True)
 assert "requestOutOfRange received " in result
 
 = UDS_RMBAEnumerator
-~ linux
+~ linux not_pypy
 
 memory = dict()
 


### PR DESCRIPTION
This PR disables UDS_RMBAEnumerator unit tests on pypy which take too long to execute

#3569 This should fix it.

We can probably revert #3560 after merging this PR.