### PR TITLE
IKEv2: improve dissection of IKEv2 redirect notifications

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -9,7 +9,6 @@ Internet Key Exchange Protocol Version 2 (IKEv2), RFC 7296
 # scapy.contrib.description = Internet Key Exchange Protocol Version 2 (IKEv2), RFC 7296
 # scapy.contrib.status = loads
 
-import logging
 import struct
 
 
@@ -31,85 +30,115 @@ from scapy.config import conf
 from scapy.volatile import RandString
 
 # see https://www.iana.org/assignments/ikev2-parameters for details
-IKEv2AttributeTypes = {"Encryption": (1, {"DES-IV64": 1,
-                                          "DES": 2,
-                                          "3DES": 3,
-                                          "RC5": 4,
-                                          "IDEA": 5,
-                                          "CAST": 6,
-                                          "Blowfish": 7,
-                                          "3IDEA": 8,
-                                          "DES-IV32": 9,
-                                          "AES-CBC": 12,
-                                          "AES-CTR": 13,
-                                          "AES-CCM-8": 14,
-                                          "AES-CCM-12": 15,
-                                          "AES-CCM-16": 16,
-                                          "AES-GCM-8ICV": 18,
-                                          "AES-GCM-12ICV": 19,
-                                          "AES-GCM-16ICV": 20,
-                                          "Camellia-CBC": 23,
-                                          "Camellia-CTR": 24,
-                                          "Camellia-CCM-8ICV": 25,
-                                          "Camellia-CCM-12ICV": 26,
-                                          "Camellia-CCM-16ICV": 27,
-                                          "ChaCha20-Poly1305": 28,
-                                          "Kuzneychik-MGM-KTREE": 32,
-                                          "MAGMA-MGM-KTREE": 33,
-                                          }, 0),
-                       "PRF": (2, {"PRF_HMAC_MD5": 1,
-                                   "PRF_HMAC_SHA1": 2,
-                                   "PRF_HMAC_TIGER": 3,
-                                   "PRF_AES128_XCBC": 4,
-                                   "PRF_HMAC_SHA2_256": 5,
-                                   "PRF_HMAC_SHA2_384": 6,
-                                   "PRF_HMAC_SHA2_512": 7,
-                                   "PRF_AES128_CMAC": 8,
-                                   "PRF_HMAC_STREEBOG_512": 9,
-                                   }, 0),
-                       "Integrity": (3, {"HMAC-MD5-96": 1,
-                                         "HMAC-SHA1-96": 2,
-                                         "DES-MAC": 3,
-                                         "KPDK-MD5": 4,
-                                         "AES-XCBC-96": 5,
-                                         "HMAC-MD5-128": 6,
-                                         "HMAC-SHA1-160": 7,
-                                         "AES-CMAC-96": 8,
-                                         "AES-128-GMAC": 9,
-                                         "AES-192-GMAC": 10,
-                                         "AES-256-GMAC": 11,
-                                         "SHA2-256-128": 12,
-                                         "SHA2-384-192": 13,
-                                         "SHA2-512-256": 14,
-                                         }, 0),
-                       "GroupDesc": (4, {"768MODPgr": 1,
-                                         "1024MODPgr": 2,
-                                         "1536MODPgr": 5,
-                                         "2048MODPgr": 14,
-                                         "3072MODPgr": 15,
-                                         "4096MODPgr": 16,
-                                         "6144MODPgr": 17,
-                                         "8192MODPgr": 18,
-                                         "256randECPgr": 19,
-                                         "384randECPgr": 20,
-                                         "521randECPgr": 21,
-                                         "1024MODP160POSgr": 22,
-                                         "2048MODP224POSgr": 23,
-                                         "2048MODP256POSgr": 24,
-                                         "192randECPgr": 25,
-                                         "224randECPgr": 26,
-                                         "brainpoolP224r1gr": 27,
-                                         "brainpoolP256r1gr": 28,
-                                         "brainpoolP384r1gr": 29,
-                                         "brainpoolP512r1gr": 30,
-                                         "curve25519gr": 31,
-                                         "curve448gr": 32,
-                                         "GOST3410_2012_256": 33,
-                                         "GOST3410_2012_512": 34,
-                                         }, 0),
-                       "Extended Sequence Number": (5, {"No ESN": 0,
-                                                        "ESN": 1}, 0),
-                       }
+IKEv2AttributeTypes = {
+    1: (
+        "Encryption",
+        {
+            1: "DES-IV64",
+            2: "DES",
+            3: "3DES",
+            4: "RC5",
+            5: "IDEA",
+            6: "CAST",
+            7: "Blowfish",
+            8: "3IDEA",
+            9: "DES-IV32",
+            12: "AES-CBC",
+            13: "AES-CTR",
+            14: "AES-CCM-8",
+            15: "AES-CCM-12",
+            16: "AES-CCM-16",
+            18: "AES-GCM-8ICV",
+            19: "AES-GCM-12ICV",
+            20: "AES-GCM-16ICV",
+            23: "Camellia-CBC",
+            24: "Camellia-CTR",
+            25: "Camellia-CCM-8ICV",
+            26: "Camellia-CCM-12ICV",
+            27: "Camellia-CCM-16ICV",
+            28: "ChaCha20-Poly1305",
+            32: "Kuzneychik-MGM-KTREE",
+            33: "MAGMA-MGM-KTREE",
+        }
+    ),
+    2: (
+        "PRF",
+        {
+            1: "PRF_HMAC_MD5",
+            2: "PRF_HMAC_SHA1",
+            3: "PRF_HMAC_TIGER",
+            4: "PRF_AES128_XCBC",
+            5: "PRF_HMAC_SHA2_256",
+            6: "PRF_HMAC_SHA2_384",
+            7: "PRF_HMAC_SHA2_512",
+            8: "PRF_AES128_CMAC",
+            9: "PRF_HMAC_STREEBOG_512",
+        }
+    ),
+    3: (
+        "Integrity",
+        {
+            1: "HMAC-MD5-96",
+            2: "HMAC-SHA1-96",
+            3: "DES-MAC",
+            4: "KPDK-MD5",
+            5: "AES-XCBC-96",
+            6: "HMAC-MD5-128",
+            7: "HMAC-SHA1-160",
+            8: "AES-CMAC-96",
+            9: "AES-128-GMAC",
+            10: "AES-192-GMAC",
+            11: "AES-256-GMAC",
+            12: "SHA2-256-128",
+            13: "SHA2-384-192",
+            14: "SHA2-512-256",
+        }
+    ),
+    4: (
+        "GroupDesc",
+        {
+            1: "768MODPgr",
+            2: "1024MODPgr",
+            5: "1536MODPgr",
+            14: "2048MODPgr",
+            15: "3072MODPgr",
+            16: "4096MODPgr",
+            17: "6144MODPgr",
+            18: "8192MODPgr",
+            19: "256randECPgr",
+            20: "384randECPgr",
+            21: "521randECPgr",
+            22: "1024MODP160POSgr",
+            23: "2048MODP224POSgr",
+            24: "2048MODP256POSgr",
+            25: "192randECPgr",
+            26: "224randECPgr",
+            27: "brainpoolP224r1gr",
+            28: "brainpoolP256r1gr",
+            29: "brainpoolP384r1gr",
+            30: "brainpoolP512r1gr",
+            31: "curve25519gr",
+            32: "curve448gr",
+            33: "GOST3410_2012_256",
+            34: "GOST3410_2012_512",
+        }
+    ),
+    5: (
+        "Extended Sequence Number",
+        {
+            0: "No ESN",
+            1: "ESN"
+        }
+    ),
+}
+
+IKEv2TransformTypes = {
+    tf_num: tf_name for tf_name, (tf_num, _) in IKEv2AttributeTypes.items()
+}
+
+IKEv2TransformAlgorithms = {
+    tf_num: tf_dict for tf_num, (_, tf_dict) in IKEv2AttributeTypes.items()
+}
 
 IKEv2AuthenticationTypes = {
     0: "Reserved",
@@ -399,52 +428,53 @@ IPProtocolIDs = {
     142: "Robust Header Compression",
 }
 
-# the name 'IKEv2TransformTypes' is actually a misnomer (since the table
-# holds info for all IKEv2 Attribute types, not just transforms, but we'll
-# keep it for backwards compatibility... for now at least
-IKEv2TransformTypes = IKEv2AttributeTypes
+IKEv2PayloadTypes = {
+    0: "None",
+    2: "Proposal",   # used only inside the SA payload
+    3: "Transform",  # used only inside the SA payload
+    33: "SA",
+    34: "KE",
+    35: "IDi",
+    36: "IDr",
+    37: "CERT",
+    38: "CERTREQ",
+    39: "AUTH",
+    40: "Nonce",
+    41: "Notify",
+    42: "Delete",
+    43: "VendorID",
+    44: "TSi",
+    45: "TSr",
+    46: "Encrypted",
+    47: "CP",
+    48: "EAP",
+    49: "GSPM",
+    50: "IDg",
+    51: "GSA",
+    52: "KD",
+    53: "Encrypted_Fragment",
+    54: "PS"
+}
 
-IKEv2TransformNum = {}
-for n in IKEv2TransformTypes:
-    val = IKEv2TransformTypes[n]
-    tmp = {}
-    for e in val[1]:
-        tmp[val[1][e]] = e
-    IKEv2TransformNum[val[0]] = tmp
 
-IKEv2Transforms = {}
-for n in IKEv2TransformTypes:
-    IKEv2Transforms[IKEv2TransformTypes[n][0]] = n
-
-del n
-del e
-del tmp
-del val
-
-# Note: Transform and Proposal can only be used inside the SA payload
-IKEv2_payload_type = ["None", "", "Proposal", "Transform"]
-
-IKEv2_payload_type.extend([""] * 29)
-IKEv2_payload_type.extend(["SA", "KE", "IDi", "IDr", "CERT", "CERTREQ", "AUTH", "Nonce", "Notify", "Delete",  # noqa: E501
-                           "VendorID", "TSi", "TSr", "Encrypted", "CP", "EAP", "", "", "", "", "Encrypted_Fragment"])  # noqa: E501
-
-IKEv2_exchange_type = [""] * 34
-IKEv2_exchange_type.extend(["IKE_SA_INIT", "IKE_AUTH", "CREATE_CHILD_SA",
-                            "INFORMATIONAL", "IKE_SESSION_RESUME"])
+IKEv2ExchangeTypes = {
+    34: "IKE_SA_INIT",
+    35: "IKE_AUTH",
+    36: "CREATE_CHILD_SA",
+    37: "INFORMATIONAL",
+    38: "IKE_SESSION_RESUME",
+    43: "IKE_INTERMEDIATE"
+}
 
 
 class IKEv2_class(Packet):
     def guess_payload_class(self, payload):
         np = self.next_payload
-        logging.debug("For IKEv2_class np=%d", np)
         if np == 0:
             return conf.raw_layer
-        elif np < len(IKEv2_payload_type):
-            pt = IKEv2_payload_type[np]
-            logging.debug(globals().get("IKEv2_%s" % pt, IKEv2_Payload))  # noqa: E501
-            return globals().get("IKEv2_%s" % pt, IKEv2_Payload)
         else:
-            return IKEv2_Payload
+            pt = IKEv2PayloadTypes.get(np, "Payload")
+            return globals().get("IKEv2_" + pt, IKEv2_Payload)
 
 
 class IKEv2(IKEv2_class):  # rfc4306
@@ -452,9 +482,9 @@ class IKEv2(IKEv2_class):  # rfc4306
     fields_desc = [
         StrFixedLenField("init_SPI", "", 8),
         StrFixedLenField("resp_SPI", "", 8),
-        ByteEnumField("next_payload", 0, IKEv2_payload_type),
+        ByteEnumField("next_payload", 0, IKEv2PayloadTypes),
         XByteField("version", 0x20),
-        ByteEnumField("exch_type", 0, IKEv2_exchange_type),
+        ByteEnumField("exch_type", 0, IKEv2ExchangeTypes),
         FlagsField("flags", 0, 8, ["res0", "res1", "res2", "Initiator", "Version", "Response", "res6", "res7"]),  # noqa: E501
         IntField("id", 0),
         IntField("length", None)  # Length of total message: packets + all payloads  # noqa: E501
@@ -504,9 +534,9 @@ class IKEv2_Transform(IKEv2_class):
         ByteEnumField("next_payload", None, {0: "last", 3: "Transform"}),
         ByteField("res", 0),
         ShortField("length", 8),
-        ByteEnumField("transform_type", None, IKEv2Transforms),
+        ByteEnumField("transform_type", None, IKEv2TransformTypes),
         ByteField("res2", 0),
-        MultiEnumField("transform_id", None, IKEv2TransformNum, depends_on=lambda pkt: pkt.transform_type, fmt="H"),  # noqa: E501
+        MultiEnumField("transform_id", None, IKEv2TransformAlgorithms, depends_on=lambda pkt: pkt.transform_type, fmt="H"),  # noqa: E501
         ConditionalField(IKEv2_Key_Length_Attribute("key_length"), lambda pkt: pkt.length > 8),  # noqa: E501
     ]
 
@@ -529,7 +559,7 @@ class IKEv2_Proposal(IKEv2_class):
 class IKEv2_Payload(IKEv2_class):
     name = "IKEv2 Payload"
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         FlagsField("flags", 0, 8, ["critical", "res1", "res2", "res3", "res4", "res5", "res6", "res7"]),  # noqa: E501
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
         StrLenField("load", "", length_from=lambda x:x.length - 4),
@@ -540,7 +570,7 @@ class IKEv2_AUTH(IKEv2_class):
     name = "IKEv2 Authentication"
     overload_fields = {IKEv2: {"next_payload": 39}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
         ByteEnumField("auth_type", None, IKEv2AuthenticationTypes),
@@ -553,7 +583,7 @@ class IKEv2_VendorID(IKEv2_class):
     name = "IKEv2 Vendor ID"
     overload_fields = {IKEv2: {"next_payload": 43}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "vendorID", "H", adjust=lambda pkt, x:x + 4),  # noqa: E501
         StrLenField("vendorID", "", length_from=lambda x:x.length - 4),
@@ -636,7 +666,7 @@ class IKEv2_TSi(IKEv2_class):
     name = "IKEv2 Traffic Selector - Initiator"
     overload_fields = {IKEv2: {"next_payload": 44}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
         FieldLenField("number_of_TSs", None, fmt="B",
@@ -652,7 +682,7 @@ class IKEv2_TSr(IKEv2_class):
     name = "IKEv2 Traffic Selector - Responder"
     overload_fields = {IKEv2: {"next_payload": 45}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
         FieldLenField("number_of_TSs", None, fmt="B",
@@ -668,7 +698,7 @@ class IKEv2_Delete(IKEv2_class):
     name = "IKEv2 Vendor ID"
     overload_fields = {IKEv2: {"next_payload": 42}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "vendorID", "H", adjust=lambda pkt, x:x + 4),  # noqa: E501
         StrLenField("vendorID", "", length_from=lambda x:x.length - 4),
@@ -679,7 +709,7 @@ class IKEv2_SA(IKEv2_class):
     name = "IKEv2 SA"
     overload_fields = {IKEv2: {"next_payload": 33}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "prop", "H", adjust=lambda pkt, x:x + 4),
         PacketLenField("prop", conf.raw_layer(), IKEv2_Proposal, length_from=lambda x:x.length - 4),  # noqa: E501
@@ -690,7 +720,7 @@ class IKEv2_Nonce(IKEv2_class):
     name = "IKEv2 Nonce"
     overload_fields = {IKEv2: {"next_payload": 40}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
         StrLenField("load", "", length_from=lambda x:x.length - 4),
@@ -701,7 +731,7 @@ class IKEv2_Notify(IKEv2_class):
     name = "IKEv2 Notify"
     overload_fields = {IKEv2: {"next_payload": 41}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
         ByteEnumField("proto", None, {0: "Reserved", 1: "IKE", 2: "AH", 3: "ESP"}),  # noqa: E501
@@ -716,10 +746,10 @@ class IKEv2_KE(IKEv2_class):
     name = "IKEv2 Key Exchange"
     overload_fields = {IKEv2: {"next_payload": 34}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
-        ShortEnumField("group", 0, IKEv2TransformTypes['GroupDesc'][1]),
+        ShortEnumField("group", 0, IKEv2TransformAlgorithms[4]),
         ShortField("res2", 0),
         StrLenField("load", "", length_from=lambda x:x.length - 8),
     ]
@@ -729,7 +759,7 @@ class IKEv2_IDi(IKEv2_class):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Initiator"
     overload_fields = {IKEv2: {"next_payload": 35}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
         ByteEnumField("IDtype", 1, {1: "IPv4_addr", 2: "FQDN", 3: "Email_addr", 5: "IPv6_addr", 11: "Key"}),  # noqa: E501
@@ -748,7 +778,7 @@ class IKEv2_IDr(IKEv2_class):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Responder"
     overload_fields = {IKEv2: {"next_payload": 36}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "ID", "H", adjust=lambda pkt, x:x + 8),
         ByteEnumField("IDtype", 1, {1: "IPv4_addr", 2: "FQDN", 3: "Email_addr", 5: "IPv6_addr", 11: "Key"}),  # noqa: E501
@@ -767,7 +797,7 @@ class IKEv2_Encrypted(IKEv2_class):
     name = "IKEv2 Encrypted and Authenticated"
     overload_fields = {IKEv2: {"next_payload": 46}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
         StrLenField("load", "", length_from=lambda x:x.length - 4),
@@ -798,7 +828,7 @@ class IKEv2_CP(IKEv2_class):  # RFC 7296, section 3.15
     name = "IKEv2 Configuration"
     overload_fields = {IKEv2: {"next_payload": 46}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
         ByteEnumField("CFGType", 1, IKEv2ConfigurationPayloadCFGTypes),
@@ -812,7 +842,7 @@ class IKEv2_Encrypted_Fragment(IKEv2_class):
     name = "IKEv2 Encrypted Fragment"
     overload_fields = {IKEv2: {"next_payload": 53}}
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "load", "H", adjust=lambda pkt, x: x + 8),  # noqa: E501
         ShortField("frag_number", 1),
@@ -824,7 +854,7 @@ class IKEv2_Encrypted_Fragment(IKEv2_class):
 class IKEv2_CERTREQ(IKEv2_class):
     name = "IKEv2 Certificate Request"
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "cert_data", "H", adjust=lambda pkt, x:x + 5),  # noqa: E501
         ByteEnumField("cert_type", 0, IKEv2CertificateEncodings),
@@ -849,7 +879,7 @@ class IKEv2_CERT(IKEv2_class):
 class IKEv2_CERT_CRT(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "x509Cert", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
         ByteEnumField("cert_type", 4, IKEv2CertificateEncodings),
@@ -860,7 +890,7 @@ class IKEv2_CERT_CRT(IKEv2_CERT):
 class IKEv2_CERT_CRL(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "x509CRL", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
         ByteEnumField("cert_type", 7, IKEv2CertificateEncodings),
@@ -871,7 +901,7 @@ class IKEv2_CERT_CRL(IKEv2_CERT):
 class IKEv2_CERT_STR(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2_payload_type),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
         ByteField("res", 0),
         FieldLenField("length", None, "cert_data", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
         ByteEnumField("cert_type", 0, IKEv2CertificateEncodings),
@@ -880,7 +910,7 @@ class IKEv2_CERT_STR(IKEv2_CERT):
 
 
 IKEv2_payload_type_overload = {}
-for i, payloadname in enumerate(IKEv2_payload_type):
+for i, payloadname in IKEv2PayloadTypes.items():
     name = "IKEv2_%s" % payloadname
     if name in globals():
         IKEv2_payload_type_overload[globals()[name]] = {"next_payload": i}

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -442,17 +442,17 @@ IKEv2PayloadTypes = {
     40: "Nonce",
     41: "Notify",
     42: "Delete",
-    43: "VendorID",
+    43: "V",
     44: "TSi",
     45: "TSr",
-    46: "Encrypted",
+    46: "SK",
     47: "CP",
     48: "EAP",
     49: "GSPM",
     50: "IDg",
     51: "GSA",
     52: "KD",
-    53: "Encrypted_Fragment",
+    53: "SKF",
     54: "PS"
 }
 
@@ -579,7 +579,7 @@ class IKEv2_AUTH(IKEv2_class):
     ]
 
 
-class IKEv2_VendorID(IKEv2_class):
+class IKEv2_V(IKEv2_class):
     name = "IKEv2 Vendor ID"
     overload_fields = {IKEv2: {"next_payload": 43}}
     fields_desc = [
@@ -793,7 +793,7 @@ class IKEv2_IDr(IKEv2_class):  # RFC 7296, section 3.5
     ]
 
 
-class IKEv2_Encrypted(IKEv2_class):
+class IKEv2_SK(IKEv2_class):
     name = "IKEv2 Encrypted and Authenticated"
     overload_fields = {IKEv2: {"next_payload": 46}}
     fields_desc = [
@@ -838,8 +838,8 @@ class IKEv2_CP(IKEv2_class):  # RFC 7296, section 3.15
     ]
 
 
-class IKEv2_Encrypted_Fragment(IKEv2_class):
-    name = "IKEv2 Encrypted Fragment"
+class IKEv2_SKF(IKEv2_class):
+    name = "IKEv2 Encrypted and Authenticated Fragment"
     overload_fields = {IKEv2: {"next_payload": 53}}
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2PayloadTypes),

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -14,13 +14,32 @@ import struct
 
 # Modified from the original ISAKMP code by Yaron Sheffer <yaronf.ietf@gmail.com>, June 2010.  # noqa: E501
 
-from scapy.packet import Packet, bind_top_down, bind_bottom_up, \
-    split_bottom_up, split_layers, Raw
-from scapy.fields import ByteEnumField, ByteField, ConditionalField, \
-    FieldLenField, FlagsField, IP6Field, IPField, IntField, MultiEnumField, \
-    MultipleTypeField, \
-    PacketField, PacketLenField, PacketListField, ShortEnumField, ShortField, \
-    StrFixedLenField, StrLenField, X3BytesField, XByteField, XIntField
+from scapy.packet import (
+    Packet, Raw,
+    bind_top_down, bind_bottom_up, bind_layers, split_bottom_up, split_layers
+)
+from scapy.fields import (
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    FieldLenField,
+    FlagsField,
+    IP6Field,
+    IPField,
+    IntField,
+    MultiEnumField,
+    MultipleTypeField,
+    PacketField,
+    PacketLenField,
+    PacketListField,
+    ShortEnumField,
+    ShortField,
+    StrFixedLenField,
+    StrLenField,
+    X3BytesField,
+    XByteField,
+    XIntField
+)
 from scapy.layers.x509 import X509_Cert, X509_CRL
 from scapy.layers.inet import IP, UDP
 from scapy.layers.ipsec import ESP
@@ -467,17 +486,12 @@ IKEv2ExchangeTypes = {
 }
 
 
-class IKEv2_class(Packet):
-    def guess_payload_class(self, payload):
-        np = self.next_payload
-        if np == 0:
-            return conf.raw_layer
-        else:
-            pt = IKEv2PayloadTypes.get(np, "Payload")
-            return globals().get("IKEv2_" + pt, IKEv2_Payload)
+class _IKEv2_Packet(Packet):
+    def default_payload_class(self, payload):
+        return IKEv2_Payload if self.next_payload else conf.raw_layer
 
 
-class IKEv2(IKEv2_class):  # rfc4306
+class IKEv2(_IKEv2_Packet):  # rfc4306
     name = "IKEv2"
     fields_desc = [
         StrFixedLenField("init_SPI", "", 8),
@@ -497,11 +511,6 @@ class IKEv2(IKEv2_class):  # rfc4306
             if version < 0x20:
                 return ISAKMP
         return cls
-
-    def guess_payload_class(self, payload):
-        if self.flags & 1:
-            return conf.raw_layer
-        return IKEv2_class.guess_payload_class(self, payload)
 
     def answers(self, other):
         if isinstance(other, IKEv2):
@@ -528,12 +537,25 @@ class IKEv2_Key_Length_Attribute(IntField):
         return IntField.h2i(self, pkt, (x if x is not None else 0) | 0x800E0000)  # noqa: E501
 
 
-class IKEv2_Transform(IKEv2_class):
-    name = "IKE Transform"
+class IKEv2_Payload(_IKEv2_Packet):
+    name = "IKEv2 Payload"
     fields_desc = [
-        ByteEnumField("next_payload", None, {0: "last", 3: "Transform"}),
-        ByteField("res", 0),
-        ShortField("length", 8),
+        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
+        FlagsField("flags", 0, 8, ["critical", "res1", "res2", "res3", "res4", "res5", "res6", "res7"]),  # noqa: E501
+        ShortField("length", None),
+        StrLenField("load", "", length_from=lambda x:x.length - 4),
+    ]
+
+    def post_build(self, pkt, pay):
+        if self.length is None:
+            pkt = pkt[:2] + struct.pack("!H", len(pkt)) + pkt[4:]
+        return pkt + pay
+
+
+class IKEv2_Transform(IKEv2_Payload):
+    name = "IKEv2 Transform"
+    fields_desc = IKEv2_Payload.fields_desc[:2] + [
+        ShortField("length", 8),  # can't be None, because 'key_length' depends on it
         ByteEnumField("transform_type", None, IKEv2TransformTypes),
         ByteField("res2", 0),
         MultiEnumField("transform_id", None, IKEv2TransformAlgorithms, depends_on=lambda pkt: pkt.transform_type, fmt="H"),  # noqa: E501
@@ -541,12 +563,9 @@ class IKEv2_Transform(IKEv2_class):
     ]
 
 
-class IKEv2_Proposal(IKEv2_class):
+class IKEv2_Proposal(IKEv2_Payload):
     name = "IKEv2 Proposal"
-    fields_desc = [
-        ByteEnumField("next_payload", None, {0: "last", 2: "Proposal"}),
-        ByteField("res", 0),
-        FieldLenField("length", None, "trans", "H", adjust=lambda pkt, x: x + 8 + (pkt.SPIsize if pkt.SPIsize else 0)),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteField("proposal", 1),
         ByteEnumField("proto", 1, {1: "IKEv2", 2: "AH", 3: "ESP"}),
         FieldLenField("SPIsize", None, "SPI", "B"),
@@ -556,36 +575,18 @@ class IKEv2_Proposal(IKEv2_class):
     ]
 
 
-class IKEv2_Payload(IKEv2_class):
-    name = "IKEv2 Payload"
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        FlagsField("flags", 0, 8, ["critical", "res1", "res2", "res3", "res4", "res5", "res6", "res7"]),  # noqa: E501
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
-        StrLenField("load", "", length_from=lambda x:x.length - 4),
-    ]
-
-
-class IKEv2_AUTH(IKEv2_class):
+class IKEv2_AUTH(IKEv2_Payload):
     name = "IKEv2 Authentication"
-    overload_fields = {IKEv2: {"next_payload": 39}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("auth_type", None, IKEv2AuthenticationTypes),
         X3BytesField("res2", 0),
         StrLenField("load", "", length_from=lambda x:x.length - 8),
     ]
 
 
-class IKEv2_V(IKEv2_class):
+class IKEv2_V(IKEv2_Payload):
     name = "IKEv2 Vendor ID"
-    overload_fields = {IKEv2: {"next_payload": 43}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "vendorID", "H", adjust=lambda pkt, x:x + 4),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         StrLenField("vendorID", "", length_from=lambda x:x.length - 4),
     ]
 
@@ -662,13 +663,9 @@ class RawTrafficSelector(TrafficSelector):
     ]
 
 
-class IKEv2_TSi(IKEv2_class):
+class IKEv2_TSi(IKEv2_Payload):
     name = "IKEv2 Traffic Selector - Initiator"
-    overload_fields = {IKEv2: {"next_payload": 44}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         FieldLenField("number_of_TSs", None, fmt="B",
                       count_of="traffic_selector"),
         X3BytesField("res2", 0),
@@ -678,13 +675,9 @@ class IKEv2_TSi(IKEv2_class):
     ]
 
 
-class IKEv2_TSr(IKEv2_class):
+class IKEv2_TSr(IKEv2_Payload):
     name = "IKEv2 Traffic Selector - Responder"
-    overload_fields = {IKEv2: {"next_payload": 45}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "traffic_selector", "H", adjust=lambda pkt, x:x + 8),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         FieldLenField("number_of_TSs", None, fmt="B",
                       count_of="traffic_selector"),
         X3BytesField("res2", 0),
@@ -694,46 +687,24 @@ class IKEv2_TSr(IKEv2_class):
     ]
 
 
-class IKEv2_Delete(IKEv2_class):
-    name = "IKEv2 Vendor ID"
-    overload_fields = {IKEv2: {"next_payload": 42}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "vendorID", "H", adjust=lambda pkt, x:x + 4),  # noqa: E501
-        StrLenField("vendorID", "", length_from=lambda x:x.length - 4),
-    ]
+class IKEv2_Delete(IKEv2_Payload):
+    name = "IKEv2 Delete"
 
 
-class IKEv2_SA(IKEv2_class):
+class IKEv2_SA(IKEv2_Payload):
     name = "IKEv2 SA"
-    overload_fields = {IKEv2: {"next_payload": 33}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "prop", "H", adjust=lambda pkt, x:x + 4),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         PacketLenField("prop", conf.raw_layer(), IKEv2_Proposal, length_from=lambda x:x.length - 4),  # noqa: E501
     ]
 
 
-class IKEv2_Nonce(IKEv2_class):
+class IKEv2_Nonce(IKEv2_Payload):
     name = "IKEv2 Nonce"
-    overload_fields = {IKEv2: {"next_payload": 40}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
-        StrLenField("load", "", length_from=lambda x:x.length - 4),
-    ]
 
 
-class IKEv2_Notify(IKEv2_class):
+class IKEv2_Notify(IKEv2_Payload):
     name = "IKEv2 Notify"
-    overload_fields = {IKEv2: {"next_payload": 41}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("proto", None, {0: "Reserved", 1: "IKE", 2: "AH", 3: "ESP"}),  # noqa: E501
         FieldLenField("SPIsize", None, "SPI", "B"),
         ShortEnumField("type", 0, IKEv2NotifyMessageTypes),
@@ -742,26 +713,18 @@ class IKEv2_Notify(IKEv2_class):
     ]
 
 
-class IKEv2_KE(IKEv2_class):
+class IKEv2_KE(IKEv2_Payload):
     name = "IKEv2 Key Exchange"
-    overload_fields = {IKEv2: {"next_payload": 34}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ShortEnumField("group", 0, IKEv2TransformAlgorithms[4]),
         ShortField("res2", 0),
         StrLenField("load", "", length_from=lambda x:x.length - 8),
     ]
 
 
-class IKEv2_IDi(IKEv2_class):  # RFC 7296, section 3.5
+class IKEv2_IDi(IKEv2_Payload):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Initiator"
-    overload_fields = {IKEv2: {"next_payload": 35}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("IDtype", 1, {1: "IPv4_addr", 2: "FQDN", 3: "Email_addr", 5: "IPv6_addr", 11: "Key"}),  # noqa: E501
         X3BytesField("res2", 0),
         MultipleTypeField(
@@ -774,13 +737,9 @@ class IKEv2_IDi(IKEv2_class):  # RFC 7296, section 3.5
     ]
 
 
-class IKEv2_IDr(IKEv2_class):  # RFC 7296, section 3.5
+class IKEv2_IDr(IKEv2_Payload):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Responder"
-    overload_fields = {IKEv2: {"next_payload": 36}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "ID", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("IDtype", 1, {1: "IPv4_addr", 2: "FQDN", 3: "Email_addr", 5: "IPv6_addr", 11: "Key"}),  # noqa: E501
         X3BytesField("res2", 0),
         MultipleTypeField(
@@ -793,15 +752,8 @@ class IKEv2_IDr(IKEv2_class):  # RFC 7296, section 3.5
     ]
 
 
-class IKEv2_SK(IKEv2_class):
+class IKEv2_SK(IKEv2_Payload):
     name = "IKEv2 Encrypted and Authenticated"
-    overload_fields = {IKEv2: {"next_payload": 46}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 4),
-        StrLenField("load", "", length_from=lambda x:x.length - 4),
-    ]
 
 
 class ConfigurationAttribute(Packet):
@@ -824,13 +776,9 @@ class ConfigurationAttribute(Packet):
         return b'', s
 
 
-class IKEv2_CP(IKEv2_class):  # RFC 7296, section 3.15
+class IKEv2_CP(IKEv2_Payload):  # RFC 7296, section 3.15
     name = "IKEv2 Configuration"
-    overload_fields = {IKEv2: {"next_payload": 46}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x:x + 8),
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("CFGType", 1, IKEv2ConfigurationPayloadCFGTypes),
         X3BytesField("res2", 0),
         PacketListField("attributes", None, ConfigurationAttribute,
@@ -838,31 +786,24 @@ class IKEv2_CP(IKEv2_class):  # RFC 7296, section 3.15
     ]
 
 
-class IKEv2_SKF(IKEv2_class):
+class IKEv2_SKF(IKEv2_Payload):
     name = "IKEv2 Encrypted and Authenticated Fragment"
-    overload_fields = {IKEv2: {"next_payload": 53}}
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "load", "H", adjust=lambda pkt, x: x + 8),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ShortField("frag_number", 1),
         ShortField("frag_total", 1),
         StrLenField("load", "", length_from=lambda x: x.length - 8),
     ]
 
 
-class IKEv2_CERTREQ(IKEv2_class):
+class IKEv2_CERTREQ(IKEv2_Payload):
     name = "IKEv2 Certificate Request"
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "cert_data", "H", adjust=lambda pkt, x:x + 5),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("cert_type", 0, IKEv2CertificateEncodings),
         StrLenField("cert_data", "", length_from=lambda x:x.length - 5),
     ]
 
 
-class IKEv2_CERT(IKEv2_class):
+class IKEv2_CERT(IKEv2_Payload):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 16:
@@ -878,10 +819,7 @@ class IKEv2_CERT(IKEv2_class):
 
 class IKEv2_CERT_CRT(IKEv2_CERT):
     name = "IKEv2 Certificate"
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "x509Cert", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("cert_type", 4, IKEv2CertificateEncodings),
         PacketLenField("x509Cert", X509_Cert(''), X509_Cert, length_from=lambda x:x.length - 5),  # noqa: E501
     ]
@@ -889,10 +827,7 @@ class IKEv2_CERT_CRT(IKEv2_CERT):
 
 class IKEv2_CERT_CRL(IKEv2_CERT):
     name = "IKEv2 Certificate"
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "x509CRL", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("cert_type", 7, IKEv2CertificateEncodings),
         PacketLenField("x509CRL", X509_CRL(''), X509_CRL, length_from=lambda x:x.length - 5),  # noqa: E501
     ]
@@ -900,23 +835,43 @@ class IKEv2_CERT_CRL(IKEv2_CERT):
 
 class IKEv2_CERT_STR(IKEv2_CERT):
     name = "IKEv2 Certificate"
-    fields_desc = [
-        ByteEnumField("next_payload", None, IKEv2PayloadTypes),
-        ByteField("res", 0),
-        FieldLenField("length", None, "cert_data", "H", adjust=lambda pkt, x: x + 5),  # noqa: E501
+    fields_desc = IKEv2_Payload.fields_desc[:3] + [
         ByteEnumField("cert_type", 0, IKEv2CertificateEncodings),
         StrLenField("cert_data", "", length_from=lambda x:x.length - 5),
     ]
 
 
-IKEv2_payload_type_overload = {}
-for i, payloadname in IKEv2PayloadTypes.items():
-    name = "IKEv2_%s" % payloadname
-    if name in globals():
-        IKEv2_payload_type_overload[globals()[name]] = {"next_payload": i}
+# TODO: the following payloads are not fully dissected yet
 
-del i, payloadname, name
-IKEv2_class._overload_fields = IKEv2_payload_type_overload.copy()
+class IKEv2_EAP(IKEv2_Payload):
+    name = "IKEv2 Extensible Authentication"
+
+
+class IKEv2_GSPM(IKEv2_Payload):
+    name = "Generic Secure Password Method"
+
+
+class IKEv2_IDg(IKEv2_Payload):
+    name = "Group Identification"
+
+
+class IKEv2_GSA(IKEv2_Payload):
+    name = "Group Security Association"
+
+
+class IKEv2_KD(IKEv2_Payload):
+    name = "Key Download"
+
+
+class IKEv2_PS(IKEv2_Payload):
+    name = "Puzzle Solution"
+
+
+# bind all IKEv2 payload classes together
+for np, name in IKEv2PayloadTypes.items():
+    cls = globals().get("IKEv2_" + name)
+    if cls:
+        bind_layers(_IKEv2_Packet, cls, next_payload=np)
 
 # the upper bindings for port 500 to ISAKMP are handled by IKEv2.dispatch_hook
 split_bottom_up(UDP, ISAKMP, dport=500)

--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -441,10 +441,10 @@ class IKEv2_class(Packet):
             return conf.raw_layer
         elif np < len(IKEv2_payload_type):
             pt = IKEv2_payload_type[np]
-            logging.debug(globals().get("IKEv2_payload_%s" % pt, IKEv2_payload))  # noqa: E501
-            return globals().get("IKEv2_payload_%s" % pt, IKEv2_payload)
+            logging.debug(globals().get("IKEv2_%s" % pt, IKEv2_Payload))  # noqa: E501
+            return globals().get("IKEv2_%s" % pt, IKEv2_Payload)
         else:
-            return IKEv2_payload
+            return IKEv2_Payload
 
 
 class IKEv2(IKEv2_class):  # rfc4306
@@ -498,7 +498,7 @@ class IKEv2_Key_Length_Attribute(IntField):
         return IntField.h2i(self, pkt, (x if x is not None else 0) | 0x800E0000)  # noqa: E501
 
 
-class IKEv2_payload_Transform(IKEv2_class):
+class IKEv2_Transform(IKEv2_class):
     name = "IKE Transform"
     fields_desc = [
         ByteEnumField("next_payload", None, {0: "last", 3: "Transform"}),
@@ -511,7 +511,7 @@ class IKEv2_payload_Transform(IKEv2_class):
     ]
 
 
-class IKEv2_payload_Proposal(IKEv2_class):
+class IKEv2_Proposal(IKEv2_class):
     name = "IKEv2 Proposal"
     fields_desc = [
         ByteEnumField("next_payload", None, {0: "last", 2: "Proposal"}),
@@ -522,11 +522,11 @@ class IKEv2_payload_Proposal(IKEv2_class):
         FieldLenField("SPIsize", None, "SPI", "B"),
         ByteField("trans_nb", None),
         StrLenField("SPI", "", length_from=lambda pkt: pkt.SPIsize),
-        PacketLenField("trans", conf.raw_layer(), IKEv2_payload_Transform, length_from=lambda pkt: pkt.length - 8 - pkt.SPIsize),  # noqa: E501
+        PacketLenField("trans", conf.raw_layer(), IKEv2_Transform, length_from=lambda pkt: pkt.length - 8 - pkt.SPIsize),  # noqa: E501
     ]
 
 
-class IKEv2_payload(IKEv2_class):
+class IKEv2_Payload(IKEv2_class):
     name = "IKEv2 Payload"
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
@@ -536,7 +536,7 @@ class IKEv2_payload(IKEv2_class):
     ]
 
 
-class IKEv2_payload_AUTH(IKEv2_class):
+class IKEv2_AUTH(IKEv2_class):
     name = "IKEv2 Authentication"
     overload_fields = {IKEv2: {"next_payload": 39}}
     fields_desc = [
@@ -549,7 +549,7 @@ class IKEv2_payload_AUTH(IKEv2_class):
     ]
 
 
-class IKEv2_payload_VendorID(IKEv2_class):
+class IKEv2_VendorID(IKEv2_class):
     name = "IKEv2 Vendor ID"
     overload_fields = {IKEv2: {"next_payload": 43}}
     fields_desc = [
@@ -632,7 +632,7 @@ class RawTrafficSelector(TrafficSelector):
     ]
 
 
-class IKEv2_payload_TSi(IKEv2_class):
+class IKEv2_TSi(IKEv2_class):
     name = "IKEv2 Traffic Selector - Initiator"
     overload_fields = {IKEv2: {"next_payload": 44}}
     fields_desc = [
@@ -648,7 +648,7 @@ class IKEv2_payload_TSi(IKEv2_class):
     ]
 
 
-class IKEv2_payload_TSr(IKEv2_class):
+class IKEv2_TSr(IKEv2_class):
     name = "IKEv2 Traffic Selector - Responder"
     overload_fields = {IKEv2: {"next_payload": 45}}
     fields_desc = [
@@ -664,7 +664,7 @@ class IKEv2_payload_TSr(IKEv2_class):
     ]
 
 
-class IKEv2_payload_Delete(IKEv2_class):
+class IKEv2_Delete(IKEv2_class):
     name = "IKEv2 Vendor ID"
     overload_fields = {IKEv2: {"next_payload": 42}}
     fields_desc = [
@@ -675,18 +675,18 @@ class IKEv2_payload_Delete(IKEv2_class):
     ]
 
 
-class IKEv2_payload_SA(IKEv2_class):
+class IKEv2_SA(IKEv2_class):
     name = "IKEv2 SA"
     overload_fields = {IKEv2: {"next_payload": 33}}
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
         ByteField("res", 0),
         FieldLenField("length", None, "prop", "H", adjust=lambda pkt, x:x + 4),
-        PacketLenField("prop", conf.raw_layer(), IKEv2_payload_Proposal, length_from=lambda x:x.length - 4),  # noqa: E501
+        PacketLenField("prop", conf.raw_layer(), IKEv2_Proposal, length_from=lambda x:x.length - 4),  # noqa: E501
     ]
 
 
-class IKEv2_payload_Nonce(IKEv2_class):
+class IKEv2_Nonce(IKEv2_class):
     name = "IKEv2 Nonce"
     overload_fields = {IKEv2: {"next_payload": 40}}
     fields_desc = [
@@ -697,7 +697,7 @@ class IKEv2_payload_Nonce(IKEv2_class):
     ]
 
 
-class IKEv2_payload_Notify(IKEv2_class):
+class IKEv2_Notify(IKEv2_class):
     name = "IKEv2 Notify"
     overload_fields = {IKEv2: {"next_payload": 41}}
     fields_desc = [
@@ -712,7 +712,7 @@ class IKEv2_payload_Notify(IKEv2_class):
     ]
 
 
-class IKEv2_payload_KE(IKEv2_class):
+class IKEv2_KE(IKEv2_class):
     name = "IKEv2 Key Exchange"
     overload_fields = {IKEv2: {"next_payload": 34}}
     fields_desc = [
@@ -725,7 +725,7 @@ class IKEv2_payload_KE(IKEv2_class):
     ]
 
 
-class IKEv2_payload_IDi(IKEv2_class):  # RFC 7296, section 3.5
+class IKEv2_IDi(IKEv2_class):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Initiator"
     overload_fields = {IKEv2: {"next_payload": 35}}
     fields_desc = [
@@ -744,7 +744,7 @@ class IKEv2_payload_IDi(IKEv2_class):  # RFC 7296, section 3.5
     ]
 
 
-class IKEv2_payload_IDr(IKEv2_class):  # RFC 7296, section 3.5
+class IKEv2_IDr(IKEv2_class):  # RFC 7296, section 3.5
     name = "IKEv2 Identification - Responder"
     overload_fields = {IKEv2: {"next_payload": 36}}
     fields_desc = [
@@ -763,7 +763,7 @@ class IKEv2_payload_IDr(IKEv2_class):  # RFC 7296, section 3.5
     ]
 
 
-class IKEv2_payload_Encrypted(IKEv2_class):
+class IKEv2_Encrypted(IKEv2_class):
     name = "IKEv2 Encrypted and Authenticated"
     overload_fields = {IKEv2: {"next_payload": 46}}
     fields_desc = [
@@ -794,7 +794,7 @@ class ConfigurationAttribute(Packet):
         return b'', s
 
 
-class IKEv2_payload_CP(IKEv2_class):  # RFC 7296, section 3.15
+class IKEv2_CP(IKEv2_class):  # RFC 7296, section 3.15
     name = "IKEv2 Configuration"
     overload_fields = {IKEv2: {"next_payload": 46}}
     fields_desc = [
@@ -808,7 +808,7 @@ class IKEv2_payload_CP(IKEv2_class):  # RFC 7296, section 3.15
     ]
 
 
-class IKEv2_payload_Encrypted_Fragment(IKEv2_class):
+class IKEv2_Encrypted_Fragment(IKEv2_class):
     name = "IKEv2 Encrypted Fragment"
     overload_fields = {IKEv2: {"next_payload": 53}}
     fields_desc = [
@@ -821,7 +821,7 @@ class IKEv2_payload_Encrypted_Fragment(IKEv2_class):
     ]
 
 
-class IKEv2_payload_CERTREQ(IKEv2_class):
+class IKEv2_CERTREQ(IKEv2_class):
     name = "IKEv2 Certificate Request"
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
@@ -832,21 +832,21 @@ class IKEv2_payload_CERTREQ(IKEv2_class):
     ]
 
 
-class IKEv2_payload_CERT(IKEv2_class):
+class IKEv2_CERT(IKEv2_class):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 16:
             ts_type = struct.unpack("!B", _pkt[4:5])[0]
             if ts_type == 4:
-                return IKEv2_payload_CERT_CRT
+                return IKEv2_CERT_CRT
             elif ts_type == 7:
-                return IKEv2_payload_CERT_CRL
+                return IKEv2_CERT_CRL
             else:
-                return IKEv2_payload_CERT_STR
-        return IKEv2_payload_CERT_STR
+                return IKEv2_CERT_STR
+        return IKEv2_CERT_STR
 
 
-class IKEv2_payload_CERT_CRT(IKEv2_payload_CERT):
+class IKEv2_CERT_CRT(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
@@ -857,7 +857,7 @@ class IKEv2_payload_CERT_CRT(IKEv2_payload_CERT):
     ]
 
 
-class IKEv2_payload_CERT_CRL(IKEv2_payload_CERT):
+class IKEv2_CERT_CRL(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
@@ -868,7 +868,7 @@ class IKEv2_payload_CERT_CRL(IKEv2_payload_CERT):
     ]
 
 
-class IKEv2_payload_CERT_STR(IKEv2_payload_CERT):
+class IKEv2_CERT_STR(IKEv2_CERT):
     name = "IKEv2 Certificate"
     fields_desc = [
         ByteEnumField("next_payload", None, IKEv2_payload_type),
@@ -881,7 +881,7 @@ class IKEv2_payload_CERT_STR(IKEv2_payload_CERT):
 
 IKEv2_payload_type_overload = {}
 for i, payloadname in enumerate(IKEv2_payload_type):
-    name = "IKEv2_payload_%s" % payloadname
+    name = "IKEv2_%s" % payloadname
     if name in globals():
         IKEv2_payload_type_overload[globals()[name]] = {"next_payload": i}
 
@@ -958,4 +958,4 @@ bind_top_down(UDP, NAT_KEEPALIVE, dport=4500, sport=4500)
 def ikev2scan(ip, **kwargs):
     """Send a IKEv2 SA to an IP and wait for answers."""
     return sr(IP(dst=ip) / UDP() / IKEv2(init_SPI=RandString(8),
-                                         exch_type=34) / IKEv2_payload_SA(prop=IKEv2_payload_Proposal()), **kwargs)  # noqa: E501
+                                         exch_type=34) / IKEv2_SA(prop=IKEv2_Proposal()), **kwargs)  # noqa: E501

--- a/test/contrib/ikev2.uts
+++ b/test/contrib/ikev2.uts
@@ -42,7 +42,7 @@ nat_detection_destination_ip = binascii.unhexlify('28cd99b9fa1267654b53f60887c9c
 transform_1 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'Encryption', transform_id = 12, length = 12, key_length = 0x80)
 transform_2 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'PRF', transform_id = 2)
 transform_3 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'Integrity', transform_id = 2)
-transform_4 = IKEv2_Transform(next_payload = 'last', transform_type = 'GroupDesc', transform_id = 2)
+transform_4 = IKEv2_Transform(next_payload = 'None', transform_type = 'GroupDesc', transform_id = 2)
 packet = IP(dst = '192.168.1.10', src = '192.168.1.130') /\
        UDP(dport = 500) /\
        IKEv2(init_SPI = b'KWdxMhjA', next_payload = 'SA', exch_type = 'IKE_SA_INIT', flags='Initiator') /\
@@ -378,11 +378,11 @@ frames = [
         ) /
         IKEv2_SA(
             next_payload='KE',
-            res=0,
+            flags='',
             length=40,
             prop=IKEv2_Proposal(
-                next_payload='last',
-                res=0,
+                next_payload='None',
+                flags='',
                 length=36,
                 proposal=1,
                 proto='IKEv2',
@@ -392,7 +392,7 @@ frames = [
                 trans=(
                     IKEv2_Transform(
                         next_payload='Transform',
-                        res=0,
+                        flags='',
                         length=12,
                         transform_type='Encryption',
                         res2=0,
@@ -401,15 +401,15 @@ frames = [
                     ) /
                     IKEv2_Transform(
                         next_payload='Transform',
-                        res=0,
+                        flags='',
                         length=8,
                         transform_type='PRF',
                         res2=0,
                         transform_id='PRF_HMAC_SHA2_256'
                     ) /
                     IKEv2_Transform(
-                        next_payload='last',
-                        res=0,
+                        next_payload='None',
+                        flags='',
                         length=8,
                         transform_type='GroupDesc',
                         res2=0,
@@ -420,7 +420,7 @@ frames = [
         ) /
         IKEv2_KE(
             next_payload='Nonce',
-            res=0,
+            flags='',
             length=72,
             group='256randECPgr',
             res2=0,
@@ -428,37 +428,37 @@ frames = [
         ) /
         IKEv2_Nonce(
             next_payload='V',
-            res=0,
+            flags='',
             length=44,
             load=b'\t\xcbS\x8b,=\xbdM\x0b\xb0\xee\xc8\xd3\x18\xcb\x80\x1a\x9bG\x15\xb2\x07\x82\x8d\x9b_\xf1\xf4\xecd\xedX\x867\x07\xbc\xf1L\xcf\x05'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xebL\x1bx\x8a\xfdJ\x9c\xb7s\nh\xd5lS!'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc1\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
         IKEv2_V(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3'
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -468,7 +468,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -478,7 +478,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='None',
-            res=0,
+            flags='',
             length=16,
             proto='Reserved',
             SPIsize=0,
@@ -524,11 +524,11 @@ frames = [
         ) /
         IKEv2_SA(
             next_payload='KE',
-            res=0,
+            flags='',
             length=40,
             prop=IKEv2_Proposal(
-                next_payload='last',
-                res=0,
+                next_payload='None',
+                flags='',
                 length=36,
                 proposal=1,
                 proto='IKEv2',
@@ -538,7 +538,7 @@ frames = [
                 trans=(
                     IKEv2_Transform(
                         next_payload='Transform',
-                        res=0,
+                        flags='',
                         length=12,
                         transform_type='Encryption',
                         res2=0,
@@ -547,15 +547,15 @@ frames = [
                     ) /
                     IKEv2_Transform(
                         next_payload='Transform',
-                        res=0,
+                        flags='',
                         length=8,
                         transform_type='PRF',
                         res2=0,
                         transform_id='PRF_HMAC_SHA2_256'
                     ) /
                     IKEv2_Transform(
-                        next_payload='last',
-                        res=0,
+                        next_payload='None',
+                        flags='',
                         length=8,
                         transform_type='GroupDesc',
                         res2=0,
@@ -566,7 +566,7 @@ frames = [
         ) /
         IKEv2_KE(
             next_payload='Nonce',
-            res=0,
+            flags='',
             length=72,
             group='256randECPgr',
             res2=0,
@@ -574,44 +574,44 @@ frames = [
         ) /
         IKEv2_Nonce(
             next_payload='CERTREQ',
-            res=0,
+            flags='',
             length=44,
             load=b'\x1d\x10}\xc5\xa7F=\xa7\xd7a\x01A9\xfb8\x1a\xf9\xcd;\x8c\x01\x81\xe6\xcd6\xa8\xae\x10^U\xaa\x7f\xe7\x1f]\xb1\xd3l)\x15'
         ) /
         IKEv2_CERTREQ(
             next_payload='V',
-            res=0,
+            flags='',
             length=5,
             cert_type='X.509 Certificate - Signature',
             cert_data=b''
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xc6\xf5z\xc3\x98\xf4\x93 \x81E\xb7X\x1e\x87\x89\x83'
         ) /
         IKEv2_V(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\x85\x81w\x03\xc6\xe3 \xd2\xaeZM\xd0 V\xc6\xd7'
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -621,7 +621,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=16,
             proto='Reserved',
             SPIsize=0,
@@ -631,7 +631,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='None',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -667,7 +667,7 @@ frames = [
         ) /
         IKEv2_SK(
             next_payload='IDi',
-            res=0,
+            flags='',
             length=1252,
             load = ike_auth_request_encrypted_payload
         )
@@ -701,7 +701,7 @@ frames = [
         ) /
         IKEv2_SK(
             next_payload='IDr',
-            res=0,
+            flags='',
             length=1244,
             load=ike_auth_response_encrypted_payload
         )
@@ -770,14 +770,14 @@ frames = [
         ) /
         IKEv2_IDi(
             next_payload='CERT',
-            res=0,
+            flags='',
             length=18,
             IDtype='Email_addr',
             res2=0x0,
             ID='ikev2-cert'
         ) /
         IKEv2_CERT_CRT(
-            next_payload='Notify', res=0, length=732,
+            next_payload='Notify', flags='', length=732,
             cert_type='X.509 Certificate - Signature',
             x509Cert=X509_Cert(
                 tbsCertificate=X509_TBSCertificate(
@@ -900,7 +900,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=8,
             proto='IKE',
             SPIsize=0,
@@ -910,7 +910,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload='CERTREQ',
-            res=0,
+            flags='',
             length=8,
             proto='IKE',
             SPIsize=0,
@@ -920,14 +920,14 @@ frames = [
         ) /
         IKEv2_CERTREQ(
             next_payload='AUTH',
-            res=0,
+            flags='',
             length=65,
             cert_type='X.509 Certificate - Signature',
             cert_data=b'\x91\xc1\xdc\x0f*\x8f\x0e;\xd7\xda\x99\x1aC\xa3\x92&5^B)\xbc\xb6*\x0e\x9d\xe9y\xfd\xa8d\xe3\xf0d`\xdc\xaa\xff\x85\x07Y\xf4\x89V#8e!N\x9a\x10\xe67oLY\xb5\xc0/6m'
         ) /
         IKEv2_AUTH(
             next_payload='CP',
-            res=0,
+            flags='',
             length=92,
             auth_type='Digital Signature',
             res2=0x0,
@@ -935,7 +935,7 @@ frames = [
         ) /
         IKEv2_CP(
             next_payload='SA',
-            res=0,
+            flags='',
             length=128,
             CFGType='CFG_REQUEST',
             res2=0x0,
@@ -971,24 +971,24 @@ frames = [
         ) /
         IKEv2_SA(
             next_payload='TSi',
-            res=0,
+            flags='',
             length=36,
             prop=IKEv2_Proposal(
-                next_payload='last',
-                res=0,
+                next_payload='None',
+                flags='',
                 length=32,
                 proposal=1,
                 proto='ESP',
                 SPIsize=4,
                 trans_nb=2,
                 SPI=b'\xc1\xa9ek',
-                trans=IKEv2_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
-                      IKEv2_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
+                trans=IKEv2_Transform(flags='', length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
+                      IKEv2_Transform(flags='', length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
             )
         ) /
         IKEv2_TSi(
             next_payload='TSr',
-            res=0,
+            flags='',
             length=24,
             number_of_TSs=1,
             res2=0x0,
@@ -1004,7 +1004,7 @@ frames = [
         ) /
         IKEv2_TSr(
             next_payload='V',
-            res=0,
+            flags='',
             length=24,
             number_of_TSs=1,
             res2=0x0,
@@ -1021,25 +1021,25 @@ frames = [
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xaf\xca\xd7\x13h\xa1\xf1\xc9k\x86\x96\xfcwW\x01\x00'
         ) /
         IKEv2_V(
             next_payload='V',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc2\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
         IKEv2_V(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=28,
             vendorID=b'NcP\n\t\xb8\xe8<\x80\xb6\x936&\x8e\xc8\xf6\x00\x0c)0\x10\x9e\x00\x00'
         ) /
         IKEv2_Notify(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -1049,7 +1049,7 @@ frames = [
         ) /
         IKEv2_Notify(
             next_payload=None,
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,
@@ -1121,7 +1121,7 @@ frames = [
         ) /
         IKEv2_IDr(
             next_payload='CERT',
-            res=0,
+            flags='',
             length=126,
             IDtype=9,
             res2=0x0,
@@ -1129,7 +1129,7 @@ frames = [
         ) /
         IKEv2_CERT_CRT(
             next_payload='AUTH',
-            res=0,
+            flags='',
             length=742,
             cert_type='X.509 Certificate - Signature',
             x509Cert=X509_Cert(
@@ -1258,7 +1258,7 @@ frames = [
         ) /
         IKEv2_AUTH(
             next_payload='CP',
-            res=0,
+            flags='',
             length=92,
             auth_type='Digital Signature',
             res2=0x0,
@@ -1266,7 +1266,7 @@ frames = [
         ) /
         IKEv2_CP(
             next_payload='SA',
-            res=0,
+            flags='',
             length=92,
             CFGType='CFG_REPLY',
             res2=0x0,
@@ -1286,29 +1286,29 @@ frames = [
         ) /
         IKEv2_SA(
             next_payload='Nonce',
-            res=0,
+            flags='',
             length=36,
             prop=IKEv2_Proposal(
-                res=0,
+                flags='',
                 length=32,
                 proposal=1,
                 proto='ESP',
                 SPIsize=4,
                 trans_nb=2,
                 SPI=b'\xac\x0f\xaf\x03',
-                trans=IKEv2_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
-                      IKEv2_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
+                trans=IKEv2_Transform(flags='', length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
+                      IKEv2_Transform(flags='', length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
             )
         ) /
         IKEv2_Nonce(
             next_payload='TSi',
-            res=0,
+            flags='',
             length=44,
             load=b'\xcf\x0eyPv]\xb7\xf77\x1d\xbb\xdf\xa1r\x04\x93\xc8<\x1b\xa4\xdc6\x17\xc3\x19*W\xb9(]\x9ac\n\xc7\x16F\x11\xfd\xf4,'
         ) /
         IKEv2_TSi(
             next_payload='TSr',
-            res=0,
+            flags='',
             length=24,
             number_of_TSs=1,
             res2=0x0,
@@ -1326,7 +1326,7 @@ frames = [
         ) /
         IKEv2_TSr(
             next_payload='V',
-            res=0,
+            flags='',
             length=24,
             number_of_TSs=1,
             res2=0x0,
@@ -1344,13 +1344,13 @@ frames = [
         ) /
         IKEv2_V(
             next_payload='Notify',
-            res=0,
+            flags='',
             length=20,
             vendorID=b'\xaf\xca\xd7\x13h\xa1\xf1\xc9k\x86\x96\xfcwW\x01\x00'
         ) /
         IKEv2_Notify(
             next_payload='None',
-            res=0,
+            flags='',
             length=8,
             proto='Reserved',
             SPIsize=0,

--- a/test/contrib/ikev2.uts
+++ b/test/contrib/ikev2.uts
@@ -89,25 +89,23 @@ assert b[IKEv2_SK].load == b'\xa8\x0c\x95{\xac\x15\xc3\xf8\xaf\xdf1Z\x81\xccK|@\
 
 = Test Certs detection
 
-a = IKEv2_CERT(raw(IKEv2_CERT_CRL()))
-b = IKEv2_CERT(raw(IKEv2_CERT_STR()))
-c = IKEv2_CERT(raw(IKEv2_CERT_CRT()))
+a = IKEv2_CERT(raw(IKEv2_CERT(cert_encoding = "X.509 Certificate - Signature")))
+b = IKEv2_CERT(raw(IKEv2_CERT(cert_encoding ="Certificate Revocation List (CRL)")))
+c = IKEv2_CERT(raw(IKEv2_CERT(cert_encoding = 0)))
 
-assert isinstance(a, IKEv2_CERT_CRL)
-assert isinstance(b, IKEv2_CERT_STR)
-assert isinstance(c, IKEv2_CERT_CRT)
+assert a.cert_encoding == 4
+assert isinstance(a.cert_data, X509_Cert)
+assert b.cert_encoding == 7
+assert isinstance(b.cert_data, X509_CRL)
+assert c.cert_encoding == 0
+assert isinstance(c.cert_data, bytes)
+
 
 = Test Certs length calculations
 ## For the length calculations see Figure 12 in RFC 7296
-a = IKEv2_CERT_CRT(raw(IKEv2_CERT_CRT()))
-assert len(a.x509Cert) > 0
-assert a.length == len(a.x509Cert) + 5
 
-b = IKEv2_CERT_CRL(raw(IKEv2_CERT_CRL()))
-assert len(b.x509CRL) > 0
-assert b.length == len(b.x509CRL) + 5
-
-c = IKEv2_CERT_STR(raw(IKEv2_CERT_STR(cert_data=b'dummy')))
+assert a.length == len(a.cert_data) + 5
+assert b.length == len(b.cert_data) + 5
 assert c.length == len(c.cert_data) + 5
 
 = Test TrafficSelector detection
@@ -385,7 +383,7 @@ frames = [
                 flags='',
                 length=36,
                 proposal=1,
-                proto='IKEv2',
+                proto='IKE',
                 SPIsize=0,
                 trans_nb=3,
                 SPI='',
@@ -531,7 +529,7 @@ frames = [
                 flags='',
                 length=36,
                 proposal=1,
-                proto='IKEv2',
+                proto='IKE',
                 SPIsize=0,
                 trans_nb=3,
                 SPI='',
@@ -582,8 +580,8 @@ frames = [
             next_payload='V',
             flags='',
             length=5,
-            cert_type='X.509 Certificate - Signature',
-            cert_data=b''
+            cert_encoding='X.509 Certificate - Signature',
+            cert_authority=b''
         ) /
         IKEv2_V(
             next_payload='V',
@@ -776,10 +774,10 @@ frames = [
             res2=0x0,
             ID='ikev2-cert'
         ) /
-        IKEv2_CERT_CRT(
+        IKEv2_CERT(
             next_payload='Notify', flags='', length=732,
-            cert_type='X.509 Certificate - Signature',
-            x509Cert=X509_Cert(
+            cert_encoding='X.509 Certificate - Signature',
+            cert_data=X509_Cert(
                 tbsCertificate=X509_TBSCertificate(
                     version=ASN1_INTEGER(2),
                     serialNumber=ASN1_INTEGER(0x1000013),
@@ -922,8 +920,8 @@ frames = [
             next_payload='AUTH',
             flags='',
             length=65,
-            cert_type='X.509 Certificate - Signature',
-            cert_data=b'\x91\xc1\xdc\x0f*\x8f\x0e;\xd7\xda\x99\x1aC\xa3\x92&5^B)\xbc\xb6*\x0e\x9d\xe9y\xfd\xa8d\xe3\xf0d`\xdc\xaa\xff\x85\x07Y\xf4\x89V#8e!N\x9a\x10\xe67oLY\xb5\xc0/6m'
+            cert_encoding='X.509 Certificate - Signature',
+            cert_authority=b'\x91\xc1\xdc\x0f*\x8f\x0e;\xd7\xda\x99\x1aC\xa3\x92&5^B)\xbc\xb6*\x0e\x9d\xe9y\xfd\xa8d\xe3\xf0d`\xdc\xaa\xff\x85\x07Y\xf4\x89V#8e!N\x9a\x10\xe67oLY\xb5\xc0/6m'
         ) /
         IKEv2_AUTH(
             next_payload='CP',
@@ -1127,12 +1125,12 @@ frames = [
             res2=0x0,
             ID=b'0t1\x0b0\t\x06\x03U\x04\x06\x13\x02DE1\x1a0\x18\x06\x03U\x04\n\x0c\x11Demo Organization1\x100\x0e\x06\x03U\x04\x0b\x0c\x07Demo OU1\x100\x0e\x06\x03U\x04\x03\x0c\x07Server11%0#\x06\t*\x86H\x86\xf7\r\x01\t\x01\x16\x16server1@demo.ncp-e.com'
         ) /
-        IKEv2_CERT_CRT(
+        IKEv2_CERT(
             next_payload='AUTH',
             flags='',
             length=742,
-            cert_type='X.509 Certificate - Signature',
-            x509Cert=X509_Cert(
+            cert_encoding='X.509 Certificate - Signature',
+            cert_data=X509_Cert(
                 tbsCertificate=X509_TBSCertificate(
                     version=ASN1_INTEGER(2),
                     serialNumber=ASN1_INTEGER(0x1000016),

--- a/test/contrib/ikev2.uts
+++ b/test/contrib/ikev2.uts
@@ -76,8 +76,8 @@ assert b[IKEv2_Nonce].payload.payload.payload.next_payload == 0
 = Dissect Encrypted Initiator Request
 
 a = Ether(b"\x00!k\x91#H\xb8'\xeb\xa6XI\x08\x00E\x00\x00Yu\xe2@\x00@\x11AQ\xc0\xa8\x01\x02\xc0\xa8\x01\x0e\x01\xf4\x01\xf4\x00E}\xe0\xeahM!Yz\xfd6\xd9\xfe*\xb2-\xac#\xac. %\x08\x00\x00\x00\x02\x00\x00\x00=*\x00\x00!\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2")
-assert a[IKEv2_Encrypted].next_payload == 42
-assert a[IKEv2_Encrypted].load == b'\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2'
+assert a[IKEv2_SK].next_payload == 42
+assert a[IKEv2_SK].load == b'\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2'
 
 = Dissect Encrypted Responder Response
 
@@ -85,7 +85,7 @@ b = Ether(b"\xb8'\xeb\xa6XI\x00!k\x91#H\x08\x00E\x00\x00Q\xd5y@\x00@\x11\xe1\xc1
 assert b[IKEv2].init_SPI == b'\xeahM!Yz\xfd6'
 assert b[IKEv2].resp_SPI == b'\xd9\xfe*\xb2-\xac#\xac'
 assert b[IKEv2].next_payload == 46
-assert b[IKEv2_Encrypted].load == b'\xa8\x0c\x95{\xac\x15\xc3\xf8\xaf\xdf1Z\x81\xccK|@\xe8f\rD'
+assert b[IKEv2_SK].load == b'\xa8\x0c\x95{\xac\x15\xc3\xf8\xaf\xdf1Z\x81\xccK|@\xe8f\rD'
 
 = Test Certs detection
 
@@ -140,12 +140,12 @@ c = IKEv2_TSr(traffic_selector=IPv4TrafficSelector() * 2)
 d = IKEv2_TSr(raw(c))
 assert d.number_of_TSs == 2
 
-= IKEv2_Encrypted_Fragment, simple tests
+= IKEv2_SKF, simple tests
 
 s = b"\x00\x00\x00\x08\x00\x01\x00\x01"
-assert raw(IKEv2_Encrypted_Fragment()) == s
+assert raw(IKEv2_SKF()) == s
 
-p = IKEv2_Encrypted_Fragment(s)
+p = IKEv2_SKF(s)
 assert p.length == 8 and p.frag_number == 1
 
 
@@ -427,30 +427,30 @@ frames = [
             load=b'\xdb%1xD\x0c\xe7v\xa7\x94\x13<\xb8\xb6\x9e^\xb0ts56W\x0cd\xd7\xb60T\x9c\x89\x9c\x07\x12\xd8(\xb3qhP\x08\x85\xe0Q\x02Ex\xaf\xc7\\\x10\x1fs\xb8\x94<\xadb\xd7J0\xf2\xbe\x1f\xca'
         ) /
         IKEv2_Nonce(
-            next_payload='VendorID',
+            next_payload='V',
             res=0,
             length=44,
             load=b'\t\xcbS\x8b,=\xbdM\x0b\xb0\xee\xc8\xd3\x18\xcb\x80\x1a\x9bG\x15\xb2\x07\x82\x8d\x9b_\xf1\xf4\xecd\xedX\x867\x07\xbc\xf1L\xcf\x05'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'\xebL\x1bx\x8a\xfdJ\x9c\xb7s\nh\xd5lS!'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc1\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
-        IKEv2_VendorID(
+        IKEv2_V(
             next_payload='Notify',
             res=0,
             length=20,
@@ -579,31 +579,31 @@ frames = [
             load=b'\x1d\x10}\xc5\xa7F=\xa7\xd7a\x01A9\xfb8\x1a\xf9\xcd;\x8c\x01\x81\xe6\xcd6\xa8\xae\x10^U\xaa\x7f\xe7\x1f]\xb1\xd3l)\x15'
         ) /
         IKEv2_CERTREQ(
-            next_payload='VendorID',
+            next_payload='V',
             res=0,
             length=5,
             cert_type='X.509 Certificate - Signature',
             cert_data=b''
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'\xc6\xf5z\xc3\x98\xf4\x93 \x81E\xb7X\x1e\x87\x89\x83'
         ) /
-        IKEv2_VendorID(
+        IKEv2_V(
             next_payload='Notify',
             res=0,
             length=20,
@@ -658,14 +658,14 @@ frames = [
         IKEv2(
             init_SPI=b'\x89\x92\x2c\x91\x5f\x35\x57\x0e',
             resp_SPI=b'\x98\xd5\x6d\x32\xe2\xa0\x47\x42',
-            next_payload='Encrypted',
+            next_payload='SK',
             version=0x20,
             exch_type='IKE_AUTH',
             flags='Initiator',
             id=1,
             length=1280
         ) /
-        IKEv2_Encrypted(
+        IKEv2_SK(
             next_payload='IDi',
             res=0,
             length=1252,
@@ -692,14 +692,14 @@ frames = [
         IKEv2(
             init_SPI=b'\x89\x92\x2c\x91\x5f\x35\x57\x0e',
             resp_SPI=b'\x98\xd5\x6d\x32\xe2\xa0\x47\x42',
-            next_payload='Encrypted',
+            next_payload='SK',
             version=0x20,
             exch_type='IKE_AUTH',
             flags='Response',
             id=1,
             length=1272
         ) /
-        IKEv2_Encrypted(
+        IKEv2_SK(
             next_payload='IDr',
             res=0,
             length=1244,
@@ -1003,7 +1003,7 @@ frames = [
             ]
         ) /
         IKEv2_TSr(
-            next_payload='VendorID',
+            next_payload='V',
             res=0,
             length=24,
             number_of_TSs=1,
@@ -1019,19 +1019,19 @@ frames = [
                     ending_address_v4='192.168.225.255')
             ]
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'\xaf\xca\xd7\x13h\xa1\xf1\xc9k\x86\x96\xfcwW\x01\x00'
         ) /
-        IKEv2_VendorID(
-            next_payload='VendorID',
+        IKEv2_V(
+            next_payload='V',
             res=0,
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc2\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
-        IKEv2_VendorID(
+        IKEv2_V(
             next_payload='Notify',
             res=0,
             length=28,
@@ -1325,7 +1325,7 @@ frames = [
             ]
         ) /
         IKEv2_TSr(
-            next_payload='VendorID',
+            next_payload='V',
             res=0,
             length=24,
             number_of_TSs=1,
@@ -1342,7 +1342,7 @@ frames = [
                 )
             ]
         ) /
-        IKEv2_VendorID(
+        IKEv2_V(
             next_payload='Notify',
             res=0,
             length=20,

--- a/test/contrib/ikev2.uts
+++ b/test/contrib/ikev2.uts
@@ -16,19 +16,19 @@ assert raw(a) == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
 = Ikev2 dissection
 
 a = IKEv2(b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00! \x00\x00\x00\x00\x00\x00\x00\x00\x000\x00\x00\x00\x14\x00\x00\x00\x10\x01\x01\x00\x00\x00\x00\x00\x08\x02\x00\x00\x03")
-assert a[IKEv2_payload_Transform].transform_type == 2
-assert a[IKEv2_payload_Transform].transform_id == 3
+assert a[IKEv2_Transform].transform_type == 2
+assert a[IKEv2_Transform].transform_id == 3
 assert a.next_payload == 33
-assert a[IKEv2_payload_SA].next_payload == 0
-assert a[IKEv2_payload_Proposal].next_payload == 0
-assert a[IKEv2_payload_Proposal].proposal == 1
-assert a[IKEv2_payload_Transform].next_payload == 0
-a[IKEv2_payload_Transform].show()
+assert a[IKEv2_SA].next_payload == 0
+assert a[IKEv2_Proposal].next_payload == 0
+assert a[IKEv2_Proposal].proposal == 1
+assert a[IKEv2_Transform].next_payload == 0
+a[IKEv2_Transform].show()
 
 
 = Build Ikev2 SA request packet
 
-a = IKEv2(init_SPI="MySPI",exch_type=34)/IKEv2_payload_SA(prop=IKEv2_payload_Proposal())
+a = IKEv2(init_SPI="MySPI",exch_type=34)/IKEv2_SA(prop=IKEv2_Proposal())
 assert raw(a) == b'MySPI\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00! "\x00\x00\x00\x00\x00\x00\x00\x00(\x00\x00\x00\x0c\x00\x00\x00\x08\x01\x01\x00\x00'
 
 = Build advanced IKEv2
@@ -39,18 +39,18 @@ key_exchange = binascii.unhexlify('bb41bb41cfaf34e3b3209672aef1c51b9d52919f1781d
 nonce = binascii.unhexlify('8dfcf8384c5c32f1b294c64eab69f98e9d8cf7e7f352971a91ff6777d47dffed')
 nat_detection_source_ip = binascii.unhexlify('e64c81c4152ad83bd6e035009fbb900406be371f')
 nat_detection_destination_ip = binascii.unhexlify('28cd99b9fa1267654b53f60887c9c35bcf67a8ff')
-transform_1 = IKEv2_payload_Transform(next_payload = 'Transform', transform_type = 'Encryption', transform_id = 12, length = 12, key_length = 0x80)
-transform_2 = IKEv2_payload_Transform(next_payload = 'Transform', transform_type = 'PRF', transform_id = 2)
-transform_3 = IKEv2_payload_Transform(next_payload = 'Transform', transform_type = 'Integrity', transform_id = 2)
-transform_4 = IKEv2_payload_Transform(next_payload = 'last', transform_type = 'GroupDesc', transform_id = 2)
+transform_1 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'Encryption', transform_id = 12, length = 12, key_length = 0x80)
+transform_2 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'PRF', transform_id = 2)
+transform_3 = IKEv2_Transform(next_payload = 'Transform', transform_type = 'Integrity', transform_id = 2)
+transform_4 = IKEv2_Transform(next_payload = 'last', transform_type = 'GroupDesc', transform_id = 2)
 packet = IP(dst = '192.168.1.10', src = '192.168.1.130') /\
        UDP(dport = 500) /\
        IKEv2(init_SPI = b'KWdxMhjA', next_payload = 'SA', exch_type = 'IKE_SA_INIT', flags='Initiator') /\
-       IKEv2_payload_SA(next_payload = 'KE', prop = IKEv2_payload_Proposal(trans_nb = 4, trans = transform_1 / transform_2 / transform_3 / transform_4, )) /\
-       IKEv2_payload_KE(next_payload = 'Nonce', group = '1024MODPgr', load = key_exchange) /\
-       IKEv2_payload_Nonce(next_payload = 'Notify', load = nonce) /\
-       IKEv2_payload_Notify(next_payload = 'Notify', type = 16388, load = nat_detection_source_ip) /\
-       IKEv2_payload_Notify(next_payload = 'None', type = 16389, load = nat_detection_destination_ip)
+       IKEv2_SA(next_payload = 'KE', prop = IKEv2_Proposal(trans_nb = 4, trans = transform_1 / transform_2 / transform_3 / transform_4, )) /\
+       IKEv2_KE(next_payload = 'Nonce', group = '1024MODPgr', load = key_exchange) /\
+       IKEv2_Nonce(next_payload = 'Notify', load = nonce) /\
+       IKEv2_Notify(next_payload = 'Notify', type = 16388, load = nat_detection_source_ip) /\
+       IKEv2_Notify(next_payload = 'None', type = 16389, load = nat_detection_destination_ip)
 
 assert raw(packet) == b'E\x00\x01L\x00\x01\x00\x00@\x11\xf5\xc3\xc0\xa8\x01\x82\xc0\xa8\x01\n\x01\xf4\x01\xf4\x018\xa6\xc0KWdxMhjA\x00\x00\x00\x00\x00\x00\x00\x00! "\x08\x00\x00\x00\x00\x00\x00\x010"\x00\x000\x00\x00\x00,\x01\x01\x00\x04\x03\x00\x00\x0c\x01\x00\x00\x0c\x80\x0e\x00\x80\x03\x00\x00\x08\x02\x00\x00\x02\x03\x00\x00\x08\x03\x00\x00\x02\x00\x00\x00\x08\x04\x00\x00\x02(\x00\x00\x88\x00\x02\x00\x00\xbbA\xbbA\xcf\xaf4\xe3\xb3 \x96r\xae\xf1\xc5\x1b\x9dR\x91\x9f\x17\x81\xd0\xb4\xcd\x88\x9dJ\xaf\xe2ah\x87v\x00\x0c=\x901PZ\xef\xc0\x18ig\xea\xf5\xa7f7%\xfb\x10,Y\xc3\x9bzp\xd8\xd9\x16\x1c;\xd0\xebDX\x88\xb5\x02\x8e\xa0c\xba\n\xe0\x1f[?0\x80\x8akg\x10\xdc\x9b\xab`\x1eA\x16\x15}\x7fX\xcf\x83\\\xb63\xc6J\xbc\xb3\xa5\xc6\x1c">\x932S\x8b\xfc\x9f(,\xb6-\x1f\x00\xf4\xee\x88\x02)\x00\x00$\x8d\xfc\xf88L\\2\xf1\xb2\x94\xc6N\xabi\xf9\x8e\x9d\x8c\xf7\xe7\xf3R\x97\x1a\x91\xffgw\xd4}\xff\xed)\x00\x00\x1c\x00\x00@\x04\xe6L\x81\xc4\x15*\xd8;\xd6\xe05\x00\x9f\xbb\x90\x04\x06\xbe7\x1f\x00\x00\x00\x1c\x00\x00@\x05(\xcd\x99\xb9\xfa\x12geKS\xf6\x08\x87\xc9\xc3[\xcfg\xa8\xff'
 
@@ -60,24 +60,24 @@ assert raw(packet) == b'E\x00\x01L\x00\x01\x00\x00@\x11\xf5\xc3\xc0\xa8\x01\x82\
 = Dissect Initiator Request
 
 a = Ether(b'\x00!k\x91#H\xb8\'\xeb\xa6XI\x08\x00E\x00\x01\x14u\xc2@\x00@\x11@\xb6\xc0\xa8\x01\x02\xc0\xa8\x01\x0e\x01\xf4\x01\xf4\x01\x00=8\xeahM!Yz\xfd6\x00\x00\x00\x00\x00\x00\x00\x00! "\x08\x00\x00\x00\x00\x00\x00\x00\xf8"\x00\x00(\x00\x00\x00$\x01\x01\x00\x03\x03\x00\x00\x0c\x01\x00\x00\x0f\x80\x0e\x00\x80\x03\x00\x00\x08\x02\x00\x00\x05\x00\x00\x00\x08\x04\x00\x00\x13(\x00\x00H\x00\x13\x00\x002\xc6\xdf\xfe\\C\xb0\xd5\x81\x1f~\xaa\xa8L\x9fx\xbf\x99\xb9\x06\x9c+\x07.\x0b\x82\xf4k\xf6\xf6m\xd4_\x97\xef\x89\xee(_\xd5\xdfRzDwkR\x9f\xc9\xd8\xa9\t\xd8B\xa6\xfbY\xb9j\tS\x95ar)\x00\x00$\xb6UF-oKf\xf8r\xcc\xd7\xf0\xf4\xb4\x85w2\x92\x139\xcb\xaaR7\xed\xba$O&+h#)\x00\x00\x1c\x00\x00@\x04\x94\x9c\x9d\xb5s\x9du\xa9t\xa4\x9c\x18F\x186\x9b4\xb7\xf9B)\x00\x00\x1c\x00\x00@\x05>r\x1bF\xbe\x07\xd51\x11B]\x7f\x80\xd2\xc6\xe2 \xc6\x07.\x00\x00\x00\x10\x00\x00@/\x00\x01\x00\x02\x00\x03\x00\x04')
-assert a[IKEv2_payload_SA].prop.trans.transform_id == 15
-assert a[IKEv2_payload_Notify].next_payload == 41
-assert IP(a[IKEv2_payload_Notify].load).src == "70.24.54.155"
-assert IP(a[IKEv2_payload_Notify].payload.load).dst == "32.198.7.46"
+assert a[IKEv2_SA].prop.trans.transform_id == 15
+assert a[IKEv2_Notify].next_payload == 41
+assert IP(a[IKEv2_Notify].load).src == "70.24.54.155"
+assert IP(a[IKEv2_Notify].payload.load).dst == "32.198.7.46"
 
 = Dissect Responder Response
 
 b = Ether(b'\xb8\'\xeb\xa6XI\x00!k\x91#H\x08\x00E\x00\x01\x0c\xd2R@\x00@\x11\xe4-\xc0\xa8\x01\x0e\xc0\xa8\x01\x02\x01\xf4\x01\xf4\x00\xf8\x07\xdd\xeahM!Yz\xfd6\xd9\xfe*\xb2-\xac#\xac! " \x00\x00\x00\x00\x00\x00\x00\xf0"\x00\x00(\x00\x00\x00$\x01\x01\x00\x03\x03\x00\x00\x0c\x01\x00\x00\x0f\x80\x0e\x00\x80\x03\x00\x00\x08\x02\x00\x00\x05\x00\x00\x00\x08\x04\x00\x00\x13(\x00\x00H\x00\x13\x00\x00,f\xbe\xad\xb6\xce\x855\xd6!\x8c\xb4\x01\xaaZ\x1e\xb4\x03[\x97\xca\xdd\xaf67J\x97\x9c\x04F\xb8\x80\x05\x06\xbf\x9do\x95\tR2k\xf3\x01\x19\x13\xda\x93\xbb\x8e@\xf8\x157k\xe1\xa0h\x01\xc0\xa6>;T)\x00\x00$\x9e]&sy\xe6\x81\xe7\xd3\x8d\x81\xc7\x10\xd3\x83@\x1d\xe7\xe3`{\x92m\x90\xa9\x95\x8a\xdc\xb5(1\xaa)\x00\x00\x1c\x00\x00@\x04z\x07\x85\'=Y 8)\xa6\x97U\x0f1\xcb\xb9N\xb7+C)\x00\x00\x1c\x00\x00@\x05\xc3\xe5\x8a\x8c\xc9\x93<\xe0\xb7\x8f*P\xe8\xde\x80\x13N\x12\xce1\x00\x00\x00\x08\x00\x00@\x14')
 assert b[UDP].dport == 500
-assert b[IKEv2_payload_KE].load == b',f\xbe\xad\xb6\xce\x855\xd6!\x8c\xb4\x01\xaaZ\x1e\xb4\x03[\x97\xca\xdd\xaf67J\x97\x9c\x04F\xb8\x80\x05\x06\xbf\x9do\x95\tR2k\xf3\x01\x19\x13\xda\x93\xbb\x8e@\xf8\x157k\xe1\xa0h\x01\xc0\xa6>;T'
-assert b[IKEv2_payload_Nonce].payload.type == 16388
-assert b[IKEv2_payload_Nonce].payload.payload.payload.next_payload == 0
+assert b[IKEv2_KE].load == b',f\xbe\xad\xb6\xce\x855\xd6!\x8c\xb4\x01\xaaZ\x1e\xb4\x03[\x97\xca\xdd\xaf67J\x97\x9c\x04F\xb8\x80\x05\x06\xbf\x9do\x95\tR2k\xf3\x01\x19\x13\xda\x93\xbb\x8e@\xf8\x157k\xe1\xa0h\x01\xc0\xa6>;T'
+assert b[IKEv2_Nonce].payload.type == 16388
+assert b[IKEv2_Nonce].payload.payload.payload.next_payload == 0
 
 = Dissect Encrypted Initiator Request
 
 a = Ether(b"\x00!k\x91#H\xb8'\xeb\xa6XI\x08\x00E\x00\x00Yu\xe2@\x00@\x11AQ\xc0\xa8\x01\x02\xc0\xa8\x01\x0e\x01\xf4\x01\xf4\x00E}\xe0\xeahM!Yz\xfd6\xd9\xfe*\xb2-\xac#\xac. %\x08\x00\x00\x00\x02\x00\x00\x00=*\x00\x00!\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2")
-assert a[IKEv2_payload_Encrypted].next_payload == 42
-assert a[IKEv2_payload_Encrypted].load == b'\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2'
+assert a[IKEv2_Encrypted].next_payload == 42
+assert a[IKEv2_Encrypted].load == b'\xcc\xa0\xb3]\xe5\xab\xc5\x1c\x99\x87\xcb\xf1\xf5\xec\xff!\x0e\xb7g\xcd\xb8Qy8;\x96Mx\xe2'
 
 = Dissect Encrypted Responder Response
 
@@ -85,29 +85,29 @@ b = Ether(b"\xb8'\xeb\xa6XI\x00!k\x91#H\x08\x00E\x00\x00Q\xd5y@\x00@\x11\xe1\xc1
 assert b[IKEv2].init_SPI == b'\xeahM!Yz\xfd6'
 assert b[IKEv2].resp_SPI == b'\xd9\xfe*\xb2-\xac#\xac'
 assert b[IKEv2].next_payload == 46
-assert b[IKEv2_payload_Encrypted].load == b'\xa8\x0c\x95{\xac\x15\xc3\xf8\xaf\xdf1Z\x81\xccK|@\xe8f\rD'
+assert b[IKEv2_Encrypted].load == b'\xa8\x0c\x95{\xac\x15\xc3\xf8\xaf\xdf1Z\x81\xccK|@\xe8f\rD'
 
 = Test Certs detection
 
-a = IKEv2_payload_CERT(raw(IKEv2_payload_CERT_CRL()))
-b = IKEv2_payload_CERT(raw(IKEv2_payload_CERT_STR()))
-c = IKEv2_payload_CERT(raw(IKEv2_payload_CERT_CRT()))
+a = IKEv2_CERT(raw(IKEv2_CERT_CRL()))
+b = IKEv2_CERT(raw(IKEv2_CERT_STR()))
+c = IKEv2_CERT(raw(IKEv2_CERT_CRT()))
 
-assert isinstance(a, IKEv2_payload_CERT_CRL)
-assert isinstance(b, IKEv2_payload_CERT_STR)
-assert isinstance(c, IKEv2_payload_CERT_CRT)
+assert isinstance(a, IKEv2_CERT_CRL)
+assert isinstance(b, IKEv2_CERT_STR)
+assert isinstance(c, IKEv2_CERT_CRT)
 
 = Test Certs length calculations
 ## For the length calculations see Figure 12 in RFC 7296
-a = IKEv2_payload_CERT_CRT(raw(IKEv2_payload_CERT_CRT()))
+a = IKEv2_CERT_CRT(raw(IKEv2_CERT_CRT()))
 assert len(a.x509Cert) > 0
 assert a.length == len(a.x509Cert) + 5
 
-b = IKEv2_payload_CERT_CRL(raw(IKEv2_payload_CERT_CRL()))
+b = IKEv2_CERT_CRL(raw(IKEv2_CERT_CRL()))
 assert len(b.x509CRL) > 0
 assert b.length == len(b.x509CRL) + 5
 
-c = IKEv2_payload_CERT_STR(raw(IKEv2_payload_CERT_STR(cert_data=b'dummy')))
+c = IKEv2_CERT_STR(raw(IKEv2_CERT_STR(cert_data=b'dummy')))
 assert c.length == len(c.cert_data) + 5
 
 = Test TrafficSelector detection
@@ -122,30 +122,30 @@ assert isinstance(c, EncryptedTrafficSelector)
 
 = Test TSi with multiple TrafficSelector dissection
 
-a = IKEv2_payload_TSi()
+a = IKEv2_TSi()
 a.traffic_selector.extend(IPv4TrafficSelector() * 2)
 a.traffic_selector.extend(IPv6TrafficSelector() * 3)
 assert len(a.traffic_selector) == 5
 
-b = IKEv2_payload_TSi(raw(a))
+b = IKEv2_TSi(raw(a))
 assert len(b.traffic_selector) == 5
 
 = Test automatic calculation of number_of_TSs field
 
-a = IKEv2_payload_TSi(traffic_selector=IPv4TrafficSelector() * 2)
-b = IKEv2_payload_TSi(raw(a))
+a = IKEv2_TSi(traffic_selector=IPv4TrafficSelector() * 2)
+b = IKEv2_TSi(raw(a))
 assert b.number_of_TSs == 2
 
-c = IKEv2_payload_TSr(traffic_selector=IPv4TrafficSelector() * 2)
-d = IKEv2_payload_TSr(raw(c))
+c = IKEv2_TSr(traffic_selector=IPv4TrafficSelector() * 2)
+d = IKEv2_TSr(raw(c))
 assert d.number_of_TSs == 2
 
-= IKEv2_payload_Encrypted_Fragment, simple tests
+= IKEv2_Encrypted_Fragment, simple tests
 
 s = b"\x00\x00\x00\x08\x00\x01\x00\x01"
-assert raw(IKEv2_payload_Encrypted_Fragment()) == s
+assert raw(IKEv2_Encrypted_Fragment()) == s
 
-p = IKEv2_payload_Encrypted_Fragment(s)
+p = IKEv2_Encrypted_Fragment(s)
 assert p.length == 8 and p.frag_number == 1
 
 
@@ -376,11 +376,11 @@ frames = [
             id=0,
             length=300
         ) /
-        IKEv2_payload_SA(
+        IKEv2_SA(
             next_payload='KE',
             res=0,
             length=40,
-            prop=IKEv2_payload_Proposal(
+            prop=IKEv2_Proposal(
                 next_payload='last',
                 res=0,
                 length=36,
@@ -390,7 +390,7 @@ frames = [
                 trans_nb=3,
                 SPI='',
                 trans=(
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='Transform',
                         res=0,
                         length=12,
@@ -399,7 +399,7 @@ frames = [
                         transform_id='AES-GCM-16ICV',
                         key_length=256
                     ) /
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='Transform',
                         res=0,
                         length=8,
@@ -407,7 +407,7 @@ frames = [
                         res2=0,
                         transform_id='PRF_HMAC_SHA2_256'
                     ) /
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='last',
                         res=0,
                         length=8,
@@ -418,7 +418,7 @@ frames = [
                 )
             )
         ) /
-        IKEv2_payload_KE(
+        IKEv2_KE(
             next_payload='Nonce',
             res=0,
             length=72,
@@ -426,37 +426,37 @@ frames = [
             res2=0,
             load=b'\xdb%1xD\x0c\xe7v\xa7\x94\x13<\xb8\xb6\x9e^\xb0ts56W\x0cd\xd7\xb60T\x9c\x89\x9c\x07\x12\xd8(\xb3qhP\x08\x85\xe0Q\x02Ex\xaf\xc7\\\x10\x1fs\xb8\x94<\xadb\xd7J0\xf2\xbe\x1f\xca'
         ) /
-        IKEv2_payload_Nonce(
+        IKEv2_Nonce(
             next_payload='VendorID',
             res=0,
             length=44,
             load=b'\t\xcbS\x8b,=\xbdM\x0b\xb0\xee\xc8\xd3\x18\xcb\x80\x1a\x9bG\x15\xb2\x07\x82\x8d\x9b_\xf1\xf4\xecd\xedX\x867\x07\xbc\xf1L\xcf\x05'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'\xebL\x1bx\x8a\xfdJ\x9c\xb7s\nh\xd5lS!'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc1\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='Notify',
             res=0,
             length=20,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3'
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=8,
@@ -466,7 +466,7 @@ frames = [
             SPI=b'',
             load=b''
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=8,
@@ -476,7 +476,7 @@ frames = [
             SPI=b'',
             load=b''
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='None',
             res=0,
             length=16,
@@ -522,11 +522,11 @@ frames = [
             id=0,
             length=305
         ) /
-        IKEv2_payload_SA(
+        IKEv2_SA(
             next_payload='KE',
             res=0,
             length=40,
-            prop=IKEv2_payload_Proposal(
+            prop=IKEv2_Proposal(
                 next_payload='last',
                 res=0,
                 length=36,
@@ -536,7 +536,7 @@ frames = [
                 trans_nb=3,
                 SPI='',
                 trans=(
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='Transform',
                         res=0,
                         length=12,
@@ -545,7 +545,7 @@ frames = [
                         transform_id='AES-GCM-16ICV',
                         key_length=256
                     ) /
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='Transform',
                         res=0,
                         length=8,
@@ -553,7 +553,7 @@ frames = [
                         res2=0,
                         transform_id='PRF_HMAC_SHA2_256'
                     ) /
-                    IKEv2_payload_Transform(
+                    IKEv2_Transform(
                         next_payload='last',
                         res=0,
                         length=8,
@@ -564,7 +564,7 @@ frames = [
                 )
             )
         ) /
-        IKEv2_payload_KE(
+        IKEv2_KE(
             next_payload='Nonce',
             res=0,
             length=72,
@@ -572,44 +572,44 @@ frames = [
             res2=0,
             load=b'\x1d\x9c\xd5\x97L\x95\x0c\x95\xe0TD\x83\xfb\x1fz\x912\xf5\xfe\x89Y\xc0\x9a\xb3\xa5Lw\x9f\xf2\xbc\xf4R*\x03\r\xc3;\x9d]\xdf\xeb\x99\xe0(\xc0\xe8\xba}\x80\xdf\xdc\xf1+\x15\x16\xdb\xe1\x80\xe6\xae\xc6dB\x8b'
         ) /
-        IKEv2_payload_Nonce(
+        IKEv2_Nonce(
             next_payload='CERTREQ',
             res=0,
             length=44,
             load=b'\x1d\x10}\xc5\xa7F=\xa7\xd7a\x01A9\xfb8\x1a\xf9\xcd;\x8c\x01\x81\xe6\xcd6\xa8\xae\x10^U\xaa\x7f\xe7\x1f]\xb1\xd3l)\x15'
         ) /
-        IKEv2_payload_CERTREQ(
+        IKEv2_CERTREQ(
             next_payload='VendorID',
             res=0,
             length=5,
             cert_type='X.509 Certificate - Signature',
             cert_data=b''
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=24,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3\xc0\x00\x00\x00'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'@H\xb7\xd5n\xbc\xe8\x85%\xe7\xde\x7f\x00\xd6\xc2\xd3'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'\xc6\xf5z\xc3\x98\xf4\x93 \x81E\xb7X\x1e\x87\x89\x83'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='Notify',
             res=0,
             length=20,
             vendorID=b'\x85\x81w\x03\xc6\xe3 \xd2\xaeZM\xd0 V\xc6\xd7'
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=8,
@@ -619,7 +619,7 @@ frames = [
             SPI=b'',
             load=b''
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=16,
@@ -629,7 +629,7 @@ frames = [
             SPI=b'',
             load=b'\x00\x01\x00\x02\x00\x03\x00\x04'
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='None',
             res=0,
             length=8,
@@ -665,7 +665,7 @@ frames = [
             id=1,
             length=1280
         ) /
-        IKEv2_payload_Encrypted(
+        IKEv2_Encrypted(
             next_payload='IDi',
             res=0,
             length=1252,
@@ -699,7 +699,7 @@ frames = [
             id=1,
             length=1272
         ) /
-        IKEv2_payload_Encrypted(
+        IKEv2_Encrypted(
             next_payload='IDr',
             res=0,
             length=1244,
@@ -768,7 +768,7 @@ frames = [
             id=1,
             length=1280
         ) /
-        IKEv2_payload_IDi(
+        IKEv2_IDi(
             next_payload='CERT',
             res=0,
             length=18,
@@ -776,7 +776,7 @@ frames = [
             res2=0x0,
             ID='ikev2-cert'
         ) /
-        IKEv2_payload_CERT_CRT(
+        IKEv2_CERT_CRT(
             next_payload='Notify', res=0, length=732,
             cert_type='X.509 Certificate - Signature',
             x509Cert=X509_Cert(
@@ -898,7 +898,7 @@ frames = [
                 )
             )
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=8,
@@ -908,7 +908,7 @@ frames = [
             SPI='',
             load=''
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='CERTREQ',
             res=0,
             length=8,
@@ -918,14 +918,14 @@ frames = [
             SPI='',
             load=''
         ) /
-        IKEv2_payload_CERTREQ(
+        IKEv2_CERTREQ(
             next_payload='AUTH',
             res=0,
             length=65,
             cert_type='X.509 Certificate - Signature',
             cert_data=b'\x91\xc1\xdc\x0f*\x8f\x0e;\xd7\xda\x99\x1aC\xa3\x92&5^B)\xbc\xb6*\x0e\x9d\xe9y\xfd\xa8d\xe3\xf0d`\xdc\xaa\xff\x85\x07Y\xf4\x89V#8e!N\x9a\x10\xe67oLY\xb5\xc0/6m'
         ) /
-        IKEv2_payload_AUTH(
+        IKEv2_AUTH(
             next_payload='CP',
             res=0,
             length=92,
@@ -933,7 +933,7 @@ frames = [
             res2=0x0,
             load=b'\x0c0\n\x06\x08*\x86H\xce=\x04\x03\x020E\x02!\x00\xc1Hj\xb5\xb3\xdbL\x8b\x08\xf3\xae\x06\x13 \x10L\x82o\xb0\x80;\xa1\xe6\xe3\rX\xc8\x00\x0b\xacQB\x02 Xe\xeaA\xbc\x99\xe0\xad\xfa(Vw\x0e\xfa\xffS\x0f.\x85P\xda\x1d\x86\xf8PM\xf0\x04\x02_\xb1-'
         ) /
-        IKEv2_payload_CP(
+        IKEv2_CP(
             next_payload='SA',
             res=0,
             length=128,
@@ -969,11 +969,11 @@ frames = [
                 ConfigurationAttribute(type=28682, length=6, value='debian')
             ]
         ) /
-        IKEv2_payload_SA(
+        IKEv2_SA(
             next_payload='TSi',
             res=0,
             length=36,
-            prop=IKEv2_payload_Proposal(
+            prop=IKEv2_Proposal(
                 next_payload='last',
                 res=0,
                 length=32,
@@ -982,11 +982,11 @@ frames = [
                 SPIsize=4,
                 trans_nb=2,
                 SPI=b'\xc1\xa9ek',
-                trans=IKEv2_payload_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
-                      IKEv2_payload_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
+                trans=IKEv2_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
+                      IKEv2_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
             )
         ) /
-        IKEv2_payload_TSi(
+        IKEv2_TSi(
             next_payload='TSr',
             res=0,
             length=24,
@@ -1002,7 +1002,7 @@ frames = [
                                     ending_address_v4='255.255.255.255')
             ]
         ) /
-        IKEv2_payload_TSr(
+        IKEv2_TSr(
             next_payload='VendorID',
             res=0,
             length=24,
@@ -1019,25 +1019,25 @@ frames = [
                     ending_address_v4='192.168.225.255')
             ]
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'\xaf\xca\xd7\x13h\xa1\xf1\xc9k\x86\x96\xfcwW\x01\x00'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='VendorID',
             res=0,
             length=20,
             vendorID=b'\xc6\x1b\xac\xa1\xf1\xa6\x0c\xc2\x08\x00\x00\x00\x00\x00\x00\x00'
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='Notify',
             res=0,
             length=28,
             vendorID=b'NcP\n\t\xb8\xe8<\x80\xb6\x936&\x8e\xc8\xf6\x00\x0c)0\x10\x9e\x00\x00'
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='Notify',
             res=0,
             length=8,
@@ -1047,7 +1047,7 @@ frames = [
             SPI='',
             load=''
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload=None,
             res=0,
             length=8,
@@ -1119,7 +1119,7 @@ frames = [
             id=1,
             length=1272
         ) /
-        IKEv2_payload_IDr(
+        IKEv2_IDr(
             next_payload='CERT',
             res=0,
             length=126,
@@ -1127,7 +1127,7 @@ frames = [
             res2=0x0,
             ID=b'0t1\x0b0\t\x06\x03U\x04\x06\x13\x02DE1\x1a0\x18\x06\x03U\x04\n\x0c\x11Demo Organization1\x100\x0e\x06\x03U\x04\x0b\x0c\x07Demo OU1\x100\x0e\x06\x03U\x04\x03\x0c\x07Server11%0#\x06\t*\x86H\x86\xf7\r\x01\t\x01\x16\x16server1@demo.ncp-e.com'
         ) /
-        IKEv2_payload_CERT_CRT(
+        IKEv2_CERT_CRT(
             next_payload='AUTH',
             res=0,
             length=742,
@@ -1256,7 +1256,7 @@ frames = [
                 )
             )
         ) /
-        IKEv2_payload_AUTH(
+        IKEv2_AUTH(
             next_payload='CP',
             res=0,
             length=92,
@@ -1264,7 +1264,7 @@ frames = [
             res2=0x0,
             load=b'\x0c0\n\x06\x08*\x86H\xce=\x04\x03\x020E\x02 x\xd6\xa7\xe8\xb3f\xbd\xe8\xf9\xc1/&\x9f+\xf6A\x16\x95\x11\xceb\x1a\x90\x05\x9a\xed\x0f\xeaGS\x8b\x0e\x02!\x00\x8c\xf3\x08\x13\xd15\xaa\xfe\x8eM\xc0\xfd\xf2\xfdYZ\x98g\xf1\xa6\x08=\x1e\x01\xa1I\xc9\x05\xec\xf9\xbf\xe6'
         ) /
-        IKEv2_payload_CP(
+        IKEv2_CP(
             next_payload='SA',
             res=0,
             length=92,
@@ -1284,11 +1284,11 @@ frames = [
                 ConfigurationAttribute(type=28674, length=0)
             ]
         ) /
-        IKEv2_payload_SA(
+        IKEv2_SA(
             next_payload='Nonce',
             res=0,
             length=36,
-            prop=IKEv2_payload_Proposal(
+            prop=IKEv2_Proposal(
                 res=0,
                 length=32,
                 proposal=1,
@@ -1296,17 +1296,17 @@ frames = [
                 SPIsize=4,
                 trans_nb=2,
                 SPI=b'\xac\x0f\xaf\x03',
-                trans=IKEv2_payload_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
-                      IKEv2_payload_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
+                trans=IKEv2_Transform(res=0, length=12, transform_type='Encryption', res2=0, transform_id='AES-GCM-16ICV', key_length=128) /
+                      IKEv2_Transform(res=0, length=8, transform_type='Extended Sequence Number', res2=0, transform_id='No ESN')
             )
         ) /
-        IKEv2_payload_Nonce(
+        IKEv2_Nonce(
             next_payload='TSi',
             res=0,
             length=44,
             load=b'\xcf\x0eyPv]\xb7\xf77\x1d\xbb\xdf\xa1r\x04\x93\xc8<\x1b\xa4\xdc6\x17\xc3\x19*W\xb9(]\x9ac\n\xc7\x16F\x11\xfd\xf4,'
         ) /
-        IKEv2_payload_TSi(
+        IKEv2_TSi(
             next_payload='TSr',
             res=0,
             length=24,
@@ -1324,7 +1324,7 @@ frames = [
                 )
             ]
         ) /
-        IKEv2_payload_TSr(
+        IKEv2_TSr(
             next_payload='VendorID',
             res=0,
             length=24,
@@ -1342,13 +1342,13 @@ frames = [
                 )
             ]
         ) /
-        IKEv2_payload_VendorID(
+        IKEv2_VendorID(
             next_payload='Notify',
             res=0,
             length=20,
             vendorID=b'\xaf\xca\xd7\x13h\xa1\xf1\xc9k\x86\x96\xfcwW\x01\x00'
         ) /
-        IKEv2_payload_Notify(
+        IKEv2_Notify(
             next_payload='None',
             res=0,
             length=8,


### PR DESCRIPTION
_Commits in chronological order. ~~The first one is a preparation for the second, main commit.~~(update: squashed into one)_

_Still a draft, because the pull request is based on the unmerged pull request #3766 and because tests are still missing._

commit [733ba89e4ec0f3fd2e0b19d9788afd27a7fdef46](https://github.com/secdev/scapy/pull/3779/commits/733ba89e4ec0f3fd2e0b19d9788afd27a7fdef46)

    IKEv2: improve dissection of IKEv2 redirect notifications
    
    This commit adds a dispatch hook for the IKEv2_payload_Notify class
    to support adding specialized classes for specific notifications
    for which the payload can be dissected further.
    
    As a first use-case, it adds two new notification classes
    
    - IKEv2_payload_Notify_Redirect
    - IKEv2_payload_Notify_Redirected_from
    
    See RFC 5685, sections 9.2 and 9.3

**Checklist:**

-   [ ] I added unit tests
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
