### PR TITLE
fix TypeError while building _OptionsField for the HBHOptUnknown of

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -823,7 +823,7 @@ class _OptionsField(PacketListField):
             autopad = 1
 
         if not autopad:
-            return b"".join(map(str, x))
+            return b"".join(map(bytes, x))
 
         curpos = self.curpos
         s = b""

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -314,6 +314,21 @@ else:
     conf.route6.ipv6_ifaces = set([conf.loopback_name])
     True
 
+= Build HBHOptUnknown for IPv6ExtHdrHopByHop with disabled autopad
+~ ipv6 hbh opt
+* Build the HBHOptUnknown of IPv6ExtHdrHopByHop with autopad=0
+v6Opt = HBHOptUnknown(otype=3, optlen=7, optdata="Beijing")
+pkt = Ether()/IPv6()/IPv6ExtHdrHopByHop(autopad=0, options=[v6Opt, ])
+pkt.build()
+
+= Build HBHOptUnknown for IPv6ExtHdrDestOpt with disabled autopad
+~ ipv6 hbh opt
+* Build the HBHOptUnknown of IPv6ExtHdrDestOpt with autopad=0
+v6Opt = HBHOptUnknown(otype=3, optlen=6, optdata="Haikou")
+pkt = Ether()/IPv6()/IPv6ExtHdrDestOpt(autopad=0, options=[v6Opt, ])
+pkt.build()
+
+
 = Test read_routes6() - check mandatory routes
 
 conf.route6


### PR DESCRIPTION
fix TypeError while building _OptionsField for the HBHOptUnknown of IPv6ExtHdrHopByHop and IPv6ExtHdrDestOpt with autopad=0

in Python 3.8.10
```
v6Opt = HBHOptUnknown(otype=3, optlen=16, optdata="... ...")
pkt = Ether()/IPv6(... ...)/IPv6ExtHdrHopByHop(autopad=0, options=[v6Opt, ])
sendp(pkt, iface="eno1", count=3)
```

Debug output:
```
  File "/root/mao/ipv6_detect/scapy/layers/inet6.py", line 809, in i2m
    return b"".join(map(str, x))
TypeError: sequence item 0: expected a bytes-like object, str found
```

Signed-off-by: Jianwei Mao <maojianwei2012@126.com>

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
