### PR TITLE
setup.cfg: Add PEP 561 py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ doc = [
 
 # setuptools specific
 
+[tool.setuptools.package-data]
+"scapy" = ["py.typed"]
+
 [tool.setuptools.packages.find]
 include = [
     "scapy*",


### PR DESCRIPTION
This is required in order to use mypy with scapy annotations in a dependent project. Otherwise you get messages like these:

error: Skipping analyzing "scapy.packet": module is installed, but missing library stubs or py.typed marker  [import-untyped]