### PR TITLE
Add AUTOSAR PDUTransport/PDU with initial batch of tests

### DIFF
--- a/scapy/contrib/automotive/autosar/__init__.py
+++ b/scapy/contrib/automotive/autosar/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Damian Zaręba <damianzrb@zohomail.eu>
+
+# scapy.contrib.status = skip
+
+"""
+Package of contrib automotive AUTOSAR modules
+that have to be loaded explicitly.
+"""

--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -7,6 +7,7 @@
 
 # scapy.contrib.description = AUTOSAR PDU packets handling package.
 # scapy.contrib.status = loads
+from typing import Tuple, Optional
 from scapy.layers.inet import UDP
 from scapy.fields import IntField, XIntField, PacketListField
 from scapy.packet import Packet, bind_bottom_up
@@ -15,11 +16,12 @@ from scapy.packet import Packet, bind_bottom_up
 class PDU(Packet):
     """
     Single PDU Packet inside PDUTransport list.
-    Contains ID and payload length, and later - raw load, free to interpret using bind_layers/bind_bottom_up method
+    Contains ID and payload length, and later - raw load.
+    It's free to interpret using bind_layers/bind_bottom_up method
 
     Based off this document:
 
-    https://www.autosar.org/fileadmin/standards/classic/22-11/AUTOSAR_SWS_IPDUMultiplexer.pdf
+    https://www.autosar.org/fileadmin/standards/classic/22-11/AUTOSAR_SWS_IPDUMultiplexer.pdf # noqa: E501
     """
     name = 'PDU'
     fields_desc = [
@@ -32,11 +34,9 @@ class PDU(Packet):
 
 
 class PDUTransport(Packet):
-
     """
     Packet representing PDUTransport containing multiple PDUs
-    FIXME: Support CAN messages as well, not only ethernet packets put on top of UDP layer
-
+    FIXME: Support CAN messages as well.
     """
     name = 'PDUTransport'
     fields_desc = [

--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Damian Zaręba <damianzrb@zohomail.eu>
+
+# scapy.contrib.description = AUTOSAR PDU packets handling package.
+# scapy.contrib.status = loads
+from scapy.layers.inet import UDP
+from scapy.fields import IntField, XIntField, PacketListField
+from scapy.packet import Packet, bind_bottom_up
+
+
+class PDU(Packet):
+    """
+    Single PDU Packet inside PDUTransport list.
+    Contains ID and payload length, and later - raw load, free to interpret using bind_layers/bind_bottom_up method
+
+    Based off this document:
+
+    https://www.autosar.org/fileadmin/standards/classic/22-11/AUTOSAR_SWS_IPDUMultiplexer.pdf
+    """
+    name = 'PDU'
+    fields_desc = [
+        XIntField('pdu_id', 0),
+        IntField('pdu_payload_len', 0)]
+
+    def extract_padding(self, s):
+        # type: (bytes) -> Tuple[bytes, Optional[bytes]]
+        return s[:self.pdu_payload_len], s[self.pdu_payload_len:]
+
+
+class PDUTransport(Packet):
+
+    """
+    Packet representing PDUTransport containing multiple PDUs
+    FIXME: Support CAN messages as well, not only ethernet packets put on top of UDP layer
+
+    """
+    name = 'PDUTransport'
+    fields_desc = [
+        PacketListField("pdus", [PDU()], PDU)
+    ]
+
+
+bind_bottom_up(UDP, PDUTransport, dport=60000)

--- a/test/configs/bsd.utsc
+++ b/test/configs/bsd.utsc
@@ -8,6 +8,7 @@
     "test/contrib/automotive/gm/*.uts",
     "test/contrib/automotive/bmw/*.uts",
     "test/contrib/automotive/xcp/*.uts",
+    "test/contrib/automotive/autosar/*.uts",
     "test/contrib/*.uts"
   ],
   "remove_testfiles": [

--- a/test/configs/linux.utsc
+++ b/test/configs/linux.utsc
@@ -10,6 +10,7 @@
     "test/contrib/automotive/gm/*.uts",
     "test/contrib/automotive/bmw/*.uts",
     "test/contrib/automotive/xcp/*.uts",
+    "test/contrib/automotive/autosar/*.uts",
     "test/tls/tests_tls_netaccess.uts"
   ],
   "remove_testfiles": [

--- a/test/configs/solaris.utsc
+++ b/test/configs/solaris.utsc
@@ -8,6 +8,7 @@
     "test/contrib/automotive/gm/*.uts",
     "test/contrib/automotive/bmw/*.uts",
     "test/contrib/automotive/xcp/*.uts",
+    "test/contrib/automotive/autosar/*.uts",
     "test/contrib/*.uts"
   ],
   "remove_testfiles": [

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -9,6 +9,7 @@
     "test\\contrib\\automotive\\bmw\\*.uts",
     "test\\contrib\\automotive\\xcp\\*.uts",
     "test\\contrib\\automotive\\*.uts",
+    "test\\contrib\\automotive\\autosar\\*.uts",
     "test\\contrib\\*.uts"
   ],
   "remove_testfiles": [

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -6,6 +6,7 @@
     "test\\contrib\\automotive\\gm\\*.uts",
     "test\\contrib\\automotive\\bmw\\*.uts",
     "test\\contrib\\automotive\\*.uts",
+    "test\\contrib\\automotive\\autosar\\*.uts",
     "tls\\tests_tls_netaccess.uts",
     "contrib\\*.uts"
   ],

--- a/test/contrib/automotive/autosar/pdu.uts
+++ b/test/contrib/automotive/autosar/pdu.uts
@@ -1,0 +1,43 @@
+% Regression tests for the PDUTransport / PDU layer
+
+
+# More information at http://www.secdev.org/projects/UTscapy/
+
+
+############
+############
+
++ PDUTransport contrib tests
+
+= Load Contrib Layer
+
+load_contrib("automotive.autosar.pdu", globals_dict=globals())
+
+= Defaults test
+
+p = PDUTransport()
+assert p.pdus == [PDU()]
+
+p = PDU()
+assert p.pdu_id == 0
+assert p.pdu_payload_len == 0
+
+= Build test pdu_id
+p = PDU(bytes(PDU(pdu_id=0x11)))
+assert len(bytes(p)) == 8
+assert p.pdu_id == 0x11
+assert p.pdu_payload_len == 0
+
+= Build test pdu_payload_len
+p = PDU(bytes(PDU(pdu_payload_len=12)))
+assert len(p) == 8
+assert p.pdu_id == 0
+assert p.pdu_payload_len == 12
+
+= Build test id and payload len with data
+p = PDU(bytes(PDU(pdu_id=0x12, pdu_payload_len=2) / Raw(b'\x22\x33')))
+assert len(p) == 10
+assert p.pdu_id == 0x12
+assert p.pdu_payload_len == 2
+assert len(p['Raw']) == 2
+assert p['Raw'] == b'\x22\x33'

--- a/test/contrib/automotive/autosar/pdu.uts
+++ b/test/contrib/automotive/autosar/pdu.uts
@@ -41,3 +41,31 @@ assert p.pdu_id == 0x12
 assert p.pdu_payload_len == 2
 assert len(p['Raw']) == 2
 assert bytes(p['Raw']) == b'\x22\x33'
+
+= Build PDUTransport with multiple PDU packets
+p1 = PDUTransport(b'\x00\x00\x00\x01\x00\x00\x00\x01\x11'
+b'\x00\x00\x00\x02\x00\x00\x00\x02\x11\x44'
+b'\x00\x00\x00\x03\x00\x00\x00\x03\x11\x33\x91')
+p2 = PDUTransport(bytes(PDUTransport(pdus=[PDU(pdu_id=0x1,pdu_payload_len=1)/Raw(b'\x11'), # noqa: E501
+PDU(pdu_id=0x2, pdu_payload_len=2) / Raw(b'\x11\x44'),
+PDU(pdu_id=0x3, pdu_payload_len=3) / Raw(b'\x11\x33\x91')])))
+# Check if packets are the same
+assert p1 == p2 
+# Check if fields are set correctly within PDU list
+assert p1.pdus[0].pdu_id == 0x1
+assert p1.pdus[0].pdu_payload_len == 1
+assert p1.pdus[1].pdu_id == 0x2
+assert p1.pdus[1].pdu_payload_len == 2
+assert p1.pdus[2].pdu_id == 0x3
+assert p1.pdus[2].pdu_payload_len == 3
+
+= Build PDUTransport with one PDU packet
+p1 = PDUTransport(b'\x00\x00\x00\x01\x00\x00\x00\x03\x11\x22\x33')
+p2 = PDUTransport(bytes(PDUTransport(pdus=[
+PDU(pdu_id=0x1, pdu_payload_len=0x3) / Raw(b'\x11\x22\x33')])))
+
+# Check if packets are the same
+assert p1 == p2 
+# Check if fields are set correctly within PDU list
+assert p1.pdus[0].pdu_id == 0x1
+assert p1.pdus[0].pdu_payload_len == 3

--- a/test/contrib/automotive/autosar/pdu.uts
+++ b/test/contrib/automotive/autosar/pdu.uts
@@ -40,4 +40,4 @@ assert len(p) == 10
 assert p.pdu_id == 0x12
 assert p.pdu_payload_len == 2
 assert len(p['Raw']) == 2
-assert p['Raw'] == b'\x22\x33'
+assert bytes(p['Raw']) == b'\x22\x33'


### PR DESCRIPTION
**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)

Add AUTOSAR PDUTransport/PDU protocol for automotive, on top of UDP (for now), which is similar to CAN signals, but for Ethernet.

Thanks for @polybassa for help with PacketListField :)

Remake of previous PR, to not break upstream.