### PR TITLE
DNS: add the DNS COOKIE EDNS(0) option

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -46,6 +46,8 @@ from scapy.fields import (
     StrField,
     StrLenField,
     UTCTimeField,
+    XStrFixedLenField,
+    XStrLenField,
 )
 from scapy.sendrecv import sr1
 from scapy.supersocket import StreamSocket
@@ -558,6 +560,16 @@ class EDNS0ClientSubnet(_EDNS0Dummy):
                                       length_from=lambda p: p.source_plen))]
 
 
+class EDNS0COOKIE(_EDNS0Dummy):
+    name = "DNS EDNS0 COOKIE"
+    fields_desc = [ShortEnumField("optcode", 10, edns0types),
+                   FieldLenField("optlen", None, length_of="server_cookie", fmt="!H",
+                                 adjust=lambda pkt, x: x + 8),
+                   XStrFixedLenField("client_cookie", b"\x00" * 8, length=8),
+                   XStrLenField("server_cookie", "",
+                                length_from=lambda pkt: max(0, pkt.optlen - 8))]
+
+
 # RFC 8914 - Extended DNS Errors
 
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes
@@ -611,6 +623,7 @@ EDNS0OPT_DISPATCHER = {
     6: EDNS0DHU,
     7: EDNS0N3U,
     8: EDNS0ClientSubnet,
+    10: EDNS0COOKIE,
     15: EDNS0ExtendedDNSError,
 }
 

--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -155,6 +155,33 @@ d = DNSRROPT(raw_d)
 assert EDNS0ClientSubnet in d.rdata[0] and d.rdata[0].family == 2 and d.rdata[0].address == "2001:db8::"
 
 
++ EDNS0 - Cookie
+
+= Basic instantiation & dissection
+
+b = b'\x00\n\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00'
+
+p = EDNS0COOKIE()
+assert raw(p) == b
+
+p = EDNS0COOKIE(b)
+assert p.optcode == 10
+assert p.optlen == 8
+assert p.client_cookie == b'\x00' * 8
+assert p.server_cookie == b''
+
+b = b'\x00\n\x00\x18\x01\x01\x01\x01\x01\x01\x01\x01\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02'
+
+p = EDNS0COOKIE(client_cookie=b'\x01' * 8, server_cookie=b'\x02' * 16)
+assert raw(p) == b
+
+p = EDNS0COOKIE(b)
+assert p.optcode == 10
+assert p.optlen == 24
+assert p.client_cookie == b'\x01' * 8
+assert p.server_cookie == b'\x02' * 16
+
+
 + EDNS0 - Extended DNS Error
 
 = Basic instantiation & dissection


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7873#section-4

The patch was also cross-checked with Wireshark:
```sh
tdecode(Ether()/IPv6()/UDP()/DNS(qd=[], ar=[DNSRROPT(rdata=[EDNS0COOKIE(client_cookie=b'\x01'*8, server_cookie=b'\x02'*16)])]))
...
Data length: 28
Option: COOKIE
    Option Code: COOKIE (10)
    Option Length: 24
    Option Data: 010101010101010102020202020202020202020202020202
    Client Cookie: 0101010101010101
    Server Cookie: 02020202020202020202020202020202
```