### PR TITLE
Fix interface selection for IPv6-only hosts

### DIFF
--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -360,3 +360,5 @@ class Route6:
 
 
 conf.route6 = Route6()
+# IPv6 routing table can influence default interface selection
+conf.ifaces.reload()


### PR DESCRIPTION
Instead of considering the full IPv4 routing table, we only look for IPv4 default route and IPv6 routes shorter or equal /8 (for instance `2000::/3`). Since the `conf.route6` is not ready yet when we first run, we reload `conf.ifaces` after loading `route6.py`.

This fixes #4304.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #4304  <!-- (add issue number here if appropriate, else remove this line) -->
