### PR TITLE
bluetooth: Fix HCI_Event_Inquiry_Result parsing

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -1807,15 +1807,16 @@ class HCI_Event_Inquiry_Result(Packet):
     name = "HCI_Inquiry_Result"
     fields_desc = [
         ByteField("num_response", 0x00),
-        FieldListField("addr", None, LEMACField,
+        FieldListField("addr", None, LEMACField("addr", None),
                        count_from=lambda p: p.num_response),
-        FieldListField("page_scan_repetition_mode", None, ByteField,
+        FieldListField("page_scan_repetition_mode", None,
+                       ByteField("page_scan_repetition_mode", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("reserved", None, LEShortField,
+        FieldListField("reserved", None, LEShortField("reserved", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("device_class", None, XLE3BytesField,
+        FieldListField("device_class", None, XLE3BytesField("device_class", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("clock_offset", None, LEShortField,
+        FieldListField("clock_offset", None, LEShortField("clock_offset", 0),
                        count_from=lambda p: p.num_response)
     ]
 

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -272,7 +272,14 @@ assert HCI_Event_Inquiry_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Inquiry_Complete].status == 0
 
 = Inquiry Result
-# TODO
+evt_pkt = HCI_Event_Inquiry_Result(b'\x01\xcb\x7f\xdbn\x8c\x9c\x01\x00\x00<\x04\x08\x8di')
+assert HCI_Event_Inquiry_Result in evt_pkt
+assert evt_pkt[HCI_Event_Inquiry_Result].num_response == 1
+assert evt_pkt[HCI_Event_Inquiry_Result].addr[0] == '9c:8c:6e:db:7f:cb'
+assert evt_pkt[HCI_Event_Inquiry_Result].page_scan_repetition_mode[0] == 1
+assert evt_pkt[HCI_Event_Inquiry_Result].device_class[0] == 0x8043c
+assert evt_pkt[HCI_Event_Inquiry_Result].clock_offset[0] == 27021
+
 
 = Connection Complete
 evt_raw_data = hex_bytes("04030b000b00093491e5b7540100")


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
This fixes a bug.

Brefore:
```
>>> HCI_Event_Inquiry_Result(b'\x01\xcb\x7f\xdbn\x8c\x9c\x01\x00\x00<\x04\x08\x8di')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\a\path\venv\Lib\site-packages\scapy\base_classes.py", line 398, in __call__
    i.__init__(*args, **kargs)
  File "C:\a\path\venv\Lib\site-packages\scapy\packet.py", line 181, in __init__      
    self.dissect(_pkt)
  File "C:\a\path\venv\Lib\site-packages\scapy\packet.py", line 1074, in dissect      
    s = self.do_dissect(s)
        ^^^^^^^^^^^^^^^^^^
  File "C:\a\path\venv\Lib\site-packages\scapy\packet.py", line 1012, in do_dissect   
    s, fval = f.getfield(self, s)
              ^^^^^^^^^^^^^^^^^^^
  File "C:\a\path\venv\Lib\site-packages\scapy\fields.py", line 2149, in getfield     
    s, v = self.field.getfield(pkt, s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Field.getfield() missing 1 required positional argument: 's'
```

After:
```
>>> HCI_Event_Inquiry_Result(b'\x01\xcb\x7f\xdbn\x8c\x9c\x01\x00\x00<\x04\x08\x8di')
<HCI_Event_Inquiry_Result  num_response=1 addr=[9c:8c:6e:db:7f:cb] page_scan_repetition_mode=[1] reserved=[0] device_class=[0x8043c] clock_offset=[27021] |>
```

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
