### PR TITLE
Fix conversion issues with FixedPointField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -3178,7 +3178,7 @@ class FixedPointField(BitField):
         if val is None:
             return val
         ival = int(val)
-        fract = int((val - ival) * 2**self.frac_bits)
+        fract = round((val - ival) * 2**self.frac_bits)
         return (ival << self.frac_bits) | fract
 
     def i2h(self, pkt, val):
@@ -3188,11 +3188,12 @@ class FixedPointField(BitField):
         pw = 2.0**self.frac_bits
         frac_part = EDecimal(val & (1 << self.frac_bits) - 1)
         frac_part /= pw  # type: ignore
-        return int_part + frac_part.normalize(int(math.log10(pw)))
+        return int_part + frac_part
 
     def i2repr(self, pkt, val):
         # type: (Optional[Packet], int) -> str
-        return str(self.i2h(pkt, val))
+        precision = int(math.log10(2.0**self.frac_bits))
+        return "{1:.{0}f}".format(precision, self.i2h(pkt, val))
 
 
 # Base class for IPv4 and IPv6 Prefixes inspired by IPField and IP6Field.

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -2213,3 +2213,19 @@ mp = MockPacket(0)
 f = XStrField('test', None)
 x = f.i2repr(mp, RandBin())
 assert x == '<RandBin>'
+
+############
+############
++ FixedPointField tests
+
+= value conversion consistency
+~ field fixedpointfield
+
+# Specific regression test value
+start = 5302425419963321
+fixedp_field = FixedPointField("fixedp", 0, 64, 32)
+
+for i in range(start - 1000, start + 1000):
+    i2h_value = fixedp_field.i2h(None, i)
+    any2i_value = fixedp_field.any2i(None, i2h_value)
+    assert i == any2i_value


### PR DESCRIPTION
Converting a value with .i2h() followed by any2i() results in a different value than the original. This is due to loss of decimal precision and not rounding when converting float to int.

Fixes #3893
Fixes #3052
