### PR TITLE
No longer use deprecated MACsec fields

### DIFF
--- a/scapy/contrib/macsec.py
+++ b/scapy/contrib/macsec.py
@@ -79,11 +79,11 @@ class MACsecSA(object):
     def make_iv(self, pkt):
         """generate an IV for the packet"""
         if self.xpn_en:
-            tmp_pn = (self.pn & 0xFFFFFFFF00000000) | (pkt[MACsec].pn & 0xFFFFFFFF)  # noqa: E501
+            tmp_pn = (self.pn & 0xFFFFFFFF00000000) | (pkt[MACsec].PN & 0xFFFFFFFF)  # noqa: E501
             tmp_iv = self.ssci + struct.pack('!Q', tmp_pn)
             return bytes(bytearray([a ^ b for a, b in zip(bytearray(tmp_iv), bytearray(self.salt))]))  # noqa: E501
         else:
-            return self.sci + struct.pack('!I', pkt[MACsec].pn)
+            return self.sci + struct.pack('!I', pkt[MACsec].PN)
 
     @staticmethod
     def split_pkt(pkt, assoclen, icvlen=0):
@@ -124,11 +124,11 @@ class MACsecSA(object):
         hdr = copy.deepcopy(pkt)
         payload = hdr.payload
         del hdr.payload
-        tag = MACsec(sci=self.sci, an=self.an,
+        tag = MACsec(SCI=self.sci, AN=self.an,
                      SC=self.send_sci,
                      E=self.e_bit(), C=self.c_bit(),
-                     shortlen=MACsecSA.shortlen(pkt),
-                     pn=(self.pn & 0xFFFFFFFF), type=pkt.type)
+                     SL=MACsecSA.shortlen(pkt),
+                     PN=(self.pn & 0xFFFFFFFF), type=pkt.type)
         hdr.type = ETH_P_MACSEC
         return hdr / tag / payload
 
@@ -241,9 +241,9 @@ class MACsec(Packet):
                          lambda pkt: "type" in pkt.fields)]
 
     def mysummary(self):
-        summary = self.sprintf("an=%MACsec.an%, pn=%MACsec.pn%")
+        summary = self.sprintf("AN=%MACsec.AN%, PN=%MACsec.PN%")
         if self.SC:
-            summary += self.sprintf(", sci=%MACsec.sci%")
+            summary += self.sprintf(", SCI=%MACsec.SCI%")
         if self.type is not None:
             summary += self.sprintf(", %MACsec.type%")
         return summary

--- a/test/contrib/macsec.uts
+++ b/test/contrib/macsec.uts
@@ -21,6 +21,7 @@ assert m[MACsec].SC
 assert m[MACsec].E
 assert m[MACsec].C
 assert m[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert m[MACsec].mysummary() == r"AN=0, PN=100, SCI='RT\x00\x13\x01V\x00\x01', IPv4"
 
 = MACsec - basic encryption - encrypted
 sa = MACsecSA(sci=b'\x52\x54\x00\x13\x01\x56\x00\x01', an=0, pn=100, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=1, send_sci=1)

--- a/test/contrib/macsec.uts
+++ b/test/contrib/macsec.uts
@@ -14,13 +14,13 @@ m = sa.encap(p)
 assert m.type == ETH_P_MACSEC
 assert m[MACsec].type == ETH_P_IP
 assert len(m) == len(p) + 16
-assert m[MACsec].an == 0
-assert m[MACsec].pn == 100
-assert m[MACsec].shortlen == 0
+assert m[MACsec].AN == 0
+assert m[MACsec].PN == 100
+assert m[MACsec].SL == 0
 assert m[MACsec].SC
 assert m[MACsec].E
 assert m[MACsec].C
-assert m[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert m[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 
 = MACsec - basic encryption - encrypted
 sa = MACsecSA(sci=b'\x52\x54\x00\x13\x01\x56\x00\x01', an=0, pn=100, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=1, send_sci=1)
@@ -30,13 +30,13 @@ e = sa.encrypt(m)
 assert e.type == ETH_P_MACSEC
 assert e[MACsec].type == None
 assert len(e) == len(p) + 16 + 16
-assert e[MACsec].an == 0
-assert e[MACsec].pn == 100
-assert e[MACsec].shortlen == 0
+assert e[MACsec].AN == 0
+assert e[MACsec].PN == 100
+assert e[MACsec].SL == 0
 assert e[MACsec].SC
 assert e[MACsec].E
 assert e[MACsec].C
-assert e[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert e[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 
 = MACsec - basic decryption - encrypted
 sa = MACsecSA(sci=b'\x52\x54\x00\x13\x01\x56\x00\x01', an=0, pn=100, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=1, send_sci=1)
@@ -47,13 +47,13 @@ d = sa.decrypt(e)
 assert d.type == ETH_P_MACSEC
 assert d[MACsec].type == ETH_P_IP
 assert len(d) == len(m)
-assert d[MACsec].an == 0
-assert d[MACsec].pn == 100
-assert d[MACsec].shortlen == 0
+assert d[MACsec].AN == 0
+assert d[MACsec].PN == 100
+assert d[MACsec].SL == 0
 assert d[MACsec].SC
 assert d[MACsec].E
 assert d[MACsec].C
-assert d[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert d[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 assert raw(d) == raw(m)
 
 = MACsec - basic decap - decrypted
@@ -74,13 +74,13 @@ m = sa.encap(p)
 assert m.type == ETH_P_MACSEC
 assert m[MACsec].type == ETH_P_IP
 assert len(m) == len(p) + 16
-assert m[MACsec].an == 0
-assert m[MACsec].pn == 200
-assert m[MACsec].shortlen == 0
+assert m[MACsec].AN == 0
+assert m[MACsec].PN == 200
+assert m[MACsec].SL == 0
 assert m[MACsec].SC
 assert not m[MACsec].E
 assert not m[MACsec].C
-assert m[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert m[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 
 = MACsec - basic encryption - integrity only
 sa = MACsecSA(sci=b'\x52\x54\x00\x13\x01\x56\x00\x01', an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
@@ -90,13 +90,13 @@ e = sa.encrypt(m)
 assert m.type == ETH_P_MACSEC
 assert e[MACsec].type == None
 assert len(e) == len(p) + 16 + 16
-assert e[MACsec].an == 0
-assert e[MACsec].pn == 200
-assert e[MACsec].shortlen == 0
+assert e[MACsec].AN == 0
+assert e[MACsec].PN == 200
+assert e[MACsec].SL == 0
 assert e[MACsec].SC
 assert not e[MACsec].E
 assert not e[MACsec].C
-assert e[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert e[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 assert raw(e)[:-16] == raw(m)
 
 = MACsec - basic decryption - integrity only
@@ -108,13 +108,13 @@ d = sa.decrypt(e)
 assert d.type == ETH_P_MACSEC
 assert d[MACsec].type == ETH_P_IP
 assert len(d) == len(m)
-assert d[MACsec].an == 0
-assert d[MACsec].pn == 200
-assert d[MACsec].shortlen == 0
+assert d[MACsec].AN == 0
+assert d[MACsec].PN == 200
+assert d[MACsec].SL == 0
 assert d[MACsec].SC
 assert not d[MACsec].E
 assert not d[MACsec].C
-assert d[MACsec].sci == b'\x52\x54\x00\x13\x01\x56\x00\x01'
+assert d[MACsec].SCI == b'\x52\x54\x00\x13\x01\x56\x00\x01'
 assert raw(d) == raw(m)
 
 = MACsec - basic decap - integrity only
@@ -130,71 +130,71 @@ assert raw(r) == raw(p)
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')
 m = sa.encap(p)
-assert m[MACsec].shortlen == 2
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 2
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 10
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 8)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 10
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 10
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 18
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 16)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 18
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 18
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 32
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 30)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 32
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 32
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 40
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 38)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 40
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 40
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 47
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 45)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 47
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 47
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 0 (48)
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=1)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 45 + "y")
 m = sa.encap(p)
-assert m[MACsec].shortlen == 0
+assert m[MACsec].SL == 0
 
 
 = MACsec - encap - shortlen 2/nosci
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=0)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')
 m = sa.encap(p)
-assert m[MACsec].shortlen == 2
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 2
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 32/nosci
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=0)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 30)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 32
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 32
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 = MACsec - encap - shortlen 47/nosci
 sa = MACsecSA(sci=0x5254001301560001, an=0, pn=200, key=b'aaaaaaaaaaaaaaaa', icvlen=16, encrypt=0, send_sci=0)
 p = Ether(src='aa:aa:aa:bb:bb:bb', dst='cc:cc:cc:dd:dd:dd')/Raw("x" * 45)
 m = sa.encap(p)
-assert m[MACsec].shortlen == 47
-assert len(m) == m[MACsec].shortlen + 20 + (8 if sa.send_sci else 0)
+assert m[MACsec].SL == 47
+assert len(m) == m[MACsec].SL + 20 + (8 if sa.send_sci else 0)
 
 
 = MACsec - authenticate


### PR DESCRIPTION
It should make it easier to run scapy with -Xdev -Werror without getting deprecation warnings like
```sh
DeprecationWarning: sci has been deprecated in favor of SCI since 2.4.4 !
...
DeprecationWarning: pn has been deprecated in favor of PN since 2.4.4 !
```

The testsuite got updated too and
```
python3 -Xdev -Werror -m scapy.tools.UTscapy -P 'load_contrib("macsec")' -t test/contrib/macsec.uts
```
is green.

It's a follow-up to d1fc7e3eb96083d09a18c66d26865bc4c2d089b1
