### PR TITLE
Set manual_trigger in packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -39,6 +39,7 @@ actions:
 jobs:
 - job: copr_build
   trigger: pull_request
+  manual_trigger: true
   targets:
   - fedora-latest-stable-aarch64
   - fedora-latest-stable-i386


### PR DESCRIPTION
This PR:
- enables manual_trigger in packit

I do think that it's overkill for every PR to be checked against all of Fedora's plateforms. Packit should probably, at least for now, only be triggered manually when the PRs are related to components that might break on unorthodox plateforms.