### PR TITLE
Support range format in IP(v6) fields

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -853,6 +853,10 @@ class IPField(Field[Union[str, Net], bytes]):
                 inet_aton(x)
             except socket.error:
                 return Net(x)
+        elif isinstance(x, tuple):
+            if len(x) != 2:
+                raise ValueError("Invalid IP format")
+            return Net(*x)
         elif isinstance(x, list):
             return [self.h2i(pkt, n) for n in x]
         return x
@@ -949,6 +953,10 @@ class IP6Field(Field[Optional[Union[str, Net6]], bytes]):
                 x = in6_ptop(x)
             except socket.error:
                 return Net6(x)  # type: ignore
+        elif isinstance(x, tuple):
+            if len(x) != 2:
+                raise ValueError("Invalid IPv6 format")
+            return Net6(*x)
         elif isinstance(x, list):
             x = [self.h2i(pkt, n) for n in x]
         return x  # type: ignore

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -3848,6 +3848,10 @@ n1 = ip.dst
 assert isinstance(n1, Net)
 ip.show()
 
+= Net using implicit format in IP
+
+assert len(list(IP(dst=("192.168.0.100", "192.168.0.199")))) == 100
+
 = Multiple IP addresses test
 ~ netaccess
 
@@ -3902,6 +3906,10 @@ ip.show()
 
 ip = IPv6(dst="www.yahoo.com")
 assert IPv6(raw(ip)).dst == [p.dst for p in ip][0]
+
+= Net6 using implicit format in IPv6
+
+assert len(list(IPv6(dst=("fe80::1", "fe80::1f")))) == 31
 
 = Multiple IPv6 addresses test
 ~ netaccess ipv6


### PR DESCRIPTION
~~This is a proposal to bring back the simple "range" format as in `Net("192.168.0.1-10")`. There are a few cases where I think it might be useful, as you can't be that precise with netmasks..~~

This is a proposal to add support for ranges in `IPField` and `IP6Field`, to be able to do:
```python
p = IP(dst=("192.168.0.100", "192.168.0.105"))
```
and have it translate it to  a `Net("192.168.0.100", "192.168.0.105")`

I would really like to hear from @p-l- what he thinks about this, what were the reasons to remove it. (@guedou feel free to chime in)

~~(also note this PR is broken for Net6 and everything != Net)~~