### PR TITLE
Pack count field of ACKNACK submessage correctly

### DIFF
--- a/scapy/contrib/rtps/rtps.py
+++ b/scapy/contrib/rtps/rtps.py
@@ -351,7 +351,8 @@ class RTPSSubMessage_ACKNACK(EPacket):
             "readerSNState",
             0, length_from=lambda pkt: pkt.octetsToNextHeader - 8 - 4
         ),
-        XNBytesField("count", 0, 4),
+        EField(IntField("count", 0),
+               endianness_from=e_flags),
     ]
 
 

--- a/test/contrib/rtps.uts
+++ b/test/contrib/rtps.uts
@@ -443,3 +443,36 @@ p1 = RTPS(
 assert p0.build() == d
 assert p1.build() == d
 assert p0 == p1
+
++ Test for pr #3915
+= RTPS ACKNACK count packing and dissection
+
+d = b"\x52\x54\x50\x53\x02\x02\x01\x0f\x01\x0f\x45\xd2\xb3\xf5\x58\xb9" \
+    b"\x01\x00\x00\x00\x06\x03\x18\x00\x00\x00\x03\xc7\x00\x00\x03\xc2" \
+    b"\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+p0 = RTPS(d)
+
+p1 = RTPS(
+    protocolVersion=ProtocolVersionPacket(major=2, minor=2),
+    vendorId=VendorIdPacket(vendor_id=0x010f),
+    guidPrefix=GUIDPrefixPacket(
+        hostId=0x010f45d2, appId=0xb3f558b9, instanceId=0x01000000
+    ),
+    magic=b"RTPS",
+) / RTPSMessage(
+    submessages=[
+        RTPSSubMessage_ACKNACK(
+            submessageId=6,
+            submessageFlags=3,
+            octetsToNextHeader=0x18,
+            reader_id=b'\x00\x00\x03\xc7',
+            writer_id=b'\x00\x00\x03\xc2',
+            readerSNState=b'\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00',
+            count=1
+        )
+    ]
+)
+
+assert p0.build() == d
+assert p1.build() == d
+assert p0 == p1


### PR DESCRIPTION
The count field of ACKNACK submessage is an integer field and should be packed using the endianness flag, just like how the count field of HEARTBEAT submessage is handled.

Currently, `count=1` is incorrectly packed as `"\x00\x00\x00\x01"` (== 16777216), regardless of the endianness bit. With this change, `count=1` is correctly packed as `"\x01\x00\x00\x00"` (== 1), given the endianness is set.
