### PR TITLE
Resolve Issue_4006

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -515,7 +515,7 @@ def sendpfast(x,  # type: _PacketIterable
         iface = conf.iface
     argv = [conf.prog.tcpreplay, "--intf1=%s" % network_name(iface)]
     if pps is not None:
-        argv.append("--pps=%i" % pps)
+        argv.append("--pps=%f" % pps)
     elif mbps is not None:
         argv.append("--mbps=%f" % mbps)
     elif realtime is not None:


### PR DESCRIPTION
Sendpfast accepts a float for the PPS value as well as the underlying tcpreplay; however, this is converted to an integer in the tcpreplay string causing flows needing refined throughput values to be inaccurate. This is a very simple fix by changing it from an integer conversion to a float. I have been doing this manually using sed in docker build to patch this, but should have submitted this when originally found.

Note: I looked to see if there were unit tests under the tests directory; however, initial look I didn't see an obvious test for sendrecv.py. Although I haven't verified if this will break any unit tests, this has been used in a container for some time with this small change with no issues and more accurate traffic flows.

fixes #4006 
