### PR TITLE
Implement ISOTP packets for CANFD layer

### DIFF
--- a/scapy/contrib/isotp/__init__.py
+++ b/scapy/contrib/isotp/__init__.py
@@ -13,14 +13,17 @@ from scapy.config import conf
 from scapy.error import log_loading
 
 from scapy.contrib.isotp.isotp_packet import ISOTP, ISOTPHeader, \
-    ISOTPHeaderEA, ISOTP_SF, ISOTP_FF, ISOTP_CF, ISOTP_FC
+    ISOTPHeaderEA, ISOTP_SF, ISOTP_FF, ISOTP_CF, ISOTP_FC, \
+    ISOTP_FF_FD, ISOTP_SF_FD, ISOTPHeaderEA_FD, ISOTPHeader_FD
 from scapy.contrib.isotp.isotp_utils import ISOTPSession, \
     ISOTPMessageBuilder
 from scapy.contrib.isotp.isotp_soft_socket import ISOTPSoftSocket
 from scapy.contrib.isotp.isotp_scanner import isotp_scan
 
 __all__ = ["ISOTP", "ISOTPHeader", "ISOTPHeaderEA", "ISOTP_SF", "ISOTP_FF",
-           "ISOTP_CF", "ISOTP_FC", "ISOTPSoftSocket", "ISOTPSession",
+           "ISOTP_CF", "ISOTP_FC", "ISOTP_FF_FD", "ISOTP_SF_FD",
+           "ISOTPSoftSocket", "ISOTPSession", "ISOTPHeader_FD",
+           "ISOTPHeaderEA_FD",
            "ISOTPSocket", "ISOTPMessageBuilder", "isotp_scan",
            "USE_CAN_ISOTP_KERNEL_MODULE", "log_isotp"]
 

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -9,10 +9,11 @@
 import struct
 import logging
 
+from scapy.config import conf
 from scapy.packet import Packet
 from scapy.fields import BitField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ConditionalField, \
-    BitEnumField, ByteField, XByteField, BitFieldLenField, StrField
+    BitEnumField, ByteField, XByteField, BitFieldLenField, StrField, FieldLenField, IntField, ShortField
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN
 from scapy.error import Scapy_Exception
@@ -217,6 +218,10 @@ class ISOTPHeader(CAN):
         """
         if self.length is None:
             pkt = pkt[:4] + chb(len(pay)) + pkt[5:]
+
+        if conf.contribs['CAN']['swap-bytes']:
+            data = CAN.inv_endianness(pkt)  # type: bytes
+            return data + pay
         return pkt + pay
 
     def guess_payload_class(self, payload):
@@ -227,15 +232,63 @@ class ISOTPHeader(CAN):
         :param payload: payload bytes string
         :return: Type of payload class
         """
+        if len(payload) < 1:
+            return self.default_payload_class(payload)
+
         t = (orb(payload[0]) & 0xf0) >> 4
         if t == 0:
-            return ISOTP_SF
+            length = (orb(payload[0]) & 0x0f)
+            if length == 0:
+                return ISOTP_SF_FD
+            else:
+                return ISOTP_SF
         elif t == 1:
-            return ISOTP_FF
+            if len(payload) < 2:
+                return self.default_payload_class(payload)
+            length = ((orb(payload[0]) & 0x0f) << 12) + orb(payload[1])
+            if length == 0:
+                return ISOTP_FF_FD
+            else:
+                return ISOTP_FF
         elif t == 2:
             return ISOTP_CF
         else:
             return ISOTP_FC
+
+
+class ISOTPHeader_FD(ISOTPHeader):
+    name = 'ISOTPHeaderFD'
+    fields_desc = [
+        FlagsField('flags', 0, 3, ['error',
+                                   'remote_transmission_request',
+                                   'extended']),
+        XBitField('identifier', 0, 29),
+        ByteField('length', None),
+        FlagsField('fd_flags', 4, 8, ['bit_rate_switch',
+                                      'error_state_indicator',
+                                      'fd_frame']),
+        ShortField('reserved', 0),
+    ]
+
+    def post_build(self, pkt, pay):
+        # type: (bytes, bytes) -> bytes
+
+        data = super().post_build(pkt, pay)
+
+        length = data[4]
+
+        if 8 < length <= 24:
+            wire_length = length + (-length) % 4
+        elif 24 < length <= 64:
+            wire_length = length + (-length) % 8
+        elif length > 64:
+            raise NotImplementedError
+        else:
+            wire_length = length
+
+        pad = b"\x00" * (wire_length - length)
+
+        return data[0:4] + chb(wire_length) + data[5:] + pad
 
 
 class ISOTPHeaderEA(ISOTPHeader):
@@ -250,7 +303,7 @@ class ISOTPHeaderEA(ISOTPHeader):
         XByteField('extended_address', 0)
     ]
 
-    def post_build(self, p, pay):
+    def post_build(self, pkt, pay):
         # type: (bytes, bytes) -> bytes
         """
         This will set the ByteField 'length' to the correct value.
@@ -258,8 +311,48 @@ class ISOTPHeaderEA(ISOTPHeader):
         is counted as payload on the CAN layer
         """
         if self.length is None:
-            p = p[:4] + chb(len(pay) + 1) + p[5:]
-        return p + pay
+            pkt = pkt[:4] + chb(len(pay) + 1) + pkt[5:]
+
+        if conf.contribs['CAN']['swap-bytes']:
+            data = CAN.inv_endianness(pkt)  # type: bytes
+            return data + pay
+        return pkt + pay
+
+
+class ISOTPHeaderEA_FD(ISOTPHeaderEA):
+    name = 'ISOTPHeaderExtendedAddressFD'
+    fields_desc = [
+        FlagsField('flags', 0, 3, ['error',
+                                   'remote_transmission_request',
+                                   'extended']),
+        XBitField('identifier', 0, 29),
+        ByteField('length', None),
+        FlagsField('fd_flags', 4, 8, ['bit_rate_switch',
+                                      'error_state_indicator',
+                                      'fd_frame']),
+        ShortField('reserved', 0),
+        XByteField('extended_address', 0)
+    ]
+
+    def post_build(self, pkt, pay):
+        # type: (bytes, bytes) -> bytes
+
+        data = super().post_build(pkt, pay)
+
+        length = data[4]
+
+        if 8 < length <= 24:
+            wire_length = length + (-length) % 4
+        elif 24 < length <= 64:
+            wire_length = length + (-length) % 8
+        elif length > 64:
+            raise NotImplementedError
+        else:
+            wire_length = length
+
+        pad = b"\x00" * (wire_length - length)
+
+        return data[0:4] + chb(wire_length) + data[5:] + pad
 
 
 ISOTP_TYPE = {0: 'single',
@@ -277,13 +370,33 @@ class ISOTP_SF(Packet):
     ]
 
 
+class ISOTP_SF_FD(Packet):
+    name = 'ISOTPSingleFrameFD'
+    fields_desc = [
+        BitEnumField('type', 0, 4, ISOTP_TYPE),
+        BitField('zero_field', 0, 4),
+        FieldLenField('message_size', None, length_of='data', fmt="B"),
+        StrLenField('data', b'', length_from=lambda pkt: pkt.message_size)
+    ]
+
+
 class ISOTP_FF(Packet):
     name = 'ISOTPFirstFrame'
     fields_desc = [
         BitEnumField('type', 1, 4, ISOTP_TYPE),
         BitField('message_size', 0, 12),
-        ConditionalField(BitField('extended_message_size', 0, 32),
+        ConditionalField(IntField('extended_message_size', 0),
                          lambda pkt: pkt.message_size == 0),
+        StrField('data', b'', fmt="B")
+    ]
+
+
+class ISOTP_FF_FD(Packet):
+    name = 'ISOTPFirstFrame'
+    fields_desc = [
+        BitEnumField('type', 1, 4, ISOTP_TYPE),
+        BitField('zero_field', 0, 12),
+        IntField('message_size', 0),
         StrField('data', b'', fmt="B")
     ]
 

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -13,7 +13,8 @@ from scapy.config import conf
 from scapy.packet import Packet
 from scapy.fields import BitField, FlagsField, StrLenField, \
     ThreeBytesField, XBitField, ConditionalField, \
-    BitEnumField, ByteField, XByteField, BitFieldLenField, StrField, FieldLenField, IntField, ShortField
+    BitEnumField, ByteField, XByteField, BitFieldLenField, StrField, \
+    FieldLenField, IntField, ShortField
 from scapy.compat import chb, orb
 from scapy.layers.can import CAN
 from scapy.error import Scapy_Exception

--- a/test/contrib/isotp_packet.uts
+++ b/test/contrib/isotp_packet.uts
@@ -195,25 +195,19 @@ assert p.type == 1
 assert p.identifier == 0
 
 = Build FF frame EA, extended size, with constructor, check for correct length assignments
-p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_FF(message_size=0,
-                                                 extended_message_size=2000,
-                                                 data=b'\xad')))
+p = ISOTPHeaderEA(bytes(ISOTPHeaderEA()/ISOTP_FF_FD(message_size=2000, data=b'\xad')))
 assert p.extended_address == 0
 assert p.length == 8
-assert p.message_size == 0
-assert p.extended_message_size == 2000
+assert p.message_size == 2000
 assert len(p.data) == 1
 assert p.data == b'\xad'
 assert p.type == 1
 assert p.identifier == 0
 
 = Build FF frame, extended size, with constructor, check for correct length assignments
-p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_FF(message_size=0,
-                                             extended_message_size=2000,
-                                             data=b'\xad')))
+p = ISOTPHeader(bytes(ISOTPHeader()/ISOTP_FF_FD(message_size=2000, data=b'\xad')))
 assert p.length == 7
-assert p.message_size == 0
-assert p.extended_message_size == 2000
+assert p.message_size == 2000
 assert len(p.data) == 1
 assert p.data == b'\xad'
 assert p.type == 1
@@ -451,3 +445,70 @@ isotpex.show()
 assert isotpex.data == dhex("AA")
 assert isotpex.rx_ext_address == 0x02
 
+= Build ISOTP_FF_FD
+
+pkt = ISOTP_FF_FD(message_size=0xffff0000)
+assert bytes(pkt) == bytes.fromhex("1000ffff0000")
+
+= Build ISOTP_SF_FD
+
+pkt = ISOTP_SF_FD(message_size=0xff)
+assert bytes(pkt) == bytes.fromhex("00ff")
+
+= Build ISOTP_FF_FD 2
+
+pkt = ISOTPHeaderEA_FD(identifier=0x7ff, extended_address=0xaf)/ISOTP_FF_FD(message_size=0xffff0000)
+assert bytes(pkt) == bytes.fromhex("000007ff 07 04 00 00 af 1000ffff0000")
+
+= Build ISOTP_SF_FD 2
+
+pkt = ISOTPHeaderEA_FD(identifier=0x7ff, extended_address=0xaf)/ISOTP_SF_FD(message_size=0xff)
+assert bytes(pkt) == bytes.fromhex("000007ff 03 04 00 00 af 00ff")
+
+= Build ISOTP_FF_FD 3
+
+pkt = ISOTPHeader_FD(identifier=0x7ff)/ISOTP_FF_FD(message_size=0xffff0000)
+assert bytes(pkt) == bytes.fromhex("000007ff 06 04 00 00 1000ffff0000")
+
+= Build ISOTP_SF_FD 3
+
+pkt = ISOTPHeader_FD(identifier=0x7ff)/ISOTP_SF_FD(message_size=0xff)
+assert bytes(pkt) == bytes.fromhex("000007ff 02 04 00 00 00ff")
+
+= Dissect ISOTPFD 1
+pkt = ISOTPHeaderEA_FD(bytes.fromhex("000007ff 07 04 00 00 af 1000ffff0000"))
+pkt.show()
+sub_pkt = pkt[ISOTP_FF_FD]
+assert pkt.identifier == 0x7ff
+assert pkt.length == 0x7
+assert pkt.fd_flags == 0x4
+assert pkt.extended_address == 0xaf
+assert sub_pkt.message_size == 0xffff0000
+
+= Dissect ISOTPFD 2
+pkt = ISOTPHeaderEA_FD(bytes.fromhex("000007ff 07 04 00 00 af 00ff00000000"))
+pkt.show()
+sub_pkt = pkt[ISOTP_SF_FD]
+assert pkt.identifier == 0x7ff
+assert pkt.length == 0x7
+assert pkt.fd_flags == 0x4
+assert pkt.extended_address == 0xaf
+assert sub_pkt.message_size == 0xff
+
+= Dissect ISOTPFD 3
+pkt = ISOTPHeader_FD(bytes.fromhex("000007ff 06 04 00 00 1000ffff0000"))
+pkt.show()
+sub_pkt = pkt[ISOTP_FF_FD]
+assert pkt.identifier == 0x7ff
+assert pkt.length == 0x6
+assert pkt.fd_flags == 0x4
+assert sub_pkt.message_size == 0xffff0000
+
+= Dissect ISOTPFD 4
+pkt = ISOTPHeader_FD(bytes.fromhex("000007ff 06 04 00 00 00ff00000000"))
+pkt.show()
+sub_pkt = pkt[ISOTP_SF_FD]
+assert pkt.identifier == 0x7ff
+assert pkt.length == 0x6
+assert pkt.fd_flags == 0x4
+assert sub_pkt.message_size == 0xff


### PR DESCRIPTION
On the CANFD protocol, two additional packets for ISOTP are possible. This PR adds those to scapy