### PR TITLE
Use little-endian byte order to pack transaction lengths in PCOM

### DIFF
--- a/scapy/contrib/scada/pcom.py
+++ b/scapy/contrib/scada/pcom.py
@@ -83,7 +83,7 @@ class PCOM(Packet):
 
     def post_build(self, pkt, pay):
         if self.len is None and pay:
-            pkt = pkt[:4] + struct.pack("H", len(pay))
+            pkt = pkt[:4] + struct.pack("<H", len(pay))
         return pkt + pay
 
 


### PR DESCRIPTION
According to
https://www.unitronicsplc.com/Download/SoftwareUtilities/Unitronics%20PCOM%20Protocol.pdf low bytes of transaction lengths come first. Other than that the "len" field itself is declared with LEShortField.

Fixes the pcom test on big endian machines:
```
>>> r = b'\x65\x00\x04\x00\x00\x00\x00\x00'
>>> raw(PCOMRequest() / b'\x00\x00\x00\x00')[2:] == r
False
>>> r =  b'\x65\x00\x04\x00\x00\x00\x00\x00'
>>> raw(PCOMResponse() / b'\x00\x00\x00\x00')[2:] == r
False
```

This patch was tested on BE and LE machines in
https://github.com/evverx/scapy/pull/1.