### PR TITLE
Improve parsing of UDS DTC Snapshots and ExtendedData

### DIFF
--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -43,6 +43,9 @@ except KeyError:
     conf.contribs['UDS'] = {'treat-response-pending-as-answer': False}
 
 
+conf.debug_dissector = True
+
+
 class UDS(ISOTP):
     services = ObservableDict(
         {0x10: 'DiagnosticSessionControl',
@@ -1070,7 +1073,10 @@ class DTCSnapshot(Packet):
     fields_desc = [
         ByteField("record_number", 0),
         ByteField("record_number_of_identifiers", 0),
-        PacketListField("snapshotData", None, next_cls_cb=next_identifier_cb)
+        PacketListField(
+            "snapshotData", None,
+            next_cls_cb=lambda pkt, lst, cur, remain: DTCSnapshot.next_identifier_cb(
+                pkt, lst, cur, remain))
     ]
 
     def extract_padding(self, s):

--- a/test/contrib/automotive/gm/scanner.uts
+++ b/test/contrib/automotive/gm/scanner.uts
@@ -108,6 +108,11 @@ config = {}
 
 s = EcuState(session=1)
 
+debug_dissector_backup = conf.debug_dissector
+
+# This tests involves corrupted Packets, therefore we need to disable the debug_dissector
+conf.debug_dissector = False
+
 assert False == e._evaluate_response(s, GMLAN(b"\x27\x01"), None, **config)
 config = {"exit_if_service_not_supported": True}
 assert not e._retry_pkt[s]
@@ -125,6 +130,7 @@ assert True == e._evaluate_response(s, GMLAN(b"\x27\x01"), GMLAN(b"\x67\x01ab"),
 assert not e._retry_pkt[s]
 assert False == e._evaluate_response(s, GMLAN(b"\x27\x01"), GMLAN(b"\x67\x02ab"), **config)
 assert not e._retry_pkt[s]
+conf.debug_dissector = debug_dissector_backup
 
 
 = Simulate ECU and run Scanner

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -276,8 +276,13 @@ resps = [EcuResponse(None, [UDS()/UDS_NR(negativeResponseCode="subFunctionNotSup
 
 es = [UDS_ServiceEnumerator]
 
+debug_dissector_backup = conf.debug_dissector
+
+# This Enumerator is sending corrupted Packets, therefore we need to disable the debug_dissector
+conf.debug_dissector = False
 scanner = executeScannerInVirtualEnvironment(
     resps, es, UDS_ServiceEnumerator_kwargs={"request_length": 3}, unstable_socket=False)
+conf.debug_dissector = debug_dissector_backup
 
 assert scanner.scan_completed
 assert scanner.progress() > 0.95

--- a/test/contrib/automotive/uds.uts
+++ b/test/contrib/automotive/uds.uts
@@ -1100,9 +1100,7 @@ assert rdtci.DTCStatusMask == 0xff
 rdtci = UDS(b'\x19\x03\xff\xee\xdd\xaa')
 assert rdtci.service == 0x19
 assert rdtci.reportType == 0x03
-assert rdtci.DTCHighByte == 0xff
-assert rdtci.DTCMiddleByte == 0xee
-assert rdtci.DTCLowByte == 0xdd
+assert rdtci.dtc == DTC(bytes.fromhex("ffeedd"))
 assert rdtci.DTCSnapshotRecordNumber == 0xaa
 
 = Check UDS_RDTCI
@@ -1110,9 +1108,7 @@ assert rdtci.DTCSnapshotRecordNumber == 0xaa
 rdtci = UDS(b'\x19\x04\xff\xee\xdd\xaa')
 assert rdtci.service == 0x19
 assert rdtci.reportType == 0x04
-assert rdtci.DTCHighByte == 0xff
-assert rdtci.DTCMiddleByte == 0xee
-assert rdtci.DTCLowByte == 0xdd
+assert rdtci.dtc == DTC(bytes.fromhex("ffeedd"))
 assert rdtci.DTCSnapshotRecordNumber == 0xaa
 
 = Check UDS_RDTCI
@@ -1127,9 +1123,7 @@ assert rdtci.DTCSnapshotRecordNumber == 0xaa
 rdtci = UDS(b'\x19\x06\xff\xee\xdd\xaa')
 assert rdtci.service == 0x19
 assert rdtci.reportType == 0x06
-assert rdtci.DTCHighByte == 0xff
-assert rdtci.DTCMiddleByte == 0xee
-assert rdtci.DTCLowByte == 0xdd
+assert rdtci.dtc == DTC(bytes.fromhex("ffeedd"))
 assert rdtci.DTCExtendedDataRecordNumber == 0xaa
 
 = Check UDS_RDTCI
@@ -1153,18 +1147,14 @@ assert rdtci.DTCStatusMask == 0xbb
 rdtci = UDS(b'\x19\x09\xff\xee\xdd')
 assert rdtci.service == 0x19
 assert rdtci.reportType == 0x09
-assert rdtci.DTCHighByte == 0xff
-assert rdtci.DTCMiddleByte == 0xee
-assert rdtci.DTCLowByte == 0xdd
+assert rdtci.dtc == DTC(bytes.fromhex("ffeedd"))
 
 = Check UDS_RDTCI
 
 rdtci = UDS(b'\x19\x10\xff\xee\xdd\xaa')
 assert rdtci.service == 0x19
 assert rdtci.reportType == 0x10
-assert rdtci.DTCHighByte == 0xff
-assert rdtci.DTCMiddleByte == 0xee
-assert rdtci.DTCLowByte == 0xdd
+assert rdtci.dtc == DTC(bytes.fromhex("ffeedd"))
 assert rdtci.DTCExtendedDataRecordNumber == 0xaa
 
 
@@ -1189,6 +1179,23 @@ rdtcipr = UDS(b'\x59\x03\xff\xee\xdd\xaa')
 assert rdtcipr.service == 0x59
 assert rdtcipr.reportType == 3
 assert rdtcipr.dataRecord == b'\xff\xee\xdd\xaa'
+
+
+= Check UDS_RDTCIPR 2
+req = UDS(bytes.fromhex("1904480a46ff"))
+resp = UDS(bytes.fromhex("5904480a46af000b170002ff6417010a8278fa170c2ff1800000800104800200028003400a8004808005054002400a400004010b170002ff6417010a82ec69170c2f2c800000800100800200028003400a80048080050540024017400004"))
+
+assert resp.answers(req)
+
+req = UDS(bytes.fromhex("1904480a47ff"))
+resp = UDS(bytes.fromhex("5904480a46af000b170002ff6417010a8278fa170c2ff1800000800104800200028003400a8004808005054002400a400004010b170002ff6417010a82ec69170c2f2c800000800100800200028003400a80048080050540024017400004"))
+
+assert not resp.answers(req)
+
+req = UDS(bytes.fromhex("1906480a46ff"))
+resp = UDS(bytes.fromhex("5906480a46af010002070328"))
+
+assert resp.answers(req)
 
 = Check UDS_RC
 


### PR DESCRIPTION
This PR changes the definition of DTCs inside the UDS_RDTCI packet to have a better representation of the DTC. Additionally, a DTC Snapshot Packet class is introduced to allow customization of DTC Snapshot records for individual ECUs