### PR TITLE
Stabilize UDS_Scanner unit tests for appveyor

### DIFF
--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -73,9 +73,6 @@ class AutomotiveTestCaseExecutor:
         self.configuration = AutomotiveTestCaseExecutorConfiguration(
             test_cases or self.default_test_case_clss, **kwargs)
 
-        self.configuration.state_graph.add_edge(
-            (self.__initial_ecu_state, self.__initial_ecu_state))
-
     def __reduce__(self):  # type: ignore
         f, t, d = super(AutomotiveTestCaseExecutor, self).__reduce__()  # type: ignore  # noqa: E501
         try:

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -186,18 +186,25 @@ class AutomotiveTestCaseExecutor:
         test_case.post_execute(
             self.socket, self.target_state, self.configuration)
 
+        self.check_new_states(test_case)
+        self.check_new_testcases(test_case)
+
+    def check_new_testcases(self, test_case):
+        # type: (AutomotiveTestCaseABC) -> None
+        if isinstance(test_case, TestCaseGenerator):
+            new_test_case = test_case.get_generated_test_case()
+            if new_test_case:
+                log_interactive.debug("Testcase generated %s", new_test_case)
+                self.configuration.add_test_case(new_test_case)
+
+    def check_new_states(self, test_case):
+        # type: (AutomotiveTestCaseABC) -> None
         if isinstance(test_case, StateGenerator):
             edge = test_case.get_new_edge(self.socket, self.configuration)
             if edge:
                 log_interactive.debug("Edge found %s", edge)
                 tf = test_case.get_transition_function(self.socket, edge)
                 self.state_graph.add_edge(edge, tf)
-
-        if isinstance(test_case, TestCaseGenerator):
-            new_test_case = test_case.get_generated_test_case()
-            if new_test_case:
-                log_interactive.debug("Testcase generated %s", new_test_case)
-                self.configuration.add_test_case(new_test_case)
 
     def scan(self, timeout=None):
         # type: (Optional[int]) -> None

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -51,9 +51,9 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
     try:
         scanner = GMLAN_Scanner(
             tester, reset_handler=reset,
-            test_cases=enumerators, timeout=0.5, retry_if_none_received=True,
+            test_cases=enumerators, timeout=0.2, retry_if_none_received=True,
             unittest=True, **kwargs)
-        scanner.scan(timeout=200)
+        scanner.scan(timeout=60)
     finally:
         tester.send(Raw(b"\xff\xff\xff"))
         sim.join(timeout=2)

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -29,6 +29,7 @@ load_layer("can")
 
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwargs):
     tester = TestSocket(GMLAN)
+    answering_machine_started = threading.Event()
     def reset():
         answering_machine.reset_state()
         sniff(timeout=0.001, opened_socket=[ecu, tester])
@@ -40,12 +41,14 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
                 ecu = TestSocket(GMLAN)
                 tester.pair(ecu)
                 answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=GMLAN, verbose=False)
+                answering_machine_started.set()
                 answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
                 return
             except OSError:
                 continue
     sim = threading.Thread(target=answering_machine_thread)
     sim.start()
+    answering_machine_started.wait(timeout=10)
     try:
         scanner = GMLAN_Scanner(
             tester, reset_handler=reset,

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -6,7 +6,6 @@
 = Imports
 
 import itertools
-import threading
 from scapy.contrib.isotp import ISOTPMessageBuilder
 
 from test.testsocket import TestSocket, cleanup_testsockets

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -28,14 +28,23 @@ load_layer("can")
 = Define Testfunction
 
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwargs):
-    ecu = TestSocket(GMLAN)
     tester = TestSocket(GMLAN)
-    ecu.pair(tester)
-    answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=GMLAN, verbose=False)
     def reset():
         answering_machine.reset_state()
         sniff(timeout=0.001, opened_socket=[ecu, tester])
-    sim = threading.Thread(target=answering_machine, kwargs={'timeout': 1000, "stop_filter": lambda x: bytes(x) == b"\xff\xff\xff"})
+    def answering_machine_thread():
+        global ecu
+        global answering_machine
+        while True:
+            try:
+                ecu = TestSocket(GMLAN)
+                tester.pair(ecu)
+                answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=GMLAN, verbose=False)
+                answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
+                return
+            except OSError:
+                continue
+    sim = threading.Thread(target=answering_machine_thread)
     sim.start()
     try:
         scanner = GMLAN_Scanner(

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -29,19 +29,21 @@ load_layer("can")
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwargs):
     tester = TestSocket(GMLAN)
     answering_machine_started = threading.Event()
+    answering_machine_running = threading.Event()
+    answering_machine_running.set()
     def reset():
         answering_machine.reset_state()
         sniff(timeout=0.001, opened_socket=[ecu, tester])
     def answering_machine_thread():
         global ecu
         global answering_machine
-        while True:
+        while answering_machine_running.is_set():
             try:
                 ecu = TestSocket(GMLAN)
                 tester.pair(ecu)
                 answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=GMLAN, verbose=False)
                 answering_machine_started.set()
-                answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
+                answering_machine(timeout=120, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
                 return
             except OSError:
                 continue
@@ -53,8 +55,13 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
             tester, reset_handler=reset,
             test_cases=enumerators, timeout=0.2, retry_if_none_received=True,
             unittest=True, **kwargs)
-        scanner.scan(timeout=60)
+        for i in range(100):
+            scanner.scan(timeout=10)
+            if scanner.scan_completed:
+                print("Scan completed after %d iterations" % i)
+                break
     finally:
+        answering_machine_running.clear()
         tester.send(Raw(b"\xff\xff\xff"))
         sim.join(timeout=2)
         assert not sim.is_alive()

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -1,4 +1,3 @@
-import threading
 % Regression tests for Simulated ECUs and UDS Scanners
 
 + Configuration

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -20,6 +20,7 @@ from scapy.contrib.automotive.uds import *
 from scapy.contrib.automotive.uds_ecu_states import *
 from scapy.contrib.automotive.uds_scan import *
 from scapy.contrib.automotive.ecu import *
+
 load_layer("can")
 
 
@@ -27,23 +28,32 @@ load_layer("can")
 
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstable_socket=True, **kwargs):
     TesterSocket = UnstableSocket if unstable_socket else TestSocket
-    ecu = TestSocket(UDS)
-    tester = TesterSocket(UDS)
     def reset():
         answering_machine.state.reset()
         answering_machine.state["session"] = 1
         sniff(timeout=0.001, opened_socket=[ecu, tester])
     def reconnect():
+        global tester
         tester = TesterSocket(UDS)
         ecu.pair(tester)
         return tester
-    ecu.pair(tester)
-    answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=UDS, verbose=False)
-    sim = threading.Thread(target=answering_machine, kwargs={'timeout': 1000, "stop_filter": lambda x: bytes(x) == b"\xff\xff\xff"})
+    def answering_machine_thread():
+        global ecu
+        global answering_machine
+        while True:
+            try:
+                ecu = TestSocket(UDS)
+                tester.pair(ecu)
+                answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=UDS, verbose=False)
+                answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
+                return
+            except OSError:
+                continue
+    sim = threading.Thread(target=answering_machine_thread)
     sim.start()
     try:
         scanner = UDS_Scanner(
-            tester, reset_handler=reset, reconnect_handler=reconnect, test_cases=enumerators, timeout=0.1,
+            reconnect(), reset_handler=reset, reconnect_handler=reconnect, test_cases=enumerators, timeout=0.1,
             retry_if_none_received=True, unittest=True,
             **kwargs)
         for i in range(100):
@@ -162,6 +172,7 @@ scanner = executeScannerInVirtualEnvironment(
                                                  0x3D, 0x3E, 0x83, 0x84, 0x85,
                                                  0x87]})
 
+scanner.show_testcases()
 assert len(scanner.state_paths) == 5
 assert scanner.scan_completed
 

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -1,3 +1,4 @@
+import threading
 % Regression tests for Simulated ECUs and UDS Scanners
 
 + Configuration
@@ -28,6 +29,7 @@ load_layer("can")
 
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstable_socket=True, **kwargs):
     TesterSocket = UnstableSocket if unstable_socket else TestSocket
+    answering_machine_started = threading.Event()
     def reset():
         answering_machine.state.reset()
         answering_machine.state["session"] = 1
@@ -45,12 +47,14 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstabl
                 ecu = TestSocket(UDS)
                 tester.pair(ecu)
                 answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=UDS, verbose=False)
+                answering_machine_started.set()
                 answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
                 return
             except OSError:
                 continue
     sim = threading.Thread(target=answering_machine_thread)
     sim.start()
+    answering_machine_started.wait(timeout=10)
     try:
         scanner = UDS_Scanner(
             reconnect(), reset_handler=reset, reconnect_handler=reconnect, test_cases=enumerators, timeout=0.1,

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -29,6 +29,8 @@ load_layer("can")
 def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstable_socket=True, **kwargs):
     TesterSocket = UnstableSocket if unstable_socket else TestSocket
     answering_machine_started = threading.Event()
+    answering_machine_running = threading.Event()
+    answering_machine_running.set()
     def reset():
         answering_machine.state.reset()
         answering_machine.state["session"] = 1
@@ -41,13 +43,13 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstabl
     def answering_machine_thread():
         global ecu
         global answering_machine
-        while True:
+        while answering_machine_running.is_set():
             try:
                 ecu = TestSocket(UDS)
                 tester.pair(ecu)
                 answering_machine = EcuAnsweringMachine(supported_responses=supported_responses, main_socket=ecu, basecls=UDS, verbose=False)
                 answering_machine_started.set()
-                answering_machine(timeout=1000, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
+                answering_machine(timeout=120, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
                 return
             except OSError:
                 continue
@@ -60,11 +62,12 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, unstabl
             retry_if_none_received=True, unittest=True,
             **kwargs)
         for i in range(100):
-            scanner.scan(timeout=20)
+            scanner.scan(timeout=10)
             if scanner.scan_completed:
                 print("Scan completed after %d iterations" % i)
                 break
     finally:
+        answering_machine_running.clear()
         tester.send(Raw(b"\xff\xff\xff"))
         sim.join(timeout=2)
     if six.PY3 and LINUX:


### PR DESCRIPTION
The UDS-Scanner unit tests sometimes fail because of an internal error in the underlying `ObjectPipe`. 
Apparently, Windows is silently closing the notification file used in `ObjectPipe` during the unit test. 

This PR is a patch to recreate a new `TestSocket` aka. `ObjectPipe` once this error appears. 

This PR should stabilize the UDS and GMLAN Scanner unit tests. 



```
[i] Start execution of enumerator: Wed May 18 17:47:48 2022
Exception in thread Thread-2777:
Traceback (most recent call last):
  File "C:\Python37-x64\lib\threading.py", line 926, in _bootstrap_inner
    self.run()
  File "C:\Python37-x64\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "C:\projects\scapy\scapy\ansmachine.py", line 202, in __call__
    self.sniff()
  File "C:\projects\scapy\scapy\ansmachine.py", line 208, in sniff
    sniff(**self.optsniff)
  File "C:\projects\scapy\scapy\sendrecv.py", line 1310, in sniff
    sniffer._run(*args, **kwargs)
  File "C:\projects\scapy\scapy\sendrecv.py", line 1257, in _run
    session.on_packet_received(p)
  File "C:\projects\scapy\scapy\sessions.py", line 106, in on_packet_received
    result = self.prn(pkt)
  File "C:\projects\scapy\scapy\ansmachine.py", line 181, in reply
    self.send_reply(reply)
  File "C:\projects\scapy\scapy\contrib\automotive\ecu.py", line 712, in send_reply
    self._main_socket.send(p)
  File "C:\projects\scapy\test\testsocket.py", line 69, in send
    super(TestSocket, r).send(sx)  # type: ignore
  File "C:\projects\scapy\scapy\automaton.py", line 183, in send
    os.write(self.__wr, b"X")
OSError: [Errno 9] Bad file descriptor
```