### PR TITLE
Import InvalidSignature from the correct location

### DIFF
--- a/scapy/layers/tls/cert.py
+++ b/scapy/layers/tls/cert.py
@@ -45,10 +45,10 @@ from scapy.layers.tls.crypto.pkcs1 import pkcs_os2ip, _get_hash, \
     _EncryptAndVerifyRSA, _DecryptAndSignRSA
 from scapy.compat import raw, bytes_encode
 if conf.crypto_valid:
+    from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import rsa, ec
-    from cryptography.hazmat.backends.openssl.ec import InvalidSignature
 
 
 # Maximum allowed size in bytes for a certificate file, to avoid


### PR DESCRIPTION
`cryptography.hazmat.backends.openssl.ec ` was not a public API, but an implementation detail, and is likely to be removed (see https://github.com/pyca/cryptography/pull/9024)