### PR TITLE
Replace some legacy exception classes with OSError

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -190,7 +190,7 @@ def _get_if_flags(ifname):
     # Get interface flags
     try:
         result = get_if(ifname, SIOCGIFFLAGS)
-    except IOError:
+    except OSError:
         warning("ioctl(SIOCGIFFLAGS) failed on %s !", ifname)
         return None
 
@@ -216,7 +216,7 @@ class BPFInterfaceProvider(InterfaceProvider):
         try:
             fcntl.ioctl(fd, BIOCSETIF, struct.pack("16s16x",
                                                    dev.network_name.encode()))
-        except IOError:
+        except OSError:
             return False
         else:
             return True

--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -115,7 +115,7 @@ class _L2bpfSocket(SuperSocket):
                     self.ins, BIOCSTSTAMP,
                     struct.pack('I', BPF_T_NANOTIME)
                 )
-            except IOError:
+            except OSError:
                 raise Scapy_Exception("BIOCSTSTAMP failed on /dev/bpf%i" %
                                       self.dev_bpf)
         # Set the BPF buffer length
@@ -124,7 +124,7 @@ class _L2bpfSocket(SuperSocket):
                 self.ins, BIOCSBLEN,
                 struct.pack('I', BPF_BUFFER_LENGTH)
             )
-        except IOError:
+        except OSError:
             raise Scapy_Exception("BIOCSBLEN failed on /dev/bpf%i" %
                                   self.dev_bpf)
 
@@ -134,7 +134,7 @@ class _L2bpfSocket(SuperSocket):
                 self.ins, BIOCSETIF,
                 struct.pack("16s16x", self.iface.encode())
             )
-        except IOError:
+        except OSError:
             raise Scapy_Exception("BIOCSETIF failed on %s" % self.iface)
         self.assigned_interface = self.iface
 
@@ -161,7 +161,7 @@ class _L2bpfSocket(SuperSocket):
                 dlt_radiotap = struct.pack('I', DLT_IEEE802_11_RADIO)
                 try:
                     fcntl.ioctl(self.ins, BIOCSDLT, dlt_radiotap)
-                except IOError:
+                except OSError:
                     raise Scapy_Exception("Can't set %s into monitor mode!" %
                                           self.iface)
             else:
@@ -171,7 +171,7 @@ class _L2bpfSocket(SuperSocket):
         # Don't block on read
         try:
             fcntl.ioctl(self.ins, BIOCIMMEDIATE, struct.pack('I', 1))
-        except IOError:
+        except OSError:
             raise Scapy_Exception("BIOCIMMEDIATE failed on /dev/bpf%i" %
                                   self.dev_bpf)
 
@@ -179,7 +179,7 @@ class _L2bpfSocket(SuperSocket):
         # Otherwise, it is written by the kernel
         try:
             fcntl.ioctl(self.ins, BIOCSHDRCMPLT, struct.pack('i', 1))
-        except IOError:
+        except OSError:
             raise Scapy_Exception("BIOCSHDRCMPLT failed on /dev/bpf%i" %
                                   self.dev_bpf)
 
@@ -216,7 +216,7 @@ class _L2bpfSocket(SuperSocket):
 
         try:
             fcntl.ioctl(self.ins, BIOCPROMISC, struct.pack('i', value))
-        except IOError:
+        except OSError:
             raise Scapy_Exception("Cannot set promiscuous mode on interface "
                                   "(%s)!" % self.iface)
 
@@ -234,7 +234,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGDLT, struct.pack('I', 0))
             ret = struct.unpack('I', ret)[0]
-        except IOError:
+        except OSError:
             cls = conf.default_l2
             warning("BIOCGDLT failed: unable to guess type. Using %s !",
                     cls.name)
@@ -254,7 +254,7 @@ class _L2bpfSocket(SuperSocket):
         if self.fd_flags is None:
             try:
                 self.fd_flags = fcntl.fcntl(self.ins, fcntl.F_GETFL)
-            except IOError:
+            except OSError:
                 warning("Cannot get flags on this file descriptor !")
                 return
 
@@ -276,7 +276,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGSTATS, struct.pack("2I", 0, 0))
             return struct.unpack("2I", ret)
-        except IOError:
+        except OSError:
             warning("Unable to get stats from BPF !")
             return (None, None)
 
@@ -286,7 +286,7 @@ class _L2bpfSocket(SuperSocket):
         try:
             ret = fcntl.ioctl(self.ins, BIOCGBLEN, struct.pack("I", 0))
             return struct.unpack("I", ret)[0]
-        except IOError:
+        except OSError:
             warning("Unable to get the BPF buffer length")
             return
 
@@ -392,7 +392,7 @@ class L2bpfListenSocket(_L2bpfSocket):
         # Get data from BPF
         try:
             bpf_buffer = os.read(self.ins, x)
-        except EnvironmentError as exc:
+        except OSError as exc:
             if exc.errno != errno.EAGAIN:
                 warning("BPF recv_raw()", exc_info=True)
             return None, None, None
@@ -446,7 +446,7 @@ class L3bpfSocket(L2bpfSocket):
         if self.assigned_interface != iff:
             try:
                 fcntl.ioctl(self.outs, BIOCSETIF, struct.pack("16s16x", iff.encode()))  # noqa: E501
-            except IOError:
+            except OSError:
                 raise Scapy_Exception("BIOCSETIF failed on %s" % iff)
             self.assigned_interface = iff
 

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -231,7 +231,7 @@ def _in6_getifaddr(ifname):
         # Check if it is a valid IPv6 address
         try:
             inet_pton(socket.AF_INET6, addr)
-        except (socket.error, ValueError):
+        except (OSError, ValueError):
             continue
 
         # Get the scope and keep the address

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -123,7 +123,7 @@ def _get_npcap_config(param_key):
         key = winreg.OpenKey(hkey, node)
         dot11_adapters, _ = winreg.QueryValueEx(key, param_key)
         winreg.CloseKey(key)
-    except WindowsError:
+    except OSError:
         return None
     return cast(str, dot11_adapters)
 
@@ -144,7 +144,7 @@ def _where(filename, dirs=None, env="PATH"):
                     for match in glob(os.path.join(path, filename))
                     if match)
     except (StopIteration, RuntimeError):
-        raise IOError("File not found: %s" % filename)
+        raise OSError("File not found: %s" % filename)
 
 
 def win_find_exe(filename, installsubdir=None, env="ProgramFiles"):
@@ -159,7 +159,7 @@ def win_find_exe(filename, installsubdir=None, env="ProgramFiles"):
                 path = _where(fn)
             else:
                 path = _where(fn, dirs=[os.path.join(os.environ[env], installsubdir)])  # noqa: E501
-        except IOError:
+        except OSError:
             path = None
         else:
             break
@@ -206,7 +206,7 @@ class WinProgPath(ProgPath):
                         self.wireshark.split(os.path.sep)[:-1]
                     ) + os.path.sep + "manuf"
                 )
-            except (IOError, OSError):  # FileNotFoundError not available on Py2 - using OSError  # noqa: E501
+            except OSError:
                 log_loading.warning("Wireshark is installed, but cannot read manuf !")  # noqa: E501
                 new_manuf = None
             if new_manuf:

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -144,13 +144,13 @@ class L3WinSocket(SuperSocket):
                                     socket.IPV6_RECVTCLASS, 1)
                 self.ins.setsockopt(socket.IPPROTO_IPV6,
                                     socket.IPV6_HOPLIMIT, 1)
-            except (OSError, socket.error):
+            except OSError:
                 pass
         else:
             try:  # Not Windows XP
                 self.ins.setsockopt(socket.IPPROTO_IP,
                                     socket.IP_RECVDSTADDR, 1)
-            except (OSError, socket.error):
+            except OSError:
                 pass
             try:  # Windows 10+ recent builds only
                 self.ins.setsockopt(
@@ -158,7 +158,7 @@ class L3WinSocket(SuperSocket):
                     socket.IP_RECVTTL,  # type: ignore
                     1
                 )
-            except (OSError, socket.error):
+            except OSError:
                 pass
         if promisc:
             # IOCTL Receive all packets
@@ -179,7 +179,7 @@ class L3WinSocket(SuperSocket):
         # type: (int) -> Optional[Packet]
         try:
             return self.recv()
-        except IOError:
+        except OSError:
             return None
 
     # https://docs.microsoft.com/en-us/windows/desktop/winsock/tcp-ip-raw-sockets-2  # noqa: E501

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -149,7 +149,7 @@ class AS_resolver_multi(AS_resolver):
         for ASres in self.resolvers_list:
             try:
                 res = ASres.resolve(*todo)
-            except socket.error:
+            except OSError:
                 continue
             todo = tuple(ip for ip in todo if ip not in [r[0] for r in res])
             ret += res

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -122,7 +122,7 @@ class Net(Gen[str]):
                 socket.getaddrinfo(name, None, cls.family)
                 if family == cls.family
             )
-        except socket.error:
+        except OSError:
             if re.search("(^|\\.)[0-9]+-[0-9]+($|\\.)", name) is not None:
                 raise Scapy_Exception("Ranges are no longer accepted in %s()" %
                                       cls.__name__)

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -318,10 +318,10 @@ def load_protocols(filename, _fallback=None, _integer_base=10,
                 )
     try:
         if not filename:
-            raise IOError
+            raise OSError
         with open(filename, "rb") as fdesc:
             _process_data(fdesc)
-    except IOError:
+    except OSError:
         if _fallback:
             _process_data(iter(_fallback.split(b"\n")))
         else:
@@ -409,7 +409,7 @@ def load_services(filename):
                         line,
                         e,
                     )
-    except IOError:
+    except OSError:
         log_loading.info("Can't open /etc/services file")
     return tdct, udct, sdct
 
@@ -540,7 +540,7 @@ else:
     if manuf_path:
         try:
             MANUFDB = load_manuf(manuf_path)
-        except (IOError, OSError):
+        except OSError:
             log_loading.warning("Cannot read wireshark manuf database")
 
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -818,7 +818,7 @@ class IPField(Field[Union[str, Net], bytes]):
         if isinstance(x, str):
             try:
                 inet_aton(x)
-            except socket.error:
+            except OSError:
                 return Net(x)
         elif isinstance(x, list):
             return [self.h2i(pkt, n) for n in x]
@@ -914,7 +914,7 @@ class IP6Field(Field[Optional[Union[str, Net6]], bytes]):
         if isinstance(x, str):
             try:
                 x = in6_ptop(x)
-            except socket.error:
+            except OSError:
                 return Net6(x)  # type: ignore
         elif isinstance(x, list):
             x = [self.h2i(pkt, n) for n in x]

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -551,7 +551,7 @@ class CandumpReader:
                 # try read to cause exception
                 fdesc.read(1)
                 fdesc.seek(0)
-            except IOError:
+            except OSError:
                 fdesc = open(filename, "rb")
             return filename, fdesc
         else:

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -620,7 +620,7 @@ class ClientSubnetv4(StrLenField):
             return self.af_default
         try:
             return self._pack_subnet(x)
-        except (OSError, socket.error):
+        except OSError:
             pkt.family = 2
             return ClientSubnetv6("", "")._pack_subnet(x)
 
@@ -630,7 +630,7 @@ class ClientSubnetv4(StrLenField):
             return 1
         try:
             return len(self._pack_subnet(x))
-        except (OSError, socket.error):
+        except OSError:
             pkt.family = 2
             return len(ClientSubnetv6("", "")._pack_subnet(x))
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -54,7 +54,7 @@ from scapy.utils6 import in6_getnsma, in6_getnsmac, in6_isaddr6to4, \
 from scapy.volatile import RandInt, RandShort
 
 if not socket.has_ipv6:
-    raise socket.error("can't use AF_INET6, IPv6 is disabled")
+    raise OSError("can't use AF_INET6, IPv6 is disabled")
 if not hasattr(socket, "IPPROTO_IPV6"):
     # Workaround for http://bugs.python.org/issue6926
     socket.IPPROTO_IPV6 = 41

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -9,7 +9,6 @@ Classes and functions for layer 2 protocols.
 
 import struct
 import time
-import socket
 
 from scapy.ansmachine import AnsweringMachine
 from scapy.arch import get_if_addr, get_if_hwaddr
@@ -163,7 +162,7 @@ class DestMACField(MACField):
         if x is None and pkt is not None:
             try:
                 x = conf.neighbor.resolve(pkt, pkt.payload)
-            except socket.error:
+            except OSError:
                 pass
             if x is None:
                 if conf.raise_no_dst_mac:

--- a/scapy/layers/sixlowpan.py
+++ b/scapy/layers/sixlowpan.py
@@ -654,7 +654,7 @@ class LoWPAN_IPHC(Packet):
         # https://tools.ietf.org/html/rfc6282#section-3.1.1
         try:
             tmp_ip = inet_pton(socket.AF_INET6, self.dst)
-        except socket.error:
+        except OSError:
             tmp_ip = b"\x00" * 16
 
         if self.m == 0 and self.dac == 0:
@@ -766,7 +766,7 @@ class LoWPAN_IPHC(Packet):
         # https://tools.ietf.org/html/rfc6282#section-3.1.1
         try:
             tmp_ip = inet_pton(socket.AF_INET6, self.src)
-        except socket.error:
+        except OSError:
             tmp_ip = b"\x00" * 16
 
         if self.sac == 0:

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -423,7 +423,7 @@ class TFTP_RRQ_server(Automaton):
                 try:
                     with open(fn) as fd:
                         self.data = fd.read()
-                except IOError:
+                except OSError:
                     pass
         if self.data is None:
             self.data = self.joker

--- a/scapy/layers/tuntap.py
+++ b/scapy/layers/tuntap.py
@@ -12,7 +12,6 @@ These allow Scapy to act as the remote side of a virtual network interface.
 
 
 import os
-import socket
 import time
 from fcntl import ioctl
 
@@ -245,6 +244,6 @@ class TunTapInterface(SimpleSocket):
             r = self.outs.write(sx)
             self.outs.flush()
             return r
-        except socket.error:
+        except OSError:
             log_runtime.error("%s send",
                               self.__class__.__name__, exc_info=True)

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -100,7 +100,7 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(),
                 compile(cfgf.read(), cf, 'exec'),
                 _globals, _locals
             )
-    except IOError as e:
+    except OSError as e:
         if interactive:
             raise
         log_loading.warning("Cannot read config file [%s] [%s]", cf, e)
@@ -376,10 +376,10 @@ def load_session(fname=None):
         fname = conf.session
     try:
         s = six.moves.cPickle.load(gzip.open(fname, "rb"))
-    except IOError:
+    except OSError:
         try:
             s = six.moves.cPickle.load(open(fname, "rb"))
-        except IOError:
+        except OSError:
             # Raise "No such file exception"
             raise
 
@@ -403,7 +403,7 @@ def update_session(fname=None):
         fname = conf.session
     try:
         s = six.moves.cPickle.load(gzip.open(fname, "rb"))
-    except IOError:
+    except OSError:
         s = six.moves.cPickle.load(open(fname, "rb"))
     scapy_session = six.moves.builtins.__dict__["scapy_session"]
     scapy_session.update(s)
@@ -428,7 +428,7 @@ def init_session(session_name,  # type: Optional[Union[str, None]]
                 try:
                     SESSION = six.moves.cPickle.load(gzip.open(session_name,
                                                                "rb"))
-                except IOError:
+                except OSError:
                     SESSION = six.moves.cPickle.load(open(session_name, "rb"))
                 log_loading.info("Using existing session [%s]", session_name)
             except ValueError:

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -58,7 +58,7 @@ None.
             fdesc = open(conf.nmap_base
                          if self.filename is None else
                          self.filename, "rb")
-        except (IOError, TypeError):
+        except (OSError, TypeError):
             warning("Cannot open nmap database [%s]", self.filename)
             self.filename = None
             return

--- a/scapy/modules/p0fv2.py
+++ b/scapy/modules/p0fv2.py
@@ -59,7 +59,7 @@ class p0fKnowledgeBase(KnowledgeBase):
     def lazy_init(self):
         try:
             f = open(self.filename)
-        except IOError:
+        except OSError:
             warning("Can't open base %s", self.filename)
             return
         try:
@@ -609,7 +609,7 @@ interface and may (are likely to) be different than those generated on
         # S & RA
         try:
             s1.connect(('127.0.0.1', port))
-        except socket.error:
+        except OSError:
             pass
         # S, SA, A, FA, A
         s1.bind(('127.0.0.1', port))

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -18,7 +18,7 @@ from scapy.compat import plain_str, hex_bytes, bytes_encode, bytes_hex
 from scapy.compat import Union
 
 _IP6_ZEROS = re.compile('(?::|^)(0(?::0)+)(?::|$)')
-_INET6_PTON_EXC = socket.error("illegal IP address string passed to inet_pton")
+_INET6_PTON_EXC = OSError("illegal IP address string passed to inet_pton")
 
 
 def _inet6_pton(addr):
@@ -54,7 +54,7 @@ used when socket.inet_pton is not available.
                 raise _INET6_PTON_EXC
             try:
                 result += socket.inet_aton(part)
-            except socket.error:
+            except OSError:
                 raise _INET6_PTON_EXC
         else:
             # Each part must be 16bit. Add missing zeroes before decoding.
@@ -91,7 +91,7 @@ def inet_pton(af, addr):
         try:
             return _INET_PTON[af](addr)
         except KeyError:
-            raise socket.error("Address family not supported by protocol")
+            raise OSError("Address family not supported by protocol")
 
 
 def _inet6_ntop(addr):

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -245,7 +245,7 @@ class Route6:
 
         try:
             inet_pton(socket.AF_INET6, dst)
-        except socket.error:
+        except OSError:
             dst = socket.getaddrinfo(savedst, None, socket.AF_INET6)[0][-1][0]
             # TODO : Check if name resolution went well
 

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -392,7 +392,7 @@ class TCPConnectPipe(Source):
         # type: () -> None
         try:
             msg = self.fd.recv(65536)
-        except socket.error:
+        except OSError:
             self.stop()
             raise
         if msg:
@@ -439,7 +439,7 @@ class TCPListenPipe(TCPConnectPipe):
         if self.connected:
             try:
                 msg = self.fd.recv(65536)
-            except socket.error:
+            except OSError:
                 self.stop()
                 raise
             if msg:
@@ -492,7 +492,7 @@ class UDPClientPipe(TCPConnectPipe):
             return
         try:
             msg = self.fd.recv(65536)
-        except socket.error:
+        except OSError:
             self.stop()
             raise
         if msg:
@@ -534,7 +534,7 @@ class UDPServerPipe(TCPListenPipe):
         if self._destination:
             try:
                 msg = self.fd.recv(65536)
-            except socket.error:
+            except OSError:
                 self.stop()
                 raise
             if msg:

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -7,7 +7,7 @@
 SuperSocket.
 """
 
-from select import select, error as select_error
+from select import select, error as OSError
 import ctypes
 import errno
 import socket
@@ -261,8 +261,8 @@ class SuperSocket:
         """
         try:
             inp, _, _ = select(sockets, [], [], remain)
-        except (IOError, select_error) as exc:
-            # select.error has no .errno attribute
+        except OSError as exc:
+            # OSError has no .errno attribute
             if not exc.args or exc.args[0] != errno.EINTR:
                 raise
         return inp
@@ -370,7 +370,7 @@ if not WINDOWS:
                     "sent using a native L3 socket ! (make sure you passed the "
                     "IP layer)"
                 )
-            except socket.error as msg:
+            except OSError as msg:
                 log_runtime.error(msg)
             return 0
 
@@ -435,7 +435,7 @@ class SSLStreamSocket(StreamSocket):
         if not pkt:
             buf = self.ins.recv(x)
             if len(buf) == 0:
-                raise socket.error((100, "Underlying stream socket tore down"))
+                raise OSError((100, "Underlying stream socket tore down"))
             self._buf += buf
 
         x = len(self._buf)

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -616,7 +616,7 @@ def strand(s1, s2):
 # Workaround bug 643005 : https://sourceforge.net/tracker/?func=detail&atid=105470&aid=643005&group_id=5470  # noqa: E501
 try:
     socket.inet_aton("255.255.255.255")
-except socket.error:
+except OSError:
     def inet_aton(ip_string):
         # type: (str) -> bytes
         if ip_string == "255.255.255.255":
@@ -633,7 +633,7 @@ def atol(x):
     # type: (str) -> int
     try:
         ip = inet_aton(x)
-    except socket.error:
+    except OSError:
         ip = inet_aton(socket.gethostbyname(x))
     return cast(int, struct.unpack("!I", ip)[0])
 
@@ -646,7 +646,7 @@ def valid_ip(addr):
         return False
     try:
         atol(addr)
-    except (OSError, ValueError, socket.error):
+    except (OSError, ValueError):
         return False
     return True
 
@@ -671,10 +671,10 @@ def valid_ip6(addr):
         return False
     try:
         inet_pton(socket.AF_INET6, addr)
-    except socket.error:
+    except OSError:
         try:
             socket.getaddrinfo(addr, None, socket.AF_INET6)[0][4][0]
-        except socket.error:
+        except OSError:
             return False
     return True
 
@@ -740,7 +740,7 @@ class ContextManagerSubprocess(object):
         if exc_value is None or exc_type is None:
             return None
         # Errored
-        if isinstance(exc_value, EnvironmentError):
+        if isinstance(exc_value, OSError):
             msg = "Could not execute %s, is it installed?" % self.prog
         else:
             msg = "%s: execution failed (%s)" % (
@@ -1205,7 +1205,7 @@ class PcapReader_metaclass(type):
             try:
                 fdesc = gzip.open(filename, "rb")  # type: _ByteStream
                 magic = fdesc.read(4)
-            except IOError:
+            except OSError:
                 fdesc = open(filename, "rb")
                 magic = fdesc.read(4)
         else:
@@ -2312,7 +2312,7 @@ class ERFEthernetReader_metaclass(PcapReader_metaclass):
                 with gzip.open(filename, "rb") as tmp:
                     tmp.read(1)
                 fdesc = gzip.open(filename, "rb")  # type: _ByteStream
-            except IOError:
+            except OSError:
                 fdesc = open(filename, "rb")
 
         else:
@@ -2895,7 +2895,7 @@ def get_terminal_width():
             s = struct.pack('HHHH', 0, 0, 0, 0)
             x = fcntl.ioctl(1, termios.TIOCGWINSZ, s)
             sizex = struct.unpack('HHHH', x)[1]
-        except IOError:
+        except OSError:
             pass
         return sizex
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def get_long_description():
             desc = readme.partition("<!-- start_ppi_description -->")[2]
             desc = desc.partition("<!-- stop_ppi_description -->")[0]
             return process_ignore_tags(desc.strip())
-    except IOError:
+    except OSError:
         return None
 
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -282,7 +282,7 @@ def test_read_routes(mock_ioctl):
     def raise_ioerror(*args, **kwargs):
         if args[1] == 0x8912:
             return args[2]
-        raise IOError
+        raise OSError
     mock_ioctl.side_effect = raise_ioerror
     read_routes()
 

--- a/test/pipetool.uts
+++ b/test/pipetool.uts
@@ -15,7 +15,7 @@ d1 > tf
 try:
   t = TermSink(name="PipeToolsPeriodicTest", keepterm=False)
   tf > t
-except (IOError, OSError):
+except OSError:
   pass
 
 p = PipeEngine(s)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1633,13 +1633,13 @@ def _test():
 
 retry_test(_test)
 
-= AS resolver - socket error
+= AS resolver - OSError
 ~ IP
 * This test checks that a failing resolver will not crash a script
 
 class MockAS_resolver(object):
   def resolve(self, *ips):
-    raise socket.error
+    raise OSError
 
 asrm = AS_resolver_multi(MockAS_resolver())
 assert len(asrm.resolve(["8.8.8.8", "8.8.4.4"])) == 0
@@ -1805,7 +1805,7 @@ import mock
 @mock.patch("scapy.supersocket.select")
 def _test_select(select):
     def f(a, b, c, d):
-        raise IOError(0)
+        raise OSError(0)
     select.side_effect = f
     try:
         SuperSocket.select([])
@@ -3420,7 +3420,7 @@ class MockSocket(object):
         self.l = [ b'\x00\x00\x00\x01', b'\x00\x00\x00\x02', b'\x00\x00\x00\x03' ]
     def recv(self, x):
         if len(self.l) == 0:
-            raise socket.error(100, 'EOF')
+            raise OSError(100, 'EOF')
         return self.l.pop(0)
     def fileno(self):
         return -1
@@ -3448,7 +3448,7 @@ assert p.data == 3
 try:
     ss.recv()
     ret = False
-except socket.error:
+except OSError:
     ret = True
 
 assert ret
@@ -3462,7 +3462,7 @@ class MockSocket(object):
         self.l = [ b'\x00\x00\x00\x01\x00\x00\x00\x02', b'\x00\x00\x00\x03\x00\x00\x00\x04' ]
     def recv(self, x):
         if len(self.l) == 0:
-            raise socket.error(100, 'EOF')
+            raise OSError(100, 'EOF')
         return self.l.pop(0)
     def fileno(self):
         return -1
@@ -3492,7 +3492,7 @@ assert p.data == 4
 try:
     ss.recv()
     ret = False
-except socket.error:
+except OSError:
     ret = True
 
 assert ret
@@ -3506,7 +3506,7 @@ class MockSocket(object):
         self.l = [ b'\x00\x00', b'\x00\x01', b'\x00\x00\x00', b'\x02', b'\x00\x00', b'\x00', b'\x03' ]
     def recv(self, x):
         if len(self.l) == 0:
-            raise socket.error(100, 'EOF')
+            raise OSError(100, 'EOF')
         return self.l.pop(0)
     def fileno(self):
         return -1

--- a/test/tls/example_client.py
+++ b/test/tls/example_client.py
@@ -62,7 +62,7 @@ if not v:
 
 try:
     socket.getaddrinfo(args.server, args.port)
-except socket.error as ex:
+except OSError as ex:
     sys.exit("Could not resolve host server: %s" % ex)
 
 if args.ciphersuite:
@@ -79,7 +79,7 @@ server_name = args.sni
 if not server_name and args.server:
     try:
         inet_aton(args.server)
-    except socket.error:
+    except OSError:
         server_name = args.server
 
 t = TLSClientAutomaton(server=args.server, dport=args.port,


### PR DESCRIPTION
The following exception classes have been merged with OSError in Python version 3.3:

    EnvironmentError, IOError, WindowsError,
    socket.error, select.error and mmap.error
