### PR TITLE
Pass the fd to the underlying NativeCANSocket

### DIFF
--- a/scapy/contrib/isotp/isotp_soft_socket.py
+++ b/scapy/contrib/isotp/isotp_soft_socket.py
@@ -133,7 +133,7 @@ class ISOTPSoftSocket(SuperSocket):
 
         if LINUX and isinstance(can_socket, str):
             from scapy.contrib.cansocket_native import NativeCANSocket
-            can_socket = NativeCANSocket(can_socket)
+            can_socket = NativeCANSocket(can_socket, fd=fd)
         elif isinstance(can_socket, str):
             raise Scapy_Exception("Provide a CANSocket object instead")
 

--- a/test/contrib/isotp_soft_socket.uts
+++ b/test/contrib/isotp_soft_socket.uts
@@ -11,6 +11,8 @@ from scapy.layers.can import *
 from scapy.contrib.isotp import *
 from scapy.contrib.isotp.isotp_soft_socket import TimeoutScheduler
 from test.testsocket import TestSocket, cleanup_testsockets
+with open(scapy_path("test/contrib/automotive/interface_mockup.py")) as f:
+    exec(f.read())
 
 = Redirect logging
 import logging
@@ -57,6 +59,18 @@ assert sniffed[0]['ISOTP'].rx_id == 0x241
 assert sniffed[0]['ISOTP'].rx_ext_address == 0xEA
 
 + ISOTPSoftSocket tests
+
+= CAN socket FD
+~ not_pypy needs_root linux vcan_socket
+
+with ISOTPSoftSocket(iface0, tx_id=0x641, rx_id=0x241, fd=True) as s:
+    assert s.impl.can_socket.fd == True
+
+= CAN socket non-FD
+~ not_pypy needs_root linux vcan_socket
+
+with ISOTPSoftSocket(iface0, tx_id=0x641, rx_id=0x241) as s:
+    assert s.impl.can_socket.fd == False
 
 = Single-frame receive
 


### PR DESCRIPTION
ISOTPSoftSocket should pass the fd (CanFD support) to the NativeCANSocket instance it creates. Otherwise it will always be created as non CanFD.