### PR TITLE
Run 2.7 tests on <=20.04

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Run mypy
         run: tox -e mypy
 
+  # https://github.com/actions/runner-images/issues/6399
+  # Python 2.7 tests must be run on ubuntu <= 20.04
   utscapy:
     name: ${{ matrix.os }} ${{ matrix.installmode }} ${{ matrix.python }} ${{ matrix.mode }} ${{ matrix.flags }}
     runs-on: ${{ matrix.os }}
@@ -67,27 +69,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["2.7", "3.10"]
-        mode: [both]
+        python: ["3.7", "3.8", "3.9", "3.10"]
+        mode: [non_root]
         installmode: ['']
         flags: ['']
         allow-failure: [false]
         include:
-          # Linux non-root only tests
-          - os: ubuntu-latest
-            python: "3.7"
-            mode: non_root
+          # Linux root tests
+          - os: ubuntu-20.04
+            python: "2.7"
+            mode: root
             allow-failure: false
           - os: ubuntu-latest
-            python: "3.8"
-            mode: non_root
-            allow-failure: false
-          - os: ubuntu-latest
-            python: "3.9"
-            mode: non_root
+            python: "3.10"
+            mode: root
             allow-failure: false
           # PyPy tests: root only
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python: "pypy2.7"
             mode: root
             allow-failure: false
@@ -112,7 +110,8 @@ jobs:
             python: "3.10"
             mode: both
             allow-failure: false
-          - os: ubuntu-latest
+          # Scanner tests
+          - os: ubuntu-20.04
             python: "pypy2.7"
             mode: root
             allow-failure: true
@@ -122,7 +121,6 @@ jobs:
             mode: root
             allow-failure: true
             flags: " -k scanner"
-          # MacOS tests
           - os: macos-12
             python: "3.10"
             mode: both


### PR DESCRIPTION
Github is [switching `ubuntu-latest` to use 22.04](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) but [python 2.7 is only supported on <= 20.04](https://github.com/actions/runner-images/issues/6399)

We are planning to drop support for 2.7 after 2.5.0, but in the meantime make the tests run.