### PR TITLE
[Automaton] add ability to work with multiple interfaces

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -873,9 +873,21 @@ class Automaton:
         # type: (Packet) -> bool
         return True
 
-    def my_send(self, pkt):
-        # type: (Packet) -> None
-        self.send_sock.send(pkt)
+    def my_send(self, pkt, iface=None):
+        # type: (Packet, Optional[Union[str, list[str]]]) -> None
+        if iface is None:
+            for socket in self.send_socks:
+                socket.send(pkt)
+        else:
+            if isinstance(iface, str):
+                ifaces = [iface]
+            elif isinstance(iface, list):
+                ifaces = iface
+            else:
+                ifaces = [conf.iface.name]
+            for socket in self.send_socks:
+                if hasattr(socket, "iface") and socket.iface in ifaces:
+                    socket.send(pkt)
 
     def timer_by_name(self, name):
         # type: (str) -> Optional[Timer]
@@ -1088,8 +1100,17 @@ class Automaton:
 
             # Start the automaton
             self.state = self.initial_states[0](self)
-            self.send_sock = self.send_sock_class(**self.socket_kargs)
-            self.listen_sock = self.recv_sock_class(**self.socket_kargs)
+            if "iface" in self.socket_kargs and \
+               isinstance(self.socket_kargs["iface"], list):
+                kargs = dict(self.socket_kargs)
+                del kargs["iface"]
+                self.send_socks = [self.send_sock_class(iface=iface, **kargs)
+                                   for iface in self.socket_kargs["iface"]]
+                self.listen_socks = [self.recv_sock_class(iface=iface, **kargs)
+                                     for iface in self.socket_kargs["iface"]]
+            else:
+                self.send_socks = [self.send_sock_class(**self.socket_kargs)]
+                self.listen_socks = [self.recv_sock_class(**self.socket_kargs)]
             self.packets = PacketList(name="session[%s]" % self.__class__.__name__)  # noqa: E501
 
             singlestep = True
@@ -1190,7 +1211,7 @@ class Automaton:
 
                 fds = [self.cmdin]
                 if len(self.recv_conditions[self.state.state]) > 0:
-                    fds.append(self.listen_sock)
+                    fds += self.listen_socks
                 for ioev in self.ioevents[self.state.state]:
                     fds.append(self.ioin[ioev.atmt_ioname])
                 while True:
@@ -1208,11 +1229,13 @@ class Automaton:
                         self.debug(5, "Looking at %r" % fd)
                         if fd == self.cmdin:
                             yield self.CommandMessage("Received command message")  # noqa: E501
-                        elif fd == self.listen_sock:
-                            pkt = self.listen_sock.recv(MTU)
+                        elif fd in self.listen_socks:
+                            pkt = fd.recv(MTU)
                             if pkt is not None:
                                 if self.master_filter(pkt):
                                     self.debug(3, "RECVD: %s" % pkt.summary())  # noqa: E501
+                                    if hasattr(fd, "iface"):
+                                        pkt.sniffed_on = fd.iface
                                     for rcvcond in self.recv_conditions[self.state.state]:  # noqa: E501
                                         self._run_condition(rcvcond, pkt, *state_output)  # noqa: E501
                                 else:

--- a/test/scapy/automaton.uts
+++ b/test/scapy/automaton.uts
@@ -499,3 +499,52 @@ if LINUX:
             # Remove the iptables rule
             assert(os.system(IPTABLE_RULE % ('D', SECDEV_IP4)) == 0)
 
+= Multiple interfaces
+~ multiple automaton interfaces
+
+import subprocess
+
+tap0, tap1 = [TunTapInterface("tap%d" % i) for i in range(2)]
+
+if six.PY2:
+    chk_kwargs = {}
+else:
+    chk_kwargs = {"timeout": 3}
+
+if LINUX:
+    for i in range(2):
+        assert subprocess.check_call(["ip", "link", "set", "tap%d" % i, "up"], **chk_kwargs) == 0
+else:
+    for i in range(2):
+        assert subprocess.check_call(["ifconfig", "tap%d" % i, "up"], **chk_kwargs) == 0
+
+class PacketMirror(Automaton):
+    @ATMT.state(initial=1)
+    def BEGIN(self):
+        self.tap0_count = 0
+        self.tap1_count = 0
+    @ATMT.receive_condition(BEGIN)
+    def mirror(self, pkt):
+        if raw(pkt)[:5] == b"hello":
+            if pkt.sniffed_on == "tap0":
+                self.tap0_count += 1
+                self.my_send(pkt, iface="tap1")
+            elif pkt.sniffed_on == "tap1":
+                self.tap1_count += 1
+    @ATMT.condition(BEGIN)
+    def send_one(self):
+        self.my_send(Raw("hello"), iface="tap0")
+    @ATMT.condition(BEGIN)
+    def send_two(self):
+        self.my_send(Raw("hello"), iface=["tap0", "tap1"])
+    @ATMT.timeout(BEGIN, 1)
+    def end_all(self):
+        raise self.END()
+    @ATMT.state(final=1)
+    def END(self):
+        pass
+
+sm = PacketMirror(iface=["tap0", "tap1"], ll=conf.L2socket)
+sm.run()
+assert sm.tap0_count == 2
+assert sm.tap1_count == 3


### PR DESCRIPTION
This PR adds support for multiple listening and sending interfaces for `Automaton`. Its syntax is similar to `sniff`'s syntax:
* when creating new `Automaton` instance, `iface` argument accepts an interface name or a list of interface names;
* `Automaton.my_send` has an optional argument `iface` that specifies an interface or a list of interfaces to send a packet to;
* `ATMT.receive_condition` can access packet's `sniffed_on` field to learn on which interface it was received.

### Rationale:
Some protocols like ERPS require PDUs to be sent and received on more than one interface. Their state machine logic requires information about the port from which the packet was received.

This PR adds support for multiple interface state machines.

This PR is related to #3636.
