### PR TITLE
fix LDP FecTLVField

### DIFF
--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -98,8 +98,10 @@ class FecTLVField(StrField):
             # mask length
             fec += struct.pack("!B", o[1])
             # Prefix
-            fec += inet_aton(o[0])
-            tmp_len += 8
+            l = o[1]+7>>3
+            p = inet_aton(o[0])
+            fec += p[:l]
+            tmp_len += 4+l
         s += struct.pack("!H", tmp_len)
         s += fec
         return s


### PR DESCRIPTION
The FEC TLV was malformed for all prefixes with length less or equal 24.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/6083768/210887013-0cf35c32-24ab-4dc8-9321-b8b2a5ae7776.png">


According to RFC5036, an address prefix is encoded according to the address family field, whose length, in bits, was specified in the prefix length field, padded to a byte boundary.

https://www.rfc-editor.org/rfc/rfc5036.html#section-3.4.1

This was already done correctly in the corresponding decode but wrong in encode function. 

I tested and monkey patched this in one of my open source projects shown here:
https://github.com/rtbrick/bngblaster/blob/dev/code/ldpupdate#L31

With fix:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/6083768/210887200-0c401da9-44e0-494e-9b7d-8578b919f86f.png">
