### PR TITLE
DNS: use the right type in MX RRs

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -706,7 +706,7 @@ class _DNSRRdummy(Packet):
 class DNSRRMX(_DNSRRdummy):
     name = "DNS MX Resource Record"
     fields_desc = [DNSStrField("rrname", ""),
-                   ShortEnumField("type", 6, dnstypes),
+                   ShortEnumField("type", 15, dnstypes),
                    ShortEnumField("rclass", 1, dnsclasses),
                    IntField("ttl", 0),
                    ShortField("rdlen", None),

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -204,6 +204,11 @@ full = b"\x04data\xc0\x0f"
 assert dns_get_str(full, full=full)[0] == b"data."
 
 
+= DNS record type 15 (MX)
+
+p = DNS(raw(DNS(qd=[],an=DNSRRMX(exchange='example.com'))))
+assert p.an[0].exchange == b'example.com.'
+
 = DNS record type 16 (TXT)
 
 p = DNS(raw(DNS(id=1,ra=1,qd=[],an=DNSRR(rrname='scapy', type='TXT', rdata="niceday", ttl=1))))


### PR DESCRIPTION
According to
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4 it's 15.