### PR TITLE
Fix TCPerror parsing

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -47,6 +47,7 @@ from scapy.fields import (
     IPField,
     IP6Field,
     IntField,
+    MayEnd,
     MultiEnumField,
     MultipleTypeField,
     PacketField,
@@ -1269,6 +1270,12 @@ class IPerror(IP):
 
 class TCPerror(TCP):
     name = "TCP in ICMP"
+    fields_desc = (
+        TCP.fields_desc[:2] +
+        # MayEnd after the 8 first octets.
+        [MayEnd(TCP.fields_desc[2])] +
+        TCP.fields_desc[3:]
+    )
 
     def answers(self, other):
         if not isinstance(other, TCP):

--- a/scapy/tools/UTscapy.py
+++ b/scapy/tools/UTscapy.py
@@ -28,7 +28,7 @@ import zlib
 
 from scapy.consts import WINDOWS
 from scapy.config import conf
-from scapy.compat import base64_bytes, bytes_hex, plain_str
+from scapy.compat import base64_bytes
 from scapy.themes import DefaultTheme, BlackAndWhite
 from scapy.utils import tex_escape
 
@@ -548,7 +548,7 @@ def run_test(test, get_interactive_session, theme, verb=3,
             # Add optional debugging data to log
             if debug.crashed_on:
                 cls, val = debug.crashed_on
-                test.output += "\n\nPACKET DISSECTION FAILED ON:\n %s(hex_bytes('%s'))" % (cls.__name__, plain_str(bytes_hex(val)))
+                test.output += "\n\nPACKET DISSECTION FAILED ON:\n %s(bytes.fromhex('%s'))" % (cls.__name__, val.hex())
                 debug.crashed_on = None
         test.prepare(theme)
         if verb > 2:

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -680,6 +680,10 @@ query = IP(dst="192.168.0.1", src="192.168.0.254", ttl=1)/ICMP()/"scapy"
 answer = IP(dst="192.168.0.254", src="192.168.0.2")/ICMP(type=11)/IPerror(dst="192.168.0.1", src="192.168.0.254", ttl=0)/ICMPerror()/"scapy"
 assert answer.answers(query) == True
 
+= IPv4 - TCPError parsing
+pkt = Ether(bytes.fromhex('005056a4302ffcbd676360c908004500003800000000f80164b6682ce6b70ad504560b004f410000000045000028400e00000106fdae0ad50456681204d7f73100507d4430f8'))
+assert TCPerror in pkt and pkt[TCPerror].sport == 63281 and pkt[TCPerror].dport == 80
+
 = IPv4 - mDNS
 a = IP(dst="224.0.0.251")
 assert a.hashret() == b"\x00"


### PR DESCRIPTION
I still really like that `UTscapy` reports the packet that makes the tests failed when sniffing. This issue fixes a bug found in the latest test: https://github.com/secdev/scapy/actions/runs/8863080304/job/24336718459?pr=4092 on an ICMP error :P

```
###(143)=[failed] send() and sniff()

>>> def _test():
...     sendp(Ether()/IP(src="9.0.0.0")/UDP(), count=3, iface=conf.iface)
... 
>>> r = sniff(timeout=3, count=1,
...           lfilter=lambda x: IP in x and x[IP].src == "9.0.0.0",
...           iface=conf.iface,
...           started_callback=_test)

Sent 3 packets.
Socket <scapy.arch.bpf.supersocket.L2bpfListenSocket object at 0x10d7fa890> failed with 'unpack requires a buffer of 4 bytes'. It was closed.
>>> 
>>> assert r
Traceback (most recent call last):
  File "<input>", line 2, in <module>
AssertionError


PACKET DISSECTION FAILED ON:
 Ether(hex_bytes('005056a4302ffcbd676360c908004500003800000000f80164b6682ce6b70ad504560b004f410000000045000028400e00000106fdae0ad50456681204d7f73100507d4430f8'))
```

This was clearly caused by https://github.com/secdev/scapy/pull/4012