### PR TITLE
[GTP_UDPPort_ExtensionHeader_wrong_default_length]

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -220,7 +220,7 @@ class GTP_ExtensionHeader(Packet):
 
 
 class GTP_UDPPort_ExtensionHeader(GTP_ExtensionHeader):
-    fields_desc = [ByteField("length", 0x40),
+    fields_desc = [ByteField("length", 0x01),
                    ShortField("udp_port", None),
                    ByteEnumField("next_ex", 0, ExtensionHeadersTypes), ]
 


### PR DESCRIPTION
- Correct length for UDPPORT Extension header length

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
