### PR TITLE
Fix scapy sdist

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md

--- a/tox.ini
+++ b/tox.ini
@@ -139,10 +139,10 @@ commands = codespell --ignore-words=.config/codespell_ignore.txt --skip="*.pyc,*
 description = "Check Scapy code distribution"
 skip_install = true
 deps = twine
-       setuptools>=38.6.0
        cmarkgfm
-commands = python setup.py --quiet sdist
-           twine check dist/*
+       build
+commands = python -m build
+           twine check --strict dist/*
 
 
 [testenv:flake8]


### PR DESCRIPTION
In 669506bd42e4141718374ba297974881fe125fb8 scapy switched to
pyproject.toml where 'readme' is dynamic and should be supplied by
setup.py. setup.py reads README.md and it works from inside the source
tree but since README.md isn't included in the sdist it fails when pip
or the build frontend builds the wheel from the sdist with:
```
distutils.errors.DistutilsOptionError: No configuration found for dynamic 'readme'.
Some dynamic fields need to be specified via `tool.setuptools.dynamic`
others must be specified via the equivalent attribute in `setup.py`.
```

This patch addresses that by removing README and letting setuptools
add README.md to the sdist automatcially.

README was added in 4f71027fcdcb1e4ca8d7e04987588d2f7e615f4b in 2016 and back then it probably made
sense because setuptools didn't include README.md in the sdist
automatically. These days setuptools can handle README.md just fine so
it's no longer necessary to keep README any more.

It makes it possible to build the wheel from the sdist again.

Fixes:
```
python3 -m build
...
* Building wheel from sdist
* Creating venv isolated environment...
* Installing packages in isolated environment... (setuptools>=62.0.0)
* Getting build dependencies for wheel...
...
  File "/tmp/build-env-vtaxy4xl/lib64/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 351, in _obtain_readme
    self._ensure_previously_set(dist, "readme")
  File "/tmp/build-env-vtaxy4xl/lib64/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 307, in _ensure_previously_set
    raise OptionError(msg)
distutils.errors.DistutilsOptionError: No configuration found for dynamic 'readme'.
Some dynamic fields need to be specified via `tool.setuptools.dynamic`
others must be specified via the equivalent attribute in `setup.py`.

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```
and
```
python3 -m pip install dist/scapy-2.5.0.dev56.tar.gz
Processing ./dist/scapy-2.5.0.dev56.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
...
```

It's a follow-up to 669506bd42e4141718374ba297974881fe125fb8