### PR TITLE
setup: sanitize package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist/
 build/
 MANIFEST
 *.egg-info/
-scapy/VERSION
 test/*.html
 .coverage*
 .tox

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -32,8 +32,7 @@ def _parse_tag(tag):
         # remove the 'v' prefix and add a '.devN' suffix
         return '%s.dev%s' % (match.group(1), match.group(2))
     else:
-        # just remove the 'v' prefix
-        return re.sub('^v', '', tag)
+        raise ValueError('tag has invalid format')
 
 
 def _version_from_git_archive():

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -10,6 +10,7 @@ Usable either from an interactive console or as a Python library.
 https://scapy.net
 """
 
+import datetime
 import os
 import re
 import subprocess
@@ -33,6 +34,35 @@ def _parse_tag(tag):
     else:
         # just remove the 'v' prefix
         return re.sub('^v', '', tag)
+
+
+def _version_from_git_archive():
+    # type: () -> str
+    """
+    Rely on git archive "export-subst" git attribute.
+    See 'man gitattributes' for more details.
+    Note: describe is only supported with git >= 2.32.0
+    but we use it to workaround GH#3121
+    """
+    git_archive_id = '$Format:%ct %(describe)$'.strip().split()
+    tstamp = git_archive_id[0]
+    tag = git_archive_id[1]
+
+    if "Format" in tstamp:
+        raise ValueError('not a git archive')
+
+    if "describe" in tag:
+        # git is too old!
+        tag = ""
+    if tag:
+        # archived revision is tagged, use the tag
+        return _parse_tag(tag)
+    elif tstamp:
+        # archived revision is not tagged, use the commit date
+        d = datetime.datetime.utcfromtimestamp(int(tstamp))
+        return d.strftime('%Y.%m.%d')
+
+    raise ValueError("invalid git archive format")
 
 
 def _version_from_git_describe():
@@ -91,40 +121,40 @@ def _version():
 
     :return: the Scapy version
     """
-    # Rely on git archive "export-subst" git attribute.
-    # See 'man gitattributes' for more details.
-    # Note: describe is only supported with git >= 2.32.0
-    # but we use it to workaround GH#3121
-    git_archive_id = '$Format:%h %(describe)$'.strip().split()
-    sha1 = git_archive_id[0]
-    tag = git_archive_id[1]
-    if "Format" not in sha1:
-        # We are in a git archive
-        if "describe" in tag:
-            # git is too old!
-            tag = ""
-        if tag:
-            return _parse_tag(tag)
-        elif sha1:
-            return "git-archive." + sha1
-        return 'unknown.version'
-    # Fallback to calling git
+    try:
+        # possibly forced by external packaging
+        return os.environ['SCAPY_VERSION']
+    except KeyError:
+        pass
+
     version_file = os.path.join(_SCAPY_PKG_DIR, 'VERSION')
     try:
-        tag = _version_from_git_describe()
-        # successfully read the tag from git, write it in VERSION for
-        # installation and/or archive generation.
-        with open(version_file, 'w') as fdesc:
-            fdesc.write(tag)
+        # file generated when running sdist
+        with open(version_file, 'r') as fdsec:
+            tag = fdsec.read()
         return tag
+    except FileNotFoundError:
+        pass
+
+    try:
+        return _version_from_git_archive()
+    except ValueError:
+        pass
+
+    try:
+        return _version_from_git_describe()
     except Exception:
-        # failed to read the tag from git, try to read it from a VERSION file
-        try:
-            with open(version_file, 'r') as fdsec:
-                tag = fdsec.read()
-            return tag
-        except Exception:
-            return 'unknown.version'
+        pass
+
+    try:
+        # last resort, use the modification date of __init__.py
+        d = datetime.datetime.utcfromtimestamp(os.path.getmtime(__file__))
+        return d.strftime('%Y.%m.%d')
+    except Exception:
+        pass
+
+    # all hope is lost
+    return '0.0.0'
 
 
 VERSION = __version__ = _version()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ Distutils setup file for Scapy.
 
 try:
     from setuptools import setup, find_packages
+    from setuptools.command.sdist import sdist
 except:
     raise ImportError("setuptools is required to install scapy !")
 import io
@@ -29,15 +30,23 @@ def get_long_description():
         return None
 
 
+class SDist(sdist):
+
+    def make_release_tree(self, base_dir, files):
+        sdist.make_release_tree(self, base_dir, files)
+        # ensure there's a scapy/VERSION file
+        fn = os.path.join(base_dir, 'scapy', 'VERSION')
+        with open(fn, 'w') as f:
+            f.write(__import__('scapy').VERSION)
+
+
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/
 setup(
     name='scapy',
     version=__import__('scapy').VERSION,
     packages=find_packages(),
     data_files=[('share/man/man1', ["doc/scapy.1"])],
-    package_data={
-        'scapy': ['VERSION'],
-    },
+    cmdclass={'sdist': SDist},
     # Build starting scripts automatically
     entry_points={
         'console_scripts': [

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4762,22 +4762,34 @@ assert pl[1][Ether].dst == '00:22:33:44:55:66'
 = _version()
 
 import os
-version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
+from datetime import datetime
 
+version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
+mtime = datetime.utcfromtimestamp(os.path.getmtime(scapy.__file__))
 version = "2.0.0"
 with open(version_filename, "w") as fd:
     fd.write(version)
 
+os.environ["SCAPY_VERSION"] = "9.9.9"
+assert scapy._version() == "9.9.9"
+del os.environ["SCAPY_VERSION"]
+
+assert scapy._version() == version
+os.unlink(version_filename)
+
 import mock
-with mock.patch("scapy._version_from_git_describe") as version_mocked:
-    with mock.patch('scapy.os.path.isdir', return_value=True):
-        version_mocked.side_effect = Exception()
-        # mocking _parse_tag is a fallback for when run outside of git
-        with mock.patch('scapy._parse_tag', return_value=version):
-            assert scapy._version() == version
-        os.unlink(version_filename)
-        with mock.patch('scapy._parse_tag', return_value='unknown.version'):
-            assert scapy._version() == "unknown.version"
+with mock.patch("scapy._version_from_git_archive") as archive:
+    archive.return_value = "4.4.4"
+    assert scapy._version() == "4.4.4"
+    archive.side_effect = ValueError()
+    with mock.patch("scapy._version_from_git_describe") as git:
+        git.return_value = "3.3.3"
+        assert scapy._version() == "3.3.3"
+        git.side_effect = Exception()
+        assert scapy._version() == mtime.strftime("%Y.%m.%d")
+        with mock.patch("os.path.getmtime") as getmtime:
+            getmtime.side_effect = Exception()
+            assert scapy._version() == "0.0.0"
 
 
 = UTscapy HTML output


### PR DESCRIPTION
Currently, when installing from a non-tagged git archive version we get an error from `pkg_resources`:

```
pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: 'git-archive.dev95ba5b8504'
```

This version does not comply with the [PEP 440](https://peps.python.org/pep-0440/) standard.

Update the parsing of git-archive `%(describe)` placeholder by adding multiple safeguards for computing `scapy.VERSION` (the first successful method is used in priority):

1. If the `SCAPY_VERSION` env var is defined, use it. This will allow downstream packaging distros to force a specific version even if they store scapy in a different repository using a different git tag scheme.

1. If the `scapy/VERSION` file exists, use its contents.

1. Try to parse a tag from a git archive `%(describe)` placeholder. If the git archive was not made on a tag, use the commit timestamp to convert it to a date `YYYY.MM.DD` which is [PEP 440](https://peps.python.org/pep-0440/) compatible.

1. Try to parse the version from `git describe`.

1. Use the last modification of `scapy/__init__.py` and generate a date `YYYY.MM.DD` which is [PEP 440](https://peps.python.org/pep-0440/) compatible.

1. Return `0.0.0`

Do not try to generate the `scapy/VERSION` file when importing `scapy` anymore but generate it by overriding the `sdist` command in `setup.py` and write it to the temp folder used for the source archive generation.

Update unit tests to ensure that order of priority is enforced.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2162667