### PR TITLE
#4360: Add stop_filter parameter to SndRcvHandler

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -130,7 +130,7 @@ class SndRcvHandler(object):
                  threaded=False,  # type: bool
                  session=None,  # type: Optional[_GlobSessionType]
                  chainEX=False,  # type: bool
-                 stop_filter=None # type: Optional[Callable[[Packet], bool]]
+                 stop_filter=None  # type: Optional[Callable[[Packet], bool]]
                  ):
         # type: (...) -> None
         # Instantiate all arguments


### PR DESCRIPTION
See #4360 for more details.

Added stop_filter param to SndRcvHandler.__init__(). 
Pass stop_filter to AsyncSniffer._run in SndRcvHandler._sndrcv_rcv. 
Check if SndRcvHandler.sniffer is running before stopping in SndRcvHandler._process_packet. 
Updated _DOC_SNDRCV_PARAMS documentation to include new parameter.

fixes #4360 