### PR TITLE
Make pack and unpack match in homeplugav.WriteModuleDataRequest

### DIFF
--- a/scapy/contrib/homeplugav.py
+++ b/scapy/contrib/homeplugav.py
@@ -641,10 +641,10 @@ class WriteModuleDataRequest(Packet):
     def post_build(self, p, pay):
         if self.DataLen is None:
             _len = len(self.ModuleData)
-            p = p[:2] + struct.pack('h', _len) + p[4:]
+            p = p[:2] + struct.pack('<H', _len) + p[4:]
         if self.checksum is None and p:
             ck = chksum32(self.ModuleData)
-            p = p[:8] + struct.pack('I', ck) + p[12:]
+            p = p[:8] + struct.pack('<I', ck) + p[12:]
         return p + pay
 
 ######################################


### PR DESCRIPTION
DataLen seems to be a little-endian field because it's defined with fmt='<H' explicitly. Wireshark dissects it as an unsigned short integer as well: https://github.com/wireshark/wireshark/blob/5ce29956e40a4c1e381d4b455c03225d9eda547b/epan/dissectors/packet-homeplug-av.c#L3526

Checksum seems to be a little-endian field because it's defined with LEIntField and Wireshark dissects it accordingly:
https://github.com/wireshark/wireshark/blob/5ce29956e40a4c1e381d4b455c03225d9eda547b/epan/dissectors/packet-homeplug-av.c#L3528

This patch was cross-checked with Wireshark to make sure that it can parse packets produced by Scapy and both DataLen and Checksum matched. For example Scapy showed
```
        DataLen   = 32768
        Offset    = 0
        checksum  = 4294967295
```
and then it was written to a pcap file that was read by Wireshark and it showed
```
    Write Module Data Request
...
        Length: 0x8000
        Offset: 0x00000000
        Checksum: 0xffffffff
```
as expected.

The patch was also tested on BE and LE machines in https://github.com/evverx/scapy/pull/1.

Fixes the WriteModuleDataRequest test on big-endian machines:
```

>>> string = b"goodchoucroute\x00\x00"
>>> pkt = WriteModuleDataRequest(ModuleData=string)
>>> pkt = WriteModuleDataRequest(pkt.build())
>>> pkt.show()
  ModuleID  = PIB
  reserved_1= 0x0
  DataLen   = 4096
  Offset    = 0
  checksum  = 3975123099
  ModuleData= 'goodchoucroute\x00\x00'

>>> a = pkt.checksum == chksum32(pkt.ModuleData)
>>> b = pkt.DataLen == len(pkt.ModuleData)
>>> a, b
(False, False)
>>> assert a and b
Traceback (most recent call last):
  File "<input>", line 2, in <module>
AssertionError
```

It's worth mentioning that there are other places where packs and unpacks should probably be fixed:
https://github.com/secdev/scapy/pull/2270#issuecomment-1431503009 but I'd leave it to homeplugav experts (which I'm not).
