### PR TITLE
Fixed fragment data size in IPv6 defragmentation

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1133,13 +1133,15 @@ def defragment6(packets):
 
     # regenerate the fragmentable part
     fragmentable = b""
+    frag_hdr_len = len(IPv6ExtHdrFragment)
     for p in res:
         q = p[IPv6ExtHdrFragment]
         offset = 8 * q.offset
         if offset != len(fragmentable):
             warning("Expected an offset of %d. Found %d. Padding with XXXX" % (len(fragmentable), offset))  # noqa: E501
+        frag_data_len = p[IPv6].plen - frag_hdr_len
         fragmentable += b"X" * (offset - len(fragmentable))
-        fragmentable += raw(q.payload)
+        fragmentable += raw(q.payload)[:frag_data_len]
 
     # Regenerate the unfragmentable part.
     q = res[0].copy()


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [ ] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
