### PR TITLE
[inet6] make ICMPv6NDOptUnknown a bit more fuzzable

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1789,7 +1789,7 @@ class ICMPv6NDOptDataField(StrLenField):
 
 class ICMPv6NDOptUnknown(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6 Neighbor Discovery Option - Scapy Unimplemented"
-    fields_desc = [ByteField("type", None),
+    fields_desc = [ByteField("type", 0),
                    FieldLenField("len", None, length_of="data", fmt="B",
                                  adjust=lambda pkt, x: (2 + x) // 8),
                    ICMPv6NDOptDataField("data", "", strip_zeros=False,

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -837,6 +837,8 @@ assert raw(p) == b
 p = ICMPv6NDOptSrcLLAddr(b)[ICMPv6NDOptUnknown]
 assert p.type == 0 and p.len == 2 and p.data == b'somestring\x00\x00\x00\x00'
 
+= ICMPv6NDOptUnknown - fuzz
+assert isinstance(fuzz(ICMPv6NDOptUnknown()).type, RandByte)
 
 ############
 ############


### PR DESCRIPTION
Without this patch the type of Neighbor Discovery options generated by fuzz(ICMPv6NDOptUnknown()) is always 0. With this patch applied option types are random.

It's a follow-up to https://github.com/secdev/scapy/pull/4233