### PR TITLE
Various patches (debian packaging)

### DIFF
--- a/doc/scapy.1
+++ b/doc/scapy.1
@@ -72,7 +72,7 @@ If a string is given as parameter, it is used to filter the layers.
 .TP
 \fBexplore()\fR
 explores available protocols.
-Allows to look for a layer or protocol through an interactive GUI.
+Allows one to look for a layer or protocol through an interactive GUI.
 If a Scapy module is given as parameter, explore this specific module.
 .TP
 \fBlsc()\fR

--- a/test/contrib/isotp_packet.uts
+++ b/test/contrib/isotp_packet.uts
@@ -406,17 +406,6 @@ except Scapy_Exception:
 
 assert ex
 
-= Fragment exception
-~ not_pypy
-
-ex = False
-try:
-    fragments = ISOTP(b"a" * (1 << 32)).fragment()
-except Scapy_Exception:
-    ex = True
-
-assert ex
-
 = Defragment an ISOTP message composed of multiple CAN frames
 fragments = [
     CAN(identifier=0x641, data=dhex("41 10 10 61 62 63 64 65")),

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -53,9 +53,19 @@ from scapy import _parse_tag, _version_from_git_describe
 from scapy.config import _version_checker
 
 b = Bunch(returncode=0, communicate=lambda *args, **kargs: (b"v2.4.5rc1-261-g44b98e14", None))
-with mock.patch('scapy.subprocess.Popen', return_value=b) as popen:
-    class GitModuleScapy(object):
-        __version__ = _version_from_git_describe()
+with mock.patch('scapy.subprocess.Popen', return_value=b):
+    with mock.patch('scapy.os.path.isdir', return_value=True):
+        class GitModuleScapy(object):
+            __version__ = _version_from_git_describe()
+
+# GH3847
+with mock.patch('scapy.subprocess.Popen', return_value=b):
+    with mock.patch('scapy.os.path.isdir', return_value=False):
+        try:
+            _version_from_git_describe()
+            assert False
+        except ValueError:
+            pass
 
 assert GitModuleScapy.__version__ == '2.4.5rc1.dev261'
 assert _version_checker(GitModuleScapy, (2, 4, 5))
@@ -4770,10 +4780,14 @@ with open(version_filename, "w") as fd:
 
 import mock
 with mock.patch("scapy._version_from_git_describe") as version_mocked:
-    version_mocked.side_effect = Exception()
-    assert scapy._version() == version
-    os.unlink(version_filename)
-    assert scapy._version() == "unknown.version"
+    with mock.patch('scapy.os.path.isdir', return_value=True):
+        version_mocked.side_effect = Exception()
+        # mocking _parse_tag is a fallback for when run outside of git
+        with mock.patch('scapy._parse_tag', return_value=version):
+            assert scapy._version() == version
+        os.unlink(version_filename)
+        with mock.patch('scapy._parse_tag', return_value='unknown.version'):
+            assert scapy._version() == "unknown.version"
 
 
 = UTscapy HTML output

--- a/test/run_tests
+++ b/test/run_tests
@@ -54,7 +54,7 @@ then
   fi
 
   # Run tox
-  export UT_FLAGS="-K tcpdump -K manufdb -K wireshark -K ci_only -K vcan_socket -K automotive_comm -K imports -K scanner"
+  export UT_FLAGS="-K tcpdump -K manufdb -K wireshark -K tshark -K ci_only -K vcan_socket -K automotive_comm -K imports -K scanner"
   export SIMPLE_TESTS="true"
   export PYTHON
   PYVER=$($PYTHON -c "import sys; print('.'.join(sys.version.split('.')[:2]))")

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -573,7 +573,7 @@ def test_summary():
         "IP / ICMP 192.168.0.9 > 192.168.0.254 time-exceeded "
         "ttl-zero-during-transit / IPerror / TCPerror / "
         "Raw" % (ftp_data, http) in result_summary
-        for ftp_data in ['21', 'ftp_data']
+        for ftp_data in ['20', 'ftp_data']
         for http in ['80', 'http', 'www_http', 'www']
     ))
 


### PR DESCRIPTION
patches as discussed in https://github.com/secdev/scapy/issues/3847

- remove resource-heavy isotp test (ftr @polybassa). I understand why it is here (there is a max limit in the spec, which it is testing), but it's a too demanding test
- fix a bug with ftp_data wrongly being tested as 21 when netbase isn't available