### PR TITLE
bluetooth: Fix exception on failed _BluetoothLibcSockets

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -2055,7 +2055,8 @@ class _BluetoothLibcSocket(SuperSocket):
         if hasattr(self, "ins"):
             if self.ins and (WINDOWS or self.ins.fileno() != -1):
                 close(self.ins.fileno())
-        close(self.hci_fd)
+        if hasattr(self, "hci_fd"):
+            close(self.hci_fd)
 
 
 class BluetoothUserSocket(_BluetoothLibcSocket):


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

If a `_BluetoothLibcSocket` fails to bind, then `self.hci_fd` will not be available, thus causing an exception when trying to execute `close(self.hci_fd)`.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
