### PR TITLE
Make RawVal work with all field types (continued)

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -469,7 +469,8 @@ class Packet(six.with_metaclass(Packet_metaclass,  # type: ignore
                 any2i = lambda x, y: y  # type: Callable[..., Any]
             else:
                 any2i = fld.any2i
-            self.fields[attr] = any2i(self, val)
+            self.fields[attr] = val if isinstance(val, RawVal) else \
+                any2i(self, val)
             self.explicit = 0
             self.raw_packet_cache = None
             self.raw_packet_cache_fields = None

--- a/test/scapy/layers/ntp.uts
+++ b/test/scapy/layers/ntp.uts
@@ -1115,26 +1115,33 @@ pkt_1 = NTP(
     sent=RawVal(time_stamp),
 )
 
+# This field is intentionally set here, rather than in the constructor above,
+# to cover a different code path:
+pkt_1.recv = RawVal(time_stamp)
+
 assert (isinstance(pkt_1.precision, RawVal)), type(pkt_1.precision)
 assert (isinstance(pkt_1.dispersion, RawVal)), type(pkt_1.dispersion)
 assert (isinstance(pkt_1.orig, RawVal)), type(pkt_1.orig)
 assert (isinstance(pkt_1.sent, RawVal)), type(pkt_1.sent)
+assert (isinstance(pkt_1.recv, RawVal)), type(pkt_1.recv)
 
 assert (pkt_1.precision.val == precision, pkt_1.precision.val)
 assert (pkt_1.dispersion.val == dispersion, pkt_1.dispersion.val)
 assert (pkt_1.orig.val == time_stamp, pkt_1.orig.val)
 assert (pkt_1.sent.val == time_stamp, pkt_1.sent.val)
+assert (pkt_1.recv.val == time_stamp, pkt_1.recv.val)
 
 time_stamp_hex = 0x00000000e67d6774
 pkt_2 = NTP(
     precision=236,
     dispersion=Decimal('0.948455810546875'),
     orig=time_stamp_hex,
-    sent=time_stamp_hex
+    sent=time_stamp_hex,
+    recv=time_stamp_hex
 )
 
 raw_pkt = (b"#\x02\n\xec\x00\x00\x00\x00\x00\x00\xf2\xce\x7f\x00\x00\x01\x00"
-           b"\x00\x00\x00\x00\x00\x00\x00\xe6}gt\x00\x00\x00\x00\x00\x00\x00"
-           b"\x00\x00\x00\x00\x00\xe6}gt\x00\x00\x00\x00")
+           b"\x00\x00\x00\x00\x00\x00\x00\xe6}gt\x00\x00\x00\x00\xe6}gt\x00"
+           b"\x00\x00\x00\xe6}gt\x00\x00\x00\x00")
 
 assert raw(pkt_1) == raw(pkt_2) == raw_pkt


### PR DESCRIPTION
This is a continuation of commit 7ba7a25fa41e07243ff7af7c693e2d1ad8af6f6a (PR #3692 "Make RawVal work with all field types (fix for issue #3691)"). This line was missed in the original fix, and covers the case where a field is set after object initialisation. The unit test has also been modified to cover this case.