### PR TITLE
bluetooth: Fix HCI_Cmd_Read_Remote_Extended_Features binding

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -2137,7 +2137,7 @@ bind_layers(HCI_Command_Hdr, HCI_Cmd_Remote_Name_Request, ogf=0x01, ocf=0x0019)
 bind_layers(HCI_Command_Hdr, HCI_Cmd_Remote_Name_Request_Cancel, ogf=0x01, ocf=0x001a)
 bind_layers(HCI_Command_Hdr, HCI_Cmd_Read_Remote_Supported_Features,
             ogf=0x01, ocf=0x001b)
-bind_layers(HCI_Command_Hdr, HCI_Cmd_Read_Remote_Supported_Features,
+bind_layers(HCI_Command_Hdr, HCI_Cmd_Read_Remote_Extended_Features,
             ogf=0x01, ocf=0x001c)
 bind_layers(HCI_Command_Hdr, HCI_Cmd_IO_Capability_Request_Reply, ogf=0x01, ocf=0x002b)
 bind_layers(HCI_Command_Hdr, HCI_Cmd_User_Confirmation_Request_Reply,


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->

Yet another bluetooth protocol fix :)
