### PR TITLE
Bind ARPHRD_NONE to IPv46 protocol layer

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -28,7 +28,7 @@ from scapy.compat import chb, orb, raw, plain_str, bytes_encode
 from scapy.consts import WINDOWS
 from scapy.config import conf
 from scapy.data import DLT_IPV6, DLT_RAW, DLT_RAW_ALT, ETHER_ANY, ETH_P_IPV6, \
-    MTU
+    MTU, ARPHRD_NONE
 from scapy.error import log_runtime, warning
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     DestIP6Field, FieldLenField, FlagsField, IntField, IP6Field, \
@@ -4075,6 +4075,7 @@ conf.l2types.register(31, IPv6)
 conf.l2types.register(DLT_IPV6, IPv6)
 conf.l2types.register(DLT_RAW, IPv46)
 conf.l2types.register_num2layer(DLT_RAW_ALT, IPv46)
+conf.l2types.register_num2layer(ARPHRD_NONE, IPv46)
 
 bind_layers(Ether, IPv6, type=0x86dd)
 bind_layers(CookedLinux, IPv6, proto=0x86dd)


### PR DESCRIPTION
Scapy L2Socket uses a 3-step process to determine the layer to be used for decoding the packets captured on a given interface:
* it checks the Ethernet protocol number (`sa_ll[3]`);
* if no L2 layer is bound to the Ethernet protocol number, it uses the ARP hardware address type (`sa_ll[1]`);
* if no L3 layer is bound to the ARP hardware address type, it fallbacks to using the default L2 layer.

https://github.com/secdev/scapy/blob/a1f999fb1721a64415af75d575cabde19625a6f5/scapy/arch/linux.py#L531-L541

Some Linux interfaces operate at layer 3. The packets captured on these interfaces have no link-layer header. For these interfaces, the protocol number (`sa_ll[3]`) is `ARPHRD_NONE`.

In the current implementation of Scapy, the `ARPHRD_NONE` protocol number is not bound to any layer. This can cause packets captured on interfaces with protocol number `ARPHRD_NONE` to be delivered to the wrong layer and decoded incorrectly.

For example, Wireguard interfaces are `ARPHRD_NONE` devices that operate at layer 3. Scapy delivers the IPv4 and IPv6 packets captured on a Wireguard interface to the IPv4 layer.

This PR binds the `ARPHRD_NONE` protocol number to the `IPv46` layer. This way, Scapy can deliver the IP packets to the IPv4 or IPv6 layer depending on the `version` field of the IP header.

Signed-off-by: Carmine Scarpitta <carmine.scarpitta@uniroma2.it>