### PR TITLE
Modify packet definition of UDS_IOCBI packet to allow customization

### DIFF
--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -1374,11 +1374,8 @@ bind_layers(UDS, UDS_RFTPR, service=0x78)
 # #########################IOCBI###################################
 class UDS_IOCBI(Packet):
     name = 'InputOutputControlByIdentifier'
-    dataIdentifiers = ObservableDict()
     fields_desc = [
-        XShortEnumField('dataIdentifier', 0, dataIdentifiers),
-        ByteField('controlOptionRecord', 0),
-        StrField('controlEnableMaskRecord', b"", fmt="B")
+        XShortEnumField('dataIdentifier', 0, UDS_RDBI.dataIdentifiers),
     ]
 
 
@@ -1388,8 +1385,7 @@ bind_layers(UDS, UDS_IOCBI, service=0x2F)
 class UDS_IOCBIPR(Packet):
     name = 'InputOutputControlByIdentifierPositiveResponse'
     fields_desc = [
-        XShortField('dataIdentifier', 0),
-        StrField('controlStatusRecord', b"", fmt="B")
+        XShortEnumField('dataIdentifier', 0, UDS_RDBI.dataIdentifiers),
     ]
 
     def answers(self, other):

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -873,7 +873,7 @@ class UDS_IOCBIEnumerator(UDS_Enumerator):
         if resp is not None:
             return "0x%04x: %s" % \
                    (tup[1].dataIdentifier,
-                    resp.controlStatusRecord)
+                    repr(resp.payload))
         else:
             return "0x%04x: No response" % tup[1].dataIdentifier
 

--- a/test/contrib/automotive/uds.uts
+++ b/test/contrib/automotive/uds.uts
@@ -1362,8 +1362,7 @@ assert rtepr.answers(rte)
 iocbi = UDS(b'\x2f\x23\x34\xffcoffee')
 assert iocbi.service == 0x2f
 assert iocbi.dataIdentifier == 0x2334
-assert iocbi.controlOptionRecord == 255
-assert iocbi.controlEnableMaskRecord == b'coffee'
+assert iocbi.load == b'\xffcoffee'
 
 = Check UDS_RFT
 


### PR DESCRIPTION
This PR removes some fields from the UDS_IOCBI packet definition to allow further customization of the payload with bind_layers. This is useful if ECUs from different brands need custom parsing of IOCBI payloads.