### PR TITLE
Update gtp.py to exclude length field size from GTP payload length

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -451,7 +451,7 @@ class IE_Base(Packet):
                 tmp_len = len(p)
                 if isinstance(self.payload, conf.padding_layer):
                     tmp_len += len(self.payload.load)
-                p = p[:1] + struct.pack("!H", tmp_len - 2) + p[3:]
+                p = p[:1] + struct.pack("!H", tmp_len - 4) + p[3:]
         return p + pay
 
 

--- a/test/contrib/gtp_v2.uts
+++ b/test/contrib/gtp_v2.uts
@@ -16,8 +16,11 @@ gtp.dport == 2123 and gtp.seq == 12345 and gtp.gtp_type == 1 and gtp.T == 0
 = GTPV2CreateSessionRequest, basic instantiation
 gtp = IP() / UDP(dport=2123) / \
     GTPHeader(gtp_type="create_session_req", teid=2807, seq=12345) / \
-    GTPV2CreateSessionRequest()
-gtp.dport == 2123 and gtp.teid == 2807 and gtp.seq == 12345
+    GTPV2CreateSessionRequest(IE_list=[IE_IMSI(IMSI=b'001030000000356'),IE_APN(APN=b'super')])
+
+assert gtp.dport == 2123 and gtp.teid == 2807 and gtp.seq == 12345
+ie = gtp.IE_list[1]
+assert ie.APN == b"super"
 
 = GTPV2EchoRequest, dissection
 h = "333333333333222222222222810080c808004588002937dd0000fd1115490a2a00010a2a0002084b084b00152d0e4001000900000100030001000daa000000003f1f382f"


### PR DESCRIPTION
Reducing length of 'length' field along with 'ietype' and 'CR_flag+instance'

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [ ] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
