### PR TITLE
Added support for Counter64 in asn1 and ber (for snmp v2c)

### DIFF
--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -275,6 +275,7 @@ class ASN1_Class_UNIVERSAL(ASN1_Class):
     BMP_STRING = cast(ASN1Tag, 30)
     IPADDRESS = cast(ASN1Tag, 0 | 0x40)     # application-specific encoding
     COUNTER32 = cast(ASN1Tag, 1 | 0x40)     # application-specific encoding
+    COUNTER64 = cast(ASN1Tag, 6 | 0x40)     # application-specific encoding
     GAUGE32 = cast(ASN1Tag, 2 | 0x40)       # application-specific encoding
     TIME_TICKS = cast(ASN1Tag, 3 | 0x40)    # application-specific encoding
 
@@ -724,6 +725,10 @@ class ASN1_IPADDRESS(ASN1_STRING):
 
 class ASN1_COUNTER32(ASN1_INTEGER):
     tag = ASN1_Class_UNIVERSAL.COUNTER32
+
+
+class ASN1_COUNTER64(ASN1_INTEGER):
+    tag = ASN1_Class_UNIVERSAL.COUNTER64
 
 
 class ASN1_GAUGE32(ASN1_INTEGER):

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -696,6 +696,10 @@ class BERcodec_COUNTER32(BERcodec_INTEGER):
     tag = ASN1_Class_UNIVERSAL.COUNTER32
 
 
+class BERcodec_COUNTER64(BERcodec_INTEGER):
+    tag = ASN1_Class_UNIVERSAL.COUNTER64
+
+
 class BERcodec_GAUGE32(BERcodec_INTEGER):
     tag = ASN1_Class_UNIVERSAL.GAUGE32
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1528,7 +1528,7 @@ o
 assert o in [
     b'\x1e\x023V',  # PyPy 2.7
     b'A\x02\x07q',  # Python 2.7
-    b'B\x02\xfe\x92',  # python 3.7-3.9
+    b'F\x02\xfe\x92',   # python 3.7-3.9
 ]
 
 = ASN1 - ASN1_BIT_STRING


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [ x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ x] I squashed commits belonging together
-   [ x] I added unit tests or explained why they are not relevant
-   [ x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
Fixes broken dissection of Counter64 values required for SNMP v2c
I don't believe unit tests are necessary since this is the same implementation that was previously in the code.
This value of 6 comes from [RFC2578 Section 2](https://datatracker.ietf.org/doc/html/rfc2578#section-2) Page 8
```
-- for counters that wrap in less than one hour with only 32 bits
Counter64 ::=
    [APPLICATION 6]
        IMPLICIT INTEGER (0..18446744073709551615)

```
Scapy may want to include the Opaque type as well from the standard but I believe that would be a different issue.
<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>
Copied implementation from commit 2e776b7917d60e640d15e4d4fb3015217443b233
Tested using device 
<!-- if required - outline impacts on other parts of the library -->

fixes #4270 <!-- (add issue number here if appropriate, else remove this line) -->
