### PR TITLE
Cache `get_if_hwaddr` for SourceMACField

### DIFF
--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -435,7 +435,10 @@ if conf.use_pcap:
                     except Exception as ex:
                         # There are at least 3 different possible exceptions
                         log_loading.warning(
-                            "Could not get MAC address of interface '%s': %s." % (ifname, ex)
+                            "Could not get MAC address of interface '%s': %s." % (
+                                ifname,
+                                ex,
+                            )
                         )
                         continue
                 if_data = {

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -432,15 +432,18 @@ if conf.use_pcap:
                     from scapy.arch import get_if_hwaddr
                     try:
                         mac = get_if_hwaddr(ifname)
-                    except Exception:
+                    except Exception as ex:
                         # There are at least 3 different possible exceptions
+                        log_loading.warning(
+                            "Could not get mac of interface '%s': %s." % (ifname, ex)
+                        )
                         continue
                 if_data = {
                     'name': ifname,
                     'description': description or ifname,
                     'network_name': ifname,
                     'index': i,
-                    'mac': mac or '00:00:00:00:00:00',
+                    'mac': mac,
                     'ips': ips,
                     'flags': flags
                 }

--- a/scapy/arch/libpcap.py
+++ b/scapy/arch/libpcap.py
@@ -435,7 +435,7 @@ if conf.use_pcap:
                     except Exception as ex:
                         # There are at least 3 different possible exceptions
                         log_loading.warning(
-                            "Could not get mac of interface '%s': %s." % (ifname, ex)
+                            "Could not get MAC address of interface '%s': %s." % (ifname, ex)
                         )
                         continue
                 if_data = {

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -784,7 +784,7 @@ class MACField(Field[Optional[str], bytes]):
 
     def i2m(self, pkt, x):
         # type: (Optional[Packet], Optional[str]) -> bytes
-        if x is None:
+        if not x:
             return b"\0\0\0\0\0\0"
         try:
             y = mac2str(x)

--- a/scapy/interfaces.py
+++ b/scapy/interfaces.py
@@ -291,8 +291,8 @@ class NetworkInterfaceDict(UserDict[str, NetworkInterface]):
                 return self.dev_from_networkname(conf.loopback_name)
             raise ValueError("Unknown network interface index %r" % if_index)
 
-    def _add_fake_iface(self, ifname):
-        # type: (str) -> None
+    def _add_fake_iface(self, ifname, mac="00:00:00:00:00:00"):
+        # type: (str, str) -> None
         """Internal function used for a testing purpose"""
         data = {
             'name': ifname,
@@ -300,7 +300,7 @@ class NetworkInterfaceDict(UserDict[str, NetworkInterface]):
             'network_name': ifname,
             'index': -1000,
             'dummy': True,
-            'mac': '00:00:00:00:00:00',
+            'mac': mac,
             'flags': 0,
             'ips': ["127.0.0.1", "::"],
             # Windows only

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -51,7 +51,7 @@ from scapy.fields import (
     XShortEnumField,
     XShortField,
 )
-from scapy.interfaces import _GlobInterfaceType
+from scapy.interfaces import _GlobInterfaceType, resolve_iface
 from scapy.packet import bind_layers, Packet
 from scapy.plist import (
     PacketList,
@@ -203,10 +203,7 @@ class SourceMACField(MACField):
             if iff is None:
                 iff = conf.iface
             if iff:
-                try:
-                    x = get_if_hwaddr(iff)
-                except Exception as e:
-                    warning("Could not get the source MAC: %s" % e)
+                x = resolve_iface(iff).mac
             if x is None:
                 x = "00:00:00:00:00:00"
         return super(SourceMACField, self).i2h(pkt, x)

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -110,23 +110,22 @@ assert exit_status == 0
 
 = IPv6 link-local address selection
 
-conf.ifaces._add_fake_iface("scapy0")
+conf.ifaces._add_fake_iface("scapy0", 'e2:39:91:79:19:10')
 
 from mock import patch
 conf.route6.routes =  [('fe80::', 64, '::', 'scapy0', ['fe80::e039:91ff:fe79:1910'], 256)]
 conf.route6.ipv6_ifaces = set(['scapy0'])
 bck_conf_iface = conf.iface
 conf.iface = "scapy0"
-with patch("scapy.layers.l2.get_if_hwaddr") as mgih:
-    mgih.return_value = 'e2:39:91:79:19:10'
-    p = Ether()/IPv6(dst="ff02::1")/ICMPv6NIQueryName(data="ff02::1")
-    print(p.sprintf("%Ether.src% > %Ether.dst%\n%IPv6.src% > %IPv6.dst%"))
-    ip6_ll_address = 'fe80::e039:91ff:fe79:1910'
-    print(p[IPv6].src, ip6_ll_address)
-    assert p[IPv6].src == ip6_ll_address
-    mac_address = 'e2:39:91:79:19:10'
-    print(p[Ether].src, mac_address)
-    assert p[Ether].src == mac_address
+
+p = Ether()/IPv6(dst="ff02::1")/ICMPv6NIQueryName(data="ff02::1")
+print(p.sprintf("%Ether.src% > %Ether.dst%\n%IPv6.src% > %IPv6.dst%"))
+ip6_ll_address = 'fe80::e039:91ff:fe79:1910'
+print(p[IPv6].src, ip6_ll_address)
+assert p[IPv6].src == ip6_ll_address
+mac_address = 'e2:39:91:79:19:10'
+print(p[Ether].src, mac_address)
+assert p[Ether].src == mac_address
 
 conf.iface = bck_conf_iface
 conf.route6.resync()


### PR DESCRIPTION
- cache `get_if_hwaddr` in the `NetworkInterface` as `get_if_hwaddr` is slow.

This speeds up `bytes(Ether())` by ~30%.

- minor fix in `connect_from_ip`