### PR TITLE
fix parsing bug in FieldListField when data is not byte-aligned

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2070,7 +2070,12 @@ class FieldListField(Field[List[Any], List[Any]]):
                 c -= 1
             s, v = self.field.getfield(pkt, s)
             val.append(v)
-        return s + ret, val
+
+        if isinstance(s, tuple):
+            s, bn = s
+            return (s + ret, bn), val
+        else:
+            return s + ret, val
 
 
 class FieldLenField(Field[int, int]):

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -362,6 +362,20 @@ p = TestFLF(struct.pack("!BIII",3,1234,2345,12345678))
 p
 assert p.len == 3 and p.lst == [1234,2345,12345678]
 
+= Disassemble unaligned
+~ field
+import struct
+class TestFLFUnaligned(Packet):
+    name="test"
+    fields_desc = [ BitFieldLenField("len", None, 3, count_of="lst"),
+                    FieldListField("lst", None, XBitField("elt",0,8), count_from=lambda pkt:pkt.len),
+                    BitField("ignore", None, 5),
+                   ]
+
+p = TestFLFUnaligned(b"\x68\x28\x48\x6a")
+p
+assert p.len == 3 and p.lst == [0x41,0x42,0x43] and p.ignore == 0xa
+
 = Manipulate
 ~ field
 a = TestFLF(lst=[4])


### PR DESCRIPTION
FieldListField parsing is broken when the field is not byte-aligned. In the unit test included with this pull request is an example where the field is offset by 3 bits. In that case, self.field.getfield() returns a tuple which is then concatenated with bytes in the return statement. This pull request fixes that bug by checking whether the return value is a tuple and handling it properly.