### PR TITLE
Let Scapy load on unsupported platforms

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -28,7 +28,9 @@ from scapy.libs.extcap import load_extcap
 
 # Typing imports
 from typing import (
+    List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -154,6 +156,25 @@ else:
         "Scapy currently does not support %s! I/O will NOT work!" % sys.platform
     )
     SIOCGIFHWADDR = 0  # mypy compat
+
+    # DUMMYS
+    def get_if_raw_addr(iff: Union[NetworkInterface, str]) -> bytes:
+        return b"\0\0\0\0"
+
+    def get_if_raw_hwaddr(iff: Union[NetworkInterface, str]) -> Tuple[int, bytes]:
+        return -1, b""
+
+    def in6_getifaddr() -> List[Tuple[str, int, str]]:
+        return []
+
+    def read_nameservers() -> List[str]:
+        return []
+
+    def read_routes() -> List[str]:
+        return []
+
+    def read_routes6() -> List[str]:
+        return []
 
 if LINUX or BSD:
     conf.load_layers.append("tuntap")

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -648,8 +648,7 @@ def _set_conf_sockets():
         conf.L2socket = _NotAvailableSocket
         conf.L2listen = _NotAvailableSocket
     else:
-        from scapy.supersocket import L3RawSocket
-        from scapy.layers.inet6 import L3RawSocket6
+        from scapy.supersocket import L3RawSocket, L3RawSocket6
         conf.L3socket = L3RawSocket
         conf.L3socket6 = L3RawSocket6
     # Reload the interfaces

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -66,7 +66,7 @@ class InterfaceProvider(object):
         if LINUX and not self.libpcap and dev.name == conf.loopback_name:
             # handle the loopback case. see troubleshooting.rst
             if ipv6:
-                from scapy.layers.inet6 import L3RawSocket6
+                from scapy.supersocket import L3RawSocket6
                 return cast(Type['scapy.supersocket.SuperSocket'], L3RawSocket6)
             else:
                 from scapy.supersocket import L3RawSocket

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -16,7 +16,13 @@ import time
 
 from scapy.config import conf
 from scapy.consts import DARWIN, WINDOWS
-from scapy.data import MTU, ETH_P_IP, SOL_PACKET, SO_TIMESTAMPNS
+from scapy.data import (
+    MTU,
+    ETH_P_IP,
+    ETH_P_IPV6,
+    SOL_PACKET,
+    SO_TIMESTAMPNS,
+)
 from scapy.compat import raw
 from scapy.error import warning, log_runtime
 from scapy.interfaces import network_name
@@ -369,6 +375,26 @@ if not WINDOWS:
             except socket.error as msg:
                 log_runtime.error(msg)
             return 0
+
+    class L3RawSocket6(L3RawSocket):
+        def __init__(self,
+                     type: int = ETH_P_IPV6,
+                     filter: Optional[str] = None,
+                     iface: Optional[_GlobInterfaceType] = None,
+                     promisc: Optional[bool] = None,
+                     nofilter: bool = False) -> None:
+            # NOTE: if fragmentation is needed, it will be done by the kernel (RFC 2292)  # noqa: E501
+            self.outs = socket.socket(
+                socket.AF_INET6,
+                socket.SOCK_RAW,
+                socket.IPPROTO_RAW
+            )
+            self.ins = socket.socket(
+                socket.AF_PACKET,
+                socket.SOCK_RAW,
+                socket.htons(type)
+            )
+            self.iface = cast(_GlobInterfaceType, iface)
 
 
 class SimpleSocket(SuperSocket):


### PR DESCRIPTION
- let Scapy load on unsupported platforms
  - mock the required arch functions (`read_routes`, etc.)
  - fix a dependency loop on those platforms, by putting `L3RawSocket6` next to its brother `L3RawSocket`

It's still miserable but at least it loads.