### PR TITLE
Make NBytesField a bit more fuzzable

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1110,6 +1110,10 @@ class NBytesField(Field[int, List[int]]):
         return (s[self.sz:],
                 self.m2i(pkt, self.struct.unpack(s[:self.sz])))  # type: ignore
 
+    def randval(self):
+        # type: () -> RandNum
+        return RandNum(0, 2 ** (self.sz * 8) - 1)
+
 
 class XNBytesField(NBytesField):
     def i2repr(self, pkt, x):

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -183,6 +183,13 @@ assert p.test2 == 0xc000ff3333
 assert p.test3 == 0xffeeddccbbaa9988776655
 assert p.test4 == 309404098707666285700277845
 
+class TestFuzzNBytesField(Packet):
+    fields_desc = [
+        NBytesField('test1', 0, 128),
+    ]
+
+f = fuzz(TestFuzzNBytesField())
+assert f.test1.max == 2 ** (128 * 8) - 1
 
 = StrField
 ~ field strfield


### PR DESCRIPTION
The default randval function inherited from the Field class generates values from 0 to 255 because the "fmt" signature of NBytesFields ends with "B". Because of that only the last byte is different:
```
>>> hexdump(f)
0000  00 00 00 00 00 00 00 00 00 45                    .........E
>>> hexdump(f)
0000  00 00 00 00 00 00 00 00 00 50                    .........P
>>> hexdump(f)
0000  00 00 00 00 00 00 00 00 00 DD                    ..........
```

With this patch applied randval uses the whole range and all the bytes are involved in fuzzing:
```
>>> hexdump(f)
0000  F2 50 65 CE 2D A7 11 95 E7 32                    .Pe.-....2
>>> hexdump(f)
0000  71 22 B3 4E 52 28 41 91 03 2C                    q".NR(A..,
>>> hexdump(f)
0000  97 61 93 29 E4 AC 10 A8 8F 02                    .a.)......
```