### PR TITLE
Remove winpcap test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,19 +11,11 @@ environment:
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       TOXENV: "py37-windows"
-      WINPCAP: "false"
       UT_FLAGS: "-K scanner"
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       TOXENV: "py37-windows"
-      WINPCAP: "true"
-      UT_FLAGS: "-K tcpdump -K scanner"
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
-      TOXENV: "py37-windows"
-      WINPCAP: "false"
       UT_FLAGS: "-k scanner"
 
 # There is no build phase for Scapy
@@ -41,25 +33,6 @@ install:
   # https://github.com/tox-dev/tox/issues/791
   - "%PYTHON%\\python -m pip install virtualenv --upgrade"
   - "%PYTHON%\\python -m pip install tox coverage"
-
-# Compatibility run with Winpcap
-# XXX Remove me when wireshark stops using it as default
-for:
-  -
-    matrix:
-      allow_failures:
-        - UT_FLAGS: "-k scanner"
-      only:
-        - WINPCAP: "true"
-    install:
-      # Install the winpcap and wireshark suites
-      - choco install -y winpcap
-      # See above for explanations
-      - choco install -n KB3033929 KB2919355 kb2999226
-      - choco install -y wireshark
-      # Install Python modules
-      - "%PYTHON%\\python -m pip install virtualenv --upgrade"
-      - "%PYTHON%\\python -m pip install tox coverage"
 
 test_script:
   # Set environment variables


### PR DESCRIPTION
Chocolatey winpcap support [is broken](http://disq.us/p/2sk5jna): the installer freezes to death.

This PR:
- removes the appveyor winpcap test

I might keep supporting it just a bit (without CI) or drop it eventually, still unsure. It was nice to have something that worked on Windows < 7 (arguably).