### PR TITLE
Make TLS automaton takes SSLv2ClientHello messages into account

### DIFF
--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -131,7 +131,8 @@ class TLSClientAutomaton(_TLSAutomaton):
         self.local_port = None
         self.socket = None
 
-        if isinstance(client_hello, (SSLv2ClientHello, TLSClientHello, TLS13ClientHello)):
+        if isinstance(client_hello, (SSLv2ClientHello, TLSClientHello,
+                                     TLS13ClientHello)):
             self.client_hello = client_hello
         else:
             self.client_hello = None

--- a/scapy/layers/tls/automaton_cli.py
+++ b/scapy/layers/tls/automaton_cli.py
@@ -131,7 +131,7 @@ class TLSClientAutomaton(_TLSAutomaton):
         self.local_port = None
         self.socket = None
 
-        if isinstance(client_hello, (TLSClientHello, TLS13ClientHello)):
+        if isinstance(client_hello, (SSLv2ClientHello, TLSClientHello, TLS13ClientHello)):
             self.client_hello = client_hello
         else:
             self.client_hello = None


### PR DESCRIPTION
I'm trying to send my own SSLv2 Client Hello message using the automaton provided:

```python
#! /usr/bin/env python3

from scapy.layers.tls.all import *

hello = SSLv2ClientHello(
    ciphers=[
        0x010080,  # SSL2_RC4_128_WITH_MD5
        0x020080,  # SSL2_RC4_128_EXPORT40_WITH_MD5
        0x030080,  # SSL2_RC2_128_CBC_WITH_MD5
        0x040080,  # SSL2_RC2_128_CBC_EXPORT40_WITH_MD5
        0x050080,  # SSL2_IDEA_128_CBC_WITH_MD5
        0x060040,  # SSL2_DES_64_CBC_WITH_MD5
        0x060140,  # SSL2_DES_64_CBC_WITH_SHA
        0x0700c0,  # SSL2_DES_192_EDE3_CBC_WITH_MD5
        0x0701c0,  # SSL2_DES_192_EDE3_CBC_WITH_SHA
        0x080080,  # SSL2_RC4_64_WITH_MD5
        0x000000   # TLS_NULL_WITH_NULL_NULL
    ]
)
automaton = TLSClientAutomaton('localhost', 443, version='sslv2', client_hello=hello, data='quit')
automaton.run()
```

Unfortunately the `client_hello ` parameter is not taken into account as we can see in the tshark result below:

```
Ethernet II, Src: 02:42:ba:98:b6:f7, Dst: 02:42:ac:11:00:02
Internet Protocol Version 4, Src: 172.17.0.1 (172.17.0.1), Dst: 172.17.0.2 (172.17.0.2)
Transmission Control Protocol, Src Port: 54976, Dst Port: 443, Seq: 1, Ack: 1, Len: 30
Transport Layer Security
    SSLv2 Record Layer: Client Hello
        [Version: SSL 2.0 (0x0002)]
        Length: 28
        Handshake Message Type: Client Hello (1)
        Version: SSL 2.0 (0x0002)
        Cipher Spec Length: 3
        Session ID Length: 0
        Challenge Length: 16
        Cipher Specs (1 specs)
            Cipher Spec: SSL2_DES_192_EDE3_CBC_WITH_MD5 (0x0700c0)
        Challenge
```

I had to make the proposed fix to have the expected result:

```
Ethernet II, Src: 02:42:ba:98:b6:f7, Dst: 02:42:ac:11:00:02
Internet Protocol Version 4, Src: 172.17.0.1 (172.17.0.1), Dst: 172.17.0.2 (172.17.0.2)
Transmission Control Protocol, Src Port: 47976, Dst Port: 443, Seq: 1, Ack: 1, Len: 44
Transport Layer Security
    SSLv2 Record Layer: Client Hello
        [Version: SSL 2.0 (0x0002)]
        Length: 42
        Handshake Message Type: Client Hello (1)
        Version: SSL 2.0 (0x0002)
        Cipher Spec Length: 33
        Session ID Length: 0
        Challenge Length: 0
        Cipher Specs (11 specs)
            Cipher Spec: SSL2_RC4_128_WITH_MD5 (0x010080)
            Cipher Spec: SSL2_RC4_128_EXPORT40_WITH_MD5 (0x020080)
            Cipher Spec: SSL2_RC2_128_CBC_WITH_MD5 (0x030080)
            Cipher Spec: SSL2_RC2_128_CBC_EXPORT40_WITH_MD5 (0x040080)
            Cipher Spec: SSL2_IDEA_128_CBC_WITH_MD5 (0x050080)
            Cipher Spec: SSL2_DES_64_CBC_WITH_MD5 (0x060040)
            Cipher Spec: Unknown (0x060140)
            Cipher Spec: SSL2_DES_192_EDE3_CBC_WITH_MD5 (0x0700c0)
            Cipher Spec: Unknown (0x0701c0)
            Cipher Spec: SSL2_RC4_64_WITH_MD5 (0x080080)
            Cipher Spec: TLS_NULL_WITH_NULL_NULL (0x000000)
```

