### PR TITLE
Fix Automaton.graph() with indirection

### DIFF
--- a/test/scapy/automaton.uts
+++ b/test/scapy/automaton.uts
@@ -446,6 +446,27 @@ graph = HelloWorld.build_graph()
 assert graph.startswith("digraph")
 assert '"BEGIN" -> "END"' in graph
 
+= Automaton graph - with indirection
+~ automaton
+
+class HelloWorld(Automaton):
+    @ATMT.state(initial=1)
+    def BEGIN(self):
+        self.count1 = 0
+        self.count2 = 0
+    @ATMT.condition(BEGIN)
+    def cnd_1(self):
+        self.cnd_generic()
+    def cnd_generic(self):
+        raise END
+    @ATMT.state(final=1)
+    def END(self):
+        pass
+
+graph = HelloWorld.build_graph()
+assert graph.startswith("digraph")
+assert '"BEGIN" -> "END"' in graph
+
 = TCP_client automaton
 ~ automaton netaccess needs_root
 * This test retries on failure because it may fail quite easily


### PR DESCRIPTION
- Fix Automaton.graph() with indirection

**Before: `TLSClientAutomaton.graph()`**
![scapy1](https://github.com/secdev/scapy/assets/10530980/1084e950-83d9-45ee-9834-c3bfea20d66c)

There are a few dangling conditions (linked to nothing, look just at the right of the BEGIN, or on the far right), or stuck states.

**After: `TLSClientAutomaton.graph()`**
![scapy2](https://github.com/secdev/scapy/assets/10530980/afcad463-054c-4b93-951f-18164674be73)
