### PR TITLE
[INET6] add the PREF64 ND option

### DIFF
--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -1252,6 +1252,32 @@ a.type==26 and a.len==1 and a.res == 0
 
 ############
 ############
++ ICMPv6NDOptPREF64 Class Test
+
+= ICMPv6NDOptPREF64 - Basic Instantiation
+raw(ICMPv6NDOptPREF64()) == b'\x26\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+= ICMPv6NDOptPREF64 - Basic Dissection
+p = ICMPv6NDOptPREF64(b'\x26\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+assert p.type == 38 and p.len == 2 and p.scaledlifetime == 0 and p.plc == 0 and p.prefix == '::'
+
+= ICMPv6NDOptPREF64 - Instantiation/Dissection with specific values
+p = ICMPv6NDOptPREF64(scaledlifetime=225, plc='/64', prefix='2003:da8:1::')
+assert raw(p) == b'\x26\x02\x07\x09\x20\x03\x0d\xa8\x00\x01\x00\x00\x00\x00\x00\x00'
+
+p = ICMPv6NDOptPREF64(raw(p))
+assert p.type == 38 and p.len == 2 and p.scaledlifetime == 225 and p.plc == 1 and p.prefix == '2003:da8:1::'
+
+p = ICMPv6NDOptPREF64(raw(p) + b'\x00\x00\x00\x00')
+assert Raw in p and len(p[Raw]) == 4
+
+= ICMPv6NDOptPREF64 - Summary Output
+ICMPv6NDOptPREF64(prefix='12:34:56::', plc='/32').mysummary() == "ICMPv6 Neighbor Discovery Option - PREF64 Option 12:34:56::/32"
+ICMPv6NDOptPREF64(prefix='12:34:56::', plc=6).mysummary() == "ICMPv6 Neighbor Discovery Option - PREF64 Option 12:34:56::[invalid PLC(6)]"
+
+
+############
+############
 + Test Node Information Query - ICMPv6NIQueryNOOP
 
 = ICMPv6NIQueryNOOP - Basic Instantiation


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8781#name-option-format
```
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |     Type      |    Length     |     Scaled Lifetime     | PLC |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                                                               |
     +                                                               +
     |              Highest 96 bits of the Prefix                    |
     +                                                               +
     |                                                               |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

                    Figure 1: NAT64 Prefix Option Format

   Fields:

   Type:  8-bit identifier of the PREF64 option type (38)

   Length:  8-bit unsigned integer.  The length of the option (including
      the Type and Length fields) is in units of 8 octets.  The sender
      MUST set the length to 2.  The receiver MUST ignore the PREF64
      option if the Length field value is not 2.

   Scaled Lifetime:  13-bit unsigned integer.  The maximum time in units
      of 8 seconds over which this NAT64 prefix MAY be used.

   PLC (Prefix Length Code):  3-bit unsigned integer.  This field
      encodes the NAT64 Prefix Length defined in [RFC6052].  The PLC
      field values 0, 1, 2, 3, 4, and 5 indicate the NAT64 prefix length
      of 96, 64, 56, 48, 40, and 32 bits, respectively.  The receiver
      MUST ignore the PREF64 option if the Prefix Length Code field is
      not set to one of those values.

   Highest 96 bits of the Prefix:  96-bit unsigned integer.  Contains
      bits 0 - 95 of the NAT64 prefix.
```

The patch was also cross-checked with Wireshark:
```
    ICMPv6 Option (PREF64 Option)
        Type: PREF64 Option (38)
        Length: 2 (16 bytes)
        0000 0111 0000 1... = Scaled Lifetime: 225
        .... .... .... .001 = PLC (Prefix Length Code): 64 bits prefix length (0x1)
        Prefix: 2003:da8:1::
```

(It's mostly prompted by https://github.com/systemd/systemd/issues/28985)