### PR TITLE
Disable ping tests on OSX

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -12,12 +12,6 @@ then
   # Linux
   OSTOX="linux"
   UT_FLAGS+=" -K tshark"
-  if [ ! -z "$GITHUB_ACTIONS" ]
-  then
-    # Due to a security policy, the firewall of the Azure runner
-    # (Standard_DS2_v2) that runs Github Actions on Linux blocks ICMP.
-    UT_FLAGS+=" -K icmp_firewall"
-  fi
   if [ -z "$SIMPLE_TESTS" ]
   then
     # check vcan
@@ -45,6 +39,13 @@ then
   then
     UT_FLAGS+=" -K not_netbsd"
   fi
+fi
+
+if [ ! -z "$GITHUB_ACTIONS" ]
+then
+  # Due to a security policy, the firewall of the Azure runner
+  # (Standard_DS2_v2) that runs Github Actions on Linux blocks ICMP.
+  UT_FLAGS+=" -K icmp_firewall"
 fi
 
 # pypy


### PR DESCRIPTION
The OSX test has begun failing the same way the linux previously did.

https://github.com/secdev/scapy/actions/runs/3990457822/jobs/6844126086

This is because of Azure firewall issues.