### PR TITLE
Add unit tests for upstream cryptography

### DIFF
--- a/test/configs/README.md
+++ b/test/configs/README.md
@@ -1,0 +1,5 @@
+### UTscapy configs
+
+- OS specifics: bsd, linux, solaris, windows
+- Other:
+  - cryptography -> used for downstream testing by pyca/cryptography

--- a/test/configs/cryptography.utsc
+++ b/test/configs/cryptography.utsc
@@ -1,0 +1,14 @@
+{
+  "testfiles": [
+    "test/tls*.uts",
+    "test/scapy/layers/ipsec.uts"
+  ],
+  "breakfailed": true,
+  "onlyfailed": true,
+  "preexec": {
+    "test/tls*.uts": "load_layer(\"tls\")"
+  },
+  "kw_ko": [
+    "mock"
+  ]
+}

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1330,6 +1330,7 @@ assert not TLSHelloRequest().tls_session_update(None)
 
 
 = Cryptography module is unavailable
+~ mock
 import scapy.libs.six as six
 import mock
 


### PR DESCRIPTION
This PR adds a test config that will be used in pyca/cryptography (see https://github.com/pyca/cryptography/pull/7234#issuecomment-1241966358) to test changes against downstream projects (very nice !)