### PR TITLE
Add stop event to automotive scanners to trigger async stop

### DIFF
--- a/scapy/contrib/automotive/gm/gmlan.py
+++ b/scapy/contrib/automotive/gm/gmlan.py
@@ -8,15 +8,15 @@
 # scapy.contrib.status = loads
 
 import struct
+
+from scapy.contrib.automotive import log_automotive
 from scapy.fields import ObservableDict, XByteEnumField, ByteEnumField, \
     ConditionalField, XByteField, StrField, XShortEnumField, XShortField, \
     X3BytesField, XIntField, ShortField, PacketField, PacketListField, \
     FieldListField, MultipleTypeField, StrFixedLenField
 from scapy.packet import Packet, bind_layers, NoPayload
 from scapy.config import conf
-from scapy.error import warning, log_loading
 from scapy.contrib.isotp import ISOTP
-
 
 """
 GMLAN
@@ -26,11 +26,11 @@ try:
     if conf.contribs['GMLAN']['treat-response-pending-as-answer']:
         pass
 except KeyError:
-    log_loading.info("Specify \"conf.contribs['GMLAN'] = "
-                     "{'treat-response-pending-as-answer': True}\" to treat "
-                     "a negative response 'RequestCorrectlyReceived-"
-                     "ResponsePending' as answer of a request. \n"
-                     "The default value is False.")
+    log_automotive.info("Specify \"conf.contribs['GMLAN'] = "
+                        "{'treat-response-pending-as-answer': True}\" to treat "
+                        "a negative response 'RequestCorrectlyReceived-"
+                        "ResponsePending' as answer of a request. \n"
+                        "The default value is False.")
     conf.contribs['GMLAN'] = {'treat-response-pending-as-answer': False}
 
 conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] = None
@@ -40,12 +40,14 @@ class GMLAN(ISOTP):
     @staticmethod
     def determine_len(x):
         if conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] is None:
-            warning("Define conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']! "  # noqa: E501
-                    "Assign either 2,3 or 4")
+            log_automotive.warning(
+                "Define conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']! "
+                "Assign either 2,3 or 4")
         if conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] \
                 not in [2, 3, 4]:
-            warning("Define conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']! "  # noqa: E501
-                    "Assign either 2,3 or 4")
+            log_automotive.warning(
+                "Define conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']! "
+                "Assign either 2,3 or 4")
         return conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme'] == x
 
     services = ObservableDict(
@@ -671,6 +673,8 @@ class GMLAN_RDI_BC(Packet):
 
 
 bind_layers(GMLAN_RDI, GMLAN_RDI_BC, subfunction=0x82)
+
+
 # TODO:This function receive single frame responses... (Implement GMLAN Socket)
 
 

--- a/scapy/contrib/automotive/gm/gmlan_scanner.py
+++ b/scapy/contrib/automotive/gm/gmlan_scanner.py
@@ -20,7 +20,7 @@ from scapy.packet import Packet
 import scapy.libs.six as six
 from scapy.config import conf
 from scapy.supersocket import SuperSocket
-from scapy.error import Scapy_Exception, warning
+from scapy.error import Scapy_Exception
 from scapy.contrib.automotive.gm.gmlanutils import GMLAN_InitDiagnostics, \
     GMLAN_TesterPresentSender
 from scapy.contrib.automotive.gm.gmlan import GMLAN, GMLAN_SA, GMLAN_RD, \
@@ -685,7 +685,8 @@ class GMLAN_RMBAEnumerator(GMLAN_Enumerator):
 
             ih.tofile("RMBA_dump.hex", format="hex")
         except ImportError:
-            warning("Install 'intelhex' to create a hex file of the memory")
+            log_automotive.warning(
+                "Install 'intelhex' to create a hex file of the memory")
 
         if dump and s is not None:
             return s + "\n"

--- a/scapy/contrib/automotive/gm/gmlanutils.py
+++ b/scapy/contrib/automotive/gm/gmlanutils.py
@@ -18,7 +18,6 @@ from scapy.config import conf
 from scapy.packet import Packet
 from scapy.supersocket import SuperSocket
 from scapy.contrib.isotp import ISOTPSocket
-from scapy.error import warning, log_loading
 from scapy.utils import PeriodicSenderThread
 
 __all__ = ["GMLAN_TesterPresentSender", "GMLAN_InitDiagnostics",
@@ -26,11 +25,10 @@ __all__ = ["GMLAN_TesterPresentSender", "GMLAN_InitDiagnostics",
            "GMLAN_TransferData", "GMLAN_TransferPayload",
            "GMLAN_ReadMemoryByAddress", "GMLAN_BroadcastSocket"]
 
-
-log_loading.info("\"conf.contribs['GMLAN']"
-                 "['treat-response-pending-as-answer']\" set to True). This "
-                 "is required by the GMLAN-Utils module to operate "
-                 "correctly.")
+log_automotive.info("\"conf.contribs['GMLAN']"
+                    "['treat-response-pending-as-answer']\" set to True). This "
+                    "is required by the GMLAN-Utils module to operate "
+                    "correctly.")
 try:
     conf.contribs['GMLAN']['treat-response-pending-as-answer'] = False
 except KeyError:
@@ -88,6 +86,7 @@ def GMLAN_InitDiagnostics(
     :param unittest: disable delays
     :return: True on success else False
     """
+
     # Helper function
     def _send_and_check_response(sock, req, timeout):
         # type: (SuperSocket, Packet, int) -> bool
@@ -158,7 +157,7 @@ def GMLAN_GetSecurityAccess(
         return False
 
     if level % 2 == 0:
-        warning("Parameter Error: Level must be an odd number.")
+        log_automotive.warning("Parameter Error: Level must be an odd number.")
         return False
 
     while retry >= 0:
@@ -251,9 +250,9 @@ def GMLAN_TransferData(
     startretry = retry
 
     scheme = conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']
-    if addr < 0 or addr >= 2**(8 * scheme):
-        warning("Error: Invalid address %s for scheme %s",
-                hex(addr), str(scheme))
+    if addr < 0 or addr >= 2 ** (8 * scheme):
+        log_automotive.warning("Error: Invalid address %s for scheme %s",
+                               hex(addr), str(scheme))
         return False
 
     # max size of dataRecord according to gmlan protocol
@@ -332,16 +331,16 @@ def GMLAN_ReadMemoryByAddress(
     retry = abs(retry)
 
     scheme = conf.contribs['GMLAN']['GMLAN_ECU_AddressingScheme']
-    if addr < 0 or addr >= 2**(8 * scheme):
-        warning("Error: Invalid address %s for scheme %s",
-                hex(addr), str(scheme))
+    if addr < 0 or addr >= 2 ** (8 * scheme):
+        log_automotive.warning("Error: Invalid address %s for scheme %s",
+                               hex(addr), str(scheme))
         return None
 
     # max size of dataRecord according to gmlan protocol
     if length <= 0 or length > (4094 - scheme):
-        warning("Error: Invalid length %s for scheme %s. "
-                "Choose between 0x1 and %s",
-                hex(length), str(scheme), hex(4094 - scheme))
+        log_automotive.warning("Error: Invalid length %s for scheme %s. "
+                               "Choose between 0x1 and %s",
+                               hex(length), str(scheme), hex(4094 - scheme))
         return None
 
     while retry >= 0:

--- a/scapy/contrib/automotive/obd/obd.py
+++ b/scapy/contrib/automotive/obd/obd.py
@@ -9,13 +9,13 @@
 
 import struct
 
+from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.obd.iid.iids import *
 from scapy.contrib.automotive.obd.mid.mids import *
 from scapy.contrib.automotive.obd.pid.pids import *
 from scapy.contrib.automotive.obd.tid.tids import *
 from scapy.contrib.automotive.obd.services import *
 from scapy.packet import bind_layers, NoPayload
-from scapy.error import log_loading
 from scapy.config import conf
 from scapy.fields import XByteEnumField
 from scapy.contrib.isotp import ISOTP
@@ -24,11 +24,11 @@ try:
     if conf.contribs['OBD']['treat-response-pending-as-answer']:
         pass
 except KeyError:
-    log_loading.info("Specify \"conf.contribs['OBD'] = "
-                     "{'treat-response-pending-as-answer': True}\" to treat "
-                     "a negative response 'requestCorrectlyReceived-"
-                     "ResponsePending' as answer of a request. \n"
-                     "The default value is False.")
+    log_automotive.info("Specify \"conf.contribs['OBD'] = "
+                        "{'treat-response-pending-as-answer': True}\" to treat "
+                        "a negative response 'requestCorrectlyReceived-"
+                        "ResponsePending' as answer of a request. \n"
+                        "The default value is False.")
     conf.contribs['OBD'] = {'treat-response-pending-as-answer': False}
 
 

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -13,6 +13,7 @@ import time
 import copy
 from collections import defaultdict, OrderedDict
 from itertools import chain
+from threading import Event
 
 from scapy.compat import Any, Union, List, Optional, Iterable, \
     Dict, Tuple, Set, Callable, cast, NamedTuple, orb
@@ -327,7 +328,8 @@ class ServiceEnumerator(AutomotiveTestCase):
     def sr1_with_retry_on_error(self, req, socket, state, timeout):
         # type: (Packet, _SocketUnion, EcuState, int) -> Optional[Packet]
         try:
-            res = socket.sr1(req, timeout=timeout, verbose=False, chainEX=True)
+            res = socket.sr1(req, timeout=timeout, verbose=False,
+                             chainEX=True, chainCC=True)
         except (OSError, ValueError, Scapy_Exception) as e:
             if not self._populate_retry(state, req):
                 log_automotive.exception(

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -13,7 +13,6 @@ import time
 import copy
 from collections import defaultdict, OrderedDict
 from itertools import chain
-from threading import Event
 
 from scapy.compat import Any, Union, List, Optional, Iterable, \
     Dict, Tuple, Set, Callable, cast, NamedTuple, orb

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -10,6 +10,7 @@ import abc
 import time
 
 from itertools import product
+from threading import Event
 
 from scapy.compat import Any, Union, List, Optional, \
     Dict, Callable, Type, cast
@@ -77,6 +78,7 @@ class AutomotiveTestCaseExecutor:
         self.configuration = AutomotiveTestCaseExecutorConfiguration(
             test_cases or self.default_test_case_clss, **kwargs)
         self.validate_test_case_kwargs()
+        self._stop_scan_event = Event()
 
     def __reduce__(self):  # type: ignore
         f, t, d = super(AutomotiveTestCaseExecutor, self).__reduce__()  # type: ignore  # noqa: E501
@@ -90,6 +92,10 @@ class AutomotiveTestCaseExecutor:
             pass
         try:
             del d["reconnect_handler"]
+        except KeyError:
+            pass
+        try:
+            del d["_stop_scan_event"]
         except KeyError:
             pass
         return f, t, d
@@ -194,7 +200,9 @@ class AutomotiveTestCaseExecutor:
         log_automotive.debug("Execute test_case %s with args %s",
                              test_case.__class__.__name__, test_case_kwargs)
 
-        test_case.execute(self.socket, self.target_state, **test_case_kwargs)
+        test_case.execute(self.socket, self.target_state,
+                          stop_event=self._stop_scan_event,
+                          **test_case_kwargs)
         test_case.post_execute(
             self.socket, self.target_state, self.configuration)
 
@@ -234,6 +242,10 @@ class AutomotiveTestCaseExecutor:
                 test_case_kwargs = self.configuration[test_case.__class__.__name__]
                 test_case.check_kwargs(test_case_kwargs)
 
+    def stop_scan(self):
+        # type: () -> None
+        self._stop_scan_event.set()
+
     def progress(self):
         # type: () -> float
         progress = []
@@ -254,6 +266,7 @@ class AutomotiveTestCaseExecutor:
         :param timeout: Time for execution.
         :return: None
         """
+        self._stop_scan_event.clear()
         kill_time = time.time() + (timeout or 0xffffffff)
         log_automotive.debug("Set kill_time to %s" % time.ctime(kill_time))
         while kill_time > time.time():
@@ -264,7 +277,7 @@ class AutomotiveTestCaseExecutor:
                     self.state_paths, self.configuration.test_cases):
                 log_automotive.info("Scan path %s", p)
                 terminate = kill_time <= time.time()
-                if terminate:
+                if terminate or self._stop_scan_event.is_set():
                     log_automotive.debug(
                         "Execution time exceeded. Terminating scan!")
                     break

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -909,6 +909,7 @@ class UDS_RMBARandomEnumerator(UDS_RMBAEnumeratorABC):
     _supported_kwargs.update({
         'unittest': (bool, None)
     })
+    del _supported_kwargs["scan_range"]
 
     _supported_kwargs_doc = ServiceEnumerator._supported_kwargs_doc + """
         :param bool unittest: Enables smaller search space for unit-test

--- a/scapy/contrib/automotive/xcp/cto_commands_slave.py
+++ b/scapy/contrib/automotive/xcp/cto_commands_slave.py
@@ -5,9 +5,8 @@
 
 # scapy.contrib.status = skip
 
-from logging import warning
-
 from scapy.config import conf
+from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.xcp.utils import get_max_cto, get_ag, \
     XCPEndiannessField, StrVarLenField
 from scapy.fields import ByteEnumField, ByteField, ShortField, StrLenField, \
@@ -79,8 +78,8 @@ class ConnectPositiveResponse(Packet):
                 conf.contribs["XCP"]["byte_order"] = new_value
 
                 desc = "Big Endian" if new_value else "Little Endian"
-                warning("Byte order changed to {0} because of received "
-                        "positive connect packet".format(desc))
+                log_automotive.warning("Byte order changed to {0} because of received "
+                                       "positive connect packet".format(desc))
 
         if conf.contribs["XCP"]["allow_ag_change"]:
             conf.contribs["XCP"][
@@ -102,7 +101,7 @@ class ConnectPositiveResponse(Packet):
                 comm_mode_basic.address_granularity_1:
             return 4
         else:
-            warning(
+            log_automotive.warning(
                 "Getting address granularity from packet failed:"
                 "both flags are 1")
 

--- a/scapy/contrib/automotive/xcp/utils.py
+++ b/scapy/contrib/automotive/xcp/utils.py
@@ -6,9 +6,9 @@
 # scapy.contrib.status = skip
 
 import struct
-from logging import warning
 
 from scapy.config import conf
+from scapy.contrib.automotive import log_automotive
 from scapy.fields import StrLenField
 from scapy.volatile import RandBin, RandNum
 
@@ -18,7 +18,7 @@ def get_max_cto():
     if max_cto:
         return max_cto
 
-    warning("Define conf.contribs['XCP']['MAX_CTO'].")
+    log_automotive.warning("Define conf.contribs['XCP']['MAX_CTO'].")
     raise KeyError("conf.contribs['XCP']['MAX_CTO'] not defined")
 
 
@@ -27,7 +27,7 @@ def get_max_dto():
     if max_dto:
         return max_dto
     else:
-        warning("Define conf.contribs['XCP']['MAX_DTO'].")
+        log_automotive.warning("Define conf.contribs['XCP']['MAX_DTO'].")
         raise KeyError("conf.contribs['XCP']['MAX_DTO'] not defined")
 
 
@@ -36,8 +36,9 @@ def get_ag():
     if address_granularity and address_granularity in [1, 2, 4]:
         return address_granularity
     else:
-        warning("Define conf.contribs['XCP']['Address_Granularity_Byte']."
-                "Assign either 1, 2 or 4")
+        log_automotive.warning(
+            "Define conf.contribs['XCP']['Address_Granularity_Byte']."
+            "Assign either 1, 2 or 4")
         return 1
 
 

--- a/scapy/contrib/isotp/__init__.py
+++ b/scapy/contrib/isotp/__init__.py
@@ -6,6 +6,8 @@
 # scapy.contrib.description = ISO-TP (ISO 15765-2)
 # scapy.contrib.status = loads
 
+import logging
+
 from scapy.consts import LINUX
 import scapy.libs.six as six
 from scapy.config import conf
@@ -14,7 +16,7 @@ from scapy.error import log_loading
 from scapy.contrib.isotp.isotp_packet import ISOTP, ISOTPHeader, \
     ISOTPHeaderEA, ISOTP_SF, ISOTP_FF, ISOTP_CF, ISOTP_FC
 from scapy.contrib.isotp.isotp_utils import ISOTPSession, \
-    ISOTPMessageBuilder, log_isotp
+    ISOTPMessageBuilder
 from scapy.contrib.isotp.isotp_soft_socket import ISOTPSoftSocket
 from scapy.contrib.isotp.isotp_scanner import isotp_scan
 
@@ -24,6 +26,8 @@ __all__ = ["ISOTP", "ISOTPHeader", "ISOTPHeaderEA", "ISOTP_SF", "ISOTP_FF",
            "USE_CAN_ISOTP_KERNEL_MODULE", "log_isotp"]
 
 USE_CAN_ISOTP_KERNEL_MODULE = False
+
+log_isotp = logging.getLogger("scapy.contrib.isotp")
 
 if six.PY3 and LINUX:
     try:

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -7,9 +7,9 @@
 # scapy.contrib.status = library
 
 import struct
+import logging
 
 from scapy.compat import Optional, List, Tuple, Any, Type
-from scapy.contrib.isotp import log_isotp
 from scapy.packet import Packet
 from scapy.fields import BitField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ConditionalField, \
@@ -17,6 +17,8 @@ from scapy.fields import BitField, FlagsField, StrLenField, \
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN
 from scapy.error import Scapy_Exception
+
+log_isotp = logging.getLogger("scapy.contrib.isotp")
 
 CAN_MAX_IDENTIFIER = (1 << 29) - 1  # Maximum 29-bit identifier
 CAN_MTU = 16

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -9,13 +9,14 @@
 import struct
 
 from scapy.compat import Optional, List, Tuple, Any, Type
+from scapy.contrib.isotp import log_isotp
 from scapy.packet import Packet
 from scapy.fields import BitField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ConditionalField, \
     BitEnumField, ByteField, XByteField, BitFieldLenField, StrField
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN
-from scapy.error import Scapy_Exception, warning
+from scapy.error import Scapy_Exception
 
 CAN_MAX_IDENTIFIER = (1 << 29) - 1  # Maximum 29-bit identifier
 CAN_MTU = 16
@@ -26,7 +27,6 @@ ISOTP_TYPES = {0: 'single',
                1: 'first',
                2: 'consecutive',
                3: 'flow_control'}
-
 
 N_PCI_SF = 0x00  # /* single frame */
 N_PCI_FF = 0x10  # /* first frame */
@@ -159,7 +159,7 @@ class ISOTP(Packet):
 
         dst = can_frames[0].identifier
         if any(frame.identifier != dst for frame in can_frames):
-            warning("Not all CAN frames have the same identifier")
+            log_isotp.warning("Not all CAN frames have the same identifier")
 
         parser = ISOTPMessageBuilder(use_extended_addressing)
         parser.feed(can_frames)
@@ -177,8 +177,9 @@ class ISOTP(Packet):
             return None
 
         if len(results) > 1:
-            warning("More than one ISOTP frame could be defragmented from the "
-                    "provided CAN frames, only returning the first one.")
+            log_isotp.warning(
+                "More than one ISOTP frame could be defragmented from the "
+                "provided CAN frames, only returning the first one.")
 
         return results[0]
 

--- a/scapy/contrib/isotp/isotp_scanner.py
+++ b/scapy/contrib/isotp/isotp_scanner.py
@@ -180,7 +180,7 @@ def scan(sock,  # type: SuperSocket
         sock.send(get_isotp_packet(value, False, extended_can_id))
         sock.sniff(prn=lambda pkt: get_isotp_fc(value, return_values,
                                                 noise_ids, False, pkt),
-                   timeout=sniff_time, store=False)
+                   timeout=sniff_time, store=False, chainCC=True)
 
     if not verify_results:
         return return_values
@@ -191,7 +191,7 @@ def scan(sock,  # type: SuperSocket
             sock.send(get_isotp_packet(value, False, extended_can_id))
             sock.sniff(prn=lambda pkt: get_isotp_fc(value, cleaned_ret_val,
                                                     noise_ids, False, pkt),
-                       timeout=sniff_time * 10, store=False)
+                       timeout=sniff_time * 10, store=False, chainCC=True)
 
     return cleaned_ret_val
 
@@ -236,7 +236,7 @@ def scan_extended(sock,  # type: SuperSocket
             send_multiple_ext(sock, ext_isotp_id, pkt, scan_block_size)
             sock.sniff(prn=lambda p: get_isotp_fc(ext_isotp_id, id_list,
                                                   noise_ids, True, p),
-                       timeout=sniff_time * 3, store=False)
+                       timeout=sniff_time * 3, store=False, chainCC=True)
             # sleep to prevent flooding
             time.sleep(sniff_time)
 
@@ -252,7 +252,7 @@ def scan_extended(sock,  # type: SuperSocket
                                                         return_values,
                                                         noise_ids, True,
                                                         pkt),
-                           timeout=sniff_time * 2, store=False)
+                           timeout=sniff_time * 2, store=False, chainCC=True)
 
     return return_values
 
@@ -308,9 +308,10 @@ def isotp_scan(sock,  # type: SuperSocket
     dummy_pkt = CAN(identifier=0x123,
                     data=b'\xaa\xbb\xcc\xdd\xee\xff\xaa\xbb')
 
-    background_pkts = sock.sniff(timeout=noise_listen_time,
-                                 started_callback=lambda:
-                                 sock.send(dummy_pkt))
+    background_pkts = sock.sniff(
+        timeout=noise_listen_time,
+        started_callback=lambda: sock.send(dummy_pkt),
+        chainCC=True)
 
     noise_ids = list(set(pkt.identifier for pkt in background_pkts))
 

--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -21,7 +21,7 @@ from scapy.contrib.isotp import log_isotp
 from scapy.packet import Packet
 from scapy.layers.can import CAN
 import scapy.libs.six as six
-from scapy.error import Scapy_Exception, warning, log_runtime
+from scapy.error import Scapy_Exception
 from scapy.supersocket import SuperSocket
 from scapy.config import conf
 from scapy.consts import LINUX
@@ -32,7 +32,6 @@ from scapy.contrib.isotp.isotp_packet import ISOTP, CAN_MAX_DLEN, N_PCI_SF, \
 
 if TYPE_CHECKING:
     from scapy.contrib.cansocket import CANSocket
-
 
 # Enum states
 ISOTP_IDLE = 0
@@ -150,7 +149,7 @@ class ISOTPSoftSocket(SuperSocket):
         self.impl = impl
         self.basecls = basecls
         if basecls is None:
-            warning('Provide a basecls ')
+            log_isotp.warning('Provide a basecls ')
 
     def close(self):
         # type: () -> None
@@ -304,13 +303,13 @@ class TimeoutScheduler:
         # Wait until the next timeout,
         # or until event.set() gets called in another thread.
         if to_wait > 0:
-            log_runtime.debug("TimeoutScheduler Thread going to sleep @ %f " +
-                              "for %fs", now, to_wait)
+            log_isotp.debug("TimeoutScheduler Thread going to sleep @ %f " +
+                            "for %fs", now, to_wait)
             interrupted = cls._event.wait(to_wait)
             new = cls._time()
-            log_runtime.debug("TimeoutScheduler Thread awake @ %f, slept for" +
-                              " %f, interrupted=%d", new, new - now,
-                              interrupted)
+            log_isotp.debug("TimeoutScheduler Thread awake @ %f, slept for" +
+                            " %f, interrupted=%d", new, new - now,
+                            interrupted)
 
         # Clear the event so that we can wait on it again,
         # Must be done before doing the callbacks to avoid losing a set().
@@ -323,7 +322,7 @@ class TimeoutScheduler:
         start when the first timeout is added and stop when the last timeout
         is removed or executed."""
 
-        log_runtime.debug("TimeoutScheduler Thread spawning @ %f", cls._time())
+        log_isotp.debug("TimeoutScheduler Thread spawning @ %f", cls._time())
 
         time_empty = None
 
@@ -345,7 +344,7 @@ class TimeoutScheduler:
         finally:
             # Worst case scenario: if this thread dies, the next scheduled
             # timeout will start a new one
-            log_runtime.debug("TimeoutScheduler Thread died @ %f", cls._time())
+            log_isotp.debug("TimeoutScheduler Thread died @ %f", cls._time())
             cls._thread = None
 
     @classmethod
@@ -580,8 +579,8 @@ class ISOTPSocketImplementation:
         # type: (Packet) -> None
         if p.identifier != self.rx_id:
             if not self.filter_warning_emitted and conf.verb >= 2:
-                warning("You should put a filter for identifier=%x on your "
-                        "CAN socket", self.rx_id)
+                log_isotp.warning("You should put a filter for identifier=%x on your "
+                                  "CAN socket", self.rx_id)
                 self.filter_warning_emitted = True
         else:
             self.on_recv(p)
@@ -590,14 +589,14 @@ class ISOTPSocketImplementation:
         # type: () -> None
         try:
             if select_objects([self.tx_queue], 0):
-                warning("TX queue not empty")
+                log_isotp.warning("TX queue not empty")
                 time.sleep(0.1)
         except OSError:
             pass
 
         try:
             if select_objects([self.rx_queue], 0):
-                warning("RX queue not empty")
+                log_isotp.warning("RX queue not empty")
         except OSError:
             pass
 
@@ -621,7 +620,7 @@ class ISOTPSocketImplementation:
             # reset rx state
             self.rx_state = ISOTP_IDLE
             if conf.verb > 2:
-                warning("RX state was reset due to timeout")
+                log_isotp.warning("RX state was reset due to timeout")
 
     def _tx_timer_handler(self):
         # type: () -> None
@@ -634,7 +633,7 @@ class ISOTPSocketImplementation:
             # we did not get any flow control frame in time
             # reset tx state
             self.tx_state = ISOTP_IDLE
-            warning("TX state was reset due to timeout")
+            log_isotp.warning("TX state was reset due to timeout")
             return
         elif self.tx_state == ISOTP_SENDING:
             # push out the next segmented pdu
@@ -642,7 +641,7 @@ class ISOTPSocketImplementation:
             max_bytes = 7 - src_off
             if self.tx_buf is None:
                 self.tx_state = ISOTP_IDLE
-                warning("TX buffer is not filled")
+                log_isotp.warning("TX buffer is not filled")
                 return
             while 1:
                 load = self.ea_hdr
@@ -706,7 +705,7 @@ class ISOTPSocketImplementation:
     def _recv_fc(self, data):
         # type: (bytes) -> None
         """Process a received 'Flow Control' frame"""
-        log_runtime.debug("Processing FC")
+        log_isotp.debug("Processing FC")
 
         if (self.tx_state != ISOTP_WAIT_FC and
                 self.tx_state != ISOTP_WAIT_FIRST_FC):
@@ -718,7 +717,7 @@ class ISOTPSocketImplementation:
 
         if len(data) < 3:
             self.tx_state = ISOTP_IDLE
-            warning("CF frame discarded because it was too short")
+            log_isotp.warning("CF frame discarded because it was too short")
             return
 
         # get communication parameters only from the first FC frame
@@ -756,17 +755,17 @@ class ISOTPSocketImplementation:
         elif isotp_fc == ISOTP_FC_OVFLW:
             # overflow in receiver side
             self.tx_state = ISOTP_IDLE
-            warning("Overflow happened at the receiver side")
+            log_isotp.warning("Overflow happened at the receiver side")
             return
         else:
             self.tx_state = ISOTP_IDLE
-            warning("Unknown FC frame type")
+            log_isotp.warning("Unknown FC frame type")
             return
 
     def _recv_sf(self, data, ts):
         # type: (bytes, Union[float, EDecimal]) -> None
         """Process a received 'Single Frame' frame"""
-        log_runtime.debug("Processing SF")
+        log_isotp.debug("Processing SF")
 
         if self.rx_timeout_handle is not None:
             self.rx_timeout_handle.cancel()
@@ -774,7 +773,8 @@ class ISOTPSocketImplementation:
 
         if self.rx_state != ISOTP_IDLE:
             if conf.verb > 2:
-                warning("RX state was reset because single frame was received")
+                log_isotp.warning("RX state was reset because "
+                                  "single frame was received")
             self.rx_state = ISOTP_IDLE
 
         length = six.indexbytes(data, 0) & 0xf
@@ -787,7 +787,7 @@ class ISOTPSocketImplementation:
     def _recv_ff(self, data, ts):
         # type: (bytes, Union[float, EDecimal]) -> None
         """Process a received 'First Frame' frame"""
-        log_runtime.debug("Processing FF")
+        log_isotp.debug("Processing FF")
 
         if self.rx_timeout_handle is not None:
             self.rx_timeout_handle.cancel()
@@ -795,7 +795,7 @@ class ISOTPSocketImplementation:
 
         if self.rx_state != ISOTP_IDLE:
             if conf.verb > 2:
-                warning("RX state was reset because first frame was received")
+                log_isotp.warning("RX state was reset because first frame was received")
             self.rx_state = ISOTP_IDLE
 
         if len(data) < 7:
@@ -841,7 +841,7 @@ class ISOTPSocketImplementation:
     def _recv_cf(self, data):
         # type: (bytes) -> None
         """Process a received 'Consecutive Frame' frame"""
-        log_runtime.debug("Processing CF")
+        log_isotp.debug("Processing CF")
 
         if self.rx_state != ISOTP_WAIT_DATA:
             return
@@ -859,20 +859,20 @@ class ISOTPSocketImplementation:
             # this is only allowed for the last CF
             if self.rx_len - self.rx_idx > self.rx_ll_dl:
                 if conf.verb > 2:
-                    warning("Received a CF with insufficient length")
+                    log_isotp.warning("Received a CF with insufficient length")
                 return
 
         if six.indexbytes(data, 0) & 0x0f != self.rx_sn:
             # Wrong sequence number
             if conf.verb > 2:
-                warning("RX state was reset because wrong sequence number was "
-                        "received")
+                log_isotp.warning("RX state was reset because wrong sequence "
+                                  "number was received")
             self.rx_state = ISOTP_IDLE
             return
 
         if self.rx_buf is None:
             if conf.verb > 2:
-                warning("rx_buf not filled with data!")
+                log_isotp.warning("rx_buf not filled with data!")
             self.rx_state = ISOTP_IDLE
             return
 
@@ -902,7 +902,7 @@ class ISOTPSocketImplementation:
                 self.can_send(load)
 
         # wait for another CF
-        log_runtime.debug("Wait for another CF")
+        log_isotp.debug("Wait for another CF")
         self.rx_timeout_handle = TimeoutScheduler.schedule(
             self.cf_timeout, self._rx_timer_handler)
 
@@ -910,13 +910,13 @@ class ISOTPSocketImplementation:
         # type: (bytes) -> None
         """Begins sending an ISOTP message. This method does not block."""
         if self.tx_state != ISOTP_IDLE:
-            warning("Socket is already sending, retry later")
+            log_isotp.warning("Socket is already sending, retry later")
             return
 
         self.tx_state = ISOTP_SENDING
         length = len(x)
         if length > ISOTP_MAX_DLEN_2015:
-            warning("Too much data for ISOTP message")
+            log_isotp.warning("Too much data for ISOTP message")
 
         if len(self.ea_hdr) + length <= 7:
             # send a single frame

--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -6,7 +6,7 @@
 
 # scapy.contrib.description = ISO-TP (ISO 15765-2) Soft Socket Library
 # scapy.contrib.status = library
-
+import logging
 import struct
 import time
 import traceback
@@ -17,7 +17,6 @@ from threading import Thread, Event, RLock
 
 from scapy.compat import Optional, Union, List, Tuple, Any, Type, cast, \
     Callable, TYPE_CHECKING
-from scapy.contrib.isotp import log_isotp
 from scapy.packet import Packet
 from scapy.layers.can import CAN
 import scapy.libs.six as six
@@ -32,6 +31,8 @@ from scapy.contrib.isotp.isotp_packet import ISOTP, CAN_MAX_DLEN, N_PCI_SF, \
 
 if TYPE_CHECKING:
     from scapy.contrib.cansocket import CANSocket
+
+log_isotp = logging.getLogger("scapy.contrib.isotp")
 
 # Enum states
 ISOTP_IDLE = 0

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -40,7 +40,7 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
         answering_machine.reset_state()
         sniff(timeout=0.001, opened_socket=[ecu, tester])
     sim = threading.Thread(target=answering_machine, kwargs={
-        "timeout": 120, "stop_filter": lambda x: bytes(x) == b"\xff\xff\xff"})
+        "timeout": 30, "stop_filter": lambda x: bytes(x) == b"\xff\xff\xff"})
     sim.start()
     try:
         scanner = GMLAN_Scanner(
@@ -48,7 +48,7 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
             test_cases=enumerators, timeout=0.2, retry_if_none_received=True,
             unittest=True, **kwargs)
         def scanner_thread():
-            for i in range(12):
+            for i in range(3):
                 print("Starting scan")
                 scanner.scan(timeout=10)
                 if scanner.scan_completed:
@@ -56,9 +56,9 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
                     return
         scanner_t = threading.Thread(target=scanner_thread)
         scanner_t.start()
-        time.sleep(120)
-        scanner.stop_scan()
-        scanner_t.join(timeout=5)
+        scanner_t.join(timeout=120)
+        if scanner_t.is_alive():
+            scanner.stop_scan()
     finally:
         tester.send(Raw(b"\xff\xff\xff"))
         sim.join(timeout=2)

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -6,6 +6,9 @@
 = Imports
 
 import itertools
+import logging
+import threading
+import time
 from scapy.contrib.isotp import ISOTPMessageBuilder
 
 from test.testsocket import TestSocket, cleanup_testsockets, open_test_sockets
@@ -23,6 +26,8 @@ from scapy.contrib.automotive.gm.gmlan_scanner import *
 from scapy.contrib.automotive.ecu import *
 load_layer("can")
 
+log_automotive.setLevel(logging.DEBUG)
+
 
 = Define Testfunction
 
@@ -34,21 +39,26 @@ def executeScannerInVirtualEnvironment(supported_responses, enumerators, **kwarg
     def reset():
         answering_machine.reset_state()
         sniff(timeout=0.001, opened_socket=[ecu, tester])
-    def answering_machine_thread():
-        answering_machine(timeout=120, stop_filter=lambda x: bytes(x) == b"\xff\xff\xff")
-    sim = threading.Thread(target=answering_machine_thread)
+    sim = threading.Thread(target=answering_machine, kwargs={
+        "timeout": 120, "stop_filter": lambda x: bytes(x) == b"\xff\xff\xff"})
     sim.start()
     try:
         scanner = GMLAN_Scanner(
             tester, reset_handler=reset,
             test_cases=enumerators, timeout=0.2, retry_if_none_received=True,
             unittest=True, **kwargs)
-        for i in range(12):
-            print("Starting scan")
-            scanner.scan(timeout=10)
-            if scanner.scan_completed:
-                print("Scan completed after %d iterations" % i)
-                break
+        def scanner_thread():
+            for i in range(12):
+                print("Starting scan")
+                scanner.scan(timeout=10)
+                if scanner.scan_completed:
+                    print("Scan completed after %d iterations" % i)
+                    return
+        scanner_t = threading.Thread(target=scanner_thread)
+        scanner_t.start()
+        time.sleep(120)
+        scanner.stop_scan()
+        scanner_t.join(timeout=5)
     finally:
         tester.send(Raw(b"\xff\xff\xff"))
         sim.join(timeout=2)

--- a/test/contrib/isotp_soft_socket.uts
+++ b/test/contrib/isotp_soft_socket.uts
@@ -25,6 +25,7 @@ except ImportError:
 log_stream = StringIO()
 handler = logging.StreamHandler(log_stream)
 log_runtime.addHandler(handler)
+log_isotp.addHandler(handler)
 
 = Definition of utility functions
 


### PR DESCRIPTION
This PR adds:
- an async stop function for automotive scanners
- cleans up warning and scapy logs in automotive / isotp layers