### PR TITLE
Tolerate malformed server_name TLS extensions

### DIFF
--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -175,12 +175,6 @@ class ServerName(Packet):
         return Padding
 
 
-class ServerListField(PacketListField):
-    def i2repr(self, pkt, x):
-        res = [p.servername for p in x]
-        return "[%s]" % ", ".join(repr(x) for x in res)
-
-
 class ServerLenField(FieldLenField):
     """
     There is no length when there are no servernames (as in a ServerHello).
@@ -200,7 +194,7 @@ class TLS_Ext_ServerName(TLS_Ext_PrettyPacketList):                 # RFC 4366
                                  adjust=lambda pkt, x: x + 2),
                    ServerLenField("servernameslen", None,
                                   length_of="servernames"),
-                   ServerListField("servernames", [], ServerName,
+                   PacketListField("servernames", [], ServerName,
                                    length_from=lambda pkt: pkt.servernameslen)]
 
 

--- a/test/tls.uts
+++ b/test/tls.uts
@@ -1524,6 +1524,21 @@ pkt = TLSServerHello(b"\x02\x00\x00\x28\x03\x03ABCDEFGHIJKLMNOPQRSTUVWXYZ012345\
 assert pkt.extlen == 0
 assert pkt.ext is None
 
+= TLS_Ext_ServerName
+
+pkt = TLS_Ext_ServerName(b"\x00\x00\x00\n\x00\x08\x00\x00\x05ab.cd")
+servernames = pkt.servernames
+assert len(servernames) == 1
+assert servernames[0].servername == b"ab.cd"
+repr(pkt)
+
+with no_debug_dissector():
+    pkt = TLS_Ext_ServerName(b"\x00\x00\x00\x04\x00\x02\x00\x00")
+    servernames = pkt.servernames
+    assert len(servernames) == 1
+    assert isinstance(servernames[0], Raw)
+    repr(pkt)
+
 = Issue 3324 - FFDH support
 
 # Dissection


### PR DESCRIPTION
The servernames packet list field can contain "Raw" instances when server_name extenstions are malformed. The "i2repr" method doesn't expect that and ends up throwing exceptions when it can't find the "servername" attribute. This patch addresses that by removing the ServerListField class and relying on PacketListField doing the right thing. Another option would be to use something like
```python
[getattr(p, "servername", p) for p in x]
```
in the "ServerListField.i2repr" method but I think full server names along with their types and lengths are more helpful.

Fixes:
```python
  File "scapy/packet.py", line 563, in __repr__
    val = f.i2repr(self, fval)
          ^^^^^^^^^^^^^^^^^^^^
  File "scapy/layers/tls/extensions.py", line 180, in i2repr
    res = [p.servername for p in x]
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "scapy/layers/tls/extensions.py", line 180, in <listcomp>
    res = [p.servername for p in x]
           ^^^^^^^^^^^^
  File "scapy/packet.py", line 467, in __getattr__
    return self.payload.__getattr__(attr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "scapy/packet.py", line 465, in __getattr__
    fld, v = self.getfield_and_val(attr)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "scapy/packet.py", line 1788, in getfield_and_val
    raise AttributeError(attr)
AttributeError: servername
```