### PR TITLE
No longer include LLTD hostnames in format strings

### DIFF
--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -715,7 +715,7 @@ class LLTDAttributeMachineName(LLTDAttribute):
     ]
 
     def mysummary(self):
-        return (self.sprintf("Hostname: %r" % self.hostname),
+        return (f"Hostname: {self.hostname!r}",
                 [LLTD, LLTDAttributeHostID])
 
 

--- a/test/scapy/layers/lltd.uts
+++ b/test/scapy/layers/lltd.uts
@@ -59,4 +59,5 @@ key, value = data.popitem()
 assert key.endswith(' [Detailed Icon Image]')
 assert value == 'abcdefg'
 
-
+= Summary
+assert LLTDAttributeMachineName(b'\x0f\x04{\x00\n\x00').mysummary()[0] == r"Hostname: '{\n'"


### PR DESCRIPTION
to prevent `sprintf` from trying to parse them.

Fixes:
```python
  File "scapy/sendrecv.py", line 1439, in tshark
  File "scapy/sendrecv.py", line 1311, in sniff
  File "scapy/sendrecv.py", line 1254, in _run
  File "scapy/sessions.py", line 109, in on_packet_received
  File "scapy/sendrecv.py", line 1436, in _cb
  File "scapy/packet.py", line 1645, in summary
  File "scapy/packet.py", line 1619, in _do_summary
  File "scapy/packet.py", line 1619, in _do_summary
  File "scapy/packet.py", line 1619, in _do_summary
  [Previous line repeated 6 more times]
  File "scapy/packet.py", line 1622, in _do_summary
  File "scapy/layers/lltd.py", line 718, in mysummary
    return (self.sprintf("Hostname: %r" % self.hostname),
  File "scapy/packet.py", line 1530, in sprintf
    j = fmt[i + 1:].index("}")
ValueError: substring not found
```