### PR TITLE
Add crypto_validator decorator to TLS13_HKDF methods to fix #4005

### DIFF
--- a/scapy/layers/tls/crypto/hkdf.py
+++ b/scapy/layers/tls/crypto/hkdf.py
@@ -9,7 +9,7 @@ Stateless HKDF for TLS 1.3.
 
 import struct
 
-from scapy.config import conf
+from scapy.config import conf, crypto_validator
 from scapy.layers.tls.crypto.pkcs1 import _get_hash
 
 if conf.crypto_valid:
@@ -20,9 +20,11 @@ if conf.crypto_valid:
 
 
 class TLS13_HKDF(object):
+    @crypto_validator
     def __init__(self, hash_name="sha256"):
         self.hash = _get_hash(hash_name)
 
+    @crypto_validator
     def extract(self, salt, ikm):
         h = self.hash
         hkdf = HKDF(h, h.digest_size, salt, None, default_backend())
@@ -30,11 +32,13 @@ class TLS13_HKDF(object):
             ikm = b"\x00" * h.digest_size
         return hkdf._extract(ikm)
 
+    @crypto_validator
     def expand(self, prk, info, L):
         h = self.hash
         hkdf = HKDFExpand(h, L, info, default_backend())
         return hkdf.derive(prk)
 
+    @crypto_validator
     def expand_label(self, secret, label, hash_value, length):
         hkdf_label = struct.pack("!H", length)
         hkdf_label += struct.pack("B", 6 + len(label))
@@ -44,6 +48,7 @@ class TLS13_HKDF(object):
         hkdf_label += hash_value
         return self.expand(secret, hkdf_label, length)
 
+    @crypto_validator
     def derive_secret(self, secret, label, messages):
         h = Hash(self.hash, backend=default_backend())
         h.update(messages)
@@ -51,6 +56,7 @@ class TLS13_HKDF(object):
         hash_len = self.hash.digest_size
         return self.expand_label(secret, label, hash_messages, hash_len)
 
+    @crypto_validator
     def compute_verify_data(self, basekey, handshake_context):
         hash_len = self.hash.digest_size
         finished_key = self.expand_label(basekey, b"finished", b"", hash_len)


### PR DESCRIPTION
Trigger an ImportError on calls to any TLS13_HKDF methods if the 'cryptography' module is missing.
