### PR TITLE
Prevent PacketListField from creating deeply nested lists

### DIFF
--- a/test/fields.uts
+++ b/test/fields.uts
@@ -751,6 +751,25 @@ assert p.data[3].data == 0xc102
 assert isinstance(p.payload, conf.raw_layer)
 assert p.payload.load == b'toto'
 
+= Test nested PacketListFields
+~ field
+# https://github.com/secdev/scapy/issues/3894
+
+class GuessPayload(Packet):
+     @classmethod
+     def dispatch_hook(cls, *args, **kargs):
+         return TestNestedPLF
+
+class TestNestedPLF(Packet):
+     fields_desc = [
+         ByteField('b', 0),
+         PacketListField('pl', [], GuessPayload)
+     ]
+
+p = TestNestedPLF(b'\x01' * 1000)
+assert len(p[Raw]) == 995
+assert p.pl[0][TestNestedPLF:4]
+assert not p.pl[0].getlayer(TestNestedPLF, 5)
 
 ############
 ############

--- a/test/scapy/layers/dhcp6.uts
+++ b/test/scapy/layers/dhcp6.uts
@@ -1167,6 +1167,13 @@ raw(DHCP6OptRelaySuppliedOpt(relaysupplied=DHCP6OptERPDomain(erpdomain=["toto.ex
 a = DHCP6OptRelaySuppliedOpt(b'\x00B\x00\x16\x00A\x00\x12\x04toto\x07example\x03com\x00')
 a.optcode == 66 and a.optlen == 22 and len(a.relaysupplied) == 1 and isinstance(a.relaysupplied[0], DHCP6OptERPDomain) and a.relaysupplied[0].erpdomain[0] == "toto.example.com."
 
+= DHCP6OptRelaySuppliedOpt - deeply nested DHCP6OptRelaySuppliedOpt
+# https://github.com/secdev/scapy/issues/3894
+
+p = DHCP6(b'\x01\x00\x00\x00' + b'\x00B\x0f\x0f' * 100)
+assert p[DHCP6OptRelaySuppliedOpt:5]
+assert not p.getlayer(DHCP6OptRelaySuppliedOpt, 6)
+assert p[Raw]
 
 ############
 ############


### PR DESCRIPTION
When do_dissect copies list fields it traverses them all the way down and it takes a lot of time and RAM if they are deeply nested. This patch addresses that by limiting the maximum depth.

It's a follow-up to aabf4b56f01fa22e039f6cd69e8058e0648b38e0 (where scapy started copying lists by traversing them).

Closes https://github.com/secdev/scapy/issues/3894