### PR TITLE
Use network byte order explicitly to pack/unpack multi-byte integers in CoAP

### DIFF
--- a/scapy/contrib/coap.py
+++ b/scapy/contrib/coap.py
@@ -107,7 +107,7 @@ def _get_abs_val(val, ext_val):
     if val >= 15:
         warning("Invalid Option Length or Delta %d" % val)
     if val == 14:
-        return 269 + struct.unpack('H', ext_val)[0]
+        return 269 + struct.unpack('!H', ext_val)[0]
     if val == 13:
         return 13 + struct.unpack('B', ext_val)[0]
     return val
@@ -127,7 +127,7 @@ class _CoAPOpt(Packet):
     @staticmethod
     def _populate_extended(val):
         if val >= 269:
-            return struct.pack('H', val - 269), 14
+            return struct.pack('!H', val - 269), 14
         if val >= 13:
             return struct.pack('B', val - 13), 13
         return None, val

--- a/test/contrib/coap.uts
+++ b/test/contrib/coap.uts
@@ -27,7 +27,8 @@ assert p.options == [('Uri-Path', b'.well-known'), ('Uri-Path', b'core')]
 assert raw(CoAP(options=[("Uri-Query", "query")])) == b'\x40\x00\x00\x00\xd5\x02\x71\x75\x65\x72\x79'
 
 = Extended option length
-assert raw(CoAP(options=[("Location-Path", 'x' * 280)])) == b'\x40\x00\x00\x00\x8e\x0b\x00' + b'\x78' * 280
+assert raw(CoAP(options=[("Location-Path", 'x' * 280)])) == b'\x40\x00\x00\x00\x8e\x00\x0b' + b'\x78' * 280
+assert len(CoAP(b'\x40\x00\x00\x00\x8e\x00\x0b' + b'\x78' * 280 + b'\xff').options[0][1]) == 280
 
 = Options should be ordered by option number
 assert raw(CoAP(options=[("Uri-Query", "b"),("Uri-Path","a")])) == b'\x40\x00\x00\x00\xb1\x61\x41\x62'


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc7252#section-1.2
> All multi-byte integers in this protocol are interpreted in network
byte order.

and according to https://www.rfc-editor.org/rfc/rfc7252#section-3.1
> A 16-bit unsigned integer in network byte order precedes the
Option Value and indicates the Option Length minus 269.

Also, judging by
https://github.com/wireshark/wireshark/blob/8cddc32d35e36d9962495c3d4358842ea88aac41/epan/dissectors/packet-coap.c#L876 wireshark uses tvb_get_ntohs (which is roughly the same as unpack('!H')) too.

It surfaced on big endian machines where `H` turned into `!H` by default https://github.com/secdev/scapy/issues/3847#issuecomment-1411565053:
```
>>> assert raw(CoAP(options=[("Location-Path", 'x' * 280)])) ==
b'\x40\x00\x00\x00\x8e\x0b\x00' + b'\x78' * 280
Traceback (most recent call last):
  File "<input>", line 2, in <module>
AssertionError
```

This patch was tested on BE and LE machines in
https://github.com/evverx/scapy/pull/1 along with some other patches making the unit tests pass.

That being said I have to admit I'm not particularly familiar with CoAP and I feel a bit uneasy about touching this code because it has been this way since 2016 (https://github.com/secdev/scapy/pull/201) and nobody appears to have complained so far.