### PR TITLE
[SSLv2] s/debug_dissect/debug_dissector/

### DIFF
--- a/scapy/layers/tls/record_sslv2.py
+++ b/scapy/layers/tls/record_sslv2.py
@@ -174,7 +174,7 @@ class SSLv2(TLS):
             except KeyboardInterrupt:
                 raise
             except Exception:
-                if conf.debug_dissect:
+                if conf.debug_dissector:
                     raise
                 p = conf.raw_layer(s, _internal=1, _underlayer=self)
             self.add_payload(p)

--- a/test/scapy/layers/tls/sslv2.uts
+++ b/test/scapy/layers/tls/sslv2.uts
@@ -273,6 +273,11 @@ assert isinstance(s.wcs.ciphersuite, SSL_CK_DES_192_EDE3_CBC_WITH_MD5)
 s.rcs.cipher.iv == b'\x01'*8
 s.wcs.cipher.iv == b'\x01'*8
 
+= Dissect invalid payload
+p = SSLv2()
+with no_debug_dissector():
+    p.do_dissect_payload(b'\x00')
+    assert raw(p.payload) == b'\x00'
 
 ###############################################################################
 ############################ Automaton behaviour ##############################


### PR DESCRIPTION
to prevent do_dissect_payload from failing with
```
  File "scapy/scapy/layers/tls/record_sslv2.py", line 177, in do_dissect_payload
    if conf.debug_dissect:
       ^^^^^^^^^^^^^^^^^^
  File "scapy/scapy/config.py", line 950, in __getattribute__
    return object.__getattribute__(self, attr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Conf' object has no attribute 'debug_dissect'
```

The test is added to exercise the Exception clause.

(I accidentally spotted it in https://github.com/secdev/scapy/pull/4082#issuecomment-1690075949 but forgot to send a PR)