### PR TITLE
UDS Scanner Update

### DIFF
--- a/scapy/contrib/automotive/scanner/configuration.py
+++ b/scapy/contrib/automotive/scanner/configuration.py
@@ -115,6 +115,7 @@ class AutomotiveTestCaseExecutorConfiguration(object):
         self.verbose = kwargs.get("verbose", False)
         self.debug = kwargs.get("debug", False)
         self.unittest = kwargs.pop("unittest", False)
+        self.delay_enter_state = kwargs.pop("delay_enter_state", 0)
         self.state_graph = Graph()
         self.test_cases = list()  # type: List[AutomotiveTestCaseABC]
         self.stages = list()  # type: List[StagedAutomotiveTestCase]

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -18,7 +18,7 @@ from typing import NamedTuple
 from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.error import Scapy_Exception
-from scapy.utils import make_lined_table, EDecimal
+from scapy.utils import make_lined_table, EDecimal, PeriodicSenderThread
 from scapy.packet import Packet
 from scapy.contrib.automotive.ecu import EcuState, EcuResponse
 from scapy.contrib.automotive.scanner.test_case import AutomotiveTestCase, \
@@ -79,7 +79,8 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         'stop_event': (threading.Event, None),
         'debug': (bool, None),
         'scan_range': ((list, tuple, range), None),
-        'unittest': (bool, None)
+        'unittest': (bool, None),
+        'disable_tps_while_sending': (bool, None)
     })
 
     _supported_kwargs_doc = AutomotiveTestCase._supported_kwargs_doc + """
@@ -119,7 +120,10 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         :param bool debug: Enables debug functions during execute.
         :param Event stop_event: Signals immediate stop of the execution.
         :param scan_range: Specifies the identifiers to be scanned.
-        :type scan_range: list or tuple or range or iterable"""
+        :type scan_range: list or tuple or range or iterable
+        :param disable_tps_while_sending: Temporary disables a TesterPresentSender
+                                          to not interact with a seed request.
+        :type disable_tps_while_sending: bool"""
 
     def __init__(self):
         # type: () -> None
@@ -130,6 +134,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         self._retry_pkt = defaultdict(list)  # type: Dict[EcuState, Union[Packet, Iterable[Packet]]]  # noqa: E501
         self._negative_response_blacklist = [0x10, 0x11]  # type: List[int]
         self._requests_per_state_estimated = None  # type: Optional[int]
+        self._tester_present_sender = None  # type: Optional[PeriodicSenderThread]
 
     @staticmethod
     @abc.abstractmethod
@@ -272,6 +277,13 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
 
         return pkts_tbs, pkts_snt, float(pkts_snt) / pkts_tbs
 
+    def pre_execute(self, socket, state, global_configuration):
+        # type: (_SocketUnion, EcuState, AutomotiveTestCaseExecutorConfiguration) -> None  # noqa: E501
+        try:
+            self._tester_present_sender = global_configuration["tps"]
+        except KeyError:
+            self._tester_present_sender = None
+
     def execute(self, socket, state, **kwargs):
         # type: (_SocketUnion, EcuState, Any) -> None
         self.check_kwargs(kwargs)
@@ -279,6 +291,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         count = kwargs.pop('count', None)
         execution_time = kwargs.pop("execution_time", 1200)
         stop_event = kwargs.pop("stop_event", None)  # type: Optional[threading.Event]  # noqa: E501
+        disable_tps = kwargs.pop("disable_tps_while_sending", False)
 
         self._prepare_runtime_estimation(**kwargs)
 
@@ -306,7 +319,13 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
             "Start execution of enumerator: %s", time.ctime())
 
         for req in it:
+            if disable_tps and self._tester_present_sender:
+                self._tester_present_sender.disable()
+
             res = self.sr1_with_retry_on_error(req, socket, state, timeout)
+
+            if disable_tps and self._tester_present_sender:
+                self._tester_present_sender.enable()
 
             self._store_result(state, req, res)
 

--- a/scapy/contrib/automotive/scanner/executor.py
+++ b/scapy/contrib/automotive/scanner/executor.py
@@ -63,7 +63,7 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
 
     def __init__(
             self,
-            socket,  # type: _SocketUnion
+            socket,  # type: Optional[_SocketUnion]
             reset_handler=None,  # type: Optional[Callable[[], None]]
             reconnect_handler=None,  # type: Optional[Callable[[], _SocketUnion]]  # noqa: E501
             test_cases=None,
@@ -74,8 +74,8 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
         # The TesterPresentSender can interfere with a test_case, since a
         # target may only allow one request at a time.
         # The SingleConversationSocket prevents interleaving requests.
-        if not isinstance(socket, SingleConversationSocket):
-            self.socket = SingleConversationSocket(socket)
+        if socket and not isinstance(socket, SingleConversationSocket):
+            self.socket = SingleConversationSocket(socket)  # type: Optional[_SocketUnion]  # noqa: E501
         else:
             self.socket = socket
 
@@ -158,7 +158,8 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
         # type: () -> None
         if self.reconnect_handler:
             try:
-                self.socket.close()
+                if self.socket:
+                    self.socket.close()
             except Exception as e:
                 log_automotive.exception(
                     "Exception '%s' during socket.close", e)
@@ -170,7 +171,7 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
             else:
                 self.socket = socket
 
-        if self.socket.closed:
+        if self.socket and self.socket.closed:
             raise Scapy_Exception(
                 "Socket closed even after reconnect. Stop scan!")
 
@@ -179,7 +180,7 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
         """
         This function ensures the correct execution of a testcase, including
         the pre_execute, execute and post_execute.
-        Finally the testcase is asked if a new edge or a new testcase was
+        Finally, the testcase is asked if a new edge or a new testcase was
         generated.
 
         :param test_case: A test case to be executed
@@ -187,6 +188,10 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
                           the current test_case
         :return: None
         """
+
+        if not self.socket:
+            log_automotive.warning("Socket is None! Leaving execute_test_case")
+            return
 
         test_case.pre_execute(
             self.socket, self.target_state, self.configuration)
@@ -231,6 +236,10 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
 
     def check_new_states(self, test_case):
         # type: (AutomotiveTestCaseABC) -> None
+        if not self.socket:
+            log_automotive.warning("Socket is None! Leaving check_new_states")
+            return
+
         if isinstance(test_case, StateGenerator):
             edge = test_case.get_new_edge(self.socket, self.configuration)
             if edge:
@@ -310,9 +319,11 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
                     if isinstance(e, OSError):
                         log_automotive.exception(
                             "OSError occurred, closing socket")
-                        self.socket.close()
-                    if cast(SuperSocket, self.socket).closed and \
-                            self.reconnect_handler is None:
+                        if self.socket:
+                            self.socket.close()
+                    if (self.socket
+                            and cast(SuperSocket, self.socket).closed
+                            and self.reconnect_handler is None):
                         log_automotive.critical(
                             "Socket went down. Need to leave scan")
                         raise e
@@ -351,6 +362,8 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
                 return False
 
             edge = (self.target_state, next_state)
+            self.configuration.stop_event.wait(
+                timeout=self.configuration.delay_enter_state)
             if not self.enter_state(*edge):
                 self.state_graph.downrate_edge(edge)
                 self.cleanup_state()
@@ -367,6 +380,10 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
         :param next_state: Desired state
         :return: True, if state could be changed successful
         """
+        if not self.socket:
+            log_automotive.warning("Socket is None! Leaving enter_state")
+            return False
+
         edge = (prev_state, next_state)
         funcs = self.state_graph.get_transition_tuple_for_edge(edge)
 
@@ -393,6 +410,10 @@ class AutomotiveTestCaseExecutor(metaclass=abc.ABCMeta):
         Executes all collected cleanup functions from a traversed path
         :return: None
         """
+        if not self.socket:
+            log_automotive.warning("Socket is None! Leaving cleanup_state")
+            return
+
         for f in self.cleanup_functions:
             if not callable(f):
                 continue

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -25,6 +25,8 @@ from scapy.contrib.automotive.ecu import *
 
 load_layer("can")
 
+conf.debug_dissector = False
+
 
 = Define Testfunction
 

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -664,7 +664,7 @@ resps = [EcuResponse(None, [UDS()/UDS_CCPR(controlType=1)]),
 
 es = [UDS_CCEnumerator]
 
-scanner = executeScannerInVirtualEnvironment(resps, es)
+scanner = executeScannerInVirtualEnvironment(resps, es, inter=0.001)
 
 assert scanner.scan_completed
 assert scanner.progress() > 0.95


### PR DESCRIPTION
This PR fixes #3942 and updates the UDS Scanner.

Additional feature, TesterPresentSender can be disabled during the send of a packet and the reception. 

The argument inter allows to delay the sending of packets. 

The Executor can now be started without a socket but with a given reconnect function to dynamically create a connection to the target after reset. 