### PR TITLE
Add bufsz parameter to RawPcapWriter constructor

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1939,6 +1939,7 @@ class RawPcapWriter(GenericRawPcapWriter):
                  sync=False,  # type: bool
                  nano=False,  # type: bool
                  snaplen=MTU,  # type: int
+                 bufsz=4096,  # type: int
                  ):
         # type: (...) -> None
         """
@@ -1963,7 +1964,6 @@ class RawPcapWriter(GenericRawPcapWriter):
         self.endian = endianness
         self.sync = sync
         self.nano = nano
-        bufsz = 4096
         if sync:
             bufsz = 0
 


### PR DESCRIPTION
I added a `bufsz` parameter to the `RawPcapWriter` constructor to allow users to specify a custom buffersize. This does will not change the behavior of any pre-existing code, and will only change the buffer size of the file being opened if specified (otherwise it will default to 4096, as the class currently does).

This will help speed up any pcap creation, especially for large pcap files.