### PR TITLE
netflow - add IP_DSCP support

### DIFF
--- a/scapy/layers/netflow.py
+++ b/scapy/layers/netflow.py
@@ -1092,6 +1092,7 @@ NetflowV9TemplateFieldDefaultLengths = {
     77: 3,
     78: 3,
     79: 3,
+    195: 1,
 }
 
 # NetflowV9 Ready-made fields
@@ -1202,6 +1203,7 @@ NetflowV9TemplateFieldDecoders = {
     160: (N9UTCTimeField, [True]),  # systemInitTimeMilliseconds
     161: (N9SecondsIntField, [True]),  # flowDurationMilliseconds
     162: (N9SecondsIntField, [False, True]),  # flowDurationMicroseconds
+    195: XByteField,  # IP_DSCP
     211: IPField,  # collectorIPv4Address
     212: IP6Field,  # collectorIPv6Address
     225: IPField,  # postNATSourceIPv4Address

--- a/test/scapy/layers/netflow.uts
+++ b/test/scapy/layers/netflow.uts
@@ -456,3 +456,30 @@ records = dissected_packets[3][NetflowDataflowsetV9].records
 assert len(records) == 24
 assert records[0].IPV4_SRC_ADDR == '20.0.1.174'
 assert records[0].IPV4_NEXT_HOP == '10.100.103.1'
+
+# test for netflow IP_DSCP (id=195)
+dscp_flowset = NetflowFlowsetV9(
+    templates=[
+        NetflowTemplateV9(
+            template_fields=[
+                NetflowTemplateFieldV9(fieldType=195),
+            ],
+            templateID=273,
+        )
+    ],
+    flowSetID=2,
+)
+
+recordClass = GetNetflowRecordV9(dscp_flowset, templateID=273)
+
+dscp_dataset = NetflowDataflowsetV9(
+    templateID=273,
+    records=[
+        recordClass(
+            IP_DSCP=42,
+        ),
+    ],
+)
+
+# record is generated with 2 zero bytes of padding
+assert(raw(dscp_dataset) == b'\x01\x11\x00\x08\x2a\x00\x00\x00')


### PR DESCRIPTION
DSCP is a one-byte field just like TOS, and is already listed in the list of possible values in the template (NetflowV910TemplateFieldTypes), this just adds it to the list of possible values.

