### PR TITLE
Add special unit test for pyca/cryptography

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -118,6 +118,25 @@ jobs:
         with:
             file: /home/runner/work/scapy/scapy/.coverage
 
+  cryptography:
+    name: pyca/cryptography test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install tox
+      run: pip install tox
+    # pyca/cryptography's CI installs cryptography
+    # then runs the tests. We therefore didn't include it in tox
+    - name: Install cryptography
+      run: pip install cryptography
+    - name: Run tests
+      run: tox -e cryptography
+
   # CODE-QL
   analyze:
     name: CodeQL analysis

--- a/test/configs/cryptography.utsc
+++ b/test/configs/cryptography.utsc
@@ -1,11 +1,14 @@
 {
   "testfiles": [
     "test/tls*.uts",
-    "test/scapy/layers/ipsec.uts"
+    "test/scapy/layers/dot11.uts",
+    "test/scapy/layers/ipsec.uts",
+    "test/contrib/macsec.uts"
   ],
   "breakfailed": true,
   "onlyfailed": true,
   "preexec": {
+    "test/contrib/*.uts": "load_contrib(\"%name%\")",
     "test/tls*.uts": "load_layer(\"tls\")"
   },
   "kw_ko": [

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,15 @@ commands =
   sudo -E {envpython} -m coverage run -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs}
   coverage combine
 
+# Test used by upstream pyca/cryptography
+[testenv:cryptography]
+description = "Scapy unit tests - pyca/cryptography variant"
+sitepackages = true
+deps =
+commands =
+  python -c "import cryptography; print('DEBUG: cryptography %s' % cryptography.__version__)"
+  python -m scapy.tools.UTscapy -c ./test/configs/cryptography.utsc
+
 # Specific functions or tests
 
 [testenv:codecov]


### PR DESCRIPTION
- add a test `cryptography` in tox to use by upstream's `pyca/cryptography` for regressions
- test it in our own unit tests to make sure we don't break theirs