### PR TITLE
feat: support FieldLenField without length_of/count_of args

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2175,9 +2175,7 @@ class FieldLenField(Field[int, int]):
                 fld, fval = pkt.getfield_and_val(self.count_of)
                 f = fld.i2count(pkt, fval)
             else:
-                raise ValueError(
-                    "Field should have either length_of or count_of"
-                )
+                f = len(pkt.payload)
             x = self.adjust(pkt, f)
         elif x is None:
             x = 0


### PR DESCRIPTION
I wanted to be able to use `LenField` in my packet, but need to fit it in 10-bits. I was hoping `BitFieldLenField` could be used to similarly get the whole payload length, but an exception is raised in `FieldLenField` when `length_of` and `count_of` are omitted.

This PR changes `FieldLenField.i2m` to return the packet payload length when `length_of` and `count_of` are omitted, rather than throwing an exception.

Now we can use it like

```python
class Header(Packet):
    name = "Header"
    fields_desc = [
        BitField("packet_id", 0, 6),
        BitFieldLenField("length", None, 10),
    ]
```

and the length field is automatically calculated based on the payload size, just like in `LenField`. The `adjust` argument works as expected.

UT's appear to pass, up to where it already fails on master. I spent some time trying to troubleshoot it but couldn't get it working.