### PR TITLE
Rewrite arch/linux

### DIFF
--- a/.config/mypy/mypy_check.py
+++ b/.config/mypy/mypy_check.py
@@ -63,57 +63,56 @@ ARGS = [
     "--ignore-missing-imports",
     # config
     "--follow-imports=skip",  # Remove eventually
-    "--config-file=" + os.path.abspath(
-        os.path.join(
-            localdir,
-            "mypy.ini"
-        )
-    ),
+    "--config-file=" + os.path.abspath(os.path.join(localdir, "mypy.ini")),
     "--show-traceback",
-] + ([
-    "--platform=" + PLATFORM
-] if PLATFORM else [])
+] + (["--platform=" + PLATFORM] if PLATFORM else [])
 
 if PLATFORM.startswith("linux"):
-    ARGS.extend([
-        "--always-true=LINUX",
-        "--always-false=OPENBSD",
-        "--always-false=FREEBSD",
-        "--always-false=NETBSD",
-        "--always-false=DARWIN",
-        "--always-false=WINDOWS",
-        "--always-false=BSD",
-    ])
+    ARGS.extend(
+        [
+            "--always-true=LINUX",
+            "--always-false=OPENBSD",
+            "--always-false=FREEBSD",
+            "--always-false=NETBSD",
+            "--always-false=DARWIN",
+            "--always-false=WINDOWS",
+            "--always-false=BSD",
+        ]
+    )
     FILES = [x for x in FILES if not x.startswith("scapy/arch/windows")]
 elif PLATFORM.startswith("win32"):
-    ARGS.extend([
-        "--always-false=LINUX",
-        "--always-false=OPENBSD",
-        "--always-false=FREEBSD",
-        "--always-false=NETBSD",
-        "--always-false=DARWIN",
-        "--always-true=WINDOWS",
-        "--always-false=WINDOWS_XP",
-        "--always-false=BSD",
-    ])
+    ARGS.extend(
+        [
+            "--always-false=LINUX",
+            "--always-false=OPENBSD",
+            "--always-false=FREEBSD",
+            "--always-false=NETBSD",
+            "--always-false=DARWIN",
+            "--always-true=WINDOWS",
+            "--always-false=WINDOWS_XP",
+            "--always-false=BSD",
+        ]
+    )
     FILES = [
-        x for x in FILES if (
-            x not in {
+        x
+        for x in FILES
+        if (
+            x
+            not in {
                 # Disabled on Windows
-                "scapy/arch/linux.py",
                 "scapy/arch/unix.py",
                 "scapy/arch/solaris.py",
                 "scapy/contrib/cansocket_native.py",
                 "scapy/contrib/isotp/isotp_native_socket.py",
             }
-        ) and not x.startswith("scapy/arch/bpf")
+        )
+        and not x.startswith("scapy/arch/bpf")
+        and not x.startswith("scapy/arch/linux")
     ]
 else:
     raise ValueError("Unknown platform")
 
 # Run mypy over the files
-ARGS += [
-    os.path.abspath(f) for f in FILES
-]
+ARGS += [os.path.abspath(f) for f in FILES]
 
 mypy_main(args=ARGS)

--- a/.config/mypy/mypy_enabled.txt
+++ b/.config/mypy/mypy_enabled.txt
@@ -16,7 +16,8 @@ scapy/arch/bpf/core.py
 scapy/arch/bpf/supersocket.py
 scapy/arch/common.py
 scapy/arch/libpcap.py
-scapy/arch/linux.py
+scapy/arch/linux/__init__.py
+scapy/arch/linux/rtnetlink.py
 scapy/arch/solaris.py
 scapy/arch/unix.py
 scapy/arch/windows/__init__.py

--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -125,7 +125,6 @@ def get_if_raw_addr6(iff):
 # Next step is to import following architecture specific functions:
 # def attach_filter(s, filter, iface)
 # def get_if(iff,cmd)
-# def get_if_index(iff)
 # def get_if_raw_addr(iff)
 # def get_if_raw_hwaddr(iff)
 # def in6_getifaddr()

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -7,12 +7,15 @@
 Functions common to different architectures
 """
 
+import socket
 import ctypes
+
 from scapy.config import conf
 from scapy.data import MTU, ARPHDR_ETHER, ARPHRD_TO_DLT
 from scapy.error import Scapy_Exception
-from scapy.interfaces import network_name
+from scapy.interfaces import network_name, resolve_iface, NetworkInterface
 from scapy.libs.structures import bpf_program
+from scapy.pton_ntop import inet_pton
 from scapy.utils import decode_locale_str
 
 # Type imports
@@ -33,7 +36,6 @@ _iff_flags = [
     "RUNNING",
     "NOARP",
     "PROMISC",
-    "NOTRAILERS",
     "ALLMULTI",
     "MASTER",
     "SLAVE",
@@ -45,6 +47,15 @@ _iff_flags = [
     "DORMANT",
     "ECHO"
 ]
+
+
+def get_if_raw_addr(iff):
+    # type: (Union[NetworkInterface, str]) -> bytes
+    """Return the raw IPv4 address of interface"""
+    iff = resolve_iface(iff)
+    if not iff.ip:
+        return b"\x00" * 4
+    return inet_pton(socket.AF_INET, iff.ip)
 
 
 # BPF HANDLERS

--- a/scapy/arch/linux/rtnetlink.py
+++ b/scapy/arch/linux/rtnetlink.py
@@ -4,7 +4,7 @@
 # Copyright (C) Gabriel Potter
 
 """
-This files implements the rtnetlink API that is used to read the network
+This file implements the rtnetlink API that is used to read the network
 configuration of the machine.
 """
 
@@ -345,7 +345,10 @@ class ifinfomsg(Packet):
         ),
         Field("ifi_change", 0xFFFFFFFF, fmt="=I"),
         # Pay
-        PacketListField("data", [], ifinfomsg_rtattr),
+        PadField(
+            PacketListField("data", [], ifinfomsg_rtattr),
+            align=16,
+        )
     ]
 
 
@@ -440,7 +443,10 @@ class ifaddrmsg(Packet):
         ByteField("ifa_scope", 0),
         Field("ifa_index", 0, fmt="=L"),
         # Pay
-        PacketListField("data", [], ifaddrmsg_rtattr),
+        PadField(
+            PacketListField("data", [], ifaddrmsg_rtattr),
+            align=16,
+        )
     ]
 
 
@@ -604,7 +610,10 @@ class rtmsg(Packet):
             },
         ),
         # Pay
-        PacketListField("data", [], rtmsg_rtattr),
+        PadField(
+            PacketListField("data", [], rtmsg_rtattr),
+            align=16,
+        )
     ]
 
 
@@ -664,8 +673,6 @@ def _get_ips(af_family=socket.AF_UNSPEC):
         / ifaddrmsg(
             ifa_family=af_family,
             data=[
-                ifaddrmsg_rtattr(),
-                ifaddrmsg_rtattr(),
                 ifaddrmsg_rtattr(),
             ],
         )

--- a/scapy/arch/linux/rtnetlink.py
+++ b/scapy/arch/linux/rtnetlink.py
@@ -1,0 +1,851 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter
+
+"""
+This files implements the rtnetlink API that is used to read the network
+configuration of the machine.
+"""
+
+import socket
+import os
+
+import scapy.utils6
+
+from scapy.consts import BIG_ENDIAN
+from scapy.config import conf
+from scapy.error import log_loading
+from scapy.packet import (
+    Packet,
+    bind_layers,
+)
+from scapy.utils import atol, itom
+
+from scapy.fields import (
+    ByteEnumField,
+    ByteField,
+    EnumField,
+    Field,
+    FieldLenField,
+    FlagsField,
+    IP6Field,
+    IPField,
+    LenField,
+    MACField,
+    MultipleTypeField,
+    PacketListField,
+    PadField,
+    StrLenField,
+    XStrLenField,
+)
+
+from scapy.arch.common import _iff_flags
+
+# Typing imports
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+)
+
+# from <linux/netlink.h> and <linux/rtnetlink.h>
+
+
+# Common header
+
+
+class rtmsghdr(Packet):
+    fields_desc = [
+        LenField("nlmsg_len", None, fmt="=L"),
+        EnumField(
+            "nlmsg_type",
+            0,
+            {
+                # netlink.h
+                3: "NLMSG_DONE",
+                # rtnetlink.h
+                16: "RTM_NEWLINK",
+                17: "RTM_DELLINK",
+                18: "RTM_GETLINK",
+                19: "RTM_SETLINK",
+                20: "RTM_NEWADDR",
+                21: "RTM_DELADDR",
+                22: "RTM_GETADDR",
+                # 23: unused
+                24: "RTM_NEWROUTE",
+                25: "RTM_DELROUTE",
+                26: "RTM_GETROUTE",
+                # 27: unused
+            },
+            fmt="=H",
+        ),
+        FlagsField(
+            "nlmsg_flags",
+            0,
+            16 if BIG_ENDIAN else -16,
+            {
+                0x01: "NLM_F_REQUEST",
+                0x02: "NLM_F_MULTI",
+                0x04: "NLM_F_ACK",
+                0x08: "NLM_F_ECHO",
+                0x10: "NLM_F_DUMP_INTR",
+                0x20: "NLM_F_DUMP_FILTERED",
+                # GET modifiers
+                0x100: "NLM_F_ROOT",
+                0x200: "NLM_F_MATCH",
+                0x400: "NLM_F_ATOMIC",
+            },
+        ),
+        Field("nlmsg_seq", 0, fmt="=L"),
+        Field("nlmsg_pid", 0, fmt="=L"),
+    ]
+
+    def extract_padding(self, s: bytes) -> Tuple[bytes, Optional[bytes]]:
+        return s[: self.nlmsg_len - 16], s[self.nlmsg_len - 16 :]
+
+
+# LINK messages
+
+
+class ifla_af_spec_inet_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField(
+            "rta_type",
+            0,
+            {
+                0x00: "IFLA_INET_UNSPEC",
+                0x01: "IFLA_INET_CONF",
+            },
+            fmt="=H",
+        ),
+        PadField(
+            MultipleTypeField(
+                [],
+                XStrLenField(
+                    "rta_data",
+                    b"\x00\x00\x00\x00",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class ifla_af_spec_inet6_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField(
+            "rta_type",
+            0,
+            {
+                0x00: "IFLA_INET6_UNSPEC",
+                0x01: "IFLA_INET6_FLAGS",
+                0x02: "IFLA_INET6_CONF",
+                0x03: "IFLA_INET6_STATS",
+                0x04: "IFLA_INET6_MCAST",
+                0x05: "IFLA_INET6_CACHEINFO",
+                0x06: "IFLA_INET6_ICMP6STATS",
+                0x07: "IFLA_INET6_TOKEN",
+                0x08: "IFLA_INET6_ADDR_GEN_MODE",
+                0x09: "IFLA_INET6_RA_MTU",
+            },
+            fmt="=H",
+        ),
+        PadField(
+            MultipleTypeField(
+                [],
+                XStrLenField(
+                    "rta_data",
+                    b"\x00\x00\x00\x00",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class ifla_af_spec_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField("rta_type", 0, socket.AddressFamily, fmt="=H"),
+        PadField(
+            MultipleTypeField(
+                [
+                    (
+                        # AF_INET
+                        PacketListField(
+                            "rta_data",
+                            [],
+                            ifla_af_spec_inet_rtattr,
+                            length_from=lambda pkt: pkt.rta_len - 4,
+                        ),
+                        lambda pkt: pkt.rta_type == 2,
+                    ),
+                    (
+                        # AF_INET6
+                        PacketListField(
+                            "rta_data",
+                            [],
+                            ifla_af_spec_inet6_rtattr,
+                            length_from=lambda pkt: pkt.rta_len - 4,
+                        ),
+                        lambda pkt: pkt.rta_type == 10,
+                    ),
+                ],
+                XStrLenField(
+                    "rta_data",
+                    b"\x00\x00\x00\x00",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class ifinfomsg_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField(
+            "rta_type",
+            0,
+            {
+                0x00: "IFLA_UNSPEC",
+                0x01: "IFLA_ADDRESS",
+                0x02: "IFLA_BROADCAST",
+                0x03: "IFLA_IFNAME",
+                0x04: "IFLA_MTU",
+                0x05: "IFLA_LINK",
+                0x06: "IFLA_QDISC",
+                0x07: "IFLA_STATS",
+                0x08: "IFLA_COST",
+                0x09: "IFLA_PRIORITY",
+                0x0A: "IFLA_MASTER",
+                0x0B: "IFLA_WIRELESS",
+                0x0C: "IFLA_PROTINFO",
+                0x0D: "IFLA_TXQLEN",
+                0x0E: "IFLA_MAP",
+                0x0F: "IFLA_WEIGHT",
+                0x10: "IFLA_OPERSTATE",
+                0x11: "IFLA_LINKMODE",
+                0x12: "IFLA_LINKINFO",
+                0x13: "IFLA_NET_NS_PID",
+                0x14: "IFLA_IFALIAS",
+                0x15: "IFLA_NUM_VS",
+                0x16: "IFLA_VFINFO_LIST",
+                0x17: "IFLA_STATS64",
+                0x18: "IFLA_VF_PORTS",
+                0x19: "IFLA_PORT_SELF",
+                0x1A: "IFLA_AF_SPEC",
+                0x1B: "IFLA_GROUP",
+                0x1C: "IFLA_NET_NS_FD",
+                0x1D: "IFLA_EXT_MASK",
+                0x1E: "IFLA_PROMISCUITY",
+                0x1F: "IFLA_NUM_TX_QUEUES",
+                0x20: "IFLA_NUM_RX_QUEUES",
+                0x21: "IFLA_CARRIER",
+                0x22: "IFLA_PHYS_PORT_ID",
+                0x23: "IFLA_CARRIER_CHANGES",
+                0x24: "IFLA_PHYS_SWITCH_ID",
+                0x25: "IFLA_LINK_NETNSID",
+                0x26: "IFLA_PHYS_PORT_NAME",
+                0x27: "IFLA_PROTO_DOWN",
+                0x28: "IFLA_GSO_MAX_SEGS",
+                0x29: "IFLA_GSO_MAX_SIZE",
+                0x2A: "IFLA_PAD",
+                0x2B: "IFLA_XDP",
+                0x2C: "IFLA_EVENT",
+                0x2D: "IFLA_NEW_NETNSID",
+                0x2E: "IFLA_IF_NETNSID",
+                0x2F: "IFLA_CARRIER_UP_COUNT",
+                0x30: "IFLA_CARRIER_DOWN_COUNT",
+                0x31: "IFLA_NEW_IFINDEX",
+                0x32: "IFLA_MIN_MTU",
+                0x33: "IFLA_MAX_MTU",
+                0x34: "IFLA_PROP_LIST",
+                0x35: "IFLA_ALT_IFNAME",
+                0x36: "IFLA_PERM_ADDRESS",
+                0x37: "IFLA_PROTO_DOWN_REASON",
+                0x38: "IFLA_PARENT_DEV_NAME",
+                0x39: "IFLA_PARENT_DEV_BUS_NAME",
+                0x3A: "IFLA_GRO_MAX_SIZE",
+                0x3B: "IFLA_TSO_MAX_SIZE",
+                0x3C: "IFLA_TSO_MAX_SEGS",
+                0x3D: "IFLA_ALLMULTI",
+            },
+            fmt="=H",
+        ),
+        PadField(
+            MultipleTypeField(
+                [
+                    (
+                        # IFLA_ADDRESS
+                        MACField("rta_data", "00:00:00:00:00:00"),
+                        lambda pkt: pkt.rta_type in [0x01, 0x36],
+                    ),
+                    (
+                        # IFLA_IFNAME
+                        StrLenField(
+                            "rta_data", b"", length_from=lambda pkt: pkt.rta_len - 4
+                        ),
+                        lambda pkt: pkt.rta_type in [0x03],
+                    ),
+                    (
+                        # IFLA_AF_SPEC
+                        PacketListField(
+                            "rta_data",
+                            [],
+                            ifla_af_spec_rtattr,
+                            length_from=lambda pkt: pkt.rta_len - 4,
+                        ),
+                        lambda pkt: pkt.rta_type == 0x1A,
+                    ),
+                ],
+                XStrLenField(
+                    "rta_data",
+                    b"",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class ifinfomsg(Packet):
+    fields_desc = [
+        ByteEnumField("ifi_family", 0, socket.AddressFamily),  # type: ignore
+        ByteField("res", 0),
+        Field("ifi_type", 0, fmt="=H"),
+        Field("ifi_index", 0, fmt="=i"),
+        FlagsField(
+            "ifi_flags",
+            0,
+            32 if BIG_ENDIAN else -32,
+            _iff_flags,
+        ),
+        Field("ifi_change", 0xFFFFFFFF, fmt="=I"),
+        # Pay
+        PacketListField("data", [], ifinfomsg_rtattr),
+    ]
+
+
+bind_layers(rtmsghdr, ifinfomsg, nlmsg_type=16)
+bind_layers(rtmsghdr, ifinfomsg, nlmsg_type=17)
+bind_layers(rtmsghdr, ifinfomsg, nlmsg_type=18)
+bind_layers(rtmsghdr, ifinfomsg, nlmsg_type=19)
+
+
+# ADDR messages
+
+
+class ifaddrmsg_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField(
+            "rta_type",
+            0,
+            {
+                0x00: "IFA_UNSPEC",
+                0x01: "IFA_ADDRESS",
+                0x02: "IFA_LOCAL",
+                0x03: "IFA_LABEL",
+                0x04: "IFA_BROADCAST",
+                0x05: "IFA_ANYCAST",
+                0x06: "IFA_CACHEINFO",
+                0x07: "IFA_MULTICAST",
+                0x08: "IFA_FLAGS",
+                0x09: "IFA_RT_PRIORITY",
+                0x0A: "IFA_TARGET_NETNSID",
+                0x0B: "IFA_PROTO",
+            },
+            fmt="=H",
+        ),
+        PadField(
+            MultipleTypeField(
+                [
+                    # IFA_ADDRESS, IFA_LOCAL, IFA_BROADCAST
+                    (
+                        IPField("rta_data", "0.0.0.0"),
+                        lambda pkt: pkt.parent
+                        and pkt.parent.ifa_family == 2
+                        and pkt.rta_type in [0x01, 0x02, 0x04],
+                    ),
+                    (
+                        IP6Field("rta_data", "::"),
+                        lambda pkt: pkt.parent
+                        and pkt.parent.ifa_family == 10
+                        and pkt.rta_type in [0x01, 0x02, 0x04],
+                    ),
+                    (
+                        # IFA_LABEL
+                        StrLenField(
+                            "rta_data", b"", length_from=lambda pkt: pkt.rta_len - 4
+                        ),
+                        lambda pkt: pkt.rta_type in [0x03],
+                    ),
+                ],
+                XStrLenField(
+                    "rta_data",
+                    b"",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class ifaddrmsg(Packet):
+    fields_desc = [
+        ByteEnumField("ifa_family", 0, socket.AddressFamily),  # type: ignore
+        ByteField("ifa_prefixlen", 0),
+        FlagsField(
+            "ifa_flags",
+            0,
+            -8,
+            {
+                0x01: "IFA_F_SECONDARY",
+                0x02: "IFA_F_NODAD",
+                0x04: "IFA_F_OPTIMISTIC",
+                0x08: "IFA_F_DADFAILED",
+                0x10: "IFA_F_HOMEADDRESS",
+                0x20: "IFA_F_DEPRECATED",
+                0x40: "IFA_F_TENTATIVE",
+                0x80: "IFA_F_PERMANENT",
+            },
+        ),
+        ByteField("ifa_scope", 0),
+        Field("ifa_index", 0, fmt="=L"),
+        # Pay
+        PacketListField("data", [], ifaddrmsg_rtattr),
+    ]
+
+
+bind_layers(rtmsghdr, ifaddrmsg, nlmsg_type=20)
+bind_layers(rtmsghdr, ifaddrmsg, nlmsg_type=21)
+bind_layers(rtmsghdr, ifaddrmsg, nlmsg_type=22)
+
+
+# ROUTE messages
+
+
+RT_CLASS = {
+    0: "RT_TABLE_UNSPEC",
+    252: "RT_TABLE_COMPAT",
+    253: "RT_TABLE_DEFAULT",
+    254: "RT_TABLE_MAIN",
+    255: "RT_TABLE_LOCAL",
+}
+
+
+class rtmsg_rtattr(Packet):
+    fields_desc = [
+        FieldLenField("rta_len", None, length_of="rta_data", fmt="=H"),
+        EnumField(
+            "rta_type",
+            0,
+            {
+                0x00: "RTA_UNSPEC",
+                0x01: "RTA_DST",
+                0x02: "RTS_SRC",
+                0x03: "RTS_IIF",
+                0x04: "RTS_OIF",
+                0x05: "RTA_GATEWAY",
+                0x06: "RTA_PRIORITY",
+                0x07: "RTA_PREFSRC",
+                0x08: "RTA_METRICS",
+                0x09: "RTA_MULTIPATH",
+                0x0B: "RTA_FLOW",
+                0x0C: "RTA_CACHEINFO",
+                0x0F: "RTA_TABLE",
+                0x10: "RTA_MARK",
+                0x11: "RTA_MFC_STATS",
+                0x12: "RTA_VIA",
+                0x13: "RTA_NEWDST",
+                0x14: "RTA_PREF",
+                0x15: "RTA_ENCAP_TYPE",
+                0x16: "RTA_ENCAP",
+                0x17: "RTA_EXPIRES",
+                0x18: "RTA_PAD",
+                0x19: "RTA_UID",
+                0x1A: "RTA_TTL_PROPAGATE",
+                0x1B: "RTA_IP_PROTO",
+                0x1C: "RTA_SPORT",
+                0x1D: "RTA_DPORT",
+                0x1E: "RTA_NH_ID",
+            },
+            fmt="=H",
+        ),
+        PadField(
+            MultipleTypeField(
+                [
+                    # RTA_DST, RTA_SRC, RTA_PREFSRC, RTA_GATEWAY
+                    (
+                        IPField("rta_data", "0.0.0.0"),
+                        lambda pkt: pkt.parent
+                        and pkt.parent.rtm_family == 2
+                        and pkt.rta_type in [0x01, 0x02, 0x05, 0x07],
+                    ),
+                    (
+                        IP6Field("rta_data", "::"),
+                        lambda pkt: pkt.parent
+                        and pkt.parent.rtm_family == 10
+                        and pkt.rta_type in [0x01, 0x02, 0x05, 0x07],
+                    ),
+                    # RTS_OIF, RTA_PRIORITY
+                    (
+                        Field("rta_data", 0, fmt="=I"),
+                        lambda pkt: pkt.rta_type in [0x04, 0x06],
+                    ),
+                    # RTA_TABLE
+                    (
+                        EnumField("rta_data", 0, RT_CLASS, fmt="=I"),
+                        lambda pkt: pkt.rta_type in [0x0F],
+                    ),
+                ],
+                XStrLenField(
+                    "rta_data",
+                    b"",
+                    length_from=lambda pkt: pkt.rta_len - 4,
+                ),
+            ),
+            align=4,
+        ),
+    ]
+
+    def default_payload_class(self, payload: bytes) -> Type[Packet]:
+        return conf.padding_layer
+
+
+class rtmsg(Packet):
+    fields_desc = [
+        ByteEnumField("rtm_family", 0, socket.AddressFamily),  # type: ignore
+        ByteField("rtm_dst_len", 0),
+        ByteField("rtm_src_len", 0),
+        ByteField("rtm_tos", 0),
+        ByteEnumField(
+            "rtm_table",
+            0,
+            RT_CLASS,
+        ),
+        ByteEnumField(
+            "rtm_protocol",
+            0,
+            {
+                0x00: "RTPROT_UNSPEC",
+                0x01: "RTPROT_REDIRECT",
+                0x02: "RTPROT_KERNEL",
+                0x03: "RTPROT_BOOT",
+                0x04: "RTPROT_STATIC",
+            },
+        ),
+        ByteEnumField(
+            "rtm_scope",
+            0,
+            {
+                0: "RT_SCOPE_UNIVERSE",
+                200: "RT_SCOPE_SITE",
+                253: "RT_SCOPE_LINK",
+                254: "RT_SCOPE_HOST",
+                255: "RT_SCOPE_NOWHERE",
+            },
+        ),
+        ByteEnumField(
+            "rtm_type",
+            0,
+            {
+                0x00: "RTN_UNSPEC",
+                0x01: "RTN_UNICAST",
+                0x02: "RTN_LOCAL",
+                0x03: "RTN_BROADCAST",
+                0x04: "RTN_ANYCAST",
+                0x05: "RTN_MULTICAST",
+                0x06: "RTN_BLACKHOLE",
+                0x07: "RTN_UNREACHABLE",
+                0x08: "RTN_PROHIBIT",
+                0x09: "RTN_THROW",
+                0x0A: "RTN_NAT",
+                0x0B: "RTN_XRESOLVE",
+            },
+        ),
+        FlagsField(
+            "rtm_flags",
+            0,
+            32 if BIG_ENDIAN else -32,
+            {
+                0x100: "RTM_F_NOTIFY",
+                0x200: "RTM_F_CLONED",
+                0x400: "RTM_F_EQUALIZE",
+                0x800: "RTM_F_PREFIX",
+                0x1000: "RTM_F_LOOKUP_TABLE",
+            },
+        ),
+        # Pay
+        PacketListField("data", [], rtmsg_rtattr),
+    ]
+
+
+bind_layers(rtmsghdr, rtmsg, nlmsg_type=24)
+bind_layers(rtmsghdr, rtmsg, nlmsg_type=25)
+bind_layers(rtmsghdr, rtmsg, nlmsg_type=26)
+
+
+class rtmsghdrs(Packet):
+    fields_desc = [
+        PacketListField("msgs", [], rtmsghdr),
+    ]
+
+
+# Utils
+
+
+def _sr1_rtrequest(pkt: Packet) -> List[Packet]:
+    """
+    Send / Receive a rtnetlink request
+    """
+    # Create socket
+    sock = socket.socket(socket.AF_NETLINK, socket.SOCK_RAW, socket.NETLINK_ROUTE)
+    pid = os.getpid()
+    sock.bind((pid, 0))  # bind to kernel
+    # Request routes
+    sock.send(bytes(rtmsghdrs(msgs=[pkt])))
+    results: List[Packet] = []
+    try:
+        while True:
+            msgs = rtmsghdrs(sock.recv(65535))
+            if not msgs:
+                log_loading.warning("Failed to read the routes using RTNETLINK !")
+                return []
+            for msg in msgs.msgs:
+                # Keep going until we find the end of the MULTI format
+                if not msg.nlmsg_flags.NLM_F_MULTI or msg.nlmsg_type == 3:
+                    return results
+                results.append(msg)
+    finally:
+        sock.close()
+
+
+def _get_ips(af_family=socket.AF_UNSPEC):
+    # type: (socket.AddressFamily) -> Dict[int, List[Dict[str, Any]]]
+    """
+    Return a mapping of all interfaces IP using a NETLINK socket.
+    """
+    pid = os.getpid()
+    results = _sr1_rtrequest(
+        rtmsghdr(
+            nlmsg_type="RTM_GETADDR",
+            nlmsg_flags="NLM_F_REQUEST+NLM_F_ROOT+NLM_F_MATCH",
+            nlmsg_seq=1,
+            nlmsg_pid=pid,
+        )
+        / ifaddrmsg(
+            ifa_family=af_family,
+            data=[
+                ifaddrmsg_rtattr(),
+                ifaddrmsg_rtattr(),
+                ifaddrmsg_rtattr(),
+            ],
+        )
+    )
+    ips: Dict[int, List[Dict[str, Any]]] = {}
+    for msg in results:
+        ifindex = msg.ifa_index
+        address = None
+        family = msg.ifa_family
+        for attr in msg.data:
+            if attr.rta_type == 0x01:  # IFA_ADDRESS
+                address = attr.rta_data
+                break
+        if address is not None:
+            data = {
+                "af_family": family,
+                "index": ifindex,
+                "address": address,
+            }
+            if family == 10:  # ipv6
+                data["scope"] = scapy.utils6.in6_getscope(address)
+            ips.setdefault(ifindex, list()).append(data)
+    return ips
+
+
+def _get_if_list():
+    # type: () -> Dict[int, Dict[str, Any]]
+    """
+    Read the interfaces list using a NETLINK socket.
+    """
+    pid = os.getpid()
+    results = _sr1_rtrequest(
+        rtmsghdr(
+            nlmsg_type="RTM_GETLINK",
+            nlmsg_flags="NLM_F_REQUEST+NLM_F_ROOT+NLM_F_MATCH",
+            nlmsg_seq=1,
+            nlmsg_pid=pid,
+        )
+        / ifinfomsg(
+            data=[
+                ifinfomsg_rtattr(rta_type="IFLA_UNSPEC"),
+            ],
+        )
+    )
+    lifips = _get_ips()
+    interfaces = {}
+    for msg in results:
+        ifindex = msg.ifi_index
+        ifname = None
+        mac = "00:00:00:00:00:00"
+        ifflags = msg.ifi_flags
+        ips = []
+        for attr in msg.data:
+            if attr.rta_type == 0x01:  # IFLA_ADDRESS
+                mac = attr.rta_data
+            elif attr.rta_type == 0x03:  # IFLA_NAME
+                ifname = attr.rta_data[:-1].decode()
+        if ifname is not None:
+            if ifindex in lifips:
+                ips = lifips[ifindex]
+            interfaces[ifindex] = {
+                "name": ifname,
+                "index": ifindex,
+                "flags": ifflags,
+                "mac": mac,
+                "ips": ips,
+            }
+    return interfaces
+
+
+def in6_getifaddr():
+    # type: () -> List[Tuple[str, int, str]]
+    """
+    Returns a list of 3-tuples of the form (addr, scope, iface) where
+    'addr' is the address of scope 'scope' associated to the interface
+    'iface'.
+
+    This is the list of all addresses of all interfaces available on
+    the system.
+    """
+    ips = _get_ips(af_family=socket.AF_INET6)
+    ifaces = _get_if_list()
+    result = []
+    for intip in ips.values():
+        for ip in intip:
+            if ip["index"] in ifaces:
+                result.append((ip["address"], ip["scope"], ifaces[ip["index"]]["name"]))
+    return result
+
+
+def _read_routes(af_family):
+    # type: (socket.AddressFamily) -> List[Packet]
+    """
+    Read routes using a NETLINK socket.
+    """
+    pid = os.getpid()
+    results = _sr1_rtrequest(
+        rtmsghdr(
+            nlmsg_type="RTM_GETROUTE",
+            nlmsg_flags="NLM_F_REQUEST+NLM_F_ROOT+NLM_F_MATCH",
+            nlmsg_seq=1,
+            nlmsg_pid=pid,
+        )
+        / rtmsg(
+            rtm_family=af_family,
+            data=[
+                rtmsg_rtattr(rta_type="RTA_TABLE", rta_data="RT_TABLE_UNSPEC"),
+            ],
+        )
+    )
+    return [msg for msg in results if msg.nlmsg_type == 24]  # RTM_NEWROUTE
+
+
+def read_routes():
+    # type: () -> List[Tuple[int, int, str, str, str, int]]
+    """
+    Read IPv4 routes for current process
+    """
+    routes = []
+    ifaces = _get_if_list()
+    results = _read_routes(socket.AF_INET)
+    for msg in results:
+        # Process the RTM_NEWROUTE
+        net = 0
+        mask = itom(msg.rtm_dst_len)
+        gw = "0.0.0.0"
+        iface = ""
+        addr = "0.0.0.0"
+        metric = 0
+        for attr in msg.data:
+            if attr.rta_type == 0x01:  # RTA_DST
+                net = atol(attr.rta_data)
+            elif attr.rta_type == 0x04:  # RTS_OIF
+                index = attr.rta_data
+                if index in ifaces:
+                    iface = ifaces[index]["name"]
+                else:
+                    iface = str(index)
+            elif attr.rta_type == 0x05:  # RTA_GATEWAY
+                gw = attr.rta_data
+            elif attr.rta_type == 0x06:  # RTA_PRIORITY
+                metric = attr.rta_data
+            elif attr.rta_type == 0x07:  # RTA_PREFSRC
+                addr = attr.rta_data
+        routes.append((net, mask, gw, iface, addr, metric))
+    return routes
+
+
+def read_routes6():
+    # type: () -> List[Tuple[str, int, str, str, List[str], int]]
+    """
+    Read IPv6 routes for current process
+    """
+    routes = []
+    ifaces = _get_if_list()
+    results = _read_routes(socket.AF_INET6)
+    lifaddr = _get_ips(af_family=socket.AF_INET6)
+    for msg in results:
+        # Process the RTM_NEWROUTE
+        prefix = "::"
+        plen = msg.rtm_dst_len
+        nh = "::"
+        index = 0
+        iface = ""
+        metric = 0
+        for attr in msg.data:
+            if attr.rta_type == 0x01:  # RTA_DST
+                prefix = attr.rta_data
+            elif attr.rta_type == 0x04:  # RTS_OIF
+                index = attr.rta_data
+                if index in ifaces:
+                    iface = ifaces[index]["name"]
+                else:
+                    iface = str(index)
+            elif attr.rta_type == 0x05:  # RTA_GATEWAY
+                nh = attr.rta_data
+            elif attr.rta_type == 0x06:  # RTA_PRIORITY
+                metric = attr.rta_data
+        devaddrs = ((x["address"], x["scope"], iface) for x in lifaddr.get(index, []))
+        cset = scapy.utils6.construct_source_candidate_set(prefix, plen, devaddrs)
+        if cset:
+            routes.append((prefix, plen, nh, iface, cset, metric))
+    return routes

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -35,12 +35,15 @@ from scapy.error import (
 )
 from scapy.interfaces import NetworkInterface, InterfaceProvider, \
     dev_from_index, resolve_iface, network_name
-from scapy.pton_ntop import inet_ntop, inet_pton
+from scapy.pton_ntop import inet_ntop
 from scapy.utils import atol, itom, mac2str, str2mac
 from scapy.utils6 import construct_source_candidate_set, in6_getscope
 from scapy.data import ARPHDR_ETHER, load_manuf
 from scapy.compat import plain_str
 from scapy.supersocket import SuperSocket
+
+# re-export
+from scapy.arch.common import get_if_raw_addr  # noqa: F401
 
 # Typing imports
 from typing import (
@@ -703,15 +706,6 @@ def get_ips(v6=False):
         else:
             res[iface] = iface.ips[4]
     return res
-
-
-def get_if_raw_addr(iff):
-    # type: (Union[NetworkInterface, str]) -> bytes
-    """Return the raw IPv4 address of interface"""
-    iff = resolve_iface(iff)
-    if not iff.ip:
-        return b"\x00" * 4
-    return inet_pton(socket.AF_INET, iff.ip)
 
 
 def get_ip_from_name(ifname, v6=False):

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -623,7 +623,7 @@ class PadField(_FieldContainer):
     __slots__ = ["fld", "_align", "_padwith"]
 
     def __init__(self, fld, align, padwith=None):
-        # type: (Field[Any, Any], int, Optional[bytes]) -> None
+        # type: (AnyField, int, Optional[bytes]) -> None
         self.fld = fld
         self._align = align
         self._padwith = padwith or b"\x00"

--- a/scapy/route.py
+++ b/scapy/route.py
@@ -145,8 +145,8 @@ class Route:
         the_net = the_rawaddr & the_msk
         self.routes.append((the_net, the_msk, '0.0.0.0', iff, the_addr, 1))
 
-    def route(self, dst=None, verbose=conf.verb):
-        # type: (Optional[str], int) -> Tuple[str, str, str]
+    def route(self, dst=None, verbose=conf.verb, _internal=False):
+        # type: (Optional[str], int, bool) -> Tuple[str, str, str]
         """Returns the IPv4 routes to a host.
         parameters:
          - dst: the IPv4 of the destination host
@@ -195,6 +195,10 @@ class Route:
         paths.sort(key=lambda x: (-x[0], x[1]))
         # Return interface
         ret = paths[0][2]
+        # Check if source is 0.0.0.0. This is a 'via' route with no src.
+        if ret[1] == "0.0.0.0" and not _internal:
+            # Then get the source from route(gw)
+            ret = (ret[0], self.route(ret[2], _internal=True)[1], ret[2])
         self.cache[dst] = ret
         return ret
 

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -85,6 +85,8 @@ def construct_source_candidate_set(
             cset = (x for x in laddr if x[1] == IPV6_ADDR_SITELOCAL)
     elif addr == '::' and plen == 0:
         cset = (x for x in laddr if x[1] == IPV6_ADDR_GLOBAL)
+    elif addr == '::1':
+        cset = (x for x in laddr if x[1] == IPV6_ADDR_LOOPBACK)
     addrs = [x[0] for x in cset]
     # TODO convert the cmd use into a key
     addrs.sort(key=cmp_to_key(cset_sort))  # Sort with global addresses first

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -79,36 +79,38 @@ with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo_x'):
 import os, socket
 from mock import patch
 
-exit_status = os.system("ip link add name scapy_lo type dummy")
-assert exit_status == 0
-exit_status = os.system("ip link set dev scapy_lo up")
-assert exit_status == 0
-
-with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo'):
-    routes = read_routes()
-
-exit_status = os.system("ip addr add dev scapy_lo 10.10.0.1/24")
-assert exit_status == 0
-
-with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo'):
-    routes = read_routes()
-
-got_lo_device = False
-for route in routes:
-    dst_int, msk_int, gw_str, if_name, if_addr, metric = route
-    if if_name == 'scapy_lo':
-        got_lo_device = True
-        assert if_addr == '10.10.0.1'
-        dst_addr = socket.inet_ntoa(struct.pack("!I", dst_int))
-        assert dst_addr == '10.10.0.0'
-        msk = socket.inet_ntoa(struct.pack("!I", msk_int))
-        assert (msk == '255.255.255.0')
-        break
-
-assert got_lo_device
-
-exit_status = os.system("ip link del dev scapy_lo")
-assert exit_status == 0
+try:
+    exit_status = os.system("ip link add name scapy_lo type dummy")
+    assert exit_status == 0
+    exit_status = os.system("ip link set dev scapy_lo up")
+    assert exit_status == 0
+    
+    with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo'):
+        routes = read_routes()
+    
+    exit_status = os.system("ip addr add dev scapy_lo 10.10.0.1/24")
+    assert exit_status == 0
+    
+    with patch('scapy.arch.linux.conf.loopback_name', 'scapy_lo'):
+        routes = read_routes()
+    
+    lo_routes = [
+        (ltoa(dst_int), ltoa(msk_int), gw_str, if_name, if_addr, metric)
+        for dst_int, msk_int, gw_str, if_name, if_addr, metric in routes
+        if if_name == "scapy_lo"
+    ]
+    lo_routes.sort(key=lambda x: x[0])
+    
+    expected_routes = [
+        (168427520, 4294967040, '0.0.0.0', 'scapy_lo', '10.10.0.1', 0),
+        (168427521, 4294967295, '0.0.0.0', 'scapy_lo', '10.10.0.1', 0),
+        (168427775, 4294967295, '0.0.0.0', 'scapy_lo', '10.10.0.1', 0),
+    ]
+    print(lo_routes)
+    print(expected_routes)
+finally:
+    exit_status = os.system("ip link del dev scapy_lo")
+    assert exit_status == 0
 
 = IPv6 link-local address selection
 

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -55,8 +55,10 @@ if exit_status == 0:
     conf.route.resync()
     print(conf.route.routes)
     assert conf.route.route("192.0.2.43") == ("scapy0.42", "203.0.113.42", "203.0.113.41")
-    route_specific = (3221226027, 4294967295, "203.0.113.41", "scapy0.42", "203.0.113.42", 0)
+    route_specific = (3221226027, 4294967295, "203.0.113.41", "scapy0.42", "0.0.0.0", 0)
     assert route_specific in conf.route.routes
+    assert conf.route.route("203.0.113.42") == ('scapy0.42', '203.0.113.42', '0.0.0.0')
+    assert conf.route.route("203.0.113.43") == ('scapy0.42', '203.0.113.42', '0.0.0.0')
     exit_status = os.system("ip link del name dev scapy0")
 else:
     assert True


### PR DESCRIPTION
This rewrites most of the arch/linux code that handles the loading of `conf.ifaces`, `conf.route` and `conf.route6`, in order to use a RTNETLINK socket (instead of the current reading of `/proc/net/XXX`).

Among those:
- the read_routes(6) functions
- the linux interfaces provider
- arch/linux util functions

This:
- adds support for multiple IPv4 addresses to interfaces
- handles interfaces aliases, etc. natively without needing additional tricks
- allows us to have filter routes by routing tables, also giving us access to 'local', rather than only all tables, giving us generally much better handling of routes.

fixes #4201
closes #3275
(maybe other issues too?)

## Note to all maintainers

This has been tested on 32 big endian architecture thanks to the folks at packit. (woooo)

This might need thorough **TESTING** on other platforms (that we don't include in the CI). I hope I didn't break anything on *BSD.