### PR TITLE
Use macOS 12

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -102,11 +102,11 @@ jobs:
             installmode: 'libpcap'
             allow-failure: false
           # MacOS tests
-          - os: macos-10.15
+          - os: macos-12
             python: "2.7"
             mode: both
             allow-failure: false
-          - os: macos-10.15
+          - os: macos-12
             python: "3.10"
             mode: both
             allow-failure: false
@@ -121,7 +121,7 @@ jobs:
             allow-failure: true
             flags: " -k scanner"
           # MacOS tests
-          - os: macos-10.15
+          - os: macos-12
             python: "3.10"
             mode: both
             allow-failure: true

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -27,7 +27,7 @@ import traceback
 import warnings
 import zlib
 
-from scapy.consts import WINDOWS
+from scapy.consts import WINDOWS, DARWIN
 import scapy.libs.six as six
 from scapy.config import conf
 from scapy.compat import base64_bytes, bytes_hex, plain_str
@@ -1130,8 +1130,9 @@ def main():
     KW_KO.append("disabled")
 
     # Process extras
-    if six.PY3:
-        KW_KO.append("FIXME_py3")
+    if six.PY2 and DARWIN:
+        # On MacOS 12, Python 2.7 find_library is broken
+        KW_KO.append("libpcap")
 
     if ANNOTATIONS_MODE:
         try:

--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -36,7 +36,7 @@ from scapy.arch.bpf.supersocket import get_dev_bpf
 fd, _ = get_dev_bpf()
 
 = Attach a BPF filter
-~ needs_root
+~ needs_root libpcap
 
 from scapy.arch.bpf.supersocket import attach_filter
 attach_filter(fd, "arp or icmp", conf.iface)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1811,7 +1811,7 @@ def _test_select(select):
 assert _test_select()
 
 = Test L2ListenTcpdump socket
-~ netaccess FIXME_py3
+~ netaccess
 
 # Needs to be fixed. Fails randomly
 #import time
@@ -2029,13 +2029,13 @@ assert list(pktpcap) == list(sniff(offline=fdesc))
 fdesc.close()
 
 = Check offline sniff() with a filter (by filename)
-~ tcpdump
+~ tcpdump libpcap
 pktpcap_flt = [(proto, sniff(offline=filename, filter=proto.__name__.lower()))
                for proto in [ICMP, UDP, TCP]]
 assert all(list(pktpcap[proto]) == list(packets) for proto, packets in pktpcap_flt)
 
 = Check offline sniff() with a filter (by file object)
-~ tcpdump
+~ tcpdump libpcap
 fdesc = open(filename, "rb")
 pktpcap_tcp = sniff(offline=fdesc, filter="tcp")
 fdesc.close()
@@ -2043,7 +2043,7 @@ assert list(pktpcap[TCP]) == list(pktpcap_tcp)
 os.unlink(filename)
 
 = Check offline sniff() with a PcapNg file and a filter (by file object)
-~ tcpdump
+~ tcpdump libpcap
 
 pcapng_data = b'\n\r\r\n`\x00\x00\x00M<+\x1a\x01\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\x04\x009\x00TShark (Wireshark) 3.2.3 (Git v3.2.3 packaged as 3.2.3-1)\x00\x00\x00\x00\x00\x00\x00`\x00\x00\x00\x01\x00\x00\x00\x14\x00\x00\x00\xe4\x00\x00\x00\xff\xff\x00\x00\x14\x00\x00\x00\x06\x00\x00\x00<\x00\x00\x00\x00\x00\x00\x00\x98\xcd\x05\x00\x19\x83\xf7\x9e\x1c\x00\x00\x00\x1c\x00\x00\x00E\x00\x00\x1c\x00\x01\x00\x00@\x11|\xce\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x08\x01r<\x00\x00\x00'
 
@@ -2057,8 +2057,8 @@ packets = sniff(offline=filename, filter="udp")
 os.unlink(filename)
 assert UDP in packets[0]
 
-= Check offline sniff() with Packets and tcpdump
-~ tcpdump
+= Check offline sniff() with Packets and tcpdump with a filter
+~ tcpdump libpcap
 
 l = sniff(offline=IP()/UDP(sport=(10000, 10001)), filter="udp")
 assert len(l) == 2
@@ -2072,7 +2072,7 @@ l = sniff(offline=IP()/UDP(sport=(10000, 10001)), filter="tcp")
 assert len(l) == 0
 
 = Check offline sniff() with Packets, tcpdump and a bad filter
-~ tcpdump
+~ tcpdump libpcap
 
 try:
     sniff(offline=IP()/UDP(), filter="bad filter")
@@ -2288,8 +2288,8 @@ data = tcpdump([Ether()/IP()/ICMP()], dump=True, args=['-nn']).split(b'\n')
 print(data)
 assert b'127.0.0.1 > 127.0.0.1: ICMP' in data[0].upper()
 
-= Check tcpdump() command with linktype
-~ tcpdump
+= Check tcpdump() command with linktype 
+~ tcpdump libpcap
 
 f = BytesIO()
 pkt = Ether()/IP()/ICMP()
@@ -2314,7 +2314,7 @@ f.close()
 del f, pkt
 
 = Check tcpdump() command with linktype and args
-~ tcpdump
+~ tcpdump libpcap
 
 f = BytesIO()
 pkt = Ether()/IP()/ICMP()


### PR DESCRIPTION
We have [until the 01/12/2022](https://github.com/actions/runner-images/issues/5583) to stop using MacOS 10.5 in our test suite. This PR is a proposal to use version 12

@guedou There appears to be an issue on Python 2.7 with OSX12, where it can't find `libpcap`. Do you think we should:
- fix the issue? (any ideas? ^^'''')
- drop support for OSX 12 on 2.7?
- try to disable that one test on OSX, 2.7...

I don't have a MacOS machine to debug this ://