### PR TITLE
Correct version nibble for ERSPAN Type II

### DIFF
--- a/scapy/contrib/erspan.py
+++ b/scapy/contrib/erspan.py
@@ -40,7 +40,7 @@ class ERSPAN_I(ERSPAN):
 class ERSPAN_II(ERSPAN):
     name = "ERSPAN II"
     match_subclass = True
-    fields_desc = [BitField("ver", 0, 4),
+    fields_desc = [BitField("ver", 1, 4),
                    BitField("vlan", 0, 12),
                    BitField("cos", 0, 3),
                    BitField("en", 0, 2),

--- a/test/contrib/erspan.uts
+++ b/test/contrib/erspan.uts
@@ -14,14 +14,14 @@ assert pkt.seqnum_present == 0
 
 pkt = GRE()/ERSPAN_II()/Ether(src="11:11:11:11:11:11", dst="ff:ff:ff:ff:ff:ff")
 b = bytes(pkt)
-assert b == b'\x10\x00\x88\xbe\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\x11\x11\x11\x11\x11\x11\x90\x00'
+assert b == b'\x10\x00\x88\xbe\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\x11\x11\x11\x11\x11\x11\x90\x00'
 
 = Dissect ERSPAN II
 
 pkt = GRE(b)
 assert pkt[GRE].proto == 0x88be
 assert pkt[GRE].seqnum_present == 1
-assert pkt[GRE][ERSPAN].ver == 0
+assert pkt[GRE][ERSPAN].ver == 1
 assert pkt[Ether].src == "11:11:11:11:11:11"
 
 + ERSPAN III


### PR DESCRIPTION
I have observed at runtime when using the `ERSPAN_II` object that the default version field is not set as I expect it. From [the IETF draft](https://datatracker.ietf.org/doc/html/draft-foschiano-erspan-03) section 4.2:

```
   Ver            [42:0]       4      ERSPAN Encapsulation version.
                                      This indicates the version of
                                      the ERSPAN encapsulation
                                      specification. Set to 0x1 for
                                      Type II.
```

This seems to be simply due to an improper default value:

https://github.com/secdev/scapy/blob/139966f37ee4188c676b958260312b1e4ad81be2/scapy/contrib/erspan.py#L40-L43

By contrast, the "Type III" packets in `scapy.contrib.erspan` already do have the correct (0x2) version for that type (section 4.3):

https://github.com/secdev/scapy/blob/139966f37ee4188c676b958260312b1e4ad81be2/scapy/contrib/erspan.py#L54-L57

Believing this to be a self-evidently correct, one-bit change, I have created the current PR in a web page, so I did not run any unit tests. If I do indeed need to update (or write) unit tests, let me know.