### PR TITLE
DNS: tweak extract_padding in EDNS(0) options

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -510,6 +510,9 @@ class EDNS0ClientSubnet(Packet):
                        ClientSubnetv4("address", "192.168.0.0",
                                       length_from=lambda p: p.source_plen))]
 
+    def extract_padding(self, p):
+        return "", p
+
 
 # RFC 8914 - Extended DNS Errors
 
@@ -557,6 +560,9 @@ class EDNS0ExtendedDNSError(Packet):
                    ShortEnumField("info_code", 0, extended_dns_error_codes),
                    StrLenField("extra_text", "",
                                length_from=lambda pkt: pkt.optlen - 2)]
+
+    def extract_padding(self, p):
+        return "", p
 
 
 # RFC 4034 - Resource Records for the DNS Security Extensions

--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -119,3 +119,7 @@ rropt = DNSRROPT(b'\x00\x00)\x04\xd0\x00\x00\x00\x00\x001\x00\x0f\x00-\x00\x06pr
 assert len(rropt.rdata) == 1
 p = rropt.rdata[0]
 assert p.info_code == 6 and p.optlen == 45 and p.extra_text == b'proof of non-existence of example.com. NSEC'
+
+p = DNSRROPT(raw(DNSRROPT(rdata=[EDNS0ExtendedDNSError(), EDNS0ClientSubnet(), EDNS0TLV()])))
+assert len(p.rdata) == 3
+assert all(Raw not in opt for opt in p.rdata)


### PR DESCRIPTION
Without this patch EDNS0ClientSubnet and EDNS0ExtendedDNSError consume all the bytes (including all the options following them):
```sh
>>> DNSRROPT(raw(DNSRROPT(rdata=[EDNS0ExtendedDNSError(), EDNS0TLV()]))).rdata
[<EDNS0ExtendedDNSError  optcode=Extended DNS Error optlen=2 info_code=Other extra_text=b'' |<Raw  load=b'\x00\x00\x00\x00' |>>]
```

With this patch applied the options are fully split:
```sh
>>> DNSRROPT(raw(DNSRROPT(rdata=[EDNS0ExtendedDNSError(), EDNS0TLV()]))).rdata
[<EDNS0ExtendedDNSError  optcode=Extended DNS Error optlen=2 info_code=Other extra_text=b'' |>,
 <EDNS0TLV  optcode=Reserved optlen=0 optdata=b'' |>]
```
