### PR TITLE
Issue template: change pip install url to https

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUGS.yml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yml
@@ -6,7 +6,7 @@ body:
       value: |
         ### Things to consider
         1.  Please check that you are using the **latest Scapy version**, e.g. installed via:
-            `pip install --upgrade git+git://github.com/secdev/scapy`
+            `pip install --upgrade git+https://github.com/secdev/scapy.git`
         2.  If you are here to ask a question - please check previous issues and online resources, and consider using Gitter instead: <https://gitter.im/secdev/scapy>
         3.  Please understand that **this is not a forum** but an issue tracker. The following article explains why you should limit questions asked on Github issues: <https://medium.com/@methane/why-you-must-not-ask-questions-on-github-issues-51d741d83fde>
 


### PR DESCRIPTION
Github doesn't support unauthenticated clones anymore, making the original command for installing scapy using git fail. This commit changes the URL to the HTTPS version.