### PR TITLE
Fix automaton socket creation

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -951,8 +951,10 @@ class Automaton:
 
             # Start the automaton
             self.state = self.initial_states[0](self)
-            self.send_sock = self.send_sock_class(**self.socket_kargs)
-            self.listen_sock = self.recv_sock_class(**self.socket_kargs)
+            self.send_sock = self.send_sock_class(**self.socket_kargs) \
+                if self.send_sock_class is not None else None
+            self.listen_sock = self.recv_sock_class(**self.socket_kargs) \
+                if self.recv_sock_class is not None else None
             self.packets = PacketList(name="session[%s]" % self.__class__.__name__)  # noqa: E501
 
             singlestep = True


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

Do not attempt to create sockets from `None` in `Automaton`. This allows to run [automaton example](https://scapy.readthedocs.io/en/latest/advanced_usage.html#first-example) without errors.

fixes #3619