### PR TITLE
Fix arping() without routes configured

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -1004,18 +1004,32 @@ class ARPingResult(SndRcvList):
 @conf.commands.register
 def arping(net, timeout=2, cache=0, verbose=None, **kargs):
     # type: (str, int, int, Optional[int], **Any) -> Tuple[ARPingResult, PacketList] # noqa: E501
-    """Send ARP who-has requests to determine which hosts are up
-arping(net, [cache=0,] [iface=conf.iface,] [verbose=conf.verb]) -> None
-Set cache=True if you want arping to modify internal ARP-Cache"""
+    """
+    Send ARP who-has requests to determine which hosts are up::
+
+        arping(net, [cache=0,] [iface=conf.iface,] [verbose=conf.verb]) -> None
+
+    Set cache=True if you want arping to modify internal ARP-Cache
+    """
     if verbose is None:
         verbose = conf.verb
+
+    hwaddr = None
+    if "iface" in kargs:
+        hwaddr = get_if_hwaddr(kargs["iface"])
+    r = conf.route.route(str(net), verbose=False)
+
     ans, unans = srp(
-        Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(pdst=net),
+        Ether(dst="ff:ff:ff:ff:ff:ff", src=hwaddr) / ARP(
+            pdst=net,
+            psrc=r[1],
+            hwsrc=hwaddr
+        ),
         verbose=verbose,
         filter="arp and arp[7] = 2",
         timeout=timeout,
         iface_hint=net,
-        **kargs
+        **kargs,
     )
     ans = ARPingResult(ans.res)
 

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -246,7 +246,8 @@ class SndRcvHandler(object):
                 self.hsent.setdefault(p.hashret(), []).append(p)
                 # Send packet
                 self.pks.send(p)
-                time.sleep(self.inter)
+                if self.inter:
+                    time.sleep(self.inter)
                 i += 1
             if self.verbose:
                 print("Finished sending %i packets." % i)


### PR DESCRIPTION
- Make `arping` work without having an IP not any routes assigned to an interface, if an `iface` parameter is provided.