### PR TITLE
Fix `layers.inet6.neighsol` timeout not actually being used

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -117,7 +117,7 @@ def neighsol(addr, src, iface, timeout=1, chainCC=0):
     p = Ether(dst=dm, src=sm) / IPv6(dst=d, src=src, hlim=255)
     p /= ICMPv6ND_NS(tgt=addr)
     p /= ICMPv6NDOptSrcLLAddr(lladdr=sm)
-    res = srp1(p, type=ETH_P_IPV6, iface=iface, timeout=1, verbose=0,
+    res = srp1(p, type=ETH_P_IPV6, iface=iface, timeout=timeout, verbose=0,
                chainCC=chainCC)
 
     return res


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [X] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [X] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

While working on a strictly timed test for IPv6 firewall we noticed that the `neighsol` function was not respecting the given timeout. Looking at the code it was apparent that the `timeout` variable was not actually used in the code. This PR fixes that.

For unit tests I might require some guidance...

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->
