### PR TITLE
Fix UTCTimeField before epoch on Windows

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -12,6 +12,7 @@ Fields: basic data structures that make up parts of packets.
 import calendar
 import collections
 import copy
+import datetime
 import inspect
 import math
 import socket
@@ -19,7 +20,6 @@ import struct
 import time
 import warnings
 
-from datetime import datetime
 from types import MethodType
 from uuid import UUID
 from enum import Enum
@@ -3520,7 +3520,12 @@ class UTCTimeField(Field[float, int]):
         elif self.custom_scaling:
             x = x / self.custom_scaling
         x += self.delta
-        t = datetime.fromtimestamp(x).strftime(self.strf)
+        # To make negative timestamps work on all plateforms (e.g. Windows),
+        # we need a trick.
+        t = (
+            datetime.datetime(1970, 1, 1) +
+            datetime.timedelta(seconds=x)
+        ).strftime(self.strf)
         return "%s (%d)" % (t, int(x))
 
     def i2m(self, pkt, x):

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -365,6 +365,28 @@ p = TestBitLenField(b'\xc0\x01\xf4')
 assert p.mode == 3
 assert p.value == 500
 
+= Test UTCTimeField
+~ field
+
+class TestUTCTimeField(Packet):
+    fields_desc = [
+        # A Windows time field. See GH#4308
+        UTCTimeField(
+            "Time",
+            None,
+            fmt="<Q",
+            epoch=[1601, 1, 1, 0, 0, 0],
+            custom_scaling=1e7,
+        )
+    ]
+
+
+p = TestUTCTimeField(Time=0)
+assert p.sprintf("%Time%") == 'Mon, 01 Jan 1601 00:00:00  (-11644473600)'
+
+p = TestUTCTimeField(Time=133587912345678900)
+assert p.sprintf("%Time%") == 'Sun, 28 Apr 2024 15:20:34  (1714317634)'
+
 ############
 ############
 + Tests on FieldListField


### PR DESCRIPTION
This PR:
- fixes UTCTimeField that have a value before 1970 on Windows

fixes #4308