### PR TITLE
Fix ICMPEcho_am description

### DIFF
--- a/doc/scapy/layers/tuntap.rst
+++ b/doc/scapy/layers/tuntap.rst
@@ -134,11 +134,10 @@ You should see those packets show up in Scapy:
     Replying 192.0.2.1 to 192.0.2.2
     Replying 192.0.2.1 to 192.0.2.2
 
-You might have noticed that didn't configure Scapy with any IP address... and
-there's a trick to this: :py:class:`ICMPEcho_am` swaps the ``source`` and
-``destination`` fields of any :py:class:`Ether` and :py:class:`IP` headers on
-the :py:class:`ICMP` packet that it receives. As a result, it actually responds
-to *any* IP address.
+You might have noticed that we didn't configure Scapy with any IP address... and
+there's a trick to this: :py:class:`ICMPEcho_am` uses the ``source`` field from
+the :py:class:`IP` header of the packet that it receives as the destination for its
+echo reply. As a result, it actually responds to *any* IP address.
 
 You can stop the :py:class:`ICMPEcho_am` AnsweringMachine with :kbd:`^C`.
 


### PR DESCRIPTION
From the ICMPEcho_am code:
```
    def make_reply(self, req):
        reply = IP(dst=req[IP].src) / ICMP()
        reply[ICMP].type = 0  # echo-reply
        reply[ICMP].seq = req[ICMP].seq
        reply[ICMP].id = req[ICMP].id
        # Force re-generation of the checksum
        reply[ICMP].chksum = None
        return reply
```

Nothing is actually swapped; the source IP address from the echo request is used as the destination for the echo reply. `src` in the echo reply is left unspecified, so it defaults to that of the outgoing interface
