### PR TITLE
Update SD class to support Explicit Initial Data Control Flag

### DIFF
--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -432,7 +432,8 @@ class SD(_SDPacketBase):
     _sdFlag = collections.namedtuple('Flag', 'mask offset')
     FLAGSDEF = {
         "REBOOT": _sdFlag(mask=0x80, offset=7),
-        "UNICAST": _sdFlag(mask=0x40, offset=6)
+        "UNICAST": _sdFlag(mask=0x40, offset=6),
+        "EXPLICIT_INITIAL_DATA_CONTROL": _sdFlag(mask=0x20, offset=5),
     }
 
     name = "SD"

--- a/test/contrib/automotive/someip.uts
+++ b/test/contrib/automotive/someip.uts
@@ -208,9 +208,16 @@ assert p.flags == 0x40
 p.set_flag("UNICAST", 0)
 assert p.flags == 0x00
 
+p.set_flag("EXPLICIT_INITIAL_DATA_CONTROL", 1)
+assert p.flags == 0x20
+
+p.set_flag("EXPLICIT_INITIAL_DATA_CONTROL", 0)
+assert p.flags == 0x00
+
 p.set_flag("REBOOT", 1)
 p.set_flag("UNICAST", 1)
-assert p.flags == 0xc0
+p.set_flag("EXPLICIT_INITIAL_DATA_CONTROL", 1)
+assert p.flags == 0xe0
 
 + SD Get SOME/IP Packet
 


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

This PR will add the `EXPLICIT_INITIAL_DATA_CONTROL` key to the `FLAGSDEF` dictionary in the `SD` class.

In the latest version, the `FLAGSDEF` dictionary is defined as follows:

```python
FLAGSDEF = {
    "REBOOT": _sdFlag(mask=0x80, offset=7),
    "UNICAST": _sdFlag(mask=0x40, offset=6)
}

```

According to the SOME/IP-SD protocol, the correct `FLAGSDEF` should be:

```python
FLAGSDEF = {
    "REBOOT": _sdFlag(mask=0x80, offset=7),
    "UNICAST": _sdFlag(mask=0x40, offset=6),
    "EXPLICIT_INITIAL_DATA_CONTROL": _sdFlag(mask=0x20, offset=5),
}

```

For more detail, please see [PRS_SOMEIPSD_00700] in [SOME/IP Service Discovery Protocol Specification](https://www.autosar.org/fileadmin/standards/R1-5-0/FO/AUTOSAR_PRS_SOMEIPServiceDiscoveryProtocol.pdf).

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #4058
