### PR TITLE
Update workflows & python versions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Scapy
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install tox
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Scapy
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install tox
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Scapy
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install tox
@@ -98,12 +98,12 @@ jobs:
             mode: both
     steps:
       - name: Checkout Scapy
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Codecov requires a fetch-depth > 1
         with:
           fetch-depth: 2
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages
@@ -111,7 +111,7 @@ jobs:
       - name: Run Tox
         run: ./.config/ci/test.sh ${{ matrix.python }} ${{ matrix.mode }}
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
             file: /home/runner/work/scapy/scapy/.coverage
 
@@ -123,12 +123,12 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
          languages: 'python'
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install tox
         run: pip install tox
       - name: Run flake8 tests
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install tox
         run: pip install tox
       - name: Build docs
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install tox
         run: pip install tox
       - name: Run mypy
@@ -63,38 +63,38 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [2.7, 3.9]
+        python: ["2.7", "3.10"]
         mode: [both]
         installmode: ['']
         include:
           # Linux non-root only tests
           - os: ubuntu-latest
-            python: 3.6
+            python: "3.7"
             mode: non_root
           - os: ubuntu-latest
-            python: 3.7
+            python: "3.8"
             mode: non_root
           - os: ubuntu-latest
-            python: 3.8
+            python: "3.9"
             mode: non_root
           # PyPy tests: root only
           - os: ubuntu-latest
-            python: pypy2
+            python: "pypy2.7"
             mode: root
           - os: ubuntu-latest
-            python: pypy3
+            python: "pypy3.9"
             mode: root
           # Libpcap test
           - os: ubuntu-latest
-            python: 3.9
+            python: "3.10"
             mode: root
             installmode: 'libpcap'
           # MacOS tests
           - os: macos-10.15
-            python: 2.7
+            python: "2.7"
             mode: both
           - os: macos-10.15
-            python: 3.9
+            python: "3.10"
             mode: both
     steps:
       - name: Checkout Scapy

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 
 
 [tox]
-envlist = py{27,34,35,36,37,38,39,py,py3}-{linux,bsd}_{non_root,root},
-          py{27,34,25,36,37,38,39,py,py3}-windows,
+envlist = py{27,34,35,36,37,38,39,310,py27,py39}-{linux,bsd}_{non_root,root},
+          py{27,34,25,36,37,38,39,310,py27,py39}-windows,
 skip_missing_interpreters = true
 minversion = 2.9
 


### PR DESCRIPTION
- use python 3.10 for main tests

Update github workflows:
- `codeql` action is deprecated
- `codecov-action` action was out of support
- update `actions/checkout` and `actions/setup-python` to their latest version

Tests will never finish since this is a workflow update.