### PR TITLE
AnsweringMachines: better defaults, various fixes, more tests

### DIFF
--- a/doc/notebooks/Scapy in 15 minutes.ipynb
+++ b/doc/notebooks/Scapy in 15 minutes.ipynb
@@ -1136,7 +1136,7 @@
     "    rep /= Dot11Elt(ID=\"Rates\",info=b'\\x82\\x84\\x0b\\x16\\x96')\n",
     "    rep /= Dot11Elt(ID=\"DSset\",info=chr(10))\n",
     "\n",
-    "    OK,return rep\n",
+    "    return rep\n",
     "\n",
     "# Start the answering machine\n",
     "#ProbeRequest_am()()  # uncomment to test"

--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -19,7 +19,7 @@ import warnings
 
 from scapy.arch import get_if_addr
 from scapy.config import conf
-from scapy.sendrecv import send, sniff, AsyncSniffer
+from scapy.sendrecv import sendp, sniff, AsyncSniffer
 from scapy.packet import Packet
 from scapy.plist import PacketList
 
@@ -75,7 +75,7 @@ class AnsweringMachine(Generic[_T], metaclass=ReferenceAM):
                           "type", "prn", "stop_filter", "opened_socket"]
     send_options = {"verbose": 0}  # type: Dict[str, Any]
     send_options_list = ["iface", "inter", "loop", "verbose", "socket"]
-    send_function = staticmethod(send)
+    send_function = staticmethod(sendp)
 
     def __init__(self, **kargs):
         # type: (Any) -> None

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -55,7 +55,7 @@ from scapy.volatile import (
 )
 
 from scapy.arch import get_if_raw_hwaddr
-from scapy.sendrecv import srp1, sendp
+from scapy.sendrecv import srp1
 from scapy.error import warning
 from scapy.config import conf
 
@@ -587,7 +587,6 @@ def dhcp_request(hw=None,
 class BOOTP_am(AnsweringMachine):
     function_name = "bootpd"
     filter = "udp and port 68 and port 67"
-    send_function = staticmethod(sendp)
 
     def parse_options(self,
                       pool=Net("192.168.1.128/25"),

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -32,6 +32,7 @@ from scapy.layers.inet6 import DomainNameListField, IP6Field, IP6ListField, \
     IPv6
 from scapy.packet import Packet, bind_bottom_up
 from scapy.pton_ntop import inet_pton
+from scapy.sendrecv import send
 from scapy.themes import Color
 from scapy.utils6 import in6_addrtovendor, in6_islladdr
 
@@ -1443,6 +1444,7 @@ bind_bottom_up(UDP, _dhcp6_dispatcher, {"dport": 546})
 class DHCPv6_am(AnsweringMachine):
     function_name = "dhcp6d"
     filter = "udp and port 546 and port 547"
+    send_function = staticmethod(send)
 
     def usage(self):
         msg = """

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -2061,7 +2061,7 @@ iwconfig wlan0 mode managed
         ip = p.getlayer(IP)
         tcp = p.getlayer(TCP)
         pay = raw(tcp.payload)
-        del p.payload.payload.payload
+        p[IP].underlayer.remove_payload()
         p.FCfield = "from-DS"
         p.addr1, p.addr2 = p.addr2, p.addr1
         p /= IP(src=ip.dst, dst=ip.src)

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -2506,15 +2506,21 @@ class ICMPEcho_am(AnsweringMachine):
         return False
 
     def print_reply(self, req, reply):
-        print("Replying %s to %s" % (reply.getlayer(IP).dst, req.dst))
+        print("Replying %s to %s" % (reply[IP].dst, req[IP].dst))
 
     def make_reply(self, req):
-        reply = IP(dst=req[IP].src) / ICMP()
+        reply = req.copy()
         reply[ICMP].type = 0  # echo-reply
-        reply[ICMP].seq = req[ICMP].seq
-        reply[ICMP].id = req[ICMP].id
         # Force re-generation of the checksum
         reply[ICMP].chksum = None
+        if req.haslayer(IP):
+            reply[IP].src, reply[IP].dst = req[IP].dst, req[IP].src
+            reply[IP].chksum = None
+        if req.haslayer(Ether):
+            reply[Ether].src, reply[Ether].dst = (
+                None if req[Ether].dst == "ff:ff:ff:ff:ff:ff" else req[Ether].dst,
+                req[Ether].src,
+            )
         return reply
 
 

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -16,8 +16,13 @@ def test_am(cls_name, packet_query, check_reply, mock_sniff, **kargs):
         kargs["prn"](packet_query)
     mock_sniff.side_effect = sniff
     am = cls_name(**kargs)
-    am.send_reply = lambda x: check_reply(x.__class__(bytes(x)))
+    called = [False]
+    def _sndrpl(x):
+        called[0] = True
+        check_reply(x.__class__(bytes(x)))
+    am.send_reply = _sndrpl
     am()
+    assert called[0], "Filter never passed for AnsweringMachine !"
 
 
 = BOOT_am
@@ -55,24 +60,53 @@ test_am(ARP_am,
 = ICMPEcho_am
 def check_ICMP_am_reply(packet):
     packet.show()
+    assert packet[Ether].src != "ff:ff:ff:ff:ff:ff"
+    assert packet[Ether].dst == "aa:aa:aa:aa:aa:aa"
     assert IP in packet and ICMP in packet
     assert packet[IP].dst == "1.1.1.1"
+    assert packet[IP].src == "2.2.2.2"
     assert packet[ICMP].seq == 12
 
 test_am(ICMPEcho_am,
-        Ether()/IP(src="1.1.1.1", dst="2.2.2.2")/ICMP(seq=12),
+        Ether(src="aa:aa:aa:aa:aa:aa", dst="ff:ff:ff:ff:ff:ff")/IP(src="1.1.1.1", dst="2.2.2.2")/ICMP(seq=12),
         check_ICMP_am_reply)
 
 = DNS_am
 def check_DNS_am_reply(packet):
+    assert packet[Ether].src == "bb:bb:bb:bb:bb:bb"
+    assert packet[Ether].dst == "aa:aa:aa:aa:aa:aa"
+    assert packet[IP].src == "127.0.0.2"
+    assert packet[IP].dst == "127.0.0.1"
     assert DNS in packet and packet[DNS].ancount == 1
     assert packet[DNS].an[0].rdata == "192.168.1.1"
     assert packet[DNS].qd[0].qname == b"www.secdev.org."
 
 test_am(DNS_am,
-        IP()/UDP()/DNS(qd=DNSQR(qname="www.secdev.org")),
+        Ether(src="aa:aa:aa:aa:aa:aa", dst="bb:bb:bb:bb:bb:bb")/IP(src="127.0.0.1", dst="127.0.0.2")/UDP()/DNS(qd=DNSQR(qname="www.secdev.org")),
         check_DNS_am_reply,
         joker="192.168.1.1")
+
+def check_DNS_am_reply_srvmatch(packet):
+    assert DNS in packet and packet[DNS].ancount == 1
+    assert isinstance(packet[DNS].an[0], DNSRRSRV)
+    assert packet[DNS].an[0].rrname == b'_ldap._tcp.dc._msdcs.scapy.fr.'
+    assert packet[DNS].an[0].port == 389
+    assert packet[DNS].an[0].target == b'dc.scapy.fr.'
+
+test_am(DNS_am,
+        Ether()/IP()/UDP()/DNS(qd=DNSQR(qname=b'_ldap._tcp.dc._msdcs.scapy.fr.', qtype="SRV")),
+        check_DNS_am_reply_srvmatch,
+        srvmatch={"_ldap._tcp.dc._msdcs.scapy.fr": (389, "dc.scapy.fr")})
+
+def check_DNS_am_reply_arpa(packet):
+    assert DNS in packet and packet[DNS].ancount == 1
+    assert packet[DNS].an[0].rdata == b"scapy."
+    assert packet[DNS].an[0].rrname == b"1.0.16.172.in-addr.arpa."
+
+test_am(DNS_am,
+        Ether()/IP()/UDP()/DNS(qd=DNSQR(qname=b"1.0.16.172.in-addr.arpa.", qtype="PTR")),
+        check_DNS_am_reply_arpa,
+        jokerarpa="scapy")
 
 def check_DNS_am_reply2(packet):
     assert DNS in packet and packet[DNS].ancount == 2
@@ -80,7 +114,7 @@ def check_DNS_am_reply2(packet):
     assert packet[DNS].an[1].rdata == "::1"
 
 test_am(DNS_am,
-        IP(b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x004\xe8\x9a\x00\x00\x01\x00\x00\x02\x00\x00\x00\x00\x00\x00\x06gaagle\x03com\x00\x00\x01\x00\x01\x06google\x03com\x00\x00\x1c\x00\x01'),
+        Ether()/IP(b'E\x00\x00H\x00\x01\x00\x00@\x11|\xa2\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x004\xe8\x9a\x00\x00\x01\x00\x00\x02\x00\x00\x00\x00\x00\x00\x06gaagle\x03com\x00\x00\x01\x00\x01\x06google\x03com\x00\x00\x1c\x00\x01'),
         check_DNS_am_reply2,
         match={"google.com": ("127.0.0.1", "::1"), "gaagle.com": "128.0.0.1"},
         joker=False)
@@ -152,16 +186,71 @@ test_WiFi_am(Dot11(FCfield="to-DS")/IP()/TCP()/"Scapy",
 = NBNS_am
 def check_NBNS_am_reply(name):
     def check(packet):
+        packet.show()
+        assert packet[Ether].src != "ff:ff:ff:ff:ff:ff"
+        assert packet[Ether].dst == "aa:aa:aa:aa:aa:aa"
         assert NBNSQueryResponse in packet and packet[NBNSQueryResponse].RR_NAME.strip() == bytes_encode(name)
     return check
 
 for server_name in (None, "", b"test", "test"):
     test_am(NBNS_am,
-            Ether()/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME="test"),
+            Ether(src="aa:aa:aa:aa:aa:aa", dst="ff:ff:ff:ff:ff:ff")/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME="test"),
             check_NBNS_am_reply("test"),
             server_name=server_name)
 
 test_am(NBNS_am,
-        Ether()/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME=b"\x85"),
+        Ether(src="aa:aa:aa:aa:aa:aa", dst="ff:ff:ff:ff:ff:ff")/IP()/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME=b"\x85"),
         check_NBNS_am_reply(b"\x85"),
         server_name=b"\x85")
+
+= LdapPing_am
+def check_LdapPing_am_reply(packet):
+    nlogon = packet[CLDAP].protocolOp.attributes[0]
+    assert nlogon.type == b"Netlogon"
+    logonresp = NETLOGON(nlogon.values[0].value.val)
+    assert isinstance(logonresp, NETLOGON_SAM_LOGON_RESPONSE_EX)
+    logonresp.show()
+    assert logonresp.DnsForestName == b'scapy.fr.', "DnsForestName"
+    assert logonresp.DnsDomainName == b'scapy.fr.', "DnsDomainName"
+    assert logonresp.DnsHostName == b'DC.scapy.fr.', "DnsHostName"
+    assert logonresp.NetbiosDomainName == b'SCAPY.', "NetbiosDomainName"
+    assert logonresp.NetbiosComputerName == b'DC.', "NetbiosComputerName"
+    assert logonresp.NtVersion == 3, "NtVersion"
+    assert logonresp.Flags == 0x3f3fd, "Flags"
+    assert logonresp.ClientSiteName == b'Default-First-Site-Name.', "ClientSiteName"
+
+test_am(LdapPing_am,
+        Ether(b'\xaa\xaa\xaa\xaa\xaa\xaa\xbb\xbb\xbb\xbb\xbb\xbb\x08\x00E\x00\x00\xaf\x9d\xb1\x00\x00\x80\x11\x9c\x89\xac\x13P\x01\xac\x13W\xdb\xc7{\x01\x85\x00\x9bV[0q\x02\x01\x01cl\x04\x00\n\x01\x00\n\x01\x00\x02\x01\x00\x02\x01\x00\x01\x01\x00\xa0M\xa3\x15\x04\tDnsDomain\x04\x08scapy.fr\xa3\x0e\x04\x04Host\x04\x06HOST01\xa3\r\x04\x05NtVer\x04\x04\x16\x00\x00 \xa3\x15\x04\x0bDnsHostName\x04\x06HOST010\n\x04\x08Netlogon'),
+        check_LdapPing_am_reply,
+        NetbiosComputerName="DC",
+        NetbiosDomainName="SCAPY",
+        DnsForestName="scapy.fr")
+
+
+def check_NBNS_LdapPing_am_reply(packet):
+    packet.show()
+    assert SMBMailslot_Write in packet, "SMBMailslot_Write"
+    assert packet[SMBMailslot_Write].Name == b'\\MAILSLOT\\NET\\GETDC510CC0AD', "SMBMailslot_Write.Name"
+    logonresp = NETLOGON(packet[SMBMailslot_Write].Data.load)
+    logonresp.show()
+    assert logonresp.DcSockAddrSize == 16, "DcSockAddrSize"
+    assert isinstance(logonresp.DcSockAddr, DcSockAddr)
+    assert logonresp.DcSockAddr.sin_family == 2, "sin_family"
+    assert logonresp.DcSockAddr.sin_port == 0, "sin_port"
+    assert logonresp.DcSockAddr.sin_zero == 0, "sin_zero"
+    assert logonresp.DcSockAddr.sin_addr == get_if_addr(conf.iface)
+    assert logonresp.DnsForestName == b'scapy.fr.', "DnsForestName"
+    assert logonresp.DnsDomainName == b'scapy.fr.', "DnsDomainName"
+    assert logonresp.DnsHostName == b'DC.scapy.fr.', "DnsHostName"
+    assert logonresp.NetbiosDomainName == b'SCAPY.', "NetbiosDomainName"
+    assert logonresp.NetbiosComputerName == b'DC.', "NetbiosComputerName"
+    assert logonresp.NtVersion == 13, "NtVersion"
+    assert logonresp.Flags == 0x3f3fd, "Flags"
+    assert logonresp.ClientSiteName == b'Default-First-Site-Name.', "ClientSiteName"
+
+test_am(LdapPing_am,
+        Ether(b'\xaa\xaa\xaa\xaa\xaa\xaa\xbb\xbb\xbb\xbb\xbb\xbb\x08\x00E\x00\x01\n\xff\x82\x00\x00\x80\x11:]\xac\x13P\x01\xac\x13W\xdb\x00\x8a\x00\x8a\x00\xf6\xd5\xcb\x10\x02\xde\x9d\xac\x13P\x01\x00\x8a\x00\xe0\x00\x00 EIEPFDFEDADBCACACACACACACACACAAA\x00 FDEDEBFAFJCACACACACACACACACACABM\x00\xffSMB%\x00\x00\x00\x00\x18\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xfe\x00\x00\x00\x00\x11\x00\x00@\x00\x02\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\\\x00@\x00\\\x00\x03\x00\x01\x00\x00\x00\x02\x00W\x00\\MAILSLOT\\NET\\NETLOGON\x00\x12\x00\x00\x00H\x00O\x00S\x00T\x000\x001\x00\x00\x00\x00\x00\\MAILSLOT\\NET\\GETDC510CC0AD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00 \xff\xff\xff\xff'),
+        check_NBNS_LdapPing_am_reply,
+        NetbiosComputerName="DC",
+        NetbiosDomainName="SCAPY",
+        DnsForestName="scapy.fr")


### PR DESCRIPTION
This PR:
- restores using `sendp` instead of `send` in AnsweringMachines. This works better in some cases (e.g. ICMP)
- Test some answering machines that were yet untested (LdapPing_am)
- Cleanup the NBNS answering machine and regroup with LdapPing_am
- fixes https://github.com/secdev/scapy/pull/4051