### PR TITLE
NetBSD 10.0+ supports bpf on lo

### DIFF
--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -35,10 +35,6 @@ then
     # the cryptogaphy module source code
     UT_FLAGS+=" -K libressl"
   fi
-  if [[ "$OSTYPE" = "netbsd" ]]
-  then
-    UT_FLAGS+=" -K not_netbsd"
-  fi
 fi
 
 if [ ! -z "$GITHUB_ACTIONS" ]

--- a/test/bpf.uts
+++ b/test/bpf.uts
@@ -146,10 +146,7 @@ s.assigned_interface = conf.loopback_name
 s.send(IP(dst="8.8.8.8")/ICMP())
 
 = L3bpfSocket - send and sniff on loopback
-~ needs_root not_netbsd
-
-# Note: as of November 2022, it is not possible to send packet on lo0
-#       using bpf on NetBSD 9.3
+~ needs_root
 
 localhost_ip = conf.ifaces[conf.loopback_name].ips[4][0]
 


### PR DESCRIPTION
- remove now unnecessary test selector for NetBSD
- closes https://github.com/secdev/scapy/issues/4350