### PR TITLE
fix verbose conf in doc

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -433,7 +433,7 @@ def send(x,  # type: _PacketIterable
     :param inter: time (in s) between two packets (default 0)
     :param loop: send packet indefinitely (default 0)
     :param count: number of packets to send (default None=1)
-    :param verbose: verbose mode (default None=conf.verbose)
+    :param verbose: verbose mode (default None=conf.verb)
     :param realtime: check that a packet was sent before sending the next one
     :param return_packets: return the sent packets
     :param socket: the socket to use (default is conf.L3socket(kargs))
@@ -465,7 +465,7 @@ def sendp(x,  # type: _PacketIterable
     :param inter: time (in s) between two packets (default 0)
     :param loop: send packet indefinitely (default 0)
     :param count: number of packets to send (default None=1)
-    :param verbose: verbose mode (default None=conf.verbose)
+    :param verbose: verbose mode (default None=conf.verb)
     :param realtime: check that a packet was sent before sending the next one
     :param return_packets: return the sent packets
     :param socket: the socket to use (default is conf.L3socket(kargs))


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

Fixes wrong doc of `conf.verbose` instead of `conf.verb`.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

