### PR TITLE
fix issue 3951 SRP does not detect valid sae auth responses

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1530,7 +1530,13 @@ class Dot11Auth(_Dot11EltUtils):
                    LEShortEnumField("status", 0, status_code)]
 
     def answers(self, other):
-        if self.seqnum == other.seqnum + 1:
+        if self.algo != other.algo:
+            return 0
+
+        if (
+            self.seqnum == other.seqnum + 1 or
+            (self.algo == 3 and self.seqnum == other.seqnum)
+        ):
             return 1
         return 0
 

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -136,6 +136,22 @@ assert not a.answers(b)
 assert not (Dot11()/Dot11Ack()).answers(Dot11())
 assert (Dot11()/LLC(dsap=2, ctrl=4)).answers(Dot11()/LLC(dsap=1, ctrl=5))
 
+# SAE
+a = Dot11()/Dot11Auth(algo=3, seqnum=1)  # non-AP STA --> AP STA      COMMIT
+b = Dot11()/Dot11Auth(algo=3, seqnum=1)  # AP STA     --> non-AP STA  COMMIT
+c = Dot11()/Dot11Auth(algo=3, seqnum=2)  # non-AP STA --> AP STA      CONFIRM
+d = Dot11()/Dot11Auth(algo=3, seqnum=2)  # AP STA     --> non-AP STA  CONFIRM
+e = Dot11()/Dot11Auth(algo=0, seqnum=1)
+
+assert b.answers(a)
+assert c.answers(b)
+assert d.answers(c)
+
+assert not a.answers(e)
+assert not c.answers(e)
+assert not e.answers(a)
+assert not e.answers(c)
+
 = Dot11Beacon network_stats()
 
 data = b'\x00\x00\x12\x00.H\x00\x00\x00\x02\x8f\t\xa0\x00\x01\x01\x00\x00\x80\x00\x00\x00\xff\xff\xff\xff\xff\xffDH\xc1\xb7\xf0uDH\xc1\xb7\xf0u\x10\xb7\x00\x00\x00\x00\x00\x00\x00\x00\x90\x01\x11\x00\x00\x06SSID76\x01\n\x82\x84\x0c\x12\x18$0H`l\x03\x01\x080\x18\x01\x00\x00\x0f\xac\x04\x02\x00\x00\x0f\xac\x04\x00\x0f\xac\x02\x01\x00\x00\x0f\xac\x02\x0c\x00\x07\tUSI\x01\x18\x00\n\x05\xe7'


### PR DESCRIPTION
This pull request fixes the following issue.
[ISSUE 3951](https://github.com/secdev/scapy/issues/3951)

fix https://github.com/secdev/scapy/issues/3951
