### PR TITLE
Pcapreader() does not work with PosixPath and WindowsPath fix #3596

### DIFF
--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -390,6 +390,13 @@ else:
     html_escape = html.escape
 
 
+if six.PY34:
+    from pathlib import PurePath
+    file_path_types = (str, bytes, PurePath)  # type: Tuple[Type[Any], ...]
+else:
+    file_path_types = (str, bytes)
+
+
 if six.PY2:
     from StringIO import StringIO
 


### PR DESCRIPTION
`Pcapreader()` works fine even if the provided `filename` is in PosixPath or WindowsPath type. Fix #3596

I don't know if this PR requires unit tests. If it does, then please guide me where they can be added.
