### PR TITLE
ci: run the fuzz target on PRs

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,39 @@
+name: CIFuzz
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    if: github.repository == 'secdev/scapy'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'scapy'
+          language: python
+          dry-run: false
+          allowed-broken-targets-percentage: 0
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'scapy'
+          language: python
+          dry-run: false
+          fuzz-seconds: 300
+      - name: Upload Crash
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts

--- a/scapy/layers/dcerpc.py
+++ b/scapy/layers/dcerpc.py
@@ -3000,7 +3000,7 @@ class DceRpc4Payload(Packet):
         for klass in cls._payload_class:
             if hasattr(klass, "can_handle") and klass.can_handle(_pkt, _underlayer):
                 return klass
-        print("DCE/RPC payload class not found or undefined (using Raw)")
+        log_runtime.warning("DCE/RPC payload class not found or undefined (using Raw)")
         return Raw
 
     @classmethod


### PR DESCRIPTION
using https://google.github.io/oss-fuzz/getting-started/continuous-integration/

It downloads the corpus OSS-Fuzz has accumulated so far (including the test cases that triggered issues in the past) and runs the fuzz target with it. It should help to catch most regressions when PRs are opened.

Prompted by https://github.com/secdev/scapy/pull/4373.

It's a draft because to make it more useful in terms of testing ~~the dissectors should probably be covered first~~ (The dissectors were (partly) covered in https://github.com/google/oss-fuzz/pull/11912).

As expected it triggered
```sh
 === Uncaught Python exception: ===
error: unpack requires a buffer of 2 bytes
Traceback (most recent call last):
  File "pcap_fuzzer.py", line 29, in TestOneInput
  File "scapy/utils.py", line 1259, in rdpcap
  File "scapy/utils.py", line 1319, in __call__
  File "scapy/utils.py", line 1883, in __init__
  File "scapy/utils.py", line 1584, in __init__
  File "scapy/utils.py", line 1648, in _read_block_shb
error: unpack requires a buffer of 2 bytes

==38== ERROR: libFuzzer: fuzz target exited
    #0 0x7f1941d7e7f1 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/asan/asan_stack.cpp:87:3
    #1 0x7f1941c816e8 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x7f1941c644cc in fuzzer::Fuzzer::ExitCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:248:3
    #3 0x7f1941a318a6  (/lib/x86_64-linux-gnu/libc.so.6+0x468a6) (BuildId: 87b331c034a6458c64ce09c03939e947212e18ce)
    #4 0x7f1941a31a5f in exit (/lib/x86_64-linux-gnu/libc.so.6+0x46a5f) (BuildId: 87b331c034a6458c64ce09c03939e947212e18ce)
    #5 0x7f193fa4eaa8 in Py_Exit /tmp/Python-3.8.3/Python/pylifecycle.c:2299:5
    #6 0x7f193fa534b1 in handle_system_exit /tmp/Python-3.8.3/Python/pythonrun.c:658:9
    #7 0x7f193fa534b1 in _PyErr_PrintEx /tmp/Python-3.8.3/Python/pythonrun.c:668:5
    #8 0x55ec2c838b73  (build-out/pcap_fuzzer.pkg+0x3b73)
    #9 0x55ec2c838f10  (build-out/pcap_fuzzer.pkg+0x3f10)
    #10 0x7f1941a0f082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 87b331c034a6458c64ce09c03939e947212e18ce)
    #11 0x55ec2c8374ad  (build-out/pcap_fuzzer.pkg+0x24ad)
```
https://github.com/secdev/scapy/actions/runs/8941500042/job/24561958924?pr=4378