### PR TITLE
Support stupid OSes

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -952,7 +952,7 @@ class Conf(ConfClass):
 
 if not Conf.ipv6_enabled:
     log_scapy.warning("IPv6 support disabled in Python. Cannot load Scapy IPv6 layers.")  # noqa: E501
-    for m in ["inet6", "dhcp6"]:
+    for m in ["inet6", "dhcp6", "sixlowpan"]:
         if m in Conf.load_layers:
             Conf.load_layers.remove(m)
 

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -26,18 +26,32 @@ from scapy.config import conf
 from scapy.compat import orb, raw, chb, bytes_encode, plain_str
 from scapy.error import log_runtime, warning, Scapy_Exception
 from scapy.packet import Packet, bind_layers, Raw
-from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
-    ConditionalField, Field, FieldLenField, FlagsField, IntField, \
-    PacketListField, ShortEnumField, ShortField, StrField, \
-    StrLenField, MultipleTypeField, UTCTimeField, I
+from scapy.fields import (
+    BitEnumField,
+    BitField,
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    Field,
+    FieldLenField,
+    FlagsField,
+    I,
+    IP6Field,
+    IntField,
+    MultipleTypeField,
+    PacketListField,
+    ShortEnumField,
+    ShortField,
+    StrField,
+    StrLenField,
+    UTCTimeField,
+)
 from scapy.sendrecv import sr1
 from scapy.supersocket import StreamSocket
 from scapy.pton_ntop import inet_ntop, inet_pton
 from scapy.volatile import RandShort
 
 from scapy.layers.inet import IP, DestIPField, IPField, UDP, TCP
-from scapy.layers.inet6 import IPv6, DestIP6Field, IP6Field
-
 
 from typing import (
     Any,
@@ -1103,7 +1117,9 @@ bind_layers(UDP, DNS, sport=5353)
 bind_layers(UDP, DNS, dport=53)
 bind_layers(UDP, DNS, sport=53)
 DestIPField.bind_addr(UDP, "224.0.0.251", dport=5353)
-DestIP6Field.bind_addr(UDP, "ff02::fb", dport=5353)
+if conf.ipv6_enabled:
+    from scapy.layers.inet6 import DestIP6Field
+    DestIP6Field.bind_addr(UDP, "ff02::fb", dport=5353)
 bind_layers(TCP, DNS, dport=53)
 bind_layers(TCP, DNS, sport=53)
 
@@ -1135,6 +1151,7 @@ def dns_resolve(qname, qtype="A", raw=False, verbose=1, **kwargs):
 
     kwargs.setdefault("timeout", 3)
     kwargs.setdefault("verbose", 0)
+    res = None
     for nameserver in conf.nameservers:
         # Try all nameservers
         try:
@@ -1310,6 +1327,7 @@ class DNS_am(AnsweringMachine):
         )
 
     def make_reply(self, req):
+        from scapy.layers.inet6 import IPv6
         if IPv6 in req:
             resp = IPv6(dst=req[IPv6].src, src=self.src_ip6)
         else:

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -12,11 +12,11 @@ A proprietary redundancy protocol for Cisco routers.
     http://www.smartnetworks.jp/2006/02/hsrp_8_hsrp_version_2.html
 """
 
+from scapy.config import conf
 from scapy.fields import ByteEnumField, ByteField, IPField, SourceIPField, \
     StrFixedLenField, XIntField, XShortField
 from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.layers.inet import DestIPField, UDP
-from scapy.layers.inet6 import DestIP6Field
 
 
 class HSRP(Packet):
@@ -66,4 +66,6 @@ bind_bottom_up(UDP, HSRP, sport=2029)
 bind_layers(UDP, HSRP, dport=1985, sport=1985)
 bind_layers(UDP, HSRP, dport=2029, sport=2029)
 DestIPField.bind_addr(UDP, "224.0.0.2", dport=1985)
-DestIP6Field.bind_addr(UDP, "ff02::66", dport=2029)
+if conf.ipv6_enabled:
+    from scapy.layers.inet6 import DestIP6Field
+    DestIP6Field.bind_addr(UDP, "ff02::66", dport=2029)

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -22,6 +22,7 @@ from scapy.fields import (
     FieldListField,
     FixedPointField,
     FlagsField,
+    IP6Field,
     IPField,
     IntField,
     LEIntField,
@@ -39,7 +40,6 @@ from scapy.fields import (
     XByteField,
     XStrFixedLenField,
 )
-from scapy.layers.inet6 import IP6Field
 from scapy.layers.inet import UDP
 from scapy.utils import lhex
 from scapy.compat import orb

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -561,6 +561,84 @@ to be used in the fancy banner.
     return lines
 
 
+def get_fancy_banner(mini: Optional[bool] = None) -> str:
+    """
+    Generates the fancy Scapy banner
+
+    :param mini: if set, force a mini banner or not. Otherwise detect
+    """
+    from scapy.config import conf
+    from scapy.utils import get_terminal_width
+    if mini is None:
+        mini_banner = (get_terminal_width() or 84) <= 75
+    else:
+        mini_banner = mini
+
+    the_logo = [
+        "                                      ",
+        "                     aSPY//YASa       ",
+        "             apyyyyCY//////////YCa    ",
+        "            sY//////YSpcs  scpCY//Pp  ",
+        " ayp ayyyyyyySCP//Pp           syY//C ",
+        " AYAsAYYYYYYYY///Ps              cY//S",
+        "         pCCCCY//p          cSSps y//Y",
+        "         SPPPP///a          pP///AC//Y",
+        "              A//A            cyP////C",
+        "              p///Ac            sC///a",
+        "              P////YCpc           A//A",
+        "       scccccp///pSP///p          p//Y",
+        "      sY/////////y  caa           S//P",
+        "       cayCyayP//Ya              pY/Ya",
+        "        sY/PsY////YCc          aC//Yp ",
+        "         sc  sccaCY//PCypaapyCP//YSs  ",
+        "                  spCPY//////YPSps    ",
+        "                       ccaacs         ",
+        "                                      ",
+    ]
+
+    # Used on mini screens
+    the_logo_mini = [
+        "      .SYPACCCSASYY  ",
+        "P /SCS/CCS        ACS",
+        "       /A          AC",
+        "     A/PS       /SPPS",
+        "        YP        (SC",
+        "       SPS/A.      SC",
+        "   Y/PACC          PP",
+        "    PY*AYC        CAA",
+        "         YYCY//SCYP  ",
+    ]
+
+    the_banner = [
+        "",
+        "",
+        "   |",
+        "   | Welcome to Scapy",
+        "   | Version %s" % conf.version,
+        "   |",
+        "   | https://github.com/secdev/scapy",
+        "   |",
+        "   | Have fun!",
+        "   |",
+    ]
+
+    if mini_banner:
+        the_logo = the_logo_mini
+        the_banner = [x[2:] for x in the_banner[3:-1]]
+        the_banner = [""] + the_banner + [""]
+    else:
+        quote, author = choice(QUOTES)
+        the_banner.extend(_prepare_quote(quote, author, max_len=39))
+        the_banner.append("   |")
+    return "\n".join(
+        logo + banner for logo, banner in zip_longest(
+            (conf.color_theme.logo(line) for line in the_logo),
+            (conf.color_theme.success(line) for line in the_banner),
+            fillvalue=""
+        )
+    )
+
+
 def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
     # type: (Optional[Any], Optional[Any], Optional[Any], int) -> None
     """
@@ -635,72 +713,7 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
         )
 
     if conf.fancy_banner:
-        from scapy.utils import get_terminal_width
-        mini_banner = (get_terminal_width() or 84) <= 75
-
-        the_logo = [
-            "                                      ",
-            "                     aSPY//YASa       ",
-            "             apyyyyCY//////////YCa    ",
-            "            sY//////YSpcs  scpCY//Pp  ",
-            " ayp ayyyyyyySCP//Pp           syY//C ",
-            " AYAsAYYYYYYYY///Ps              cY//S",
-            "         pCCCCY//p          cSSps y//Y",
-            "         SPPPP///a          pP///AC//Y",
-            "              A//A            cyP////C",
-            "              p///Ac            sC///a",
-            "              P////YCpc           A//A",
-            "       scccccp///pSP///p          p//Y",
-            "      sY/////////y  caa           S//P",
-            "       cayCyayP//Ya              pY/Ya",
-            "        sY/PsY////YCc          aC//Yp ",
-            "         sc  sccaCY//PCypaapyCP//YSs  ",
-            "                  spCPY//////YPSps    ",
-            "                       ccaacs         ",
-            "                                      ",
-        ]
-
-        # Used on mini screens
-        the_logo_mini = [
-            "      .SYPACCCSASYY  ",
-            "P /SCS/CCS        ACS",
-            "       /A          AC",
-            "     A/PS       /SPPS",
-            "        YP        (SC",
-            "       SPS/A.      SC",
-            "   Y/PACC          PP",
-            "    PY*AYC        CAA",
-            "         YYCY//SCYP  ",
-        ]
-
-        the_banner = [
-            "",
-            "",
-            "   |",
-            "   | Welcome to Scapy",
-            "   | Version %s" % conf.version,
-            "   |",
-            "   | https://github.com/secdev/scapy",
-            "   |",
-            "   | Have fun!",
-            "   |",
-        ]
-
-        if mini_banner:
-            the_logo = the_logo_mini
-            the_banner = [x[2:] for x in the_banner[3:-1]]
-            the_banner = [""] + the_banner + [""]
-        else:
-            quote, author = choice(QUOTES)
-            the_banner.extend(_prepare_quote(quote, author, max_len=39))
-            the_banner.append("   |")
-        banner_text = "\n".join(
-            logo + banner for logo, banner in zip_longest(
-                (conf.color_theme.logo(line) for line in the_logo),
-                (conf.color_theme.success(line) for line in the_banner),
-                fillvalue=""
-            )
-        )
+        banner_text = get_fancy_banner()
     else:
         banner_text = "Welcome to Scapy (%s)" % conf.version
     if mybanner is not None:

--- a/scapy/pton_ntop.py
+++ b/scapy/pton_ntop.py
@@ -87,6 +87,8 @@ def inet_pton(af, addr):
     addr = plain_str(addr)
     # Use inet_pton if available
     try:
+        if not socket.has_ipv6:
+            raise AttributeError
         return socket.inet_pton(af, addr)
     except AttributeError:
         try:
@@ -134,6 +136,8 @@ def inet_ntop(af, addr):
     # Use inet_ntop if available
     addr = bytes_encode(addr)
     try:
+        if not socket.has_ipv6:
+            raise AttributeError
         return socket.inet_ntop(af, addr)
     except AttributeError:
         try:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2927,8 +2927,9 @@ def get_terminal_width():
         s = struct.pack('HHHH', 0, 0, 0, 0)
         x = fcntl.ioctl(1, termios.TIOCGWINSZ, s)
         sizex = struct.unpack('HHHH', x)[1]
-    except IOError:
-        pass
+    except (IOError, ModuleNotFoundError):
+        # If everything failed, return default terminal size
+        sizex = 79
     return sizex
 
 


### PR DESCRIPTION
- restore support for OSes that do not support IPv6
- move banner generation into its own function (main.py), and add `mini` argument