### PR TITLE
Python 3: `Packet.__str__()` returns `.command()`, without the warning

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -582,8 +582,7 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
     else:
         def __str__(self):
             # type: () -> str
-            warning("Calling str(pkt) on Python 3 makes no sense!")
-            return str(self.build())
+            return self.summary()
 
     def __bytes__(self):
         # type: () -> bytes


### PR DESCRIPTION
Rationale: Scapy has leaved supporting both Python 2 and Python 3 long enough, I think it is safe now to remove this warning. Moreover, having this warning confuses IDEs (see #3548).

In the Python philosophy, where `repr()` returns a formal representation of the object and `str()` an informal representation, I think the output of the existing (maybe one day, to be deprecated?) method `.command()` makes total sense for this.

fixes #3548