### PR TITLE
Various DHCP fixes

### DIFF
--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -188,15 +188,7 @@ class ClasslessStaticRoutesField(Field):
         return struct.pack('b', prefix) + dest + router
 
     def getfield(self, pkt, s):
-        if not s:
-            return None
-
         prefix = orb(s[0])
-        # if prefix is invalid value ( 0 > prefix > 32 ) then break
-        if prefix > 32 or prefix < 0:
-            warning("Invalid prefix value: %d (0x%x)", prefix, prefix)
-            return s, []
-
         route_len = 5 + (prefix + 7) // 8
         return s[route_len:], self.m2i(pkt, s[:route_len])
 

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -449,6 +449,16 @@ class DHCPOptionsField(StrField):
                 else:
                     olen = orb(x[1])
                     lval = [f.name]
+
+                    if olen == 0:
+                        try:
+                            _, val = f.getfield(pkt, b'')
+                        except Exception:
+                            opt.append(x)
+                            break
+                        else:
+                            lval.append(val)
+
                     try:
                         left = x[2:olen + 2]
                         while left:

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -92,6 +92,21 @@ assert DHCP(b"\x37\x00").options == [("param_req_list", [])]
 assert DHCP(b"\x79\x00").options == [("classless_static_routes", [])]
 assert DHCP(b"\x01\x0C\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b").options == [("subnet_mask", "0.1.2.3", "4.5.6.7", "8.9.10.11")]
 
+b = b"\x79\x01\xff"
+p = DHCP(b)
+assert p.options == [b]
+p.clear_cache()
+assert raw(p) == b
+
+b = b"\x79\x0a\x21\x01\x02\x03\x04\x05\x06\x07\x08\x09"
+p = DHCP(b)
+assert p.options == [b]
+p.clear_cache()
+assert raw(p) == b
+
+b = b"\x79\x09\x20\x01\x02\x03\x04\x05\x06\x07\x08\xff"
+assert DHCP(b).options == [("classless_static_routes", ["1.2.3.4/32:5.6.7.8"]), "end"]
+
 = DHCPOptions
 
 # Issue #2786

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -84,6 +84,14 @@ assert p4[DHCP].options[0] == ("mud-url", b"https://example.org")
 p5 = IP(s5)
 assert DHCP in p5
 assert p5[DHCP].options[0] == ("classless_static_routes", ["192.168.123.4/32:10.0.0.1", "169.254.254.0/24:10.0.1.2"])
+
+repr(DHCP(b"\x01\x00"))
+assert DHCP(b"\x01\x00").options == [b"\x01\x00"]
+assert DHCP(b"\x28\x00").options == [("NIS_domain", b"")]
+assert DHCP(b"\x37\x00").options == [("param_req_list", [])]
+assert DHCP(b"\x79\x00").options == [("classless_static_routes", [])]
+assert DHCP(b"\x01\x0C\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b").options == [("subnet_mask", "0.1.2.3", "4.5.6.7", "8.9.10.11")]
+
 = DHCPOptions
 
 # Issue #2786


### PR DESCRIPTION
This PR fixes three different issues. Below are the commit messages I copied verbatim just in case:
<details>
  <summary>Parse zero-length DHCP options as well</summary>

Until https://github.com/secdev/scapy/commit/0db2a8cfb02195e6bba777ef9794fd33e605f11f was merged zero-length
DHCP options were parsed at least once and the "options" list contained
tuples with at least two elements. This patch restores that.

It prevents `repr(DHCP(...))` from crashing with something like
```
TypeError: ord() expected a character, but string of length 23 found
```
and also lets the fields with meaningfull empty values to be initialized
properly. For example,
```
>>> DHCP(b"\x79\x00").options
[('classless_static_routes',)]
```
turns into
```
[("classless_static_routes", [])]
```

It's a follow-up to https://github.com/secdev/scapy/commit/0db2a8cfb02195e6bba777ef9794fd33e605f11f
</details>

<details>
<summary>Fix the "Classless Static Route" parser</summary>

FieldListField expects its fields to either fully consume bytes or throw
exceptions if those bytes can't be consumed. The "Classless Static
Route" field didn't do that when it received invalid subnet mask widths
and it led to a loop where FieldListField tried to parse the same
sequence of bytes and append the same value to the list over and over
again until scapy got interrupted manually or got killed by the OOM killer.

This patch addresses that by throwing exceptions when classless static
routes can't be consumed. It basically relies on inet_ntoa rejecting
anything other than 4 bytes. The test suite is updated to cover the
corner cases. Other than that the DHCP parser was fuzzed for about an
hour and nothing popped up.

It's a follow-up to https://github.com/secdev/scapy/commit/f5b718881441637e9f8cab75515981b32247f707
</details>
