### PR TITLE
UTscapy: treat SyntaxWarning as errors

### DIFF
--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -971,6 +971,9 @@ def main():
     logger = logging.getLogger("scapy")
     logger.addHandler(logging.StreamHandler())
 
+    # Treat SyntaxWarning as errors
+    warnings.filterwarnings("error", category=SyntaxWarning)
+
     import scapy
     print(dash + " UTScapy - Scapy %s - %s" % (
         scapy.__version__, sys.version.split(" ")[0]


### PR DESCRIPTION
fix https://github.com/secdev/scapy/issues/3962

We can probably just enable this entirely. This should be fine.