### PR TITLE
Fix several syntax errors

### DIFF
--- a/test/contrib/isotp_message_builder.uts
+++ b/test/contrib/isotp_message_builder.uts
@@ -83,7 +83,7 @@ m = ISOTPMessageBuilder()
 m.feed(CAN(identifier=0x241, data=dhex("E2 04 01 02 03 04")))
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xE2
+assert msg.rx_ext_address == 0xE2
 assert msg.data == dhex("01 02 03 04")
 
 = Single CAN frame that has 2 valid interpretations
@@ -113,9 +113,9 @@ m.feed(CAN(identifier=0x241, data=dhex("EA 25 1E 1F 20 21 22 23")))
 m.feed(CAN(identifier=0x241, data=dhex("EA 26 24 25 26 27 28"   )))
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xEA
+assert msg.ext_address == 0xEA
 assert msg.time == 1005
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28")
 
@@ -132,9 +132,9 @@ m.feed(CAN(identifier=0x241, data=dhex("EA 25 1E 1F 20 21 22 23")))
 m.feed(CAN(identifier=0x241, data=dhex("EA 26 24 25 26 27 28"   )))
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xAE
+assert msg.ext_address == 0xAE
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28")
 
 = Verify that an EA starting with 1 will still work
@@ -146,9 +146,9 @@ m.feed(CAN(identifier=0x241, data=dhex("1A 22 0C 0D 0E 0F 10 11")))
 m.feed(CAN(identifier=0x241, data=dhex("1A 23 12 13 14 15 16 17")))
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0x1A
+assert msg.rx_ext_address == 0x1A
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0x1A
+assert msg.ext_address == 0x1A
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14")
 
 = Verify that an EA of 07 will still work
@@ -158,9 +158,9 @@ m.feed(CAN(identifier=0x641, data=dhex("07 30 03 00"            )))
 m.feed(CAN(identifier=0x241, data=dhex("07 21 06 07 08 09 0A 0B")))
 msg = m.pop(0x241, 0x07)
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0x07
+assert msg.rx_ext_address == 0x07
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0x07
+assert msg.ext_address == 0x07
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A")
 
 = Verify that three interleaved messages can be sniffed simultaneously on the same identifier and extended address (very unrealistic)
@@ -187,21 +187,21 @@ m.feed(CAN(identifier=0x241, data=dhex("EA 25 1E 1F 20 21 22 23")))
 m.feed(CAN(identifier=0x241, data=dhex("EA 26 24 25 26 27 28"   ))) # end of message A
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.data == dhex("A6 A7 A8")
 assert msg.time == 200
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xEA
+assert msg.ext_address == 0xEA
 assert msg.time == 400
 assert msg.data == dhex("31 32 33 34 35 36 37 38 39 3A 3B 3C 3D 3E 3F 40")
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xEA
+assert msg.ext_address == 0xEA
 assert msg.time == 300
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28")
 
@@ -221,9 +221,9 @@ msgs = [
 m.feed(msgs)
 msg = m.pop()
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xEA
+assert msg.ext_address == 0xEA
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28")
 
 = Verify multiple frames with EA from list and iterator
@@ -248,9 +248,9 @@ isotpmsgs = [x for x in m]
 assert len(isotpmsgs) == 3
 msg = isotpmsgs[0]
 assert msg.rx_id == 0x241
-assert msg.rx_ext_address is 0xEA
+assert msg.rx_ext_address == 0xEA
 assert msg.tx_id == 0x641
-assert msg.ext_address is 0xEA
+assert msg.ext_address == 0xEA
 assert msg.data == dhex("01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20 21 22 23 24 25 26 27 28")
 
 assert isotpmsgs[1] == isotpmsgs[2]

--- a/test/contrib/isotp_soft_socket.uts
+++ b/test/contrib/isotp_soft_socket.uts
@@ -59,9 +59,9 @@ with TestSocket(CAN) as s, TestSocket(CAN) as tx_sock:
 
 assert sniffed[0]['ISOTP'].data == bytearray(range(1, 0x29))
 assert sniffed[0]['ISOTP'].tx_id == 0x641
-assert sniffed[0]['ISOTP'].ext_address is 0xEA
+assert sniffed[0]['ISOTP'].ext_address == 0xEA
 assert sniffed[0]['ISOTP'].rx_id == 0x241
-assert sniffed[0]['ISOTP'].rx_ext_address is 0xEA
+assert sniffed[0]['ISOTP'].rx_ext_address == 0xEA
 
 + ISOTPSoftSocket tests
 

--- a/test/contrib/rtr.uts
+++ b/test/contrib/rtr.uts
@@ -230,9 +230,9 @@ RTRErrorReport in pkt and pkt.error_code == 0 and pkt.erroneous_PDU == b'' and p
 = filled values build
 
 pkt = IP()/TCP(dport=323)/RTRErrorReport(error_code=1, error_text='Internal Error')
-RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
+RTRErrorReport in pkt and pkt.error_code == 1 and pkt.error_text == b'Internal Error'
 
 = dissection
 
 pkt = IP(b'E\x00\x00F\x00\x01\x00\x00@\x06|\xaf\x7f\x00\x00\x01\x7f\x00\x00\x01 Z\x01C\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\xdc\x15\x00\x00\x00\n\x00\x01\x00\x00\x00\x1e\x00\x00\x00\x00\x00\x00\x00\x0eInternal Error')
-RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
+RTRErrorReport in pkt and pkt.error_code == 1 and pkt.error_text == b'Internal Error'


### PR DESCRIPTION
I found a subtle bug in UTscapy where it swallows syntax errors like
```python
RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
                                                    ^
SyntaxError: invalid decimal literal
```
and It boils down to `code.InteractiveInterpreter()` swallowing syntax errors unless syntax warnings are treated as errors:
```
python3 -c '1and print(12)'
<string>:1: SyntaxWarning: invalid decimal literal
12
```
I haven't fully fixed that bug yet but in the process several syntax errors popped up and they are addressed here.

Fixes:
```python
>>> RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
Traceback (most recent call last):
  File "/usr/lib64/python3.11/codeop.py", line 153, in __call__
    return _maybe_compile(self.compiler, source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 73, in _maybe_compile
    return compiler(source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 118, in __call__
    codeob = compile(source, filename, symbol, self.flags, True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<input>", line 2
    RTRErrorReport in pkt and pkt.error_code == 1and pkt.error_text == b'Internal Error'
                                                ^
SyntaxError: invalid decimal literal
```
and
```python
>>> assert msg.rx_ext_address is 0xE2
Traceback (most recent call last):
  File "/usr/lib64/python3.11/codeop.py", line 153, in __call__
    return _maybe_compile(self.compiler, source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 73, in _maybe_compile
    return compiler(source, filename, symbol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/codeop.py", line 118, in __call__
    codeob = compile(source, filename, symbol, self.flags, True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<input>", line 2
SyntaxError: "is" with a literal. Did you mean "=="?
```