### PR TITLE
Correct misleading documentation

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1028,7 +1028,7 @@ class AsyncSniffer(object):
                      we have to stop the capture after this packet.
                      --Ex: stop_filter = lambda x: x.haslayer(TCP)
         iface: interface or list of interfaces (default: None for sniffing
-               on all interfaces).
+               on the default interface).
         monitor: use monitor mode. May not be available on all OS
         started_callback: called as soon as the sniffer starts sniffing
                           (default: None).


### PR DESCRIPTION
# Overview
Update the comment for the `iface` argument for the `AsyncSniffer` class as it was incorrect.

# Details
The readthedocs documentation claims the following functionality for the `iface` argument given to the `AsyncSniffer` class: "interface or list of interfaces (default: None for sniffing on all interfaces)". In reality if `iface` is `None`, then `conf.iface` is used which is the "default interface", not all interfaces. This lead to a lot of confusion when an application was able to sniff packets just fine on my computer, but not on another computer.

Line that handles `iface` being `None`: https://github.com/secdev/scapy/blob/master/scapy/sendrecv.py#L1188
