### PR TITLE
update type of `default` param in LEFieldLenField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2871,7 +2871,7 @@ class LEFieldLenField(FieldLenField):
     def __init__(
             self,
             name,  # type: str
-            default,  # type: int
+            default,  # type: Optional[Any]
             length_of=None,  # type: Optional[str]
             fmt="<H",  # type: str
             count_of=None,  # type: Optional[str]


### PR DESCRIPTION
The `default` type should be same as its parent `FieldLenField`

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
