### PR TITLE
Make parent available in guess_payload_class

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1414,7 +1414,11 @@ class _PacketField(_StrField[K]):
 
     def m2i(self, pkt, m):
         # type: (Optional[Packet], bytes) -> Packet
-        return self.cls(m)
+        try:
+            # we want to set parent wherever possible
+            return self.cls(m, _parent=pkt)  # type: ignore
+        except TypeError:
+            return self.cls(m)
 
     def getfield(self,
                  pkt,  # type: Packet
@@ -1648,7 +1652,11 @@ class PacketListField(_PacketField[List[BasePacket]]):
                 c -= 1
             try:
                 if cls is not None:
-                    p = cls(remain)
+                    try:
+                        # we want to set parent wherever possible
+                        p = cls(remain, _parent=pkt)
+                    except TypeError:
+                        p = cls(remain)
                 else:
                     p = self.m2i(pkt, remain)
             except Exception:

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -464,10 +464,31 @@ IP in p and TCP in p and UDP in p and p[TCP].seq == 1234567
 = Test parent reference
 ~ field lengthfield
 x=TestPLF(plist=[IP()/TCP(), IP()/UDP()])
+assert p.getlayer(IP, 1).parent == p and p.getlayer(IP, 2).parent == p
 p = TestPLF(raw(x))
-p
-p.show()
-p.getlayer(IP, 1).parent == p and p.getlayer(IP, 2).parent == p
+assert p.getlayer(IP, 1).parent == p and p.getlayer(IP, 2).parent == p
+
+= Test parent reference in guess_payload_class
+
+class TestGuessPLFInner(Packet):
+    name="test guess inner"
+    fields_desc=[ LenField("foo", None) ]
+    def guess_payload_class(self, payload):
+        self.parentflag = True
+        if self.parent is None:
+            # all exceptions are caught, so have to use flag
+            self.parentflag = False
+        return super(TestGuessPLFInner, self).guess_payload_class(payload)
+
+class TestGuessPLF(Packet):
+    name="test guess"
+    fields_desc=[PacketListField("plist", None, TestGuessPLFInner,
+                                 next_cls_cb=lambda p,l,c,r: TestGuessPLFInner if len(l) == 0 else None)]
+
+x=TestGuessPLF(plist=TestGuessPLFInner()/Raw(b'123'))
+p=TestGuessPLF(raw(x))
+assert p[TestGuessPLFInner].parentflag
+assert p[TestGuessPLFInner].parent == p
 
 = Nested PacketListField
 ~ field lengthfield
@@ -2110,6 +2131,27 @@ assert isinstance(p.packet.short1, RandShort)
 assert isinstance(p.packet.byte, RandByte)
 assert isinstance(p.packet.long, RandLong)
 assert isinstance(p.short2, RandShort)
+
+= Test parent reference in guess_payload_class
+
+class TestGuessInner(Packet):
+    name="test guess inner"
+    fields_desc=[ ByteField("foo", 0) ]
+    def guess_payload_class(self, payload):
+        self.parentflag = True
+        if self.parent is None:
+            # all exceptions are caught, so have to use flag
+            self.parentflag = False
+        return super(TestGuessInner, self).guess_payload_class(payload)
+
+class TestGuess(Packet):
+    name="test guess"
+    fields_desc=[ PacketField("pf", None, TestGuessInner) ]
+
+x=TestGuess(pf=TestGuessInner()/Raw(b'123'))
+p=TestGuess(raw(x))
+assert p[TestGuessInner].parentflag
+assert p[TestGuessInner].parent == p
 
 ############
 ############


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

This is a continuation of #3607. This PR moves parent initialization earlier, so that `parent` would be available in `guess_payload_class` function, and adds tests for `PacketListField` and `_PacketField` cases.

