### PR TITLE
Tolerate decoding errors in NetBIOS names

### DIFF
--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -142,7 +142,7 @@ class NBNSQueryRequest(Packet):
 
     def mysummary(self):
         return "NBNSQueryRequest who has '\\\\%s'" % (
-            self.QUESTION_NAME.strip().decode()
+            self.QUESTION_NAME.strip().decode(errors="backslashreplace")
         )
 
 
@@ -181,7 +181,7 @@ class NBNSQueryResponse(Packet):
         if not self.ADDR_ENTRY:
             return "NBNSQueryResponse"
         return "NBNSQueryResponse '\\\\%s' is at %s" % (
-            self.RR_NAME.strip().decode(),
+            self.RR_NAME.strip().decode(errors="backslashreplace"),
             self.ADDR_ENTRY[0].NB_ADDRESS
         )
 
@@ -199,7 +199,7 @@ class NBNSNodeStatusRequest(NBNSQueryRequest):
 
     def mysummary(self):
         return "NBNSNodeStatusRequest who has '\\\\%s'" % (
-            self.QUESTION_NAME.strip().decode()
+            self.QUESTION_NAME.strip().decode(errors="backslashreplace")
         )
 
 

--- a/test/scapy/layers/netbios.uts
+++ b/test/scapy/layers/netbios.uts
@@ -15,8 +15,12 @@ assert raw(z) == b'\x00\x00\x01\x10\x00\x01\x00\x00\x00\x00\x00\x00 FEEFFDFEDBCA
 pkt = IP(dst='192.168.0.255')/UDP(sport=137, dport='netbios_ns')/z
 pkt = IP(raw(pkt))
 assert pkt.QUESTION_NAME == b'TEST1          '
+assert pkt[NBNSQueryRequest].mysummary() == r"NBNSQueryRequest who has '\\TEST1'"
 
 assert NBNSQueryRequest in NBNSHeader(raw(z))
+
+z = NBNSQueryRequest(b' PPCACACACACACACACACACACACACACAAA\x00\x00 \x00\x01')
+assert z.mysummary() == r"NBNSQueryRequest who has '\\\xff'"
 
 = NBNSQueryResponse - build & dissect
 
@@ -26,6 +30,11 @@ assert raw(z) == b'\x00\x00\x85\x00\x00\x00\x00\x01\x00\x00\x00\x00 EGFCEFEECACA
 pkt = NBNSHeader(raw(z))
 assert NBNSQueryResponse in pkt
 assert pkt.ADDR_ENTRY[0].NB_ADDRESS == "192.168.0.13"
+assert pkt[NBNSQueryResponse].mysummary() == r"NBNSQueryResponse '\\FRED' is at 192.168.0.13"
+
+z = NBNSQueryResponse(b' PPFCEFEECACACACACACACACACACACAAA\x00\x00 \x00\x01\x00\x04\x93\xe0\x00\x06\x00\x00\xc0\xa8\x00\r')
+assert z.mysummary() == r"NBNSQueryResponse '\\\xffRED' is at 192.168.0.13"
+
 
 = NBNSNodeStatusResponse - build & dissect
 
@@ -39,10 +48,14 @@ assert NBNSNodeStatusResponse in pkt
 
 pkt = UDP()/NBNSHeader()/NBNSNodeStatusRequest()
 assert raw(pkt.payload) == b'\x00\x00\x00\x10\x00\x01\x00\x00\x00\x00\x00\x00 CKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\x00\x00!\x00\x01'
+assert pkt[NBNSNodeStatusRequest].mysummary() == "NBNSNodeStatusRequest who has '\\\\*\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'"
 
 resp = UDP(b'\x00\x89\x00\x89\x00\xc9v>\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00 CKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\x00\x00!\x00\x01\x00\x00\x00\x00\x00\x89\x05DOMAIN         \x00\x84\x00SRV1           \x00\x04\x00DOMAIN         \x1c\x84\x00SRV1            \x04\x00DOMAIN         \x1b\x04\x00RT\x00iX\x13\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 assert [x.NETBIOS_NAME.strip() for x in resp.NODE_NAME] == [b'DOMAIN', b'SRV1', b'DOMAIN', b'SRV1', b'DOMAIN']
 assert resp.answers(pkt)
+
+z = NBNSNodeStatusRequest(b' PPCACACACACACACACACACACACACACAAA\x00\x00!\x00\x01')
+assert z.mysummary() == r"NBNSNodeStatusRequest who has '\\\xff'"
 
 = NBNSWackResponse - build & dissect
 


### PR DESCRIPTION
Fixes:
```
File scapy/scapy/sendrecv.py:1438, in tshark(*args, **kargs)
File scapy/scapy/sendrecv.py:1310, in sniff(*args, **kwargs)
File scapy/scapy/sendrecv.py:1253, in AsyncSniffer._run(self, count, store, offline, quiet, prn, lfilter, L2socket, timeout, opened_socket, stop_filter, iface, started_callback, session, session_kwargs, **karg)
File scapy/scapy/sessions.py:109, in DefaultSession.on_packet_received(self, pkt)
File scapy/scapy/sendrecv.py:1435, in tshark.<locals>._cb(pkt)
File scapy/scapy/packet.py:1637, in Packet.summary(self, intern)
File scapy/scapy/packet.py:1611, in Packet._do_summary(self)
File scapy/scapy/packet.py:1611, in Packet._do_summary(self)
    [... skipping similar frames: Packet._do_summary at line 1611 (1 times)]
File scapy/scapy/packet.py:1611, in Packet._do_summary(self)
File scapy/scapy/packet.py:1614, in Packet._do_summary(self)
File scapy/scapy/layers/netbios.py:145, in NBNSQueryRequest.mysummary(self)
    143 def mysummary(self):
    144     return "NBNSQueryRequest who has '\\\\%s'" % (
--> 145         self.QUESTION_NAME.strip().decode()
    146     )
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

It's a follow-up to c17140a419e3e4496706faa1cb9753816a6c586b