### PR TITLE
DNS: make it possible to include empty strings in TXT RDATA

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -369,6 +369,9 @@ class DNSTextField(StrLenField):
     def i2m(self, pkt, s):
         ret_s = b""
         for text in s:
+            if not text:
+                ret_s += b"\x00"
+                continue
             text = bytes_encode(text)
             # The initial string must be split into a list of strings
             # prepended with theirs sizes.
@@ -943,7 +946,7 @@ class DNSRR(Packet):
                                         length_from=lambda pkt: pkt.rdlen),
                                lambda pkt: pkt.type in [2, 3, 4, 5, 12]),
                            # TEXT
-                           (DNSTextField("rdata", [],
+                           (DNSTextField("rdata", [""],
                                          length_from=lambda pkt: pkt.rdlen),
                                lambda pkt: pkt.type == 16),
                        ],

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -213,6 +213,31 @@ p = DNS(raw(DNS(id=1,ra=1,qd=[],an=DNSRR(rrname='secdev', type='TXT', rdata=["sw
 assert p[DNS].an[0].rdata == [b"sweet", b"celestia"]
 assert raw(p) == b'\x00\x01\x01\x80\x00\x00\x00\x01\x00\x00\x00\x00\x06secdev\x00\x00\x10\x00\x01\x00\x00\x00\x01\x00\x0f\x05sweet\x08celestia'
 
+# TXT RR with one empty string
+b = b'\x05scapy\x00\x00\x10\x00\x01\x00\x00\x00\x00\x00\x01\x00'
+rr = DNSRR(b)
+assert rr.rdata == [b""]
+assert rr.rdlen == 1
+rr.clear_cache()
+assert DNSRR(raw(rr)).rdata == [b""]
+
+rr = DNSRR(rrname='scapy', type='TXT', rdata=[""])
+assert raw(rr) == b
+
+rr = DNSRR(rrname='scapy', type='TXT')
+assert raw(rr) == b
+
+# TXT RR with zero-length RDATA
+b = b'\x05scapy\x00\x00\x10\x00\x01\x00\x00\x00\x00\x00\x00'
+rr = DNSRR(b)
+assert rr.rdata == []
+assert rr.rdlen == 0
+rr.clear_cache()
+assert DNSRR(raw(rr)).rdata == []
+
+rr = DNSRR(rrname='scapy', type='TXT', rdata=[])
+assert raw(rr) == b
+
 = DNS - Malformed DNS over TCP message
 
 _old_dbg = conf.debug_dissector


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc1035#section-3.3.14 TXT RDATA holds one or more `<character-string>`s where `<character-string>` is a single length octet followed by that number of characters.

This patch makes it possible to include empty strings (by appending zero-bytes showing that their length is zero).

It also changes the default value to avoid generating TXT RRs with zero-length TXT RDATA by default. It's still possible to generate zero-length TXT RDATA by passing rdata=[] explicitly.

The patch was cross-checked with Wireshark
```sh
    Answers
        scapy: type TXT, class IN
            Name: scapy
            Type: TXT (Text strings) (16)
            Class: IN (0x0001)
            Time to live: 0 (0 seconds)
            Data length: 4
            TXT Length: 0
            TXT: 
            TXT Length: 1
            TXT: a
            TXT Length: 0
            TXT: 
```
Without this PR the two empty strings aren't included:
```
    Answers
        scapy: type TXT, class IN
            Name: scapy
            Type: TXT (Text strings) (16)
            Class: IN (0x0001)
            Time to live: 0 (0 seconds)
            Data length: 2
            TXT Length: 1
            TXT: a
```