### PR TITLE
Extract IPv6 payload with the Jumbo option correctly

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -302,10 +302,12 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             jumbo_len = None
             idx = 0
             offset = 4 * idx + 2
+            # TODO: don't go past the first Hop-by-Hop extension header here
+            # TODO: min(hbh_len, len(data)) or something like that should suffice
             while offset <= len(data):
                 opt_type = orb(data[offset])
                 if opt_type == 0xc2:  # Jumbo option
-                    jumbo_len = struct.unpack("I", data[offset + 2:offset + 2 + 4])[0]  # noqa: E501
+                    jumbo_len = struct.unpack("!I", data[offset + 2:offset + 2 + 4])[0]  # noqa: E501
                     break
                 offset = 4 * idx + 2
                 idx += 1
@@ -314,6 +316,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                 log_runtime.info("Scapy did not find a Jumbo option")
                 jumbo_len = 0
 
+            # TODO: hbh_len shouldn't be addede here. jumbo_len should already include it.
             tmp_len = hbh_len + jumbo_len
         else:
             tmp_len = self.plen

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -588,6 +588,10 @@ raw(Jumbo(optlen=6, jumboplen=0xffffffff)) == b'\xc2\x06\xff\xff\xff\xff'
 a=Jumbo(b'\xc2\x06\xff\xff\xff\xff')
 a.otype == 0xc2 and a.optlen == 6 and a.jumboplen == 0xffffffff
 
+= Jumbo - Network byte order length
+a = Jumbo(b'\xc2\x04\x00\x01\x00\x00')
+assert a.jumboplen == 0x00010000
+assert raw(Jumbo(jumboplen=65536)) == b'\xc2\x04\x00\x01\x00\x00'
 
 ############
 ############
@@ -659,6 +663,13 @@ raw(IPv6ExtHdrHopByHop(options=[RouterAlert(), HAO(), Jumbo()])) == b';\x03\x05\
 = IPv6ExtHdrHopByHop - Basic Dissection
 a=IPv6ExtHdrHopByHop(b';\x00\x01\x04\x00\x00\x00\x00')
 a.nh == 59 and a.len == 0 and len(a.options) == 1 and isinstance(a.options[0], PadN) and a.options[0].otype == 1 and a.options[0].optlen == 4 and a.options[0].optdata == b'\x00'*4
+
+= IPv6ExtHdrHopByHop - Dissection with the Jumbo option
+p = IPv6(raw(IPv6(nh=0, plen=0)/IPv6ExtHdrHopByHop(options=[Jumbo(jumboplen=65536)])/IPv6ExtHdrRouting()/(b'\x01' * 65520)/b'junk'))
+assert IPv6ExtHdrHopByHop in p and IPv6ExtHdrRouting in p
+assert len(p.payload) == 65540
+assert p[Raw].load == b'\x01' * 65520
+assert p[Padding].load == b'junk'
 
 #= IPv6ExtHdrHopByHop - Automatic length computation
 #raw(IPv6ExtHdrHopByHop(options=["toto"])) == b'\x00\x00toto'


### PR DESCRIPTION
It's more of a bug report at this point probably but it already contains one bug fix and a few tests reproducing the issue.

I ran into this while I was looking for packs that don't match their unpacks.
