### PR TITLE
Add 802.11v BSS transition management request & response

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1544,6 +1544,45 @@ class Dot11Action(Packet):
     ]
 
 
+# 802.11-2016 9.6.14.1
+
+class Dot11WNM(Packet):
+    name = "802.11 WNM Action"
+    fields_desc = [
+        ByteEnumField("action", 0x00, {
+            0x00: "Event Request",
+            0x01: "Event Report",
+            0x02: "Diagnostic Request",
+            0x03: "Diagnostic Report",
+            0x04: "Location Configuration Request",
+            0x05: "Location Configuration Response",
+            0x06: "BSS Transition Management Query",
+            0x07: "BSS Transition Management Request",
+            0x08: "BSS Transition Management Response",
+            0x09: "FMS Request",
+            0x0A: "FMS Response",
+            0x0B: "Collocated Interference Request",
+            0x0C: "Collocated Interference Report",
+            0x0D: "TFS Request",
+            0x0E: "TFS Response",
+            0x0F: "TFS Notify",
+            0x10: "WNM Sleep Mode Request",
+            0x11: "WNM Sleep Mode Response",
+            0x12: "TIM Broadcast Request",
+            0x13: "TIM Broadcast Response",
+            0x14: "QoS Traffic Capability Update",
+            0x15: "Channel Usage Request",
+            0x16: "Channel Usage Response",
+            0x17: "DMS Request",
+            0x18: "DMS Response",
+            0x19: "Timing Measurement Request",
+            0x1A: "WNM Notification Request",
+            0x1B: "WNM Notification Response",
+            0x1C: "WNM-Notify Response"
+        })
+    ]
+
+
 ###################
 # 802.11 Security #
 ###################
@@ -1710,6 +1749,7 @@ bind_layers(Dot11Auth, Dot11Elt,)
 bind_layers(Dot11Elt, Dot11Elt,)
 bind_layers(Dot11TKIP, conf.raw_layer)
 bind_layers(Dot11CCMP, conf.raw_layer)
+bind_layers(Dot11Action, Dot11WNM, category=0x0A)
 
 
 conf.l2types.register(DLT_IEEE802_11, Dot11)

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1512,6 +1512,38 @@ class Dot11Ack(Packet):
     name = "802.11 Ack packet"
 
 
+# 802.11-2016 9.4.1.11
+
+class Dot11Action(Packet):
+    name = "802.11 Action"
+    fields_desc = [
+        ByteEnumField("category", 0x00, {
+            0x00: "Spectrum Management",
+            0x01: "QoS",
+            0x02: "DLS",
+            0x03: "Block",
+            0x04: "Public",
+            0x05: "Radio Measurement",
+            0x06: "Fast BSS Transition",
+            0x07: "HT",
+            0x08: "SA Query",
+            0x09: "Protected Dual of Public Action",
+            0x0A: "WNM",
+            0x0B: "Unprotected WNM",
+            0x0C: "TDLS",
+            0x0D: "Mesh",
+            0x0E: "Multihop",
+            0x0F: "Self-protected",
+            0x10: "DMG",
+            0x11: "Reserved Wi-Fi Alliance",
+            0x12: "Fast Session Transfer",
+            0x13: "Robust AV Streaming",
+            0x14: "Unprotected DMG",
+            0x15: "VHT"
+        })
+    ]
+
+
 ###################
 # 802.11 Security #
 ###################
@@ -1652,6 +1684,8 @@ bind_top_down(Dot11, Dot11QoS, type=2, subtype=0xc)
 bind_layers(PrismHeader, Dot11,)
 bind_layers(Dot11, LLC, type=2)
 bind_layers(Dot11QoS, LLC,)
+
+# 802.11-2016 9.2.4.1.3 Type and Subtype subfields
 bind_layers(Dot11, Dot11AssoReq, subtype=0, type=0)
 bind_layers(Dot11, Dot11AssoResp, subtype=1, type=0)
 bind_layers(Dot11, Dot11ReassoReq, subtype=2, type=0)
@@ -1663,6 +1697,7 @@ bind_layers(Dot11, Dot11ATIM, subtype=9, type=0)
 bind_layers(Dot11, Dot11Disas, subtype=10, type=0)
 bind_layers(Dot11, Dot11Auth, subtype=11, type=0)
 bind_layers(Dot11, Dot11Deauth, subtype=12, type=0)
+bind_layers(Dot11, Dot11Action, subtype=13, type=0)
 bind_layers(Dot11, Dot11Ack, subtype=13, type=1)
 bind_layers(Dot11Beacon, Dot11Elt,)
 bind_layers(Dot11AssoReq, Dot11Elt,)

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -692,3 +692,8 @@ assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].op_clas
 assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].channel == 12
 assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].phy_type == 0
 
+= Dot11Ack
+
+pkt = Dot11(bytes(Dot11()/Dot11Ack()))
+assert pkt.subtype == 13
+assert pkt.type == 1

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -638,3 +638,57 @@ assert Dot11EltMicrosoftWPA(raw(Dot11EltMicrosoftWPA())).nb_akm_suites == 1
 assert Dot11EltMicrosoftWPA(raw(Dot11EltMicrosoftWPA(akm_suites=[AKMSuite(suite="PSK")]))).nb_akm_suites == 1
 assert Dot11EltMicrosoftWPA(raw(Dot11EltMicrosoftWPA(akm_suites=[AKMSuite(suite="PSK"), AKMSuite(suite="802.1X")]))).nb_akm_suites == 2
 
+= Dot11BSSTMRequest - dissection
+
+pkt = RadioTap(b"\x00\x008\x00/@@\xa0 \x08\x00\xa0 \x08\x00\x00\x7f\x89&\x88\x00\x00\x00\x00\x10\x0c\xcc\x15@\x01\xe4\x00\x00\x00\x00\x00\x00\x00\x00\x00\x8f\xe7&\x88\x00\x00\x00\x00\x16\x00\x11\x03\xe4\x00\xde\x01\xd0\x00<\x00\x92U\x1f\xe9g9J\xf2\x1c\x03)\x89J\xf2\x1c\x03)\x89\xc0\xce\n\x07\x01\x05\x05\x00\xff4\x10F\xf2\x1c\x03)\x89\x00\x00\x00\x00Q\x0b\x00\x03\x01\xff\xaaV\xdaY")
+assert Dot11BSSTMRequest in pkt
+
+assert pkt[Dot11Action].category == 10
+assert pkt[Dot11Action][Dot11WNM].action == 7
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].token == 1
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].mode.Preferred_Candidate_List_Included
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].mode.Disassociation_Imminent
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].disassociation_timer == 5
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].validity_interval == 255
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].type == 52
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].len == 16
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].BSSID == "46:f2:1c:03:29:89"
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].AP_reach == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].security == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].key_scope == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].capabilities == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].mobility == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].HT == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].VHT == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].FTM == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].reserved == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].op_class == 81
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].channel == 11
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMRequest].neighbor_report[0].phy_type == 0
+
+= Dot11BSSTMResponse - dissection
+
+pkt = RadioTap(b"\x00\x00,\x00\xae@\x00\xa0 \x08\x00\xa0 \x08\x00\xa0 \x08\x00\xa0 \x08\x00\x00\x10\x0c<\x14@\x01\xce\x00d\x00\x00\x00\xd0\x00\xca\x01\xca\x02\xcc\x03\xd0\x00<\x00df$J\xe1\xc4\xa0\xcc+\xbe\xc9Odf$J\xe1\xc4p\x0c\n\x08\x01\x06\x004\rdf$J\xe1\xc3\x00\x00\x00\x00\x04\x0c\x00<\xdd\xdf=")
+assert Dot11BSSTMResponse in pkt
+
+assert pkt[Dot11Action].category == 10
+assert pkt[Dot11Action][Dot11WNM].action == 8
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].token == 1
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].status == 6
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].termination_delay == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].type == 52
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].len == 13
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].BSSID == "64:66:24:4a:e1:c3"
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].AP_reach == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].security == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].key_scope == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].capabilities == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].mobility == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].HT == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].VHT == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].FTM == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].reserved == 0
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].op_class == 4
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].channel == 12
+assert pkt[Dot11Action][Dot11WNM][Dot11BSSTMResponse].neighbor_report[0].phy_type == 0
+


### PR DESCRIPTION
This PR will add 802.11 action frame categories (802.11-2016 9.4.1.11), 802.11 WNM frame action fields (802.11-2016 9.6.14.1), and 802.11v BSS transition (BTM) request and response frames (802.11-2016 9.6.14.9-10) to the dot11 layer.

802.11v BTM frames are part of the WNM protocol, which is a category of action management frames. They are used to steer wireless stations to and from a BSS. This PR includes required fields and optional Neighbor Report element field. Neighbor Report (802.11-2016 9.4.2.37) element can contain various sub elements; only BSS Termination Duration sub element is added, and for the rest, generic `SubelemTLV` is used.

Tests: air-sniffed BTM request and response frames are added. For response, a frame with status code = 6 is used, which contains the Neighbor Report element and will provide more coverage for the test.