### PR TITLE
Add conf.nameservers + small dns resolver

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -44,6 +44,7 @@ __all__ = [  # noqa: F405
     "get_if_raw_hwaddr",
     "get_working_if",
     "in6_getifaddr",
+    "read_nameservers",
     "read_routes",
     "read_routes6",
     "SIOCGIFHWADDR",
@@ -119,6 +120,7 @@ def get_if_raw_addr6(iff):
 # def get_if_raw_addr(iff)
 # def get_if_raw_hwaddr(iff)
 # def in6_getifaddr()
+# def read_nameservers()
 # def read_routes()
 # def read_routes6()
 # def set_promisc(s,iff,val=1)
@@ -126,7 +128,12 @@ def get_if_raw_addr6(iff):
 if LINUX:
     from scapy.arch.linux import *  # noqa F403
 elif BSD:
-    from scapy.arch.unix import read_routes, read_routes6, in6_getifaddr  # noqa: E501
+    from scapy.arch.unix import (  # noqa F403
+        read_nameservers,
+        read_routes,
+        read_routes6,
+        in6_getifaddr,
+    )
     from scapy.arch.bpf.core import *  # noqa F403
     if not conf.use_pcap:
         # Native

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -47,6 +47,9 @@ from scapy.packet import Packet, Padding
 from scapy.pton_ntop import inet_ntop
 from scapy.supersocket import SuperSocket
 
+# re-export
+from scapy.arch.unix import read_nameservers  # noqa: F401
+
 # Typing imports
 from typing import (
     Any,

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -8,6 +8,7 @@ Common customizations for all Unix-like operating systems other than Linux
 """
 
 import os
+import re
 import socket
 import struct
 from fcntl import ioctl
@@ -409,3 +410,18 @@ def read_routes6():
 
     fd_netstat.close()
     return routes
+
+
+#######
+# DNS #
+#######
+
+def read_nameservers() -> List[str]:
+    """Return the nameservers configured by the OS
+    """
+    try:
+        with open('/etc/resolv.conf', 'r') as fd:
+            return re.findall(r"nameserver\s+([^\s]+)", fd.read())
+    except FileNotFoundError:
+        warning("Could not retrieve the OS's nameserver !")
+        return []

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -17,9 +17,13 @@ import warnings
 
 import winreg
 
-from scapy.arch.windows.structures import _windows_title, \
-    GetAdaptersAddresses, GetIpForwardTable, GetIpForwardTable2, \
-    get_service_status
+from scapy.arch.windows.structures import (
+    _windows_title,
+    GetAdaptersAddresses,
+    GetIpForwardTable,
+    GetIpForwardTable2,
+    get_service_status,
+)
 from scapy.consts import WINDOWS, WINDOWS_XP
 from scapy.config import conf, ProgPath
 from scapy.error import (
@@ -263,32 +267,32 @@ def get_windows_if_list(extended=False):
         data = bytearray(x["physical_address"])
         return str2mac(bytes(data)[:size])
 
+    def _resolve_ips(y):
+        # type: (List[Dict[str, Any]]) -> List[str]
+        if not isinstance(y, list):
+            return []
+        ips = []
+        for ip in y:
+            addr = ip['address']['address'].contents
+            if addr.si_family == socket.AF_INET6:
+                ip_key = "Ipv6"
+                si_key = "sin6_addr"
+            else:
+                ip_key = "Ipv4"
+                si_key = "sin_addr"
+            data = getattr(addr, ip_key)
+            data = getattr(data, si_key)
+            data = bytes(bytearray(data.byte))
+            # Build IP
+            if data:
+                ips.append(inet_ntop(addr.si_family, data))
+        return ips
+
     def _get_ips(x):
         # type: (Dict[str, Any]) -> List[str]
         unicast = x['first_unicast_address']
         anycast = x['first_anycast_address']
         multicast = x['first_multicast_address']
-
-        def _resolve_ips(y):
-            # type: (List[Dict[str, Any]]) -> List[str]
-            if not isinstance(y, list):
-                return []
-            ips = []
-            for ip in y:
-                addr = ip['address']['address'].contents
-                if addr.si_family == socket.AF_INET6:
-                    ip_key = "Ipv6"
-                    si_key = "sin6_addr"
-                else:
-                    ip_key = "Ipv4"
-                    si_key = "sin_addr"
-                data = getattr(addr, ip_key)
-                data = getattr(data, si_key)
-                data = bytes(bytearray(data.byte))
-                # Build IP
-                if data:
-                    ips.append(inet_ntop(addr.si_family, data))
-            return ips
 
         ips = []
         ips.extend(_resolve_ips(unicast))
@@ -306,7 +310,8 @@ def get_windows_if_list(extended=False):
             "mac": _get_mac(x),
             "ipv4_metric": 0 if WINDOWS_XP else x["ipv4_metric"],
             "ipv6_metric": 0 if WINDOWS_XP else x["ipv6_metric"],
-            "ips": _get_ips(x)
+            "ips": _get_ips(x),
+            "nameservers": _resolve_ips(x["first_dns_server_address"])
         } for x in GetAdaptersAddresses()
     ]
 
@@ -329,6 +334,7 @@ class NetworkInterface_Win(NetworkInterface):
         self.cache_mode = None  # type: Optional[bool]
         self.ipv4_metric = None  # type: Optional[int]
         self.ipv6_metric = None  # type: Optional[int]
+        self.nameservers = []  # type: List[str]
         self.guid = None  # type: Optional[str]
         self.raw80211 = None  # type: Optional[bool]
         super(NetworkInterface_Win, self).__init__(provider, data)
@@ -344,6 +350,7 @@ class NetworkInterface_Win(NetworkInterface):
         self.guid = data['guid']
         self.ipv4_metric = data['ipv4_metric']
         self.ipv6_metric = data['ipv6_metric']
+        self.nameservers = data['nameservers']
 
         try:
             # Npcap loopback interface
@@ -640,7 +647,8 @@ class WindowsInterfacesProvider(InterfaceProvider):
                     'ipv4_metric': 0,
                     'ipv6_metric': 0,
                     'ips': ips,
-                    'flags': flags
+                    'flags': flags,
+                    'nameservers': [],
                 }
             # No KeyError will happen here, as we get it from cache
             results[netw] = NetworkInterface_Win(self, data)
@@ -1016,3 +1024,15 @@ class _NotAvailableSocket(SuperSocket):
             "winpcap is not installed. You may use conf.L3socket or"
             "conf.L3socket6 to access layer 3"
         )
+
+
+#######
+# DNS #
+#######
+
+def read_nameservers() -> List[str]:
+    """Return the nameservers configured by the OS (on the default interface)
+    """
+    # Windows has support for different DNS servers on each network interface,
+    # but to be cross-platform we only return the servers for the default one.
+    return cast(NetworkInterface_Win, conf.iface).nameservers

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -344,8 +344,8 @@ def lsc():
     print(repr(conf.commands))
 
 
-class CacheInstance(Dict[str, Any], object):
-    __slots__ = ["timeout", "name", "_timetable", "__dict__"]
+class CacheInstance(Dict[str, Any]):
+    __slots__ = ["timeout", "name", "_timetable"]
 
     def __init__(self, name="noname", timeout=None):
         # type: (str, Optional[int]) -> None
@@ -355,11 +355,8 @@ class CacheInstance(Dict[str, Any], object):
 
     def flush(self):
         # type: () -> None
-        CacheInstance.__init__(
-            self,
-            name=self.name,
-            timeout=self.timeout
-        )
+        self._timetable.clear()
+        self.clear()
 
     def __getitem__(self, item):
         # type: (str) -> Any
@@ -403,20 +400,23 @@ class CacheInstance(Dict[str, Any], object):
     def iteritems(self):
         # type: () -> Iterator[Tuple[str, Any]]
         if self.timeout is None:
-            return self.__dict__.items()  # type: ignore
+            return super(CacheInstance, self).items()  # type: ignore
         t0 = time.time()
         return (
-            (k, v) for (k, v) in self.__dict__.items()
+            (k, v)
+            for (k, v) in super(CacheInstance, self).items()
             if t0 - self._timetable[k] < self.timeout
         )
 
     def iterkeys(self):
         # type: () -> Iterator[str]
         if self.timeout is None:
-            return self.__dict__.keys()  # type: ignore
+            return super(CacheInstance, self).keys()  # type: ignore
         t0 = time.time()
         return (
-            k for k in self.__dict__ if t0 - self._timetable[k] < self.timeout
+            k
+            for k in super(CacheInstance, self).keys()
+            if t0 - self._timetable[k] < self.timeout
         )
 
     def __iter__(self):
@@ -426,39 +426,25 @@ class CacheInstance(Dict[str, Any], object):
     def itervalues(self):
         # type: () -> Iterator[Tuple[str, Any]]
         if self.timeout is None:
-            return self.__dict__.values()  # type: ignore
+            return super(CacheInstance, self).values()  # type: ignore
         t0 = time.time()
         return (
-            v for (k, v) in self.__dict__.items()
+            v
+            for (k, v) in super(CacheInstance, self).items()
             if t0 - self._timetable[k] < self.timeout
         )
 
     def items(self):
         # type: () -> Any
-        if self.timeout is None:
-            return super(CacheInstance, self).items()
-        t0 = time.time()
-        return [
-            (k, v) for (k, v) in self.__dict__.items()
-            if t0 - self._timetable[k] < self.timeout
-        ]
+        return list(self.iteritems())
 
     def keys(self):
         # type: () -> Any
-        if self.timeout is None:
-            return super(CacheInstance, self).keys()
-        t0 = time.time()
-        return [k for k in self.__dict__ if t0 - self._timetable[k] < self.timeout]
+        return list(self.iterkeys())
 
     def values(self):
         # type: () -> Any
-        if self.timeout is None:
-            return list(self.values())
-        t0 = time.time()
-        return [
-            v for (k, v) in self.__dict__.items()
-            if t0 - self._timetable[k] < self.timeout
-        ]
+        return list(self.itervalues())
 
     def __len__(self):
         # type: () -> int
@@ -474,9 +460,9 @@ class CacheInstance(Dict[str, Any], object):
         # type: () -> str
         s = []
         if self:
-            mk = max(len(k) for k in self.__dict__)
+            mk = max(len(k) for k in self)
             fmt = "%%-%is %%s" % (mk + 1)
-            for item in self.__dict__.items():
+            for item in self.items():
                 s.append(fmt % item)
         return "\n".join(s)
 

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -785,8 +785,10 @@ class Conf(ConfClass):
     ifaces = None  # type: 'scapy.interfaces.NetworkInterfaceDict'
     #: holds the cache of interfaces loaded from Libpcap
     cache_pcapiflist = {}  # type: Dict[str, Tuple[str, List[str], Any, str]]
-    neighbor = None  # type: 'scapy.layers.l2.Neighbor'
     # `neighbor` will be filed by scapy.layers.l2
+    neighbor = None  # type: 'scapy.layers.l2.Neighbor'
+    #: holds the name servers IP/hosts used for custom DNS resolution
+    nameservers = None  # type: str
     #: holds the Scapy IPv4 routing table and provides methods to
     #: manipulate it
     route = None  # type: 'scapy.route.Route'
@@ -828,6 +830,7 @@ class Conf(ConfClass):
     stats_classic_protocols = []  # type: List[Type[Packet]]
     stats_dot11_protocols = []  # type: List[Type[Packet]]
     temp_files = []  # type: List[str]
+    #: netcache holds time-based caches for net operations
     netcache = NetCache()
     geoip_city = None
     # can, tls, http and a few others are not loaded by default

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -287,6 +287,7 @@ class NetworkInterfaceDict(UserDict[str, NetworkInterface]):
             'guid': "{%s}" % uuid.uuid1(),
             'ipv4_metric': 0,
             'ipv6_metric': 0,
+            'nameservers': [],
         }
         if WINDOWS:
             from scapy.arch.windows import NetworkInterface_Win, \

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -17,6 +17,20 @@ def _test():
 
 dns_ans = retry_test(_test)
 
+= DNS request using dns_resolve
+~ netaccess DNS
+* this is not using a raw socket so should also work without root
+
+val = dns_resolve(qname="google.com", qtype="A")
+assert val
+assert inet_pton(socket.AF_INET, val)
+assert val == conf.netcache.dns_cache["google.com_A"]
+
+val = dns_resolve(qname="google.com", qtype="AAAA")
+assert val
+assert inet_pton(socket.AF_INET6, val)
+assert val == conf.netcache.dns_cache["google.com_AAAA"]
+
 = DNS labels
 ~ DNS
 query = DNSQR(qname=b"www.secdev.org")


### PR DESCRIPTION
- adds `conf.nameservers` which is read from either `resolv.conf` or the windows C API
- adds a small `dns_resolve` (propose better name?) util that queries the server in `conf.nameservers`
- fixes issues with `CacheInstance` and minor cleanups (found randomly while doing this)

The purpose of this is to have a very simple and reliable API to use in other Scapy scripts / functions, and not to have the more "craft-it-yourself" approach (that's also very nice) you'd have with `sr1(IP()/UDP()/DNS())`. I'm using that in a future PR.