### PR TITLE
ci: bring back the manufdb tests

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^# check$/a%check\\n./test/run_tests -c test/configs/linux.utsc -K netaccess -K scanner -K manufdb' .packit_rpm/scapy.spec"
+    - "sed -i '/^# check$/a%check\\n./test/run_tests -c test/configs/linux.utsc -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"
@@ -40,6 +40,7 @@ jobs:
 - job: copr_build
   trigger: pull_request
   manual_trigger: true
+  enable_net: true
   targets:
   - fedora-latest-stable-aarch64
   - fedora-latest-stable-i386


### PR DESCRIPTION
now that https://github.com/secdev/scapy/pull/4351 is merged and https://github.com/secdev/scapy/issues/4280 is closed.

and also run the netaccess tests.

It's a follow-up to 86c7a05a1430a47a24d45705784b2e113fb3149d and was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/7395288/.