### PR TITLE
Remove usage of cryptography's `register_interface`

### DIFF
--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -16,7 +16,6 @@ import scapy.libs.six as six
 
 if conf.crypto_valid:
     from cryptography.utils import (
-        register_interface,
         CryptographyDeprecationWarning,
     )
     from cryptography.hazmat.primitives.ciphers import (Cipher, algorithms, modes,  # noqa: E501
@@ -193,9 +192,7 @@ if conf.crypto_valid:
 # silently not declared, and the corresponding suites will have 'usable' False.
 
 if conf.crypto_valid:
-    @register_interface(BlockCipherAlgorithm)
-    @register_interface(CipherAlgorithm)
-    class _ARC2(object):
+    class _ARC2(BlockCipherAlgorithm, CipherAlgorithm):
         name = "RC2"
         block_size = 64
         key_sizes = frozenset([128])

--- a/scapy/layers/tls/crypto/pkcs1.py
+++ b/scapy/layers/tls/crypto/pkcs1.py
@@ -19,7 +19,6 @@ import scapy.libs.six as six
 from scapy.config import conf, crypto_validator
 from scapy.error import warning
 if conf.crypto_valid:
-    from cryptography import utils
     from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes
@@ -96,8 +95,7 @@ _get_hash = None
 if conf.crypto_valid:
 
     # first, we add the "md5-sha1" hash from openssl to python-cryptography
-    @utils.register_interface(HashAlgorithm)
-    class MD5_SHA1(object):
+    class MD5_SHA1(HashAlgorithm):
         name = "md5-sha1"
         digest_size = 36
         block_size = 64

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -1,4 +1,5 @@
 % Regression tests for GMLAN Scanners
+~ scanner
 
 + Configuration
 ~ conf

--- a/test/contrib/automotive/obd/scanner.uts
+++ b/test/contrib/automotive/obd/scanner.uts
@@ -1,5 +1,5 @@
 % Regression tests for obd_scan
-
+~ scanner
 
 + Configuration
 ~ conf

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -1,4 +1,5 @@
 % Regression tests for Simulated ECUs and UDS Scanners
+~ scanner
 
 + Configuration
 ~ conf

--- a/test/contrib/isotpscan.uts
+++ b/test/contrib/isotpscan.uts
@@ -1,4 +1,5 @@
 % Regression tests for isotp_scan
+~ scanner
 
 + Configuration
 ~ conf

--- a/test/run_tests
+++ b/test/run_tests
@@ -54,7 +54,7 @@ then
   fi
 
   # Run tox
-  export UT_FLAGS="-K tcpdump -K manufdb -K wireshark -K ci_only -K vcan_socket -K automotive_comm -K imports"
+  export UT_FLAGS="-K tcpdump -K manufdb -K wireshark -K ci_only -K vcan_socket -K automotive_comm -K imports -K scanner"
   export SIMPLE_TESTS="true"
   PYVER=$($PYTHON -c "import sys; print('.'.join(sys.version.split('.')[:2]))")
   ${DIR}/.config/ci/test.sh $PYVER non_root

--- a/test/tools/isotpscanner.uts
+++ b/test/tools/isotpscanner.uts
@@ -1,5 +1,5 @@
 % Regression tests for isotpscanner
-~ vcan_socket needs_root linux not_pypy automotive_comm
+~ vcan_socket needs_root linux not_pypy automotive_comm scanner
 
 
 + Configuration

--- a/test/tools/obdscanner.uts
+++ b/test/tools/obdscanner.uts
@@ -1,5 +1,5 @@
 % Regression tests for obdscanner
-~ vcan_socket needs_root linux not_pypy automotive_comm
+~ vcan_socket needs_root linux not_pypy automotive_comm scanner
 
 + Configuration
 ~ conf

--- a/test/tools/xcpscanner.uts
+++ b/test/tools/xcpscanner.uts
@@ -1,4 +1,5 @@
 % Regression tests for the XCP_CAN
+~ scanner
 
 + Basic operations
 


### PR DESCRIPTION
cryptography removed `register_interface` without changelog nor deperecation notices (quite uncommon from them :/) https://github.com/pyca/cryptography/pull/7234