### PR TITLE
conf: load usb layer

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -1019,6 +1019,7 @@ class Conf(ConfClass):
         'smbserver',
         'snmp',
         'tftp',
+        'usb',
         'vrrp',
         'vxlan',
         'x509',


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

Load USB layer by adding it to `conf.load_layers`. This is because otherwise `DLT_USBPCAP` does not get registered and USB pcaps are not correctly parsed...

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
