### PR TITLE
fixing some parsing of data that is not byte-aligned

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1768,7 +1768,12 @@ class PacketListField(_PacketField[List[BasePacket]]):
                 else:
                     remain = b""
             lst.append(p)
-        return remain + ret, lst
+
+        if isinstance(remain, tuple):
+            remain, nb = remain
+            return (remain + ret, nb), lst
+        else:
+            return remain + ret, lst
 
     def i2m(self,
             pkt,  # type: Optional[Packet]
@@ -2070,7 +2075,12 @@ class FieldListField(Field[List[Any], List[Any]]):
                 c -= 1
             s, v = self.field.getfield(pkt, s)
             val.append(v)
-        return s + ret, val
+
+        if isinstance(s, tuple):
+            s, bn = s
+            return (s + ret, bn), val
+        else:
+            return s + ret, val
 
 
 class FieldLenField(Field[int, int]):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1881,7 +1881,11 @@ class Raw(Packet):
     def __init__(self, _pkt=b"", *args, **kwargs):
         # type: (bytes, *Any, **Any) -> None
         if _pkt and not isinstance(_pkt, bytes):
-            _pkt = bytes_encode(_pkt)
+            if isinstance(_pkt, tuple):
+                _pkt, bn = _pkt
+                _pkt = bytes_encode(_pkt), bn
+            else:
+                _pkt = bytes_encode(_pkt)
         super(Raw, self).__init__(_pkt, *args, **kwargs)
 
     def answers(self, other):

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -362,6 +362,20 @@ p = TestFLF(struct.pack("!BIII",3,1234,2345,12345678))
 p
 assert p.len == 3 and p.lst == [1234,2345,12345678]
 
+= Disassemble unaligned
+~ field
+import struct
+class TestFLFUnaligned(Packet):
+    name="test"
+    fields_desc = [ BitFieldLenField("len", None, 3, count_of="lst"),
+                    FieldListField("lst", None, XBitField("elt",0,8), count_from=lambda pkt:pkt.len),
+                    BitField("ignore", None, 5),
+                   ]
+
+p = TestFLFUnaligned(b"\x68\x28\x48\x6a")
+p
+assert p.len == 3 and p.lst == [0x41,0x42,0x43] and p.ignore == 0xa
+
 = Manipulate
 ~ field
 a = TestFLF(lst=[4])
@@ -2244,3 +2258,47 @@ mp = MockPacket(0)
 f = XStrField('test', None)
 x = f.i2repr(mp, RandBin())
 assert x == '<RandBin>'
+
+############
+############
++ Raw() tests
+
+= unaligned data
+
+p = Raw(b"abc")
+p
+
+offsetdata = bytes.fromhex("0" + p.load.hex() + "0")
+
+p = Raw((offsetdata, 4))
+p
+
+############
+############
++ PacketListField() tests
+
+= unaligned data
+
+class PInner(Packet):
+    name = "PInner"
+    fields_desc = [
+        BitField("x", 0, 8),
+    ]
+    def extract_padding(self, s):
+        return '', s
+
+class POuter(Packet):
+    name = "POuter"
+    fields_desc = [
+        BitField("indent", 0, 4),
+        BitFieldLenField("pcount", None, 8, count_of="plist"),
+        PacketListField("plist", None, PInner,
+                             count_from=lambda pkt: pkt.pcount),
+    ]
+
+p = POuter(b"\xf0\x44\x14\x24\x34\x40")
+p
+
+assert p.indent == 0xf
+assert p.pcount == 4
+assert [p.x for p in p.plist] == [0x41, 0x42, 0x43, 0x44]


### PR DESCRIPTION
Some parsing is broken when the data is not byte-aligned. 