### PR TITLE
Don't require newline at end of pcapng comment

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1553,12 +1553,7 @@ class RawPcapNgReader(RawPcapReader):
                     tsresol & 127
                 )
             if code == 1 and length >= 1 and 4 + length < len(options):
-                comment = options[4:4 + length]
-                newline_index = comment.find(b"\n")
-                if newline_index == -1:
-                    warning("PcapNg: invalid comment option")
-                    break
-                opts["comment"] = comment[:newline_index]
+                opts["comment"] = options[4:4 + length]
             if code == 0:
                 if length != 0:
                     warning("PcapNg: invalid option length %d for end-of-option" % length)  # noqa: E501
@@ -2210,8 +2205,6 @@ class RawPcapNgWriter(GenericRawPcapWriter):
         comment_opt = None
         if comment:
             comment = bytes_encode(comment)
-            if not comment.endswith(b"\n"):
-                comment += b"\n"
             comment_opt = struct.pack(self.endian + "HH", 1, len(comment))
 
             # Pad Option Value to 32 bits

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1961,7 +1961,7 @@ p = Ether() / IPv6() / TCP()
 p.comment = b"Hello Scapy!"
 wrpcapng(tmpfile, p)
 l = rdpcap(tmpfile)
-assert l[0].comment.strip() == p.comment
+assert l[0].comment == p.comment
 
 = Read a pcap file with wirelen != captured len
 pktpcapwirelen = rdpcap(pcapwirelenfile)


### PR DESCRIPTION
I couldn't find anything in the spec about requiring this.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->
