### PR TITLE
Add 'connect_from_ip' command

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -773,7 +773,9 @@ def arpcachepoison(
     target,  # type: Union[str, List[str]]
     addresses,  # type: Union[str, Tuple[str, str], List[Tuple[str, str]]]
     broadcast=False,  # type: bool
+    count=None,  # type: Optional[int]
     interval=15,  # type: int
+    **kwargs,  # type: Any
 ):
     # type: (...) -> None
     """Poison targets' ARP cache
@@ -815,9 +817,12 @@ def arpcachepoison(
             hwsrc=y, hwdst="00:00:00:00:00:00")
         for x, y in couple_list
     ]
+    if count is not None:
+        sendp(p, iface_hint=str_target, count=count, inter=interval, **kwargs)
+        return
     try:
         while True:
-            sendp(p, iface_hint=str_target)
+            sendp(p, iface_hint=str_target, **kwargs)
             time.sleep(interval)
     except KeyboardInterrupt:
         pass

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -373,6 +373,7 @@ if not WINDOWS:
 
 class SimpleSocket(SuperSocket):
     desc = "wrapper around a classic socket"
+    __selectable_force_select__ = True
 
     def __init__(self, sock):
         # type: (socket.socket) -> None


### PR DESCRIPTION
This PR adds a very small wrapper over `TCP_client` called `connect_asip`. This allows to open a TCP socket that spoofs another IP, without having to change the host IP. This is very useful for some specific scanning purposes.

Also cleans up a bit the `_IO_fdwrapper` on windows to support sockets.