### PR TITLE
[DHCPv6] add the NTP Server Option

### DIFF
--- a/test/scapy/layers/dhcp6.uts
+++ b/test/scapy/layers/dhcp6.uts
@@ -1054,6 +1054,81 @@ raw(DHCP6OptLQClientLink(linkaddress=["2001:db8::1", "2001:db8::2"])) == b'\x000
 a = DHCP6OptLQClientLink(b'\x000\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
 a.optcode == 48 and a.optlen == 32 and len(a.linkaddress) == 2 and a.linkaddress[0] == "2001:db8::1" and a.linkaddress[1] == "2001:db8::2"
 
+
+############
+############
++ Test DHCP6 Option - NTP Server
+
+= DHCP6NTPSubOptSrvAddr - Basic dissection/instantiation
+b = b'\x00\x01' + b'\x00\x10' + b'\x00' * 16
+assert raw(DHCP6NTPSubOptSrvAddr()) == b
+
+p = DHCP6NTPSubOptSrvAddr(b)
+assert p.optcode == 1 and p.optlen == 16 and p.addr == '::'
+
+= DHCP6NTPSubOptSrvAddr - Dissection/instantiation with specific values
+b = b'\x00\x01' + b'\x00\x10' + b'\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+assert raw(DHCP6NTPSubOptSrvAddr(addr='2001:db8::1')) == b
+
+p = DHCP6NTPSubOptSrvAddr(b)
+assert p.optcode == 1 and p.optlen == 16 and p.addr == '2001:db8::1'
+
+= DHCP6NTPSubOptMCAddr - Basic dissection/instantiation
+b = b'\x00\x02' + b'\x00\x10' + b'\x00' * 16
+assert raw(DHCP6NTPSubOptMCAddr()) == b
+
+p = DHCP6NTPSubOptMCAddr(b)
+assert p.optcode == 2 and p.optlen == 16 and p.addr == '::'
+
+= DHCP6NTPSubOptMCAddr - Dissection/instantiation with specific values
+b = b'\x00\x02' + b'\x00\x10' + b'\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01'
+assert raw(DHCP6NTPSubOptMCAddr(addr='ff02::101')) == b
+
+p = DHCP6NTPSubOptMCAddr(b)
+assert p.optcode == 2 and p.optlen == 16 and p.addr == 'ff02::101'
+
+= DHCP6NTPSubOptSrvFQDN - Basic dissection/instantiation
+b = b'\x00\x03' + b'\x00\x01' + b'\x00'
+assert raw(DHCP6NTPSubOptSrvFQDN()) == b
+
+p = DHCP6NTPSubOptSrvFQDN(b)
+assert p.optcode == 3 and p.optlen == 1 and p.fqdn == b'.'
+
+= DHCP6NTPSubOptSrvFQDN - Dissection/instantiation with specific values
+b = b'\x00\x03' + b'\x00\x0d' + b'\x07example\x03com\x00'
+assert raw(DHCP6NTPSubOptSrvFQDN(fqdn='example.com')) == b
+
+p = DHCP6NTPSubOptSrvFQDN(b)
+assert p.optcode == 3 and p.optlen == 13 and p.fqdn == b'example.com.'
+
+= DHCP6OptNTPServer - Basic dissection/instantiation
+b = b'\x00\x38' + b'\x00\x00'
+assert raw(DHCP6OptNTPServer()) == b
+
+p = DHCP6OptNTPServer(b)
+assert p.optcode == 56 and p.optlen == 0 and p.ntpserver == []
+
+= DHCP6OptNTPServer - Dissection/instantiation with specific values
+srv_addr = b'\x00\x01' + b'\x00\x10' + b'\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+mc_addr = b'\x00\x02' + b'\x00\x10' + b'\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01'
+srv_fqdn = b'\x00\x03' + b'\x00\x0d' + b'\x07example\x03com\x00'
+b = b'\x00\x38' + b'\x00\x39' + srv_addr + mc_addr + srv_fqdn
+
+p = DHCP6OptNTPServer(
+    ntpserver=[DHCP6NTPSubOptSrvAddr(addr='2001:db8::1'),
+               DHCP6NTPSubOptMCAddr(addr='ff02::101'),
+               DHCP6NTPSubOptSrvFQDN(fqdn='example.com'),
+               ]
+)
+assert raw(p) == b
+
+p = DHCP6OptNTPServer(b)
+assert p.optcode == 56 and p.optlen == 57 and len(p.ntpserver) == 3
+assert p.ntpserver[0] == DHCP6NTPSubOptSrvAddr(srv_addr)
+assert p.ntpserver[1] == DHCP6NTPSubOptMCAddr(mc_addr)
+assert p.ntpserver[2] == DHCP6NTPSubOptSrvFQDN(srv_fqdn)
+
+
 ############
 ############
 + Test DHCP6 Option - Boot File URL


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc5908#section-4

The patch was cross-checked with Wireshark:

        Option: NTP Server (56)
        Length: 57
        NTP Server Address
            Suboption: NTP Server Address (1)
            Length: 16
            NTP Server Address: 2001:db8::1
        NTP Multicast Address
            Suboption: NTP Multicast Address (2)
            Length: 16
            NTP Multicast Address: ff02::101
        NTP Server FQDN
            Suboption: NTP Server FQDN (3)
            Length: 13
            NTP Server FQDN: example.com.