### PR TITLE
Add additional errno handling to ISOTPNativeSocket

### DIFF
--- a/scapy/contrib/isotp/isotp_native_socket.py
+++ b/scapy/contrib/isotp/isotp_native_socket.py
@@ -380,7 +380,13 @@ class ISOTPNativeSocket(SuperSocket):
                                   "Increasing `stmin` could solve this problem.")
             elif e.errno == 110:
                 log_isotp.warning('Captured no data, socket read timed out.')
+            elif e.errno == 70:
+                log_isotp.warning(
+                    'Communication error on send. '
+                    'TX path flowcontrol reception timeout.')
             else:
+                log_isotp.error(
+                    'Unknown error code received %d. Closing socket!', e.errno)
                 self.close()
             return None, None, None
 


### PR DESCRIPTION
 This PR should prevent an accidental close of the socket if errno 70 is received. 