### PR TITLE
LLDP add PoE TLV

### DIFF
--- a/test/contrib/lldp.uts
+++ b/test/contrib/lldp.uts
@@ -370,3 +370,489 @@ try:
     frm = frm.build()
 except:
     assert False
+
+~ tshark
+
+= Define check_tshark function
+
+def check_tshark(pkt, frame_type, selector):
+    import tempfile, os
+    fd, pcapfilename = tempfile.mkstemp()
+    wrpcap(pcapfilename, pkt)
+    rv = tcpdump(pcapfilename, prog=conf.prog.tshark, getfd=True,
+                 args=['-Y', frame_type, '-T', 'fields', '-e', selector], dump=True, wait=True)
+    os.close(fd)
+    os.unlink(pcapfilename)
+    return rv.decode("utf8").strip()
+
+= Power via MDI tests
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+      LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+      LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+      LLDPDUTimeToLive()/\
+      LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                        subtype=0x42,
+                                        data=b'FooBar'*5
+                                        )/\
+      LLDPDUPowerViaMDI(MDI_power_support='PSE MDI power enabled+PSE MDI power supported',
+                        PSE_power_pair='alt B',
+                        power_class='class 3')/\
+      LLDPDUEndOfLLDPDU()
+
+frm = frm.build()
+frm = Ether(frm)
+poe_layer = frm[LLDPDUPowerViaMDI]
+# Legacy PoE TLV is not supported by WireShark
+assert poe_layer
+assert poe_layer._type == 127
+assert int(check_tshark(frm, "lldp", "lldp.tlv.type").split(',')[-2], 0) == 127
+assert poe_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3
+assert int(check_tshark(frm, "lldp", "lldp.orgtlv.oui").split(',')[-1], 0) == 4623
+assert poe_layer.subtype == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.subtype"), 0) == 0x02
+assert poe_layer._length == 7
+assert int(check_tshark(frm, "lldp", "lldp.tlv.len").split(',')[-2], 0) == 7
+assert poe_layer.MDI_power_support == 6
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_support"), 0) == 6
+assert poe_layer.PSE_power_pair == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pse_pair"), 0) == 2
+assert poe_layer.power_class == 4
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_class"), 0) == 4
+
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+            LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+            LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+            LLDPDUTimeToLive()/\
+            LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                              subtype=0x42,
+                                              data=b'FooBar'*5
+                                              )
+# invalid length
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDI(_length=8)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidLengthField:
+    pass
+
+= Power via MDI with DDL classification extension tests
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+      LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+      LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+      LLDPDUTimeToLive()/\
+      LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                        subtype=0x42,
+                                        data=b'FooBar'*5
+                                        )/\
+      LLDPDUPowerViaMDIDDL(MDI_power_support='PSE pairs controlled+PSE MDI power enabled',
+                           PSE_power_pair='alt A',
+                           power_class='class 4 and above',
+			   power_type_no='type 2',
+                           power_type_dir='PSE',
+			   power_source='backup source',
+			   power_prio='high',
+			   PD_requested_power=2.21111,
+			   PSE_allocated_power=1.521212121)/\
+      LLDPDUEndOfLLDPDU()
+
+frm = frm.build()
+frm = Ether(frm)
+poe_layer = frm[LLDPDUPowerViaMDIDDL]
+assert poe_layer
+assert poe_layer._type == 127
+assert int(check_tshark(frm, "lldp", "lldp.tlv.type").split(',')[-2], 0) == 127
+assert poe_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3
+assert int(check_tshark(frm, "lldp", "lldp.orgtlv.oui").split(',')[-1], 0) == 4623
+assert poe_layer.subtype == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.subtype"), 0) == 0x02
+assert poe_layer._length == 12
+assert int(check_tshark(frm, "lldp", "lldp.tlv.len").split(',')[-2], 0) == 12
+assert poe_layer.MDI_power_support == 12
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_support"), 0) == 12
+assert poe_layer.PSE_power_pair == 1
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pse_pair"), 0) == 1
+# NOTE: wireshark mixes power_prio and PD_4PID fields. Result will be incerrect if PD_4PID==1
+assert poe_layer.power_class == 5
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_class"), 0) == 5
+assert poe_layer.power_type_no == 0
+assert poe_layer.power_type_dir == 0
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_type"), 0) == 0
+assert poe_layer.power_source == 0b10
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_source"), 0) == 0b10
+assert poe_layer.power_prio == 0b10
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_priority"), 0) == 0b10
+assert poe_layer.PD_requested_power == 2.2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pde_requested"), 0) == 22
+assert poe_layer.PSE_allocated_power == 1.5
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pse_allocated"), 0) == 15
+
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+            LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+            LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+            LLDPDUTimeToLive()/\
+            LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                              subtype=0x42,
+                                              data=b'FooBar'*5
+                                              )
+# invalid length
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIDDL(_length=8)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidLengthField:
+    pass
+
+# invalid power
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIDDL(PD_requested_power=100)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIDDL(PSE_allocated_power=100)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+= Power via MDI with DDL classification and Type 3 and 4 extensions tests
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+      LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+      LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+      LLDPDUTimeToLive()/\
+      LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                        subtype=0x42,
+                                        data=b'FooBar'*5
+                                        )/\
+      LLDPDUPowerViaMDIType34(MDI_power_support='port class PSE+PSE pairs controlled+PSE MDI power enabled',
+                              PSE_power_pair='alt B',
+                              power_class='class 2',
+                              power_type_no='type 1',
+                              power_type_dir='PD',
+                              power_source='PSE and local',
+                              PD_4PID='not supported',
+                              power_prio='low',
+                              PD_requested_power=12.21111,
+                              PSE_allocated_power=11.521212121,
+                              PD_requested_power_mode_A=2.3,
+                              PD_requested_power_mode_B=3.3,
+                              PD_allocated_power_alt_A=3.1,
+                              PD_allocated_power_alt_B=0.5,
+                              PSE_powering_status='4-pair powering single-signature PD',
+                              PD_powered_status='powered single-signature PD',
+                              PD_power_pair_ext='both alts',
+                              dual_signature_class_mode_A='class 4',
+                              dual_signature_class_mode_B='class 2',
+                              power_class_ext='dual-signature pd',
+                              power_type_ext='type 4 single-signature PD',
+                              PD_load='dual-signature and electrically isolated',
+                              PSE_max_available_power=33.333,
+                              autoclass='autoclass completed+autoclass request',
+                              power_down_req='power down',
+                              power_down_time=123)/\
+    LLDPDUEndOfLLDPDU()
+
+frm = frm.build()
+frm = Ether(frm)
+poe_layer = frm[LLDPDUPowerViaMDIType34]
+assert poe_layer
+assert poe_layer._type == 127
+assert int(check_tshark(frm, "lldp", "lldp.tlv.type").split(',')[-2], 0) == 127
+assert poe_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3
+assert int(check_tshark(frm, "lldp", "lldp.orgtlv.oui").split(',')[-1], 0) == 4623
+assert poe_layer.subtype == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.subtype"), 0) == 0x02
+assert poe_layer._length == 29
+assert int(check_tshark(frm, "lldp", "lldp.tlv.len").split(',')[-2], 0) == 29
+assert poe_layer.MDI_power_support == 13
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_support"), 0) == 13
+assert poe_layer.PSE_power_pair == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pse_pair"), 0) == 2
+# NOTE: wireshark mixes power_prio and PD_4PID fields. Result will be incerrect if PD_4PID==1
+assert poe_layer.PD_4PID == 0
+assert poe_layer.power_class == 3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_class"), 0) == 3
+assert poe_layer.power_type_no == 1
+assert poe_layer.power_type_dir == 1
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_type"), 0) == 3
+assert poe_layer.power_source == 0b11
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_source"), 0) == 0b11
+assert poe_layer.power_prio == 0b11
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_power_priority"), 0) == 0b11
+assert poe_layer.PD_requested_power == 12.2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pde_requested"), 0) == 122
+assert poe_layer.PSE_allocated_power == 11.5
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.mdi_pse_allocated"), 0) == 115
+assert poe_layer.PD_requested_power_mode_A == 2.3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pd_requested_power_value_mode_a"), 0) == 23
+assert poe_layer.PD_requested_power_mode_B == 3.3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pd_requested_power_value_mode_b"), 0) == 33
+assert poe_layer.PD_allocated_power_alt_A == 3.1
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pse_allocated_power_value_alt_a"), 0) == 31
+assert poe_layer.PD_allocated_power_alt_B == 0.5
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pse_allocated_power_value_alt_b"), 0) == 5
+assert poe_layer.PSE_powering_status == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_pse_powering_status"), 0) == 2
+assert poe_layer.PD_powered_status == 1
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_pd_powered_status"), 0) == 1
+assert poe_layer.PD_power_pair_ext == 3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_pse_power_pairs_ext"), 0) == 3
+assert poe_layer.dual_signature_class_mode_A == 4
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pwr_class_ext_a"), 0) == 4
+assert poe_layer.dual_signature_class_mode_B == 2
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_ds_pwr_class_ext_b"), 0) == 2
+assert poe_layer.power_class_ext == 15
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_pwr_class_ext_"), 0) == 15
+assert poe_layer.power_type_ext == 4
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_power_type_ext"), 0) == 4
+assert poe_layer.PD_load == 1
+assert poe_layer.PSE_max_available_power == 33.3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_pse_maximum_available_power_value"), 0) == 333
+assert poe_layer.autoclass == 3
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_autoclass"), 0) == 3
+assert poe_layer.power_down_req == 0x1d
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_power_down_request"), 0) == 0x1d
+assert poe_layer.power_down_time == 123
+assert int(check_tshark(frm, "lldp", "lldp.ieee.802_3.bt_power_down_time"), 0) == 123
+
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+            LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+            LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+            LLDPDUTimeToLive()/\
+            LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                              subtype=0x42,
+                                              data=b'FooBar'*5
+                                              )
+# invalid length
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(_length=8)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidLengthField:
+    pass
+
+# invalid power
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PD_requested_power=100)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PSE_allocated_power=100)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PD_requested_power_mode_A=50)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PD_requested_power_mode_B=50)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PD_allocated_power_alt_A=50)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PD_allocated_power_alt_B=50)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(PSE_max_available_power=100)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+# invalid time
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIType34(power_down_time=(1<<18))/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+= Power via MDI measurements tests
+
+import struct
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+    LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+    LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+    LLDPDUTimeToLive()/\
+    LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                      subtype=0x42,
+                                      data=b'FooBar'*5
+                                      )/\
+    LLDPDUPowerViaMDIMeasure(support='power+current',
+                             source='mode B',
+                             request='energy+voltage+current',
+                             valid='power',
+                             voltage_uncertainty=52.25,
+                             current_uncertainty=3.211,
+                             power_uncertainty=140,
+                             energy_uncertainty=2600,
+                             voltage_measurement=22.123,
+                             current_measurement=3.2121,
+                             power_measurement=123.12,
+                             energy_measurement=21123400,
+                             power_price_index='not available')/\
+    LLDPDUEndOfLLDPDU()
+
+frm = frm.build()
+frm = Ether(frm)
+poe_layer = frm[LLDPDUPowerViaMDIMeasure]
+poe_layer_raw = raw(poe_layer)
+
+# PoE measure TLV is not supported by WireShark
+
+assert poe_layer
+assert poe_layer._type == 127
+assert poe_layer.org_code == LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3
+assert poe_layer.subtype == 8
+assert poe_layer._length == 26
+assert poe_layer.support == 0b0110
+assert poe_layer.source == 0b10
+assert poe_layer.request == 0b1101
+assert poe_layer.valid == 0b0010
+assert poe_layer.voltage_uncertainty == 52.25
+assert struct.unpack(">H", poe_layer_raw[8:10])[0] == 52250
+assert poe_layer.current_uncertainty == 3.211
+assert struct.unpack(">H", poe_layer_raw[10:12])[0] == 32110
+assert poe_layer.power_uncertainty == 140
+assert struct.unpack(">H", poe_layer_raw[12:14])[0] == 14000
+assert poe_layer.energy_uncertainty == 2600
+assert struct.unpack(">H", poe_layer_raw[14:16])[0] == 26
+assert poe_layer.voltage_measurement == 22.123
+assert struct.unpack(">H", poe_layer_raw[16:18])[0] == 22123
+assert poe_layer.current_measurement == 3.2121
+assert struct.unpack(">H", poe_layer_raw[18:20])[0] == 32121
+assert poe_layer.power_measurement == 123.12
+assert struct.unpack(">H", poe_layer_raw[20:22])[0] == 12312
+assert poe_layer.energy_measurement == 21123400
+assert struct.unpack(">I", poe_layer_raw[22:26])[0] == 211234
+assert poe_layer.power_price_index == 0xffff
+
+frm = Ether(src='01:01:01:01:01:01', dst=LLDP_NEAREST_BRIDGE_MAC)/\
+            LLDPDUChassisID(subtype=LLDPDUChassisID.SUBTYPE_MAC_ADDRESS, id=b'\x06\x05\x04\x03\x02\x01')/\
+            LLDPDUPortID(subtype=LLDPDUPortID.SUBTYPE_MAC_ADDRESS, id=b'\x01\x02\x03\x04\x05\x06')/\
+            LLDPDUTimeToLive()/\
+            LLDPDUGenericOrganisationSpecific(org_code=LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_PNO,
+                                              subtype=0x42,
+                                              data=b'FooBar'*5
+                                              )
+# invalid length
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(_length=8)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidLengthField:
+    pass
+
+# invalid voltage
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(voltage_uncertainty=500)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(voltage_measurement=500)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+# invalid current
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(current_uncertainty=500)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(current_measurement=500)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+# invalid energy
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(energy_uncertainty=66000000)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+# invalid power
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(power_uncertainty=5000)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(power_measurement=5000)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass
+
+# invalid power price index
+try:
+    Ether((frm/
+           LLDPDUPowerViaMDIMeasure(power_price_index=150)/
+           LLDPDUEndOfLLDPDU()).build())
+    assert False
+except LLDPInvalidFieldValue:
+    pass


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

This PR adds PoE (IEEE802.3bt) organization specific TLVs for LLDP layer

Different versions of PoE TLVs were added as separate classes instead of using `ConditionalField` to allow the user explicitly instantiate the desired TLV version.
