### PR TITLE
ReadTheDocs: fix displayed Scapy version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,13 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+  # To show the correct Scapy version, we must unshallow
+  # https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#python
 python:
   install:
     - method: pip


### PR DESCRIPTION
- Currently wrongly shows "2023.XX.XX" as the Scapy version on https://scapy.readthedocs.io/en/latest/