### PR TITLE
DNS: add HINFO resource record

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -765,6 +765,19 @@ class _DNSRRdummy(Packet):
         return conf.padding_layer
 
 
+class DNSRRHINFO(_DNSRRdummy):
+    name = "DNS HINFO Resource Record"
+    fields_desc = [DNSStrField("rrname", ""),
+                   ShortEnumField("type", 13, dnstypes),
+                   ShortEnumField("rclass", 1, dnsclasses),
+                   IntField("ttl", 0),
+                   ShortField("rdlen", None),
+                   FieldLenField("cpulen", None, fmt="!B", length_of="cpu"),
+                   StrLenField("cpu", "", length_from=lambda x: x.cpulen),
+                   FieldLenField("oslen", None, fmt="!B", length_of="os"),
+                   StrLenField("os", "", length_from=lambda x: x.oslen)]
+
+
 class DNSRRMX(_DNSRRdummy):
     name = "DNS MX Resource Record"
     fields_desc = [DNSStrField("rrname", ""),
@@ -1053,6 +1066,7 @@ class DNSRRTSIG(_DNSRRdummy):
 
 DNSRR_DISPATCHER = {
     6: DNSRRSOA,         # RFC 1035
+    13: DNSRRHINFO,      # RFC 1035
     15: DNSRRMX,         # RFC 1035
     33: DNSRRSRV,        # RFC 2782
     41: DNSRROPT,        # RFC 1671

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -213,6 +213,27 @@ full = b"\x04data\xc0\x0f"
 assert dns_get_str(full, full=full)[0] == b"data."
 
 
+= DNS record type 13 (HINFO)
+
+b = b'\x00\x00\r\x00\x01\x00\x00\x00\x00\x00\x02\x00\x00'
+
+p = DNSRRHINFO()
+assert raw(p) == b
+
+p = DNSRRHINFO(b)
+assert p.cpu == b'' and p.os == b''
+
+b = b'\x00\x00\r\x00\x01\x00\x00\x00\x00\x00\r\x06X86_64\x05LINUX'
+
+p = DNSRRHINFO(cpu='X86_64', os='LINUX')
+assert raw(p) == b
+
+p = DNSRRHINFO(b)
+assert p.cpu == b'X86_64' and p.os == b'LINUX'
+
+d = DNS(raw(DNS(qd=[],an=[p])))
+assert raw(d.an[0]) == raw(p)
+
 = DNS record type 15 (MX)
 
 p = DNS(raw(DNS(qd=[],an=DNSRRMX(exchange='example.com'))))


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc1035#section-3.3.2

The patch was also cross-checked with Wireshark:
```python
tdecode(Ether()/IP()/UDP()/DNS(raw(DNS(an=[DNSRRHINFO(rrname='H.local', os='OS', cpu='CPU')]))))
...
    Answers
        H.local: type HINFO, class IN, CPU CPU, OS OS
            Name: H.local
            Type: HINFO (host information) (13)
            Class: IN (0x0001)
            Time to live: 0 (0 seconds)
            Data length: 7
            CPU Length: 3
            CPU: CPU
            OS Length: 2
            OS: OS
```