### PR TITLE
Add wheel requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'tox>=3.0.0'
         ]
     },
+    setup_requires=['wheel'],
     # We use __file__ in scapy/__init__.py, therefore Scapy isn't zip safe
     zip_safe=False,
 


### PR DESCRIPTION
Some Debian-based systems don't have `wheel` pre-installed from the Python package. This causes issues when installing scapy using pip.

`wheel` is required by the bdist_wheel target in setup.cfg.
