### PR TITLE
Use the typing module (Python 3)

### DIFF
--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -22,7 +22,7 @@ from scapy.sendrecv import send, sniff, AsyncSniffer
 from scapy.packet import Packet
 from scapy.plist import PacketList
 
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -25,7 +25,7 @@ from scapy.interfaces import NetworkInterface, network_name
 from scapy.pton_ntop import inet_pton, inet_ntop
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Optional,
     Union,
 )

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -17,7 +17,7 @@ from scapy.utils import decode_locale_str
 
 # Type imports
 import scapy
-from scapy.compat import (
+from typing import (
     Optional,
     Union,
 )

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -37,7 +37,7 @@ from scapy.utils import str2mac, decode_locale_str
 
 import scapy.consts
 
-from scapy.compat import (
+from typing import (
     cast,
     Dict,
     List,

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -48,7 +48,7 @@ from scapy.pton_ntop import inet_ntop
 from scapy.supersocket import SuperSocket
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -23,7 +23,7 @@ from scapy.utils6 import in6_getscope, construct_source_candidate_set
 from scapy.utils6 import in6_isvalid, in6_ismlladdr, in6_ismnladdr
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     List,
     Optional,
     Tuple,

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -39,17 +39,17 @@ from scapy.compat import plain_str
 from scapy.supersocket import SuperSocket
 
 # Typing imports
-from scapy.compat import (
-    cast,
-    overload,
+from typing import (
     Any,
     Dict,
     List,
-    Literal,
     Optional,
     Tuple,
     Union,
+    cast,
+    overload,
 )
+from scapy.compat import Literal
 
 conf.use_pcap = True
 

--- a/scapy/arch/windows/native.py
+++ b/scapy/arch/windows/native.py
@@ -58,7 +58,7 @@ from scapy.interfaces import resolve_iface, _GlobInterfaceType
 from scapy.supersocket import SuperSocket
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     List,
     Optional,

--- a/scapy/arch/windows/structures.py
+++ b/scapy/arch/windows/structures.py
@@ -25,7 +25,7 @@ from scapy.config import conf
 from scapy.consts import WINDOWS_XP
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     List,

--- a/scapy/as_resolvers.py
+++ b/scapy/as_resolvers.py
@@ -12,7 +12,7 @@ import socket
 from scapy.config import conf
 from scapy.compat import plain_str
 
-from scapy.compat import (
+from typing import (
     Any,
     Optional,
     Tuple,

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -17,7 +17,7 @@ from scapy.volatile import RandField, RandIP, GeneralizedTime
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
 from scapy.compat import plain_str, bytes_encode, chb, orb
 
-from scapy.compat import (
+from typing import (
     Any,
     AnyStr,
     Dict,

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -28,7 +28,7 @@ from scapy.asn1.asn1 import (
     _ASN1_ERROR,
 )
 
-from scapy.compat import (
+from typing import (
     Any,
     AnyStr,
     Dict,

--- a/scapy/asn1/mib.py
+++ b/scapy/asn1/mib.py
@@ -15,7 +15,7 @@ from scapy.config import conf
 from scapy.utils import do_graph
 from scapy.compat import plain_str
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     List,

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -42,7 +42,7 @@ from scapy.volatile import (
 
 from scapy import packet
 
-from scapy.compat import (
+from typing import (
     Any,
     AnyStr,
     Callable,
@@ -52,12 +52,10 @@ from scapy.compat import (
     Optional,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     TYPE_CHECKING,
-)
-from typing import (
-    TypeVar,
 )
 
 if TYPE_CHECKING:

--- a/scapy/asn1packet.py
+++ b/scapy/asn1packet.py
@@ -12,7 +12,7 @@ Packet holding data in Abstract Syntax Notation (ASN.1).
 from scapy.base_classes import Packet_metaclass
 from scapy.packet import Packet
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     Tuple,

--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -34,10 +34,10 @@ from scapy.supersocket import SuperSocket
 from scapy.packet import Packet
 from scapy.consts import WINDOWS
 
-from scapy.compat import (
+# Typing imports
+from typing import (
     Any,
     Callable,
-    DecoratorCallable,
     Deque,
     Dict,
     Generic,
@@ -52,6 +52,7 @@ from scapy.compat import (
     Union,
     cast,
 )
+from scapy.compat import DecoratorCallable
 
 
 def select_objects(inputs, remain):
@@ -173,7 +174,7 @@ class ObjectPipe(Generic[_T]):
         return self.__rd
 
     def send(self, obj):
-        # type: (Union[_T]) -> int
+        # type: (_T) -> int
         self.__queue.append(obj)
         if WINDOWS:
             self._winset()

--- a/scapy/autorun.py
+++ b/scapy/autorun.py
@@ -21,7 +21,7 @@ from scapy.themes import NoTheme, DefaultTheme, HTMLTheme2, LatexTheme2
 from scapy.error import log_scapy, Scapy_Exception
 from scapy.utils import tex_escape
 
-from scapy.compat import (
+from typing import (
     Any,
     Optional,
     TextIO,

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -28,7 +28,7 @@ import scapy
 from scapy.error import Scapy_Exception
 from scapy.consts import WINDOWS
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     Generic,

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -8,45 +8,26 @@ Python 2 and 3 link classes.
 
 import base64
 import binascii
-import collections
 import struct
 import sys
+
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Optional,
+    TypeVar,
+    TYPE_CHECKING,
+    Union,
+)
 
 # Very important: will issue typing errors otherwise
 __all__ = [
     # typing
-    'Any',
-    'AnyStr',
-    'Callable',
-    'DefaultDict',
-    'Deque',
-    'Dict',
-    'Generic',
-    'IO',
-    'Iterable',
-    'Iterable',
-    'Iterator',
-    'List',
+    'DecoratorCallable',
     'Literal',
-    'NewType',
-    'NoReturn',
-    'Optional',
-    'Pattern',
-    'Sequence',
-    'Set',
     'Self',
-    'Sized',
-    'TextIO',
-    'Tuple',
-    'Type',
-    'TypeVar',
-    'Union',
     'UserDict',
-    'ValuesView',
-    'cast',
-    'overload',
-    'FAKE_TYPING',
-    'TYPE_CHECKING',
     # compat
     'base64_bytes',
     'bytes_base64',
@@ -54,7 +35,6 @@ __all__ = [
     'bytes_hex',
     'chb',
     'hex_bytes',
-    'lambda_tuple_converter',
     'orb',
     'plain_str',
     'raw',
@@ -64,25 +44,9 @@ __all__ = [
 
 # Note:
 # supporting typing on multiple python versions is a nightmare.
-# Since Python 3.7, Generic is a type instead of a metaclass,
-# therefore we can't support both at the same time. Our strategy
-# is to only use the typing module if the Python version is >= 3.7
-# and use totally fake replacements otherwise.
-# HOWEVER, when using the fake ones, to emulate stub Generic
-# fields (e.g. _PacketField[str]) we need to add a fake
-# __getitem__ to Field_metaclass
-
-try:
-    import typing  # noqa: F401
-    from typing import TYPE_CHECKING
-    if sys.version_info[0:2] <= (3, 6):
-        # Generic is messed up before Python 3.7
-        # https://github.com/python/typing/issues/449
-        raise ImportError
-    FAKE_TYPING = False
-except ImportError:
-    FAKE_TYPING = True
-    TYPE_CHECKING = False
+# we provide a FakeType class to be able to use types added on
+# later Python versions (since we run mypy on 3.11), on older
+# ones.
 
 
 # Import or create fake types
@@ -108,71 +72,6 @@ def _FakeType(name, cls=object):
             # type: () -> str
             return "<Fake typing.%s>" % self.name
     return _FT(name)
-
-
-if not FAKE_TYPING:
-    # Only required if using mypy-lang for static typing
-    from typing import (
-        Any,
-        AnyStr,
-        Callable,
-        DefaultDict,
-        Deque,
-        Dict,
-        Generic,
-        IO,
-        Iterable,
-        Iterator,
-        List,
-        NewType,
-        NoReturn,
-        Optional,
-        Pattern,
-        Sequence,
-        Set,
-        Sized,
-        TextIO,
-        Tuple,
-        Type,
-        TypeVar,
-        Union,
-        ValuesView,
-        cast,
-        overload,
-    )
-else:
-    # Let's be creative and make some fake ones.
-    def cast(_type, obj):  # type: ignore
-        return obj
-
-    Any = _FakeType("Any")
-    AnyStr = _FakeType("AnyStr")  # type: ignore
-    Callable = _FakeType("Callable")
-    DefaultDict = _FakeType("DefaultDict",  # type: ignore
-                            collections.defaultdict)
-    Deque = _FakeType("Deque")  # type: ignore
-    Dict = _FakeType("Dict", dict)  # type: ignore
-    IO = _FakeType("IO")  # type: ignore
-    Iterable = _FakeType("Iterable")  # type: ignore
-    Iterator = _FakeType("Iterator")  # type: ignore
-    List = _FakeType("List", list)  # type: ignore
-    NewType = _FakeType("NewType")  # type: ignore
-    NoReturn = _FakeType("NoReturn")
-    Optional = _FakeType("Optional")
-    Pattern = _FakeType("Pattern")  # type: ignore
-    Sequence = _FakeType("Sequence", list)  # type: ignore
-    Set = _FakeType("Set", set)  # type: ignore
-    TextIO = _FakeType("TextIO")  # type: ignore
-    Tuple = _FakeType("Tuple")
-    Type = _FakeType("Type", type)
-    TypeVar = _FakeType("TypeVar")  # type: ignore
-    Union = _FakeType("Union")
-    ValuesView = _FakeType("List", list)  # type: ignore
-
-    class Sized:  # type: ignore
-        pass
-
-    overload = lambda x: x
 
 
 # Python 3.8 Only
@@ -204,22 +103,6 @@ else:
 DecoratorCallable = TypeVar("DecoratorCallable", bound=Callable[..., Any])
 
 
-def lambda_tuple_converter(func):
-    # type: (DecoratorCallable) -> DecoratorCallable
-    """
-    Converts a Python 2 function as
-      lambda (x,y): x + y
-    In the Python 3 format:
-      lambda x,y : x + y
-    """
-    if func is not None and func.__code__.co_argcount == 1:
-        return lambda *args: func(  # type: ignore
-            args[0] if len(args) == 1 else args
-        )
-    else:
-        return func
-
-
 # This is ugly, but we don't want to move raw() out of compat.py
 # and it makes it much clearer
 if TYPE_CHECKING:
@@ -227,7 +110,7 @@ if TYPE_CHECKING:
 
 
 def raw(x):
-    # type: (Union[Packet]) -> bytes
+    # type: (Packet) -> bytes
     """
     Builds a packet and returns its bytes representation.
     This function is and will always be cross-version compatible

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -25,11 +25,11 @@ from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
 from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
 from scapy.themes import NoTheme, apply_ipython_style
 
-from scapy.compat import (
+# Typing imports
+from typing import (
     cast,
     Any,
     Callable,
-    DecoratorCallable,
     Dict,
     Iterator,
     List,
@@ -43,11 +43,12 @@ from scapy.compat import (
     TYPE_CHECKING,
 )
 from types import ModuleType
+from scapy.compat import DecoratorCallable
 
 if TYPE_CHECKING:
     # Do not import at runtime
     import scapy.as_resolvers
-    from scapy.nmap import NmapKnowledgeBase
+    from scapy.modules.nmap import NmapKnowledgeBase
     from scapy.packet import Packet
     from scapy.supersocket import SuperSocket  # noqa: F401
     import scapy.asn1.asn1

--- a/scapy/contrib/automotive/bmw/enumerator.py
+++ b/scapy/contrib/automotive/bmw/enumerator.py
@@ -8,11 +8,15 @@
 
 
 from scapy.packet import Packet
-from scapy.compat import Any, Iterable
 from scapy.contrib.automotive.scanner.enumerator import _AutomotiveTestCaseScanResult  # noqa: E501
 from scapy.contrib.automotive.uds import UDS
 from scapy.contrib.automotive.bmw.definitions import DEV_JOB
 from scapy.contrib.automotive.uds_scan import UDS_Enumerator
+
+from typing import (
+    Any,
+    Iterable,
+)
 
 
 class BMW_DevJobEnumerator(UDS_Enumerator):

--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -10,7 +10,6 @@ import struct
 import socket
 import time
 
-from scapy.compat import Optional, Tuple, Type, Iterable, List, Union
 from scapy.contrib.automotive import log_automotive
 from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.fields import IntField, ShortEnumField, XByteField
@@ -18,6 +17,15 @@ from scapy.layers.inet import TCP
 from scapy.supersocket import StreamSocket
 from scapy.contrib.automotive.uds import UDS, UDS_TP
 from scapy.data import MTU
+
+from typing import (
+    Optional,
+    Tuple,
+    Type,
+    Iterable,
+    List,
+    Union,
+)
 
 
 """

--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -21,7 +21,12 @@ from scapy.supersocket import StreamSocket
 from scapy.layers.inet import TCP, UDP
 from scapy.contrib.automotive.uds import UDS
 from scapy.data import MTU
-from scapy.compat import Union, Tuple, Optional
+
+from typing import (
+    Union,
+    Tuple,
+    Optional,
+)
 
 
 class DoIP(Packet):

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -15,14 +15,27 @@ from collections import defaultdict
 from types import GeneratorType
 from threading import Lock
 
-from scapy.compat import Any, Union, Iterable, Callable, List, Optional, \
-    Tuple, Type, cast, Dict, orb
+from scapy.compat import orb
 from scapy.packet import Raw, Packet
 from scapy.plist import PacketList
 from scapy.sessions import DefaultSession
 from scapy.ansmachine import AnsweringMachine
 from scapy.supersocket import SuperSocket
 from scapy.error import Scapy_Exception
+
+# Typing imports
+from typing import (
+    Any,
+    Union,
+    Iterable,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    cast,
+    Dict,
+)
 
 
 __all__ = ["EcuState", "Ecu", "EcuResponse", "EcuSession",

--- a/scapy/contrib/automotive/gm/gmlan_logging.py
+++ b/scapy/contrib/automotive/gm/gmlan_logging.py
@@ -13,8 +13,13 @@ from scapy.contrib.automotive.gm.gmlan import GMLAN_SA, GMLAN_IDO, GMLAN_DC, \
     GMLAN_RDBI, GMLAN_RDBIPR, GMLAN_RDBPI, GMLAN_RDBPIPR, GMLAN_RDBPKTI, \
     GMLAN_RFRD, GMLAN_RFRDPR, GMLAN_RMBA, GMLAN_RMBAPR, GMLAN_DDM, GMLAN_DDMPR
 from scapy.packet import Packet
-from scapy.compat import Tuple, Any
 from scapy.contrib.automotive.ecu import Ecu
+
+# Typing imports
+from typing import (
+    Any,
+    Tuple,
+)
 
 
 @Ecu.extend_pkt_with_logging(GMLAN_IDO)

--- a/scapy/contrib/automotive/gm/gmlan_scanner.py
+++ b/scapy/contrib/automotive/gm/gmlan_scanner.py
@@ -13,8 +13,7 @@ import copy
 
 from collections import defaultdict
 
-from scapy.compat import Optional, List, Type, Any, Tuple, Iterable, Dict, \
-    cast, Callable, orb
+from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.packet import Packet
 from scapy.config import conf
@@ -42,6 +41,18 @@ from scapy.contrib.automotive.scanner.executor import \
 # TODO: Refactor this import
 from scapy.contrib.automotive.gm.gmlan_ecu_states import *  # noqa: F401, F403
 
+# Typing imports
+from typing import (
+    Optional,
+    List,
+    Type,
+    Any,
+    Tuple,
+    Iterable,
+    Dict,
+    cast,
+    Callable,
+)
 
 __all__ = ["GMLAN_Scanner", "GMLAN_ServiceEnumerator", "GMLAN_RDBIEnumerator",
            "GMLAN_RDBPIEnumerator", "GMLAN_RMBAEnumerator",

--- a/scapy/contrib/automotive/gm/gmlanutils.py
+++ b/scapy/contrib/automotive/gm/gmlanutils.py
@@ -9,7 +9,6 @@
 
 import time
 
-from scapy.compat import Optional, cast, Callable
 from scapy.contrib.automotive import log_automotive
 
 from scapy.contrib.automotive.gm.gmlan import GMLAN, GMLAN_SA, GMLAN_RD, \
@@ -19,6 +18,12 @@ from scapy.packet import Packet
 from scapy.supersocket import SuperSocket
 from scapy.contrib.isotp import ISOTPSocket
 from scapy.utils import PeriodicSenderThread
+
+from typing import (
+    Optional,
+    cast,
+    Callable,
+)
 
 __all__ = ["GMLAN_TesterPresentSender", "GMLAN_InitDiagnostics",
            "GMLAN_GetSecurityAccess", "GMLAN_RequestDownload",

--- a/scapy/contrib/automotive/kwp.py
+++ b/scapy/contrib/automotive/kwp.py
@@ -17,7 +17,11 @@ from scapy.error import log_loading
 from scapy.utils import PeriodicSenderThread
 from scapy.plist import _PacketIterable
 from scapy.contrib.isotp import ISOTP
-from scapy.compat import Dict, Any
+
+from typing import (
+    Dict,
+    Any,
+)
 
 
 try:

--- a/scapy/contrib/automotive/obd/scanner.py
+++ b/scapy/contrib/automotive/obd/scanner.py
@@ -10,7 +10,6 @@
 
 import copy
 
-from scapy.compat import List, Type, Any, Iterable
 from scapy.contrib.automotive.obd.obd import OBD, OBD_S03, OBD_S07, OBD_S0A, \
     OBD_S01, OBD_S06, OBD_S08, OBD_S09, OBD_NR, OBD_S02, OBD_S02_Record
 from scapy.config import conf
@@ -24,6 +23,14 @@ from scapy.contrib.automotive.scanner.executor import \
 from scapy.contrib.automotive.ecu import EcuState
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCaseABC, \
     _SocketUnion
+
+# Typing imports
+from typing import (
+    List,
+    Type,
+    Any,
+    Iterable,
+)
 
 
 class OBD_Enumerator(ServiceEnumerator):

--- a/scapy/contrib/automotive/scanner/configuration.py
+++ b/scapy/contrib/automotive/scanner/configuration.py
@@ -9,11 +9,20 @@
 import inspect
 from threading import Event
 
-from scapy.compat import Any, Union, List, Type, Set, cast
 from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.scanner.graph import Graph
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCaseABC
 from scapy.contrib.automotive.scanner.staged_test_case import StagedAutomotiveTestCase  # noqa: E501
+
+# Typing imports
+from typing import (
+    Any,
+    Union,
+    List,
+    Type,
+    Set,
+    cast,
+)
 
 
 class AutomotiveTestCaseExecutorConfiguration(object):

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -15,8 +15,7 @@ from collections import defaultdict, OrderedDict
 from itertools import chain
 from typing import NamedTuple
 
-from scapy.compat import Any, Union, List, Optional, Iterable, \
-    Dict, Tuple, Set, Callable, cast, orb
+from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.error import Scapy_Exception
 from scapy.utils import make_lined_table, EDecimal
@@ -27,6 +26,20 @@ from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCase, \
 from scapy.contrib.automotive.scanner.configuration import \
     AutomotiveTestCaseExecutorConfiguration
 from scapy.contrib.automotive.scanner.graph import _Edge
+
+# Typing imports
+from typing import (
+    Any,
+    Union,
+    List,
+    Optional,
+    Iterable,
+    Dict,
+    Tuple,
+    Set,
+    Callable,
+    cast,
+)
 
 # Definition outside the class ServiceEnumerator to allow pickling
 _AutomotiveTestCaseScanResult = NamedTuple(
@@ -526,7 +539,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
              len(self.results_without_response)) + "\n"
 
         s += "Statistics per state\n"
-        s += make_lined_table(stats, lambda x: x, dump=True, sortx=str,
+        s += make_lined_table(stats, lambda *x: x, dump=True, sortx=str,
                               sorty=str) or ""
 
         return s + "\n"
@@ -649,8 +662,9 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
     def _show_results_information(self, **kwargs):
         # type: (Any) -> str
         def _get_table_entry(
-                tup  # type: _AutomotiveTestCaseScanResult
+            *args: Any
         ):  # type: (...) -> Tuple[str, str, str]
+            tup = cast(_AutomotiveTestCaseScanResult, args)
             return self._get_table_entry_x(tup), \
                 self._get_table_entry_y(tup), \
                 self._get_table_entry_z(tup)

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -11,8 +11,6 @@ import time
 
 from itertools import product
 
-from scapy.compat import Any, Union, List, Optional, \
-    Dict, Callable, Type, cast
 from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.scanner.graph import Graph
 from scapy.error import Scapy_Exception
@@ -24,6 +22,18 @@ from scapy.contrib.automotive.scanner.configuration import \
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCaseABC, \
     _SocketUnion, _CleanupCallable, StateGenerator, TestCaseGenerator, \
     AutomotiveTestCase
+
+# Typing imports
+from typing import (
+    Any,
+    Union,
+    List,
+    Optional,
+    Dict,
+    Callable,
+    Type,
+    cast,
+)
 
 
 class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):

--- a/scapy/contrib/automotive/scanner/graph.py
+++ b/scapy/contrib/automotive/scanner/graph.py
@@ -8,9 +8,19 @@
 
 from collections import defaultdict
 
-from scapy.compat import Union, List, Optional, Dict, Tuple, Set, TYPE_CHECKING
 from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.ecu import EcuState
+
+# Typing imports
+from typing import (
+    Union,
+    List,
+    Optional,
+    Dict,
+    Tuple,
+    Set,
+    TYPE_CHECKING,
+)
 
 _Edge = Tuple[EcuState, EcuState]
 

--- a/scapy/contrib/automotive/scanner/staged_test_case.py
+++ b/scapy/contrib/automotive/scanner/staged_test_case.py
@@ -7,14 +7,23 @@
 # scapy.contrib.status = library
 
 
-from scapy.compat import Any, List, Optional, Dict, Callable, cast, \
-    TYPE_CHECKING, Tuple
 from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.scanner.graph import _Edge
 from scapy.contrib.automotive.ecu import EcuState, EcuResponse, Ecu
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCaseABC, \
     TestCaseGenerator, StateGenerator, _SocketUnion
 
+# Typing imports
+from typing import (
+    Any,
+    List,
+    Optional,
+    Dict,
+    Callable,
+    cast,
+    Tuple,
+    TYPE_CHECKING,
+)
 if TYPE_CHECKING:
     from scapy.contrib.automotive.scanner.test_case import _TransitionTuple
     from scapy.contrib.automotive.scanner.configuration import \

--- a/scapy/contrib/automotive/scanner/test_case.py
+++ b/scapy/contrib/automotive/scanner/test_case.py
@@ -10,8 +10,6 @@
 import abc
 from collections import defaultdict
 
-from scapy.compat import Any, Union, List, Optional, \
-    Dict, Tuple, Set, Callable, TYPE_CHECKING
 from scapy.utils import make_lined_table, SingleConversationSocket
 from scapy.supersocket import SuperSocket
 from scapy.contrib.automotive.scanner.graph import _Edge
@@ -19,6 +17,18 @@ from scapy.contrib.automotive.ecu import EcuState, EcuResponse
 from scapy.error import Scapy_Exception
 
 
+# Typing imports
+from typing import (
+    Any,
+    Union,
+    List,
+    Optional,
+    Dict,
+    Tuple,
+    Set,
+    Callable,
+    TYPE_CHECKING,
+)
 if TYPE_CHECKING:
     from scapy.contrib.automotive.scanner.configuration import AutomotiveTestCaseExecutorConfiguration  # noqa: E501
 
@@ -209,7 +219,7 @@ class AutomotiveTestCase(AutomotiveTestCaseABC):
         completed = [(state, self._state_completed[state])
                      for state in self.scanned_states]
         return make_lined_table(
-            completed, lambda tup: ("Scan state completed", tup[0], tup[1]),
+            completed, lambda x, y: ("Scan state completed", x, y),
             dump=True) or ""
 
     def show(self, dump=False, filtered=True, verbose=False):

--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -6,6 +6,10 @@
 # scapy.contrib.description = Unified Diagnostic Service (UDS)
 # scapy.contrib.status = loads
 
+"""
+UDS
+"""
+
 import struct
 
 from scapy.fields import ByteEnumField, StrField, ConditionalField, \
@@ -18,11 +22,12 @@ from scapy.config import conf
 from scapy.error import log_loading
 from scapy.utils import PeriodicSenderThread
 from scapy.contrib.isotp import ISOTP
-from scapy.compat import Dict, Union
 
-"""
-UDS
-"""
+# Typing imports
+from typing import (
+    Dict,
+    Union,
+)
 
 try:
     if conf.contribs['UDS']['treat-response-pending-as-answer']:

--- a/scapy/contrib/automotive/uds_logging.py
+++ b/scapy/contrib/automotive/uds_logging.py
@@ -14,8 +14,12 @@ from scapy.contrib.automotive.uds import UDS_DSCPR, UDS_ERPR, UDS_SAPR, \
     UDS_RTE, UDS_RTEPR, UDS_RFTPR, UDS_IOCBI, UDS_RDBI, UDS_RMBA, UDS_WDBI, \
     UDS_CDTCS, UDS_CDTCSPR, UDS_SDT, UDS_SDTPR, UDS_RUPR
 from scapy.packet import Packet
-from scapy.compat import Tuple, Any
 from scapy.contrib.automotive.ecu import Ecu
+
+from typing import (
+    Any,
+    Tuple,
+)
 
 
 @Ecu.extend_pkt_with_logging(UDS_DSC)

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -16,10 +16,7 @@ import inspect
 
 from collections import defaultdict
 
-from typing import NamedTuple
-
-from scapy.compat import Dict, Optional, List, Type, Any, Iterable, \
-    cast, Union, orb, Set, Sequence
+from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.packet import Raw, Packet
 from scapy.error import Scapy_Exception
@@ -41,6 +38,21 @@ from scapy.contrib.automotive.scanner.executor import AutomotiveTestCaseExecutor
 
 # TODO: Refactor this import
 from scapy.contrib.automotive.uds_ecu_states import *  # noqa: F401, F403
+
+# typing imports
+from typing import (
+    Dict,
+    Optional,
+    NamedTuple,
+    List,
+    Type,
+    Any,
+    Iterable,
+    cast,
+    Union,
+    Set,
+    Sequence,
+)
 
 
 # Definition outside the class UDS_RMBASequentialEnumerator

--- a/scapy/contrib/automotive/xcp/scanner.py
+++ b/scapy/contrib/automotive/xcp/scanner.py
@@ -7,7 +7,6 @@
 # scapy.contrib.status = loads
 import logging
 from collections import namedtuple
-from scapy.compat import Optional, List, Type, Iterator
 
 from scapy.config import conf
 from scapy.contrib.automotive import log_automotive
@@ -17,6 +16,14 @@ from scapy.contrib.automotive.xcp.cto_commands_slave import \
     ConnectPositiveResponse, TransportLayerCmdGetSlaveIdResponse
 from scapy.contrib.automotive.xcp.xcp import CTORequest, XCPOnCAN
 from scapy.contrib.cansocket_native import CANSocket
+
+# Typing imports
+from typing import (
+    Optional,
+    List,
+    Type,
+    Iterator,
+)
 
 XCPScannerResult = namedtuple('XCPScannerResult', 'request_id response_id')
 

--- a/scapy/contrib/cansocket_native.py
+++ b/scapy/contrib/cansocket_native.py
@@ -20,7 +20,17 @@ from scapy.error import Scapy_Exception, warning
 from scapy.packet import Packet
 from scapy.layers.can import CAN, CAN_MTU, CAN_FD_MTU
 from scapy.arch.linux import get_last_packet_timestamp
-from scapy.compat import List, Dict, Type, Any, Optional, Tuple, raw, cast
+from scapy.compat import raw
+
+from typing import (
+    List,
+    Dict,
+    Type,
+    Any,
+    Optional,
+    Tuple,
+    cast,
+)
 
 conf.contribs['NativeCANSocket'] = {'channel': "can0"}
 

--- a/scapy/contrib/cansocket_python_can.py
+++ b/scapy/contrib/cansocket_python_can.py
@@ -23,8 +23,15 @@ from scapy.supersocket import SuperSocket
 from scapy.layers.can import CAN
 from scapy.packet import Packet
 from scapy.error import warning
-from scapy.compat import List, Type, Tuple, Dict, Any, \
-    Optional, cast
+from typing import (
+    List,
+    Type,
+    Tuple,
+    Dict,
+    Any,
+    Optional,
+    cast,
+)
 
 from can import Message as can_Message
 from can import CanError as can_CanError

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -27,8 +27,16 @@ from scapy.compat import raw, plain_str, hex_bytes, orb, chb, bytes_encode
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".
 # Sized must be one of the superclasses of a class implementing __len__
-from scapy.compat import Optional, List, Union, Callable, Any, \
-    Tuple, Sized, Pattern  # noqa: F401
+from typing import (
+    Optional,
+    List,
+    Union,
+    Callable,
+    Any,
+    Tuple,
+    Sized,
+    Pattern,
+)
 from scapy.base_classes import Packet_metaclass  # noqa: F401
 
 import scapy.fields as fields

--- a/scapy/contrib/isotp/isotp_native_socket.py
+++ b/scapy/contrib/isotp/isotp_native_socket.py
@@ -11,7 +11,6 @@ from ctypes.util import find_library
 import struct
 import socket
 
-from scapy.compat import Optional, Union, Tuple, Type, cast
 from scapy.contrib.isotp import log_isotp
 from scapy.packet import Packet
 from scapy.error import Scapy_Exception
@@ -21,6 +20,15 @@ from scapy.config import conf
 from scapy.arch.linux import get_last_packet_timestamp, SIOCGIFINDEX
 from scapy.contrib.isotp.isotp_packet import ISOTP
 from scapy.layers.can import CAN_MTU, CAN_FD_MTU, CAN_MAX_DLEN, CAN_FD_MAX_DLEN
+
+# Typing imports
+from typing import (
+    Optional,
+    Union,
+    Tuple,
+    Type,
+    cast,
+)
 
 LIBC = ctypes.cdll.LoadLibrary(find_library("c"))  # type: ignore
 

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -9,7 +9,6 @@
 import struct
 import logging
 
-from scapy.compat import Optional, List, Tuple, Any, Type, cast
 from scapy.packet import Packet
 from scapy.fields import BitField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ConditionalField, \
@@ -17,6 +16,16 @@ from scapy.fields import BitField, FlagsField, StrLenField, \
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN
 from scapy.error import Scapy_Exception
+
+# Typing imports
+from typing import (
+    Optional,
+    List,
+    Tuple,
+    Any,
+    Type,
+    cast,
+)
 
 log_isotp = logging.getLogger("scapy.contrib.isotp")
 

--- a/scapy/contrib/isotp/isotp_scanner.py
+++ b/scapy/contrib/isotp/isotp_scanner.py
@@ -11,7 +11,6 @@ import time
 
 from threading import Event
 
-from scapy.compat import Iterable, Optional, Union, List, Tuple, Dict, Any
 from scapy.packet import Packet
 from scapy.compat import orb
 from scapy.layers.can import CAN
@@ -19,6 +18,17 @@ from scapy.supersocket import SuperSocket
 from scapy.contrib.cansocket import PYTHON_CAN
 from scapy.contrib.isotp.isotp_packet import ISOTPHeader, ISOTPHeaderEA, \
     ISOTP_FF, ISOTP
+
+# Typing imports
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 log_isotp = logging.getLogger("scapy.contrib.isotp")
 

--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -15,8 +15,6 @@ import socket
 
 from threading import Thread, Event, RLock
 
-from scapy.compat import Optional, Union, List, Tuple, Any, Type, cast, \
-    Callable, TYPE_CHECKING
 from scapy.packet import Packet
 from scapy.layers.can import CAN
 from scapy.error import Scapy_Exception
@@ -28,6 +26,18 @@ from scapy.automaton import ObjectPipe, select_objects
 from scapy.contrib.isotp.isotp_packet import ISOTP, CAN_MAX_DLEN, N_PCI_SF, \
     N_PCI_CF, N_PCI_FC, N_PCI_FF, ISOTP_MAX_DLEN, ISOTP_MAX_DLEN_2015
 
+# Typing imports
+from typing import (
+    Optional,
+    Union,
+    List,
+    Tuple,
+    Any,
+    Type,
+    cast,
+    Callable,
+    TYPE_CHECKING,
+)
 if TYPE_CHECKING:
     from scapy.contrib.cansocket import CANSocket
 

--- a/scapy/contrib/isotp/isotp_utils.py
+++ b/scapy/contrib/isotp/isotp_utils.py
@@ -10,13 +10,23 @@
 
 import struct
 
-from scapy.compat import Iterable, Optional, Union, List, Tuple, Dict, Any, \
-    Type
 from scapy.utils import EDecimal
 from scapy.packet import Packet
 from scapy.sessions import DefaultSession
 from scapy.contrib.isotp.isotp_packet import ISOTP, N_PCI_CF, N_PCI_SF, \
     N_PCI_FF, N_PCI_FC
+
+# Typing imports
+from typing import (
+    Iterable,
+    Optional,
+    Union,
+    List,
+    Tuple,
+    Dict,
+    Any,
+    Type,
+)
 
 
 class ISOTPMessageBuilderIter(object):

--- a/scapy/contrib/postgres.py
+++ b/scapy/contrib/postgres.py
@@ -7,7 +7,12 @@
 
 import struct
 
-from scapy.compat import Optional, Callable, Any, Tuple  # noqa: F401
+from typing import (
+    Optional,
+    Callable,
+    Any,
+    Tuple,
+)
 from scapy.fields import (
     ByteField,
     CharEnumField,

--- a/scapy/contrib/roce.py
+++ b/scapy/contrib/roce.py
@@ -19,7 +19,10 @@ from scapy.compat import raw
 from scapy.error import warning
 from zlib import crc32
 import struct
-from scapy.compat import Tuple
+
+from typing import (
+    Tuple
+)
 
 _transports = {
     'RC': 0x00,

--- a/scapy/contrib/tcpao.py
+++ b/scapy/contrib/tcpao.py
@@ -9,7 +9,7 @@
 """Packet-processing utilities implementing RFC5925 and RFC5926"""
 
 import logging
-from scapy.compat import orb, Union
+from scapy.compat import orb
 from scapy.layers.inet import IP, TCP
 from scapy.layers.inet import tcp_pseudoheader
 from scapy.layers.inet6 import IPv6
@@ -17,6 +17,10 @@ from scapy.packet import Packet
 from scapy.pton_ntop import inet_pton
 import socket
 import struct
+
+from typing import (
+    Union,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/scapy/dadict.py
+++ b/scapy/dadict.py
@@ -10,7 +10,7 @@ Direct Access dictionary.
 from scapy.error import Scapy_Exception
 from scapy.compat import plain_str
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     Generic,

--- a/scapy/data.py
+++ b/scapy/data.py
@@ -17,7 +17,7 @@ from scapy.consts import FREEBSD, NETBSD, OPENBSD, WINDOWS
 from scapy.error import log_loading
 from scapy.compat import plain_str
 
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/error.py
+++ b/scapy/error.py
@@ -20,7 +20,7 @@ from scapy.consts import WINDOWS
 
 # Typing imports
 from logging import LogRecord
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     Tuple,

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -40,7 +40,7 @@ from scapy.base_classes import Gen, Net, BasePacket, Field_metaclass
 from scapy.error import warning
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     AnyStr,
     Callable,

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -18,7 +18,8 @@ from scapy.utils6 import in6_isvalid
 
 # Typing imports
 import scapy
-from scapy.compat import (
+from scapy.compat import UserDict
+from typing import (
     Any,
     DefaultDict,
     Dict,
@@ -28,7 +29,6 @@ from scapy.compat import (
     Tuple,
     Type,
     Union,
-    UserDict,
 )
 
 

--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -13,10 +13,8 @@ import os
 import gzip
 import struct
 
-from scapy.compat import Tuple, Optional, Type, List, Union, Callable, IO, \
-    Any, cast, hex_bytes, chb
-
 from scapy.config import conf
+from scapy.compat import chb, hex_bytes
 from scapy.data import DLT_CAN_SOCKETCAN
 from scapy.fields import FieldLenField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ScalingField, ConditionalField, LenField, ShortField
@@ -27,6 +25,19 @@ from scapy.error import Scapy_Exception
 from scapy.plist import PacketList
 from scapy.supersocket import SuperSocket
 from scapy.utils import _ByteStream
+
+# Typing imports
+from typing import (
+    Tuple,
+    Optional,
+    Type,
+    List,
+    Union,
+    Callable,
+    IO,
+    Any,
+    cast,
+)
 
 __all__ = ["CAN", "SignalPacket", "SignalField", "LESignedSignalField",
            "LEUnsignedSignalField", "LEFloatSignalField", "BEFloatSignalField",

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -31,7 +31,7 @@ from scapy.layers.inet import IP, DestIPField, IPField, UDP, TCP
 from scapy.layers.inet6 import IPv6, DestIP6Field, IP6Field
 
 
-from scapy.compat import (
+from typing import (
     Any,
     Optional,
     Tuple,

--- a/scapy/layers/gssapi.py
+++ b/scapy/layers/gssapi.py
@@ -60,7 +60,8 @@ from scapy.layers.ntlm import (
     _NTLMPayloadField,
 )
 
-from scapy.compat import (
+# Typing imports
+from typing import (
     Dict,
     Tuple,
 )

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -61,7 +61,9 @@ from scapy.plist import (
 from scapy.sendrecv import sendp, srp, srp1, srploop
 from scapy.utils import checksum, hexdump, hexstr, inet_ntoa, inet_aton, \
     mac2str, valid_mac, valid_net, valid_net6
-from scapy.compat import (
+
+# Typing imports
+from typing import (
     Any,
     Callable,
     Dict,
@@ -74,6 +76,8 @@ from scapy.compat import (
     cast,
 )
 from scapy.interfaces import NetworkInterface
+
+
 if conf.route is None:
     # unused import, only to initialize conf.route
     import scapy.route  # noqa: F401

--- a/scapy/layers/ntlm.py
+++ b/scapy/layers/ntlm.py
@@ -57,7 +57,8 @@ from scapy.supersocket import SSLStreamSocket, StreamSocket
 
 from scapy.layers.tls.crypto.hash import Hash_MD5
 
-from scapy.compat import (
+# Typing imports
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -26,7 +26,7 @@ from scapy.layers.tls.crypto.hkdf import TLS13_HKDF
 from scapy.layers.tls.crypto.prf import PRF
 
 # Typing imports
-from scapy.compat import Dict
+from typing import Dict
 
 
 def load_nss_keys(filename):

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -34,7 +34,7 @@ from scapy.error import (
 from scapy.themes import DefaultTheme, BlackAndWhite, apply_ipython_style
 from scapy.consts import WINDOWS
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     List,

--- a/scapy/modules/nmap.py
+++ b/scapy/modules/nmap.py
@@ -26,9 +26,18 @@ from scapy.error import warning
 from scapy.layers.inet import IP, TCP, UDP, ICMP, UDPerror, IPerror
 from scapy.packet import NoPayload, Packet
 from scapy.sendrecv import sr
-from scapy.compat import plain_str, raw, Dict, List, Tuple, Optional, cast, Union
+from scapy.compat import plain_str, raw
 from scapy.plist import SndRcvList, PacketList
 
+# Typing imports
+from typing import (
+    Dict,
+    List,
+    Tuple,
+    Optional,
+    cast,
+    Union,
+)
 
 if WINDOWS:
     conf.nmap_base = os.environ["ProgramFiles"] + "\\nmap\\nmap-os-fingerprints"  # noqa: E501

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -47,7 +47,7 @@ from scapy.error import Scapy_Exception, log_runtime, warning
 from scapy.libs.test_pyx import PYX
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,
@@ -60,10 +60,10 @@ from scapy.compat import (
     Type,
     TypeVar,
     Union,
-    Self,
     Sequence,
     cast,
 )
+from scapy.compat import Self
 
 try:
     import pyx

--- a/scapy/pipetool.py
+++ b/scapy/pipetool.py
@@ -19,7 +19,7 @@ from scapy.error import log_runtime, warning
 from scapy.config import conf
 from scapy.utils import get_temp_file, do_graph
 
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -12,7 +12,6 @@ import os
 from collections import defaultdict
 from typing import NamedTuple
 
-from scapy.compat import lambda_tuple_converter
 from scapy.config import conf
 from scapy.base_classes import (
     BasePacket,
@@ -26,7 +25,7 @@ from scapy.utils import do_graph, hexdump, make_table, make_lined_table, \
 from functools import reduce
 
 # typings
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     DefaultDict,
@@ -203,12 +202,6 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
         :param lfilter: truth function to apply to each packet to decide
                         whether it will be displayed
         """
-        # Python 2 backward compatibility
-        if prn is not None:
-            prn = lambda_tuple_converter(prn)
-        if lfilter is not None:
-            lfilter = lambda_tuple_converter(lfilter)
-
         for r in self.res:
             if lfilter is not None:
                 if not lfilter(*r):
@@ -230,12 +223,6 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
         :param lfilter: truth function to apply to each packet to decide
                         whether it will be displayed
         """
-        # Python 2 backward compatibility
-        if prn is not None:
-            prn = lambda_tuple_converter(prn)
-        if lfilter is not None:
-            lfilter = lambda_tuple_converter(lfilter)
-
         for i, res in enumerate(self.res):
             if lfilter is not None:
                 if not lfilter(*res):
@@ -257,9 +244,6 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
         function has to take a packet as the only argument and return
         a boolean value.
         """
-        # Python 2 backward compatibility
-        func = lambda_tuple_converter(func)
-
         return self.__class__([x for x in self.res if func(*x)],
                               name="filtered %s" % self.listname)
 
@@ -298,11 +282,6 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
             MATPLOTLIB_INLINED,
             MATPLOTLIB_DEFAULT_PLOT_KARGS
         )
-
-        # Python 2 backward compatibility
-        f = lambda_tuple_converter(f)
-        if lfilter is not None:
-            lfilter = lambda_tuple_converter(lfilter)
 
         # Get the list of packets
         if lfilter is None:
@@ -383,11 +362,6 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
             MATPLOTLIB_INLINED,
             MATPLOTLIB_DEFAULT_PLOT_KARGS
         )
-
-        # Python 2 backward compatibility
-        f = lambda_tuple_converter(f)
-        if lfilter is not None:
-            lfilter = lambda_tuple_converter(lfilter)
 
         # Get the list of packets
         if lfilter is None:

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -15,7 +15,8 @@ import re
 import binascii
 from scapy.compat import plain_str, hex_bytes, bytes_encode, bytes_hex
 
-from scapy.compat import Union
+# Typing imports
+from typing import Union
 
 _IP6_ZEROS = re.compile('(?::|^)(0(?::0)+)(?::|$)')
 _INET6_PTON_EXC = socket.error("illegal IP address string passed to inet_pton")

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -14,7 +14,7 @@ from scapy.error import Scapy_Exception, warning
 from scapy.interfaces import resolve_iface
 from scapy.utils import atol, ltoa, itom, pretty_list
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     List,

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -25,7 +25,7 @@ from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.error import warning, log_loading
 from scapy.utils import pretty_list
 
-from scapy.compat import (
+from typing import (
     Any,
     Dict,
     List,

--- a/scapy/scapypipes.py
+++ b/scapy/scapypipes.py
@@ -16,7 +16,7 @@ from scapy.pipetool import Source, Drain, Sink
 from scapy.utils import ContextManagerSubprocess, PcapReader, PcapWriter
 
 from scapy.supersocket import SuperSocket
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     List,

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -37,7 +37,7 @@ from scapy.sessions import DefaultSession
 from scapy.supersocket import SuperSocket, IterSocket
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     Dict,

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -17,7 +17,7 @@ from scapy.plist import PacketList
 from scapy.pton_ntop import inet_pton
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     DefaultDict,

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -31,7 +31,7 @@ from scapy.utils import PcapReader, tcpdump
 
 # Typing imports
 from scapy.interfaces import _GlobInterfaceType
-from scapy.compat import (
+from typing import (
     Any,
     Iterator,
     List,

--- a/scapy/themes.py
+++ b/scapy/themes.py
@@ -14,7 +14,7 @@ Color themes for the interactive console.
 import html
 import sys
 
-from scapy.compat import (
+from typing import (
     Any,
     Callable,
     List,

--- a/scapy/tools/automotive/isotpscanner.py
+++ b/scapy/tools/automotive/isotpscanner.py
@@ -15,7 +15,13 @@ from ast import literal_eval
 
 from scapy.config import conf
 from scapy.consts import LINUX
-from scapy.compat import Tuple, Optional, Any
+
+# Typing imports
+from typing import (
+    Tuple,
+    Optional,
+    Any,
+)
 
 if not LINUX or conf.use_pypy:
     conf.contribs['CANSocket'] = {'use-python-can': True}

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -35,13 +35,20 @@ import warnings
 from scapy.config import conf
 from scapy.consts import DARWIN, OPENBSD, WINDOWS
 from scapy.data import MTU, DLT_EN10MB, DLT_RAW
-from scapy.compat import orb, plain_str, chb, bytes_base64,\
-    base64_bytes, hex_bytes, lambda_tuple_converter, bytes_encode
+from scapy.compat import (
+    orb,
+    plain_str,
+    chb,
+    bytes_base64,
+    base64_bytes,
+    hex_bytes,
+    bytes_encode,
+)
 from scapy.error import log_runtime, Scapy_Exception, warning
 from scapy.pton_ntop import inet_pton
 
 # Typing imports
-from scapy.compat import (
+from typing import (
     cast,
     Any,
     AnyStr,
@@ -50,7 +57,6 @@ from scapy.compat import (
     IO,
     Iterator,
     List,
-    Literal,
     Optional,
     TYPE_CHECKING,
     Tuple,
@@ -58,6 +64,7 @@ from scapy.compat import (
     Union,
     overload,
 )
+from scapy.compat import Literal
 
 if TYPE_CHECKING:
     from scapy.packet import Packet
@@ -3003,9 +3010,6 @@ def __make_table(
     vy = {}  # type: Dict[str, Optional[int]]
     vz = {}  # type: Dict[Tuple[str, str], str]
     vxf = {}  # type: Dict[str, str]
-
-    # Python 2 backward compatibility
-    fxyz = lambda_tuple_converter(fxyz)
 
     tmp_len = 0
     for e in data:

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -24,7 +24,7 @@ from scapy.volatile import RandMAC, RandBin
 from scapy.error import warning, Scapy_Exception
 from functools import reduce, cmp_to_key
 
-from scapy.compat import (
+from typing import (
     Iterator,
     List,
     Optional,

--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -22,7 +22,7 @@ from scapy.base_classes import Net
 from scapy.compat import bytes_encode, chb, plain_str
 from scapy.utils import corrupt_bits, corrupt_bytes
 
-from scapy.compat import (
+from typing import (
     List,
     TypeVar,
     Generic,

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -4560,7 +4560,7 @@ def test_multiplot(mock_plt):
     mock_plt.plot = fake_plot
     tmp = [IP(id=i)/TCP() for i in range(10)]
     plist = PacketList([tuple(tmp[i-2:i]) for i in range(2, 10, 2)])
-    lines = plist.multiplot(lambda x: (x[1][IP].src, (x[1].time, x[1][IP].id)))
+    lines = plist.multiplot(lambda x, y: (y[IP].src, (y.time, y[IP].id)))
     assert len(lines) == 1
     assert len(lines[0]) == 4
 

--- a/test/testsocket.py
+++ b/test/testsocket.py
@@ -17,7 +17,16 @@ from scapy.automaton import ObjectPipe, select_objects
 from scapy.data import MTU
 from scapy.packet import Packet
 from scapy.error import Scapy_Exception
-from scapy.compat import Optional, Type, Tuple, Any, List, cast
+
+# Typing imports
+from typing import (
+    Optional,
+    Type,
+    Tuple,
+    Any,
+    List,
+    cast,
+)
 from scapy.supersocket import SuperSocket
 
 


### PR DESCRIPTION
At first I wanted to replace `scapy.compat` in one go but that's way too much work. So for now:
- replace `scapy.compat` stubs with `typing` when possible (keep the ones only available in 3.8, 3.9 and 3.11)
- remove `lambda_tuple_converter` used for Python 2 compatibility