### PR TITLE
Bump mypy to 1.7.0 and tox cleanup

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -84,13 +84,13 @@ if [ -z $TOXENV ]
 then
   case ${SCAPY_TOX_CHOSEN} in
     both)
-      export TOXENV="${TESTVER}_non_root,${TESTVER}_root"
+      export TOXENV="${TESTVER}-non_root,${TESTVER}-root"
       ;;
     root)
-      export TOXENV="${TESTVER}_root"
+      export TOXENV="${TESTVER}-root"
       ;;
     *)
-      export TOXENV="${TESTVER}_non_root"
+      export TOXENV="${TESTVER}-non_root"
       ;;
   esac
 fi

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install tox
         run: pip install tox
       - name: Run flake8 tests
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install tox
         run: pip install tox
       - name: Run mypy
@@ -78,7 +78,7 @@ jobs:
         include:
           # Linux root tests
           - os: ubuntu-latest
-            python: "3.11"
+            python: "3.12"
             mode: root
             flags: " -K scanner"
           # PyPy tests: root only
@@ -88,18 +88,18 @@ jobs:
             flags: " -K scanner"
           # Libpcap test
           - os: ubuntu-latest
-            python: "3.11"
+            python: "3.12"
             mode: root
             installmode: 'libpcap'
             flags: " -K scanner"
           # macOS tests
           - os: macos-12
-            python: "3.11"
+            python: "3.12"
             mode: both
             flags: " -K scanner"
           # Scanner tests
           - os: ubuntu-latest
-            python: "3.11"
+            python: "3.12"
             mode: root
             allow-failure: 'true'
             flags: " -k scanner"
@@ -109,7 +109,7 @@ jobs:
             allow-failure: 'true'
             flags: " -k scanner"
           - os: macos-12
-            python: "3.11"
+            python: "3.12"
             mode: both
             allow-failure: 'true'
             flags: " -k scanner"
@@ -139,7 +139,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install tox
       run: pip install tox
     # pyca/cryptography's CI installs cryptography

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ all = [
     "cryptography>=2.0",
     "matplotlib",
 ]
-docs = [
+doc = [
     "sphinx>=7.0.0",
     "sphinx_rtd_theme>=1.3.0",
     "tox>=3.0.0",

--- a/scapy/asn1fields.py
+++ b/scapy/asn1fields.py
@@ -452,7 +452,7 @@ class ASN1F_SEQUENCE(ASN1F_field[List[Any], List[Any]]):
 
     def get_fields_list(self):
         # type: () -> List[ASN1F_field[Any, Any]]
-        return reduce(lambda x, y: x + y.get_fields_list(),  # type: ignore
+        return reduce(lambda x, y: x + y.get_fields_list(),
                       self.seq, [])
 
     def m2i(self, pkt, s):
@@ -497,7 +497,7 @@ class ASN1F_SEQUENCE(ASN1F_field[List[Any], List[Any]]):
 
     def build(self, pkt):
         # type: (ASN1_Packet) -> bytes
-        s = reduce(lambda x, y: x + y.build(pkt),  # type: ignore
+        s = reduce(lambda x, y: x + y.build(pkt),
                    self.seq, b"")
         return super(ASN1F_SEQUENCE, self).i2m(pkt, s)
 
@@ -506,7 +506,7 @@ class ASN1F_SET(ASN1F_SEQUENCE):
     ASN1_tag = ASN1_Class_UNIVERSAL.SET
 
 
-_SEQ_T = Union['ASN1_Packet', Type[ASN1F_field], 'ASN1F_PACKET']
+_SEQ_T = Union['ASN1_Packet', Type[ASN1F_field[Any, Any]], 'ASN1F_PACKET']
 
 
 class ASN1F_SEQUENCE_OF(ASN1F_field[List[_SEQ_T],
@@ -656,7 +656,7 @@ class ASN1F_optional(ASN1F_element):
         return self._field.i2repr(pkt, x)
 
 
-_CHOICE_T = Union['ASN1_Packet', Type[ASN1F_field], 'ASN1F_PACKET']
+_CHOICE_T = Union['ASN1_Packet', Type[ASN1F_field[Any, Any]], 'ASN1F_PACKET']
 
 
 class ASN1F_CHOICE(ASN1F_field[_CHOICE_T, ASN1_Object[Any]]):

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -26,6 +26,7 @@ __all__ = [
     # typing
     'DecoratorCallable',
     'Literal',
+    'Protocol',
     'Self',
     'UserDict',
     # compat
@@ -45,7 +46,7 @@ __all__ = [
 # Note:
 # supporting typing on multiple python versions is a nightmare.
 # we provide a FakeType class to be able to use types added on
-# later Python versions (since we run mypy on 3.11), on older
+# later Python versions (since we run mypy on 3.12), on older
 # ones.
 
 
@@ -77,8 +78,12 @@ def _FakeType(name, cls=object):
 # Python 3.8 Only
 if sys.version_info >= (3, 8):
     from typing import Literal
+    from typing import Protocol
 else:
     Literal = _FakeType("Literal")
+
+    class Protocol:
+        pass
 
 
 # Python 3.9 Only

--- a/scapy/config.py
+++ b/scapy/config.py
@@ -23,7 +23,7 @@ from scapy import VERSION
 from scapy.base_classes import BasePacket
 from scapy.consts import DARWIN, WINDOWS, LINUX, BSD, SOLARIS
 from scapy.error import log_scapy, warning, ScapyInvalidPlatformException
-from scapy.themes import NoTheme, apply_ipython_style
+from scapy.themes import ColorTheme, NoTheme, apply_ipython_style
 
 # Typing imports
 from typing import (
@@ -135,20 +135,20 @@ ReadOnlyAttribute.__doc__ = "Read-only class attribute"
 
 
 class ProgPath(ConfClass):
-    _default = "<System default>"
-    universal_open = "open" if DARWIN else "xdg-open"
-    pdfreader = universal_open
-    psreader = universal_open
-    svgreader = universal_open
-    dot = "dot"
-    display = "display"
-    tcpdump = "tcpdump"
-    tcpreplay = "tcpreplay"
-    hexedit = "hexer"
-    tshark = "tshark"
-    wireshark = "wireshark"
-    ifconfig = "ifconfig"
-    extcap_folders = [
+    _default: str = "<System default>"
+    universal_open: str = "open" if DARWIN else "xdg-open"
+    pdfreader: str = universal_open
+    psreader: str = universal_open
+    svgreader: str = universal_open
+    dot: str = "dot"
+    display: str = "display"
+    tcpdump: str = "tcpdump"
+    tcpreplay: str = "tcpreplay"
+    hexedit: str = "hexer"
+    tshark: str = "tshark"
+    wireshark: str = "wireshark"
+    ifconfig: str = "ifconfig"
+    extcap_folders: List[str] = [
         os.path.join(os.path.expanduser("~"), ".config", "wireshark", "extcap"),
         "/usr/lib/x86_64-linux-gnu/wireshark/extcap",
     ]
@@ -389,7 +389,7 @@ class CacheInstance(Dict[str, Any]):
         self._timetable[item] = time.time()
         super(CacheInstance, self).__setitem__(item, v)
 
-    def update(self,  # type: ignore
+    def update(self,
                other,  # type: Any
                **kwargs  # type: Any
                ):
@@ -404,7 +404,7 @@ class CacheInstance(Dict[str, Any]):
     def iteritems(self):
         # type: () -> Iterator[Tuple[str, Any]]
         if self.timeout is None:
-            return super(CacheInstance, self).items()  # type: ignore
+            return super(CacheInstance, self).items()
         t0 = time.time()
         return (
             (k, v)
@@ -415,7 +415,7 @@ class CacheInstance(Dict[str, Any]):
     def iterkeys(self):
         # type: () -> Iterator[str]
         if self.timeout is None:
-            return super(CacheInstance, self).keys()  # type: ignore
+            return super(CacheInstance, self).keys()
         t0 = time.time()
         return (
             k
@@ -430,7 +430,7 @@ class CacheInstance(Dict[str, Any]):
     def itervalues(self):
         # type: () -> Iterator[Tuple[str, Any]]
         if self.timeout is None:
-            return super(CacheInstance, self).values()  # type: ignore
+            return super(CacheInstance, self).values()
         t0 = time.time()
         return (
             v
@@ -616,7 +616,7 @@ def _set_conf_sockets():
             Interceptor.set_from_hook(conf, "use_pcap", False)
         else:
             conf.L3socket = L3pcapSocket
-            conf.L3socket6 = functools.partial(  # type: ignore
+            conf.L3socket6 = functools.partial(
                 L3pcapSocket, filter="ip6")
             conf.L2socket = L2pcapSocket
             conf.L2listen = L2pcapListenSocket
@@ -624,7 +624,7 @@ def _set_conf_sockets():
         from scapy.arch.bpf.supersocket import L2bpfListenSocket, \
             L2bpfSocket, L3bpfSocket
         conf.L3socket = L3bpfSocket
-        conf.L3socket6 = functools.partial(  # type: ignore
+        conf.L3socket6 = functools.partial(
             L3bpfSocket, filter="ip6")
         conf.L2socket = L2bpfSocket
         conf.L2listen = L2bpfListenSocket
@@ -698,7 +698,7 @@ def _iface_changer(attr, val, old):
                 "See conf.ifaces output"
             )
         return iface
-    return val  # type: ignore
+    return val
 
 
 def _reset_tls_nss_keys(attr, val, old):
@@ -712,8 +712,8 @@ class Conf(ConfClass):
     """
     This object contains the configuration of Scapy.
     """
-    version = ReadOnlyAttribute("version", VERSION)
-    session = ""  #: filename where the session will be saved
+    version: str = ReadOnlyAttribute("version", VERSION)
+    session: str = ""  #: filename where the session will be saved
     interactive = False
     #: can be "ipython", "bpython", "ptpython", "ptipython", "python" or "auto".
     #: Default: Auto
@@ -723,15 +723,15 @@ class Conf(ConfClass):
     #: if 1, prevents any unwanted packet to go out (ARP, DNS, ...)
     stealth = "not implemented"
     #: selects the default output interface for srp() and sendp().
-    iface = Interceptor("iface", None, _iface_changer)  # type: 'scapy.interfaces.NetworkInterface'  # type: ignore  # noqa: E501
-    layers = LayersList()
+    iface = Interceptor("iface", None, _iface_changer)  # type: 'scapy.interfaces.NetworkInterface'  # noqa: E501
+    layers: LayersList = LayersList()
     commands = CommandsList()  # type: CommandsList
     #: Codec used by default for ASN1 objects
     ASN1_default_codec = None  # type: 'scapy.asn1.asn1.ASN1Codec'
     #: choose the AS resolver class to use
     AS_resolver = None  # type: scapy.as_resolvers.AS_resolver
     dot15d4_protocol = None  # Used in dot15d4.py
-    logLevel = Interceptor("logLevel", log_scapy.level, _loglevel_changer)
+    logLevel: int = Interceptor("logLevel", log_scapy.level, _loglevel_changer)
     #: if 0, doesn't check that IPID matches between IP sent and
     #: ICMP IP citation received
     #: if 1, checks that they either are equal or byte swapped
@@ -749,7 +749,7 @@ class Conf(ConfClass):
     #: ones in ICMP citation
     check_TCPerror_seqack = False
     verb = 2  #: level of verbosity, from 0 (almost mute) to 3 (verbose)
-    prompt = Interceptor("prompt", ">>> ", _prompt_changer)
+    prompt: str = Interceptor("prompt", ">>> ", _prompt_changer)
     #: default mode for the promiscuous mode of a socket (to get answers if you
     #: spoof on a lan)
     sniff_promisc = True  # type: bool
@@ -757,8 +757,8 @@ class Conf(ConfClass):
     raw_summary = False  # type: Union[bool, Callable[[bytes], Any]]
     padding_layer = None  # type: Type[Packet]
     default_l2 = None  # type: Type[Packet]
-    l2types = Num2Layer()
-    l3types = Num2Layer()
+    l2types: Num2Layer = Num2Layer()
+    l3types: Num2Layer = Num2Layer()
     L3socket = None  # type: Type[scapy.supersocket.SuperSocket]
     L3socket6 = None  # type: Type[scapy.supersocket.SuperSocket]
     L2socket = None  # type: Type[scapy.supersocket.SuperSocket]
@@ -769,10 +769,13 @@ class Conf(ConfClass):
     mib = None  # type: 'scapy.asn1.mib.MIBDict'
     bufsize = 2**16
     #: history file
-    histfile = os.getenv('SCAPY_HISTFILE',
-                         os.path.join(os.path.expanduser("~"),
-                                      ".config", "scapy",
-                                      "history"))
+    histfile: str = os.getenv(
+        'SCAPY_HISTFILE',
+        os.path.join(
+            os.path.expanduser("~"),
+            ".config", "scapy", "history"
+        )
+    )
     #: includes padding in disassembled packets
     padding = 1
     #: BPF filter for packets to ignore
@@ -808,36 +811,36 @@ class Conf(ConfClass):
     auto_fragment = True
     #: raise exception when a packet dissector raises an exception
     debug_dissector = False
-    color_theme = Interceptor("color_theme", NoTheme(), _prompt_changer)
+    color_theme: ColorTheme = Interceptor("color_theme", NoTheme(), _prompt_changer)
     #: how much time between warnings from the same place
     warning_threshold = 5
-    prog = ProgPath()
+    prog: ProgPath = ProgPath()
     #: holds list of fields for which resolution should be done
-    resolve = Resolve()
+    resolve: Resolve = Resolve()
     #: holds list of enum fields for which conversion to string
     #: should NOT be done
-    noenum = Resolve()
-    emph = Emphasize()
+    noenum: Resolve = Resolve()
+    emph: Emphasize = Emphasize()
     #: read only attribute to show if PyPy is in use
-    use_pypy = ReadOnlyAttribute("use_pypy", isPyPy())
+    use_pypy: bool = ReadOnlyAttribute("use_pypy", isPyPy())
     #: use libpcap integration or not. Changing this value will update
     #: the conf.L[2/3] sockets
-    use_pcap = Interceptor(
+    use_pcap: bool = Interceptor(
         "use_pcap",
         os.getenv("SCAPY_USE_LIBPCAP", "").lower().startswith("y"),
         _socket_changer
     )
-    use_bpf = Interceptor("use_bpf", False, _socket_changer)
+    use_bpf: bool = Interceptor("use_bpf", False, _socket_changer)
     use_npcap = False
-    ipv6_enabled = socket.has_ipv6
+    ipv6_enabled: bool = socket.has_ipv6
     stats_classic_protocols = []  # type: List[Type[Packet]]
     stats_dot11_protocols = []  # type: List[Type[Packet]]
     temp_files = []  # type: List[str]
     #: netcache holds time-based caches for net operations
-    netcache = NetCache()
+    netcache: NetCache = NetCache()
     geoip_city = None
     # can, tls, http and a few others are not loaded by default
-    load_layers = [
+    load_layers: List[str] = [
         'bluetooth',
         'bluetooth4LE',
         'dcerpc',
@@ -903,7 +906,7 @@ class Conf(ConfClass):
     #: When True, raise exception if no dst MAC found otherwise broadcast.
     #: Default is False.
     raise_no_dst_mac = False
-    loopback_name = "lo" if LINUX else "lo0"
+    loopback_name: str = "lo" if LINUX else "lo0"
     nmap_base = ""  # type: str
     nmap_kdb = None  # type: Optional[NmapKnowledgeBase]
     #: a safety mechanism: the maximum amount of items included in a PacketListField
@@ -918,7 +921,7 @@ class Conf(ConfClass):
         _reset_tls_nss_keys
     )
     #: Dictionary containing parsed NSS Keys
-    tls_nss_keys = None
+    tls_nss_keys: Dict[str, bytes] = None
 
     def __getattribute__(self, attr):
         # type: (str) -> Any
@@ -971,7 +974,7 @@ def crypto_validator(func):
             raise ImportError("Cannot execute crypto-related method! "
                               "Please install python-cryptography v1.7 or later.")  # noqa: E501
         return func(*args, **kwargs)
-    return func_in  # type: ignore
+    return func_in
 
 
 def scapy_delete_temp_files():

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -1267,7 +1267,7 @@ class Packet(
         if _subclass:
             match = issubtype
         else:
-            match = lambda cls1, cls2: bool(cls1 == cls2)
+            match = lambda x, t: bool(x == t)
         if cls is None or match(self.__class__, cls) \
            or cls in [self.__class__.__name__, self._name]:
             return True
@@ -1300,7 +1300,7 @@ values.
         if _subclass:
             match = issubtype
         else:
-            match = lambda cls1, cls2: bool(cls1 == cls2)
+            match = lambda x, t: bool(x == t)
         # Note:
         # cls can be int, packet, str
         # string_class_name can be packet, str (packet or packet+field)
@@ -1422,8 +1422,8 @@ values.
         """
 
         if dump:
-            from scapy.themes import AnsiColorTheme
-            ct = AnsiColorTheme()  # No color for dump output
+            from scapy.themes import ColorTheme, AnsiColorTheme
+            ct: ColorTheme = AnsiColorTheme()  # No color for dump output
         else:
             ct = conf.color_theme
         s = "%s%s %s %s \n" % (label_lvl,
@@ -2121,7 +2121,7 @@ def explore(layer=None):
         # Check for prompt_toolkit >= 3.0.0
         call_ptk = lambda x: cast(str, x)  # type: Callable[[Any], str]
         if _version_checker(prompt_toolkit, (3, 0)):
-            call_ptk = lambda x: x.run()  # type: ignore
+            call_ptk = lambda x: x.run()
         # 1 - Ask for layer or contrib
         btn_diag = button_dialog(
             title="Scapy v%s" % conf.version,

--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -379,7 +379,7 @@ class _PacketList(Generic[_Inner], metaclass=PacketList_metaclass):
             kargs = MATPLOTLIB_DEFAULT_PLOT_KARGS
 
         if plot_xy:
-            lines = [plt.plot(*list(zip(*pl)), **dict(kargs, label=k))  # type: ignore
+            lines = [plt.plot(*list(zip(*pl)), **dict(kargs, label=k))
                      for k, pl in d.items()]
         else:
             lines = [plt.plot(pl, **dict(kargs, label=k))

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,15 @@
 # Copyright (C) 2020 Guillaume Valadon <guillaume@valadon.net>
 
 
+# Tox environments:
+# py{version}-{os}-{non_root,root}
+# In our testing, version can be 37 to 312 or py39 for pypy39
+
 [tox]
-envlist = py{27,34,35,36,37,38,39,310,311,py27,py39}-{linux,bsd}_{non_root,root},
-          py{27,34,35,36,37,38,39,310,311,py27,py39}-windows,
+# minversion = 4.0
 skip_missing_interpreters = true
-minversion = 4.0
+# envlist = default when doing 'tox'
+envlist = py{37,38,39,310,311,312}-{linux,bsd,windows}-non_root
 
 # Main tests
 
@@ -36,14 +40,14 @@ deps = mock
        brotli < 1.1.0 ; sys_platform != 'win32'
        zstandard ; sys_platform != 'win32'
 platform =
-  linux_non_root,linux_root: linux
-  bsd_non_root,bsd_root: darwin|freebsd|openbsd|netbsd
+  linux: linux
+  bsd: darwin|freebsd|openbsd|netbsd
   windows: win32
 commands =
-  linux_non_root: {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -N {posargs}
-  linux_root: sudo -E {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs}
-  bsd_non_root: {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -N {posargs}
-  bsd_root: sudo -E {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark {posargs}
+  linux-non_root: {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc -N {posargs}
+  linux-root: sudo -E {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c ./test/configs/linux.utsc {posargs}
+  bsd-non_root: {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark -N {posargs}
+  bsd-root: sudo -E {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c test/configs/bsd.utsc -K manufdb -K tshark {posargs}
   windows: {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy -c test/configs/windows.utsc {posargs}
   {env:DISABLE_COVERAGE:coverage combine}
   {env:DISABLE_COVERAGE:coverage xml -i}
@@ -99,7 +103,7 @@ commands =
 [testenv:mypy]
 description = "Check Scapy compliance against static typing"
 skip_install = true
-deps = mypy==1.1.1
+deps = mypy==1.7.0
        typing
        types-mock
 commands = python .config/mypy/mypy_check.py linux
@@ -108,10 +112,9 @@ commands = python .config/mypy/mypy_check.py linux
 
 [testenv:docs]
 description = "Build the docs"
-skip_install = true
+deps =
+extras = doc
 changedir = {toxinidir}/doc/scapy
-deps = sphinx>=2.4.2
-       sphinx_rtd_theme
 commands =
   sphinx-build -W --keep-going -b html . _build/html
 


### PR DESCRIPTION
- bump mypy version to 1.7.0 (discovers more issues) and fix the typing issues triggered by the bump
- small cleanup to the tox.ini config, simplify the defaults. If tox was not buggy (https://github.com/tox-dev/tox/issues/3153) this would have restablished simply typing `tox` to autoselect the environment.