### PR TITLE
TLS test

### DIFF
--- a/scapy/layers/tls/automaton.py
+++ b/scapy/layers/tls/automaton.py
@@ -64,6 +64,11 @@ class _TLSAutomaton(Automaton):
     which has not yet been interpreted as a TLS record is kept in 'remain_in'.
     """
 
+    def __init__(self, *args, **kwargs):
+        kwargs["ll"] = lambda *args, **kwargs: None
+        kwargs["recvsock"] = lambda *args, **kwargs: None
+        super(_TLSAutomaton, self).__init__(*args, **kwargs)
+
     def parse_args(self, mycert=None, mykey=None, **kargs):
 
         self.verbose = kargs.pop("verbose", True)

--- a/test/scapy/layers/tls/example_client.py
+++ b/test/scapy/layers/tls/example_client.py
@@ -12,17 +12,14 @@ Default protocol version is TLS 1.3.
 import os
 import socket
 import sys
-
-basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../../"))
-sys.path=[basedir]+sys.path
+from argparse import ArgumentParser
 
 from scapy.config import conf
 from scapy.utils import inet_aton
 from scapy.layers.tls.automaton_cli import TLSClientAutomaton
 from scapy.layers.tls.basefields import _tls_version_options
 from scapy.layers.tls.handshake import TLSClientHello, TLS13ClientHello
-
-from argparse import ArgumentParser
+from scapy.tools.UTscapy import scapy_path
 
 psk = None
 parser = ArgumentParser(description='Simple TLS Client')
@@ -86,8 +83,8 @@ t = TLSClientAutomaton(server=args.server, dport=args.port,
                        server_name=server_name,
                        client_hello=ch,
                        version=args.version,
-                       mycert=basedir+"/test/tls/pki/cli_cert.pem",
-                       mykey=basedir+"/test/tls/pki/cli_key.pem",
+                       mycert=scapy_path("/test/scapy/layers/tls/pki/cli_cert.pem"),
+                       mykey=scapy_path("/test/scapy/layers/tls/pki/cli_key.pem"),
                        psk=args.psk,
                        psk_mode=psk_mode,
                        resumption_master_secret=args.res_master,

--- a/test/scapy/layers/tls/example_server.py
+++ b/test/scapy/layers/tls/example_server.py
@@ -14,13 +14,11 @@ will be preferred to any other suite the client might propose.
 
 import os
 import sys
-
-basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../../"))
-sys.path=[basedir]+sys.path
+from argparse import ArgumentParser
 
 from scapy.config import conf
 from scapy.layers.tls.automaton_srv import TLSServerAutomaton
-from argparse import ArgumentParser
+from scapy.tools.UTscapy import scapy_path
 
 parser = ArgumentParser(description='Simple TLS Server')
 parser.add_argument("--psk",
@@ -48,8 +46,8 @@ if args.no_pfs and args.psk:
 else:
     psk_mode = "psk_dhe_ke"
 
-t = TLSServerAutomaton(mycert=basedir+'/test/tls/pki/srv_cert.pem',
-                       mykey=basedir+'/test/tls/pki/srv_key.pem',
+t = TLSServerAutomaton(mycert=scapy_path('/test/scapy/layers/tls/pki/srv_cert.pem'),
+                       mykey=scapy_path('/test/scapy/layers/tls/pki/srv_key.pem'),
                        preferred_ciphersuite=pcs,
                        client_auth=args.client_auth,
                        curve=args.curve,

--- a/test/scapy/layers/tls/tlsclientserver.uts
+++ b/test/scapy/layers/tls/tlsclientserver.uts
@@ -1,17 +1,15 @@
 % TLS session establishment tests
 
-~ crypto needs_root
+~ crypto
 
 # More information at http://www.secdev.org/projects/UTscapy/
 
 ############
 ############
-+ TLS server automaton tests
-~ server
+
++ Common util functions
 
 = Load server util functions
-~ client
-
 
 import sys, os, re, time, subprocess
 from queue import Queue
@@ -161,6 +159,8 @@ def test_tls_server(suite="", version="", tls13=False, client_auth=False, psk=No
     print(ret)
     assert ret[0]
 
++ TLS server automaton tests
+~ server needs_root
 
 = Testing TLS server with TLS 1.0 and TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 ~ open_ssl_client
@@ -283,6 +283,10 @@ def test_tls_client(suite, version, curve=None, cookie=False, client_auth=False,
 
 test_tls_client("0700c0", "0002")
 
+= Testing TLS server and client with SSLv2 and SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5
+
+test_tls_client("040080", "0002")
+
 = Testing TLS client with SSLv3 and TLS_RSA_EXPORT_WITH_RC4_40_MD5
 
 test_tls_client("0003", "0300")
@@ -290,6 +294,10 @@ test_tls_client("0003", "0300")
 = Testing TLS client with TLS 1.0 and TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
 
 test_tls_client("0088", "0301")
+
+= Testing TLS client with TLS 1.0 and TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5
+
+test_tls_client("0006", "0301")
 
 = Testing TLS client with TLS 1.1 and TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 


### PR DESCRIPTION
- add a test for `TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5` and `SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5` to test https://github.com/secdev/scapy/pull/4285
- fix `example_client.py` and `example_server.py` since the reorg
- do not require root to spawn a TLS client/server automata