### PR TITLE
Use $PYTHON if it exists

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -92,7 +92,7 @@ then
 fi
 
 # Configure OpenSSL
-export OPENSSL_CONF=$(python `dirname $BASH_SOURCE`/openssl.py)
+export OPENSSL_CONF=$(${PYTHON:=python} `dirname $BASH_SOURCE`/openssl.py)
 
 # Dump vars (the others were already dumped in install.sh)
 echo UT_FLAGS=$UT_FLAGS


### PR DESCRIPTION
Following a recent change made by @gpotter2, this PR use the content of $PYTHON or defaults to python.