### PR TITLE
hexdiff: restore algorithms, doc

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -867,11 +867,11 @@ assert fletcher16_checkbytes(b"\x28\x07", 1) == b"\xaf("
 
 = Test hexdiff function
 ~ not_pypy
-def test_hexdiff(a, b, autojunk=False):
+def test_hexdiff(a, b, algo=None, autojunk=False):
     conf_color_theme = conf.color_theme
     conf.color_theme = BlackAndWhite()
     with ContextManagerCaptureOutput() as cmco:
-        hexdiff(a, b, autojunk=autojunk)
+        hexdiff(a, b, algo=algo, autojunk=autojunk)
         result_hexdiff = cmco.get_output()
     conf.interactive = True
     conf.color_theme = conf_color_theme
@@ -901,12 +901,12 @@ expected += "0010        7F 00 00 01                                        ....
 expected += "     0010   7F 00 00 02                                        ....\n"
 assert result_hexdiff == expected
 
-# Compare using autojunk
+# Compare using difflib
 
 a = "A" * 1000 + "findme" + "B" * 1000
 b = "A" * 1000 + "B" * 1000
-ret1 = test_hexdiff(a, b)
-ret2 = test_hexdiff(a, b, autojunk=True)
+ret1 = test_hexdiff(a, b, algo="difflib")
+ret2 = test_hexdiff(a, b, algo="difflib", autojunk=True)
 
 expected_ret1 = """
 03d0 03d0   41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41   AAAAAAAAAAAAAAAA


### PR DESCRIPTION
This PR:
- restores the use of a modified Wagner Fischer algorithm in `hexdiff`, alongside `difflib`: in some cases, it's far more accurate than `difflib`. The drawback being that it is much less efficient (o(n^2)) making it unusable on very big strings.
- keep the two algorithms side by side, and chose which one to use based on the estimated complexity. We only use `difflib` if the complexity is too high to use `wagnerfischer`.
- document the implementation of our (phil's?) Wagner Fischer algorithm

This PR partially reverts https://github.com/secdev/scapy/pull/2849. It's one of those days where I finally understand what the cryptic code I previously thought "was dumb" did... and it wasn't dumb :) Props to older maintainers for keeping the history, having https://github.com/secdev/scapy/commit/2b99db22f15e75a03410acf92be1b571388822b2 was very useful for my understanding.

For reviewers, test:

```
hexdiff(IP(dst="192.168.0.100", ttl=2)/UDP()/DNS(), IP(dst="192.168.0.200", ttl=1)/TCP()/DNS())
hexdiff(IP(dst="192.168.0.100", ttl=2)/UDP()/DNS(), IP(dst="192.168.0.200", ttl=1)/TCP()/DNS(), algo="difflib")
```