### PR TITLE
Make repr(NTPInfoPeer) work

### DIFF
--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -76,7 +76,7 @@ class TimeStampField(FixedPointField):
             return "--"
         val = self.i2h(pkt, val)
         if val < _NTP_BASETIME:
-            return val
+            return str(val)
         return time.strftime(
             "%a, %d %b %Y %H:%M:%S +0000",
             time.gmtime(int(val - _NTP_BASETIME))

--- a/test/scapy/layers/ntp.uts
+++ b/test/scapy/layers/ntp.uts
@@ -466,6 +466,7 @@ assert p.version == 2
 assert p.mode == 7
 assert p.request_code == 2
 assert isinstance(p.data[0], NTPInfoPeer)
+repr(p.data[0])
 assert p.data[0].dstaddr == "192.168.122.102"
 assert p.data[0].srcaddr == "192.168.122.101"
 assert p.data[0].srcport == 123


### PR DESCRIPTION
`TimeStampField.i2repr` should convert EDecimals to strings by analogy with `FixedPointField.i2repr` to make it possible for the "filtoffset" packet list field to assemble its repr.

Fixes:
```python
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "scapy/packet.py", line 563, in __repr__
    val = f.i2repr(self, fval)
          ^^^^^^^^^^^^^^^^^^^^
  File "scapy/fields.py", line 2042, in i2repr
    return "[%s]" % ", ".join(self.field.i2repr(pkt, v) for v in x)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, EDecimal found
```