### PR TITLE
Make m2i match i2m in NBytesField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1134,7 +1134,7 @@ class NBytesField(Field[int, List[int]]):
             return x
         # x can be a tuple when coming from struct.unpack  (from getfield)
         if isinstance(x, (list, tuple)):
-            return sum(d * (256 ** i) for i, d in enumerate(x))
+            return sum(d * (256 ** i) for i, d in enumerate(reversed(x)))
         return 0
 
     def i2repr(self, pkt, x):

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -32,7 +32,7 @@ assert parsed.attributes == [
       STUNPriority(priority=1847591167),
       STUNIceControlling(tie_breaker=0x1b0ab98b6e8effa6),
       STUNUsername(length=37, username="oNph:Ht11MaRZHc4GOLJUsbu1R3YCs72HYN25"),
-      STUNMessageIntegrity(hmac_sha1=0x77e7f03e7f9e1996be42339159db1f682147bcfc),
+      STUNMessageIntegrity(hmac_sha1=0xfcbc4721681fdb59913342be96199e7f3ef0e777),
       STUNFingerprint(crc_32=0x8718c3a4)
 ]
 
@@ -59,7 +59,7 @@ assert parsed.attributes == [
       STUNIceControlling(tie_breaker=0xa696819e91c937da),
       STUNUseCandidate(),
       STUNPriority(priority=1845501695),
-      STUNMessageIntegrity(hmac_sha1=0x5fbd89b9c76b674db13a433112f3e0b1faaa87c1),
+      STUNMessageIntegrity(hmac_sha1=0xc187aafab1e0f31231433ab14d676bc7b989bd5f),
       STUNFingerprint(crc_32=0xc9566cfc)
 
 ]
@@ -79,7 +79,7 @@ assert parsed.magic_cookie == 0x2112A442
 assert parsed.transaction_id == 0xcfacb2a43aa2de5a9d56d85a, parsed.transaction_id
 assert parsed.attributes == [
       STUNXorMappedAddress(xport=40480, xip="172.20.0.42"),
-      STUNMessageIntegrity(hmac_sha1=0x7d968d4241fa89d8e3f8ffe302c8975823c91fb7),
+      STUNMessageIntegrity(hmac_sha1=0xb71fc9235897c802e3fff8e3d889fa41428d967d),
       STUNFingerprint(crc_32=0xea9b6559)
 ]
 
@@ -103,7 +103,7 @@ assert parsed.attributes[0] == STUNXorMappedAddress(xport=25000, xip="172.20.0.2
 assert parsed.attributes == [
       STUNXorMappedAddress(xport=25000, xip="172.20.0.200"),
       STUNUsername(length=37, username="Ht11MaRZHc4GOLJUsbu1R3YCs72HYN25:oNph"),
-      STUNMessageIntegrity(hmac_sha1=0x317065df81598d6cc8ca3bd684ca65fb6d03674b),
+      STUNMessageIntegrity(hmac_sha1=0x4b67036dfb65ca84d63bcac86c8d5981df657031),
       STUNFingerprint(crc_32=0x4041e9c3)
 ]
 

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -204,6 +204,14 @@ class TestFuzzNBytesField(Packet):
 f = fuzz(TestFuzzNBytesField())
 assert f.test1.max == 2 ** (128 * 8) - 1
 
+p2 = TestNBytesField(raw(p))
+assert p2.sprintf('%test1% %test2% %test3% %test4%') == '18838586676582 0xc000ff3333 0xffeeddccbbaa9988776655 309404098707666285700277845'
+assert p2.test1 == 18838586676582
+assert p2.test2 == 0xc000ff3333
+assert p2.test3 == 0xffeeddccbbaa9988776655
+assert p2.test4 == 309404098707666285700277845
+assert raw(p2) == raw(TestNBytesField(test1=p2.test1, test2=p2.test2, test3=p2.test3, test4=p2.test4))
+
 = StrField
 ~ field strfield
 ~ field strlenfield

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -178,7 +178,7 @@ assert cmd[HCI_Cmd_Authentication_Requested].handle == 256
 cmd = HCI_Hdr(hex_bytes("010b041676d56f9501006c9016a48a009180086a39200f03d3dd"))
 assert HCI_Cmd_Link_Key_Request_Reply in cmd
 assert cmd[HCI_Cmd_Link_Key_Request_Reply].bd_addr == "00:01:95:6f:d5:76"
-assert cmd[HCI_Cmd_Link_Key_Request_Reply].link_key == 294855023751241435024024030130491265132
+assert cmd[HCI_Cmd_Link_Key_Request_Reply].link_key == 0x6c9016a48a009180086a39200f03d3dd
 
 = Set Connection Encryption
 


### PR DESCRIPTION
Closes https://github.com/secdev/scapy/issues/3876