### PR TITLE
No longer include DNSSLs in format strings

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1972,7 +1972,7 @@ class ICMPv6NDOptRDNSS(_ICMPv6NDGuessPayload, Packet):  # RFC 5006
                                 length_from=lambda pkt: 8 * (pkt.len - 1))]
 
     def mysummary(self):
-        return self.sprintf("%name% " + ", ".join(self.dns))
+        return self.sprintf("%name% ") + ", ".join(self.dns)
 
 
 class ICMPv6NDOptEFA(_ICMPv6NDGuessPayload, Packet):  # RFC 5175 (prev. 5075)
@@ -2049,7 +2049,7 @@ class ICMPv6NDOptDNSSL(_ICMPv6NDGuessPayload, Packet):  # RFC 6106
                    ]
 
     def mysummary(self):
-        return self.sprintf("%name% " + ", ".join(self.searchlist))
+        return self.sprintf("%name% ") + ", ".join(self.searchlist)
 
 # End of ICMPv6 Neighbor Discovery Options.
 

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -1198,7 +1198,7 @@ p = ICMPv6NDOptDNSSL(b'\x1f\x02\x00\x00\x00\x00\x00<\x04home\x00\x00\x00')
 p.type == 31 and p.len == 2 and p.res == 0 and p.lifetime == 60 and p.searchlist == ["home."]
 
 = ICMPv6NDOptDNSSL - Summary Output
-ICMPv6NDOptDNSSL(searchlist=["home.", "office."]).mysummary() == "ICMPv6 Neighbor Discovery Option - DNS Search List Option home., office."
+ICMPv6NDOptDNSSL(searchlist=["home.", "office.", "{"]).mysummary() == "ICMPv6 Neighbor Discovery Option - DNS Search List Option home., office., {"
 
 
 ############


### PR DESCRIPTION
to prevent `sprintf` from trying to parse them. `ICMPv6NDOptRDNSS.mysummary` was changed too even though special characters should never get past `inet_pton` and reach `sprintf` there.

It's a follow-up to f2a137c0388494318662b19f7082b492c7c22fca.

Fixes:
```python
  File "scapy/sendrecv.py", line 1439, in tshark
  File "scapy/sendrecv.py", line 1311, in sniff
  File "scapy/sendrecv.py", line 1254, in _run
  File "scapy/sessions.py", line 109, in on_packet_received
  File "scapy/sendrecv.py", line 1436, in _cb
  File "scapy/packet.py", line 1645, in summary
  File "scapy/packet.py", line 1619, in _do_summary
  File "scapy/packet.py", line 1619, in _do_summary
  File "scapy/packet.py", line 1619, in _do_summary
  [Previous line repeated 2 more times]
  File "scapy/packet.py", line 1622, in _do_summary
  File "scapy/layers/inet6.py", line 2052, in mysummary
  File "scapy/packet.py", line 1530, in sprintf
    j = fmt[i + 1:].index("}")
        ^^^^^^^^^^^^^^^^^^^^^^
ValueError: substring not found
```