### PR TITLE
Support loop=0 in sendpfast

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -489,7 +489,7 @@ def sendpfast(x,  # type: _PacketIterable
               pps=None,  # type: Optional[float]
               mbps=None,  # type: Optional[float]
               realtime=False,  # type: bool
-              loop=0,  # type: int
+              loop=None,  # type: Optional[int]
               file_cache=False,  # type: bool
               iface=None,  # type: Optional[_GlobInterfaceType]
               replay_args=None,  # type: Optional[List[str]]
@@ -501,7 +501,8 @@ def sendpfast(x,  # type: _PacketIterable
     :param pps:  packets per second
     :param mbps: MBits per second
     :param realtime: use packet's timestamp, bending time with real-time value
-    :param loop: number of times to process the packet list
+    :param loop: number of times to process the packet list. 0 implies
+        infinite loop
     :param file_cache: cache packets in RAM instead of reading from
         disk at each iteration
     :param iface: output interface
@@ -522,7 +523,7 @@ def sendpfast(x,  # type: _PacketIterable
     else:
         argv.append("--topspeed")
 
-    if loop:
+    if loop is not None:
         argv.append("--loop=%i" % loop)
     if file_cache:
         argv.append("--preload-pcap")


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
Makes sendpfast recognize 0 as a valid loop value

Didn't add unit tests since I didn't find any relevant existing unit tests for sendpfast

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #3640  <!-- (add issue number here if appropriate, else remove this line) -->
