### PR TITLE
Fixes an issue, where TLSClientHello extensions were overwritten

### DIFF
--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -292,16 +292,16 @@ class TLSClientAutomaton(_TLSAutomaton):
             p = self.client_hello
         else:
             p = TLSClientHello()
-        ext = []
-        # Add TLS_Ext_SignatureAlgorithms for TLS 1.2 ClientHello
-        if self.cur_session.advertised_tls_version == 0x0303:
-            ext += [TLS_Ext_SignatureAlgorithms(sig_algs=["sha256+rsa"])]
-        # Add TLS_Ext_ServerName
-        if self.server_name:
-            ext += TLS_Ext_ServerName(
-                servernames=[ServerName(servername=self.server_name)]
-            )
-        p.ext = ext
+            ext = []
+            # Add TLS_Ext_SignatureAlgorithms for TLS 1.2 ClientHello
+            if self.cur_session.advertised_tls_version == 0x0303:
+                ext += [TLS_Ext_SignatureAlgorithms(sig_algs=["sha256+rsa"])]
+            # Add TLS_Ext_ServerName
+            if self.server_name:
+                ext += TLS_Ext_ServerName(
+                    servernames=[ServerName(servername=self.server_name)]
+                )
+            p.ext = ext
         self.add_msg(p)
         raise self.ADDED_CLIENTHELLO()
 


### PR DESCRIPTION
Fixes https://github.com/secdev/scapy/issues/4247 and probably also https://github.com/secdev/scapy/issues/3617

The extensions of an TLSClientHello frame were overwritten because of a wrong indention

fix #4247
fix #3617