### PR TITLE
layers/sctp.py: Add support for multiple new chunk types

### DIFF
--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -161,6 +161,7 @@ sctpchunktypescls = {
     14: "SCTPChunkShutdownComplete",
     15: "SCTPChunkAuthentication",
     64: "SCTPChunkIData",
+    132: "SCTPChunkPad",
     0x80: "SCTPChunkAddressConfAck",
     0xc1: "SCTPChunkAddressConf",
 }
@@ -181,6 +182,7 @@ sctpchunktypes = {
     14: "shutdown-complete",
     15: "authentication",
     64: "i-data",
+    132: "pad",
     0x80: "address-configuration-ack",
     0xc1: "address-configuration",
 }
@@ -728,6 +730,17 @@ class SCTPChunkAddressConf(_SCTPChunkGuessPayload, Packet):
                                  adjust=lambda pkt, x:x + 8),
                    IntField("seq", 0),
                    ChunkParamField("params", None, length_from=lambda pkt:pkt.len - 8),  # noqa: E501
+                   ]
+
+
+class SCTPChunkPad(_SCTPChunkGuessPayload, Packet):
+    fields_desc = [ByteEnumField("type", 132, sctpchunktypes),
+                   XByteField("flags", None),
+                   FieldLenField("len", None, length_of="padding",
+                                 adjust=lambda pkt, x:x + 8),
+                   PadField(StrLenField("padding", None,
+                                        length_from=lambda pkt: pkt.len - 8),
+                            4, padwith=b"\x00")
                    ]
 
 

--- a/test/scapy/layers/sctp.uts
+++ b/test/scapy/layers/sctp.uts
@@ -51,6 +51,23 @@ assert p.stream_seq == 0
 assert p.len == (len("data") + 16)
 assert p.data == b"data"
 
+= basic SCTPChunkIData - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x40\x02\x00\x18\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x64\x61\x74\x61"
+p = SCTP(blob).lastlayer()
+assert isinstance(p, SCTPChunkIData)
+assert p.reserved == 0
+assert p.delay_sack == 0
+assert p.unordered == 0
+assert p.beginning == 1
+assert p.ending == 0
+assert p.tsn == 0
+assert p.stream_id == 0
+assert p.reserved_16 == 0
+assert p.ppid_fsn == 2
+assert p.len == (len("data") + 20)
+assert p.data == b"data"
+
 = basic SCTPChunkInit - Dissection
 ~ sctp
 blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"

--- a/test/scapy/layers/sctp.uts
+++ b/test/scapy/layers/sctp.uts
@@ -271,6 +271,15 @@ assert p.len == 8
 assert p.seq == 0
 assert p.params == []
 
+= basic SCTPChunkPad - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x84\x00\x00\x0b\x70\x61\x64\x00"
+p = SCTP(blob).lastlayer()
+assert isinstance(p, SCTPChunkPad)
+assert p.flags == 0
+assert p.len == 11
+assert p.padding == b'pad'
+
 = SCTPChunkParamRandom - Consecutive calls
 ~ sctp
 param1, param2 = SCTPChunkParamRandom(), SCTPChunkParamRandom()

--- a/test/scapy/layers/sctp.uts
+++ b/test/scapy/layers/sctp.uts
@@ -280,6 +280,15 @@ assert p.flags == 0
 assert p.len == 11
 assert p.padding == b'pad'
 
+= basic SCTPChunkReConfig - Dissection
+~ sctp
+blob = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x82\x00\x00\x04"
+p = SCTP(blob).lastlayer()
+assert isinstance(p, SCTPChunkReConfig)
+assert p.flags == 0
+assert p.len == 4
+assert p.params == []
+
 = SCTPChunkParamRandom - Consecutive calls
 ~ sctp
 param1, param2 = SCTPChunkParamRandom(), SCTPChunkParamRandom()


### PR DESCRIPTION
Add support to forge I-DATA, PAD, and RE-CONFIG chunks based on corresponding RFCs.