### PR TITLE
layers.inet.fragment: use fragsize=8 if argument is lower than that

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -619,6 +619,7 @@ class IP(Packet, IPTools):
 
     def fragment(self, fragsize=1480):
         """Fragment IP datagrams"""
+        fragsize = max(fragsize, 8)
         lastfragsz = fragsize
         fragsize -= fragsize % 8
         lst = []
@@ -1139,6 +1140,7 @@ conf.neighbor.register_l3(Dot3, IP, inet_register_l3)
 @conf.commands.register
 def fragment(pkt, fragsize=1480):
     """Fragment a big IP datagram"""
+    fragsize = max(fragsize, 8)
     lastfragsz = fragsize
     fragsize -= fragsize % 8
     lst = []

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -150,6 +150,25 @@ assert len(frags2) == 2
 assert len(frags2[0]) == 20 + paylen - paylen % 8
 assert len(frags2[1]) == 20 + 1 + paylen % 8
 
+= fragment() with fragsize lower than 8
+paylen = 5
+fragsize = paylen
+frags1 = fragment(IP() / ("X" * paylen), paylen)
+assert len(frags1) == 1
+assert bytes(frags1[0].payload) == b"X" * paylen
+
+fragsize = paylen + 1
+frags2 = fragment(IP() / ("X" * paylen), fragsize)
+assert len(frags2) == 1
+assert bytes(frags2[0].payload) == b"X" * paylen
+
+paylen = 16
+fragsize = 5
+frags3 = fragment(IP() / ("X" * paylen), fragsize)
+assert len(frags3) == 2
+assert bytes(frags3[0].payload) == b"X" * 8
+assert bytes(frags3[1].payload) == b"X" * 8
+
 = defrag()
 nonfrag, unfrag, badfrag = defrag(frags)
 assert not nonfrag


### PR DESCRIPTION
fragment was raising a ZeroDivisionError when given a frag size < 8. This is a regression, as versions older than 2.4.4 didn't have this problem. It was a side-effect of fixing fragment to support frag sizes that are not multiples of 8.

This commit simply tops up frag size to 8 if it's lower, as IP can't really handle fragments smaller than that anyway, due to the way the Fragment Offset field works.
