### PR TITLE
Do not attempt to delete the temporary file twice in sendpfast()

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -553,7 +553,8 @@ def sendpfast(x,  # type: _PacketIterable
                 results = _parse_tcpreplay_result(stdout, stderr, argv)
             elif conf.verb > 2:
                 log_runtime.info(stdout.decode())
-    os.unlink(f)
+    if os.path.exists(f):
+        os.unlink(f)
     return results
 
 


### PR DESCRIPTION
When tcpreplay errors out inside `sendpfast()` for any reason (missing binary, malformed extra args...) the deletion of the temporary capture file happens twice ([while](https://github.com/secdev/scapy/blob/e3e843114c0bcc048290db6d1b94b53329310770/scapy/sendrecv.py#L546) and [after](https://github.com/secdev/scapy/blob/e3e843114c0bcc048290db6d1b94b53329310770/scapy/sendrecv.py#L556) raising the Exception) and generates extra output that shadows the actual error since it gets printed last.

No tests seem to be impacted by this small change nor it warrants a new one in my opinion.