### PR TITLE
Ensure that packet is set to p param to type of bytes. In certain sit…

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -102,7 +102,7 @@ class BGPFieldIPv4(Field):
         return int(mask), ip
 
     def i2h(self, pkt, i):
-        """"Internal" representation to "human" representation
+        """Internal" representation to "human" representation
         (x.x.x.x/y)."""
         mask, ip = i
         return ip + "/" + str(mask)
@@ -115,7 +115,7 @@ class BGPFieldIPv4(Field):
         return self.mask2iplen(mask) + 1
 
     def i2m(self, pkt, i):
-        """"Internal" (IP as bytes, mask as int) to "machine"
+        """Internal" (IP as bytes, mask as int) to "machine"
         representation."""
         mask, ip = i
         ip = socket.inet_aton(str(ip))
@@ -131,7 +131,7 @@ class BGPFieldIPv4(Field):
         
         example:
             s = b'\x18\x03\x03\x03' 24/3.3.3
-        """"
+        """
         length = self.mask2iplen(orb(s[0])) + 1
         return s[length:], self.m2i(pkt, s[:length])
 
@@ -175,7 +175,7 @@ class BGPFieldIPv6(Field):
         return int(mask), ip
 
     def i2h(self, pkt, i):
-        """"Internal" representation to "human" representation."""
+        """Internal" representation to "human" representation."""
         mask, ip = i
         return ip + "/" + str(mask)
 
@@ -187,7 +187,7 @@ class BGPFieldIPv6(Field):
         return self.mask2iplen(mask) + 1
 
     def i2m(self, pkt, i):
-        """"Internal" (IP as bytes, mask as int) to "machine" representation."""  # noqa: E501
+        """Internal" (IP as bytes, mask as int) to "machine" representation."""  # noqa: E501
         mask, ip = i
         ip = pton_ntop.inet_pton(socket.AF_INET6, ip)
         return struct.pack(">B", mask) + ip[:self.mask2iplen(mask)]


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)

Ensure that params that representing packets are set to type bytes. In certain situations where bgp fields for open messages were being set, this function was initializing packet variable to a str and returning.

Fix bgp path_attrib length field. Should be type byte, not int.

Adding fuzz() support to bgp open and update.

Allow for BGPFieldLenField len to be fuzzed, but fixed when recalled.

