### PR TITLE
Fix length calculation for GTPv2 header

### DIFF
--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -257,7 +257,7 @@ class GTPHeader(Packet):
     def post_build(self, p, pay):
         p += pay
         if self.length is None:
-            tmp_len = len(p) - 8
+            tmp_len = len(p) - 4 if self.version == 2 else len(p) - 8
             p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
         return p
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -257,6 +257,9 @@ class GTPHeader(Packet):
     def post_build(self, p, pay):
         p += pay
         if self.length is None:
+            # The message length field is calculated different in GTPv1 and GTPv2.  # noqa: E501
+            # For GTPv1 it is defined as the rest of the packet following the mandatory 8-byte GTP header  # noqa: E501
+            # For GTPv2 it is defined as the length of the message in bytes excluding the mandatory part of the GTP-C header (the first 4 bytes)  # noqa: E501
             tmp_len = len(p) - 4 if self.version == 2 else len(p) - 8
             p = p[:2] + struct.pack("!H", tmp_len) + p[4:]
         return p

--- a/test/contrib/gtp_v2.uts
+++ b/test/contrib/gtp_v2.uts
@@ -439,6 +439,11 @@ assert not (GTPHeader(seq=1)/GTPV2EchoResponse()).answers(GTPHeader(seq=1)/GTPV2
 gtp = GTPHeader(gtp_type="create_session_req") / ("X"*32)
 gtp.show2()
 
+= GTPHeader length calculation
+h = GTPHeader(seq=12345, version=2, T=1, teid=1234)/("X"*32)
+h = GTPHeader(h.do_build())
+h[GTPHeader].length == len(bytes(h)) - 4
+
 = GTPHeader hashret
 req = GTPHeader(gtp_type="create_session_req", seq=1) / ("X"*32)
 res = GTPHeader(gtp_type="create_session_res", seq=1) / ("Y"*32)


### PR DESCRIPTION
3GPP TS 29.274 states in Section 5.5.1:
"Octets 3 to 4 represent the Message Length field. This field shall indicate the length of the message in octets excluding the mandatory part of the GTP-C header (the first 4 octets). The TEID (if present) and the Sequence Number shall be included in the length count."

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

