### PR TITLE
Fix proposition for #3831 - Options Template length not compliant with RFC 3954

### DIFF
--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -1659,12 +1659,12 @@ class NetflowOptionsFlowsetV9(Packet):
         return conf.padding_layer
 
     def post_build(self, pkt, pay):
-        if self.length is None:
-            pkt = pkt[:2] + struct.pack("!H", len(pkt)) + pkt[4:]
         if self.pad is None:
             # Padding 4-bytes with b"\x00"
             start = 10 + self.option_scope_length + self.option_field_length
             pkt = pkt[:start] + (-len(pkt) % 4) * b"\x00"
+        if self.length is None:
+            pkt = pkt[:2] + struct.pack("!H", len(pkt)) + pkt[4:]
         return pkt + pay
 
 

--- a/test/scapy/layers/netflow.uts
+++ b/test/scapy/layers/netflow.uts
@@ -156,6 +156,22 @@ assert pkt[NetflowOptionsFlowsetV9].pad == b"\x00\x00"
 pkt[NetflowOptionsFlowsetV9].pad = None
 assert raw(pkt) == dat
 
+= NetflowV9 - Options Template build
+~ netflow
+
+option_templateFlowSet_256 = NetflowOptionsFlowsetV9(
+    templateID = 256,
+    option_scope_length = 4*1,
+    option_field_length = 4*3,
+    scopes = [
+        NetflowOptionsFlowsetScopeV9(scopeFieldType=1,	scopeFieldlength= 4),
+    ],
+    options = [
+        NetflowOptionsFlowsetOptionV9(optionFieldType= 10,	optionFieldlength= 4),
+        NetflowOptionsFlowsetOptionV9(optionFieldType= 82,	optionFieldlength= 32),
+        NetflowOptionsFlowsetOptionV9(optionFieldType= 83,	optionFieldlength= 240)
+    ])
+assert raw(option_templateFlowSet_256) == b'\x00\x01\x00\x1c\x01\x00\x00\x04\x00\x0c\x00\x01\x00\x04\x00\n\x00\x04\x00R\x00 \x00S\x00\xf0\x00\x00'
 
 ############
 ############


### PR DESCRIPTION
Compute the flowset length *after* padding instead of computing it before.
Details in #3831 