### PR TITLE
Register ETH_P_ALL to IPv46

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -27,8 +27,15 @@ from scapy.base_classes import Gen
 from scapy.compat import chb, orb, raw, plain_str, bytes_encode
 from scapy.consts import WINDOWS
 from scapy.config import conf
-from scapy.data import DLT_IPV6, DLT_RAW, DLT_RAW_ALT, ETHER_ANY, ETH_P_IPV6, \
-    MTU
+from scapy.data import (
+    DLT_IPV6,
+    DLT_RAW,
+    DLT_RAW_ALT,
+    ETHER_ANY,
+    ETH_P_ALL,
+    ETH_P_IPV6,
+    MTU,
+)
 from scapy.error import log_runtime, warning
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     DestIP6Field, FieldLenField, FlagsField, IntField, IP6Field, \
@@ -4071,6 +4078,7 @@ _load_dict(ipv6nhcls)
 #############################################################################
 
 conf.l3types.register(ETH_P_IPV6, IPv6)
+conf.l3types.register_num2layer(ETH_P_ALL, IPv46)
 conf.l2types.register(31, IPv6)
 conf.l2types.register(DLT_IPV6, IPv6)
 conf.l2types.register(DLT_RAW, IPv46)


### PR DESCRIPTION
This PR fixes #3751 in a way that I think is better (see https://github.com/secdev/scapy/pull/3751#issuecomment-1268159561) as it avoids mixing `DLT_*` values with `ARPHDR_*` values which looks like a hack to me. It fixes what I understand as being the "real" problem / bug here.

@cscarpitta what do you think?
