### PR TITLE
Fixes #191

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -1523,6 +1523,7 @@ class BluetoothUserSocket(SuperSocket):
         if r != 0:
             raise BluetoothSocketError("Unable to bind")
 
+        self.hci_fd = s
         self.ins = self.outs = socket.fromfd(s, 31, 3, 1)
 
     def send_command(self, cmd):
@@ -1564,6 +1565,7 @@ class BluetoothUserSocket(SuperSocket):
         if hasattr(self, "ins"):
             if self.ins and (WINDOWS or self.ins.fileno() != -1):
                 close(self.ins.fileno())
+        close(self.hci_fd)
 
 
 conf.BTsocket = BluetoothRFCommSocket


### PR DESCRIPTION
This PR fixes a bug in the `BluetoothUserSocket` implementation that made impossible to close and reopen the socket without having an error ("device or resource busy"), previously reported in issue #191.

`BluetoothUserSocket` did not close the first socket returned by the first call to socket(), leaving this socket alive. OS returns "Device or resource busy" because of this when one try to instantiate a new `BluetoothUserSocket`.
Closing this first socket in `BluetoothUserSocket`'s `close()` method frees all the file descriptors and solved this issue.

Fixes #191.
