### PR TITLE
Fix regression: scapy sessions

### DIFF
--- a/test/regression.uts
+++ b/test/regression.uts
@@ -666,7 +666,7 @@ try:
 except:
     code_interact_import = "scapy.main.code.interact"
 else:
-    code_interact_import = "IPython.start_ipython"
+    code_interact_import = "IPython.embed"
 
 @mock.patch(code_interact_import)
 def interact_emulator(code_int, extra_args=[]):


### PR DESCRIPTION
This PR fixes the sessions regressions.
- fixes https://github.com/secdev/scapy/issues/4245
- fix a small bug in the order in which Scapy is loaded that would cause pickled packets payloads not to be properly parsed

Apparently it was mostly due to some sort of regression with IPython's `start_python` not performing as expected. Switching to their `embed` function fixed it. Or maybe we should have used it from the beggining :/