### PR TITLE
Use L3RawSocket(6) automatically on lo

### DIFF
--- a/doc/scapy/installation.rst
+++ b/doc/scapy/installation.rst
@@ -309,41 +309,6 @@ Screenshots
    :scale: 80
    :align: center
 
-Known bugs
-^^^^^^^^^^
-
-You may bump into the following bugs, which are platform-specific, if Scapy didn't manage work around them automatically:
-
- * You may not be able to capture WLAN traffic on Windows. Reasons are explained on the `Wireshark wiki <https://wiki.wireshark.org/CaptureSetup/WLAN>`_ and in the `WinPcap FAQ <https://www.winpcap.org/misc/faq.htm>`_. Try switching off promiscuous mode with ``conf.sniff_promisc=False``.
- * Packets sometimes cannot be sent to localhost (or local IP addresses on your own host).
- 
-Winpcap/Npcap conflicts
-^^^^^^^^^^^^^^^^^^^^^^^
-
-As ``Winpcap`` is becoming old, it's recommended to use ``Npcap`` instead. ``Npcap`` is part of the ``Nmap`` project.
-
-.. note::
-    This does NOT apply for Windows XP, which isn't supported by ``Npcap``.
-
-1. If you get the message ``'Winpcap is installed over Npcap.'`` it means that you have installed both Winpcap and Npcap versions, which isn't recommended.
-
-You may first **uninstall winpcap from your Program Files**, then you will need to remove::
-
-    C:/Windows/System32/wpcap.dll
-    C:/Windows/System32/Packet.dll
-
-And if you are on an x64 machine::
-
-   C:/Windows/SysWOW64/wpcap.dll
-   C:/Windows/SysWOW64/Packet.dll
-
-To use ``Npcap`` instead, as those files are not removed by the ``Winpcap`` un-installer.
-
-2. If you get the message ``'The installed Windump version does not work with Npcap'`` it surely means that you have installed an old version of ``Windump``, made for ``Winpcap``.
-Download the correct one on https://github.com/hsluoyz/WinDump/releases
-
-In some cases, it could also mean that you had installed ``Npcap`` and ``Winpcap``, and that ``Windump`` is using ``Winpcap``. Fully delete ``Winpcap`` using the above method to solve the problem.
-
 Build the documentation offline
 ===============================
 

--- a/doc/scapy/troubleshooting.rst
+++ b/doc/scapy/troubleshooting.rst
@@ -8,21 +8,33 @@ FAQ
 I can't sniff/inject packets in monitor mode.
 ---------------------------------------------
 
-The use monitor mode varies greatly depending on the platform.
+The use monitor mode varies greatly depending on the platform, reasons are explained on the `Wireshark wiki <https://wiki.wireshark.org/CaptureSetup/WLAN>`_:
 
-- **Using Libpcap**
-  ``libpcap`` must be called differently by Scapy in order for it to create the sockets in monitor mode. You will need to pass the ``monitor=True`` to any calls that open a socket (``send``, ``sniff``...) or to a Scapy socket that you create yourself (``conf.L2Socket``...)
+    *Unfortunately, changing the 802.11 capture modes is very platform/network adapter/driver/libpcap dependent, and might not be possible at all (Windows is very limited here).*
+
+Here is some guidance on how to properly use monitor mode with Scapy:
+
+- **Using Libpcap (or Npcap)**:
+    ``libpcap`` must be called differently by Scapy in order for it to create the sockets in monitor mode. You will need to pass the ``monitor=True`` to any calls that open a socket (``send``, ``sniff``...) or to a Scapy socket that you create yourself (``conf.L2Socket``...)
+
+    **On Windows**, you additionally need to turn on monitor mode on the WiFi card, use::
+
+        # Of course, conf.iface can be replaced by any interfaces accessed through conf.ifaces
+        >>> conf.iface.setmonitor(True)
+
 - **Native Linux (with libpcap disabled):**
-  You should set the interface in monitor mode on your own. I personally like
-  to use iwconfig for that (replace ``monitor`` by ``managed`` to disable)::
+    You should set the interface in monitor mode on your own. The easiest way to do that is to use ``airmon-ng``::
 
-    $ sudo ifconfig IFACE down
-    $ sudo iwconfig IFACE mode monitor
-    $ sudo ifconfig IFACE up
+        $ sudo airmon-ng start wlan0
+    
+    You can also use::
 
-**If you are using Npcap:** please note that Npcap ``npcap-0.9983`` broke the 802.11 util back in 2019. It has yet to be fixed (as of Npcap 0.9994) so in the meantime, use `npcap-0.9982.exe <https://nmap.org/npcap/dist/npcap-0.9982.exe>`_
+        $ iw dev wlan0 interface add mon0 type monitor
+        $ ifconfig mon0 up
 
-.. note:: many adapters do not support monitor mode, especially on Windows, or may incorrectly report the headers. See `the Wireshark doc about this <https://wiki.wireshark.org/CaptureSetup/WLAN>`_
+    If you want to enable monitor mode manually, have a look at https://wiki.wireshark.org/CaptureSetup/WLAN#linux
+
+.. warning:: **If you are using Npcap:** please note that Npcap ``npcap-0.9983`` broke the 802.11 support until ``npcap-1.3.0``. Avoid using those versions.
 
 We make our best to make this work, if your adapter works with Wireshark for instance, but not with Scapy, feel free to report an issue.
 
@@ -35,12 +47,14 @@ I can't ping 127.0.0.1 (or ::1). Scapy does not work with 127.0.0.1 (or ::1) on 
 
 The loopback interface is a very special interface. Packets going through it are not really assembled and disassembled. The kernel routes the packet to its destination while it is still stored an internal structure. What you see with ```tcpdump -i lo``` is only a fake to make you think everything is normal. The kernel is not aware of what Scapy is doing behind his back, so what you see on the loopback interface is also a fake. Except this one did not come from a local structure. Thus the kernel will never receive it.
 
-On Linux, in order to speak to local IPv4 applications, you need to build your packets one layer upper, using a PF_INET/SOCK_RAW socket instead of a PF_PACKET/SOCK_RAW (or its equivalent on other systems than Linux)::
+.. note:: Starting from Scapy > **2.5.0**, Scapy will automatically use ``L3RawSocket`` when necessary when using L3-functions (sr-like) on the loopback interface, when libpcap is not in use.
+
+**On Linux**, in order to speak to local IPv4 applications, you need to build your packets one layer upper, using a PF_INET/SOCK_RAW socket instead of a PF_PACKET/SOCK_RAW (or its equivalent on other systems than Linux)::
 
     >>> conf.L3socket
     <class __main__.L3PacketSocket at 0xb7bdf5fc>
     >>> conf.L3socket = L3RawSocket
-    >>> sr1(IP(dst) / ICMP())
+    >>> sr1(IP() / ICMP())
     <IP  version=4L ihl=5L tos=0x0 len=28 id=40953 flags= frag=0L ttl=64 proto=ICMP chksum=0xdce5 src=127.0.0.1 dst=127.0.0.1 options='' |<ICMP  type=echo-reply code=0 chksum=0xffff id=0x0 seq=0x0 |>>
 
 With IPv6, you can simply do::
@@ -50,11 +64,20 @@ With IPv6, you can simply do::
     <IPv6  version=6 tc=0 fl=866674 plen=8 nh=ICMPv6 hlim=64 src=::1 dst=::1 |<ICMPv6EchoReply  type=Echo Reply code=0 cksum=0x7ebb id=0x0 seq=0x0 |>>
 
     # Layer 2
-    >>> conf.iface = "lo"
-    >>> srp1(Ether() / IPv6() / ICMPv6EchoRequest())
+    >>> srp1(Ether() / IPv6() / ICMPv6EchoRequest(), iface=conf.loopback_name)
     <Ether  dst=00:00:00:00:00:00 src=00:00:00:00:00:00 type=IPv6 |<IPv6  version=6 tc=0 fl=866674 plen=8 nh=ICMPv6 hlim=64 src=::1 dst=::1 |<ICMPv6EchoReply  type=Echo Reply code=0 cksum=0x7ebb id=0x0 seq=0x0 |>>>
 
-On Windows, BSD, and macOS, you must deactivate the local firewall and set ````conf.iface``` to the loopback interface prior to using the following commands::
+.. warning::
+    On Linux, libpcap does not support loopback IPv4 pings:
+        >>> conf.use_pcap = True
+        >>> sr1(IP() / ICMP())
+        Begin emission:
+        Finished sending 1 packets.
+        .....................................
+
+    You can disable libpcap using ``conf.use_pcap = False`` or bypass it on layer 3 using ``conf.L3socket = L3RawSocket``.
+
+**On Windows, BSD, and macOS**, you must deactivate/configure the local firewall prior to using the following commands::
 
     # Layer 3
     >>> sr1(IP() / ICMP())
@@ -63,10 +86,44 @@ On Windows, BSD, and macOS, you must deactivate the local firewall and set ````c
     <IPv6  version=6 tc=0 fl=866674 plen=8 nh=ICMPv6 hlim=64 src=::1 dst=::1 |<ICMPv6EchoReply  type=Echo Reply code=0 cksum=0x7ebb id=0x0 seq=0x0 |>>
 
     # Layer 2
-    >>> srp1(Loopback() / IP() / ICMP())
+    >>> srp1(Loopback() / IP() / ICMP(), iface=conf.loopback_name)
     <Loopback  type=IPv4 |<IP  version=4 ihl=5 tos=0x0 len=28 id=56066 flags= frag=0 ttl=64 proto=icmp chksum=0x0 src=127.0.0.1 dst=127.0.0.1 |<ICMP  type=echo-reply code=0 chksum=0xffff id=0x0 seq=0x0 |>>>
-    >>> srp1(Loopback() / IPv6() / ICMPv6EchoRequest())
+    >>> srp1(Loopback() / IPv6() / ICMPv6EchoRequest(), iface=conf.loopback_name)
     <Loopback  type=IPv6 |<IPv6  version=6 tc=0 fl=0 plen=8 nh=ICMPv6 hlim=64 src=::1 dst=::1 |<ICMPv6EchoReply  type=Echo Reply code=0 cksum=0x7ebb id=0x0 seq=0x0 |>>>
+
+Getting 'failed to set hardware filter to promiscuous mode' error
+-----------------------------------------------------------------
+
+Disable promiscuous mode::
+
+    conf.sniff_promisc = False
+
+Scapy says there are 'Winpcap/Npcap conflicts'
+----------------------------------------------
+
+**On Windows**, as ``Winpcap`` is becoming old, it's recommended to use ``Npcap`` instead. ``Npcap`` is part of the ``Nmap`` project.
+
+.. note::
+    This does NOT apply for Windows XP, which isn't supported by ``Npcap``. On XP, uninstall ``Npcap`` and keep ``Winpcap``.
+
+1. If you get the message ``'Winpcap is installed over Npcap.'`` it means that you have installed both Winpcap and Npcap versions, which isn't recommended.
+
+You may first **uninstall winpcap from your Program Files**, then you will need to remove some files that are not deleted by the ``Winpcap`` uninstaller::
+
+    C:/Windows/System32/wpcap.dll
+    C:/Windows/System32/Packet.dll
+
+And if you are on an x64 machine, additionally the 32-bit variants::
+
+   C:/Windows/SysWOW64/wpcap.dll
+   C:/Windows/SysWOW64/Packet.dll
+
+Once that is done, you'll be able to use ``Npcap`` properly.
+
+2. If you get the message ``'The installed Windump version does not work with Npcap'`` it means that you have probably installed an old version of ``Windump``, made for ``Winpcap``.
+Download the one compatible with ``Npcap`` on https://github.com/hsluoyz/WinDump/releases
+
+In some cases, it could also mean that you had installed both ``Npcap`` and ``Winpcap``, and that the Npcap ``Windump`` is using ``Winpcap``. Fully delete ``Winpcap`` using the above method to solve the problem.
 
 
 BPF filters do not work. I'm on a ppp link

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1230,21 +1230,9 @@ Wireless frame injection
    single: FakeAP, Dot11, wireless, WLAN
 
 .. note::
-   See the TroubleShooting section for more information on the usage of Monitor mode among Scapy.
+   See the :doc:`TroubleShooting <troubleshooting>` section for more information on the usage of Monitor mode among Scapy.
 
-Provided that your wireless card and driver are correctly configured for frame injection
-
-::
-
-    $ iw dev wlan0 interface add mon0 type monitor
-    $ ifconfig mon0 up
-
-On Windows, if using Npcap, the equivalent would be to call::
-
-    >>> # Of course, conf.iface can be replaced by any interfaces accessed through conf.ifaces
-    ... conf.iface.setmonitor(True)
-
-you can have a kind of FakeAP::
+Provided that your wireless card and driver are correctly configured for frame injection, you can have a kind of FakeAP::
 
     >>> sendp(RadioTap()/
               Dot11(addr1="ff:ff:ff:ff:ff:ff",

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -744,10 +744,8 @@ class Conf(ConfClass):
     check_TCPerror_seqack = False
     verb = 2  #: level of verbosity, from 0 (almost mute) to 3 (verbose)
     prompt = Interceptor("prompt", ">>> ", _prompt_changer)
-    #: default mode for listening socket (to get answers if you
+    #: default mode for the promiscuous mode of a socket (to get answers if you
     #: spoof on a lan)
-    promisc = True
-    #: default mode for sniff()
     sniff_promisc = True  # type: bool
     raw_layer = None  # type: Type[Packet]
     raw_summary = False  # type: Union[bool, Callable[[bytes], Any]]

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -11,12 +11,9 @@
 = L3RawSocket
 ~ netaccess IP TCP linux needs_root
 
-old_l3socket = conf.L3socket
-conf.L3socket = L3RawSocket
 with no_debug_dissector():
     x = sr1(IP(dst="www.google.com")/TCP(sport=RandShort(), dport=80, flags="S"),timeout=3)
 
-conf.L3socket = old_l3socket
 x
 assert x[IP].ottl() in [32, 64, 128, 255]
 assert 0 <= x[IP].hops() <= 126
@@ -309,16 +306,20 @@ assert test_L3PacketSocket_sendto_python3()
 
 import os
 from scapy.sendrecv import _interface_selection
-assert _interface_selection(None, IP(dst="8.8.8.8")/UDP()) == conf.iface
+assert _interface_selection(None, IP(dst="8.8.8.8")/UDP()) == (conf.iface, False)
 exit_status = os.system("ip link add name scapy0 type dummy")
 exit_status = os.system("ip addr add 192.0.2.1/24 dev scapy0")
+exit_status = os.system("ip addr add fc00::/24 dev scapy0")
 exit_status = os.system("ip link set scapy0 up")
 conf.ifaces.reload()
 conf.route.resync()
-assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == "scapy0"
+conf.route6.resync()
+assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == ("scapy0", False)
+assert _interface_selection(None, IPv6(dst="fc00::ae0d")/UDP()) == ("scapy0", True)
 exit_status = os.system("ip link del name dev scapy0")
 conf.ifaces.reload()
 conf.route.resync()
+conf.route6.resync()
 
 = Test 802.Q sniffing
 ~ linux needs_root veth

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1463,6 +1463,7 @@ retry_test(_test)
 = Latency check: localhost ICMP
 ~ netaccess needs_root linux latency
 
+# Note: still needs to enforce L3RawSocket as this won't work otherwise with libpcap
 sock = conf.L3socket
 conf.L3socket = L3RawSocket
 


### PR DESCRIPTION
Since we already have a mechanism for selecting the `L3socket` based on the interface (this was designed more towards special bluetooth/usb interfaces), we can very simply add a check to use `L3RawSocket(6)` when using the loopback interface.

This removes the necessity to use `conf.L3socket = L3RawSocket` when using loopback.

**I am however unsure if this is necessary on BSD/OSX**. @guedou what do you think?