### PR TITLE
Add RPL Hop-by-Hop option (RFC 6553)

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -57,6 +57,7 @@ from scapy.fields import (
     StrLenField,
     X3BytesField,
     XBitField,
+    XByteField,
     XIntField,
     XShortField,
 )
@@ -783,6 +784,27 @@ class RouterAlert(Packet):  # RFC 2711 - IPv6 Hop-By-Hop Option
         return b"", p
 
 
+class RplOption(Packet):    # RFC 6553 - RPL Option
+    name = "RPL Option"
+    fields_desc = [_OTypeField("otype", 0x63, _hbhopts),
+                   ByteField("optlen", 4),
+                   BitField("Down", 0, 1),
+                   BitField("RankError", 0, 1),
+                   BitField("ForwardError", 0, 1),
+                   BitField("unused", 0, 5),
+                   XByteField("RplInstanceId", 0),
+                   XShortField("SenderRank", 0)]
+
+    def alignment_delta(self, curpos):  # alignment requirement : 2n+0
+        x = 2
+        y = 0
+        delta = x * ((curpos - y + x - 1) // x) + y - curpos
+        return delta
+
+    def extract_padding(self, p):
+        return b"", p
+
+
 class Jumbo(Packet):  # IPv6 Hop-By-Hop Option
     name = "Jumbo Payload"
     fields_desc = [_OTypeField("otype", 0xC2, _hbhopts),
@@ -818,6 +840,7 @@ class HAO(Packet):  # IPv6 Destination Options Header Option
 _hbhoptcls = {0x00: Pad1,
               0x01: PadN,
               0x05: RouterAlert,
+              0x63: RplOption,
               0xC2: Jumbo,
               0xC9: HAO}
 

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -572,6 +572,25 @@ raw(RouterAlert(optlen=3, value=0xffff)) == b'\x05\x03\xff\xff'
 a=RouterAlert(b'\x05\x03\xff\xff')
 a.otype == 0x05 and a.optlen == 3 and a.value == 0xffff
 
+############
+############
++ Test RPL Option (RFC 6553)
+
+= RplOption - Basic Instantiation
+raw(RplOption()) == b'c\x04\x00\x00\x00\x00'
+
+= RplOption - Basic Dissection
+a=RplOption(b'c\x04\x00\x00\x00\x00')
+a.otype == 0x63 and a.optlen == 4 and a.Down == False and a.RankError == 0 and a.ForwardError == 0 and a.RplInstanceId == 0 and a.SenderRank == 0
+
+= RplOption - Instantiation with specific values
+a=RplOption(RplInstanceId=0x1e, SenderRank=0x800)
+a.otype == 0x63 and a.optlen == 4 and a.Down == False and a.RankError == 0 and a.ForwardError == 0 and a.RplInstanceId == 0x1e and a.SenderRank == 0x800
+
+= RplOption - Instantiation with specific values
+a=RplOption(Down=True, RplInstanceId=0x1e, SenderRank=0x800)
+a.otype == 0x63 and a.optlen == 4 and a.Down == True and a.RankError == 0 and a.ForwardError == 0 and a.RplInstanceId == 0x1e and a.SenderRank == 0x800
+raw(a) == b'c\x04\x80\x1e\x08\x00'
 
 ############
 ############
@@ -628,6 +647,9 @@ raw(IPv6ExtHdrHopByHop(options=[HAO()])) == b';\x02\x01\x02\x00\x00\xc9\x10\x00\
 
 = IPv6ExtHdrHopByHop - Instantiation with RouterAlert option
 raw(IPv6ExtHdrHopByHop(options=[RouterAlert()])) == b';\x00\x05\x02\x00\x00\x01\x00'
+
+= IPv6ExtHdrHopByHop - Instantiation with RPL option
+raw(IPv6ExtHdrHopByHop(options=[RplOption()])) == b';\x00c\x04\x00\x00\x00\x00'
  
 = IPv6ExtHdrHopByHop - Instantiation with Jumbo option
 raw(IPv6ExtHdrHopByHop(options=[Jumbo()])) == b';\x00\xc2\x04\x00\x00\x00\x00'


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] The PR is complete

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

This adds support for the RPL Option, defined in [RFC 6553](https://www.rfc-editor.org/rfc/rfc6553.html), which is used in the Hop-by-Hop options.
