### PR TITLE
Radiotap MCS alignment fix

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -386,10 +386,7 @@ class RadioTap(Packet):
             lambda pkt: pkt.present and pkt.present.ChannelPlus),
         # MCS
         ConditionalField(
-            ReversePadField(
-                FlagsField("knownMCS", None, -8, _rt_knownmcs),
-                2
-            ),
+            FlagsField("knownMCS", None, -8, _rt_knownmcs),
             lambda pkt: pkt.present and pkt.present.MCS),
         ConditionalField(
             BitField("Ness_LSB", 0, 1),


### PR DESCRIPTION
padding alignment used to be 4, now it's 2, but in radiotap.org the alignment is 1 so the ReversePadField is redundant.