### PR TITLE
Fallback to IPv6 default routes for network interface detection

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -226,6 +226,9 @@ make\_table()    displays a table according to a lambda function
 Sending packets
 ---------------
 
+.. note::
+   Scapy automatically detects the network interface to be used by default, and stores this result in ``conf.iface``. Packets built by Scapy uses this variable to set relevant fields such as Ethernet source addresses. When sending packets, with functions such as ``send()``, Scapy will use the network interface stored in ``conf.iface``. This behavior can be changed using the ``iface=`` argument.  With IPv6 and link-local addresses, it is mandatory to setup both ``conf.iface`` and ``iface=`` the same value to get the desired result, as Scapy cannot find which interface to use for link-local communications.
+
 .. index::
    single: Sending packets, send
    

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -360,3 +360,6 @@ class Route6:
 
 
 conf.route6 = Route6()
+
+# Reload interfaces
+conf.ifaces.reload()

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -334,6 +334,20 @@ assert "cuz you know the way to go" + conf.iface  # right +
 
 _test_get_working_if()
 
+# Test IPv6 default route interface selection
+ni4 = NetworkInterface(InterfaceProvider(), {"name": conf.loopback_name, "ips": ["127.0.0.1"], "mac": "aa:aa:aa:aa:aa:aa"})
+ni6 = NetworkInterface(InterfaceProvider(), {"name": "scapy0", "ips": ["::1"], "mac": "aa:aa:aa:aa:aa:aa"})
+
+import mock
+@mock.patch("scapy.interfaces.conf.ifaces.values")
+@mock.patch("scapy.interfaces.conf.route.routes", [(0, 0, '0.0.0.0', 'lo0', '127.0.0.1', 1)])
+@mock.patch("scapy.interfaces.conf.route6.routes", [("::", 0, "", ni6, [""], 0)])
+def _test_get_working_if_v6(ifaces_values):
+    ifaces_values.side_effect = lambda: []
+    assert get_working_if() == ni6
+
+_test_get_working_if_v6()
+
 = Test conf.ifaces
 
 conf.iface


### PR DESCRIPTION
This PR improves the selection of the default interface in an IPv6-only environment. See https://github.com/secdev/scapy/issues/4304 for context

~~To maintainers: shoud I add unit tests?~~