### PR TITLE
Recognize DNS cookies

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -541,7 +541,7 @@ class DNS(Packet):
 # RFC 2671 - Extension Mechanisms for DNS (EDNS0)
 
 edns0types = {0: "Reserved", 1: "LLQ", 2: "UL", 3: "NSID", 4: "Reserved",
-              5: "PING", 8: "edns-client-subnet"}
+              5: "PING", 8: "edns-client-subnet", 10: "COOKIE"}
 
 
 class EDNS0TLV(Packet):

--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -54,6 +54,13 @@ raw(tlv) == b'\x00\x05\x00\x04\x00\x11"3'
 #conf.debug_dissector = old_debug_dissector
 #len(r.ar) and r.ar.rdata[0].optcode == 4  # XXX: should be 5
 
++ Test EDNS-COOKIE
+
+= EDNS-COOKIE - basic instantiation
+tlv = EDNS0TLV(optcode="COOKIE", optdata=b"\x01" * 8)
+assert tlv.optcode == 10
+assert raw(tlv) == b"\x00\x0A\x00\x08\x01\x01\x01\x01\x01\x01\x01\x01"
+
 + Test DNS Name Server Identifier (NSID) Option
 
 = NSID- basic instantiation


### PR DESCRIPTION
It's mostly prompted by relatively new dig and delv sending cookies by default (unless `+nocookie`/`+noedns`/... is specified explicitly).

https://datatracker.ietf.org/doc/html/rfc7873#section-4