### PR TITLE
Fix show() on non-UTC Kerberos

### DIFF
--- a/scapy/modules/ticketer.py
+++ b/scapy/modules/ticketer.py
@@ -368,7 +368,7 @@ class Ticketer:
         with open(self.fname, "wb") as fd:
             return fd.write(bytes(self.ccache))
 
-    def show(self):
+    def show(self, utc=False):
         """
         Show the content of a CCache
         """
@@ -382,7 +382,10 @@ class Ticketer:
             if x is None:
                 return "None"
             else:
-                x = datetime.fromtimestamp(x)
+                x = datetime.fromtimestamp(
+                    x,
+                    tz=timezone.utc if utc else None
+                )
             return x.strftime("%d/%m/%y %H:%M:%S")
 
         for i, cred in enumerate(self.ccache.credentials):

--- a/test/scapy/layers/kerberos.uts
+++ b/test/scapy/layers/kerberos.uts
@@ -914,7 +914,7 @@ with mock.patch('scapy.libs.rfc3961.os.urandom', side_effect=fake_random):
 = Ticketer++ - Call show()
 
 with ContextManagerCaptureOutput() as cmco:
-    t.show()
+    t.show(utc=True)
     outp = cmco.get_output().strip()
 
 print(outp)


### PR DESCRIPTION
- During testing of ticketer++, force the timezone to be UTC 

fix https://github.com/secdev/scapy/issues/4264
