### PR TITLE
DoIp: fix socket not handling IPv6 link-local address

### DIFF
--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -279,7 +279,8 @@ class DoIPSocket(StreamSocket):
         s = socket.socket(sock_family, socket.SOCK_STREAM)
         s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.connect((self.ip, self.port))
+        addrinfo = socket.getaddrinfo(self.ip, self.port, proto=socket.IPPROTO_TCP)
+        s.connect(addrinfo[0][-1])
         StreamSocket.__init__(self, s, DoIP)
 
     def _activate_routing(self,
@@ -323,6 +324,7 @@ class DoIPSocket6(DoIPSocket):
 
     Example:
         >>> socket = DoIPSocket6("2001:16b8:3f0e:2f00:21a:37ff:febf:edb9")
+        >>> socket_link_local = DoIPSocket6("fe80::30e8:80ff:fe07:6d43%eth1")
         >>> pkt = DoIP(payload_type=0x8001, source_address=0xe80, target_address=0x1000) / UDS() / UDS_RDBI(identifiers=[0x1000])
         >>> resp = socket.sr1(pkt, timeout=1)
     """  # noqa: E501


### PR DESCRIPTION
Fix for the issue where calling ```s.connect()``` via ```UDS_DoIPSocket6()``` on a ipv6 link local address will result in the error
```OSError: [Errno 22] Invalid argument```

transmission over ipv6 link local addresses cannot be done until their scope ids/zone ids are also mentioned.

This can be easily obtained using ```getaddrinfo``` which also works for any ipv4 address.
e.g)
```
>>> addrinfo = socket.getaddrinfo("fe80::9480:f529:aa6c:c2ba%enp0s3", None, proto=socket.IPPROTO_TCP)
>>> print(addrinfo[0][-1])
('fe80::9480:f529:aa6c:c2ba', 0, 0, 2)
```
2 is the scope id for my iface name enp0s3.