### PR TITLE
fix-minor-test

### DIFF
--- a/test/p0fv2.uts
+++ b/test/p0fv2.uts
@@ -21,7 +21,8 @@ except ImportError:
 def _load_database(file):
     for i in range(10):
         try:
-            open(file, 'wb').write(urlopen('https://raw.githubusercontent.com/p0f/p0f/4b4d1f384abebbb9b1b25b8f3c6df5ad7ab365f7/' + file).read())
+            with open(file, 'wb') as fd:
+                fd.write(urlopen('https://raw.githubusercontent.com/p0f/p0f/4b4d1f384abebbb9b1b25b8f3c6df5ad7ab365f7/' + file).read())
             break
         except:
             raise

--- a/test/tftp.uts
+++ b/test/tftp.uts
@@ -43,6 +43,8 @@ class MockTFTPSocket(object):
         return pkt
     def send(self, *args, **kargs):
         pass
+    def close(self):
+        pass
 
 
 = TFTP_read() automaton


### PR DESCRIPTION
See https://github.com/secdev/scapy/issues/3847

```
./test/run_tests -t test/tftp.uts -n 0-3 -F
━ UTScapy - Scapy 2.5.0.dev12 - 3.10.9
 └ Non-root mode
 └ Booting scapy...
 └ Discovering tests files...
━ Loading: test/tftp.uts
passed CBBFDA20 000.00s Test answers
passed D559286B 000.00s Utilities
passed F88AFFD0 000.01s TFTP_read() automaton
passed A974A974 000.01s TFTP_read() automaton error
Exception in thread scapy.automaton _do_start:
Traceback (most recent call last):
  File "/usr/lib64/python3.10/threading.py", line 1016, in _bootstrap_inner
Campaign CRC=913D7EA5 in 000.02s SHA=3A46E0AF5C478AAD6EA6C1B0822E5EEC7DC92353
PASSED=4 FAILED=0
✓ All campaigns executed. Writing output...

Regression tests for TFTP
━ Run at 13:38:31 from [test/tftp.uts] by UTscapy in 0.021495580673217773
 └ Passed=4
 └ Failed=0


UTscapy ended successfully

WARNING: UNFINISHED THREADS
[<_MainThread(MainThread, started 139756419569472)>, <Thread(scapy.automaton _do_start, started daemon 139756339910208)>]
    self.run()
  File "/usr/lib64/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/vagrant/scapy/scapy/automaton.py", line 1160, in _do_control
    self.listen_sock.close()
AttributeError: 'MockReadSocket' object has no attribute 'close'
```