### PR TITLE
Add SPDX License identifiers

### DIFF
--- a/.config/mypy/mypy_check.py
+++ b/.config/mypy/mypy_check.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Performs Static typing checks over Scapy's codebase

--- a/.config/mypy/mypy_deployment_stats.py
+++ b/.config/mypy/mypy_deployment_stats.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See https://scapy.net for more information
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Generate MyPy deployment stats

--- a/doc/scapy/_ext/scapy_doc.py
+++ b/doc/scapy/_ext/scapy_doc.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 A Sphinx Extension for Scapy's doc preprocessing

--- a/doc/vagrant_ci/Vagrantfile
+++ b/doc/vagrant_ci/Vagrantfile
@@ -1,10 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 Vagrant.configure("2") do |config|
 

--- a/doc/vagrant_ci/provision_freebsd.sh
+++ b/doc/vagrant_ci/provision_freebsd.sh
@@ -1,9 +1,9 @@
 #!/usr/local/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 pkg update
 pkg install --yes git python2 python3 py37-virtualenv py27-sqlite3 py37-sqlite3 bash rust

--- a/doc/vagrant_ci/provision_netbsd.sh
+++ b/doc/vagrant_ci/provision_netbsd.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 RELEASE="9.0_2020Q4"
 

--- a/doc/vagrant_ci/provision_openbsd.sh
+++ b/doc/vagrant_ci/provision_openbsd.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 sudo pkg_add git python-2.7.18p0 python3 py-virtualenv
 sudo mkdir -p /usr/local/test/

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Scapy: create, send, sniff, dissect and manipulate network packets.

--- a/scapy/__main__.py
+++ b/scapy/__main__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Scapy: create, send, sniff, dissect and manipulate network packets.

--- a/scapy/all.py
+++ b/scapy/all.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Aggregate top level objects from all Scapy modules.

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Answering machines.

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Operating system specific functionality.

--- a/scapy/arch/bpf/__init__.py
+++ b/scapy/arch/bpf/__init__.py
@@ -1,4 +1,7 @@
-# Guillaume Valadon <guillaume@valadon.net>
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Guillaume Valadon <guillaume@valadon.net>
 
 """
 Scapy BSD native support

--- a/scapy/arch/bpf/consts.py
+++ b/scapy/arch/bpf/consts.py
@@ -1,4 +1,7 @@
-# Guillaume Valadon <guillaume@valadon.net>
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Guillaume Valadon <guillaume@valadon.net>
 
 """
 Scapy BSD native support - constants

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -1,4 +1,7 @@
-# Guillaume Valadon <guillaume@valadon.net>
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Guillaume Valadon <guillaume@valadon.net>
 
 """
 Scapy *BSD native support - core

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -1,4 +1,7 @@
-# Guillaume Valadon <guillaume@valadon.net>
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Guillaume Valadon <guillaume@valadon.net>
 
 """
 Scapy *BSD native support - BPF sockets

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Functions common to different architectures

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Packet sending and receiving libpcap/WinPcap.

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Linux specific functions.

--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Customization for the Solaris operation system.

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Common customizations for all Unix-like operating systems other than Linux

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Customizations needed to support Microsoft Windows.

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Native Microsoft Windows sockets (L3 only)

--- a/scapy/arch/windows/structures.py
+++ b/scapy/arch/windows/structures.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 # flake8: noqa E266
 # (We keep comment boxes, it's then one-line comments)

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Resolve Autonomous Systems (AS).

--- a/scapy/asn1/__init__.py
+++ b/scapy/asn1/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Package holding ASN.1 related modules.

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Modified by Maxence Tury <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
+# Acknowledgment: Maxence Tury <maxence.tury@ssi.gouv.fr>
 
 """
 ASN.1 (Abstract Syntax Notation One)

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Modified by Maxence Tury <maxence.tury@ssi.gouv.fr>
+# Acknowledgment: Maxence Tury <maxence.tury@ssi.gouv.fr>
 # Acknowledgment: Ralph Broenink
-# This program is published under a GPLv2 license
 
 """
 Basic Encoding Rules (BER) for ASN.1

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Modified by Maxence Tury <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
+# Acknowledgment: Maxence Tury <maxence.tury@ssi.gouv.fr>
 
 """
 Management Information Base (MIB) parsing

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Enhanced by Maxence Tury <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
+# Acknowledgment: Maxence Tury <maxence.tury@ssi.gouv.fr>
 
 """
 Classes that implement ASN.1 data structures.

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 ASN.1 Packet

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Automata with states, transitions and actions.

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Run commands when the Scapy interpreter starts.

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Generators and packet meta classes.

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 Python 2 and 3 link classes.

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Implementation of the configuration object.

--- a/scapy/consts.py
+++ b/scapy/consts.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 This file contains constants

--- a/scapy/contrib/__init__.py
+++ b/scapy/contrib/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Package of contrib modules that have to be loaded explicitly.

--- a/scapy/contrib/altbeacon.py
+++ b/scapy/contrib/altbeacon.py
@@ -1,10 +1,7 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
-# altbeacon.py - protocol handlers for AltBeacon
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 (or later) license
 #
 # scapy.contrib.description = AltBeacon BLE proximity beacon
 # scapy.contrib.status = loads

--- a/scapy/contrib/aoe.py
+++ b/scapy/contrib/aoe.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
 # See https://scapy.net/ for more information
 # Copyright (C) 2018 antoine.torre <torreantoine1@gmail.com>

--- a/scapy/contrib/aoe.py
+++ b/scapy/contrib/aoe.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2018 antoine.torre <torreantoine1@gmail.com>
-##
-# This program is published under a GPLv2 license
 
 
 # scapy.contrib.description = ATA Over Internet

--- a/scapy/contrib/automotive/__init__.py
+++ b/scapy/contrib/automotive/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/bmw/__init__.py
+++ b/scapy/contrib/automotive/bmw/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/bmw/definitions.py
+++ b/scapy/contrib/automotive/bmw/definitions.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = BMW specific definitions for UDS
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/bmw/enumerator.py
+++ b/scapy/contrib/automotive/bmw/enumerator.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = BMW specific enumerators
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = HSFZ - BMW High-Speed-Fahrzeug-Zugang
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/ccp.py
+++ b/scapy/contrib/automotive/ccp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = CAN Calibration Protocol (CCP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Diagnostic over IP (DoIP) / ISO 13400
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -1,9 +1,7 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Helper class for tracking Ecu states (Ecu)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/gm/__init__.py
+++ b/scapy/contrib/automotive/gm/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/gm/gmlan.py
+++ b/scapy/contrib/automotive/gm/gmlan.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Enrico Pozzobon <enrico.pozzobon@gmail.com>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = General Motors Local Area Network (GMLAN)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/gm/gmlan_ecu_states.py
+++ b/scapy/contrib/automotive/gm/gmlan_ecu_states.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = GMLAN EcuState modifications
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/gm/gmlan_logging.py
+++ b/scapy/contrib/automotive/gm/gmlan_logging.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = GMLAN Ecu logging additions
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/gm/gmlan_scanner.py
+++ b/scapy/contrib/automotive/gm/gmlan_scanner.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = GMLAN AutomotiveTestCaseExecutor Utilities
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/gm/gmlanutils.py
+++ b/scapy/contrib/automotive/gm/gmlanutils.py
@@ -1,10 +1,8 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Markus Schroetter <project.m.schroetter@gmail.com>
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
+# Copyright (C) Markus Schroetter <project.m.schroetter@gmail.com>
 
 # scapy.contrib.description = GMLAN Utilities
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/kwp.py
+++ b/scapy/contrib/automotive/kwp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Keyword Protocol 2000 (KWP2000) / ISO 14230
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/obd/__init__.py
+++ b/scapy/contrib/automotive/obd/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/iid/__init__.py
+++ b/scapy/contrib/automotive/obd/iid/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/iid/iids.py
+++ b/scapy/contrib/automotive/obd/iid/iids.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/mid/__init__.py
+++ b/scapy/contrib/automotive/obd/mid/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/mid/mids.py
+++ b/scapy/contrib/automotive/obd/mid/mids.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/obd.py
+++ b/scapy/contrib/automotive/obd/obd.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = On Board Diagnostic Protocol (OBD-II)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/obd/packet.py
+++ b/scapy/contrib/automotive/obd/packet.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/__init__.py
+++ b/scapy/contrib/automotive/obd/pid/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids.py
+++ b/scapy/contrib/automotive/obd/pid/pids.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_00_1F.py
+++ b/scapy/contrib/automotive/obd/pid/pids_00_1F.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_20_3F.py
+++ b/scapy/contrib/automotive/obd/pid/pids_20_3F.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_40_5F.py
+++ b/scapy/contrib/automotive/obd/pid/pids_40_5F.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_60_7F.py
+++ b/scapy/contrib/automotive/obd/pid/pids_60_7F.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_80_9F.py
+++ b/scapy/contrib/automotive/obd/pid/pids_80_9F.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/pid/pids_A0_C0.py
+++ b/scapy/contrib/automotive/obd/pid/pids_A0_C0.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/scanner.py
+++ b/scapy/contrib/automotive/obd/scanner.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.korb@e-mundo.de>
 # Copyright (C) Friedrich Feigel <friedrich.feigel@e-mundo.de>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = OnBoardDiagnosticScanner
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/obd/services.py
+++ b/scapy/contrib/automotive/obd/services.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/tid/__init__.py
+++ b/scapy/contrib/automotive/obd/tid/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/obd/tid/tids.py
+++ b/scapy/contrib/automotive/obd/tid/tids.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.d.korb@gmail.com>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/scanner/__init__.py
+++ b/scapy/contrib/automotive/scanner/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Automotive Scanner Library
 # scapy.contrib.status = skip

--- a/scapy/contrib/automotive/scanner/configuration.py
+++ b/scapy/contrib/automotive/scanner/configuration.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = AutomotiveTestCaseExecutorConfiguration
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ServiceEnumerator definitions
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = AutomotiveTestCaseExecutor base class
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/scanner/graph.py
+++ b/scapy/contrib/automotive/scanner/graph.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Graph library for AutomotiveTestCaseExecutor
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/scanner/staged_test_case.py
+++ b/scapy/contrib/automotive/scanner/staged_test_case.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Staged AutomotiveTestCase base classes
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/scanner/test_case.py
+++ b/scapy/contrib/automotive/scanner/test_case.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = TestCase base class definitions
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Sebastian Baar <sebastian.baar@gmx.de>
+
 # MIT License
 
 # Copyright (c) 2018 Jose Amores
@@ -20,10 +25,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Sebastian Baar <sebastian.baar@gmx.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Scalable service-Oriented MiddlewarE/IP (SOME/IP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0-only OR MIT
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
 # See https://scapy.net/ for more information
 # Copyright (C) Sebastian Baar <sebastian.baar@gmx.de>

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -1,30 +1,8 @@
-# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-License-Identifier: GPL-2.0-only OR MIT
 # This file is part of Scapy
 # See https://scapy.net/ for more information
 # Copyright (C) Sebastian Baar <sebastian.baar@gmx.de>
-
-# MIT License
-
 # Copyright (c) 2018 Jose Amores
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 
 # scapy.contrib.description = Scalable service-Oriented MiddlewarE/IP (SOME/IP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Unified Diagnostic Service (UDS)
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/uds_ecu_states.py
+++ b/scapy/contrib/automotive/uds_ecu_states.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = UDS EcuState modifications
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/uds_logging.py
+++ b/scapy/contrib/automotive/uds_logging.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = UDS Ecu logging additions
 # scapy.contrib.status = library

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = UDS AutomotiveTestCaseExecutor
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/volkswagen/__init__.py
+++ b/scapy/contrib/automotive/volkswagen/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/volkswagen/definitions.py
+++ b/scapy/contrib/automotive/volkswagen/definitions.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Jonas Schmidt <jonas.schmidt@st.othr.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Volkswagen specific definitions for UDS
 # scapy.contrib.status = skip

--- a/scapy/contrib/automotive/xcp/__init__.py
+++ b/scapy/contrib/automotive/xcp/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/xcp/cto_commands_master.py
+++ b/scapy/contrib/automotive/xcp/cto_commands_master.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/xcp/cto_commands_slave.py
+++ b/scapy/contrib/automotive/xcp/cto_commands_slave.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/xcp/scanner.py
+++ b/scapy/contrib/automotive/xcp/scanner.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = XCPScanner
 # scapy.contrib.status = loads

--- a/scapy/contrib/automotive/xcp/utils.py
+++ b/scapy/contrib/automotive/xcp/utils.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/automotive/xcp/xcp.py
+++ b/scapy/contrib/automotive/xcp/xcp.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Universal calibration and measurement protocol (XCP) # noqa: E501
 # scapy.contrib.status = loads

--- a/scapy/contrib/avs.py
+++ b/scapy/contrib/avs.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = AVS WLAN Monitor Header
 # scapy.contrib.status = loads

--- a/scapy/contrib/bfd.py
+++ b/scapy/contrib/bfd.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Parag Bhide
-# This program is published under GPLv2 license
 
 """
 BFD - Bidirectional Forwarding Detection - RFC 5880, 5881, 7130, 7881

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = BGP v0.1
 # scapy.contrib.status = loads

--- a/scapy/contrib/bier.py
+++ b/scapy/contrib/bier.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Bit Index Explicit Replication (BIER)
 # scapy.contrib.status = loads

--- a/scapy/contrib/bp.py
+++ b/scapy/contrib/bp.py
@@ -1,26 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2012 The MITRE Corporation
 
 """
- Copyright 2012, The MITRE Corporation::
-
-                              NOTICE
+.. centered::
+    NOTICE
     This software/technical data was produced for the U.S. Government
     under Prime Contract No. NASA-03001 and JPL Contract No. 1295026
-      and is subject to FAR 52.227-14 (6/87) Rights in Data General,
-        and Article GP-51, Rights in Data  General, respectively.
-       This software is publicly released under MITRE case #12-3054
+    and is subject to FAR 52.227-14 (6/87) Rights in Data General,
+    and Article GP-51, Rights in Data  General, respectively.
+    This software is publicly released under MITRE case #12-3054
 """
 
 # scapy.contrib.description = Bundle Protocol (BP)

--- a/scapy/contrib/cansocket.py
+++ b/scapy/contrib/cansocket.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = CANSocket Utils
 # scapy.contrib.status = loads

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Native CANSocket
 # scapy.contrib.status = loads

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = python-can CANSocket
 # scapy.contrib.status = loads

--- a/scapy/contrib/carp.py
+++ b/scapy/contrib/carp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Common Address Redundancy Protocol (CARP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -1,25 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2006 Nicolas Bareil  <nicolas.bareil AT eads DOT net>
+#                    Arnaud Ebalard  <arnaud.ebalard AT eads DOT net>
+#                    EADS/CRC security team
+
 # scapy.contrib.description = Cisco Discovery Protocol (CDP)
 # scapy.contrib.status = loads
 
-#############################################################################
-#                                                                           #
-#  cdp.py --- Cisco Discovery Protocol (CDP) extension for Scapy            #
-#                                                                           #
-#  Copyright (C) 2006    Nicolas Bareil  <nicolas.bareil AT eads DOT net>   #
-#                        Arnaud Ebalard  <arnaud.ebalard AT eads DOT net>   #
-#                        EADS/CRC security team                             #
-#                                                                           #
-#  This file is part of Scapy                                               #
-#  Scapy is free software: you can redistribute it and/or modify it         #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation; version 2.                    #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#                                                                           #
-#############################################################################
+"""
+Cisco Discovery Protocol (CDP) extension for Scapy
+"""
 
 from __future__ import absolute_import
 import struct

--- a/scapy/contrib/chdlc.py
+++ b/scapy/contrib/chdlc.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Cisco HDLC and SLARP
 # scapy.contrib.status = loads

--- a/scapy/contrib/coap.py
+++ b/scapy/contrib/coap.py
@@ -1,19 +1,6 @@
-# This file is part of Scapy.
-# See http://www.secdev.org/projects/scapy for more information.
-#
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# (at your option) any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy.  If not, see <http://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2016 Anmol Sarma <me@anmolsarma.in>
 
 # scapy.contrib.description = Constrained Application Protocol (CoAP)

--- a/scapy/contrib/concox.py
+++ b/scapy/contrib/concox.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2019 Juciano Cardoso <cjuciano@gmail.com>
 #               2019 Guillaume Valadon <guillaume.valadon@netatmo.com>
-##
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Concox CRX1 unit tests
 # scapy.contrib.status = loads

--- a/scapy/contrib/dce_rpc.py
+++ b/scapy/contrib/dce_rpc.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2016 Gauthier Sebaux
+
+# scapy.contrib.description = DCE/RPC
+# scapy.contrib.status = loads
+
+"""
+A basic dissector for DCE/RPC.
+Isn't reliable for all packets and for building
+"""
+
+import struct
+
+from scapy.packet import Packet, Raw, bind_layers
+from scapy.fields import (
+    BitEnumField,
+    ByteEnumField,
+    ByteField,
+    FlagsField,
+    IntField,
+    LenField,
+    ShortField,
+    UUIDField,
+    XByteField,
+    XShortField,
+)
+
+
+# Fields
+class EndiannessField(object):
+    """Field which change the endianness of a sub-field"""
+    __slots__ = ["fld", "endianess_from"]
+
+    def __init__(self, fld, endianess_from):
+        self.fld = fld
+        self.endianess_from = endianess_from
+
+    def set_endianess(self, pkt):
+        """Add the endianness to the format"""
+        end = self.endianess_from(pkt)
+        if isinstance(end, str) and end:
+            if isinstance(self.fld, UUIDField):
+                self.fld.uuid_fmt = (UUIDField.FORMAT_LE if end == '<'
+                                     else UUIDField.FORMAT_BE)
+            else:
+                # fld.fmt should always start with a order specifier, cf field
+                # init
+                self.fld.fmt = end[0] + self.fld.fmt[1:]
+                self.fld.struct = struct.Struct(self.fld.fmt)
+
+    def getfield(self, pkt, buf):
+        """retrieve the field with endianness"""
+        self.set_endianess(pkt)
+        return self.fld.getfield(pkt, buf)
+
+    def addfield(self, pkt, buf, val):
+        """add the field with endianness to the buffer"""
+        self.set_endianess(pkt)
+        return self.fld.addfield(pkt, buf, val)
+
+    def __getattr__(self, attr):
+        return getattr(self.fld, attr)
+
+
+# DCE/RPC Packet
+DCE_RPC_TYPE = ["request", "ping", "response", "fault", "working", "no_call",
+                "reject", "acknowledge", "connectionless_cancel", "frag_ack",
+                "cancel_ack"]
+DCE_RPC_FLAGS1 = ["reserved_0", "last_frag", "frag", "no_frag_ack", "maybe",
+                  "idempotent", "broadcast", "reserved_7"]
+DCE_RPC_FLAGS2 = ["reserved_0", "cancel_pending", "reserved_2", "reserved_3",
+                  "reserved_4", "reserved_5", "reserved_6", "reserved_7"]
+
+
+def dce_rpc_endianess(pkt):
+    """Determine the right endianness sign for a given DCE/RPC packet"""
+    if pkt.endianness == 0:  # big endian
+        return ">"
+    elif pkt.endianness == 1:  # little endian
+        return "<"
+    else:
+        return "!"
+
+
+class DceRpc(Packet):
+    """DCE/RPC packet"""
+    name = "DCE/RPC"
+    fields_desc = [
+        ByteField("version", 4),
+        ByteEnumField("type", 0, DCE_RPC_TYPE),
+        FlagsField("flags1", 0, 8, DCE_RPC_FLAGS1),
+        FlagsField("flags2", 0, 8, DCE_RPC_FLAGS2),
+        BitEnumField("endianness", 0, 4, ["big", "little"]),
+        BitEnumField("encoding", 0, 4, ["ASCII", "EBCDIC"]),
+        ByteEnumField("float", 0, ["IEEE", "VAX", "CRAY", "IBM"]),
+        ByteField("DataRepr_reserved", 0),
+        XByteField("serial_high", 0),
+        EndiannessField(UUIDField("object_uuid", None),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(UUIDField("interface_uuid", None),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(UUIDField("activity", None),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("boot_time", 0),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("interface_version", 1),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(IntField("sequence_num", 0),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(ShortField("opnum", 0),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(XShortField("interface_hint", 0xffff),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(XShortField("activity_hint", 0xffff),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(LenField("frag_len", None, fmt="H"),
+                        endianess_from=dce_rpc_endianess),
+        EndiannessField(ShortField("frag_num", 0),
+                        endianess_from=dce_rpc_endianess),
+        ByteEnumField("auth", 0, ["none"]),  # TODO other auth ?
+        XByteField("serial_low", 0),
+    ]
+
+
+# Heuristically way to find the payload class
+#
+# To add a possible payload to a DCE/RPC packet, one must first create the
+# packet class, then instead of binding layers using bind_layers, he must
+# call DceRpcPayload.register_possible_payload() with the payload class as
+# parameter.
+#
+# To be able to decide if the payload class is capable of handling the rest of
+# the dissection, the classmethod can_handle() should be implemented in the
+# payload class. This method is given the rest of the string to dissect as
+# first argument, and the DceRpc packet instance as second argument. Based on
+# this information, the method must return True if the class is capable of
+# handling the dissection, False otherwise
+class DceRpcPayload(Packet):
+    """Dummy class which use the dispatch_hook to find the payload class"""
+    _payload_class = []
+
+    @classmethod
+    def dispatch_hook(cls, _pkt, _underlayer=None, *args, **kargs):
+        """dispatch_hook to choose among different registered payloads"""
+        for klass in cls._payload_class:
+            if hasattr(klass, "can_handle") and \
+                    klass.can_handle(_pkt, _underlayer):
+                return klass
+        print("DCE/RPC payload class not found or undefined (using Raw)")
+        return Raw
+
+    @classmethod
+    def register_possible_payload(cls, pay):
+        """Method to call from possible DCE/RPC endpoint to register it as
+        possible payload"""
+        cls._payload_class.append(pay)
+
+
+bind_layers(DceRpc, DceRpcPayload)

--- a/scapy/contrib/diameter.py
+++ b/scapy/contrib/diameter.py
@@ -1,22 +1,23 @@
-##########################################################################
-#
-#       Diameter protocol implementation for Scapy
-#   Original Author: patrick battistello
-#
-#   This implements the base Diameter protocol RFC6733 and the additional standards:  # noqa: E501
-#     RFC7155, RFC4004, RFC4006, RFC4072, RFC4740, RFC5778, RFC5447, RFC6942, RFC5777  # noqa: E501
-#     ETS29229 V12.3.0 (2014-09), ETS29272 V13.1.0 (2015-03), ETS29329 V12.5.0 (2014-12),  # noqa: E501
-#     ETS29212 V13.1.0 (2015-03), ETS32299 V13.0.0 (2015-03), ETS29210 V6.7.0 (2006-12),  # noqa: E501
-#     ETS29214 V13.1.0 (2015-03), ETS29273 V12.7.0 (2015-03), ETS29173 V12.3.0 (2015-03),  # noqa: E501
-#     ETS29172 V12.5.0 (2015-03), ETS29215 V13.1.0 (2015-03), ETS29209 V6.8.0 (2011-09),  # noqa: E501
-#     ETS29061 V13.0.0 (2015-03), ETS29219 V13.0.0 (2014-12)
-#
-#       IMPORTANT note:
-#
-#           - Some Diameter fields (Unsigned64, Float32, ...) have not been tested yet due to lack  # noqa: E501
-#               of network captures containing AVPs of that types contributions are welcomed.  # noqa: E501
-#
-##########################################################################
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Acknowledgment: Patrick Battistello
+
+"""
+Diameter protocol implementation for Scapy
+
+This implements the base Diameter protocol RFC6733 and the additional standards:  # noqa: E501
+    RFC7155, RFC4004, RFC4006, RFC4072, RFC4740, RFC5778, RFC5447, RFC6942, RFC5777  # noqa: E501
+    ETS29229 V12.3.0 (2014-09), ETS29272 V13.1.0 (2015-03), ETS29329 V12.5.0 (2014-12),  # noqa: E501
+    ETS29212 V13.1.0 (2015-03), ETS32299 V13.0.0 (2015-03), ETS29210 V6.7.0 (2006-12),  # noqa: E501
+    ETS29214 V13.1.0 (2015-03), ETS29273 V12.7.0 (2015-03), ETS29173 V12.3.0 (2015-03),  # noqa: E501
+    ETS29172 V12.5.0 (2015-03), ETS29215 V13.1.0 (2015-03), ETS29209 V6.8.0 (2011-09),  # noqa: E501
+    ETS29061 V13.0.0 (2015-03), ETS29219 V13.0.0 (2014-12)
+
+IMPORTANT note:
+    - Some Diameter fields (Unsigned64, Float32, ...) have not been tested yet due to lack  # noqa: E501
+        of network captures containing AVPs of that types contributions are welcomed.  # noqa: E501
+"""
 
 # scapy.contrib.description = Diameter
 # scapy.contrib.status = loads

--- a/scapy/contrib/dtp.py
+++ b/scapy/contrib/dtp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Dynamic Trunking Protocol (DTP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/eddystone.py
+++ b/scapy/contrib/eddystone.py
@@ -1,10 +1,7 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
-# eddystone.py - protocol handlers for Eddystone beacons
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 (or later) license
 #
 # scapy.contrib.description = Eddystone BLE proximity beacon
 # scapy.contrib.status = loads

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -1,16 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2009 Jochen Bartl
 
 # scapy.contrib.description = Enhanced Interior Gateway Routing Protocol (EIGRP)
 # scapy.contrib.status = loads
@@ -20,19 +11,13 @@
     ~~~~~~~~~~~~~~~~~~~~~
 
     :version:   2009-08-13
-    :copyright: 2009 by Jochen Bartl
     :e-mail:    lobo@c3a.de / jochen.bartl@gmail.com
-    :license:   GPL v2
 
     :TODO
 
     - Replace TLV code with a more generic solution
         * http://trac.secdev.org/scapy/ticket/90
     - Write function for calculating authentication data
-
-    :Known bugs:
-
-        -
 
     :Thanks:
 

--- a/scapy/contrib/eigrp.py
+++ b/scapy/contrib/eigrp.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-2.0-only
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
 # See https://scapy.net/ for more information
 # Copyright (C) 2009 Jochen Bartl

--- a/scapy/contrib/enipTCP.py
+++ b/scapy/contrib/enipTCP.py
@@ -1,26 +1,17 @@
-# coding: utf8
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2019 Jose Diogo Monteiro <jdlopes@student.dei.uc.pt>
 
 # scapy.contrib.description = EtherNet/IP
 # scapy.contrib.status = loads
 
-# Copyright (C) 2019 Jose Diogo Monteiro <jdlopes@student.dei.uc.pt>
-# Based on https://github.com/scy-phy/scapy-cip-enip
-# Routines for EtherNet/IP (Industrial Protocol) dissection
-# EtherNet/IP Home: www.odva.org
+"""
+EtherNet/IP (Industrial Protocol)
+
+Based on https://github.com/scy-phy/scapy-cip-enip
+EtherNet/IP Home: www.odva.org
+"""
 
 import struct
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/erspan.py
+++ b/scapy/contrib/erspan.py
@@ -1,6 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# This program is published under GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 ERSPAN - Encapsulated Remote SPAN

--- a/scapy/contrib/esmc.py
+++ b/scapy/contrib/esmc.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Ethernet Synchronization Message Channel (ESMC)
 # scapy.contrib.status = loads

--- a/scapy/contrib/ethercat.py
+++ b/scapy/contrib/ethercat.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = EtherCat
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :author:    Thomas Tannhaeuser, hecke@naberius.de
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/etherip.py
+++ b/scapy/contrib/etherip.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = EtherIP
 # scapy.contrib.status = loads

--- a/scapy/contrib/exposure_notification.py
+++ b/scapy/contrib/exposure_notification.py
@@ -1,13 +1,11 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
-# exposure_notification.py - Apple/Google Exposure Notification System
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) 2020 Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 (or later) license
-#
+
 # scapy.contrib.description = Apple/Google Exposure Notification System (ENS)
 # scapy.contrib.status = loads
+
 """
 Apple/Google Exposure Notification System (ENS), formerly known as
 Privacy-Preserving Contact Tracing Project.

--- a/scapy/contrib/geneve.py
+++ b/scapy/contrib/geneve.py
@@ -1,18 +1,7 @@
-# Copyright (C) 2018 Hao Zheng <haozheng10@gmail.com>
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2018 Hao Zheng <haozheng10@gmail.com>
 
 # scapy.contrib.description = Generic Network Virtualization Encapsulation (GENEVE)
 # scapy.contrib.status = loads

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -1,10 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2018 Leonardo Monteiro <decastromonteiro@gmail.com>
 #               2017 Alexis Sultan    <alexis.sultan@sfr.com>
 #               2017 Alessio Deiana <adeiana@gmail.com>
 #               2014 Guillaume Valadon <guillaume.valadon@ssi.gouv.fr>
 #               2012 ffranz <ffranz@iniqua.com>
-##
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = GPRS Tunneling Protocol (GTP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -1,19 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Alessio Deiana <adeiana@gmail.com>
 # 2017 Alexis Sultan <alexis.sultan@sfr.com>
-
-# This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 # scapy.contrib.description = GPRS Tunneling Protocol v2 (GTPv2)
 # scapy.contrib.status = loads

--- a/scapy/contrib/gxrp.py
+++ b/scapy/contrib/gxrp.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = Generic Attribute Register Protocol (GARP)
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :author:    Sergey Matsievskiy, matsievskiysv@gmail.com
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/homeplugav.py
+++ b/scapy/contrib/homeplugav.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = HomePlugAV Layer
 # scapy.contrib.status = loads

--- a/scapy/contrib/homepluggp.py
+++ b/scapy/contrib/homepluggp.py
@@ -1,18 +1,6 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = HomePlugGP Layer
 # scapy.contrib.status = loads

--- a/scapy/contrib/homeplugsg.py
+++ b/scapy/contrib/homeplugsg.py
@@ -1,18 +1,6 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = HomePlugSG Layer
 # scapy.contrib.status = loads

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -1,23 +1,14 @@
-#############################################################################
-#                                                                           #
-#  http2.py --- HTTP/2 support for Scapy                                    #
-#               see RFC7540 and RFC7541                                     #
-#               for more information                                        #
-#                                                                           #
-#  Copyright (C) 2016  Florian Maury <florian.maury@ssi.gouv.fr>            #
-#                                                                           #
-#  This file is part of Scapy                                               #
-#  Scapy is free software: you can redistribute it and/or modify it         #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation.                               #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#                                                                           #
-#############################################################################
-"""http2 Module
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2016  Florian Maury <florian.maury@ssi.gouv.fr>
+
+"""
+http2
+
+HTTP/2 support for Scapy
+see RFC7540 and RFC7541 for more information
+
 Implements packets and fields required to encode/decode HTTP/2 Frames
 and HPack encoded headers
 """

--- a/scapy/contrib/ibeacon.py
+++ b/scapy/contrib/ibeacon.py
@@ -1,11 +1,8 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
-# ibeacon.py - protocol handlers for iBeacons and other Apple devices
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 (or later) license
-#
+
 # scapy.contrib.description = iBeacon BLE proximity beacon
 # scapy.contrib.status = loads
 """

--- a/scapy/contrib/icmp_extensions.py
+++ b/scapy/contrib/icmp_extensions.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = ICMP Extensions
 # scapy.contrib.status = loads

--- a/scapy/contrib/ife.py
+++ b/scapy/contrib/ife.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = ForCES Inter-FE LFB type (IFE)
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :author:    Alexander Aring, aring@mojatatu.com
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/igmp.py
+++ b/scapy/contrib/igmp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Internet Group Management Protocol v1/v2 (IGMP/IGMPv2)
 # scapy.contrib.status = loads

--- a/scapy/contrib/igmpv3.py
+++ b/scapy/contrib/igmpv3.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Internet Group Management Protocol v3 (IGMPv3)
 # scapy.contrib.status = loads

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Internet Key Exchange v2 (IKEv2)
 # scapy.contrib.status = loads

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -1,16 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2014-2016 BENOCS GmbH, Berlin (Germany)
+# Copyright (C) 2020 Metaswitch, London (UK)
 
 # scapy.contrib.description = Intermediate System to Intermediate System (ISIS)
 # scapy.contrib.status = loads
@@ -19,24 +11,9 @@
     IS-IS Scapy Extension
     ~~~~~~~~~~~~~~~~~~~~~
 
-    :copyright: 2014-2016 BENOCS GmbH, Berlin (Germany)
-    :author:    Marcel Patzlaff, mpatzlaff@benocs.com
-                Michal Kaliszan, mkaliszan@benocs.com
-
-    :copyright: 2020 Metaswitch, London (UK)
-    :author:    Tom Zhu, tom.zhu@metaswitch.com
-
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
+    :authors:    Marcel Patzlaff, mpatzlaff@benocs.com
+                 Michal Kaliszan, mkaliszan@benocs.com
+                 Tom Zhu, tom.zhu@metaswitch.com
 
     :description:
 

--- a/scapy/contrib/isotp/__init__.py
+++ b/scapy/contrib/isotp/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2)
 # scapy.contrib.status = loads

--- a/scapy/contrib/isotp/isotp_native_socket.py
+++ b/scapy/contrib/isotp/isotp_native_socket.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Native Socket Library
 # scapy.contrib.status = library

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -1,8 +1,7 @@
-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Packet Definitions
 # scapy.contrib.status = library

--- a/scapy/contrib/isotp/isotp_scanner.py
+++ b/scapy/contrib/isotp/isotp_scanner.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Alexander Schroeder <alexander1.schroeder@st.othr.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Scanner Utility
 # scapy.contrib.status = library

--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Enrico Pozzobon <enricopozzobon@gmail.com>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Soft Socket Library
 # scapy.contrib.status = library

--- a/scapy/contrib/isotp/isotp_utils.py
+++ b/scapy/contrib/isotp/isotp_utils.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Enrico Pozzobon <enricopozzobon@gmail.com>
 # Copyright (C) Alexander Schroeder <alexander1.schroeder@st.othr.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Utilities
 # scapy.contrib.status = library

--- a/scapy/contrib/knx.py
+++ b/scapy/contrib/knx.py
@@ -1,31 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2021 Julien BEDEL <contact[at]julienbedel.com>
 #                    Claire VACHEROT <lex[at]lex.os>
 
-# This module provides Scapy layers for KNXNet/IP communications over UDP
-# according to KNX specifications v2.1 / ISO-IEC 14543-3.
-# Specifications can be downloaded for free here :
-# https://my.knx.org/en/shop/knx-specifications
-#
-# Currently, the module (partially) supports the following services :
-#   * SEARCH REQUEST/RESPONSE
-#   * DESCRIPTION REQUEST/RESPONSE
-#   * CONNECT, DISCONNECT, CONNECTION_STATE REQUEST/RESPONSE
-#   * CONFIGURATION REQUEST/RESPONSE
-#   * TUNNELING REQUEST/RESPONSE
+"""
+KNXNet/IP
+
+This module provides Scapy layers for KNXNet/IP communications over UDP
+according to KNX specifications v2.1 / ISO-IEC 14543-3.
+Specifications can be downloaded for free here :
+https://my.knx.org/en/shop/knx-specifications
+
+Currently, the module (partially) supports the following services :
+* SEARCH REQUEST/RESPONSE
+* DESCRIPTION REQUEST/RESPONSE
+* CONNECT, DISCONNECT, CONNECTION_STATE REQUEST/RESPONSE
+* CONFIGURATION REQUEST/RESPONSE
+* TUNNELING REQUEST/RESPONSE
+"""
 
 # scapy.contrib.description = KNX Protocol
 # scapy.contrib.status = loads

--- a/scapy/contrib/lacp.py
+++ b/scapy/contrib/lacp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Link Aggregation Control Protocol (LACP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-3.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
 # See https://scapy.net/ for more information
 # Copyright (C) 2010 Florian Duraffourg

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -1,22 +1,17 @@
+# SPDX-License-Identifier: GPL-3.0
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2010 Florian Duraffourg
+
 # scapy.contrib.description = Label Distribution Protocol (LDP)
 # scapy.contrib.status = loads
 
-# http://git.savannah.gnu.org/cgit/ldpscapy.git/snapshot/ldpscapy-5285b81d6e628043df2a83301b292f24a95f0ba1.tar.gz
+"""
+Label Distribution Protocol (LDP)
 
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+http://git.savannah.gnu.org/cgit/ldpscapy.git/snapshot/ldpscapy-5285b81d6e628043df2a83301b292f24a95f0ba1.tar.gz
 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# Copyright (C) 2010 Florian Duraffourg
+"""
 
 from __future__ import absolute_import
 import struct

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = Link Layer Discovery Protocol (LLDP)
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :author:    Thomas Tannhaeuser, hecke@naberius.de
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/loraphy2wan.py
+++ b/scapy/contrib/loraphy2wan.py
@@ -1,23 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2020  Sebastien Dudek (@FlUxIuS)
 
 # scapy.contrib.description = LoRa PHY to WAN Layer
 # scapy.contrib.status = loads
 
 """
-Copyright (C) 2020  Sebastien Dudek (@FlUxIuS)
-initially developed @PentHertz
+LoRa PHY to WAN Layer
+
+Initially developed @PentHertz
 and improved at @Trend Micro
 
 Spec: lorawantm_specification v1.1

--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -1,26 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright 2012 (C) The MITRE Corporation
 
 """
- Copyright 2012, The MITRE Corporation::
-
-                              NOTICE
+.. centered::
+    NOTICE
     This software/technical data was produced for the U.S. Government
     under Prime Contract No. NASA-03001 and JPL Contract No. 1295026
-      and is subject to FAR 52.227-14 (6/87) Rights in Data General,
-        and Article GP-51, Rights in Data  General, respectively.
-       This software is publicly released under MITRE case #12-3054
+    and is subject to FAR 52.227-14 (6/87) Rights in Data General,
+    and Article GP-51, Rights in Data  General, respectively.
+    This software is publicly released under MITRE case #12-3054
 """
 
 # scapy.contrib.description = Licklider Transmission Protocol (LTP)

--- a/scapy/contrib/mac_control.py
+++ b/scapy/contrib/mac_control.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = MACControl
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~
 
     :author:    Thomas Tannhaeuser, hecke@naberius.de
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/macsec.py
+++ b/scapy/contrib/macsec.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Sabrina Dubroca <sd@queasysnail.net>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = 802.1AE - IEEE MAC Security standard (MACsec)
 # scapy.contrib.status = loads

--- a/scapy/contrib/modbus.py
+++ b/scapy/contrib/modbus.py
@@ -1,24 +1,14 @@
-# coding: utf8
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2017 Arthur Gervais
+#                    Ken LE PRADO,
+#                    Sebastien Mainand
+#                    Thomas Aurel
 
 # scapy.contrib.description = ModBus Protocol
 # scapy.contrib.status = loads
 
-# Copyright (C) 2017 Arthur Gervais, Ken LE PRADO, Sébastien Mainand,
-# Thomas Aurel
 
 import struct
 

--- a/scapy/contrib/mount.py
+++ b/scapy/contrib/mount.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Lucas Preston <lucas.preston@infinite.io>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = NFS Mount v3
 # scapy.contrib.status = loads

--- a/scapy/contrib/mpls.py
+++ b/scapy/contrib/mpls.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Multiprotocol Label Switching (MPLS)
 # scapy.contrib.status = loads

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Santiago Hernandez Ramos <shramos@protonmail.com>
-# This program is published under GPLv2 license
 
 # scapy.contrib.description = Message Queuing Telemetry Transport (MQTT)
 # scapy.contrib.status = loads

--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -1,10 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) 2019 Freie Universitaet Berlin
-# This program is published under GPLv2 license
-#
-# Specification:
-#   http://www.mqtt.org/new/wp-content/uploads/2009/06/MQTT-SN_spec_v1.2.pdf
+
+"""
+MQTT for Sensor Networks (MQTT-SN)
+
+Specification:
+http://www.mqtt.org/new/wp-content/uploads/2009/06/MQTT-SN_spec_v1.2.pdf
+"""
+
 
 # scapy.contrib.description = MQTT for Sensor Networks (MQTT-SN)
 # scapy.contrib.status = loads

--- a/scapy/contrib/nfs.py
+++ b/scapy/contrib/nfs.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Lucas Preston <lucas.preston@infinite.io>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Network File System (NFS) v3
 # scapy.contrib.status = loads

--- a/scapy/contrib/nlm.py
+++ b/scapy/contrib/nlm.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Lucas Preston <lucas.preston@infinite.io>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Network Lock Manager (NLM) v4
 # scapy.contrib.status = loads

--- a/scapy/contrib/nsh.py
+++ b/scapy/contrib/nsh.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Network Services Headers (NSH)
 # scapy.contrib.status = loads

--- a/scapy/contrib/oncrpc.py
+++ b/scapy/contrib/oncrpc.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Lucas Preston <lucas.preston@infinite.io>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = ONC-RPC v2
 # scapy.contrib.status = loads

--- a/scapy/contrib/opc_da.py
+++ b/scapy/contrib/opc_da.py
@@ -1,22 +1,8 @@
-# coding: utf8
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software FounDation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) GuillaumeF <guillaume4favre@gmail.com>
 
-# Copyright (C)
-# @Author: GuillaumeF
-# @Email:  guillaume4favre@gmail.com
 # @Date:   2016-10-18
 # @Last modified by:   GuillaumeF
 # @Last modified by:   Sebastien Mainand

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -1,12 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
 # Copyright (C) 2014 Maxence Tury <maxence.tury@ssi.gouv.fr>
-# OpenFlow is an open standard used in SDN deployments.
-# Based on OpenFlow v1.0.1
-# Specifications can be retrieved from https://www.opennetworking.org/
+
+"""
+OpenFlow v1.0.1
+
+OpenFlow is an open standard used in SDN deployments.
+Specifications can be retrieved from https://www.opennetworking.org/
+"""
 
 # scapy.contrib.description = Openflow v1.0
 # scapy.contrib.status = loads

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -1,12 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
 # Copyright (C) 2014 Maxence Tury <maxence.tury@ssi.gouv.fr>
-# OpenFlow is an open standard used in SDN deployments.
-# Based on OpenFlow v1.3.4
-# Specifications can be retrieved from https://www.opennetworking.org/
+
+"""
+OpenFlow v1.3.4
+
+OpenFlow is an open standard used in SDN deployments.
+Specifications can be retrieved from https://www.opennetworking.org/
+"""
+
 
 # scapy.contrib.description = OpenFlow v1.3
 # scapy.contrib.status = loads

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -1,28 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (c) 2008 Dirk Loss <dirk-loss de>
+# Copyright (c) 2010 Jochen Bartl <jochen.bartl gmail com>
+
 # scapy.contrib.description = Open Shortest Path First (OSPF)
 # scapy.contrib.status = loads
-
-# This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
 
 """
 OSPF extension for Scapy <http://www.secdev.org/scapy>
 
 This module provides Scapy layers for the Open Shortest Path First
 routing protocol as defined in RFC 2328 and RFC 5340.
-
-Copyright (c) 2008 Dirk Loss  :  mail dirk-loss de
-Copyright (c) 2010 Jochen Bartl  :  jochen.bartl gmail com
 """
 
 

--- a/scapy/contrib/pfcp.py
+++ b/scapy/contrib/pfcp.py
@@ -1,22 +1,11 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2019 Travelping GmbH <info@travelping.com>
 
-# This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
-# 3GPP TS 29.244
+"""
+3GPP TS 29.244
+"""
 
 # scapy.contrib.description = 3GPP Packet Forwarding Control Protocol
 # scapy.contrib.status = loads

--- a/scapy/contrib/pim.py
+++ b/scapy/contrib/pim.py
@@ -1,17 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-#
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = Protocol Independent Multicast (PIM)
 # scapy.contrib.status = loads
 """

--- a/scapy/contrib/pnio.py
+++ b/scapy/contrib/pnio.py
@@ -1,18 +1,6 @@
-# coding: utf8
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2016 Gauthier Sebaux
 
 # scapy.contrib.description = ProfinetIO RTC (+Profisafe) layer

--- a/scapy/contrib/pnio_dcp.py
+++ b/scapy/contrib/pnio_dcp.py
@@ -1,19 +1,6 @@
-# coding: utf8
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2019 Stefan Mehner (stefan.mehner@b-tu.de)
 
 # scapy.contrib.description = Profinet DCP layer

--- a/scapy/contrib/pnio_rpc.py
+++ b/scapy/contrib/pnio_rpc.py
@@ -1,17 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2016 Gauthier Sebaux
 
 # scapy.contrib.description = ProfinetIO Remote Procedure Call (RPC)

--- a/scapy/contrib/portmap.py
+++ b/scapy/contrib/portmap.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Lucas Preston <lucas.preston@infinite.io>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = Portmapper v2
 # scapy.contrib.status = loads

--- a/scapy/contrib/ppi_cace.py
+++ b/scapy/contrib/ppi_cace.py
@@ -1,17 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # author: <jellch@harris.com>
 
 # scapy.contrib.description = CACE Per-Packet Information (PPI)

--- a/scapy/contrib/ppi_geotag.py
+++ b/scapy/contrib/ppi_geotag.py
@@ -1,17 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # author: <jellch@harris.com>
 
 # scapy.contrib.description = CACE Per-Packet Information (PPI) Geolocation

--- a/scapy/contrib/ripng.py
+++ b/scapy/contrib/ripng.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Routing Information Protocol next gen (RIPng)
 # scapy.contrib.status = loads

--- a/scapy/contrib/roce.py
+++ b/scapy/contrib/roce.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Haggai Eran <haggai.eran@gmail.com>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = RoCE v2
 # scapy.contrib.status = loads

--- a/scapy/contrib/rpl.py
+++ b/scapy/contrib/rpl.py
@@ -1,22 +1,8 @@
-# This file is part of Scapy.
-# See http://www.secdev.org/projects/scapy for more information.
-#
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# (at your option) any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy.  If not, see <http://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2020 Rahul Jadhav <nyrahul@gmail.com>
 
-# RFC 6550
 # scapy.contrib.description = Routing Protocol for LLNs (RPL)
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/rpl_metrics.py
+++ b/scapy/contrib/rpl_metrics.py
@@ -1,22 +1,8 @@
-# This file is part of Scapy.
-# See http://www.secdev.org/projects/scapy for more information.
-#
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# (at your option) any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy.  If not, see <http://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2020 Rahul Jadhav <nyrahul@gmail.com>
 
-# RFC 6551
 # scapy.contrib.description = Routing Metrics used for Path Calc in LLNs
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/rsvp.py
+++ b/scapy/contrib/rsvp.py
@@ -1,18 +1,10 @@
-# RSVP layer
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+
+"""
+RSVP layer
+"""
 
 # scapy.contrib.description = Resource Reservation Protocol (RSVP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/rtcp.py
+++ b/scapy/contrib/rtcp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Pavel Oborin <oborin.p@gmail.com>
-# This program is published under a GPLv2 license
 
 # RFC 3550
 # scapy.contrib.description = Real-Time Transport Control Protocol

--- a/scapy/contrib/rtps/__init__.py
+++ b/scapy/contrib/rtps/__init__.py
@@ -1,20 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2021 Trend Micro Incorporated
+
 """
 Real-Time Publish-Subscribe Protocol (RTPS) dissection
-
-Copyright (C) 2021 Trend Micro Incorporated
-
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
-Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 # scapy.contrib.description = Real-Time Publish-Subscribe Protocol (RTPS)

--- a/scapy/contrib/rtps/common_types.py
+++ b/scapy/contrib/rtps/common_types.py
@@ -1,21 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2021 Trend Micro Incorporated
+# Copyright (C) 2021 Alias Robotics S.L.
+
 """
 Real-Time Publish-Subscribe Protocol (RTPS) dissection
-
-Copyright (C) 2021 Trend Micro Incorporated
-Copyright (C) 2021 Alias Robotics S.L.
-
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
-Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 # scapy.contrib.description = RTPS common types

--- a/scapy/contrib/rtps/pid_types.py
+++ b/scapy/contrib/rtps/pid_types.py
@@ -1,21 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2021 Trend Micro Incorporated
+# Copyright (C) 2021 Alias Robotics S.L.
+
 """
 Real-Time Publish-Subscribe Protocol (RTPS) dissection
-
-Copyright (C) 2021 Trend Micro Incorporated
-Copyright (C) 2021 Alias Robotics S.L.
-
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
-Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 # scapy.contrib.description = RTPS PID type definitions

--- a/scapy/contrib/rtps/rtps.py
+++ b/scapy/contrib/rtps/rtps.py
@@ -1,21 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2021 Trend Micro Incorporated
+# Copyright (C) 2021 Alias Robotics S.L.
+
 """
 Real-Time Publish-Subscribe Protocol (RTPS) dissection
-
-Copyright (C) 2021 Trend Micro Incorporated
-Copyright (C) 2021 Alias Robotics S.L.
-
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
-Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 # scapy.contrib.description = RTPS abstractions

--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -1,21 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2018 Francois Contat <francois.contat@ssi.gouv.fr>
 
-# Based on RTR RFC 6810 https://tools.ietf.org/html/rfc6810 for version 0
-# Based on RTR RFC 8210 https://tools.ietf.org/html/rfc8210 for version 1
+"""
+RTR
+
+Based on RTR RFC 6810 https://tools.ietf.org/html/rfc6810 for version 0
+Based on RTR RFC 8210 https://tools.ietf.org/html/rfc8210 for version 1
+"""
 
 # scapy.contrib.description = The RPKI to Router Protocol
 # scapy.contrib.status = loads

--- a/scapy/contrib/scada/__init__.py
+++ b/scapy/contrib/scada/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
-#
+
 # scapy.contrib.status = skip
 
 

--- a/scapy/contrib/scada/iec104/__init__.py
+++ b/scapy/contrib/scada/iec104/__init__.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
-#
+
 # scapy.contrib.description = IEC-60870-5-104 APCI / APDU layer definitions
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/scada/iec104/iec104_fields.py
+++ b/scapy/contrib/scada/iec104/iec104_fields.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/scada/iec104/iec104_information_elements.py
+++ b/scapy/contrib/scada/iec104/iec104_information_elements.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.status = skip
 

--- a/scapy/contrib/scada/iec104/iec104_information_objects.py
+++ b/scapy/contrib/scada/iec104/iec104_information_objects.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Thomas Tannhaeuser <hecke@naberius.de>
-# This program is published under a GPLv2 license
-#
+
 # scapy.contrib.description = IEC-60870-5-104 ASDU layers / IO definitions
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/scada/pcom.py
+++ b/scapy/contrib/scada/pcom.py
@@ -1,28 +1,19 @@
-# coding: utf8
-
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright (C) 2019 Luis Rosa <lmrosa@dei.uc.pt>
 
 # scapy.contrib.description = PCOM Protocol
 # scapy.contrib.status = loads
 
-# Copyright (C) 2019 Luis Rosa <lmrosa@dei.uc.pt>
-#
-# PCOM is a protocol to communicate with Unitronics PLCs either by serial
-# or TCP. Two modes are available, ASCII and Binary.
-#
-# See https://unitronicsplc.com/Download/SoftwareUtilities/Unitronics%20PCOM%20Protocol.pdf # noqa
+"""
+PCOM
+
+PCOM is a protocol to communicate with Unitronics PLCs either by serial
+or TCP. Two modes are available, ASCII and Binary.
+
+https://unitronicsplc.com/Download/SoftwareUtilities/Unitronics%20PCOM%20Protocol.pdf
+"""
 
 import struct
 

--- a/scapy/contrib/sdnv.py
+++ b/scapy/contrib/sdnv.py
@@ -1,26 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
+# Copyright 2012 (C) The MITRE Corporation
 
 """
- Copyright 2012, The MITRE Corporation::
-
-                              NOTICE
+.. centered::
+    NOTICE
     This software/technical data was produced for the U.S. Government
     under Prime Contract No. NASA-03001 and JPL Contract No. 1295026
-      and is subject to FAR 52.227-14 (6/87) Rights in Data General,
-        and Article GP-51, Rights in Data  General, respectively.
-       This software is publicly released under MITRE case #12-3054
+    and is subject to FAR 52.227-14 (6/87) Rights in Data General,
+    and Article GP-51, Rights in Data  General, respectively.
+    This software is publicly released under MITRE case #12-3054
 """
 
 # scapy.contrib.description = Self-Delimiting Numeric Values (SDNV)

--- a/scapy/contrib/sebek.py
+++ b/scapy/contrib/sebek.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Sebek: kernel module for data collection on honeypots.

--- a/scapy/contrib/send.py
+++ b/scapy/contrib/send.py
@@ -1,21 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2009 Adline Stephane <adline.stephane@gmail.com>
-# Copyright     2018 Gabriel Potter <gabriel@potter.fr>
+# Copyright     2018 Gabriel Potter <gabriel[]potter[]fr>
 
-# Partial support of RFC3971
+"""
+Secure Neighbor Discovery (SEND) - RFC3971
+"""
+
 # scapy.contrib.description = Secure Neighbor Discovery (SEND) (ICMPv6)
 # scapy.contrib.status = loads
 

--- a/scapy/contrib/skinny.py
+++ b/scapy/contrib/skinny.py
@@ -1,25 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+#  Copyright (C) 2006 Nicolas Bareil <nicolas.bareil <at> eads.net>
+#                     EADS/CRC security team
+
 # scapy.contrib.description = Skinny Call Control Protocol (SCCP)
 # scapy.contrib.status = loads
 
-
-#############################################################################
-#                                                                           #
-#  scapy-skinny.py --- Skinny Call Control Protocol (SCCP) extension        #
-#                                                                           #
-#  Copyright (C) 2006    Nicolas Bareil      <nicolas.bareil@ eads.net>     #
-#                        EADS/CRC security team                             #
-#                                                                           #
-#  This file is part of Scapy                                               #
-#  Scapy is free software: you can redistribute it and/or modify            #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation; version 2.                    #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#                                                                           #
-#############################################################################
+"""
+Skinny Call Control Protocol (SCCP) extension
+"""
 
 from __future__ import absolute_import
 import time

--- a/scapy/contrib/slowprot.py
+++ b/scapy/contrib/slowprot.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Slow Protocol
 # scapy.contrib.status = loads

--- a/scapy/contrib/socks.py
+++ b/scapy/contrib/socks.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Socket Secure (SOCKS)
 # scapy.contrib.status = loads

--- a/scapy/contrib/spbm.py
+++ b/scapy/contrib/spbm.py
@@ -1,39 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
-# IEEE 802.1aq - Shorest Path Bridging Mac-in-mac (SPBM):
-# Ethernet based link state protocol that enables Layer 2 Unicast, Layer 2 Multicast, Layer 3 Unicast, and Layer 3 Multicast virtualized services  # noqa: E501
-# https://en.wikipedia.org/wiki/IEEE_802.1aq
-# Modeled after the scapy VXLAN contribution
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = Shorest Path Bridging Mac-in-mac (SBPM)
 # scapy.contrib.status = loads
 
 """
- Example SPB Frame Creation
+IEEE 802.1aq - Shorest Path Bridging Mac-in-mac (SPBM):
 
- Note the outer Dot1Q Ethertype marking (0x88e7)
+Ethernet based link state protocol that enables
+- Layer 2 Unicast
+- Layer 2 Multicast
+- Layer 3 Unicast
+- Layer 3 Multicast virtualized services
 
- backboneEther     = Ether(dst='00:bb:00:00:90:00', src='00:bb:00:00:40:00', type=0x8100)  # noqa: E501
- backboneDot1Q     = Dot1Q(vlan=4051,type=0x88e7)
- backboneServiceID = SPBM(prio=1,isid=20011)
- customerEther     = Ether(dst='00:1b:4f:5e:ca:00',src='00:00:00:00:00:01',type=0x8100)  # noqa: E501
- customerDot1Q     = Dot1Q(prio=1,vlan=11,type=0x0800)
- customerIP        = IP(src='10.100.11.10',dst='10.100.12.10',id=0x0629,len=106)  # noqa: E501
- customerUDP       = UDP(sport=1024,dport=1025,chksum=0,len=86)
+https://en.wikipedia.org/wiki/IEEE_802.1aq
+Modeled after the scapy VXLAN contribution
 
- spb_example = backboneEther/backboneDot1Q/backboneServiceID/customerEther/customerDot1Q/customerIP/customerUDP/"Payload"  # noqa: E501
+Example SPB Frame Creation
+__________________________
+
+Note the outer Dot1Q Ethertype marking (0x88e7)
+
+::
+    backboneEther     = Ether(dst='00:bb:00:00:90:00', src='00:bb:00:00:40:00', type=0x8100)  # noqa: E501
+    backboneDot1Q     = Dot1Q(vlan=4051,type=0x88e7)
+    backboneServiceID = SPBM(prio=1,isid=20011)
+    customerEther     = Ether(dst='00:1b:4f:5e:ca:00',src='00:00:00:00:00:01',type=0x8100)  # noqa: E501
+    customerDot1Q     = Dot1Q(prio=1,vlan=11,type=0x0800)
+    customerIP        = IP(src='10.100.11.10',dst='10.100.12.10',id=0x0629,len=106)  # noqa: E501
+    customerUDP       = UDP(sport=1024,dport=1025,chksum=0,len=86)
+
+    spb_example = backboneEther/backboneDot1Q/backboneServiceID/customerEther/customerDot1Q/customerIP/customerUDP/"Payload"  # noqa: E501
 """
 
 from scapy.packet import Packet, bind_layers

--- a/scapy/contrib/tacacs.py
+++ b/scapy/contrib/tacacs.py
@@ -1,20 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Francois Contat <francois.contat@ssi.gouv.fr>
 
-# Based on tacacs+ v6 draft https://tools.ietf.org/html/draft-ietf-opsawg-tacacs-06  # noqa: E501
+"""
+TACACS
+
+Based on tacacs+ v6 draft
+https://tools.ietf.org/html/draft-ietf-opsawg-tacacs-06
+"""
 
 # scapy.contrib.description = Terminal Access Controller Access-Control System+
 # scapy.contrib.status = loads

--- a/scapy/contrib/tcpao.py
+++ b/scapy/contrib/tcpao.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Leonard Crestez <cdleonard@gmail.com>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = TCP-AO Signature Calculation
 # scapy.contrib.status = loads

--- a/scapy/contrib/tzsp.py
+++ b/scapy/contrib/tzsp.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # scapy.contrib.description = TaZmen Sniffer Protocol (TZSP)
 # scapy.contrib.status = loads
 
@@ -6,17 +10,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :author:    Thomas Tannhaeuser, hecke@naberius.de
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/contrib/ubberlogger.py
+++ b/scapy/contrib/ubberlogger.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # Author: Sylvain SARMEJEANNE
 

--- a/scapy/contrib/vqp.py
+++ b/scapy/contrib/vqp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = VLAN Query Protocol
 # scapy.contrib.status = loads

--- a/scapy/contrib/vtp.py
+++ b/scapy/contrib/vtp.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = VLAN Trunking Protocol (VTP)
 # scapy.contrib.status = loads

--- a/scapy/contrib/wireguard.py
+++ b/scapy/contrib/wireguard.py
@@ -1,17 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = WireGuard
 # scapy.contrib.status = loads

--- a/scapy/contrib/wpa_eapol.py
+++ b/scapy/contrib/wpa_eapol.py
@@ -1,16 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
+# See https://scapy.net/ for more information
 
 # scapy.contrib.description = WPA EAPOL-KEY
 # scapy.contrib.status = loads

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Direct Access dictionary.

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Global variables and functions for handling external data sets.

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Logging subsystem and basic exception class.

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1,9 +1,9 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 license
+
 
 """
 Fields: basic data structures that make up parts of packets.

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Interfaces management

--- a/scapy/layers/__init__.py
+++ b/scapy/layers/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Layer package.

--- a/scapy/layers/all.py
+++ b/scapy/layers/all.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 All layers. Configurable with conf.load_layers.

--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Mike Ryan <mikeryan@lacklustre.net>
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 license
 
 """
 Bluetooth layers, sockets and send/receive functions.

--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -1,8 +1,9 @@
-# This file is for use with Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Airbus DS CyberSecurity
 # Authors: Jean-Michel Picod, Arnaud Lebrun, Jonathan Christofer Demay
-# This program is published under a GPLv2 license
 
 """Bluetooth 4LE layer"""
 

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 
 """A minimal implementation of the CANopen protocol, based on

--- a/scapy/layers/clns.py
+++ b/scapy/layers/clns.py
@@ -1,20 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2014, 2015 BENOCS GmbH, Berlin (Germany)
+
 """
     CLNS Extension
     ~~~~~~~~~~~~~~~~~~~~~
 
     :copyright: 2014, 2015 BENOCS GmbH, Berlin (Germany)
     :author:    Marcel Patzlaff, mpatzlaff@benocs.com
-    :license:   GPLv2
-
-        This module is free software; you can redistribute it and/or
-        modify it under the terms of the GNU General Public License
-        as published by the Free Software Foundation; either version 2
-        of the License, or (at your option) any later version.
-
-        This module is distributed in the hope that it will be useful,
-        but WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-        GNU General Public License for more details.
 
     :description:
 

--- a/scapy/layers/dcerpc.py
+++ b/scapy/layers/dcerpc.py
@@ -1,17 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) 2016 Gauthier Sebaux
 #               2022 Gabriel Potter
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 DHCP (Dynamic Host Configuration Protocol) and BOOTP

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
+# Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) 2005  Guillaume Valadon <guedou@hongo.wide.ad.jp>
 #                     Arnaud Ebalard <arnaud.ebalard@eads.net>
 

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 DNS: Domain Name System.

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1,18 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Scapy is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
-# any later version.
-#
-# Scapy is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Scapy. If not, see <http://www.gnu.org/licenses/>.
-
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 
 """

--- a/scapy/layers/dot15d4.py
+++ b/scapy/layers/dot15d4.py
@@ -1,11 +1,11 @@
-# This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Ryan Speers <ryan@rmspeers.com> 2011-2012
 # Copyright (C) Roger Meyer <roger.meyer@csus.edu>: 2012-03-10 Added frames
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>: 2018
-# Copyright (C) 2020 Dimitrios-Georgios Akestoridis <akestoridis@cmu.edu>
-# This program is published under a GPLv2 license
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>: 2018
+# Copyright (C) Dimitrios-Georgios Akestoridis <akestoridis@cmu.edu>
 
 """
 Wireless MAC according to IEEE 802.15.4.

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Extensible Authentication Protocol (EAP)

--- a/scapy/layers/gprs.py
+++ b/scapy/layers/gprs.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 GPRS (General Packet Radio Service) for mobile data communication.

--- a/scapy/layers/gssapi.py
+++ b/scapy/layers/gssapi.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Gabriel Potter
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Generic Security Services (GSS) API

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -1,35 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
-#############################################################################
-#                                                                           #
-#  hsrp.py --- HSRP  protocol support for Scapy                             #
-#                                                                           #
-#  Copyright (C) 2010  Mathieu RENARD mathieu.renard(at)gmail.com           #
-#                                                                           #
-#  This program is free software; you can redistribute it and/or modify it  #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation; version 2.                    #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#                                                                           #
-#############################################################################
-# HSRP Version 1
-# Ref. RFC 2281
-# HSRP Version 2
-# Ref. http://www.smartnetworks.jp/2006/02/hsrp_8_hsrp_version_2.html
-##
-# $Log: hsrp.py,v $
-# Revision 0.2  2011/05/01 15:23:34  mrenard
-# Cleanup code
+# See https://scapy.net/ for more information
+# Copyright (C)  Mathieu RENARD <mathieu.renard(at)gmail.com>
 
 """
-HSRP (Hot Standby Router Protocol): proprietary redundancy protocol for Cisco routers.  # noqa: E501
+HSRP (Hot Standby Router Protocol)
+A proprietary redundancy protocol for Cisco routers.
+
+- HSRP Version 1: RFC 2281
+- HSRP Version 2:
+    http://www.smartnetworks.jp/2006/02/hsrp_8_hsrp_version_2.html
 """
 
 from scapy.fields import ByteEnumField, ByteField, IPField, SourceIPField, \

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -1,10 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) 2019 Gabriel Potter <gabriel@potter.fr>
+# See https://scapy.net/ for more information
 # Copyright (C) 2012 Luca Invernizzi <invernizzi.l@gmail.com>
 # Copyright (C) 2012 Steeve Barbeau <http://www.sbarbeau.fr>
-
-# This program is published under a GPLv2 license
+# Copyright (C) 2019 Gabriel Potter <gabriel[]potter[]fr>
 
 """
 HTTP 1.0 layer.
@@ -39,7 +38,6 @@ You can turn auto-decompression/auto-compression off with:
 # This file is a modified version of the former scapy_http plugin.
 # It was reimplemented for scapy 2.4.3+ using sessions, stream handling.
 # Original Authors : Steeve Barbeau, Luca Invernizzi
-# Originally published under a GPLv2 license
 
 import io
 import os

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 IPv4 (Internet Protocol v4).

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1,22 +1,11 @@
-#############################################################################
-#                                                                           #
-#  inet6.py --- IPv6 support for Scapy                                      #
-#               see http://natisbad.org/IPv6/                               #
-#               for more information                                        #
-#                                                                           #
-#  Copyright (C) 2005  Guillaume Valadon <guedou@hongo.wide.ad.jp>          #
-#                      Arnaud Ebalard <arnaud.ebalard@eads.net>             #
-#                                                                           #
-#  This program is free software; you can redistribute it and/or modify it  #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation.                               #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#                                                                           #
-#############################################################################
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Guillaume Valadon <guedou@hongo.wide.ad.jp>
+# Copyright (C) Arnaud Ebalard <arnaud.ebalard@eads.net>
+
+# Cool history about this file: http://natisbad.org/scapy/index.html
+
 
 """
 IPv6 (Internet Protocol v6).

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -1,17 +1,8 @@
-#############################################################################
-#  ipsec.py --- IPsec support for Scapy                                     #
-#                                                                           #
-#  Copyright (C) 2014  6WIND                                                #
-#                                                                           #
-#  This program is free software; you can redistribute it and/or modify it  #
-#  under the terms of the GNU General Public License version 2 as           #
-#  published by the Free Software Foundation.                               #
-#                                                                           #
-#  This program is distributed in the hope that it will be useful, but      #
-#  WITHOUT ANY WARRANTY; without even the implied warranty of               #
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        #
-#  General Public License for more details.                                 #
-#############################################################################
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2014 6WIND
+
 r"""
 IPsec layer
 ===========

--- a/scapy/layers/ir.py
+++ b/scapy/layers/ir.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 IrDA infrared data communication.

--- a/scapy/layers/isakmp.py
+++ b/scapy/layers/isakmp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 ISAKMP (Internet Security Association and Key Management Protocol).

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Classes and functions for layer 2 protocols.

--- a/scapy/layers/l2tp.py
+++ b/scapy/layers/l2tp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 L2TP (Layer 2 Tunneling Protocol) for VPNs.

--- a/scapy/layers/ldap.py
+++ b/scapy/layers/ldap.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
-# This program is published under a GPLv2 license
 
 """
 LDAP

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 LLMNR (Link Local Multicast Node Resolution).

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """LLTD Protocol
 

--- a/scapy/layers/mgcp.py
+++ b/scapy/layers/mgcp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 MGCP (Media Gateway Control Protocol)

--- a/scapy/layers/mobileip.py
+++ b/scapy/layers/mobileip.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Mobile IP.

--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 NetBIOS over TCP/IP

--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+
 # Netflow V5 appended by spaceB0x and Guillaume Valadon
-# Netflow V9/10 appended ny Gabriel Potter
+# Netflow V9/10 appended by Gabriel Potter
 
 """
 Cisco NetFlow protocol v1, v5, v9 and v10 (IPFix)

--- a/scapy/layers/ntlm.py
+++ b/scapy/layers/ntlm.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Philippe Biondi <gabriel[]potter[]fr>
 
 """
 NTLM

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 NTP (Network Time Protocol).

--- a/scapy/layers/pflog.py
+++ b/scapy/layers/pflog.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 PFLog: OpenBSD PF packet filter logging.

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 PPP (Point to Point Protocol)

--- a/scapy/layers/pptp.py
+++ b/scapy/layers/pptp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Jan Sebechlebsky <sebechlebskyjan@gmail.com>
-# This program is published under a GPLv2 license
 
 """
 PPTP (Point to Point Tunneling Protocol)

--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Vincent Mauge   <vmauge.nospam@nospam.gmail.com>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Acknowledgment: Vincent Mauge <vmauge.nospam@nospam.gmail.com>
 
 """
 RADIUS (Remote Authentication Dial In User Service)

--- a/scapy/layers/rip.py
+++ b/scapy/layers/rip.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 RIP (Routing Information Protocol).

--- a/scapy/layers/rtp.py
+++ b/scapy/layers/rtp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 RTP (Real-time Transport Protocol).

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) 6WIND <olivier.matz@6wind.com>
-# This program is published under a GPLv2 license
 
 """
 SCTP (Stream Control Transmission Protocol).

--- a/scapy/layers/sixlowpan.py
+++ b/scapy/layers/sixlowpan.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Cesar A. Bernardini <mesarpe@gmail.com>
 #               Intern at INRIA Grand Nancy Est
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 """
 6LoWPAN Protocol Stack
 ======================

--- a/scapy/layers/skinny.py
+++ b/scapy/layers/skinny.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Skinny Call Control Protocol (SCCP)

--- a/scapy/layers/smb.py
+++ b/scapy/layers/smb.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 SMB (Server Message Block), also known as CIFS.

--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 SMB (Server Message Block), also known as CIFS - version 2

--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 SNMP (Simple Network Management Protocol).

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 TFTP (Trivial File Transfer Protocol).

--- a/scapy/layers/tls/__init__.py
+++ b/scapy/layers/tls/__init__.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard <arno@natisbad.com>
 #               2015, 2016, 2017 Maxence Tury <maxence.tury@ssi.gouv.fr>
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 Tools for handling TLS sessions and digital certificates.

--- a/scapy/layers/tls/all.py
+++ b/scapy/layers/tls/all.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Aggregate top level objects from all TLS modules.

--- a/scapy/layers/tls/automaton.py
+++ b/scapy/layers/tls/automaton.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 The _TLSAutomaton class provides methods common to both TLS client and server.

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS client automaton. This makes for a primitive TLS stack.

--- a/scapy/layers/tls/automaton_srv.py
+++ b/scapy/layers/tls/automaton_srv.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS server automaton. This makes for a primitive TLS stack.

--- a/scapy/layers/tls/basefields.py
+++ b/scapy/layers/tls/basefields.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS base fields, used for record parsing/building. As several operations depend

--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2008 Arnaud Ebalard <arnaud.ebalard@eads.net>
 #                                   <arno@natisbad.org>
 #   2015, 2016, 2017 Maxence Tury   <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
 
 """
 High-level methods for PKI objects (X.509 certificates, CRLs, asymmetric keys).

--- a/scapy/layers/tls/crypto/__init__.py
+++ b/scapy/layers/tls/crypto/__init__.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #                     2015, 2016 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Cryptographic capabilities for TLS.

--- a/scapy/layers/tls/crypto/all.py
+++ b/scapy/layers/tls/crypto/all.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Aggregate some TLS crypto objects.

--- a/scapy/layers/tls/crypto/cipher_aead.py
+++ b/scapy/layers/tls/crypto/cipher_aead.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Authenticated Encryption with Associated Data ciphers.

--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Block ciphers.

--- a/scapy/layers/tls/crypto/cipher_stream.py
+++ b/scapy/layers/tls/crypto/cipher_stream.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Stream ciphers.

--- a/scapy/layers/tls/crypto/ciphers.py
+++ b/scapy/layers/tls/crypto/ciphers.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS ciphers.

--- a/scapy/layers/tls/crypto/common.py
+++ b/scapy/layers/tls/crypto/common.py
@@ -1,6 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 TLS ciphers.

--- a/scapy/layers/tls/crypto/compression.py
+++ b/scapy/layers/tls/crypto/compression.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS compression.

--- a/scapy/layers/tls/crypto/groups.py
+++ b/scapy/layers/tls/crypto/groups.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 This is a register for DH groups from RFC 3526 and RFC 4306.

--- a/scapy/layers/tls/crypto/h_mac.py
+++ b/scapy/layers/tls/crypto/h_mac.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 HMAC classes.

--- a/scapy/layers/tls/crypto/hash.py
+++ b/scapy/layers/tls/crypto/hash.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Hash classes.

--- a/scapy/layers/tls/crypto/hkdf.py
+++ b/scapy/layers/tls/crypto/hkdf.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Stateless HKDF for TLS 1.3.

--- a/scapy/layers/tls/crypto/kx_algs.py
+++ b/scapy/layers/tls/crypto/kx_algs.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 Key Exchange algorithms as listed in appendix C of RFC 4346.

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2008 Arnaud Ebalard <arno@natisbad.org>
 #   2015, 2016, 2017 Maxence Tury <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
 
 """
 PKCS #1 methods as defined in RFC 3447.

--- a/scapy/layers/tls/crypto/prf.py
+++ b/scapy/layers/tls/crypto/prf.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
-# 2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
+#               2015, 2016, 2017 Maxence Tury
 
 """
 TLS Pseudorandom Function.

--- a/scapy/layers/tls/crypto/suites.py
+++ b/scapy/layers/tls/crypto/suites.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS cipher suites.

--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS handshake extensions.

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS handshake fields & logic.

--- a/scapy/layers/tls/handshake_sslv2.py
+++ b/scapy/layers/tls/handshake_sslv2.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 SSLv2 handshake fields & logic.

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS key exchange logic.

--- a/scapy/layers/tls/keyexchange_tls13.py
+++ b/scapy/layers/tls/keyexchange_tls13.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS 1.3 key exchange logic.

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
 #               2019 Gabriel Potter
-# This program is published under a GPLv2 license
 
 """
 Common TLS fields & bindings.

--- a/scapy/layers/tls/record_sslv2.py
+++ b/scapy/layers/tls/record_sslv2.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 SSLv2 Record.

--- a/scapy/layers/tls/record_tls13.py
+++ b/scapy/layers/tls/record_tls13.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 Common TLS 1.3 fields & bindings.

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
 #               2019 Romain Perez
-# This program is published under a GPLv2 license
 
 """
 TLS session handler.

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) 2007, 2008, 2009 Arnaud Ebalard
 #               2015, 2016, 2017 Maxence Tury
-# This program is published under a GPLv2 license
 
 """
 TLS helpers, provided as out-of-context methods.

--- a/scapy/layers/tuntap.py
+++ b/scapy/layers/tuntap.py
@@ -1,9 +1,8 @@
-# -*- mode: python3; indent-tabs-mode: nil; tab-width: 4 -*-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
-# This program is published under a GPLv2 license
 
 """
 Implementation of TUN/TAP interfaces.

--- a/scapy/layers/usb.py
+++ b/scapy/layers/usb.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """
 Default USB frames & Basic implementation

--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) 6WIND <olivier.matz@6wind.com>
-# This program is published under a GPLv2 license
 
 """
 VRRP (Virtual Router Redundancy Protocol).

--- a/scapy/layers/vxlan.py
+++ b/scapy/layers/vxlan.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Virtual eXtensible Local Area Network (VXLAN)

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -1,8 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# Enhanced by Maxence Tury <maxence.tury@ssi.gouv.fr>
-# This program is published under a GPLv2 license
+# Acknowledgment: Maxence Tury <maxence.tury@ssi.gouv.fr>
+
+# Cool history about this file: http://natisbad.org/scapy/index.html
 
 """
 X.509 certificates.

--- a/scapy/layers/zigbee.py
+++ b/scapy/layers/zigbee.py
@@ -1,11 +1,10 @@
-# This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Ryan Speers <ryan@rmspeers.com> 2011-2012
 # Copyright (C) Roger Meyer <roger.meyer@csus.edu>: 2012-03-10 Added frames
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>: 2018
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>: 2018
 # Copyright (C) 2020-2021 Dimitrios-Georgios Akestoridis <akestoridis@cmu.edu>
-# This program is published under a GPLv2 license
 
 """
 ZigBee bindings for IEEE 802.15.4.

--- a/scapy/libs/__init__.py
+++ b/scapy/libs/__init__.py
@@ -1,6 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 Library bindings

--- a/scapy/libs/ethertypes.py
+++ b/scapy/libs/ethertypes.py
@@ -1,5 +1,5 @@
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 
 """
 /*

--- a/scapy/libs/matplot.py
+++ b/scapy/libs/matplot.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 External link to matplotlib

--- a/scapy/libs/six.py
+++ b/scapy/libs/six.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# This file is published as part of Scapy under GPLv2 or later
+# This file is published as part of Scapy
 
 """Utilities for writing code that runs on Python 2 and 3"""
 

--- a/scapy/libs/structures.py
+++ b/scapy/libs/structures.py
@@ -1,6 +1,6 @@
-# This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
+# # This file is part of Scapy
+# See https://scapy.net/ for more information
 
 """
 Commonly used structures shared across Scapy

--- a/scapy/libs/test_pyx.py
+++ b/scapy/libs/test_pyx.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 External link to pyx

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Massimo Ciani (2009)
-#               Gabriel Potter (2016-2019)
-# This program is published under a GPLv2 license
+# Copyright (C) Gabriel Potter
 
 # Modified for scapy's usage - To support Npcap/Monitor mode
 

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Main module for interactive startup.

--- a/scapy/modules/__init__.py
+++ b/scapy/modules/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Package of extension modules that have to be loaded explicitly.

--- a/scapy/modules/krack/__init__.py
+++ b/scapy/modules/krack/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 """Module implementing Krack Attack on client, as a custom WPA Access Point
 
 Requires the python cryptography package v1.7+. See https://cryptography.io/

--- a/scapy/modules/krack/automaton.py
+++ b/scapy/modules/krack/automaton.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 import hmac
 import hashlib
 from itertools import count

--- a/scapy/modules/krack/crypto.py
+++ b/scapy/modules/krack/crypto.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 import hashlib
 import hmac
 from struct import unpack, pack

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """Clone of Nmap's first generation OS fingerprinting.
 

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Clone of p0f v3 passive OS fingerprinting

--- a/scapy/modules/p0fv2.py
+++ b/scapy/modules/p0fv2.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Clone of p0f v2 passive OS fingerprinting

--- a/scapy/modules/voip.py
+++ b/scapy/modules/voip.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 VoIP (Voice over IP) related functions

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Packet class

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 from __future__ import print_function
 import os

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 PacketList: holds several packets and allows to do operations on them.

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Convert IPv6 addresses between textual representation and binary.

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Routing and handling of network interfaces.

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
 # Copyright (C) 2005  Guillaume Valadon <guedou@hongo.wide.ad.jp>
 #                     Arnaud Ebalard <arnaud.ebalard@eads.net>
 

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 from __future__ import print_function
 import socket

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Functions to send and receive packets.

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 Sessions: decode flow of packets when sniffing

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 SuperSocket.

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Color themes for the interactive console.

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Unit testing infrastructure for Scapy

--- a/scapy/tools/__init__.py
+++ b/scapy/tools/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 Additional tools to be run separately

--- a/scapy/tools/automotive/__init__.py
+++ b/scapy/tools/automotive/__init__.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 """
 Automotive related tools to be run separately

--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -1,8 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
 # Copyright (C) Alexander Schroeder <alexander1.schroeder@st.othr.de>
-# This program is published under a GPLv2 license
 
 from __future__ import print_function
 

--- a/scapy/tools/automotive/obdscanner.py
+++ b/scapy/tools/automotive/obdscanner.py
@@ -1,11 +1,9 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Andreas Korb <andreas.korb@e-mundo.de>
 # Copyright (C) Friedrich Feigel <friedrich.feigel@e-mundo.de>
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 from __future__ import print_function
 

--- a/scapy/tools/automotive/xcpscanner.py
+++ b/scapy/tools/automotive/xcpscanner.py
@@ -1,11 +1,9 @@
-#! /usr/bin/env python
-
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Fabian Wiche <f.wiche@gmx.de>
 # Copyright (C) Tabea Spahn <tabea.spahn@e-mundo.de>
 
-# This program is published under a GPLv2 license
 import argparse
 import signal
 import sys

--- a/scapy/tools/check_asdis.py
+++ b/scapy/tools/check_asdis.py
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Philippe Biondi <phil@secdev.org>
+
 from __future__ import print_function
 import getopt
 

--- a/scapy/tools/generate_ethertypes.py
+++ b/scapy/tools/generate_ethertypes.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# Copyright (C) Gabriel Potter <gabriel@potter.fr>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter <gabriel[]potter[]fr>
 
 """Generate the ethertypes file (/etc/ethertypes) based on the OpenBSD source
 https://github.com/openbsd/src/blob/master/sys/net/ethertypes.h

--- a/scapy/tools/scapy_pyannotate.py
+++ b/scapy/tools/scapy_pyannotate.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
-# Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
+# See https://scapy.net/ for more information
 
 """
 Wrap Scapy's shell in pyannotate.

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
 
 """
 General utility functions.

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
-# This program is published under a GPLv2 license
-
 # Copyright (C) 2005  Guillaume Valadon <guedou@hongo.wide.ad.jp>
 #                     Arnaud Ebalard <arnaud.ebalard@eads.net>
 

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -1,9 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Philippe Biondi <phil@secdev.org>
 # Copyright (C) Michael Farrell <micolous+git@gmail.com>
 # Copyright (C) Gauthier Sebaux
-# This program is published under a GPLv2 license
 
 """
 Fields that hold random numbers.

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     description='Scapy: interactive packet manipulation tool',
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
-    license='GPLv2',
+    license='GPL-2.0-only',
     url='https://scapy.net',
     project_urls={
         'Documentation': 'https://scapy.readthedocs.io',

--- a/test/benchmark/common.py
+++ b/test/benchmark/common.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Guillaume Valadon
-# This program is published under a GPLv2 license
 
 import os
 import sys

--- a/test/benchmark/dissection_and_build.py
+++ b/test/benchmark/dissection_and_build.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Guillaume Valadon
-# This program is published under a GPLv2 license
 
 from common import *
 import time

--- a/test/benchmark/latency_router.py
+++ b/test/benchmark/latency_router.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Gabriel Potter
-# This program is published under a GPLv2 license
 
 
 # https://github.com/secdev/scapy/issues/1791

--- a/test/contrib/automotive/interface_mockup.py
+++ b/test/contrib/automotive/interface_mockup.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 
 # """ Default imports required for setup of CAN interfaces  """

--- a/test/testsocket.py
+++ b/test/testsocket.py
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
-# See http://www.secdev.org/projects/scapy for more information
+# See https://scapy.net/ for more information
 # Copyright (C) Nils Weiss <nils@we155.de>
-# This program is published under a GPLv2 license
 
 # scapy.contrib.description = TestSocket library for unit tests
 # scapy.contrib.status = library

--- a/test/tls/__init__.py
+++ b/test/tls/__init__.py
@@ -1,6 +1,7 @@
-## This file is part of Scapy
-## Copyright (C) 2016 Maxence Tury <maxence.tury@ssi.gouv.fr>
-## This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) 2016 Maxence Tury <maxence.tury@ssi.gouv.fr>
 
 """
 Examples and test PKI for the TLS module.

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-## This file is part of Scapy
-## This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 
 """
 Basic TLS client. A ciphersuite may be commanded via a first argument.

--- a/test/tls/example_server.py
+++ b/test/tls/example_server.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-## This file is part of Scapy
-## This program is published under a GPLv2 license
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
 
 """
 Basic TLS server. A preferred ciphersuite may be provided as first argument.


### PR DESCRIPTION
- Adds SPDX License identifiers as discussed in https://github.com/secdev/scapy/issues/3321
- removes all of the repeated GPLv2 headers

**Now that the format is standard, we can easily tweak it / change it were we to change our minds**

Notes:
- Quite a bunch of files were licensed under `GPL-2.0-or-later`. Of course we aren't changing that
- Relicensing ldp.py according to https://github.com/secdev/scapy/issues/3478

**If any of you would like to change one of their old email addresses, now is the time ! Feel free to just tell me and I'll update them**

fixes https://github.com/secdev/scapy/issues/3321
fixes https://github.com/secdev/scapy/issues/3478

```bash
$ grep -R GPL-2.0-only | wc -l
264
$ grep -R GPL-2.0-or-later | wc -l
70
$ grep -R GPL-3.0 | wc -l
1
```