### PR TITLE
Fix several assertions and deprecation warnings

### DIFF
--- a/test/scapy/layers/ntp.uts
+++ b/test/scapy/layers/ntp.uts
@@ -1128,11 +1128,11 @@ assert (isinstance(pkt_1.orig, RawVal)), type(pkt_1.orig)
 assert (isinstance(pkt_1.sent, RawVal)), type(pkt_1.sent)
 assert (isinstance(pkt_1.recv, RawVal)), type(pkt_1.recv)
 
-assert (pkt_1.precision.val == precision, pkt_1.precision.val)
-assert (pkt_1.dispersion.val == dispersion, pkt_1.dispersion.val)
-assert (pkt_1.orig.val == time_stamp, pkt_1.orig.val)
-assert (pkt_1.sent.val == time_stamp, pkt_1.sent.val)
-assert (pkt_1.recv.val == time_stamp, pkt_1.recv.val)
+assert pkt_1.precision.val == precision, pkt_1.precision.val
+assert pkt_1.dispersion.val == dispersion, pkt_1.dispersion.val
+assert pkt_1.orig.val == time_stamp, pkt_1.orig.val
+assert pkt_1.sent.val == time_stamp, pkt_1.sent.val
+assert pkt_1.recv.val == time_stamp, pkt_1.recv.val
 
 time_stamp_hex = 0x00000000e67d6774
 pkt_2 = NTP(

--- a/test/tls/tests_tls_netaccess.uts
+++ b/test/tls/tests_tls_netaccess.uts
@@ -145,8 +145,7 @@ def test_tls_server(suite="", version="", tls13=False, client_auth=False, psk=No
     q_ = Queue()
     th_ = threading.Thread(target=run_tls_test_server, args=(msg, q_),
                            kwargs={"curve": None, "cookie": False, "client_auth": client_auth, "psk": psk},
-                           name="test_tls_server %s %s" % (suite, version))
-    th_.setDaemon(True)
+                           name="test_tls_server %s %s" % (suite, version), daemon=True)
     th_.start()
     # Synchronise threads
     q_.get()
@@ -254,8 +253,7 @@ def test_tls_client(suite, version, curve=None, cookie=False, client_auth=False,
     th_ = threading.Thread(target=run_tls_test_server, args=(msg, q_),
                            kwargs={"curve": None, "cookie": False, "client_auth": client_auth,
                                    "handle_session_ticket": sess_in_out},
-                           name="test_tls_client %s %s" % (suite, version))
-    th_.setDaemon(True)
+                           name="test_tls_client %s %s" % (suite, version), daemon=True)
     th_.start()
     # Synchronise threads
     print("Syncrhonising...")


### PR DESCRIPTION
Fixes:
```
>>> assert (pkt_1.precision.val == precision, pkt_1.precision.val)
Traceback (most recent call last):
  File "/usr/lib64/python3.11/codeop.py", line 153, in __call__
    return _maybe_compile(self.compiler, source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 73, in _maybe_compile
    return compiler(source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 118, in __call__
    codeob = compile(source, filename, symbol, self.flags, True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<input>", line 2
SyntaxError: assertion is always true, perhaps remove parentheses?
```
and
```
>>> test_tls_server("ECDHE-RSA-AES128-SHA", "-tls1")
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "<input>", line 9, in test_tls_server
  File "/usr/lib64/python3.11/threading.py", line 1240, in setDaemon
    warnings.warn('setDaemon() is deprecated, set the daemon attribute instead',
DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```