### PR TITLE
[Hinty] Core typing: windows

### DIFF
--- a/.config/mypy/mypy.ini
+++ b/.config/mypy/mypy.ini
@@ -8,6 +8,9 @@ ignore_missing_imports = True
 
 # Layers specific config
 
+[mypy-scapy.arch.*]
+implicit_reexport = True
+
 [mypy-scapy.layers.*,scapy.contrib.*]
 warn_return_any = False
 

--- a/.config/mypy/mypy_check.py
+++ b/.config/mypy/mypy_check.py
@@ -22,6 +22,16 @@ import sys
 
 from mypy.main import main as mypy_main
 
+# Check platform arg
+
+PLATFORM = None
+
+if len(sys.argv) >= 2:
+    if len(sys.argv) > 2:
+        print("Usage: mypy_check.py [platform]")
+        sys.exit(1)
+    PLATFORM = sys.argv[1]
+
 # Load files
 
 localdir = os.path.split(__file__)[0]
@@ -31,7 +41,7 @@ with io.open(os.path.join(localdir, "mypy_enabled.txt")) as fd:
 
 if not FILES:
     print("No files specified. Arborting")
-    sys.exit(0)
+    sys.exit(1)
 
 # Generate mypy arguments
 
@@ -60,9 +70,11 @@ ARGS = [
         )
     ),
     "--show-traceback",
-] + [os.path.abspath(f) for f in FILES]
+] + ([
+    "--platform=" + PLATFORM
+] if PLATFORM else [])
 
-if sys.platform.startswith("linux"):
+if PLATFORM.startswith("linux"):
     ARGS.extend([
         "--always-true=LINUX",
         "--always-false=OPENBSD",
@@ -72,7 +84,8 @@ if sys.platform.startswith("linux"):
         "--always-false=WINDOWS",
         "--always-false=BSD",
     ])
-if sys.platform.startswith("win32"):
+    FILES = [x for x in FILES if not x.startswith("scapy/arch/windows")]
+elif PLATFORM.startswith("win32"):
     ARGS.extend([
         "--always-false=LINUX",
         "--always-false=OPENBSD",
@@ -83,7 +96,23 @@ if sys.platform.startswith("win32"):
         "--always-false=WINDOWS_XP",
         "--always-false=BSD",
     ])
+    FILES = [
+        x for x in FILES if (
+            x not in [
+                # Disabled on Windows
+                "scapy/arch/linux.py",
+                "scapy/arch/solaris.py",
+                "scapy/contrib/cansocket_native.py",
+                "scapy/contrib/isotp/isotp_native_socket.py",
+            ]
+        ) and not x.startswith("scapy/arch/bpf")
+    ]
+else:
+    raise ValueError("Unknown platform")
 
 # Run mypy over the files
+ARGS += [
+    os.path.abspath(f) for f in FILES
+]
 
 mypy_main(None, sys.stdout, sys.stderr, ARGS)

--- a/.config/mypy/mypy_check.py
+++ b/.config/mypy/mypy_check.py
@@ -98,13 +98,13 @@ elif PLATFORM.startswith("win32"):
     ])
     FILES = [
         x for x in FILES if (
-            x not in [
+            x not in {
                 # Disabled on Windows
                 "scapy/arch/linux.py",
                 "scapy/arch/solaris.py",
                 "scapy/contrib/cansocket_native.py",
                 "scapy/contrib/isotp/isotp_native_socket.py",
-            ]
+            }
         ) and not x.startswith("scapy/arch/bpf")
     ]
 else:

--- a/.config/mypy/mypy_deployment_stats.py
+++ b/.config/mypy/mypy_deployment_stats.py
@@ -30,7 +30,7 @@ ALL_FILES = [
 # Process
 
 REMAINING = defaultdict(list)
-MODULES = defaultdict(lambda: (0, 0))
+MODULES = defaultdict(lambda: (0, 0, 0, 0))
 
 for f in ALL_FILES:
     with open(os.path.join(rootpath, f)) as fd:
@@ -40,21 +40,24 @@ for f in ALL_FILES:
         mod = parts[1]
     else:
         mod = "[core]"
-    e, l = MODULES[mod]
+    e, l, t, a = MODULES[mod]
     if f in FILES:
         e += lines
+        t += 1
     else:
         REMAINING[mod].append(f)
     l += lines
-    MODULES[mod] = (e, l)
+    a += 1
+    MODULES[mod] = (e, l, t, a)
 
 ENABLED = sum(x[0] for x in MODULES.values())
 TOTAL = sum(x[1] for x in MODULES.values())
 
-print("*The numbers correspond to the amount of lines per files processed*")
 print("**MyPy Support: %.2f%%**" % (ENABLED / TOTAL * 100))
+print("| Module | Typed code (lines) | Typed files |")
+print("| --- | --- | --- |")
 for mod, dat in MODULES.items():
-    print("- `%s`: %.2f%%" % (mod, dat[0] / dat[1] * 100))
+    print("|`%s` | %.2f%% | %s/%s |" % (mod, dat[0] / dat[1] * 100, dat[2], dat[3]))
 
 print()
 COREMODS = REMAINING["[core]"]

--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -15,6 +15,9 @@ scapy/arch/libpcap.py
 scapy/arch/linux.py
 scapy/arch/unix.py
 scapy/arch/solaris.py
+scapy/arch/windows/__init__.py
+scapy/arch/windows/native.py
+scapy/arch/windows/structures.py
 scapy/as_resolvers.py
 scapy/asn1/__init__.py
 scapy/asn1/asn1.py

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -7,8 +7,8 @@
 Operating system specific functionality.
 """
 
-from __future__ import absolute_import
 import socket
+import sys
 
 from scapy.compat import orb
 from scapy.config import conf, _set_conf_sockets
@@ -20,7 +20,7 @@ from scapy.data import (
     ARPHDR_TUN,
     IPV6_ADDR_GLOBAL
 )
-from scapy.error import Scapy_Exception
+from scapy.error import log_loading, Scapy_Exception
 from scapy.interfaces import NetworkInterface, network_name
 from scapy.pton_ntop import inet_pton, inet_ntop
 
@@ -46,6 +46,7 @@ __all__ = [  # noqa: F405
     "in6_getifaddr",
     "read_routes",
     "read_routes6",
+    "SIOCGIFHWADDR",
 ]
 
 # BACKWARD COMPATIBILITY
@@ -60,7 +61,7 @@ from scapy.interfaces import (
 
 def str2mac(s):
     # Duplicated from scapy/utils.py for import reasons
-    # type: (str) -> str
+    # type: (bytes) -> str
     return ("%02x:" * 6)[:-1] % tuple(orb(x) for x in s)
 
 
@@ -77,7 +78,8 @@ def get_if_hwaddr(iff):
     """
     Returns the MAC (hardware) address of an interface
     """
-    addrfamily, mac = get_if_raw_hwaddr(iff)  # type: ignore # noqa: F405
+    from scapy.arch import get_if_raw_hwaddr
+    addrfamily, mac = get_if_raw_hwaddr(iff)  # noqa: F405
     if addrfamily in [ARPHDR_ETHER, ARPHDR_LOOPBACK, ARPHDR_PPP, ARPHDR_TUN]:
         return str2mac(mac)
     else:
@@ -130,11 +132,18 @@ elif BSD:
         # Native
         from scapy.arch.bpf.supersocket import *  # noqa F403
         conf.use_bpf = True
+    SIOCGIFHWADDR = 0  # mypy compat
 elif SOLARIS:
     from scapy.arch.solaris import *  # noqa F403
 elif WINDOWS:
     from scapy.arch.windows import *  # noqa F403
     from scapy.arch.windows.native import *  # noqa F403
+    SIOCGIFHWADDR = 0  # mypy compat
+else:
+    log_loading.critical(
+        "Scapy currently does not support %s! I/O will NOT work!" % sys.platform
+    )
+    SIOCGIFHWADDR = 0  # mypy compat
 
 if LINUX or BSD:
     conf.load_layers.append("tuntap")

--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -21,8 +21,8 @@ import subprocess
 
 import scapy
 from scapy.arch.bpf.consts import BIOCSETF, SIOCGIFFLAGS, BIOCSETIF
-from scapy.arch.common import get_if, compile_filter, _iff_flags
-from scapy.arch.unix import in6_getifaddr
+from scapy.arch.common import compile_filter, _iff_flags
+from scapy.arch.unix import get_if, in6_getifaddr
 from scapy.compat import plain_str
 from scapy.config import conf
 from scapy.consts import LINUX

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -29,9 +29,8 @@ from scapy.consts import LINUX
 from scapy.arch.common import (
     _iff_flags,
     compile_filter,
-    get_if,
-    get_if_raw_hwaddr,
 )
+from scapy.arch.unix import get_if, get_if_raw_hwaddr
 from scapy.config import conf
 from scapy.data import MTU, ETH_P_ALL, SOL_PACKET, SO_ATTACH_FILTER, \
     SO_TIMESTAMPNS

--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -20,11 +20,12 @@ SIOCGIFHWADDR = 0xc02069b9  # Get hardware address
 
 from scapy.arch.libpcap import *  # noqa: F401, F403, E402
 from scapy.arch.unix import *  # noqa: F401, F403, E402
-from scapy.arch.common import get_if_raw_hwaddr  # noqa: F401, F403, E402
+
+from scapy.interfaces import NetworkInterface  # noqa: E402
 
 
 def get_working_if():
-    # type: () -> str
+    # type: () -> NetworkInterface
     """Return an interface that works"""
     try:
         # return the interface associated with the route with smallest
@@ -33,4 +34,4 @@ def get_working_if():
     except ValueError:
         # no route
         iface = conf.loopback_name
-    return iface
+    return conf.ifaces.dev_from_name(iface)

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -450,7 +450,7 @@ class _CanvasDumpExtended(object):
         if filename is None:
             fname = get_temp_file(autoext=kargs.get("suffix", ".eps"))
             canvas.writeEPSfile(fname)
-            if WINDOWS and conf.prog.psreader is None:
+            if WINDOWS and not conf.prog.psreader:
                 os.startfile(fname)
             else:
                 with ContextManagerSubprocess(conf.prog.psreader):
@@ -475,7 +475,7 @@ class _CanvasDumpExtended(object):
         if filename is None:
             fname = get_temp_file(autoext=kargs.get("suffix", ".pdf"))
             canvas.writePDFfile(fname)
-            if WINDOWS and conf.prog.pdfreader is None:
+            if WINDOWS and not conf.prog.pdfreader:
                 os.startfile(fname)
             else:
                 with ContextManagerSubprocess(conf.prog.pdfreader):
@@ -500,7 +500,7 @@ class _CanvasDumpExtended(object):
         if filename is None:
             fname = get_temp_file(autoext=kargs.get("suffix", ".svg"))
             canvas.writeSVGfile(fname)
-            if WINDOWS and conf.prog.svgreader is None:
+            if WINDOWS and not conf.prog.svgreader:
                 os.startfile(fname)
             else:
                 with ContextManagerSubprocess(conf.prog.svgreader):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -232,6 +232,7 @@ else:
     class AddressFamily:
         AF_INET = socket.AF_INET
         AF_INET6 = socket.AF_INET6
+        AF_UNSPEC = socket.AF_UNSPEC
 
 
 ###########

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -41,7 +41,7 @@ from scapy.layers.l2 import CookedLinux, Ether, GRE, Loopback, SNAP
 import scapy.libs.six as six
 from scapy.packet import bind_layers, Packet, Raw
 from scapy.sendrecv import sendp, sniff, sr, srp1
-from scapy.supersocket import SuperSocket, L3RawSocket
+from scapy.supersocket import SuperSocket
 from scapy.utils import checksum, strxor
 from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.utils6 import in6_getnsma, in6_getnsmac, in6_isaddr6to4, \
@@ -3368,12 +3368,15 @@ def traceroute6(target, dport=80, minttl=1, maxttl=30, sport=RandShort(),
 #############################################################################
 
 
-class L3RawSocket6(L3RawSocket):
-    def __init__(self, type=ETH_P_IPV6, filter=None, iface=None, promisc=None, nofilter=0):  # noqa: E501
-        # NOTE: if fragmentation is needed, it will be done by the kernel (RFC 2292)  # noqa: E501
-        self.outs = socket.socket(socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
-        self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
-        self.iface = iface
+if not WINDOWS:
+    from scapy.supersocket import L3RawSocket
+
+    class L3RawSocket6(L3RawSocket):
+        def __init__(self, type=ETH_P_IPV6, filter=None, iface=None, promisc=None, nofilter=0):  # noqa: E501
+            # NOTE: if fragmentation is needed, it will be done by the kernel (RFC 2292)  # noqa: E501
+            self.outs = socket.socket(socket.AF_INET6, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
+            self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
+            self.iface = iface
 
 
 def IPv6inIP(dst='203.178.135.36', src=None):

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -690,7 +690,13 @@ class TermSink(Sink):
                 self.name = "Scapy" if self.name is None else self.name
                 # Start a powershell in a new window and print the PID
                 cmd = "$app = Start-Process PowerShell -ArgumentList '-command &{$host.ui.RawUI.WindowTitle=\\\"%s\\\";Get-Content \\\"%s\\\" -wait}' -passthru; echo $app.Id" % (self.name, self.__f.replace("\\", "\\\\"))  # noqa: E501
-                proc = subprocess.Popen([conf.prog.powershell, cmd], stdout=subprocess.PIPE)  # noqa: E501
+                proc = subprocess.Popen(
+                    [
+                        getattr(conf.prog, "powershell"),
+                        cmd
+                    ],
+                    stdout=subprocess.PIPE
+                )
                 output, _ = proc.communicate()
                 # This is the process PID
                 self.pid = int(output)

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -111,7 +111,7 @@ class SuperSocket:
         else:
             return 0
 
-    if six.PY2:
+    if six.PY2 or WINDOWS:
         def _recv_raw(self, sock, x):
             # type: (socket.socket, int) -> Tuple[bytes, Any, Optional[float]]
             """Internal function to receive a Packet"""
@@ -283,96 +283,97 @@ class SuperSocket:
         self.close()
 
 
-class L3RawSocket(SuperSocket):
-    desc = "Layer 3 using Raw sockets (PF_INET/SOCK_RAW)"
+if not WINDOWS:
+    class L3RawSocket(SuperSocket):
+        desc = "Layer 3 using Raw sockets (PF_INET/SOCK_RAW)"
 
-    def __init__(self,
-                 type=ETH_P_IP,  # type: int
-                 filter=None,  # type: Optional[str]
-                 iface=None,  # type: Optional[_GlobInterfaceType]
-                 promisc=None,  # type: Optional[bool]
-                 nofilter=0  # type: int
-                 ):
-        # type: (...) -> None
-        self.outs = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
-        self.outs.setsockopt(socket.SOL_IP, socket.IP_HDRINCL, 1)
-        self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
-        if iface is not None:
-            iface = network_name(iface)
-            self.iface = iface
-            self.ins.bind((iface, type))
-        else:
-            self.iface = "any"
-        if not six.PY2:
+        def __init__(self,
+                     type=ETH_P_IP,  # type: int
+                     filter=None,  # type: Optional[str]
+                     iface=None,  # type: Optional[_GlobInterfaceType]
+                     promisc=None,  # type: Optional[bool]
+                     nofilter=0  # type: int
+                     ):
+            # type: (...) -> None
+            self.outs = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_RAW)  # noqa: E501
+            self.outs.setsockopt(socket.SOL_IP, socket.IP_HDRINCL, 1)
+            self.ins = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))  # noqa: E501
+            if iface is not None:
+                iface = network_name(iface)
+                self.iface = iface
+                self.ins.bind((iface, type))
+            else:
+                self.iface = "any"
+            if not six.PY2:
+                try:
+                    # Receive Auxiliary Data (VLAN tags)
+                    self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
+                    self.ins.setsockopt(
+                        socket.SOL_SOCKET,
+                        SO_TIMESTAMPNS,
+                        1
+                    )
+                    self.auxdata_available = True
+                except OSError:
+                    # Note: Auxiliary Data is only supported since
+                    #       Linux 2.6.21
+                    msg = "Your Linux Kernel does not support Auxiliary Data!"
+                    log_runtime.info(msg)
+
+        def recv(self, x=MTU):
+            # type: (int) -> Optional[Packet]
+            data, sa_ll, ts = self._recv_raw(self.ins, x)
+            if sa_ll[2] == socket.PACKET_OUTGOING:
+                return None
+            if sa_ll[3] in conf.l2types:
+                cls = conf.l2types.num2layer[sa_ll[3]]  # type: Type[Packet]
+                lvl = 2
+            elif sa_ll[1] in conf.l3types:
+                cls = conf.l3types.num2layer[sa_ll[1]]
+                lvl = 3
+            else:
+                cls = conf.default_l2
+                warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3], cls.name)  # noqa: E501
+                lvl = 3
+
             try:
-                # Receive Auxiliary Data (VLAN tags)
-                self.ins.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
-                self.ins.setsockopt(
-                    socket.SOL_SOCKET,
-                    SO_TIMESTAMPNS,
-                    1
-                )
-                self.auxdata_available = True
-            except OSError:
-                # Note: Auxiliary Data is only supported since
-                #       Linux 2.6.21
-                msg = "Your Linux Kernel does not support Auxiliary Data!"
-                log_runtime.info(msg)
-
-    def recv(self, x=MTU):
-        # type: (int) -> Optional[Packet]
-        data, sa_ll, ts = self._recv_raw(self.ins, x)
-        if sa_ll[2] == socket.PACKET_OUTGOING:
-            return None
-        if sa_ll[3] in conf.l2types:
-            cls = conf.l2types.num2layer[sa_ll[3]]  # type: Type[Packet]
-            lvl = 2
-        elif sa_ll[1] in conf.l3types:
-            cls = conf.l3types.num2layer[sa_ll[1]]
-            lvl = 3
-        else:
-            cls = conf.default_l2
-            warning("Unable to guess type (interface=%s protocol=%#x family=%i). Using %s", sa_ll[0], sa_ll[1], sa_ll[3], cls.name)  # noqa: E501
-            lvl = 3
-
-        try:
-            pkt = cls(data)
-        except KeyboardInterrupt:
-            raise
-        except Exception:
-            if conf.debug_dissector:
+                pkt = cls(data)
+            except KeyboardInterrupt:
                 raise
-            pkt = conf.raw_layer(data)
+            except Exception:
+                if conf.debug_dissector:
+                    raise
+                pkt = conf.raw_layer(data)
 
-        if lvl == 2:
-            pkt = pkt.payload
+            if lvl == 2:
+                pkt = pkt.payload
 
-        if pkt is not None:
-            if ts is None:
-                from scapy.arch.linux import get_last_packet_timestamp
-                ts = get_last_packet_timestamp(self.ins)
-            pkt.time = ts
-        return pkt
+            if pkt is not None:
+                if ts is None:
+                    from scapy.arch.linux import get_last_packet_timestamp
+                    ts = get_last_packet_timestamp(self.ins)
+                pkt.time = ts
+            return pkt
 
-    def send(self, x):
-        # type: (Packet) -> int
-        try:
-            sx = raw(x)
-            if self.outs:
-                x.sent_time = time.time()
-                return self.outs.sendto(
-                    sx,
-                    (x.dst, 0)
+        def send(self, x):
+            # type: (Packet) -> int
+            try:
+                sx = raw(x)
+                if self.outs:
+                    x.sent_time = time.time()
+                    return self.outs.sendto(
+                        sx,
+                        (x.dst, 0)
+                    )
+            except AttributeError:
+                raise ValueError(
+                    "Missing 'dst' attribute in the first layer to be "
+                    "sent using a native L3 socket ! (make sure you passed the "
+                    "IP layer)"
                 )
-        except AttributeError:
-            raise ValueError(
-                "Missing 'dst' attribute in the first layer to be "
-                "sent using a native L3 socket ! (make sure you passed the "
-                "IP layer)"
-            )
-        except socket.error as msg:
-            log_runtime.error(msg)
-        return 0
+            except socket.error as msg:
+                log_runtime.error(msg)
+            return 0
 
 
 class SimpleSocket(SuperSocket):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -868,8 +868,8 @@ def do_graph(
                 warning("Temporary file '%s' could not be written. Graphic will not be displayed.", tempfile)  # noqa: E501
                 break
         else:
-            if conf.prog.display == conf.prog._default:
-                os.startfile(target.name)  # type: ignore
+            if WINDOWS and conf.prog.display == conf.prog._default:
+                os.startfile(target.name)
             else:
                 with ContextManagerSubprocess(conf.prog.display):
                     subprocess.Popen([conf.prog.display, target.name])

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,8 @@ skip_install = true
 deps = mypy==0.931
        typing
        types-mock
-commands = python .config/mypy/mypy_check.py
+commands = python .config/mypy/mypy_check.py linux
+           python .config/mypy/mypy_check.py win32
 
 
 [testenv:docs]


### PR DESCRIPTION
It's been a long time since I've done one of those.

- Core typing of Windows
- Change the mypy CI to test Linux AND Windows independently
- bunch of fixes everywhere, especially inconsistencies with the use of `NetworkInterface` or `str` in routes, that were sometimes messed up (but it worked because `NetworkInterface` can act as a string for backward compatibility)