### PR TITLE
Fix doipsocket6

### DIFF
--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -375,6 +375,7 @@ class DoIPSocket6(DoIPSocket):
         self.ip = ip
         self.port = port
         self.source_address = source_address
+        self.buffer = b""
         super(DoIPSocket6, self)._init_socket(socket.AF_INET6)
 
         if activate_routing:

--- a/test/contrib/automotive/doip.uts
+++ b/test/contrib/automotive/doip.uts
@@ -430,7 +430,7 @@ def server():
 server_thread = threading.Thread(target=server)
 server_thread.start()
 server_up.wait(timeout=1)
-sock = DoIPSocket(activate_routing=False)
+sock = DoIPSocket6(activate_routing=False)
 
 pkts = sock.sniff(timeout=1, count=2)
 assert len(pkts) == 2

--- a/test/contrib/automotive/doip.uts
+++ b/test/contrib/automotive/doip.uts
@@ -430,3 +430,7 @@ def server():
 server_thread = threading.Thread(target=server)
 server_thread.start()
 server_up.wait(timeout=1)
+sock = DoIPSocket(activate_routing=False)
+
+pkts = sock.sniff(timeout=1, count=2)
+assert len(pkts) == 2

--- a/test/contrib/automotive/doip.uts
+++ b/test/contrib/automotive/doip.uts
@@ -407,3 +407,26 @@ sock = DoIPSocket(activate_routing=False)
 
 pkts = sock.sniff(timeout=1, count=2)
 assert len(pkts) == 2
+
+= Test DoIPSocket6
+
+server_up = threading.Event()
+def server():
+    buffer = b'\x02\xfd\x80\x02\x00\x00\x00\x05\x00\x00\x00\x00\x00\x02\xfd\x80\x01\x00\x00\x00\n\x10\x10\x0e\x80P\x03\x002\x01\xf4'
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(('::1', 13400))
+        sock.listen(1)
+        server_up.set()
+        connection, address = sock.accept()
+        connection.send(buffer)
+        connection.close()
+    finally:
+        sock.close()
+
+
+server_thread = threading.Thread(target=server)
+server_thread.start()
+server_up.wait(timeout=1)


### PR DESCRIPTION
minor fix in doip.py adding the "buffer" variable which was introduced in the last fix for DoIP.
Since DoIPSocket6 has an own __init__ function, this vairable is not inherited.
