### PR TITLE
DNS: add the DAU, DHU and N3U EDNS(0) options

### DIFF
--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -78,6 +78,63 @@ def _test():
 retry_test(_test)
 
 
++ EDNS0 - DAU
+
+= Basic instantiation & dissection
+
+b = b'\x00\x05\x00\x00'
+
+p = EDNS0DAU()
+assert raw(p) == b
+
+p = EDNS0DAU(b)
+assert p.optcode == 5 and p.optlen == 0 and p.alg_code == []
+
+b = raw(EDNS0DAU(alg_code=['RSA/SHA-256', 'RSA/SHA-512']))
+
+p = EDNS0DAU(b)
+repr(p)
+assert p.optcode == 5 and p.optlen == 2 and p.alg_code == [8, 10]
+
+
++ EDNS0 - DHU
+
+= Basic instantiation & dissection
+
+b = b'\x00\x06\x00\x00'
+
+p = EDNS0DHU()
+assert raw(p) == b
+
+p = EDNS0DHU(b)
+assert p.optcode == 6 and p.optlen == 0 and p.alg_code == []
+
+b = raw(EDNS0DHU(alg_code=['SHA-1', 'SHA-256', 'SHA-384']))
+
+p = EDNS0DHU(b)
+repr(p)
+assert p.optcode == 6 and p.optlen == 3 and p.alg_code == [1, 2, 4]
+
+
++ EDNS0 - N3U
+
+= Basic instantiation & dissection
+
+b = b'\x00\x07\x00\x00'
+
+p = EDNS0N3U()
+assert raw(p) == b
+
+p = EDNS0N3U(b)
+assert p.optcode == 7 and p.optlen == 0 and p.alg_code == []
+
+b = raw(EDNS0N3U(alg_code=['SHA-1']))
+
+p = EDNS0N3U(b)
+repr(p)
+assert p.optcode == 7 and p.optlen == 1 and p.alg_code == [1]
+
+
 + EDNS0 - Client Subnet
 
 = Basic instantiation & dissection
@@ -123,3 +180,8 @@ assert p.info_code == 6 and p.optlen == 45 and p.extra_text == b'proof of non-ex
 p = DNSRROPT(raw(DNSRROPT(rdata=[EDNS0ExtendedDNSError(), EDNS0ClientSubnet(), EDNS0TLV()])))
 assert len(p.rdata) == 3
 assert all(Raw not in opt for opt in p.rdata)
+
+for opt_class in EDNS0OPT_DISPATCHER.values():
+    p = DNSRROPT(raw(DNSRROPT(rdata=[EDNS0TLV(), opt_class(), opt_class()])))
+    assert len(p.rdata) == 3
+    assert all(Raw not in opt for opt in p.rdata)


### PR DESCRIPTION
These options are used for signaling cryptographic algorithm understanding in DNS Security Extensions (DNSSEC): https://www.rfc-editor.org/rfc/rfc6975.html

The patch was cross-checked with Wireshark:
```sh
>>> dau = EDNS0DAU(alg_code=['RSA/SHA-256', 'RSA/SHA-512'])
>>> dhu = EDNS0DHU(alg_code=['SHA-1', 'SHA-256', 'SHA-384'])
>>> n3u = EDNS0N3U(alg_code=['SHA-1'])
>>> tdecode(Ether()/IP()/UDP()/DNS(ar=[DNSRROPT(rdata=[dau, dhu, n3u])]))
...
            Option: DAU - DNSSEC Algorithm Understood (RFC6975)
                Option Code: DAU - DNSSEC Algorithm Understood (RFC6975) (5)
                Option Length: 2
                Option Data: 080a
                DAU: RSA/SHA-256 (8)
                DAU: RSA/SHA-512 (10)
            Option: DHU - DS Hash Understood (RFC6975)
                Option Code: DHU - DS Hash Understood (RFC6975) (6)
                Option Length: 3
                Option Data: 010204
                DHU: SHA-1 (1)
                DHU: SHA-256 (2)
                DHU: SHA-384 (4)
            Option: N3U - NSEC3 Hash Understood (RFC6975)
                Option Code: N3U - NSEC3 Hash Understood (RFC6975) (7)
                Option Length: 1
                Option Data: 01
                N3U: SHA-1 (1)
```
