### PR TITLE
Extended Sequence Numbers support in ESP

### DIFF
--- a/test/scapy/layers/ipsec.uts
+++ b/test/scapy/layers/ipsec.uts
@@ -1507,6 +1507,31 @@ except IPSecIntegrityError as err:
     err
 
 #######################################
+= IPv4 / ESP - Transport - AES-CBC - HMAC-SHA2-256-128 -- ESN
+
+p = IP(src='1.1.1.1', dst='2.2.2.2')
+p /= TCP(sport=45012, dport=80)
+p /= Raw('hello world')
+p = IP(raw(p))
+p
+
+enc_key = bytes.fromhex("85ee354b4675a9c5d16e3d6f4118043b")
+auth_key = bytes.fromhex("6f79bf94da7dde3c86009934d9258f1b3fc2f5382aca9c9cb8e216eed235f34c")
+
+sa = SecurityAssociation(ESP, spi=0xcf54ccdf, crypt_algo='AES-CBC',
+                         crypt_key=enc_key,
+                         auth_algo='SHA2-256-128', auth_key=auth_key,
+                         esn_en=True, esn=68)
+e = sa.encrypt(p, iv=bytes.fromhex("11223344112233441122334411223344"))
+
+
+assert bytes(e) == bytes.fromhex("4500006c000100004032745a0101010102020202cf54ccdf0000000111223344112233441122334411223344f5bda519c9ae64f283f0fc18a8d253eca8b34c2120c8958a97ec9d8e67756da2523fce9b5541c57fddf090afc2bfd97e8703203953f853eb61482e4c1384d4c8")
+
+* integrity verification should pass
+d = sa.decrypt(e)
+d
+
+#######################################
 = IPv4 / ESP - Transport - AES-GCM - NULL
 
 p = IP(src='1.1.1.1', dst='2.2.2.2')


### PR DESCRIPTION
Based on rfc4303 / 2.2.1. Extended (64-bit) Sequence Number
 If a separate integrity algorithm is employed, the high
 order bits are included in the implicit ESP trailer, but are not
 transmitted, analogous to integrity algorithm padding bits. 

So, for ESP mode when aead is not used, we need to add ESN to the end of packet to be authenticated (if authentication operation is required)
