### PR TITLE
Add OAM layer

### DIFF
--- a/scapy/contrib/oam.py
+++ b/scapy/contrib/oam.py
@@ -1,0 +1,663 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
+# scapy.contrib.description = Operation, administration and maintenance (OAM)
+# scapy.contrib.status = loads
+
+"""
+    Operation, administration and maintenance (OAM)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :author:    Sergey Matsievskiy, matsievskiysv@gmail.com
+
+    :description:
+
+        This module provides Scapy layers for the OAM protocol.
+
+        normative references:
+          - ITU-T Rec. G.8013/Y.1731 (08/2019) - Operation, administration and
+            maintenance (OAM) functions and mechanisms for Ethernet-based
+            networks (https://www.itu.int/rec/T-REC-G.8013)
+          - ITU-T Rec. G.8031/Y.1342 (01/2015) - Ethernet linear protection
+            switching (https://www.itu.int/rec/T-REC-G.8031)
+          - ITU-T Rec. G.8032/Y.1344 (02/2022) - Ethernet ring protection
+            switching (https://www.itu.int/rec/T-REC-G.8032)
+"""
+
+from scapy.fields import (
+    BitEnumField,
+    BitField,
+    ByteField,
+    ConditionalField,
+    EnumField,
+    FCSField,
+    FlagsField,
+    IntField,
+    LenField,
+    LongField,
+    MACField,
+    MultipleTypeField,
+    NBytesField,
+    OUIField,
+    PacketField,
+    PadField,
+    PacketListField,
+    ShortField,
+    FieldListField,
+)
+from scapy.layers.l2 import Dot1Q
+from scapy.packet import Packet, bind_layers
+from binascii import crc32
+import struct
+
+
+class MepIdField(ShortField):
+    """
+    Short field with insignificant three leading bytes
+    """
+
+    def __init__(self, name, default):
+        super(MepIdField, self).__init__(
+            name, default & 0x1FFF if default is not None else default
+        )
+
+
+class MegId(Packet):
+    """
+    MEG ID
+    """
+
+    name = "MEG ID"
+
+    fields_desc = [
+        ByteField("resv", 1),
+        ByteField("format", 0),
+        MultipleTypeField(
+            [
+                (
+                    LenField("length", 13, fmt="B"),
+                    lambda p: p.format == 32,
+                ),
+                (
+                    LenField("length", 15, fmt="B"),
+                    lambda p: p.format == 33,
+                )
+            ],
+            LenField("length", 45, fmt="B"),
+        ),
+        PadField(
+            MultipleTypeField(
+                [
+                    (
+                        FieldListField("values", [0] * 13,
+                                       ByteField("value", 0),
+                                       count_from=lambda pkt: pkt.length),
+                        lambda x: x.format == 32,
+                    ),
+                    (
+                        FieldListField("values", [0] * 15,
+                                       ByteField("value", 0),
+                                       count_from=lambda pkt: pkt.length),
+                        lambda x: x.format == 33,
+                    )
+                ],
+                NBytesField("values", 0, sz=45),
+            ),
+            45),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM_TLV(Packet):
+    """
+    OAM TLV
+    """
+
+    name = "OAM TLV"
+    fields_desc = [ByteField("type", 1), LenField("length", None)]
+
+    def extract_padding(self, s):
+        return s[:self.length], s[self.length:]
+
+
+class OAM_DATA_TLV(Packet):
+    """
+    OAM Data TLV
+    """
+
+    name = "OAM Data TLV"
+    fields_desc = [ByteField("type", 3), LenField("length", None)]
+
+    def extract_padding(self, s):
+        return s[:self.length], s[self.length:]
+
+
+class OAM_TEST_TLV(Packet):
+    """
+    OAM test TLV data
+    """
+
+    name = "OAM test TLV"
+
+    fields_desc = [
+        ByteField("type", 32),
+        MultipleTypeField(
+            [
+                (
+                    LenField("length", None, adjust=lambda l: l + 5),
+                    lambda p: p.pat_type == 1 or p.pat_type == 3,
+                )
+            ],
+            LenField("length", None, adjust=lambda l: l + 1),
+        ),
+        EnumField(
+            "pat_type",
+            0,
+            {
+                0: "Null signal without CRC-32",
+                1: "Null signal with CRC-32",
+                2: "PRBS 2^-31 - 1 without CRC-32",
+                3: "PRBS 2^-31 - 1 with CRC-32",
+            },
+            fmt="B",
+        ),
+        ConditionalField(
+            FCSField("crc", None, fmt="!I"),
+            lambda p: p.pat_type == 1 or p.pat_type == 3,
+        ),
+    ]
+
+    def do_dissect(self, s):
+        if ord(s[3:4]) == 1 or ord(s[3:4]) == 3:
+            # move crc to the end of packet
+            length = struct.unpack("!H", s[1:3])[0]
+            crc_end = 3 + length
+            crc_start = crc_end - 4
+            s1 = s[:crc_start]
+            s2 = s[crc_start:crc_end]
+            s3 = s[crc_end:]
+            s = s1 + s3 + s2
+        s = super(OAM_TEST_TLV, self).do_dissect(s)
+        return s
+
+    def post_build(self, p, pay):
+        if ord(p[3:4]) == 1 or ord(p[3:4]) == 3:
+            p1 = p
+            p2 = pay[:-4]
+            p3 = struct.pack("!I", crc32(p1 + p2) % (1 << 32))
+            return p1 + p2 + p3
+        else:
+            return p + pay
+
+    def extract_padding(self, s):
+        if self.pat_type == 1 or self.pat_type == 3:
+            # we already consumed crc
+            return s[:self.length - 5], s[self.length - 5:]
+        else:
+            return s[:self.length - 1], s[self.length - 1:]
+
+
+class OAM_LTM_TLV(Packet):
+    """
+    OAM LTM TLV data
+    """
+
+    name = "OAM LTM Egress ID TLV"
+
+    fields_desc = [
+        ByteField("type", 7),
+        LenField("length", 8),
+        LongField("egress_id", 0),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM_LTR_TLV(Packet):
+    """
+    OAM LTR TLV data
+    """
+
+    name = "OAM LTR Egress ID TLV"
+
+    fields_desc = [
+        ByteField("type", 8),
+        LenField("length", 16),
+        # NOTE: wireshark interprets this field as short+MAC
+        LongField("last_egress_id", 0),
+        # NOTE: wireshark interprets this field as short+MAC
+        LongField("next_egress_id", 0),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM_LTR_IG_TLV(Packet):
+    """
+    OAM LTR TLV data
+    """
+
+    name = "OAM LTR Ingress TLV"
+
+    fields_desc = [
+        ByteField("type", 5),
+        LenField("length", 7),
+        ByteField("ingress_act", 0),
+        MACField("ingress_mac", None),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM_LTR_EG_TLV(Packet):
+    """
+    OAM LTR TLV data
+    """
+
+    name = "OAM LTR Egress TLV"
+
+    fields_desc = [
+        ByteField("type", 6),
+        LenField("length", 7),
+        ByteField("egress_act", 0),
+        MACField("egress_mac", None),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM_TEST_ID_TLV(Packet):
+    """
+    OAM Test ID TLV data
+    """
+
+    name = "OAM Test ID TLV"
+
+    fields_desc = [
+        ByteField("type", 36),
+        LenField("length", 32),
+        IntField("test_id", 0),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+def guess_tlv_type(pkt, lst, cur, remain):
+    if remain[0:1] == b'\x00':
+        return None
+    elif remain[0:1] == b'\x03':
+        return OAM_DATA_TLV
+    elif remain[0:1] == b'\x05':
+        return OAM_LTR_IG_TLV
+    elif remain[0:1] == b'\x06':
+        return OAM_LTR_EG_TLV
+    elif remain[0:1] == b'\x07':
+        return OAM_LTM_TLV
+    elif remain[0:1] == b'\x08':
+        return OAM_LTR_TLV
+    elif remain[0:1] == b'\x20':
+        return OAM_TEST_TLV
+    elif remain[0:1] == b'\x24':
+        return OAM_TEST_ID_TLV
+    else:
+        return OAM_TLV
+
+
+class PTP_TIMESTAMP(Packet):
+    """
+    PTP timestamp
+    """
+
+    # TODO: should be a part of PTP module
+    name = "PTP timestamp"
+    fields_desc = [IntField("seconds", 0), IntField("nanoseconds", 0)]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class APS(Packet):
+    """
+    Linear protective switching APS data packet
+    """
+
+    name = "APS"
+
+    fields_desc = [
+        BitEnumField(
+            "req_st",
+            0,
+            4,
+            {
+                0b0000: "No request (NR)",
+                0b0001: "Do not request (DNR)",
+                0b0010: "Reverse request (RR)",
+                0b0100: "Exercise (EXER)",
+                0b0101: "Wait-to-restore (WTR)",
+                0b0110: "Deprecated",
+                0b0111: "Manual switch (MS)",
+                0b1001: "Signal degrade (SD)",
+                0b1011: "Signal fail for working (SF)",
+                0b1101: "Forced switch (FS)",
+                0b1110: "Signal fail on protection (SF-P)",
+                0b1111: "Lockout of protection (LO)",
+            },
+        ),
+        FlagsField(
+            "prot_type",
+            0,
+            4,
+            {
+                (1 << 3): "A",
+                (1 << 2): "B",
+                (1 << 1): "D",
+                (1 << 0): "R",
+            },
+        ),
+        EnumField(
+            "req_sig", 0, {0: "Null signal", 1: "Normal traffic"}, fmt="B"
+        ),
+        EnumField(
+            "br_sig", 0, {0: "Null signal", 1: "Normal traffic"}, fmt="B"
+        ),
+        FlagsField("br_type", 0, 8, {(1 << 7): "T"}),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class RAPS(Packet):
+    """
+    Ring protective switching R-APS data packet
+    """
+
+    name = "R-APS"
+
+    fields_desc = [
+        BitEnumField(
+            "req_st",
+            0,
+            4,
+            {
+                0b0000: "No request (NR)",
+                0b0111: "Manual switch (MS)",
+                0b1011: "Signal fail(SF)",
+                0b1101: "Forced switch (FS)",
+                0b1110: "Event",
+            },
+        ),
+        MultipleTypeField(
+            [
+                (
+                    BitEnumField("sub_code", 0, 4, {0b0000: "Flush"}),
+                    lambda p: p.req_st == 0b1110,
+                )
+            ],
+            BitField("sub_code", 0, 4),
+        ),
+        FlagsField(
+            "status",
+            0,
+            8,
+            {
+                (1 << 7): "RB",
+                (1 << 6): "DNF",
+                (1 << 5): "BPR",
+            },
+        ),
+        MACField("node_id", None),
+        NBytesField("resv", 0, 24),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class OAM(Packet):
+    """
+    OAM data unit
+    """
+
+    name = "OAM"
+
+    OPCODES = {
+        1: "Continuity Check Message (CCM)",
+        3: "Loopback Message (LBM)",
+        2: "Loopback Reply (LBR)",
+        5: "Linktrace Message (LTM)",
+        4: "Linktrace Reply (LTR)",
+        32: "Generic Notification Message (GNM)",
+        33: "Alarm Indication Signal (AIS)",
+        35: "Lock Signal (LCK)",
+        37: "Test Signal (TST)",
+        39: "Automatic Protection Switching (APS)",
+        40: "Ring-Automatic Protection Switching (R-APS)",
+        41: "Maintenance Communication Channel (MCC)",
+        43: "Loss Measurement Message (LMM)",
+        42: "Loss Measurement Reply (LMR)",
+        45: "One Way Delay Measurement (1DM)",
+        47: "Delay Measurement Message (DMM)",
+        46: "Delay Measurement Reply (DMR)",
+        49: "Experimental OAM Message (EXM)",
+        48: "Experimental OAM Reply (EXR)",
+        51: "Vendor Specific Message (VSM)",
+        50: "Vendor Specific Reply (VSR)",
+        52: "Client Signal Fail (CSF)",
+        53: "One Way Synthetic Loss Measurement (1SL)",
+        55: "Synthetic Loss Message (SLM)",
+        54: "Synthetic Loss Reply (SLR)",
+    }
+
+    TIME_FLAGS = {
+        0b000: "Invalid value",
+        0b001: "Trans Int 3.33ms",
+        0b010: "Trans Int 10ms",
+        0b011: "Trans Int 100ms",
+        0b100: "Trans Int 1s",
+        0b101: "Trans Int 10s",
+        0b110: "Trans Int 1min",
+        0b111: "Trans Int 10min",
+    }
+
+    PERIOD_FLAGS = {
+        0b100: "1 frame per second",
+        0b110: "1 frame per minute",
+    }
+
+    BNM_PERIOD_FLAGS = {
+        0b100: "1 frame per second",
+        0b101: "1 frame per 10 seconds",
+        0b110: "1 frame per minute",
+    }
+
+    fields_desc = [
+        # Common fields
+        BitField("mel", 0, 3),
+        MultipleTypeField(
+            [(BitField("version", 1, 5), lambda x: x.opcode in [43, 45, 47])],
+            BitField("version", 0, 5),
+        ),
+        EnumField("opcode", None, OPCODES, fmt="B"),
+        MultipleTypeField(
+            [
+                (
+                    FlagsField("flags", 0, 5, {(1 << 4): "RDI"}),
+                    lambda x: x.opcode == 1,
+                ),
+                (
+                    FlagsField("flags", 0, 8, {(1 << 7): "HWonly"}),
+                    lambda x: x.opcode == 5,
+                ),
+                (
+                    FlagsField(
+                        "flags",
+                        0,
+                        8,
+                        {
+                            (1 << 7): "HWonly",
+                            (1 << 6): "FwdYes",
+                            (1 << 5): "TerminalMEP",
+                        },
+                    ),
+                    lambda x: x.opcode == 4,
+                ),
+                (BitField("flags", 0, 5), lambda x: x.opcode in [33, 35, 32]),
+                (
+                    FlagsField("flags", 0, 8, {1: "Proactive"}),
+                    lambda x: x.opcode in [43, 45, 47],
+                ),
+                (
+                    BitEnumField(
+                        "flags",
+                        0,
+                        5,
+                        {
+                            0b000: "LOS",
+                            0b001: "FDI",
+                            0b010: "RDI",
+                            0b011: "DCI",
+                        },
+                    ),
+                    lambda x: x.opcode == 52,
+                ),
+            ],
+            ByteField("flags", 0),
+        ),
+        ConditionalField(
+            MultipleTypeField(
+                [
+                    (
+                        BitEnumField("period", 1, 3, TIME_FLAGS),
+                        lambda x: x.opcode == 1,
+                    ),
+                    (
+                        BitEnumField("period", 0b110, 3, BNM_PERIOD_FLAGS),
+                        lambda x: x.opcode in [13, 32],
+                    ),
+                ],
+                BitEnumField("period", 0b110, 3, PERIOD_FLAGS),
+            ),
+            lambda x: x.opcode in [1, 33, 35, 52, 32],
+        ),
+        MultipleTypeField(
+            [
+                (ByteField("tlv_offset", 70), lambda x: x.opcode == 1),
+                (
+                    ByteField("tlv_offset", 4),
+                    lambda x: x.opcode in [3, 2, 37, 39],
+                ),
+                (ByteField("tlv_offset", 17), lambda x: x.opcode == 5),
+                (ByteField("tlv_offset", 6), lambda x: x.opcode == 4),
+                (ByteField("tlv_offset", 32), lambda x: x.opcode in [40, 47]),
+                (ByteField("tlv_offset", 12), lambda x: x.opcode == 43),
+                (
+                    ByteField("tlv_offset", 16),
+                    lambda x: x.opcode in [45, 54, 53, 55],
+                ),
+                (ByteField("tlv_offset", 13), lambda x: x.opcode == 32),
+                (
+                    ByteField("tlv_offset", 10),
+                    lambda x: x.opcode == 41
+                ),
+            ],
+            ByteField("tlv_offset", 0),
+        ),
+        # End common fields
+        ConditionalField(
+            IntField("seq_num", 0), lambda x: x.opcode in [1, 3, 2, 37]
+        ),
+        ConditionalField(IntField("trans_id", 0),
+                         lambda x: x.opcode in [5, 4]),
+        ConditionalField(
+            OUIField("oui", None), lambda x: x.opcode in [41, 49, 48, 51, 50]
+        ),
+        ConditionalField(
+            MultipleTypeField(
+                [(ByteField("subopcode", 1), lambda x: x.opcode == 32)],
+                ByteField("subopcode", 0),
+            ),
+            lambda x: x.opcode in [41, 49, 48, 51, 50, 32],
+        ),
+        ConditionalField(
+            MepIdField("mep_id", 0),
+            lambda x: x.opcode == 1 \
+            or (x.opcode == 41 and x.subopcode == 1 and x.oui == 6567),
+        ),
+        ConditionalField(
+            PacketField("meg_id", MegId(), MegId), lambda x: x.opcode == 0x01
+        ),
+        ConditionalField(
+            ShortField("src_mep_id", 0), lambda x: x.opcode in [55, 54, 53]
+        ),
+        ConditionalField(
+            ShortField("rcv_mep_id", 0), lambda x: x.opcode in [55, 54, 53]
+        ),
+        ConditionalField(
+            IntField("test_id", 0), lambda x: x.opcode in [55, 54, 53]
+        ),
+        ConditionalField(
+            IntField("txfcf", 0), lambda x: x.opcode in [1, 43, 42, 55, 54, 53]
+        ),
+        ConditionalField(IntField("rxfcb", 0), lambda x: x.opcode == 1),
+        ConditionalField(IntField("rxfcf", 0), lambda x: x.opcode in [43, 42]),
+        ConditionalField(
+            IntField("txfcb", 0), lambda x: x.opcode in [1, 43, 42, 55, 54]
+        ),
+        ConditionalField(IntField("resv", 0), lambda x: x.opcode in [1, 53]),
+        ConditionalField(ByteField("ttl", 0), lambda x: x.opcode in [5, 4]),
+        ConditionalField(MACField("orig_mac", None), lambda x: x.opcode == 5),
+        ConditionalField(MACField("targ_mac", None), lambda x: x.opcode == 5),
+        ConditionalField(ByteField("relay_act", None),
+                         lambda x: x.opcode == 4),
+        ConditionalField(
+            PacketField("txtsf", PTP_TIMESTAMP(), PTP_TIMESTAMP),
+            lambda x: x.opcode in [45, 47, 46],
+        ),
+        ConditionalField(
+            PacketField("rxtsf", PTP_TIMESTAMP(), PTP_TIMESTAMP),
+            lambda x: x.opcode in [45, 47, 46],
+        ),
+        ConditionalField(
+            PacketField("txtsb", PTP_TIMESTAMP(), PTP_TIMESTAMP),
+            lambda x: x.opcode in [47, 46],
+        ),
+        ConditionalField(
+            PacketField("rxtsb", PTP_TIMESTAMP(), PTP_TIMESTAMP),
+            lambda x: x.opcode in [47, 46],
+        ),
+        ConditionalField(
+            IntField("expct_dur", None),
+            lambda x: x.opcode == 41 and x.subopcode == 1 and x.oui == 6567,
+        ),
+        ConditionalField(IntField("nom_bdw", None), lambda x: x.opcode == 32),
+        ConditionalField(IntField("curr_bdw", None), lambda x: x.opcode == 32),
+        ConditionalField(IntField("port_id", None), lambda x: x.opcode == 32),
+        ConditionalField(
+            PacketField("aps", APS(), APS), lambda x: x.opcode == 39
+        ),
+        ConditionalField(
+            PacketField("raps", RAPS(), RAPS), lambda x: x.opcode == 40
+        ),
+        ConditionalField(
+            PacketListField("tlvs", [], next_cls_cb=guess_tlv_type),
+            lambda x: x.opcode in [3, 2, 5, 4, 37, 45, 47, 46, 55, 54, 53],
+        ),
+        ConditionalField(
+            IntField("opt_data", None),
+            lambda x: x.opcode in [49, 48, 51, 50] and False,
+        ),  # FIXME: field documented elsewhere
+        # TODO: add EXM, EXR, VSM and VSR data
+        ByteField("end_tlv", 0),
+    ]
+
+
+bind_layers(Dot1Q, OAM, type=0x8902)

--- a/test/contrib/oam.uts
+++ b/test/contrib/oam.uts
@@ -142,10 +142,10 @@ assert pkt.length == 15
 assert len(raw(pkt)) == 48
 
 + OAM
+~ tshark
 
-= CCM
+= Define check_tshark function
 
-# FIXME: find a way to define this globally and remove duplicates
 def check_tshark(pkt, string):
     import tempfile, os
     fd, pcapfilename = tempfile.mkstemp()
@@ -154,6 +154,8 @@ def check_tshark(pkt, string):
     assert string in rv.decode("utf8")
     os.close(fd)
     os.unlink(pcapfilename)
+
+= CCM
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Continuity Check Message (CCM)",
@@ -183,15 +185,6 @@ check_tshark(pkt, "(CCM)")
 
 = LBM
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Loopback Message (LBM)",
                     seq_num=33,
@@ -213,15 +206,6 @@ assert raw(pkt[OAM].tlvs[2].payload) == b'789'
 check_tshark(pkt, "(LBM)")
 
 = LTM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Linktrace Message (LTM)",
@@ -246,15 +230,6 @@ assert pkt[OAM].tlvs[0].egress_id == 12
 check_tshark(pkt, "(LTM)")
 
 = LTR
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Linktrace Reply (LTR)",
@@ -306,15 +281,6 @@ check_tshark(pkt, "(LTR)")
 
 = AIS
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Alarm Indication Signal (AIS)",
                     period="1 frame per second")))
@@ -327,15 +293,6 @@ check_tshark(pkt, "(AIS)")
 
 = LCK
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Lock Signal (LCK)",
                     period="1 frame per second")))
@@ -347,15 +304,6 @@ assert pkt[OAM].period == 0b100
 check_tshark(pkt, "(LCK)")
 
 = TST
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Test Signal (TST)",
@@ -414,15 +362,6 @@ check_tshark(pkt, "(TST)")
 
 = APS
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Automatic Protection Switching (APS)",
                     aps=APS(req_st="Forced switch (FS)",
@@ -446,15 +385,6 @@ check_tshark(pkt, "(APS)")
 
 = RAPS
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Ring-Automatic Protection Switching (R-APS)",
                     raps=RAPS(req_st="Event",
@@ -475,15 +405,6 @@ check_tshark(pkt, "(R-APS)")
 
 = MCC
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Maintenance Communication Channel (MCC)",
                     oui=12,
@@ -496,15 +417,6 @@ assert pkt[OAM].subopcode == 2
 check_tshark(pkt, "(MCC)")
 
 = LMM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Loss Measurement Message (LMM)",
@@ -526,15 +438,6 @@ check_tshark(pkt, "(LMM)")
 
 = LMR
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Loss Measurement Reply (LMR)",
                     txfcf=1,
@@ -549,15 +452,6 @@ assert pkt[OAM].txfcb == 3
 check_tshark(pkt, "(LMR)")
 
 = 1DM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="One Way Delay Measurement (1DM)",
@@ -588,15 +482,6 @@ assert pkt[OAM].tlvs[2].test_id == 5
 check_tshark(pkt, "(1DM)")
 
 = DMM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Delay Measurement Message (DMM)",
@@ -634,15 +519,6 @@ check_tshark(pkt, "(DMM)")
 
 = EXM
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Experimental OAM Message (EXM)",
                     oui=123,
@@ -655,15 +531,6 @@ assert pkt[OAM].subopcode == 33
 check_tshark(pkt, "(EXM)")
 
 = EXR
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Experimental OAM Reply (EXR)",
@@ -678,15 +545,6 @@ check_tshark(pkt, "(EXR)")
 
 = VSM
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Vendor Specific Message (VSM)",
                     oui=123,
@@ -699,15 +557,6 @@ assert pkt[OAM].subopcode == 33
 check_tshark(pkt, "(VSM)")
 
 = CSF
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Client Signal Fail (CSF)",
@@ -722,15 +571,6 @@ assert pkt[OAM].period == 0b110
 check_tshark(pkt, "(CSF)")
 
 = SLM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Synthetic Loss Message (SLM)",
@@ -760,15 +600,6 @@ check_tshark(pkt, "(SLM)")
 
 = SLR
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Synthetic Loss Reply (SLR)",
                     test_id=11,
@@ -797,15 +628,6 @@ check_tshark(pkt, "(SLR)")
 
 = 1SL
 
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
-
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="One Way Synthetic Loss Measurement (1SL)",
                     test_id=11,
@@ -829,15 +651,6 @@ assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
 check_tshark(pkt, "(1SL)")
 
 = GNM
-
-def check_tshark(pkt, string):
-    import tempfile, os
-    fd, pcapfilename = tempfile.mkstemp()
-    wrpcap(pcapfilename, pkt)
-    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
-    assert string in rv.decode("utf8")
-    os.close(fd)
-    os.unlink(pcapfilename)
 
 pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
                 OAM(opcode="Generic Notification Message (GNM)",

--- a/test/contrib/oam.uts
+++ b/test/contrib/oam.uts
@@ -1,0 +1,857 @@
+# OAM unit tests
+#
+# Type the following command to launch start the tests:
+# $ test/run_tests -P "load_contrib('oam')" -t test/contrib/oam.uts
+
++ TLV
+
+= Generic TLV
+
+pkt = OAM_TLV(raw(OAM_TLV()/Raw(b'123')))
+assert pkt.type == 1
+assert pkt.length == 3
+
+= Data TLV
+
+pkt = OAM_DATA_TLV(raw(OAM_DATA_TLV()/Raw(b'123')))
+assert pkt.type == 3
+assert pkt.length == 3
+
+= Test TLV
+
+from binascii import crc32
+
+pkt = OAM_TEST_TLV(raw(OAM_TEST_TLV(pat_type="Null signal without CRC-32")/Raw(b'123')))
+assert pkt.type == 32
+assert pkt.length == 4
+assert raw(pkt.payload) == b'123'
+pkt = OAM_TEST_TLV(raw(OAM_TEST_TLV(pat_type="Null signal with CRC-32")/Raw(b'123')))
+assert pkt.type == 32
+assert pkt.length == 8
+assert pkt.crc == crc32(raw(pkt)[:-4]) % (1 << 32)
+assert pkt.crc == 0xad147086
+assert raw(pkt.payload) == b'123'
+pkt = OAM_TEST_TLV(raw(OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 without CRC-32")/Raw(b'123')))
+assert pkt.type == 32
+assert pkt.length == 4
+assert raw(pkt.payload) == b'123'
+pkt = OAM_TEST_TLV(raw(OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 with CRC-32")/Raw(b'123')))
+assert pkt.type == 32
+assert pkt.length == 8
+assert pkt.crc == crc32(raw(pkt)[:-4]) % (1 << 32)
+assert pkt.crc == 0x71db80d
+assert raw(pkt.payload) == b'123'
+
+= LTM TLV
+
+pkt = OAM_LTM_TLV(raw(OAM_LTM_TLV(egress_id=3)/Raw(b'123')))
+assert pkt.type == 7
+assert pkt.length == 8
+assert pkt.egress_id == 3
+
+= LTR TLV
+
+pkt = OAM_LTR_TLV(raw(OAM_LTR_TLV(last_egress_id=2, next_egress_id=4)/Raw(b'123')))
+assert pkt.type == 8
+assert pkt.length == 16
+assert pkt.last_egress_id == 2
+assert pkt.next_egress_id == 4
+
+= LTR IG TLV
+
+pkt = OAM_LTR_IG_TLV(raw(OAM_LTR_IG_TLV(ingress_act=2, ingress_mac="00:11:22:33:44:55")/Raw(b'123')))
+assert pkt.type == 5
+assert pkt.length == 7
+assert pkt.ingress_act == 2
+assert pkt.ingress_mac == "00:11:22:33:44:55"
+
+= LTR EG TLV
+
+pkt = OAM_LTR_EG_TLV(raw(OAM_LTR_EG_TLV(egress_act=2, egress_mac="00:11:22:33:44:55")/Raw(b'123')))
+assert pkt.type == 6
+assert pkt.length == 7
+assert pkt.egress_act == 2
+assert pkt.egress_mac == "00:11:22:33:44:55"
+
+= TEST ID TLV
+
+pkt = OAM_TEST_ID_TLV(raw(OAM_TEST_ID_TLV(test_id=1)/Raw(b'123')))
+assert pkt.type == 36
+assert pkt.length == 32
+assert pkt.test_id == 1
+
+= PTP TIMESTAMP
+
+pkt = PTP_TIMESTAMP(raw(PTP_TIMESTAMP(seconds=5, nanoseconds=10)/Raw(b'123')))
+assert pkt.seconds == 5
+assert pkt.nanoseconds == 10
+
+= APS
+
+pkt = APS(raw(APS(req_st="Wait-to-restore (WTR)",
+                  prot_type="D+A",
+                  req_sig="Normal traffic",
+                  br_sig="Normal traffic",
+                  br_type="T")/Raw(b'123')))
+assert pkt.req_st == 0b0101
+assert pkt.prot_type == 0b1010
+assert pkt.req_sig == 1
+assert pkt.br_sig == 1
+assert pkt.br_type == 0b10000000
+
+= RAPS
+
+pkt = RAPS(raw(RAPS(req_st="Signal fail(SF)",
+                    status="RB+BPR",
+                    node_id="00:11:22:33:44:55")/Raw(b'123')))
+assert pkt.req_st == 0b1011
+assert pkt.sub_code == 0b0000
+assert pkt.status == 0b10100000
+assert pkt.node_id == "00:11:22:33:44:55"
+
++ MEG ID
+
+= MEG ID
+
+pkt = MegId(raw(MegId(format=1,
+                      values=int(0xdeadbeef))))
+assert pkt.format == 1
+# FIXME: make compatible with python2
+# assert pkt.values.to_bytes(45, "little")[-4:] == b"\xde\xad\xbe\xef"
+assert pkt.length == 45
+assert len(raw(pkt)) == 48
+
+= MEG ICC ID
+
+pkt = MegId(raw(MegId(format=32,
+                      values=list(range(13)))))
+
+assert pkt.format == 32
+assert pkt.values == list(range(13))
+assert pkt.length == 13
+assert len(raw(pkt)) == 48
+
+= MEG ICC and CC ID
+
+pkt = MegId(raw(MegId(format=33,
+                      values=list(range(15)))))
+
+assert pkt.format == 33
+assert pkt.values == list(range(15))
+assert pkt.length == 15
+assert len(raw(pkt)) == 48
+
++ OAM
+
+= CCM
+
+# FIXME: find a way to define this globally and remove duplicates
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Continuity Check Message (CCM)",
+                    flags="RDI",
+                    period="Trans Int 10s",
+                    mep_id=0xffff,
+                    meg_id=MegId(format=32,
+                                 values=list(range(13))),
+                    txfcf=1,
+                    rxfcb=2,
+                    txfcb=3)))
+
+assert pkt[OAM].opcode == 1
+assert pkt[OAM].period == 5
+assert pkt[OAM].tlv_offset == 70
+assert pkt[OAM].flags.RDI == True
+assert pkt[OAM].flags == 1<<4
+assert pkt[OAM].mep_id == 0xffff
+assert pkt[OAM].meg_id.format == 32
+assert pkt[OAM].meg_id.length == 13
+assert pkt[OAM].meg_id.values == list(range(13))
+assert pkt[OAM].txfcf == 1
+assert pkt[OAM].rxfcb == 2
+assert pkt[OAM].txfcb == 3
+
+check_tshark(pkt, "(CCM)")
+
+= LBM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Loopback Message (LBM)",
+                    seq_num=33,
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456'),
+                          OAM_DATA_TLV()/Raw(b'789')])))
+
+assert pkt[OAM].opcode == 3
+assert pkt[OAM].tlv_offset == 4
+assert pkt[OAM].seq_num == 33
+for i in range(3):
+    assert pkt[OAM].tlvs[i].type == 3
+    assert pkt[OAM].tlvs[i].length == 3
+
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert raw(pkt[OAM].tlvs[1].payload) == b'456'
+assert raw(pkt[OAM].tlvs[2].payload) == b'789'
+
+check_tshark(pkt, "(LBM)")
+
+= LTM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Linktrace Message (LTM)",
+                    trans_id=12,
+		    ttl=21,
+                    flags="HWonly",
+		    orig_mac="12:34:56:78:90:11",
+		    targ_mac="12:34:56:78:90:22",
+                    tlvs=[OAM_LTM_TLV(egress_id=12)])))
+
+assert pkt[OAM].opcode == 5
+assert pkt[OAM].tlv_offset == 17
+assert pkt[OAM].ttl == 21
+assert pkt[OAM].flags.HWonly == True
+assert pkt[OAM].flags == 1<<7
+assert pkt[OAM].orig_mac == "12:34:56:78:90:11"
+assert pkt[OAM].targ_mac == "12:34:56:78:90:22"
+assert pkt[OAM].tlvs[0].type == 7
+assert pkt[OAM].tlvs[0].length == 8
+assert pkt[OAM].tlvs[0].egress_id == 12
+
+check_tshark(pkt, "(LTM)")
+
+= LTR
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Linktrace Reply (LTR)",
+                    trans_id=21,
+		    ttl=12,
+                    flags="HWonly+TerminalMEP",
+		    relay_act=8,
+                    tlvs=[OAM_LTR_TLV(last_egress_id=1, next_egress_id=2),
+                          OAM_LTR_TLV(last_egress_id=3, next_egress_id=4),
+                          OAM_LTR_IG_TLV(ingress_act=1, ingress_mac="12:34:56:78:90:11"),
+                          OAM_LTR_IG_TLV(ingress_act=6, ingress_mac="12:34:56:78:90:22"),
+                          OAM_LTR_EG_TLV(egress_act=2, egress_mac="12:34:56:78:90:33"),
+                          OAM_LTR_EG_TLV(egress_act=3, egress_mac="12:34:56:78:90:44")])))
+
+assert pkt[OAM].opcode == 4
+assert pkt[OAM].tlv_offset == 6
+assert pkt[OAM].ttl == 12
+assert pkt[OAM].flags.HWonly == True
+assert pkt[OAM].flags.FwdYes == False
+assert pkt[OAM].flags.TerminalMEP == True
+assert pkt[OAM].flags == (1<<7) | (1<<5)
+assert pkt[OAM].relay_act == 8
+assert pkt[OAM].tlvs[0].type == 8
+assert pkt[OAM].tlvs[0].length == 16
+assert pkt[OAM].tlvs[0].last_egress_id == 1
+assert pkt[OAM].tlvs[0].next_egress_id == 2
+assert pkt[OAM].tlvs[1].type == 8
+assert pkt[OAM].tlvs[1].length == 16
+assert pkt[OAM].tlvs[1].last_egress_id == 3
+assert pkt[OAM].tlvs[1].next_egress_id == 4
+assert pkt[OAM].tlvs[2].type == 5
+assert pkt[OAM].tlvs[2].length == 7
+assert pkt[OAM].tlvs[2].ingress_act == 1
+assert pkt[OAM].tlvs[2].ingress_mac == "12:34:56:78:90:11"
+assert pkt[OAM].tlvs[3].type == 5
+assert pkt[OAM].tlvs[3].length == 7
+assert pkt[OAM].tlvs[3].ingress_act == 6
+assert pkt[OAM].tlvs[3].ingress_mac == "12:34:56:78:90:22"
+assert pkt[OAM].tlvs[4].type == 6
+assert pkt[OAM].tlvs[4].length == 7
+assert pkt[OAM].tlvs[4].egress_act == 2
+assert pkt[OAM].tlvs[4].egress_mac == "12:34:56:78:90:33"
+assert pkt[OAM].tlvs[5].type == 6
+assert pkt[OAM].tlvs[5].length == 7
+assert pkt[OAM].tlvs[5].egress_act == 3
+assert pkt[OAM].tlvs[5].egress_mac == "12:34:56:78:90:44"
+
+check_tshark(pkt, "(LTR)")
+
+= AIS
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Alarm Indication Signal (AIS)",
+                    period="1 frame per second")))
+
+assert pkt[OAM].opcode == 33
+assert pkt[OAM].tlv_offset == 0
+assert pkt[OAM].period == 0b100
+
+check_tshark(pkt, "(AIS)")
+
+= LCK
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Lock Signal (LCK)",
+                    period="1 frame per second")))
+
+assert pkt[OAM].opcode == 35
+assert pkt[OAM].tlv_offset == 0
+assert pkt[OAM].period == 0b100
+
+check_tshark(pkt, "(LCK)")
+
+= TST
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Test Signal (TST)",
+                    seq_num=15,
+                    tlvs=[OAM_TEST_TLV(pat_type="Null signal without CRC-32")/Raw(b'123'),
+                          OAM_TEST_TLV(pat_type="Null signal without CRC-32")/Raw(b'23456'),
+                          OAM_TEST_TLV(pat_type="Null signal with CRC-32")/Raw(b'123'),
+                          OAM_TEST_TLV(pat_type="Null signal with CRC-32")/Raw(b'23456'),
+                          OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 without CRC-32")/Raw(b'123'),
+                          OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 without CRC-32")/Raw(b'23456'),
+                          OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 with CRC-32")/Raw(b'123'),
+                          OAM_TEST_TLV(pat_type="PRBS 2^-31 - 1 with CRC-32")/Raw(b'23456')])))
+
+assert pkt[OAM].opcode == 37
+assert pkt[OAM].tlv_offset == 4
+assert pkt[OAM].seq_num == 15
+
+assert pkt[OAM].tlvs[0].type == 32
+assert pkt[OAM].tlvs[0].length == 4
+assert pkt[OAM].tlvs[0].pat_type == 0
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 32
+assert pkt[OAM].tlvs[1].length == 6
+assert pkt[OAM].tlvs[1].pat_type == 0
+assert raw(pkt[OAM].tlvs[1].payload) == b'23456'
+assert pkt[OAM].tlvs[2].type == 32
+assert pkt[OAM].tlvs[2].length == 8
+assert pkt[OAM].tlvs[2].pat_type == 1
+assert raw(pkt[OAM].tlvs[2].payload) == b'123'
+assert pkt[OAM].tlvs[2].crc == crc32(raw(pkt[OAM].tlvs[2])[:-4]) % (1 << 32)
+assert pkt[OAM].tlvs[3].type == 32
+assert pkt[OAM].tlvs[3].length == 10
+assert pkt[OAM].tlvs[3].pat_type == 1
+assert raw(pkt[OAM].tlvs[3].payload) == b'23456'
+assert pkt[OAM].tlvs[3].crc == crc32(raw(pkt[OAM].tlvs[3])[:-4]) % (1 << 32)
+assert pkt[OAM].tlvs[4].type == 32
+assert pkt[OAM].tlvs[4].length == 4
+assert pkt[OAM].tlvs[4].pat_type == 2
+assert raw(pkt[OAM].tlvs[4].payload) == b'123'
+assert pkt[OAM].tlvs[5].type == 32
+assert pkt[OAM].tlvs[5].length == 6
+assert pkt[OAM].tlvs[5].pat_type == 2
+assert raw(pkt[OAM].tlvs[5].payload) == b'23456'
+assert pkt[OAM].tlvs[6].type == 32
+assert pkt[OAM].tlvs[6].length == 8
+assert pkt[OAM].tlvs[6].pat_type == 3
+assert raw(pkt[OAM].tlvs[6].payload) == b'123'
+assert pkt[OAM].tlvs[6].crc == crc32(raw(pkt[OAM].tlvs[6])[:-4]) % (1 << 32)
+assert pkt[OAM].tlvs[7].type == 32
+assert pkt[OAM].tlvs[7].length == 10
+assert pkt[OAM].tlvs[7].pat_type == 3
+assert raw(pkt[OAM].tlvs[7].payload) == b'23456'
+assert pkt[OAM].tlvs[7].crc == crc32(raw(pkt[OAM].tlvs[7])[:-4]) % (1 << 32)
+
+check_tshark(pkt, "(TST)")
+
+= APS
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Automatic Protection Switching (APS)",
+                    aps=APS(req_st="Forced switch (FS)",
+                            prot_type="A+B+R",
+                            req_sig="Normal traffic",
+                            br_sig="Null signal",
+                            br_type="T"))))
+
+assert pkt[OAM].opcode == 39
+assert pkt[APS].req_st == 0b1101
+assert pkt[APS].prot_type.A == True
+assert pkt[APS].prot_type.B == True
+assert pkt[APS].prot_type.R == True
+assert pkt[APS].prot_type == 0b1101
+assert pkt[APS].req_sig == 1
+assert pkt[APS].br_sig == 0
+assert pkt[APS].br_type.T == True
+assert pkt[APS].br_type == (1 << 7)
+
+check_tshark(pkt, "(APS)")
+
+= RAPS
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Ring-Automatic Protection Switching (R-APS)",
+                    raps=RAPS(req_st="Event",
+                              sub_code="Flush",
+                              status="RB+BPR",
+                              node_id="12:12:12:23:23:23"))))
+
+assert pkt[OAM].opcode == 40
+assert pkt[RAPS].req_st == 0b1110
+assert pkt[RAPS].sub_code == 0b0000
+assert pkt[RAPS].status.RB == True
+assert pkt[RAPS].status.DNF == False
+assert pkt[RAPS].status.BPR == True
+assert pkt[RAPS].status == (1 << 7) | (1 << 5)
+assert pkt[RAPS].node_id == "12:12:12:23:23:23"
+
+check_tshark(pkt, "(R-APS)")
+
+= MCC
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Maintenance Communication Channel (MCC)",
+                    oui=12,
+                    subopcode=2)))
+
+assert pkt[OAM].opcode == 41
+assert pkt[OAM].oui == 12
+assert pkt[OAM].subopcode == 2
+
+check_tshark(pkt, "(MCC)")
+
+= LMM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Loss Measurement Message (LMM)",
+                    flags="Proactive",
+                    txfcf=1,
+                    rxfcf=2,
+                    txfcb=3)))
+
+assert pkt[OAM].opcode == 43
+assert pkt[OAM].version == 1
+assert pkt[OAM].tlv_offset == 12
+assert pkt[OAM].flags == 1
+assert pkt[OAM].flags.Proactive == True
+assert pkt[OAM].txfcf == 1
+assert pkt[OAM].rxfcf == 2
+assert pkt[OAM].txfcb == 3
+
+check_tshark(pkt, "(LMM)")
+
+= LMR
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Loss Measurement Reply (LMR)",
+                    txfcf=1,
+                    rxfcf=2,
+                    txfcb=3)))
+
+assert pkt[OAM].opcode == 42
+assert pkt[OAM].txfcf == 1
+assert pkt[OAM].rxfcf == 2
+assert pkt[OAM].txfcb == 3
+
+check_tshark(pkt, "(LMR)")
+
+= 1DM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="One Way Delay Measurement (1DM)",
+                    txtsf=PTP_TIMESTAMP(seconds=1, nanoseconds=2),
+                    rxtsf=PTP_TIMESTAMP(seconds=3, nanoseconds=4),
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456789'),
+                          OAM_TEST_ID_TLV(test_id=5)])))
+
+assert pkt[OAM].opcode == 45
+assert pkt[OAM].version == 1
+assert pkt[OAM].tlv_offset == 16
+assert pkt[OAM].txtsf.seconds == 1
+assert pkt[OAM].txtsf.nanoseconds == 2
+assert pkt[OAM].rxtsf.seconds == 3
+assert pkt[OAM].rxtsf.nanoseconds == 4
+assert pkt[OAM].tlvs[0].type == 3
+assert pkt[OAM].tlvs[0].length == 3
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 3
+assert pkt[OAM].tlvs[1].length == 6
+assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
+assert pkt[OAM].tlvs[2].type == 36
+assert pkt[OAM].tlvs[2].length == 32
+assert pkt[OAM].tlvs[2].test_id == 5
+
+# FIXME: for some reason wireshark does not like OAM_TEST_ID_TLV here
+check_tshark(pkt, "(1DM)")
+
+= DMM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Delay Measurement Message (DMM)",
+                    txtsf=PTP_TIMESTAMP(seconds=1, nanoseconds=2),
+                    txtsb=PTP_TIMESTAMP(seconds=2, nanoseconds=1),
+                    rxtsf=PTP_TIMESTAMP(seconds=3, nanoseconds=4),
+                    rxtsb=PTP_TIMESTAMP(seconds=6, nanoseconds=5),
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456789'),
+                          OAM_TEST_ID_TLV(test_id=5)])))
+
+assert pkt[OAM].opcode == 47
+assert pkt[OAM].version == 1
+assert pkt[OAM].tlv_offset == 32
+assert pkt[OAM].txtsf.seconds == 1
+assert pkt[OAM].txtsf.nanoseconds == 2
+assert pkt[OAM].rxtsf.seconds == 3
+assert pkt[OAM].rxtsf.nanoseconds == 4
+assert pkt[OAM].txtsb.seconds == 2
+assert pkt[OAM].txtsb.nanoseconds == 1
+assert pkt[OAM].rxtsb.seconds == 6
+assert pkt[OAM].rxtsb.nanoseconds == 5
+assert pkt[OAM].tlvs[0].type == 3
+assert pkt[OAM].tlvs[0].length == 3
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 3
+assert pkt[OAM].tlvs[1].length == 6
+assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
+assert pkt[OAM].tlvs[2].type == 36
+assert pkt[OAM].tlvs[2].length == 32
+assert pkt[OAM].tlvs[2].test_id == 5
+
+# FIXME: for some reason wireshark does not like OAM_TEST_ID_TLV here
+check_tshark(pkt, "(DMM)")
+
+= EXM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Experimental OAM Message (EXM)",
+                    oui=123,
+                    subopcode=33)))
+
+assert pkt[OAM].opcode == 49
+assert pkt[OAM].oui == 123
+assert pkt[OAM].subopcode == 33
+
+check_tshark(pkt, "(EXM)")
+
+= EXR
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Experimental OAM Reply (EXR)",
+                    oui=123,
+                    subopcode=33)))
+
+assert pkt[OAM].opcode == 48
+assert pkt[OAM].oui == 123
+assert pkt[OAM].subopcode == 33
+
+check_tshark(pkt, "(EXR)")
+
+= VSM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Vendor Specific Message (VSM)",
+                    oui=123,
+                    subopcode=33)))
+
+assert pkt[OAM].opcode == 51
+assert pkt[OAM].oui == 123
+assert pkt[OAM].subopcode == 33
+
+check_tshark(pkt, "(VSM)")
+
+= CSF
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Client Signal Fail (CSF)",
+                    flags="RDI",
+                    period="1 frame per minute")))
+
+assert pkt[OAM].opcode == 52
+assert pkt[OAM].tlv_offset == 0
+assert pkt[OAM].flags == 0b010
+assert pkt[OAM].period == 0b110
+
+check_tshark(pkt, "(CSF)")
+
+= SLM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Synthetic Loss Message (SLM)",
+                    test_id=11,
+                    src_mep_id=12,
+                    rcv_mep_id=34,
+                    txfcf=3,
+                    txfcb=9,
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456789')])))
+
+assert pkt[OAM].opcode == 55
+assert pkt[OAM].tlv_offset == 16
+assert pkt[OAM].test_id == 11
+assert pkt[OAM].src_mep_id == 12
+assert pkt[OAM].rcv_mep_id == 34
+assert pkt[OAM].txfcf == 3
+assert pkt[OAM].txfcb == 9
+assert pkt[OAM].tlvs[0].type == 3
+assert pkt[OAM].tlvs[0].length == 3
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 3
+assert pkt[OAM].tlvs[1].length == 6
+assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
+
+check_tshark(pkt, "(SLM)")
+
+= SLR
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Synthetic Loss Reply (SLR)",
+                    test_id=11,
+                    src_mep_id=12,
+                    rcv_mep_id=34,
+                    txfcf=3,
+                    txfcb=9,
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456789')])))
+
+assert pkt[OAM].opcode == 54
+assert pkt[OAM].tlv_offset == 16
+assert pkt[OAM].test_id == 11
+assert pkt[OAM].src_mep_id == 12
+assert pkt[OAM].rcv_mep_id == 34
+assert pkt[OAM].txfcf == 3
+assert pkt[OAM].txfcb == 9
+assert pkt[OAM].tlvs[0].type == 3
+assert pkt[OAM].tlvs[0].length == 3
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 3
+assert pkt[OAM].tlvs[1].length == 6
+assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
+
+check_tshark(pkt, "(SLR)")
+
+= 1SL
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="One Way Synthetic Loss Measurement (1SL)",
+                    test_id=11,
+                    src_mep_id=12,
+                    txfcf=3,
+                    tlvs=[OAM_DATA_TLV()/Raw(b'123'),
+                          OAM_DATA_TLV()/Raw(b'456789')])))
+
+assert pkt[OAM].opcode == 53
+assert pkt[OAM].tlv_offset == 16
+assert pkt[OAM].test_id == 11
+assert pkt[OAM].src_mep_id == 12
+assert pkt[OAM].txfcf == 3
+assert pkt[OAM].tlvs[0].type == 3
+assert pkt[OAM].tlvs[0].length == 3
+assert raw(pkt[OAM].tlvs[0].payload) == b'123'
+assert pkt[OAM].tlvs[1].type == 3
+assert pkt[OAM].tlvs[1].length == 6
+assert raw(pkt[OAM].tlvs[1].payload) == b'456789'
+
+check_tshark(pkt, "(1SL)")
+
+= GNM
+
+def check_tshark(pkt, string):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True, args=['-Y', 'cfm'], dump=True, wait=True)
+    assert string in rv.decode("utf8")
+    os.close(fd)
+    os.unlink(pcapfilename)
+
+pkt = Ether(raw(Ether(dst="00:11:22:33:44:55")/Dot1Q()/
+                OAM(opcode="Generic Notification Message (GNM)",
+                    period="1 frame per minute",
+                    nom_bdw=1,
+                    curr_bdw=2,
+                    port_id=3)))
+
+assert pkt[OAM].opcode == 32
+assert pkt[OAM].tlv_offset == 13
+assert pkt[OAM].period == 0b110
+assert pkt[OAM].subopcode == 1
+assert pkt[OAM].nom_bdw == 1
+assert pkt[OAM].curr_bdw == 2
+assert pkt[OAM].port_id == 3
+
+check_tshark(pkt, "(GNM)")


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

## Description

This PR adds [OAM](https://www.itu.int/rec/T-REC-G.8013) protocol layer, which includes [APS](https://www.itu.int/rec/T-REC-G.8031) and [RAPS](https://www.itu.int/rec/T-REC-G.8032) protocols.

## Issues with code:
* This PR defines `PTP_TIMESTAMP` packet type, which probably should be defined elsewhere.
* Some `OAM_LTR_TLV` fields are interpreted a bit differently in Wireshark
* `EXM`, `EXR`, `VSM` and `VSR` have optional fields, which type and length are not specified by the standard, thus were omitted.
* For some reason, Wireshark throws exception on `OAM_TEST_ID_TLV` dissection. But it seems like a Wireshark's bug.
* ~~I couldn't find a way to define `check_tshark` function for all test cases, so there's a lot of code duplication.~~