### PR TITLE
AsyncSniffer catch errors on join()

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1072,12 +1072,19 @@ class AsyncSniffer(object):
         self.running = False
         self.thread = None  # type: Optional[Thread]
         self.results = None  # type: Optional[PacketList]
+        self.exception = None  # type: Optional[Exception]
 
     def _setup_thread(self):
         # type: () -> None
+        def _run_catch(self=self, *args, **kwargs):
+            # type: (Any, *Any, **Any) -> None
+            try:
+                self._run(*args, **kwargs)
+            except Exception as ex:
+                self.exception = ex
         # Prepare sniffing thread
         self.thread = Thread(
-            target=self._run,
+            target=_run_catch,
             args=self.args,
             kwargs=self.kwargs,
             name="AsyncSniffer"
@@ -1332,6 +1339,8 @@ class AsyncSniffer(object):
         # type: (*Any, **Any) -> None
         if self.thread:
             self.thread.join(*args, **kwargs)
+        if self.exception is not None:
+            raise self.exception
 
 
 @conf.commands.register

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1729,6 +1729,16 @@ def _test():
 
 retry_test(_test)
 
+= Test sniffing with AsyncSniffer on failed
+
+try:
+    sniffer = AsyncSniffer(iface="this_interface_does_not_exists")
+    sniffer.start()
+    sniffer.join()
+    assert False, "Should have errored by now"
+except (OSError, Scapy_Exception):
+    assert True
+
 = Sending a TCP syn 'forever' at layer 2 and layer 3
 ~ netaccess needs_root IP
 def _test():


### PR DESCRIPTION
- raise errors on `join()` in `AsyncSniffer`
- fixes https://github.com/secdev/scapy/issues/4322