### PR TITLE
Fix CI

### DIFF
--- a/.config/ci/openssl.py
+++ b/.config/ci/openssl.py
@@ -21,31 +21,23 @@ OPENSSL_DIR = re.search(
 ).group(1).decode()
 OPENSSL_CONFIG = os.path.join(OPENSSL_DIR, 'openssl.cnf')
 
-# https://askubuntu.com/a/1233456
-HEADER = b"openssl_conf = default_conf\n"
-FOOTER = b"""
-[ default_conf ]
+# https://www.openssl.org/docs/manmaster/man5/config.html
+DATA = b"""
+openssl_conf = openssl_init
 
-ssl_conf = ssl_sect
+[openssl_init]
+ssl_conf = ssl_configuration
 
-[ssl_sect]
+[ssl_configuration]
+system_default = tls_system_default
 
-system_default = system_default_sect
-
-[system_default_sect]
-MinProtocol = TLSv1.2
-CipherString = DEFAULT:@SECLEVEL=1
-"""
+[tls_system_default]
+MinProtocol = TLSv1
+CipherString = DEFAULT:@SECLEVEL=0
+Options = UnsafeLegacyRenegotiation
+""".strip()
 
 # Copy and edit
-try:
-    with open(OPENSSL_CONFIG, 'rb') as fd:
-        DATA = fd.read()
-except FileNotFoundError:
-    DATA = b""
-
-DATA = HEADER + DATA + FOOTER
-
 with tempfile.NamedTemporaryFile(suffix=".cnf", delete=False) as fd:
     fd.write(DATA)
     print(fd.name)

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -92,11 +92,13 @@ then
 fi
 
 # Configure OpenSSL
-export OPENSSL_CONF=$($PYTHON `dirname $BASH_SOURCE`/openssl.py)
+export OPENSSL_CONF=$(python `dirname $BASH_SOURCE`/openssl.py)
 
 # Dump vars (the others were already dumped in install.sh)
 echo UT_FLAGS=$UT_FLAGS
 echo TOXENV=$TOXENV
+echo OPENSSL_CONF=$OPENSSL_CONF
+echo OPENSSL_VER=$(openssl version)
 
 # Launch Scapy unit tests
 TOX_PARALLEL_NO_SPINNER=1 tox -- ${UT_FLAGS} || exit 1

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,17 @@ minversion = 2.9
 
 [testenv]
 description = "Scapy unit tests"
-whitelist_externals = sudo
+allowlist_externals = sudo
 parallel_show_output = true
-passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT OPENSSL_CONF
-          # Used by scapy
-          SCAPY_USE_LIBPCAP
+passenv =
+    PATH
+    PWD
+    PROGRAMFILES
+    WINDIR
+    SYSTEMROOT
+    OPENSSL_CONF
+    # Used by scapy
+    SCAPY_USE_LIBPCAP
 deps = mock
        # cryptography requirements
        setuptools>=18.5
@@ -43,12 +49,17 @@ commands =
 
 [testenv:py38-isotp_kernel_module]
 description = "Scapy unit tests - ISOTP Linux kernel module"
-whitelist_externals = sudo
+allowlist_externals = sudo
                       git
                       bash
                       lsmod
                       modprobe
-passenv = PATH PWD PROGRAMFILES WINDIR SYSTEMROOT
+passenv =
+    PATH
+    PWD
+    PROGRAMFILES
+    WINDIR
+    SYSTEMROOT
 deps = {[testenv]deps}
 commands =
   sudo apt-get -qy install build-essential linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
@@ -75,7 +86,13 @@ commands =
 
 [testenv:codecov]
 description = "Upload coverage results to codecov"
-passenv = TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_*
+passenv =
+    TOXENV
+    CI
+    TRAVIS
+    TRAVIS_*
+    APPVEYOR
+    APPVEYOR_*
 deps = codecov
 commands = codecov -e TOXENV
 
@@ -84,7 +101,7 @@ commands = codecov -e TOXENV
 [testenv:apitree]
 description = "Regenerates the API reference doc tree"
 skip_install = true
-changedir = doc/scapy
+changedir = {toxinidir}/doc/scapy
 deps = sphinx
 commands =
   sphinx-apidoc -f --no-toc -d 1 --separate --module-first --templatedir=_templates --output-dir api ../../scapy ../../scapy/modules/ ../../scapy/libs/ ../../scapy/tools/ ../../scapy/arch/ ../../scapy/contrib/scada/* ../../scapy/all.py ../../scapy/layers/all.py ../../scapy/compat.py
@@ -103,7 +120,7 @@ commands = python .config/mypy/mypy_check.py linux
 [testenv:docs]
 description = "Build the docs"
 skip_install = true
-changedir = doc/scapy
+changedir = {toxinidir}/doc/scapy
 deps = sphinx>=2.4.2
        sphinx_rtd_theme
 commands =
@@ -114,7 +131,7 @@ commands =
 [testenv:docs2]
 description = "Build the docs without rebuilding the API tree"
 skip_install = true
-changedir = doc/scapy
+changedir = {toxinidir}/doc/scapy
 deps = {[testenv:docs]deps}
 setenv =
   SCAPY_APITREE = 0


### PR DESCRIPTION
Fix the shitstorm of failing tests

- tox 4 broke several things:
  - `whitelist_externals` was removed from tox (renamed `allowlist_externals`)
  - lists can't be separated using spaces anymore
  - `changedir` isn't relative to the `tox.ini` directory anymore... >:(
- Openssl 3.0 has changed its config defaults (i.e. we now need a SECLEVEL of 0 to use TLS 1.0 for our testing)
- `$PYTHON` is not defined