### PR TITLE
Add packet as underlayer to all packets in PacketListField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1666,6 +1666,7 @@ class PacketListField(_PacketField[List[BasePacket]]):
                             c += 1
                 else:
                     remain = b""
+            p.add_underlayer(pkt)
             lst.append(p)
         return remain + ret, lst
 


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

This trivial PR adds the current packet as an `underlayer` to all packets in `PacketListField`, providing a way to reference lower protocol layers from the packet object. This is particularly useful for implementation of `guess_payload_class` method for the elements of `PacketListField`.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
