### PR TITLE
automotive/uds: special case to allow sending malformed 7f request

### DIFF
--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -124,7 +124,8 @@ class UDS(ISOTP):
 
     def hashret(self):
         # type: () -> bytes
-        if self.service == 0x7f:
+        if self.service == 0x7f and len(self) >= 2 and \
+                (bytes(self.payload) != b'\x00' and bytes(self.payload) != b'\x00\x00'):
             return struct.pack('B', self.requestServiceId & ~0x40)
         return struct.pack('B', self.service & ~0x40)
 

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -1097,6 +1097,51 @@ tc.show()
 
 assert len(tc.results_with_negative_response) == 4
 
+= UDS_ServiceEnumerator, all range
+
+def req_handler(resp, req):
+    if req.service != 0x22:
+        return False
+    if len(req) == 1:
+        resp.negativeResponseCode="generalReject"
+        return True
+    if len(req) == 2:
+        resp.negativeResponseCode="incorrectMessageLengthOrInvalidFormat"
+        return True
+    if len(req) == 3:
+        resp.negativeResponseCode="requestOutOfRange"
+        return True
+    return False
+
+resps = [EcuResponse(None, [UDS()/UDS_NR(negativeResponseCode="subFunctionNotSupported", requestServiceId="ReadDataByIdentifier")], req_handler)]
+
+es = [UDS_ServiceEnumerator]
+
+debug_dissector_backup = conf.debug_dissector
+
+# This Enumerator is sending corrupted Packets, therefore we need to disable the debug_dissector
+conf.debug_dissector = False
+scanner = executeScannerInVirtualEnvironment(
+    resps, es, UDS_ServiceEnumerator_kwargs={"request_length": 3, "scan_range": range(256)}, unstable_socket=False)
+conf.debug_dissector = debug_dissector_backup
+
+assert scanner.scan_completed
+assert scanner.progress() > 0.95
+tc = scanner.configuration.test_cases[0]
+
+assert len(tc.results_without_response) < 10
+if tc.results_without_response:
+    tc.show()
+
+tc.show()
+
+assert len(tc.scanned_states) == 1
+
+result = tc.show(dump=True)
+
+assert "incorrectMessageLengthOrInvalidFormat" in result
+assert "requestOutOfRange" in result
+
 + Cleanup
 
 = Delete testsockets

--- a/test/contrib/automotive/uds.uts
+++ b/test/contrib/automotive/uds.uts
@@ -1412,6 +1412,11 @@ rftpr_build = UDS()/UDS_RFTPR(modeOfOperation=0x1,
                               compressionMethod=1, encryptingMethod=1)
 assert bytes(rftpr_build) == bytes(rftpr)
 
+= Check (invalid) UDS_NRC, no reply-to service
+
+nrc = UDS(b'\x7f')
+assert nrc.service == 0x7f
+
 = Check UDS_NRC
 
 nrc = UDS(b'\x7f\x22\x33')


### PR DESCRIPTION
Similar to the motivation in https://github.com/secdev/scapy/issues/3947#issuecomment-1479767620 : I would like to scan all the possible services including a nonsense/malformed/invalid request to a 7f service.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
enables uds scanning of 0x00 - 0xff without crash

Similar to the motivation in https://github.com/secdev/scapy/issues/3947#issuecomment-1479767620 : I would like to scan all the possible services including a nonsense/malformed/invalid request to a 7f service.

It is definitely invalid UDS to make requests to services with 0x40 bit set; however, the motivation is precisely to test targets with invalid UDS.

At present `UDS_Scanner(isock, test_cases=[UDS_ServiceEnumerator], UDS_ServiceEnumerator_kwargs={...,'scan_range': range(256)})` will fail with `AttributeError: requestServiceId` when the scanner gets to sending `017f`. This small patch makes scapy.contrib.automotive.uds.UDS.hashret() check if the payload.fields has requestedServiceId before trying to grab that field value for struct.pack().

I'm proposing the patch here even though this is invalid UDS because a crash seems like the wrong outcome. Happy to adapt the patch or testing -- or withdraw at you discretion.
