### PR TITLE
tests: use conf.ifaces instead of IFACES

### DIFF
--- a/test/linux.uts
+++ b/test/linux.uts
@@ -113,7 +113,7 @@ assert exit_status == 0
 
 = IPv6 link-local address selection
 
-IFACES._add_fake_iface("scapy0")
+conf.ifaces._add_fake_iface("scapy0")
 
 from mock import patch
 conf.route6.routes =  [('fe80::', 64, '::', 'scapy0', ['fe80::e039:91ff:fe79:1910'], 256)]

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -273,7 +273,7 @@ bytes_hex(get_if_raw_addr(conf.iface))
 
 def get_dummy_interface():
     """Returns a dummy network interface"""
-    IFACES._add_fake_iface("dummy0")
+    conf.ifaces._add_fake_iface("dummy0")
     return "dummy0"
 
 get_if_raw_addr(get_dummy_interface())
@@ -3298,10 +3298,9 @@ test_netbsd_7_0()
 
 import scapy
 
-IFACES._add_fake_iface("enp3s0")
-IFACES._add_fake_iface("lo")
+conf.ifaces._add_fake_iface("enp3s0")
+conf.ifaces._add_fake_iface("lo")
 
-old_routes = conf.route.routes
 old_iface = conf.iface
 old_loopback = conf.loopback_name
 try:
@@ -3328,17 +3327,15 @@ try:
 finally:
     conf.loopback_name = old_loopback
     conf.iface = old_iface
-    conf.route.routes = old_routes
-    conf.route.invalidate_cache()
-    IFACES.reload()
+    conf.route.resync()
+    conf.ifaces.reload()
 
 
 = Mocked IPv6 routes calls
 
-IFACES._add_fake_iface("enp3s0")
-IFACES._add_fake_iface("lo")
+conf.ifaces._add_fake_iface("enp3s0")
+conf.ifaces._add_fake_iface("lo")
 
-old_routes = conf.route6.routes
 old_iface = conf.iface
 old_loopback = conf.loopback_name
 try:
@@ -3367,6 +3364,7 @@ finally:
     conf.loopback_name = old_loopback
     conf.iface = old_iface
     conf.route6.resync()
+    conf.ifaces.reload()
 
 = Find a link-local address when conf.iface does not support IPv6
 
@@ -3892,6 +3890,9 @@ conf.route.routes = [
 assert sorted(conf.route.get_if_bcast(dummy_interface)) == sorted(['169.254.255.255', '172.21.230.255', '239.255.255.255'])
 conf.route.routes = bck_conf_route_routes
 
+= Remove dummy interface
+
+conf.ifaces.reload()
 
 ############
 ############

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -1793,9 +1793,9 @@ assert defragment6(pkts).plen == 1508
 + Test Route6 class
 
 = Fake interfaces
-IFACES._add_fake_iface("eth0")
-IFACES._add_fake_iface("lo")
-IFACES._add_fake_iface("scapy0")
+conf.ifaces._add_fake_iface("eth0")
+conf.ifaces._add_fake_iface("lo")
+conf.ifaces._add_fake_iface("scapy0")
 
 = Route6 - Route6 flushing
 conf_iface = conf.iface

--- a/test/windows.uts
+++ b/test/windows.uts
@@ -50,6 +50,7 @@ assert status
 
 from scapy.interfaces import get_if_list
 
+print(get_if_list())
 assert all(x.startswith(r"\Device\NPF_") for x in get_if_list())
 
 = test pcap_service_stop
@@ -69,14 +70,14 @@ assert pcap_service_status()[2] == True
 @mock.patch("scapy.arch.windows.get_windows_if_list")
 def _test_autostart_ui(mocked_getiflist):
     mocked_getiflist.side_effect = lambda: []
-    IFACES.reload()
-    assert all(x.index < 0 for x in IFACES.data.values())
+    conf.ifaces.reload()
+    assert all(x.index < 0 for x in conf.ifaces.data.values())
 
 try:
-    old_ifaces = IFACES.data.copy()
+    old_ifaces = conf.ifaces.data.copy()
     _test_autostart_ui()
 finally:
-     IFACES.data = old_ifaces
+     conf.ifaces.data = old_ifaces
 
 ######### Native mode ###########
 


### PR DESCRIPTION
IFACES is obsolete (used to be windows-only). `conf.ifaces` is the new thing