### PR TITLE
asn1.mib: correct the ASN1 oid for `basicConstraints`

### DIFF
--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -376,7 +376,7 @@ certificateExtension_oids = {
     "2.5.29.7": "subjectAltName",
     "2.5.29.8": "issuerAltName",
     "2.5.29.9": "subjectDirectoryAttributes",
-    "2.5.29.10": "basicConstraints",
+    "2.5.29.10": "basicConstraints(obsolete)",
     "2.5.29.14": "subjectKeyIdentifier",
     "2.5.29.15": "keyUsage",
     "2.5.29.16": "privateKeyUsagePeriod",


### PR DESCRIPTION
The `certificateExtension_oids` dictionary contains two oid values for `basicConstraints`, namely [oid 2.5.29.10] and [oid 2.5.29.19].

The former is obsolete since 2000 and has been replaced by the latter. Unfortunately, the obsolete oid is chosen when the ASN1_OID object is constructed from its name:

    >>> oid1=ASN1_OID('basicConstraints')
    >>> oid1
    <ASN1_OID['basicConstraints']>
    >>> oid1.val
    '2.5.29.10'

This bug caused a one byte discrepancy with an ASN1_ID dissected from an X509 certificate.

    >>> oid2
    <ASN1_OID['basicConstraints']>
    >>> oid1 == oid2
    False
    >>> oid2.val
    '2.5.29.19'

*Note*: both oids have been present in the dictionary for quite a while, but only after commit 5143eff9 (Reverse MIB storage format, 2018-09-23) the bug became manifest, because previously the obsolete oid value was overwritten by the correct one in the dictionary:

    ~/src/scapy$ git show 5143eff9 | grep basicConstraints

    -    "basicConstraints": "2.5.29.10",
    -    "basicConstraints": "2.5.29.19",
    +    "2.5.29.10": "basicConstraints",
    +    "2.5.29.19": "basicConstraints",

[oid 2.5.29.10]: http://oid-info.com/get/2.5.29.10
[oid 2.5.29.19]: http://oid-info.com/get/2.5.29.19
