### PR TITLE
fix SOMEIP answers function, in case there is SD above

### DIFF
--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -125,11 +125,21 @@ class SOMEIP(Packet):
         if isinstance(other, type(self)):
             if self.msg_type in [SOMEIP.TYPE_REQUEST_NO_RET,
                                  SOMEIP.TYPE_REQUEST_NORET_ACK,
-                                 SOMEIP.TYPE_NOTIFICATION,
                                  SOMEIP.TYPE_TP_REQUEST_NO_RET,
                                  SOMEIP.TYPE_TP_NOTIFICATION]:
                 return 0
+
+            # if Notification but not SD
+            if (self.msg_type == SOMEIP.TYPE_NOTIFICATION and (self.srv_id != SD.SOMEIP_MSGID_SRVID
+                                                               or self.sub_id != SD.SOMEIP_MSGID_SUBID
+                                                               or self.event_id != SD.SOMEIP_MSGID_EVENTID
+                                                               or self.proto_ver != SD.SOMEIP_PROTO_VER
+                                                               or self.iface_ver != SD.SOMEIP_IFACE_VER
+                                                               or self.retcode != SD.SOMEIP_RETCODE)):
+                return 0
+
             return self.payload.answers(other.payload)
+
         return 0
 
     @staticmethod


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [V] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [V] I squashed commits belonging together
-   [] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
This fixes a bug in the answers function of SOMEIP, in case there is a SD above it. it should be considered.
<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
