### PR TITLE
Skip the Ether part of hashret in the LLTD build/dissection test

### DIFF
--- a/test/scapy/layers/lltd.uts
+++ b/test/scapy/layers/lltd.uts
@@ -20,7 +20,7 @@ assert pkt.dst == pkt.real_dst
 assert pkt.src == pkt.real_src
 assert pkt.tos == 0
 assert pkt.function == 0
-assert pkt.hashret() == b'\xd9\x88\x00\x00'
+assert pkt.hashret()[2:] == b'\x00\x00'
 
 = Attribute build / dissection
 assert isinstance(LLTDAttribute(), LLTDAttribute)


### PR DESCRIPTION
Ether.hashret converts EtherTypes into bytes using the native byte order so the first two bytes of pkt.hashret in this particular case can be either b'\xd9\x88' or b'\x88\xd9'.

To judge from
https://github.com/secdev/scapy/commit/43738be928242713837e36d522a530dd9bd1c2c9 and https://github.com/secdev/scapy/issues/3133
the idea behind this test was to make sure that both Ether.hashret and LLTD.hashret can be concatenated into bytes without throwing TypeErrors along the way and pkt.hashret()[2:] should be enough for that.

Now that only
Python3 is supported it could probably be replaced with just isinstance(bytes) but I thought it would still make sense to check that LLTD.hashret produces two zero bytes as expected.

Another option would probably be to check whether the test is run on big endian machines and swap the first two bytes accordingly or always use the same endianness to pack the "type" field but it can in theory break something because Ether().hashret() has always returned the "type" field packed in the machine's native order and some scripts can rely on that somehow probably.

Fixes the LLTD test on big-endian machines:
```

>>> pkt = Ether(raw(Ether(dst=ETHER_BROADCAST, src=RandMAC()) / LLTD(tos=0, function=0)))
>>> assert LLTD in pkt
>>> assert pkt.dst == pkt.real_dst
>>> assert pkt.src == pkt.real_src
>>> assert pkt.tos == 0
>>> assert pkt.function == 0
>>> assert pkt.hashret() == b'\xd9\x88\x00\x00'
Traceback (most recent call last):
  File "<input>", line 2, in <module>
AssertionError
```

It was tested on BE and LE machines in https://github.com/evverx/scapy/pull/1. Combined with https://github.com/secdev/scapy/pull/3903 it should finally make the tests pass on big-endian machines.