### PR TITLE
bluetooth: Remove duplicage XLEShortField implementation

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -43,23 +43,20 @@ from scapy.fields import (
     XByteField,
     XLELongField,
     XStrLenField,
+    XLEShortField,
 )
 from scapy.supersocket import SuperSocket
 from scapy.sendrecv import sndrcv
 from scapy.data import MTU
 from scapy.consts import WINDOWS
 from scapy.error import warning
-from scapy.utils import lhex, mac2str, str2mac
+from scapy.utils import mac2str, str2mac
 from scapy.volatile import RandMAC
 
 
 ##########
 # Fields #
 ##########
-
-class XLEShortField(LEShortField):
-    def i2repr(self, pkt, x):
-        return lhex(self.i2h(pkt, x))
 
 
 class LEMACField(Field):


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->

Remove duplicage XLEShortField implementation in bluetooth layer
