### PR TITLE
Get FixedPointField.i2h to accept None

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -3204,8 +3204,10 @@ class FixedPointField(BitField):
         return (ival << self.frac_bits) | fract
 
     def i2h(self, pkt, val):
-        # type: (Optional[Packet], int) -> EDecimal
+        # type: (Optional[Packet], Optional[int]) -> Optional[EDecimal]
         # A bit of trickery to get precise floats
+        if val is None:
+            return val
         int_part = val >> self.frac_bits
         pw = 2.0**self.frac_bits
         frac_part = EDecimal(val & (1 << self.frac_bits) - 1)

--- a/test/scapy/layers/ntp.uts
+++ b/test/scapy/layers/ntp.uts
@@ -25,18 +25,23 @@ assert not NTPControl in p
 assert not NTPPrivate in p
 assert NTP in p
 assert p.mysummary() == "NTP v4, client"
+ls(p)
+
 p = NTPControl()
 assert not NTPHeader in p
 assert NTPControl in p
 assert not NTPPrivate in p
 assert NTP in p
 assert p.mysummary() == "NTP v2, NTP control message"
+ls(p)
+
 p = NTPPrivate()
 assert not NTPHeader in p
 assert not NTPControl in p
 assert NTPPrivate in p
 assert NTP in p
 assert p.mysummary() == "NTP v2, reserved for private use"
+ls(p)
 
 = NTP - Layers (2)
 p = NTPHeader()


### PR DESCRIPTION
to make it possible for its derived classes to accept None too. For example ntp.TimeStampField has to be able to handle None to calculate timestamps when packets are assembled.

Fixes:
```python
orig       : TimeStampField  (64 bits)           = Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "scapy/packet.py", line 2379, in ls
    print("%-15r" % (getattr(obj, fname),), end=' ')
                     ^^^^^^^^^^^^^^^^^^^
  File "scapy/packet.py", line 469, in __getattr__
    return v if isinstance(v, RawVal) else fld.i2h(self, v)
                                           ^^^^^^^^^^^^^^^^
  File "scapy/fields.py", line 3209, in i2h
    int_part = val >> self.frac_bits
               ~~~~^^~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for >>: 'NoneType' and 'int'
```

Also closes https://github.com/secdev/scapy/issues/3872