### PR TITLE
[inet6] recognize unknown router advertisement options

### DIFF
--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -780,18 +780,40 @@ b.answers(a)
 + ICMPv6NDOptUnknown Class Test
 
 = ICMPv6NDOptUnknown - Basic Instantiation
-raw(ICMPv6NDOptUnknown()) == b'\x00\x02'
+b = b'\x00\x01\x00\x00\x00\x00\x00\x00'
+
+raw(ICMPv6NDOptUnknown()) == b
 
 = ICMPv6NDOptUnknown - Instantiation with specific values
-raw(ICMPv6NDOptUnknown(len=4, data="somestring")) == b'\x00\x04somestring'
+raw(ICMPv6NDOptUnknown(data="somestring")) == b'\x00\x02somestring\x00\x00\x00\x00'
 
 = ICMPv6NDOptUnknown - Basic Dissection
-a=ICMPv6NDOptUnknown(b'\x00\x02')
-a.type == 0 and a.len == 2
+b = b'\x00\x01\x00\x00\x00\x00\x00\x00'
+
+p = ICMPv6NDOptUnknown(b)
+p.type == 0 and p.len == 1 and p.data == b'\x00' * 6
+
+p = ICMPv6NDOptUnknown(b + b'\x00')
+assert Raw in p and raw(p[Raw]) == b'\x00'
+
+p = ICMPv6NDOptUnknown(b + b'\x00\x00')
+assert raw(p[ICMPv6NDOptUnknown:2]) == b'\x00\x00'
 
 = ICMPv6NDOptUnknown - Dissection with specific values 
-a=ICMPv6NDOptUnknown(b'\x00\x04somerawing')
-a.type == 0 and a.len==4 and a.data == b"so" and isinstance(a.payload, Raw) and a.payload.load == b"merawing"
+p = ICMPv6NDOptUnknown(b'\x00\x01string')
+assert p.type == 0 and p.len == 1 and p.data == b'string'
+
+p = ICMPv6NDOptUnknown(b'\x00\x04somestring')
+assert p.type == 0 and p.len == 4 and p.data == b'somestring'
+
+= ICMPv6NDOptUnknown - Instantiation/Dissection with unknown option in the middle
+b = b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x02somestring\x00\x00\x00\x00%\x01\x00\x00\x00\x00\x00\x00'
+
+p = ICMPv6NDOptSrcLLAddr()/ICMPv6NDOptUnknown(data='somestring')/ICMPv6NDOptCaptivePortal()
+assert raw(p) == b
+
+p = ICMPv6NDOptSrcLLAddr(b)[ICMPv6NDOptUnknown]
+assert p.type == 0 and p.len == 2 and p.data == b'somestring\x00\x00\x00\x00'
 
 
 ############
@@ -1231,8 +1253,10 @@ p = ICMPv6NDOptCaptivePortal(b"\x25\x03https://example.com\x00\x00\x00")
 p.type == 37 and p.len == 3 and p.URI == b"https://example.com"
 
 = ICMPv6NDOptCaptivePortal - Dissection with zero length
-p = ICMPv6NDOptCaptivePortal(b"\x25\x00abcdefgh")
-p.type == 37 and p.len == 0 and p.URI == b"abcdef" and Raw in p and len(p[Raw]) == 2
+p = ICMPv6NDOptCaptivePortal(b"\x25\x00abcdef\x00\x01")
+p.type == 37 and p.len == 0 and p.URI == b"abcdef"
+pay = p.payload
+assert pay.type == 0 and pay.len == 1 and pay.data == b""
 
 = ICMPv6NDOptCaptivePortal - Summary Output
 ICMPv6NDOptCaptivePortal(URI="https://example.com").mysummary() == "ICMPv6 Neighbor Discovery Option - Captive-Portal Option b'https://example.com'"
@@ -1269,7 +1293,7 @@ p = ICMPv6NDOptPREF64(raw(p))
 assert p.type == 38 and p.len == 2 and p.scaledlifetime == 225 and p.plc == 1 and p.prefix == '2003:da8:1::'
 
 p = ICMPv6NDOptPREF64(raw(p) + b'\x00\x00\x00\x00')
-assert Raw in p and len(p[Raw]) == 4
+assert ICMPv6NDOptUnknown in p and len(p[ICMPv6NDOptUnknown]) == 4
 
 = ICMPv6NDOptPREF64 - Summary Output
 ICMPv6NDOptPREF64(prefix='12:34:56::', plc='/32').mysummary() == "ICMPv6 Neighbor Discovery Option - PREF64 Option 12:34:56::/32"


### PR DESCRIPTION
According to https://www.rfc-editor.org/rfc/rfc4861.html#section-4.6
```
All options are of the form:

        0                   1                   2                   3
        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
       |     Type      |    Length     |              ...              |
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```
where
```
      Length         8-bit unsigned integer.  The length of the option
                     (including the type and length fields) in units of
                     8 octets.
```

This patch makes it possible to recognize/generate unknown options by introducing a new field where lengths are calculated according to the RFC and options are padded with zeroes if necessary. By default trailing zeroes aren't stripped to make it easier to process options where trailing zeroes can be mixed up with actual data (like the encrypted DNS option for example). The captive portal option was switched to the new field too but there trailing zeroes are still stripped.

fuzz(ICMPv6NDOptUnknown(type=...)) is much more effective now because it generates options valid enough to get past basic checks but nonsensical enough to trigger interesting issues like
https://github.com/systemd/systemd/pull/30952#discussion_r1466173103
https://github.com/systemd/systemd/pull/30952#discussion_r1466813680

ICMPv6NDOptUnknown is also used instead of Raw to guess payloads so router advertisements can be parsed even when unknown options pop up in the middle.

The patch was also cross-checked with Wireshark:
```
>>> tdecode(Ether()/IPv6()/ICMPv6ND_RA()/ICMPv6NDOptSrcLLAddr()/ICMPv6NDOptUnknown(data='watwatwat')/ICMPv6NDOptCaptivePortal())
...
    ICMPv6 Option (Source link-layer address : 00:00:00:00:00:00)
        Type: Source link-layer address (1)
        Length: 1 (8 bytes)
        Link-layer address: 00:00:00_00:00:00 (00:00:00:00:00:00)
    ICMPv6 Option (Unknown 0)
        Type: Unknown (0)
        Length: 2 (16 bytes)
        [Expert Info (Note/Undecoded): Dissector for ICMPv6 Option (0) code not implemented, Contact Wireshark developers if you want this supported]
            [Dissector for ICMPv6 Option (0) code not implemented, Contact Wireshark developers if you want this supported]
            [Severity level: Note]
            [Group: Undecoded]
        Data: 7761747761747761740000000000
    ICMPv6 Option (DHCP Captive-Portal)
        Type: DHCP Captive-Portal (37)
        Length: 1 (8 bytes)
        Captive Portal:
```