### PR TITLE
Show NTP version and mode instead of question marks

### DIFF
--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -209,7 +209,9 @@ class NTP(Packet):
         return s
 
     def mysummary(self):
-        return self.sprintf("NTP v%ir,NTP.version%, %NTP.mode%")
+        return self.sprintf(
+            "NTP v%ir,{0}.version%, %{0}.mode%".format(self.__class__.__name__)
+        )
 
 
 class _NTPAuthenticatorPaddingField(StrField):
@@ -795,7 +797,7 @@ class NTPControl(NTP):
     fields_desc = [
         BitField("zeros", 0, 2),
         BitField("version", 2, 3),
-        BitField("mode", 6, 3),
+        BitEnumField("mode", 6, 3, _ntp_modes),
         BitField("response", 0, 1),
         BitField("err", 0, 1),
         BitField("more", 0, 1),
@@ -1777,7 +1779,7 @@ class NTPPrivate(NTP):
         BitField("response", 0, 1),
         BitField("more", 0, 1),
         BitField("version", 2, 3),
-        BitField("mode", 0, 3),
+        BitEnumField("mode", 7, 3, _ntp_modes),
         BitField("auth", 0, 1),
         BitField("seq", 0, 7),
         ByteEnumField("implementation", 0, _implementations),

--- a/test/scapy/layers/ntp.uts
+++ b/test/scapy/layers/ntp.uts
@@ -24,16 +24,19 @@ assert NTPHeader in p
 assert not NTPControl in p
 assert not NTPPrivate in p
 assert NTP in p
+assert p.mysummary() == "NTP v4, client"
 p = NTPControl()
 assert not NTPHeader in p
 assert NTPControl in p
 assert not NTPPrivate in p
 assert NTP in p
+assert p.mysummary() == "NTP v2, NTP control message"
 p = NTPPrivate()
 assert not NTPHeader in p
 assert not NTPControl in p
 assert NTPPrivate in p
 assert NTP in p
+assert p.mysummary() == "NTP v2, reserved for private use"
 
 = NTP - Layers (2)
 p = NTPHeader()


### PR DESCRIPTION
In 1e48e13fc594f8d925451c7e2706086d21102716 NTP switched to dispatch_hook and all the fields including "version" and "mode" moved to the NTP subclasses. This PR adjusts the mysummary method accordingly.

With this patch applied tshark() prints something like
```
   17	Ether / IP / UDP / NTP v4, client
   18	Ether / IP / UDP / NTP v4, server
```
instead of
```
   17	Ether / IP / UDP / NTP v??, ??
   18	Ether / IP / UDP / NTP v??, ??
```

It's a follow-up to 1e48e13fc594f8d925451c7e2706086d21102716
