### PR TITLE
Add a final empty label (.) on DNS strings

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -284,6 +284,8 @@ class DNSStrField(StrLenField):
     def h2i(self, pkt, x):
         if not x:
             return b"."
+        if x[-1:] != b".":
+            return x + b"."
         return x
 
     def i2m(self, pkt, x):

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -17,6 +17,11 @@ def _test():
 
 dns_ans = retry_test(_test)
 
+= DNS labels
+~ DNS
+query = DNSQR(qname=b"www.secdev.org")
+assert query.qname == query.__class__(raw(query)).qname
+
 = DNS packet manipulation
 ~ netaccess needs_root IP UDP DNS
 dns_ans.show()


### PR DESCRIPTION
The added test should make the reason of this change clear: for now, the `.qname` returned values differ between crafted and captured packets.

Now the `.qname` attribute always shows the final empty label (or final ".").

Reported by @Frky
