### PR TITLE
Improve answering machines, dns_resolve, renames

### DIFF
--- a/doc/scapy/routing.rst
+++ b/doc/scapy/routing.rst
@@ -6,6 +6,7 @@ Scapy maintains its own network stack, which is independent from the one of your
 It possesses its own *interfaces list*, *routing table*, *ARP cache*, *IPv6 neighbour* cache, *nameservers* config... and so on, all of which is configurable.
 
 Here are a few examples of where this is used::
+
 - When you use ``sr()/send()``, Scapy will use internally its own routing table (``conf.route``) in order to find which interface to use, and eventually send an ARP request.
 - When using ``dns_resolve()``, Scapy uses its own nameservers list (``conf.nameservers``) to perform the request
 - etc.

--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1434,28 +1434,32 @@ Visualizing the results in a list::
     >>> res.nsummary(prn=lambda s,r: r.src, lfilter=lambda s,r: r.haslayer(ISAKMP) ) 
 
 
-DNS spoof
----------
+DNS server
+----------
 
-See :class:`~scapy.layers.dns.DNS_am`::
+By default, ``dnsd`` uses a joker (IPv4 only): it answers to all unknown servers with the joker. See :class:`~scapy.layers.dns.DNS_am`::
 
-    >>> dns_spoof(iface="tap0", joker="192.168.1.1")
+    >>> dnsd(iface="tap0", match={"google.com": "1.1.1.1"}, joker="192.168.1.1")
 
-LLMNR spoof
------------
+You can also use ``relay=True`` to replace the joker behavior with a forward to a server included in ``conf.nameservers``.
+
+LLMNR server
+------------
 
 See :class:`~scapy.layers.llmnr.LLMNR_am`::
 
     >>> conf.iface = "tap0"
-    >>> llmnr_spoof(iface="tap0", from_ip=Net("10.0.0.1/24"))
+    >>> llmnrd(iface="tap0", from_ip=Net("10.0.0.1/24"))
 
-Netbios spoof
--------------
+Note that ``llmnrd`` extends the ``dnsd`` API.
+
+Netbios server
+--------------
 
 See :class:`~scapy.layers.netbios.NBNS_am`::
 
-    >>> nbns_spoof(iface="eth0")  # With local IP
-    >>> nbns_spoof(iface="eth0", ip="192.168.122.17")  # With some other IP
+    >>> nbnsd(iface="eth0")  # With local IP
+    >>> nbnsd(iface="eth0", ip="192.168.122.17")  # With some other IP
 
 Node status request (get NetbiosName from IP)
 ---------------------------------------------

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -593,7 +593,7 @@ class BOOTP_am(AnsweringMachine):
                       network="192.168.1.0/24",
                       gw="192.168.1.1",
                       nameserver=None,
-                      domain="localnet",
+                      domain=None,
                       renewal_time=60,
                       lease_time=1800):
         """

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -14,7 +14,13 @@ RFC also envisions LLMNR over TCP. Like vista, we don't support it -- arno
 
 import struct
 
-from scapy.fields import BitEnumField, BitField, ShortField
+from scapy.fields import (
+    BitEnumField,
+    BitField,
+    DestField,
+    DestIP6Field,
+    ShortField,
+)
 from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.compat import orb
 from scapy.layers.inet import UDP
@@ -88,9 +94,14 @@ bind_bottom_up(UDP, _LLMNR, dport=5355)
 bind_bottom_up(UDP, _LLMNR, sport=5355)
 bind_layers(UDP, _LLMNR, sport=5355, dport=5355)
 
+DestField.bind_addr(LLMNRQuery, _LLMNR_IPv4_mcast_addr, dport=5355)
+DestField.bind_addr(LLMNRResponse, _LLMNR_IPv4_mcast_addr, dport=5355)
+DestIP6Field.bind_addr(LLMNRQuery, _LLMNR_IPv6_mcast_Addr, dport=5355)
+DestIP6Field.bind_addr(LLMNRResponse, _LLMNR_IPv6_mcast_Addr, dport=5355)
+
 
 class LLMNR_am(DNS_am):
-    function_name = "llmnr_spoof"
+    function_name = "llmnrd"
     filter = "udp port 5355"
     cls = LLMNRQuery
 

--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -355,7 +355,7 @@ bind_layers(TCP, NBTSession, dport=139, sport=139)
 
 
 class NBNS_am(AnsweringMachine):
-    function_name = "nbns_spoof"
+    function_name = "nbnsd"
     filter = "udp port 137"
     sniff_options = {"store": 0}
 

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -37,7 +37,8 @@ def check_DHCP_am_reply(packet):
 
 test_am(DHCP_am,
         Ether()/IP()/UDP()/BOOTP(op=1)/DHCP(options=[('message-type', 'request')]),
-        check_DHCP_am_reply)
+        check_DHCP_am_reply,
+        domain="localnet")
 
 
 = ARP_am
@@ -72,6 +73,17 @@ test_am(DNS_am,
         IP()/UDP()/DNS(qd=DNSQR(qname="www.secdev.org")),
         check_DNS_am_reply,
         joker="192.168.1.1")
+
+def check_DNS_am_reply2(packet):
+    assert DNS in packet and packet[DNS].ancount == 2
+    assert packet[DNS].an[0].rdata == "128.0.0.1"
+    assert packet[DNS].an[1].rdata == "::1"
+
+test_am(DNS_am,
+        IP(b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x004\xe8\x9a\x00\x00\x01\x00\x00\x02\x00\x00\x00\x00\x00\x00\x06gaagle\x03com\x00\x00\x01\x00\x01\x06google\x03com\x00\x00\x1c\x00\x01'),
+        check_DNS_am_reply2,
+        match={"google.com": ("127.0.0.1", "::1"), "gaagle.com": "128.0.0.1"},
+        joker=False)
 
 = DHCPv6_am - Basic Instantiaion
 ~ osx netaccess

--- a/test/scapy/layers/dhcp.uts
+++ b/test/scapy/layers/dhcp.uts
@@ -121,5 +121,5 @@ assert DHCPRevOptions['static-routes'][0] == 33
 
 assert dhcpd
 import IPython
-assert IPython.lib.pretty.pretty(dhcpd) == '<function scapy.ansmachine.dhcpd(self, pool=Net("192.168.1.128/25"), network=\'192.168.1.0/24\', gw=\'192.168.1.1\', nameserver=None, domain=\'localnet\', renewal_time=60, lease_time=1800)>'
+assert IPython.lib.pretty.pretty(dhcpd) == '<function scapy.ansmachine.dhcpd(self, pool=Net("192.168.1.128/25"), network=\'192.168.1.0/24\', gw=\'192.168.1.1\', nameserver=None, domain=None, renewal_time=60, lease_time=1800)>'
 


### PR DESCRIPTION
Some more work on handy oneliners.
- **support dnsd relay mode**: oneliner DNS server that forwards to a real server, only replacing some values.

```python
>>> # DNS server that replaces google.com. Forwards using conf.nameservers
>>> dnsd(match={"google.com": ("1.1.1.1", "::1")}, relay=True)
```

- bind multicast LLMNR addresses
- do not set a default domain for `dhcpd`. This breaks Windows DNS by default
- rename some answering machines (makes much more sense, also consistent with `dhcpd`, `icmpechod`...)
  - `dns_spoof` -> `dnsd`
  - `llmnr_spoof` -> `llmnrd`
  - `nbns_spoof` -> `nbnsd`