### PR TITLE
Re-order version detection mechanisms

### DIFF
--- a/.config/appveyor/InstallNpcap.ps1
+++ b/.config/appveyor/InstallNpcap.ps1
@@ -68,7 +68,7 @@ if ($success -ne 0){
 Write-Output ('Installing: ' + $file)
 
 # Run installer
-$process = Start-Process $file -ArgumentList "/loopback_support=yes /S" -PassThru -Wait
+$process = Start-Process $file -ArgumentList "/loopback_support=yes /winpcap_mode=no /S" -PassThru -Wait
 if($process.ExitCode -eq 0) {
     echo "Npcap installation completed !"
     exit 0

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -91,6 +91,24 @@ def _version():
 
     :return: the Scapy version
     """
+    # Rely on git archive "export-subst" git attribute.
+    # See 'man gitattributes' for more details.
+    # Note: describe is only supported with git >= 2.32.0
+    # but we use it to workaround GH#3121
+    git_archive_id = '$Format:%h %(describe)$'.strip().split()
+    sha1 = git_archive_id[0]
+    tag = git_archive_id[1]
+    if "Format" not in sha1:
+        # We are in a git archive
+        if "describe" in tag:
+            # git is too old!
+            tag = ""
+        if tag:
+            return _parse_tag(tag)
+        elif sha1:
+            return "git-archive." + sha1
+        return 'unknown.version'
+    # Fallback to calling git
     version_file = os.path.join(_SCAPY_PKG_DIR, 'VERSION')
     try:
         tag = _version_from_git_describe()
@@ -106,22 +124,7 @@ def _version():
                 tag = fdsec.read()
             return tag
         except Exception:
-            # Rely on git archive "export-subst" git attribute.
-            # See 'man gitattributes' for more details.
-            # Note: describe is only supported with git >= 2.32.0
-            # but we use it to workaround GH#3121
-            git_archive_id = '$Format:%h %(describe:tags)$'.strip().split()
-            sha1 = git_archive_id[0]
-            tag = git_archive_id[1]
-            if "describe" in tag:
-                # git is too old !
-                tag = None
-            if tag:
-                return _parse_tag(tag)
-            elif sha1:
-                return "git-archive.dev" + sha1
-            else:
-                return 'unknown.version'
+            return 'unknown.version'
 
 
 VERSION = __version__ = _version()

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -691,7 +691,7 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
                 cfg.TerminalInteractiveShell.confirm_exit = False
                 cfg.TerminalInteractiveShell.separate_in = u''
             if int(IPython.__version__[0]) >= 6:
-                cfg.TerminalInteractiveShell.term_title_format = ("Scapy v%s" %
+                cfg.TerminalInteractiveShell.term_title_format = ("Scapy %s" %
                                                                   conf.version)
                 # As of IPython 6-7, the jedi completion module is a dumpster
                 # of fire that should be scrapped never to be seen again.

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -46,13 +46,19 @@ assert _version_checker(FakeModule3, (2, 4, 2))
 
 = Check Scapy version
 
+import mock
+
 import scapy
 from scapy import _parse_tag, _version_from_git_describe
+from scapy.config import _version_checker
 
-class GitModuleScapy(object):
-    __version__ = _version_from_git_describe()
+b = Bunch(returncode=0, communicate=lambda *args, **kargs: (b"v2.4.5rc1-261-g44b98e14", None))
+with mock.patch('scapy.subprocess.Popen', return_value=b) as popen:
+    class GitModuleScapy(object):
+        __version__ = _version_from_git_describe()
 
-assert _parse_tag("v2.3.2-346-g164a52c075c8") == '2.3.2.dev346'
+assert GitModuleScapy.__version__ == '2.4.5rc1.dev261'
+assert _version_checker(GitModuleScapy, (2, 4, 5))
 
 = List layers
 ~ conf command
@@ -4674,20 +4680,20 @@ assert pl[1][Ether].dst == '00:22:33:44:55:66'
 + Scapy version
 
 = _version()
-~ ci_only
 
 import os
 version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
 
-version = scapy._version()
-assert(os.path.exists(version_filename))
+version = "2.0.0"
+with open(version_filename, "w") as fd:
+    fd.write(version)
 
 import mock
 with mock.patch("scapy._version_from_git_describe") as version_mocked:
-  version_mocked.side_effect = Exception()
-  assert(scapy._version() == version)
-  os.unlink(version_filename)
-  assert(scapy._version() == "git-archive.dev$Format:%h")
+    version_mocked.side_effect = Exception()
+    assert(scapy._version() == version)
+    os.unlink(version_filename)
+    assert(scapy._version() == "unknown.version")
 
 
 = UTscapy HTML output


### PR DESCRIPTION
- fixes OSX tests
- slightly improves startup in released versions of Scapy, by first checking the archived ID