### PR TITLE
Improve dns_resolve

### DIFF
--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -23,13 +23,13 @@ dns_ans = retry_test(_test)
 
 val = dns_resolve(qname="google.com", qtype="A")
 assert val
-assert inet_pton(socket.AF_INET, val)
-assert val == conf.netcache.dns_cache["google.com_A"]
+assert inet_pton(socket.AF_INET, val.rdata)
+assert val == conf.netcache.dns_cache[b'google.com.;\x01']
 
 val = dns_resolve(qname="google.com", qtype="AAAA")
 assert val
-assert inet_pton(socket.AF_INET6, val)
-assert val == conf.netcache.dns_cache["google.com_AAAA"]
+assert inet_pton(socket.AF_INET6, val.rdata)
+assert val == conf.netcache.dns_cache[b'google.com.;\x1c']
 
 = DNS labels
 ~ DNS


### PR DESCRIPTION
Literally after merging https://github.com/secdev/scapy/pull/4070 I realized it would have been better to return the entire RR rather than the arbitrary `rdata` field.