### PR TITLE
btle: Add core v5.3 control pdus

### DIFF
--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -164,7 +164,31 @@ class BTLEFeatureField(FlagsField):
              'le_ext_adv',
              'le_periodic_adv',
              'ch_sel_alg',
-             'le_pwr_class']
+             'le_pwr_class'
+             'min_used_channels',
+             'conn_cte_req',
+             'conn_cte_rsp',
+             'connless_cte_tx',
+             'connless_cte_rx',
+             'antenna_switching_cte_aod_tx',
+             'antenna_switching_cte_aoa_rx',
+             'cte_rx',
+             'periodic_adv_sync_transfer_tx',
+             'periodic_adv_sync_transfer_rx',
+             'sleep_clock_accuracy_updates',
+             'remote_public_key_validation',
+             'cis_central',
+             'cis_peripheral',
+             'iso_broadcaster',
+             'synchronized_receiver',
+             'connected_iso_host_support',
+             'le_power_control_request',
+             'le_power_control_request',
+             'le_path_loss_monitoring',
+             'periodic_adv_adi_support',
+             'connection_subrating',
+             'connection_subrating_host_support',
+             'channel_classification']
         )
 
 
@@ -395,6 +419,23 @@ BTLE_BTLE_CTRL_opcode = {
     0x16: 'LL_PHY_REQ',
     0x17: 'LL_PHY_RSP',
     0x18: 'LL_PHY_UPDATE_IND',
+    0x19: 'LL_MIN_USED_CHANNELS',
+    0x1A: 'LL_CTE_REQ',
+    0x1B: 'LL_CTE_RSP',
+    0x1C: 'LL_PERIODIC_SYNC_IND',
+    0x1D: 'LL_CLOCK_ACCURACY_REQ',
+    0x1E: 'LL_CLOCK_ACCURACY_RSP',
+    0x1F: 'LL_CIS_REQ',
+    0x20: 'LL_CIS_RSP',
+    0x21: 'LL_CIS_IND',
+    0x22: 'LL_CIS_TERMINATE_IND',
+    0x23: 'LL_POWER_CONTROL_REQ',
+    0x24: 'LL_POWER_CONTROL_RSP',
+    0x25: 'LL_POWER_CHANGE_IND',
+    0x26: 'LL_SUBRATE_REQ',
+    0x27: 'LL_SUBRATE_IND',
+    0x28: 'LL_CHANNEL_REPORTING_IND',
+    0x29: 'LL_CHANNEL_STATUS_IND',
 }
 
 
@@ -620,6 +661,181 @@ class LL_MIN_USED_CHANNELS_IND(Packet):
     ]
 
 
+class LL_CTE_REQ(Packet):
+    name = "LL_CTE_REQ"
+    fields_desc = [
+        LEBitField('min_cte_len_req', 0, 5),
+        LEBitField('rfu', 0, 1),
+        LEBitField("cte_type_req", 0, 2)
+    ]
+
+
+class LL_CTE_RSP(Packet):
+    name = "LL_CTE_RSP"
+    fields_desc = []
+
+
+class LL_PERIODIC_SYNC_IND(Packet):
+    name = "LL_PERIODIC_SYNC_IND"
+    fields_desc = [
+        XLEShortField("id", 251),
+        LEBitField("sync_info", 0, 18 * 8),
+        XLEShortField("conn_event_count", 0),
+        XLEShortField("last_pa_event_counter", 0),
+        LEBitField('sid', 0, 4),
+        LEBitField('a_type', 0, 1),
+        LEBitField('sca', 0, 3),
+        BTLEPhysField('phy', 0),
+        BDAddrField("AdvA", None),
+        XLEShortField("sync_conn_event_count", 0),
+    ]
+
+
+class LL_CLOCK_ACCURACY_REQ(Packet):
+    name = "LL_CLOCK_ACCURACY_REQ"
+    fields_desc = [
+        XByteField("sca", 0),
+    ]
+
+
+class LL_CLOCK_ACCURACY_RSP(Packet):
+    name = "LL_CLOCK_ACCURACY_RSP"
+    fields_desc = [
+        XByteField("sca", 0),
+    ]
+
+
+class LL_CIS_REQ(Packet):
+    name = 'LL_CIS_REQ'
+    fields_desc = [
+        XByteField("cig_id", 0),
+        XByteField("cis_id", 0),
+        BTLEPhysField('phy_c_to_p', 0),
+        BTLEPhysField('phy_p_to_c', 0),
+        LEBitField('max_sdu_c_to_p', 0, 12),
+        LEBitField('rfu1', 0, 3),
+        LEBitField('framed', 0, 1),
+        LEBitField('max_sdu_p_to_c', 0, 12),
+        LEBitField('rfu2', 0, 4),
+        LEBitField('sdu_interval_c_to_p', 0, 20),
+        LEBitField('rfu3', 0, 4),
+        LEBitField('sdu_interval_p_to_c', 0, 20),
+        LEBitField('rfu4', 0, 4),
+        XLEShortField("max_pdu_c_to_p", 0),
+        XLEShortField("max_pdu_p_to_c", 0),
+        XByteField("nse", 0),
+        X3BytesField("subinterval", 0x0),
+        LEBitField('bn_c_to_p', 0, 4),
+        LEBitField('bn_p_to_c', 0, 4),
+        ByteField("ft_c_to_p", 0),
+        ByteField("ft_p_to_c", 0),
+        XLEShortField("iso_interval", 0),
+        X3BytesField("cis_offset_min", 0x0),
+        X3BytesField("cis_offset_max", 0x0),
+        XLEShortField("conn_event_count", 0),
+    ]
+
+
+class LL_CIS_RSP(Packet):
+    name = 'LL_CIS_RSP'
+    fields_desc = [
+        X3BytesField("cis_offset_min", 0x0),
+        X3BytesField("cis_offset_max", 0x0),
+        XLEShortField("conn_event_count", 0),
+    ]
+
+
+class LL_CIS_IND(Packet):
+    name = 'LL_CIS_IND'
+    fields_desc = [
+        XIntField("AA", 0x00),
+        X3BytesField("cis_offset", 0x0),
+        X3BytesField("cig_sync_delay", 0x0),
+        X3BytesField("cis_sync_delay", 0x0),
+        XLEShortField("conn_event_count", 0),
+    ]
+
+
+class LL_CIS_TERMINATE_IND(Packet):
+    name = 'LL_CIS_TERMINATE_IND'
+    fields_desc = [
+        ByteField("cig_id", 0x0),
+        ByteField("cis_id", 0x0),
+        ByteField("error_code", 0x0),
+    ]
+
+
+class LL_POWER_CONTROL_REQ(Packet):
+    name = 'LL_POWER_CONTROL_REQ'
+    fields_desc = [
+        ByteField("phy", 0x0),
+        SignedByteField("delta", 0x0),
+        SignedByteField("tx_power", 0x0),
+    ]
+
+
+class LL_POWER_CONTROL_RSP(Packet):
+    name = 'LL_POWER_CONTROL_RSP'
+    fields_desc = [
+        LEBitField("min", 0, 1),
+        LEBitField("max", 0, 1),
+        LEBitField("rfu", 0, 6),
+        SignedByteField("delta", 0),
+        SignedByteField("tx_power", 0x0),
+        ByteField("apr", 0x0),
+    ]
+
+
+class LL_POWER_CHANGE_IND(Packet):
+    name = 'LL_POWER_CHANGE_IND'
+    fields_desc = [
+        ByteField("phy", 0x0),
+        LEBitField("min", 0, 1),
+        LEBitField("max", 0, 1),
+        LEBitField("rfu", 0, 6),
+        SignedByteField("delta", 0),
+        ByteField("tx_power", 0x0),
+    ]
+
+
+class LL_SUBRATE_REQ(Packet):
+    name = 'LL_SUBRATE_REQ'
+    fields_desc = [
+        LEShortField("subrate_factor_min", 0x0),
+        LEShortField("subrate_factor_max", 0x0),
+        LEShortField("max_latency", 0x0),
+        LEShortField("continuation_number", 0x0),
+        LEShortField("timeout", 0x0),
+    ]
+
+
+class LL_SUBRATE_IND(Packet):
+    name = 'LL_SUBRATE_IND'
+    fields_desc = [
+        LEShortField("subrate_factor", 0x0),
+        LEShortField("subrate_base_event", 0x0),
+        LEShortField("latency", 0x0),
+        LEShortField("continuation_number", 0x0),
+        LEShortField("timeout", 0x0),
+    ]
+
+
+class LL_CHANNEL_REPORTING_IND(Packet):
+    name = 'LL_SUBRATE_IND'
+    fields_desc = [
+        ByteField("enable", 0x0),
+        ByteField("min_spacing", 0x0),
+        ByteField("max_delay", 0x0),
+    ]
+
+
+class LL_CHANNEL_STATUS_IND(Packet):
+    name = 'LL_CHANNEL_STATUS_IND'
+    fields_desc = [
+        LEBitField("channel_classification", 0, 10 * 8),
+    ]
+
+
 # Advertisement (37-39) channel PDUs
 bind_layers(BTLE, BTLE_ADV, access_addr=0x8E89BED6)
 bind_layers(BTLE, BTLE_DATA)
@@ -662,6 +878,22 @@ bind_layers(BTLE_CTRL, LL_PHY_REQ, opcode=0x16)
 bind_layers(BTLE_CTRL, LL_PHY_RSP, opcode=0x17)
 bind_layers(BTLE_CTRL, LL_PHY_UPDATE_IND, opcode=0x18)
 bind_layers(BTLE_CTRL, LL_MIN_USED_CHANNELS_IND, opcode=0x19)
+bind_layers(BTLE_CTRL, LL_CTE_REQ, opcode=0x1A)
+bind_layers(BTLE_CTRL, LL_CTE_RSP, opcode=0x1B)
+bind_layers(BTLE_CTRL, LL_PERIODIC_SYNC_IND, opcode=0x1C)
+bind_layers(BTLE_CTRL, LL_CLOCK_ACCURACY_REQ, opcode=0x1D)
+bind_layers(BTLE_CTRL, LL_CLOCK_ACCURACY_RSP, opcode=0x1E)
+bind_layers(BTLE_CTRL, LL_CIS_REQ, opcode=0x1F)
+bind_layers(BTLE_CTRL, LL_CIS_RSP, opcode=0x20)
+bind_layers(BTLE_CTRL, LL_CIS_IND, opcode=0x21)
+bind_layers(BTLE_CTRL, LL_CIS_TERMINATE_IND, opcode=0x22)
+bind_layers(BTLE_CTRL, LL_POWER_CONTROL_REQ, opcode=0x23)
+bind_layers(BTLE_CTRL, LL_POWER_CONTROL_RSP, opcode=0x24)
+bind_layers(BTLE_CTRL, LL_POWER_CHANGE_IND, opcode=0x25)
+bind_layers(BTLE_CTRL, LL_SUBRATE_REQ, opcode=0x26)
+bind_layers(BTLE_CTRL, LL_SUBRATE_IND, opcode=0x27)
+bind_layers(BTLE_CTRL, LL_CHANNEL_REPORTING_IND, opcode=0x28)
+bind_layers(BTLE_CTRL, LL_CHANNEL_STATUS_IND, opcode=0x29)
 
 
 conf.l2types.register(DLT_BLUETOOTH_LE_LL, BTLE)

--- a/test/scapy/layers/bluetooth4LE.uts
+++ b/test/scapy/layers/bluetooth4LE.uts
@@ -103,17 +103,18 @@ assert test[LL_UNKNOWN_RSP].code == 4
 
 = LL_FEATURE_REQ
 
-test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / LL_FEATURE_REQ(feature_set=0x1234)
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / LL_FEATURE_REQ(feature_set=0x011234)
 test = BTLE(raw(test))
 assert test[LL_FEATURE_REQ].feature_set == \
-    "ext_reject_ind+le_ping+le_data_len_ext+tx_mod_idx+le_ext_adv"
+    "ext_reject_ind+le_ping+le_data_len_ext+tx_mod_idx+le_ext_adv+conn_cte_req"
 
 = LL_FEATURE_RSP
 
-test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / LL_FEATURE_RSP(feature_set=0x4321)
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / LL_FEATURE_RSP(feature_set=0x104321)
 test = BTLE(raw(test))
+print(test[LL_FEATURE_RSP].feature_set)
 assert test[LL_FEATURE_RSP].feature_set == \
-    "le_encryption+le_data_len_ext+le_2m_phy+tx_mod_idx+ch_sel_alg"
+    "le_encryption+le_data_len_ext+le_2m_phy+tx_mod_idx+ch_sel_alg+antenna_switching_cte_aod_tx"
 
 = LL_PAUSE_ENC_REQ
 
@@ -261,6 +262,210 @@ test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
 test = BTLE(raw(test))
 assert test[LL_MIN_USED_CHANNELS_IND].phys == "phy_1m+phy_2m"
 assert test[LL_MIN_USED_CHANNELS_IND].min_used_channels == 3
+
+# LL_CTE_REQ
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CTE_REQ(min_cte_len_req=20, rfu=1, cte_type_req=2)
+test = BTLE(raw(test))
+assert test[LL_CTE_REQ].min_cte_len_req == 20
+assert test[LL_CTE_REQ].rfu == 1
+assert test[LL_CTE_REQ].cte_type_req == 2
+
+
+# LL_CTE_RSP
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CTE_RSP()
+test = BTLE(raw(test))
+
+
+# LL_PERIODIC_SYNC_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_PERIODIC_SYNC_IND(id=2,
+                         sync_info=12345,
+                         conn_event_count=0x4321,
+                         last_pa_event_counter=0xabcd, sid=0xF,
+                         a_type=1, sca=3, phy=2, AdvA="cc:bb:bb:bb:bb:bb",
+                         sync_conn_event_count=32)
+test = BTLE(raw(test))
+assert test[LL_PERIODIC_SYNC_IND].id == 2
+assert test[LL_PERIODIC_SYNC_IND].sync_info == 12345
+assert test[LL_PERIODIC_SYNC_IND].conn_event_count == 0x4321
+assert test[LL_PERIODIC_SYNC_IND].last_pa_event_counter == 0xabcd
+assert test[LL_PERIODIC_SYNC_IND].sid == 0xF
+assert test[LL_PERIODIC_SYNC_IND].a_type == 1
+assert test[LL_PERIODIC_SYNC_IND].sca == 3
+assert test[LL_PERIODIC_SYNC_IND].phy == 2
+assert test[LL_PERIODIC_SYNC_IND].AdvA == "cc:bb:bb:bb:bb:bb"
+assert test[LL_PERIODIC_SYNC_IND].sync_conn_event_count == 32
+
+
+# LL_CLOCK_ACCURACY_REQ
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CLOCK_ACCURACY_REQ(sca=2)
+test = BTLE(raw(test))
+assert test[LL_CLOCK_ACCURACY_REQ].sca == 2
+
+
+# LL_CLOCK_ACCURACY_RSP
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CLOCK_ACCURACY_RSP(sca=3)
+test = BTLE(raw(test))
+assert test[LL_CLOCK_ACCURACY_RSP].sca == 3
+
+
+# LL_CIS_REQ
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CIS_REQ(cig_id=3, cis_id=2, phy_c_to_p=1, phy_p_to_c=2,
+               max_sdu_c_to_p=123, max_sdu_p_to_c=321,
+               sdu_interval_c_to_p=234, framed=1, sdu_interval_p_to_c=432,
+               max_pdu_c_to_p=123, max_pdu_p_to_c=234,
+               nse=10, subinterval=4567,
+               bn_c_to_p=3, bn_p_to_c=2,
+               ft_c_to_p=15, ft_p_to_c=16,
+               iso_interval=12345,
+               cis_offset_min=1, cis_offset_max=999,
+               conn_event_count=2)
+test = BTLE(raw(test))
+assert test[LL_CIS_REQ].cig_id == 3
+assert test[LL_CIS_REQ].cis_id == 2
+assert test[LL_CIS_REQ].phy_c_to_p == 1
+assert test[LL_CIS_REQ].phy_p_to_c == 2
+assert test[LL_CIS_REQ].max_sdu_c_to_p == 123
+assert test[LL_CIS_REQ].framed == 1
+assert test[LL_CIS_REQ].max_sdu_p_to_c == 321
+assert test[LL_CIS_REQ].sdu_interval_c_to_p == 234
+assert test[LL_CIS_REQ].sdu_interval_p_to_c == 432
+assert test[LL_CIS_REQ].max_pdu_c_to_p == 123
+assert test[LL_CIS_REQ].max_pdu_p_to_c == 234
+assert test[LL_CIS_REQ].nse == 10
+assert test[LL_CIS_REQ].subinterval == 4567
+assert test[LL_CIS_REQ].bn_c_to_p == 3
+assert test[LL_CIS_REQ].bn_p_to_c == 2
+assert test[LL_CIS_REQ].ft_c_to_p == 15
+assert test[LL_CIS_REQ].ft_p_to_c == 16
+assert test[LL_CIS_REQ].iso_interval == 12345
+assert test[LL_CIS_REQ].cis_offset_min == 1
+assert test[LL_CIS_REQ].cis_offset_max == 999
+assert test[LL_CIS_REQ].conn_event_count == 2
+
+
+# LL_CIS_RSP
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CIS_RSP(cis_offset_min=1, cis_offset_max=999, conn_event_count=400)
+test = BTLE(raw(test))
+assert test[LL_CIS_RSP].cis_offset_min == 1
+assert test[LL_CIS_RSP].cis_offset_max == 999
+assert test[LL_CIS_RSP].conn_event_count == 400
+
+
+# LL_CIS_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CIS_IND(AA=0x12345678, cis_offset=1,
+               cig_sync_delay=999, cis_sync_delay=400, conn_event_count=300)
+test = BTLE(raw(test))
+assert test[LL_CIS_IND].AA == 0x12345678
+assert test[LL_CIS_IND].cis_offset == 1
+assert test[LL_CIS_IND].cig_sync_delay == 999
+assert test[LL_CIS_IND].cis_sync_delay == 400
+assert test[LL_CIS_IND].conn_event_count == 300
+
+
+# LL_CIS_TERMINATE_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CIS_TERMINATE_IND(cig_id=33, cis_id=44, error_code=55)
+test = BTLE(raw(test))
+assert test[LL_CIS_TERMINATE_IND].cig_id == 33
+assert test[LL_CIS_TERMINATE_IND].cis_id == 44
+assert test[LL_CIS_TERMINATE_IND].error_code == 55
+
+
+# LL_POWER_CONTROL_REQ
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_POWER_CONTROL_REQ(phy=3, delta=-34, tx_power=55)
+test = BTLE(raw(test))
+assert test[LL_POWER_CONTROL_REQ].phy == 3
+assert test[LL_POWER_CONTROL_REQ].delta == -34
+assert test[LL_POWER_CONTROL_REQ].tx_power == 55
+
+
+# LL_POWER_CONTROL_RSP
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_POWER_CONTROL_RSP(min=0, max=1, delta=-34, tx_power=55, apr=4)
+test = BTLE(raw(test))
+assert test[LL_POWER_CONTROL_RSP].min == 0
+assert test[LL_POWER_CONTROL_RSP].max == 1
+assert test[LL_POWER_CONTROL_RSP].delta == -34
+assert test[LL_POWER_CONTROL_RSP].tx_power == 55
+assert test[LL_POWER_CONTROL_RSP].apr == 4
+
+
+# LL_POWER_CHANGE_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_POWER_CHANGE_IND(phy=3, min=0, max=1, delta=-34, tx_power=55)
+test = BTLE(raw(test))
+assert test[LL_POWER_CHANGE_IND].phy == 3
+assert test[LL_POWER_CHANGE_IND].min == 0
+assert test[LL_POWER_CHANGE_IND].max == 1
+assert test[LL_POWER_CHANGE_IND].delta == -34
+assert test[LL_POWER_CHANGE_IND].tx_power == 55
+
+
+
+# LL_SUBRATE_REQ
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_SUBRATE_REQ(subrate_factor_min=3, subrate_factor_max=0,
+                   max_latency=1, continuation_number=123, timeout=55)
+test = BTLE(raw(test))
+assert test[LL_SUBRATE_REQ].subrate_factor_min == 3
+assert test[LL_SUBRATE_REQ].subrate_factor_max == 0
+assert test[LL_SUBRATE_REQ].max_latency == 1
+assert test[LL_SUBRATE_REQ].continuation_number == 123
+assert test[LL_SUBRATE_REQ].timeout == 55
+
+
+# LL_SUBRATE_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_SUBRATE_IND(subrate_factor=3, subrate_base_event=0,
+                   latency=1, continuation_number=123, timeout=55)
+test = BTLE(raw(test))
+assert test[LL_SUBRATE_IND].subrate_factor == 3
+assert test[LL_SUBRATE_IND].subrate_base_event == 0
+assert test[LL_SUBRATE_IND].latency == 1
+assert test[LL_SUBRATE_IND].continuation_number == 123
+assert test[LL_SUBRATE_IND].timeout == 55
+
+
+# LL_CHANNEL_REPORTING_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CHANNEL_REPORTING_IND(enable=1, min_spacing=123, max_delay=124)
+test = BTLE(raw(test))
+assert test[LL_CHANNEL_REPORTING_IND].enable == 1
+assert test[LL_CHANNEL_REPORTING_IND].min_spacing == 123
+assert test[LL_CHANNEL_REPORTING_IND].max_delay == 124
+
+
+# LL_CHANNEL_STATUS_IND
+
+test = BTLE(access_addr=1) / BTLE_DATA() / BTLE_CTRL() / \
+    LL_CHANNEL_STATUS_IND(channel_classification=123456789012345)
+test = BTLE(raw(test))
+assert test[LL_CHANNEL_STATUS_IND].channel_classification == 123456789012345
+
 
 = BTLE_DATA + BTLE_EMPTY_PDU
 


### PR DESCRIPTION
Adds the Control PDUs that were added in spec revision 5.1, 5.2 and 5.3.

This changes only support using a scapy as a packet builder.
Dissection is not yet implemented.

