### PR TITLE
Cleanup getmacbyip and add in4_is*

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -84,6 +84,11 @@ from scapy.utils6 import in6_getnsma, in6_getnsmac, in6_isaddr6to4, \
     in6_isllsnmaddr, in6_ismaddr, Net6, teredoAddrExtractInfo
 from scapy.volatile import RandInt, RandShort
 
+# Typing
+from typing import (
+    Optional,
+)
+
 if not socket.has_ipv6:
     raise socket.error("can't use AF_INET6, IPv6 is disabled")
 if not hasattr(socket, "IPPROTO_IPV6"):
@@ -135,19 +140,24 @@ def neighsol(addr, src, iface, timeout=1, chainCC=0):
 
 @conf.commands.register
 def getmacbyip6(ip6, chainCC=0):
-    """Returns the MAC address corresponding to an IPv6 address
+    # type: (str, int) -> Optional[str]
+    """
+    Returns the MAC address used to reach a given IPv6 address.
 
     neighborCache.get() method is used on instantiated neighbor cache.
     Resolution mechanism is described in associated doc string.
 
     (chainCC parameter value ends up being passed to sending function
      used to perform the resolution, if needed)
-    """
 
+    .. seealso:: :func:`~scapy.layers.l2.getmacbyip` for IPv4.
+    """
+    # Sanitize the IP
     if isinstance(ip6, Net6):
         ip6 = str(ip6)
 
-    if in6_ismaddr(ip6):  # Multicast
+    # Multicast
+    if in6_ismaddr(ip6):  # mcast @
         mac = in6_getnsmac(inet_pton(socket.AF_INET6, ip6))
         return mac
 

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -15,7 +15,7 @@ import time
 from scapy.ansmachine import AnsweringMachine
 from scapy.arch import get_if_addr, get_if_hwaddr
 from scapy.base_classes import Gen, Net
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.config import conf
 from scapy import consts
 from scapy.data import ARPHDR_ETHER, ARPHDR_LOOPBACK, ARPHDR_METRICOM, \

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -861,7 +861,7 @@ def in4_ismaddr(str):
     Returns True if provided address in printable format belongs to
     allocated Multicast address space (224.0.0.0/4).
     """
-    return in4_isincluded(str, '224.0.0.0', 4)
+    return in4_isincluded(str, "224.0.0.0", 4)
 
 
 def in4_ismlladdr(str):

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -704,13 +704,22 @@ def zerofree_randstring(length):
                     for _ in range(length))
 
 
+def stror(s1, s2):
+    # type: (bytes, bytes) -> bytes
+    """
+    Returns the binary OR of the 2 provided strings s1 and s2. s1 and s2
+    must be of same length.
+    """
+    return b"".join(map(lambda x, y: struct.pack("!B", x | y), s1, s2))
+
+
 def strxor(s1, s2):
     # type: (bytes, bytes) -> bytes
     """
     Returns the binary XOR of the 2 provided strings s1 and s2. s1 and s2
     must be of same length.
     """
-    return b"".join(map(lambda x, y: chb(orb(x) ^ orb(y)), s1, s2))
+    return b"".join(map(lambda x, y: struct.pack("!B", x ^ y), s1, s2))
 
 
 def strand(s1, s2):
@@ -719,7 +728,7 @@ def strand(s1, s2):
     Returns the binary AND of the 2 provided strings s1 and s2. s1 and s2
     must be of same length.
     """
-    return b"".join(map(lambda x, y: chb(orb(x) & orb(y)), s1, s2))
+    return b"".join(map(lambda x, y: struct.pack("!B", x & y), s1, s2))
 
 
 def strrot(s1, count, right=True):
@@ -817,6 +826,93 @@ def ltoa(x):
 def itom(x):
     # type: (int) -> int
     return (0xffffffff00000000 >> x) & 0xffffffff
+
+
+def in4_cidr2mask(m):
+    # type: (int) -> bytes
+    """
+    Return the mask (bitstring) associated with provided length
+    value. For instance if function is called on 20, return value is
+    b'\xff\xff\xf0\x00'.
+    """
+    if m > 32 or m < 0:
+        raise Scapy_Exception("value provided to in4_cidr2mask outside [0, 32] domain (%d)" % m)  # noqa: E501
+
+    return strxor(
+        b"\xff" * 4,
+        struct.pack(">I", 2**(32 - m) - 1)
+    )
+
+
+def in4_isincluded(addr, prefix, mask):
+    # type: (str, str, int) -> bool
+    """
+    Returns True when 'addr' belongs to prefix/mask. False otherwise.
+    """
+    temp = inet_pton(socket.AF_INET, addr)
+    pref = in4_cidr2mask(mask)
+    zero = inet_pton(socket.AF_INET, prefix)
+    return zero == strand(temp, pref)
+
+
+def in4_ismaddr(str):
+    # type: (str) -> bool
+    """
+    Returns True if provided address in printable format belongs to
+    allocated Multicast address space (224.0.0.0/4).
+    """
+    return in4_isincluded(str, '224.0.0.0', 4)
+
+
+def in4_ismlladdr(str):
+    # type: (str) -> bool
+    """
+    Returns True if address belongs to link-local multicast address
+    space (224.0.0.0/24)
+    """
+    return in4_isincluded(str, "224.0.0.0", 24)
+
+
+def in4_ismgladdr(str):
+    # type: (str) -> bool
+    """
+    Returns True if address belongs to global multicast address
+    space (224.0.1.0-238.255.255.255).
+    """
+    return (
+        in4_isincluded(str, "224.0.0.0", 4) and
+        not in4_isincluded(str, "224.0.0.0", 24) and
+        not in4_isincluded(str, "239.0.0.0", 8)
+    )
+
+
+def in4_ismlsaddr(str):
+    # type: (str) -> bool
+    """
+    Returns True if address belongs to limited scope multicast address
+    space (239.0.0.0/8).
+    """
+    return in4_isincluded(str, "239.0.0.0", 8)
+
+
+def in4_isaddrllallnodes(str):
+    # type: (str) -> bool
+    """
+    Returns True if address is the link-local all-nodes multicast
+    address (224.0.0.1).
+    """
+    return (inet_pton(socket.AF_INET, "224.0.0.1") ==
+            inet_pton(socket.AF_INET, str))
+
+
+def in4_getnsmac(a):
+    # type: (bytes) -> str
+    """
+    Return the multicast mac address associated with provided
+    IPv4 address. Passed address must be in network format.
+    """
+
+    return "01:00:5e:%.2x:%.2x:%.2x" % (a[1] & 0x7f, a[2], a[3])
 
 
 def decode_locale_str(x):

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -17,7 +17,11 @@ from scapy.base_classes import Net
 from scapy.data import IPV6_ADDR_GLOBAL, IPV6_ADDR_LINKLOCAL, \
     IPV6_ADDR_SITELOCAL, IPV6_ADDR_LOOPBACK, IPV6_ADDR_UNICAST,\
     IPV6_ADDR_MULTICAST, IPV6_ADDR_6TO4, IPV6_ADDR_UNSPECIFIED
-from scapy.utils import strxor
+from scapy.utils import (
+    strxor,
+    stror,
+    strand,
+)
 from scapy.compat import orb, chb
 from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.volatile import RandMAC, RandBin
@@ -591,18 +595,6 @@ def in6_isanycast(x):  # RFC 2526
         return False
 
 
-def _in6_bitops(xa1, xa2, operator=0):
-    # type: (bytes, bytes, int) -> bytes
-    a1 = struct.unpack('4I', xa1)
-    a2 = struct.unpack('4I', xa2)
-    fop = [lambda x, y: x | y,
-           lambda x, y: x & y,
-           lambda x, y: x ^ y
-           ]
-    ret = map(fop[operator % len(fop)], a1, a2)
-    return b"".join(struct.pack('I', x) for x in ret)
-
-
 def in6_or(a1, a2):
     # type: (bytes, bytes) -> bytes
     """
@@ -610,7 +602,7 @@ def in6_or(a1, a2):
     passed in network format. Return value is also an IPv6 address
     in network format.
     """
-    return _in6_bitops(a1, a2, 0)
+    return stror(a1, a2)
 
 
 def in6_and(a1, a2):
@@ -620,7 +612,7 @@ def in6_and(a1, a2):
     passed in network format. Return value is also an IPv6 address
     in network format.
     """
-    return _in6_bitops(a1, a2, 1)
+    return strand(a1, a2)
 
 
 def in6_xor(a1, a2):
@@ -630,7 +622,7 @@ def in6_xor(a1, a2):
     passed in network format. Return value is also an IPv6 address
     in network format.
     """
-    return _in6_bitops(a1, a2, 2)
+    return strxor(a1, a2)
 
 
 def in6_cidr2mask(m):

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -532,6 +532,28 @@ assert (Ether() / ARP()).route()[0] is not None
 assert (Ether() / ARP()).payload.route()[0] is not None
 assert (ARP(ptype=0, pdst="hello. this isn't a valid IP")).route()[0] is None
 
+= utils/in4_is*
+
+assert in4_ismaddr("224.0.0.1")
+assert not in4_ismaddr("192.168.0.1")
+assert in4_ismaddr("239.0.0.255")
+
+assert in4_ismlladdr("224.0.0.1")
+assert in4_ismlladdr("224.0.0.255")
+assert not in4_ismlladdr("224.0.1.255")
+
+assert in4_ismgladdr("235.0.0.1")
+assert not in4_ismgladdr("224.0.0.1")
+assert not in4_ismgladdr("239.0.0.1")
+
+assert in4_ismlsaddr("239.0.0.1")
+assert not in4_ismlsaddr("224.0.0.1")
+
+assert in4_isaddrllallnodes("224.0.0.1")
+assert not in4_isaddrllallnodes("224.0.0.3")
+
+assert in4_getnsmac(b'\xe0\x00\x00\x01') == '01:00:5e:00:00:01'
+assert getmacbyip("224.0.0.1") == '01:00:5e:00:00:01'
 
 = plain_str test
 
@@ -944,7 +966,7 @@ random.seed(0x2807)
 zerofree_randstring(4) in [b"\xd2\x12\xe4\x5b", b'\xd3\x8b\x13\x12']
 
 = Test strand function
-assert strand("AC", "BC") == b'@C'
+assert strand(b"AC", b"BC") == b'@C'
 
 = Test export_object and import_object functions
 import mock


### PR DESCRIPTION
I think `in6_is*` functions are cool, and it's sad they have no equivalent for IPv4. It also makes the code more readable as those functions are very well documented.

This PR:
- adds `in4_is*` functions that mimic the IPv6 ones in `utils.py`
- cleanup `getmacbyip`. use those functions
- minor cleanups to `utils6.py`