### PR TITLE
Fix tests

### DIFF
--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -3,7 +3,6 @@
     "test\\*.uts",
     "test\\scapy\\layers\\*.uts",
     "test\\scapy\\layers\\tls\\*.uts",
-    "test\\tls\\tests_tls_netaccess.uts",
     "test\\contrib\\automotive\\obd\\*.uts",
     "test\\contrib\\automotive\\scanner\\*.uts",
     "test\\contrib\\automotive\\gm\\*.uts",

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,8 @@ deps = mock
        coverage[toml]
        python-can
        # disabled on windows because they require c++ dependencies
-       brotli ; sys_platform != 'win32'
+       # brotli 1.1.0 broken https://github.com/google/brotli/issues/1072
+       brotli < 1.1.0 ; sys_platform != 'win32'
        zstandard ; sys_platform != 'win32'
 platform =
   linux_non_root,linux_root: linux


### PR DESCRIPTION
- fix PyPy tests by pinning brotli
- fix Windows tests by removing leftover

fix https://github.com/secdev/scapy/issues/4115