### PR TITLE
Fix L2 dst address computation (very intrusive)

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1099,6 +1099,9 @@ conf.l3types.register_num2layer(ETH_P_ALL, IP)
 
 
 def inet_register_l3(l2, l3):
+    """
+    Resolves the default L2 dst address when IP is used.
+    """
     return getmacbyip(l3.dst)
 
 

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1100,7 +1100,7 @@ conf.l3types.register_num2layer(ETH_P_ALL, IP)
 
 def inet_register_l3(l2, l3):
     """
-    Resolves the default L2 dst address when IP is used.
+    Resolves the default L2 destination address when IP is used.
     """
     return getmacbyip(l3.dst)
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -475,6 +475,9 @@ class IPv46(IP):
 
 
 def inet6_register_l3(l2, l3):
+    """
+    Resolves the default L2 dst address when IPv6 is used.
+    """
     return getmacbyip6(l3.dst)
 
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -476,7 +476,7 @@ class IPv46(IP):
 
 def inet6_register_l3(l2, l3):
     """
-    Resolves the default L2 dst address when IPv6 is used.
+    Resolves the default L2 destination address when IPv6 is used.
     """
     return getmacbyip6(l3.dst)
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -183,7 +183,7 @@ class DestMACField(MACField):
                 else:
                     x = "ff:ff:ff:ff:ff:ff"
                     warning(
-                        "Mac address to reach destination not found. Using broadcast."
+                        "MAC address to reach destination not found. Using broadcast."
                     )
         return super(DestMACField, self).i2m(pkt, x)
 
@@ -317,7 +317,7 @@ class LLC(Packet):
 
 def l2_register_l3(l2: Packet, l3: Packet) -> Optional[str]:
     """
-    Delegates resolving the default L2 dst address to the payload of L3.
+    Delegates resolving the default L2 destination address to the payload of L3.
     """
     neighbor = conf.neighbor  # type: Neighbor
     return neighbor.resolve(l2, l3.payload)
@@ -562,13 +562,14 @@ class ARP(Packet):
 
 def l2_register_l3_arp(l2: Packet, l3: Packet) -> Optional[str]:
     """
-    Resolves the default L2 dst address when ARP is used.
+    Resolves the default L2 destination address when ARP is used.
     """
     if l3.op == 1:  # who-has
         return "ff:ff:ff:ff:ff:ff"
     elif l3.op == 2:  # is-at
         log_runtime.warning(
-            "You should be providing the Ethernet dst mac when sending is-at ARP."
+            "You should be providing the Ethernet destination MAC address when "
+            "sending an is-at ARP."
         )
     # Need ARP request to send ARP request...
     plen = l3.get_field("pdst").i2len(l3, l3.pdst)
@@ -579,7 +580,7 @@ def l2_register_l3_arp(l2: Packet, l3: Packet) -> Optional[str]:
         return getmacbyip6(l3.pdst)
     # Can't even do that
     log_runtime.warning(
-        "You should be providing the Ethernet dst mac when sending this "
+        "You should be providing the Ethernet destination mac when sending this "
         "kind of ARP packets."
     )
     return None

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -572,6 +572,28 @@ assert isinstance(pkt, UDP) and pkt.dport == 5353
 pkt = pkt.payload
 assert isinstance(pkt, DNS) and isinstance(pkt.payload, NoPayload)
 
+= Layer binding with show()
+* getmacbyip must only be called when building
+
+import mock
+
+def _err(*_):
+    raise ValueError
+
+with mock.patch("scapy.layers.l2.getmacbyip", side_effect=_err):
+    with mock.patch("scapy.layers.inet.getmacbyip", side_effect=_err):
+        # ARP who-has should never call getmacbyip
+        pkt1 = Ether() / ARP(pdst="10.0.0.1")
+        pkt1.show()
+        bytes(pkt1)
+        # IP should only call getmacbyip when building
+        pkt2 = Ether() / IP(dst="10.0.0.1")
+        pkt2.show()
+        try:
+            bytes(pkt2)
+            assert False, "Should have called getmacbyip"
+        except ValueError:
+            pass
 
 ############
 ############


### PR DESCRIPTION
Two absolutely horrifying issues, that have been there since the beginning of times.

- **Currently if you do**:
```python
>>> pkt = Ether()/ARP(pdst="10.0.0.1")
>>> srp(pkt)
```
it sends a `ARP` request implicitly to resolve the Ethernet destination of the L2 dst... then sends it a who-has request. This makes no sense, that's two ARP who-has requests.

- **Currently if you do**:
```python
>>> pkt = Ether() / IP(pdst="10.0.0.1")
>>> pkt.show()
```
it also sends a `ARP` request implicitly. This looks like an unintended behavior, I'd argue the L2 dst should only be resolved  when building the packet (when using send, show2, etc.)

**This PR does two things:**
- in general, only resolve the Ethernet dst address when building the packet, and not just when printing it
- fix ARP which has a completly broken default behavior