### PR TITLE
[LLMNR] recognize the "T"entative bit

### DIFF
--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -37,7 +37,8 @@ class LLMNRQuery(DNSCompressedPacket):
         BitField("qr", 0, 1),
         BitEnumField("opcode", 0, 4, {0: "QUERY"}),
         BitField("c", 0, 1),
-        BitField("tc", 0, 2),
+        BitField("tc", 0, 1),
+        BitField("t", 0, 1),
         BitField("z", 0, 4)
     ] + DNS.fields_desc[-9:]
     overload_fields = {UDP: {"sport": 5355, "dport": 5355}}

--- a/test/scapy/layers/llmnr.uts
+++ b/test/scapy/layers/llmnr.uts
@@ -10,12 +10,17 @@ assert pkt.sport == 5355
 assert pkt.dport == 5355
 assert pkt[LLMNRQuery].opcode == 0
 
+= Dissection with the "T"entative bit set and the "TrunCation" bit unset
+r = LLMNRResponse(b'\x87\xdf\x81\x00\x00\x01\x00\x01\x00\x00\x00\x00\x01C\x00\x00\x01\x00\x01\xc0\x0c\x00\x01\x00\x01\x00\x00\x00\x1e\x00\x04\xc0\xa8-\x15')
+assert r.tc == 0 and r.t == 1
+
 = Packet build / dissection
 pkt = UDP(raw(UDP()/LLMNRResponse()))
 assert LLMNRResponse in pkt
 assert pkt.qr == 1
 assert pkt.c == 0
 assert pkt.tc == 0
+assert pkt.t == 0
 assert pkt.z == 0
 assert pkt.rcode == 0
 assert pkt.qdcount == 0


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc4795#section-2.1.1 the TC bit is followed by the T bit:
```
                                      1  1  1  1  1  1
        0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
      +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
      |                      ID                       |
      +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
      |QR|   Opcode  | C|TC| T| Z| Z| Z| Z|   RCODE   |
      +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
```
where the 'T'entative bit is set in a response if the responder is authoritative for the name, but has not yet verified the uniqueness of the name.

This patch splits the 2-bit "TC" field into two 1-bit fields corresponding to the "TC" and "T" bits.

The test is added to make sure that tentative responses can be dissected. It was also cross-checked with Wireshark:
```
Link-local Multicast Name Resolution (response)
    Transaction ID: 0x87df
    Flags: 0x8100 Standard query response, No error
        1... .... .... .... = Response: Message is a response
        .000 0... .... .... = Opcode: Standard query (0)
        .... .0.. .... .... = Conflict: The name is considered unique
        .... ..0. .... .... = Truncated: Message is not truncated
        .... ...1 .... .... = Tentative: Tentative
        .... .... .... 0000 = Reply code: No error (0)
```