### PR TITLE
Fix error handling for pcap_create() and pcap_activate().

### DIFF
--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -150,6 +150,9 @@ if conf.use_pcap:
     try:
         from scapy.libs.winpcapy import (
             PCAP_ERRBUF_SIZE,
+            PCAP_ERROR,
+            PCAP_ERROR_NO_SUCH_DEVICE,
+            PCAP_ERROR_PERM_DENIED,
             bpf_program,
             pcap_close,
             pcap_compile,
@@ -286,15 +289,40 @@ if conf.use_pcap:
                 # Npcap-only functions
                 from scapy.libs.winpcapy import pcap_create, \
                     pcap_set_snaplen, pcap_set_promisc, \
-                    pcap_set_timeout, pcap_set_rfmon, pcap_activate
+                    pcap_set_timeout, pcap_set_rfmon, pcap_activate, \
+                    pcap_statustostr, pcap_geterr
                 self.pcap = pcap_create(self.iface, self.errbuf)
+                if not self.pcap:
+                    error = decode_locale_str(bytearray(self.errbuf).strip(b"\x00"))
+                    if error:
+                        raise OSError(error)
                 pcap_set_snaplen(self.pcap, snaplen)
                 pcap_set_promisc(self.pcap, promisc)
                 pcap_set_timeout(self.pcap, to_ms)
                 if pcap_set_rfmon(self.pcap, 1) != 0:
                     log_runtime.error("Could not set monitor mode")
-                if pcap_activate(self.pcap) != 0:
-                    raise OSError("Could not activate the pcap handler")
+                status = pcap_activate(self.pcap)
+                # status == 0 means success
+                # status < 0 means error
+                # status > 0 means success, but with a warning
+                if status < 0:
+                    # self.iface, and strings we get back from
+                    # pcap_geterr() and pcap_statustostr(), have the
+                    # type "bytes".
+                    #
+                    # decode_locale_str() turns them into strings.
+                    iface = decode_locale_str(bytearray(self.iface).strip(b"\x00"))
+                    errstr = decode_locale_str(bytearray(pcap_geterr(self.pcap)).strip(b"\x00"))
+                    statusstr = decode_locale_str(bytearray(pcap_statustostr(status)).strip(b"\x00"))
+                    if status == PCAP_ERROR:
+                        errmsg = errstr
+                    elif status == PCAP_ERROR_NO_SUCH_DEVICE:
+                        errmsg = "%s: %s\n(%s)" % (iface, statusstr, errstr)
+                    elif status == PCAP_ERROR_PERM_DENIED and errstr != "":
+                        errmsg = "%s: %s\n(%s)" % (iface, statusstr, errstr)
+                    else:
+                        errmsg = "%s: %s" % (iface, statusstr)
+                    raise OSError(errmsg)
             else:
                 self.pcap = pcap_open_live(self.iface,
                                            snaplen, promisc, to_ms,

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -311,9 +311,15 @@ if conf.use_pcap:
                     # type "bytes".
                     #
                     # decode_locale_str() turns them into strings.
-                    iface = decode_locale_str(bytearray(self.iface).strip(b"\x00"))
-                    errstr = decode_locale_str(bytearray(pcap_geterr(self.pcap)).strip(b"\x00"))
-                    statusstr = decode_locale_str(bytearray(pcap_statustostr(status)).strip(b"\x00"))
+                    iface = decode_locale_str(
+                        bytearray(self.iface).strip(b"\x00")
+                    )
+                    errstr = decode_locale_str(
+                        bytearray(pcap_geterr(self.pcap)).strip(b"\x00")
+                    )
+                    statusstr = decode_locale_str(
+                        bytearray(pcap_statustostr(status)).strip(b"\x00")
+                    )
                     if status == PCAP_ERROR:
                         errmsg = errstr
                     elif status == PCAP_ERROR_NO_SUCH_DEVICE:

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -348,7 +348,8 @@ pcap_open_offline.restype = POINTER(pcap_t)
 pcap_open_offline.argtypes = [STRING, STRING]
 
 try:
-    # NPCAP/LINUX ONLY function
+    # Functions not available on WINPCAP
+
     # int pcap_set_rfmon (pcap_t *p)
     # sets whether monitor mode should be set on a capture handle when the
     # handle is activated.
@@ -391,6 +392,12 @@ try:
     pcap_inject = _lib.pcap_inject
     pcap_inject.restype = c_int
     pcap_inject.argtypes = [POINTER(pcap_t), c_void_p, c_int]
+
+    # const char * pcap_statustostr (int error)
+    # print the text of the status (error or warning) corresponding to error.
+    pcap_statustostr = _lib.pcap_statustostr
+    pcap_statustostr.restype = STRING
+    pcap_statustostr.argtypes = [c_int]
 except AttributeError:
     pass
 
@@ -649,12 +656,6 @@ pcap_geterr.argtypes = [POINTER(pcap_t)]
 pcap_strerror = _lib.pcap_strerror
 pcap_strerror.restype = STRING
 pcap_strerror.argtypes = [c_int]
-
-# const char * pcap_statustostr (int error)
-# print the text of the status (error or warning) corresponding to error.
-pcap_statustostr = _lib.pcap_statustostr
-pcap_statustostr.restype = STRING
-pcap_statustostr.argtypes = [c_int]
 
 # const char *   pcap_lib_version (void)
 # Returns a pointer to a string giving information about the version of

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -5,7 +5,9 @@
 # Copyright (C) Gabriel Potter
 
 # Modified for scapy's usage - To support Npcap/Monitor mode
-
+#
+# NOTE: the "winpcap" in the name nonwithstanding, this is for use
+# with libpcap on non-Windows platforms, as well as for WinPcap and Npcap.
 
 from ctypes import *
 from ctypes.util import find_library
@@ -222,6 +224,60 @@ MODE_CAPT = 0
 # define  MODE_STAT   1
 #   Statistical mode, to be used when calling pcap_setmode().
 MODE_STAT = 1
+
+#   Error codes for the pcap API.
+#   These will all be negative, so you can check for the success or
+#   failure of a call that returns these codes by checking for a
+#   negative value.
+#
+#   generic error code
+# define PCAP_ERROR			-1
+PCAP_ERROR = -1
+#   loop terminated by pcap_breakloop
+# define PCAP_ERROR_BREAK		-2
+PCAP_ERROR_BREAK = -2
+#   the capture needs to be activated
+# define PCAP_ERROR_NOT_ACTIVATED	-3
+PCAP_ERROR_NOT_ACTIVATED = -3
+#   the operation can't be performed on already activated captures
+# define PCAP_ERROR_ACTIVATED		-4
+PCAP_ERROR_ACTIVATED = -4
+#   no such device exists
+# define PCAP_ERROR_NO_SUCH_DEVICE	-5
+PCAP_ERROR_NO_SUCH_DEVICE = -5
+#   this device doesn't support rfmon (monitor) mode */
+# define PCAP_ERROR_RFMON_NOTSUP	-6
+PCAP_ERROR_RFMON_NOTSUP = -6
+#   operation supported only in monitor mode
+# define PCAP_ERROR_NOT_RFMON		-7
+PCAP_ERROR_NOT_RFMON = -7
+#   no permission to open the device
+# define PCAP_ERROR_PERM_DENIED		-8
+PCAP_ERROR_PERM_DENIED = -8
+#   interface isn't up
+# define PCAP_ERROR_IFACE_NOT_UP	-9
+PCAP_ERROR_IFACE_NOT_UP = -9
+#define PCAP_ERROR_CANTSET_TSTAMP_TYPE	-10
+#   this device doesn't support setting the time stamp type
+#   you don't have permission to capture in promiscuous mode
+# define PCAP_ERROR_PROMISC_PERM_DENIED	-11
+PCAP_ERROR_PROMISC_PERM_DENIED = -11
+#   the requested time stamp precision is not supported 
+# define PCAP_ERROR_TSTAMP_PRECISION_NOTSUP -12
+PCAP_ERROR_TSTAMP_PRECISION_NOTSUP = -12
+
+#   Warning codes for the pcap API.
+#   These will all be positive and non-zero, so they won't look like
+#   errors.
+#   generic warning code
+# define PCAP_WARNING			1
+PCAP_WARNING = 1
+#   this device doesn't support promiscuous mode
+# define PCAP_WARNING_PROMISC_NOTSUP	2
+PCAP_WARNING_PROMISC_NOTSUP = 2
+#   the requested time stamp type is not supported
+# define PCAP_WARNING_TSTAMP_TYPE_NOTSUP	3
+PCAP_WARNING_TSTAMP_TYPE_NOTSUP = 3
 
 ##
 # END Defines
@@ -593,6 +649,12 @@ pcap_geterr.argtypes = [POINTER(pcap_t)]
 pcap_strerror = _lib.pcap_strerror
 pcap_strerror.restype = STRING
 pcap_strerror.argtypes = [c_int]
+
+# const char * pcap_statustostr (int error)
+# print the text of the status (error or warning) corresponding to error.
+pcap_statustostr = _lib.pcap_statustostr
+pcap_statustostr.restype = STRING
+pcap_statustostr.argtypes = [c_int]
 
 # const char *   pcap_lib_version (void)
 # Returns a pointer to a string giving information about the version of

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -257,12 +257,12 @@ PCAP_ERROR_PERM_DENIED = -8
 #   interface isn't up
 # define PCAP_ERROR_IFACE_NOT_UP	-9
 PCAP_ERROR_IFACE_NOT_UP = -9
-#define PCAP_ERROR_CANTSET_TSTAMP_TYPE	-10
+# define PCAP_ERROR_CANTSET_TSTAMP_TYPE	-10
 #   this device doesn't support setting the time stamp type
 #   you don't have permission to capture in promiscuous mode
 # define PCAP_ERROR_PROMISC_PERM_DENIED	-11
 PCAP_ERROR_PROMISC_PERM_DENIED = -11
-#   the requested time stamp precision is not supported 
+#   the requested time stamp precision is not supported
 # define PCAP_ERROR_TSTAMP_PRECISION_NOTSUP -12
 PCAP_ERROR_TSTAMP_PRECISION_NOTSUP = -12
 


### PR DESCRIPTION
This 1) handles pcap_create() failing and 2) provides a useful error message if pcap_activate() fails.