### PR TITLE
Update python versions (pyproject.toml / RTFD / tests)

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install tox
         run: pip install tox
       - name: Run flake8 tests
@@ -32,15 +32,16 @@ jobs:
       - name: Run gitarchive check
         run: tox -e gitarchive
   docs:
+    # 'runs-on' and 'python-version' should match the ones defined in .readthedocs.yml
     name: Build doc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Scapy
         uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install tox
         run: pip install tox
       - name: Build docs
@@ -69,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         mode: [non_root]
         installmode: ['']
         flags: [" -K scanner"]
@@ -77,7 +78,7 @@ jobs:
         include:
           # Linux root tests
           - os: ubuntu-latest
-            python: "3.10"
+            python: "3.11"
             mode: root
             flags: " -K scanner"
           # PyPy tests: root only
@@ -87,18 +88,18 @@ jobs:
             flags: " -K scanner"
           # Libpcap test
           - os: ubuntu-latest
-            python: "3.10"
+            python: "3.11"
             mode: root
             installmode: 'libpcap'
             flags: " -K scanner"
           # macOS tests
           - os: macos-12
-            python: "3.10"
+            python: "3.11"
             mode: both
             flags: " -K scanner"
           # Scanner tests
           - os: ubuntu-latest
-            python: "3.10"
+            python: "3.11"
             mode: root
             allow-failure: 'true'
             flags: " -k scanner"
@@ -108,7 +109,7 @@ jobs:
             allow-failure: 'true'
             flags: " -k scanner"
           - os: macos-12
-            python: "3.10"
+            python: "3.11"
             mode: both
             allow-failure: 'true'
             flags: " -k scanner"
@@ -138,7 +139,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install tox
       run: pip install tox
     # pyca/cryptography's CI installs cryptography

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,9 +9,9 @@ formats:
   - pdf
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
   # To show the correct Scapy version, we must unshallow
   # https://docs.readthedocs.io/en/stable/build-customization.html#unshallow-git-clone
   jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Security",
     "Topic :: System :: Networking",
     "Topic :: System :: Networking :: Monitoring",


### PR DESCRIPTION
- update tests build python versions (add 3.11 and 3.12)
- update readthedocs build python version
- mark 3.11 and 3.12 as supported