### PR TITLE
run_scapy: prefer the Python Launcher on Windows

### DIFF
--- a/run_scapy.bat
+++ b/run_scapy.bat
@@ -1,17 +1,30 @@
 @echo off
+setlocal
 set PYTHONPATH=%~dp0
 REM shift will not work with %*
 set "_args=%*"
+IF "%PYTHON%" == "" set PYTHON=py
+WHERE %PYTHON% >nul 2>&1
+IF %ERRORLEVEL% NEQ 0 set PYTHON=
 IF "%1" == "-2" (
-  set PYTHON=python
+  if "%PYTHON%" == "py" (
+    set "PYTHON=py -2"
+  ) else (
+    set PYTHON=python
+  )
   set "_args=%_args:~3%"
 ) ELSE IF "%1" == "-3" (
-  set PYTHON=python3
+  if "%PYTHON%" == "py" (
+    set "PYTHON=py -3"
+  ) else (
+    set PYTHON=python3
+  )
   set "_args=%_args:~3%"
+) else (
+  IF "%PYTHON%" == "" set PYTHON=python3
+  WHERE %PYTHON% >nul 2>&1
+  IF %ERRORLEVEL% NEQ 0 set PYTHON=python
 )
-IF "%PYTHON%" == "" set PYTHON=python3
-WHERE %PYTHON% >nul 2>&1
-IF %ERRORLEVEL% NEQ 0 set PYTHON=python
 %PYTHON% -m scapy %_args%
 title Scapy - dead
 PAUSE


### PR DESCRIPTION
Use the Python Launcher py.exe if it is found and let it handle the -2/-3 argument.

Also add a 'setlocal' to prevent the script from messing with the callers variables.

Fixes #3818