### PR TITLE
Minor improvements to build & ci

### DIFF
--- a/.config/ci/install.sh
+++ b/.config/ci/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # Usage:
 # ./install.sh [install mode]
 

--- a/.config/ci/openssl.py
+++ b/.config/ci/openssl.py
@@ -1,4 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
+# See https://scapy.net/ for more information
 # Copyright (C) Gabriel Potter
 
 """

--- a/.config/ci/test.sh
+++ b/.config/ci/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
 # test.sh
 # Usage:
 #   ./test.sh [tox version] [both/root/non_root (default root)]

--- a/.config/ci/zipapp.sh
+++ b/.config/ci/zipapp.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
+# Build a zipapp for Scapy
+
+DIR=$(realpath "$(dirname "$0")/../../")
+cd $DIR
+
+if [ ! -e "pyproject.toml" ]; then
+    echo "zipapp.sh must be called from scapy root folder"
+    exit 1
+fi
+
+if [ -z "$PYTHON" ]
+then
+  PYTHON=${PYTHON:-python3}
+fi
+
+# Get temp directory
+TMPFLD="$(mktemp -d)"
+if [ -z "$TMPFLD" ] || [ ! -d "$TMPFLD" ]; then
+    echo "Error: 'mktemp -d' failed"
+    exit 1
+fi
+ARCH="$TMPFLD/archive"
+SCPY="$TMPFLD/scapy"
+mkdir "$ARCH"
+mkdir "$SCPY"
+
+# Create git archive
+git archive HEAD -o "$ARCH/scapy.tar.gz"
+
+# Unpack the archive to a temporary directory
+if [ ! -e "$ARCH/scapy.tar.gz" ]; then
+    echo "ERROR: git archive failed"
+    exit 1
+fi
+tar -xvf "$ARCH/scapy.tar.gz" -C "$SCPY"
+
+# Remove unnecessary files
+cd "$SCPY" && find . -not \( \
+    -wholename "./scapy*" -o \
+    -wholename "./pyproject.toml" -o \
+    -wholename "./LICENSE" \
+\) -print
+cd $DIR
+
+# Get DEST file
+DEST="./dist/scapy.pyz"
+if [ ! -d "./dist" ]; then
+    mkdir dist
+fi
+
+echo "$SCPY"
+# Build the zipapp
+echo "Building zipapp"
+$PYTHON -m zipapp \
+    -o "$DEST" \
+    -p "/usr/bin/env python3" \
+    -m "scapy.main:interact" \
+    -c \
+    "$SCPY"
+
+# Cleanup
+rm -rf "$TMPFLD"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ doc = [
 
 # setuptools specific
 
-[tool.setuptools]
-zip-safe = false  # We use __file__ in scapy/__init__.py, therefore Scapy isn't zip safe
-
 [tool.setuptools.packages.find]
 include = [
     "scapy*",
@@ -90,7 +87,7 @@ omit = [
     # Scapy tools
     "scapy/tools/",
     # Scapy external modules
-    "scapy/libs/six.py",
-    "scapy/libs/winpcapy.py",
     "scapy/libs/ethertypes.py",
+    "scapy/libs/manuf.py",
+    "scapy/libs/winpcapy.py",
 ]

--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -144,7 +144,7 @@ def _version():
         with open(version_file, 'r') as fdsec:
             tag = fdsec.read()
         return tag
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         pass
 
     # Method 2: from the archive tag, exported when using git archives

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -422,10 +422,10 @@ def save_session(fname="", session=None, pickleProto=-1):
     log_interactive.info("Saving session into [%s]", fname)
 
     if not session:
-        try:
+        if conf.interactive_shell in ["ipython", "ptipython"]:
             from IPython import get_ipython
             session = get_ipython().user_ns
-        except Exception:
+        else:
             session = builtins.__dict__["scapy_session"]
 
     if not session:
@@ -934,6 +934,7 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
                 cfg.InteractiveShellEmbed.confirm_exit = False
                 cfg.InteractiveShellEmbed.separate_in = u''
             if int(IPython.__version__[0]) >= 6:
+                cfg.InteractiveShellEmbed.term_title = True
                 cfg.InteractiveShellEmbed.term_title_format = ("Scapy %s" %
                                                                conf.version)
                 # As of IPython 6-7, the jedi completion module is a dumpster


### PR DESCRIPTION
- add missing SPDX to ci files
- fix a tiny bug in `scapy/main.py` in the handling sessions on `ptipython`
- add `.config/ci/zipapp.sh` script that generates a zipapp from Scapy
- fixes a tiny bug in `scapy/__init__.py` preventing Scapy's zipapp to work
- fix a tiny bug in `scapy/main.py` leading to the title of the window on Windows not to be updated
- remove `zip_safe` ([obsolete](https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html))