### PR TITLE
Revert "enable enumerator unit tests for linux"

### DIFF
--- a/test/contrib/automotive/scanner/enumerator.uts
+++ b/test/contrib/automotive/scanner/enumerator.uts
@@ -1,5 +1,5 @@
 % Regression tests for enumerators
-~ linux
+~ disabled
 
 + Load general modules
 


### PR DESCRIPTION
This reverts commit ef1875acdcd6ae65d30311c093288f40fc0e1b9d.

