### PR TITLE
Add packet as underlayer to all packets in PacketListField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1422,6 +1422,7 @@ class _PacketField(_StrField[K]):
                  ):
         # type: (...) -> Tuple[bytes, K]
         i = self.m2i(pkt, s)
+        i.add_parent(pkt)
         remain = b""
         if conf.padding_layer in i:
             r = i[conf.padding_layer]
@@ -1474,7 +1475,8 @@ class PacketListField(_PacketField[List[BasePacket]]):
     that might occur right in the middle of another Packet field.
     This field type may also be used to indicate that a series of Packet
     instances have a sibling semantic instead of a parent/child relationship
-    (i.e. a stack of layers).
+    (i.e. a stack of layers). All elements in PacketListField have current
+    packet referenced in parent field.
     """
     __slots__ = ["count_from", "length_from", "next_cls_cb"]
     islist = 1
@@ -1666,6 +1668,8 @@ class PacketListField(_PacketField[List[BasePacket]]):
                             c += 1
                 else:
                     remain = b""
+            if isinstance(p, BasePacket):
+                p.add_parent(pkt)
             lst.append(p)
         return remain + ret, lst
 

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -85,8 +85,8 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         "packetfields",
         "original", "explicit", "raw_packet_cache",
         "raw_packet_cache_fields", "_pkt", "post_transforms",
-        # then payload and underlayer
-        "payload", "underlayer",
+        # then payload, underlayer and parent
+        "payload", "underlayer", "parent",
         "name",
         # used for sr()
         "_answered",
@@ -131,6 +131,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                  post_transform=None,  # type: Any
                  _internal=0,  # type: int
                  _underlayer=None,  # type: Optional[Packet]
+                 _parent=None,  # type: Optional[Packet]
                  **fields  # type: Any
                  ):
         # type: (...) -> None
@@ -148,6 +149,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
         self.payload = NoPayload()
         self.init_fields()
         self.underlayer = _underlayer
+        self.parent = _parent
         self.original = _pkt
         self.explicit = 0
         self.raw_packet_cache = None  # type: Optional[bytes]
@@ -367,6 +369,20 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     def remove_underlayer(self, other):
         # type: (Packet) -> None
         self.underlayer = None
+
+    def add_parent(self, parent):
+        # type: (Packet) -> None
+        """Set packet parent.
+        When packet is an element in PacketListField, parent field would
+        point to the list owner packet."""
+        self.parent = parent
+
+    def remove_parent(self, other):
+        # type: (Packet) -> None
+        """Remove packet parent.
+        When packet is an element in PacketListField, parent field would
+        point to the list owner packet."""
+        self.parent = None
 
     def copy(self):
         # type: () -> Packet
@@ -1665,6 +1681,14 @@ class NoPayload(Packet):
         pass
 
     def remove_underlayer(self, other):
+        # type: (Packet) -> None
+        pass
+
+    def add_parent(self, parent):
+        # type: (Any) -> None
+        pass
+
+    def remove_parent(self, other):
         # type: (Packet) -> None
         pass
 

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -461,6 +461,14 @@ p
 p.show()
 IP in p and TCP in p and UDP in p and p[TCP].seq == 1234567
 
+= Test parent reference
+~ field lengthfield
+x=TestPLF(plist=[IP()/TCP(), IP()/UDP()])
+p = TestPLF(raw(x))
+p
+p.show()
+p.getlayer(IP, 1).parent == p and p.getlayer(IP, 2).parent == p
+
 = Nested PacketListField
 ~ field lengthfield
 y=IP()/TCP(seq=111111)/TestPLF(plist=[IP()/TCP(seq=222222),IP()/UDP()])


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

This trivial PR adds the current packet as an underlayer to all packets in PacketListField, providing a way to reference lower protocol layers from the packet object. This is particularly useful for implementation of guess_payload_class method for the elements of PacketListField.
