### PR TITLE
Set flake's max-line-length to 88 (black)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ commands = flake8 scapy/
 # flake8 configuration
 [flake8]
 ignore = E731, W504
-max-line-length = 88  # same as black
+max-line-length = 88
 per-file-ignores =
     scapy/all.py:F403,F401
     scapy/asn1/mib.py:E501

--- a/tox.ini
+++ b/tox.ini
@@ -140,6 +140,7 @@ commands = flake8 scapy/
 # flake8 configuration
 [flake8]
 ignore = E731, W504
+max-line-length = 88  # same as black
 per-file-ignores =
     scapy/all.py:F403,F401
     scapy/asn1/mib.py:E501


### PR DESCRIPTION
For consistency with black, the other main linter, let's slightly increase the max line length to something that makes more sense (79 is pain)