### PR TITLE
GRE-in-UDP uses port 4754 (see RFC 8086)

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1089,6 +1089,7 @@ bind_layers(IP, ICMP, frag=0, proto=1)
 bind_layers(IP, TCP, frag=0, proto=6)
 bind_layers(IP, UDP, frag=0, proto=17)
 bind_layers(IP, GRE, frag=0, proto=47)
+bind_layers(UDP, GRE, dport=4754)
 
 conf.l2types.register(DLT_RAW, IP)
 conf.l2types.register_num2layer(DLT_RAW_ALT, IP)

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -595,6 +595,60 @@ with mock.patch("scapy.layers.l2.getmacbyip", side_effect=_err):
         except ValueError:
             pass
 
+= GRE binding tests
+
+* Test GRE-in-IP
+pkt = Ether(raw(Ether()/IP()/GRE()/IP()/UDP()))
+assert isinstance(pkt, Ether)
+pkt = pkt.payload
+assert isinstance(pkt, IP) and pkt.proto == 47
+pkt = pkt.payload
+assert isinstance(pkt, GRE) and pkt.proto == 0x0800
+pkt = pkt.payload
+assert isinstance(pkt, IP)
+pkt = pkt.payload
+assert isinstance(pkt, UDP)
+
+* Test GRE-in-IPv6
+pkt = Ether(raw(Ether()/IPv6()/GRE()/IPv6()/UDP()))
+assert isinstance(pkt, Ether)
+pkt = pkt.payload
+assert isinstance(pkt, IPv6) and pkt.nh == 47
+pkt = pkt.payload
+assert isinstance(pkt, GRE) and pkt.proto == 0x86dd
+pkt = pkt.payload
+assert isinstance(pkt, IPv6)
+pkt = pkt.payload
+assert isinstance(pkt, UDP)
+
+* Test GRE-in-UDP
+pkt = Ether(raw(Ether()/IP()/UDP()/GRE()/IP()/UDP()))
+assert isinstance(pkt, Ether)
+pkt = pkt.payload
+assert isinstance(pkt, IP)
+pkt = pkt.payload
+assert isinstance(pkt, UDP) and pkt.dport == 4754
+pkt = pkt.payload
+assert isinstance(pkt, GRE) and pkt.proto == 0x0800
+pkt = pkt.payload
+assert isinstance(pkt, IP)
+pkt = pkt.payload
+assert isinstance(pkt, UDP)
+
+* Test GRE-in-UDP (IPv6)
+pkt = Ether(raw(Ether()/IPv6()/UDP()/GRE()/IPv6()/UDP()))
+assert isinstance(pkt, Ether)
+pkt = pkt.payload
+assert isinstance(pkt, IPv6)
+pkt = pkt.payload
+assert isinstance(pkt, UDP) and pkt.dport == 4754
+pkt = pkt.payload
+assert isinstance(pkt, GRE) and pkt.proto == 0x86dd
+pkt = pkt.payload
+assert isinstance(pkt, IPv6)
+pkt = pkt.payload
+assert isinstance(pkt, UDP)
+
 ############
 ############
 + inet.py


### PR DESCRIPTION
GRE-in-UDP uses port 4754 (see RFC 8086)

This change just adds the `bind_layers`; I can add a test as well, just not sure what file it should go in.  I see some GRE stuff in pptp and erspan, but maybe inet and/or inet6 would make more sense.