### PR TITLE
Pass bitfield size keyword arguments to parent class.

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2377,7 +2377,7 @@ class BitFixedLenField(BitField):
 
 
 class BitFieldLenField(BitField):
-    __slots__ = ["length_of", "count_of", "adjust"]
+    __slots__ = ["length_of", "count_of", "adjust", "tot_size", "end_tot_size"]
 
     def __init__(self,
                  name,  # type: str
@@ -2386,9 +2386,12 @@ class BitFieldLenField(BitField):
                  length_of=None,  # type: Optional[Union[Callable[[Optional[Packet]], int], str]]  # noqa: E501
                  count_of=None,  # type: Optional[str]
                  adjust=lambda pkt, x: x,  # type: Callable[[Optional[Packet], int], int]  # noqa: E501
+                 tot_size=0,  # type: int
+                 end_tot_size=0,  # type: int
                  ):
         # type: (...) -> None
-        super(BitFieldLenField, self).__init__(name, default, size)
+        super(BitFieldLenField, self).__init__(name, default, size,
+                                               tot_size, end_tot_size)
         self.length_of = length_of
         self.count_of = count_of
         self.adjust = adjust

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -294,25 +294,25 @@ p.len == 4 and p.str == b"ABC" and Raw in p
 = BitFieldLenField test
 ~ field
 class TestBFLenF(Packet):
-    fields_desc = [ BitFieldLenField("len", None, 4, length_of="str" , adjust=lambda pkt,x:x+1),
-                    BitField("nothing",0xfff, 12),
+    fields_desc = [ BitFieldLenField("len", None, 4, length_of="str" , adjust=lambda pkt,x:x+1, tot_size=-2),
+                    BitField("nothing",0xfff, 12, end_tot_size=-2),
                     StrLenField("str", "default", length_from=lambda pkt:pkt.len-1, ) ]
 
 a=TestBFLenF()
 r = raw(a)
 r
-assert r == b"\x8f\xffdefault"
+assert r == b"\xff\x8fdefault"
 
 a.str=""
 r = raw(a)
 r
-assert r == b"\x1f\xff"
+assert r == b"\xff\x1f"
 
-p = TestBFLenF(b"\x1f\xff@@")
+p = TestBFLenF(b"\xff\x1f@@")
 p
 assert p.len == 1 and p.str == b"" and Raw in p and p[Raw].load == b"@@"
 
-p = TestBFLenF(b"\x6f\xffabcdeFGH")
+p = TestBFLenF(b"\xff\x6fabcdeFGH")
 p
 assert p.len == 6 and p.str == b"abcde" and Raw in p and p[Raw].load == b"FGH"
 


### PR DESCRIPTION
This PR adds the bitfield size arguments to the `BitFieldLenField` class, passing them to the parent class. Should allow users to use this field as the start or end field in a series of bitfields.