### PR TITLE
Bgp update errors

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -2187,8 +2187,10 @@ class BGPUpdate(BGP):
     ]
 
     def post_build(self, p, pay):
+        # type: (bytes, bytes) -> bytes
         subpacklen = lambda p: len(p)
-        packet = ""
+        packet = p
+
         if self.withdrawn_routes_len is None:
             wl = sum(map(subpacklen, self.withdrawn_routes))
             packet = p[:0] + struct.pack("!H", wl) + p[2:]

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -2129,7 +2129,7 @@ class BGPPathAttr(Packet):
             if extended_length:
                 packet = packet + p[2:4]
             else:
-                packet = packet + p[2]
+                packet = packet + p[2].to_bytes(1, byteorder='little')
         else:
             if extended_length:
                 packet = packet + struct.pack("!H", length)


### PR DESCRIPTION
Fixed BGP Update message fields having incorrect types during post_build().
Bugs discovered while testing scapy 2.5.0 and Automaton.