### PR TITLE
[inet6] add Captive-Portal RA option

### DIFF
--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -1210,6 +1210,36 @@ ICMPv6NDOptDNSSL(searchlist=["home.", "office.", "{"]).mysummary() == "ICMPv6 Ne
 
 ############
 ############
++ ICMPv6NDOptCaptivePortal Class Test
+
+= ICMPv6NDOptCaptivePortal - Basic Instantiation
+raw(ICMPv6NDOptCaptivePortal()) == b"\x25\x01\x00\x00\x00\x00\x00\x00"
+
+= ICMPv6NDOptCaptivePortal - Instantiation with captive portal URI
+raw(ICMPv6NDOptCaptivePortal(URI="https://example.com")) == b"\x25\x03https://example.com\x00\x00\x00"
+
+= ICMPv6NDOptCaptivePortal - Instantiation where total length is already a multiple of 8 bytes
+p = ICMPv6NDOptCaptivePortal(URI="abcdef")
+len(p) == 8 and raw(p) == b"\x25\x01abcdef" and ICMPv6NDOptCaptivePortal(raw(p)).URI == b"abcdef"
+
+= ICMPv6NDOptCaptivePortal - Basic Dissection
+p = ICMPv6NDOptCaptivePortal(b"\x25\x01\x00\x00\x00\x00\x00\x00")
+p.type == 37 and p.len == 1 and p.URI == b""
+
+= ICMPv6NDOptCaptivePortal - Basic Dissection with captive portal URI
+p = ICMPv6NDOptCaptivePortal(b"\x25\x03https://example.com\x00\x00\x00")
+p.type == 37 and p.len == 3 and p.URI == b"https://example.com"
+
+= ICMPv6NDOptCaptivePortal - Dissection with zero length
+p = ICMPv6NDOptCaptivePortal(b"\x25\x00abcdefgh")
+p.type == 37 and p.len == 0 and p.URI == b"abcdef" and Raw in p and len(p[Raw]) == 2
+
+= ICMPv6NDOptCaptivePortal - Summary Output
+ICMPv6NDOptCaptivePortal(URI="https://example.com").mysummary() == "ICMPv6 Neighbor Discovery Option - Captive-Portal Option 'https://example.com'"
+
+
+############
+############
 + ICMPv6NDOptEFA Class Test
 
 = ICMPv6NDOptEFA - Basic Instantiation


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc8910.html#name-the-captive-portal-ipv6-ra-
```
    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |     Type      |     Length    |              URI              .
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               .
   .                                                               .
   .                                                               .
   .                                                               .
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

Type: 37

Length: 8-bit unsigned integer. The length of the option
   (including the Type and Length fields) in units of 8 bytes.

URI: The URI for the captive portal API endpoint to which the
   user should connect. This MUST be padded with NUL (0x00) to
   make the total option length (including the Type and Length
   fields) a multiple of 8 bytes.
```

Combined with f37c4021eb191b2cf95693dc308a06d2bfb17717 this patch should fully cover RFC8910.

The patch has been used and tested downstream for about a week and helped to trigger various issues like
https://github.com/systemd/systemd/issues/28229
https://github.com/systemd/systemd/issues/28231
https://github.com/systemd/systemd/issues/28277
https://github.com/systemd/systemd/issues/28283