### PR TITLE
Tolerate non-UTF-8 NetBIOS names in NetBIOS answering machines

### DIFF
--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -13,6 +13,7 @@ import struct
 from scapy.arch import get_if_addr
 from scapy.base_classes import Net
 from scapy.ansmachine import AnsweringMachine
+from scapy.compat import bytes_encode
 from scapy.config import conf
 
 from scapy.packet import Packet, bind_bottom_up, bind_layers, bind_top_down
@@ -366,7 +367,7 @@ class NBNS_am(AnsweringMachine):
         :param from_ip: an IP (can have a netmask) to filter on
         :param ip: the IP to answer with
         """
-        self.ServerName = server_name
+        self.ServerName = bytes_encode(server_name or "")
         self.ip = ip
         if isinstance(from_ip, str):
             self.from_ip = Net(from_ip)
@@ -378,8 +379,7 @@ class NBNS_am(AnsweringMachine):
             return False
         return NBNSQueryRequest in req and (
             not self.ServerName or
-            req[NBNSQueryRequest].QUESTION_NAME.decode().strip() ==
-            self.ServerName
+            req[NBNSQueryRequest].QUESTION_NAME.strip() == self.ServerName
         )
 
     def make_reply(self, req):

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -133,3 +133,21 @@ def check_WiFi_am_reply(packet):
 test_WiFi_am(Dot11(FCfield="to-DS")/IP()/TCP()/"Scapy",
              check_WiFi_am_reply,
              iffrom="scapy0", ifto="scapy1", replace="5c4pY", pattern="Scapy")
+
+
+= NBNS_am
+def check_NBNS_am_reply(name):
+    def check(packet):
+        assert NBNSQueryResponse in packet and packet[NBNSQueryResponse].RR_NAME == bytes_encode(name)
+    return check
+
+for server_name in (None, "", b"test", "test"):
+    test_am(NBNS_am,
+            Ether()/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME="test"),
+            check_NBNS_am_reply("test"),
+            server_name=server_name)
+
+test_am(NBNS_am,
+        Ether()/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME=b"\x85"),
+        check_NBNS_am_reply(b"\x85"),
+        server_name=b"\x85")


### PR DESCRIPTION
NetBIOS names encoded using non-UTF-8 encodings can't be decoded without specifying them explicitly (and for that to work they have to be inferred based on bytes). It's kind of possible but instead of guessing encodings `is_request` uses raw question names and `server_name` is converted to bytes instead. To make it possible to spoof all sorts of hosts NBNS_am also accepts bytes as server_names directly (but the patch is backward-compatible with the previous versions accepting strings only). Empty strings and Nones are still equivalent and keep working too.

Fixes:
```python
  File "scapy/ansmachine.py", line 57, in <lambda>
  File "scapy/ansmachine.py", line 211, in __call__
  File "scapy/ansmachine.py", line 217, in sniff
  File "scapy/sendrecv.py", line 1311, in sniff
  File "scapy/sendrecv.py", line 1254, in _run
  File "scapy/sessions.py", line 109, in on_packet_received
  File "scapy/ansmachine.py", line 167, in reply
  File "scapy/layers/netbios.py", line 381, in is_request
    req[NBNSQueryRequest].QUESTION_NAME.decode().strip() ==
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf0 in position 0: invalid continuation byte
```