### PR TITLE
Add basic implementation of AUTOSAR SecOC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ all = [
     "matplotlib",
 ]
 doc = [
+    "cryptography>=2.0",
     "sphinx>=7.0.0",
     "sphinx_rtd_theme>=1.3.0",
     "tox>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ all = [
     "matplotlib",
 ]
 doc = [
-    "cryptography>=2.0",
     "sphinx>=7.0.0",
     "sphinx_rtd_theme>=1.3.0",
     "tox>=3.0.0",

--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -9,7 +9,7 @@
 # scapy.contrib.status = loads
 from typing import Tuple, Optional
 from scapy.layers.inet import UDP
-from scapy.fields import IntField, XIntField, PacketListField, LenField
+from scapy.fields import XIntField, PacketListField, LenField
 from scapy.packet import Packet, bind_bottom_up
 
 

--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -9,7 +9,7 @@
 # scapy.contrib.status = loads
 from typing import Tuple, Optional
 from scapy.layers.inet import UDP
-from scapy.fields import IntField, XIntField, PacketListField
+from scapy.fields import IntField, XIntField, PacketListField, LenField
 from scapy.packet import Packet, bind_bottom_up
 
 
@@ -26,7 +26,7 @@ class PDU(Packet):
     name = 'PDU'
     fields_desc = [
         XIntField('pdu_id', 0),
-        IntField('pdu_payload_len', 0)]
+        LenField('pdu_payload_len', 0, fmt="I")]
 
     def extract_padding(self, s):
         # type: (bytes) -> Tuple[bytes, Optional[bytes]]

--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -26,7 +26,7 @@ class PDU(Packet):
     name = 'PDU'
     fields_desc = [
         XIntField('pdu_id', 0),
-        LenField('pdu_payload_len', 0, fmt="I")]
+        LenField('pdu_payload_len', None, fmt="I")]
 
     def extract_padding(self, s):
         # type: (bytes) -> Tuple[bytes, Optional[bytes]]

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -96,7 +96,7 @@ class SecOC_PDU(Packet):
     def get_message_authentication_code(self):
         payload = self.get_secoc_payload()
         key = self.get_secoc_key()
-        freshness_value = self.get_freshness_value()
+        freshness_value = self.get_secoc_freshness_value()
         return self.calculate_cmac(key, payload, freshness_value)
 
     @staticmethod

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -72,7 +72,7 @@ class SecOC_PDU(Packet):
     secoc_protected_pdus_by_identifier: Set[int] = set()
 
     def secoc_authenticate(self) -> None:
-        self.tfv = self.get_secoc_freshness_value()[-1:]
+        self.tfv = struct.unpack(">B", self.get_secoc_freshness_value()[-1:])[0]
         self.tmac = self.get_message_authentication_code()[0:3]
 
     def secoc_verify(self) -> bool:

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -50,9 +50,9 @@ class PduPayloadField(PacketLenField):
         # type: (Optional[Packet], bytes) -> Packet
         try:
             # we want to set parent wherever possible
-            return self.cls(self, m, _parent=pkt)  # type: ignore
+            return self.cls(pkt, m, _parent=pkt)  # type: ignore
         except TypeError:
-            return self.cls(self, m)
+            return self.cls(pkt, m)
 
 
 class SecOC_PDU(Packet):

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -69,7 +69,7 @@ class SecOC_PDU(Packet):
         XByteField("tfv", 0),  # truncated freshness value
         XStrFixedLenField("tmac", None, length=3)]  # truncated message authentication code # noqa: E501
 
-    pdu_payload_cls_by_identifier: Dict[int, Type[Packet]] = defaultdict(Raw)
+    pdu_payload_cls_by_identifier: Dict[int, Type[Packet]] = dict()
     secoc_protected_pdus_by_identifier: Set[int] = set()
 
     def secoc_authenticate(self) -> None:

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -10,7 +10,6 @@
 SecOC
 """
 import struct
-from collections import defaultdict
 
 from cryptography.hazmat.primitives import cmac
 from cryptography.hazmat.primitives.ciphers import algorithms

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -11,8 +11,15 @@ SecOC
 """
 import struct
 
-from cryptography.hazmat.primitives import cmac
-from cryptography.hazmat.primitives.ciphers import algorithms
+from scapy.config import conf
+from scapy.error import log_loading
+
+if conf.crypto_valid:
+    from cryptography.hazmat.primitives import cmac
+    from cryptography.hazmat.primitives.ciphers import algorithms
+else:
+    log_loading.info("Can't import python-cryptography v1.7+. "
+                     "Disabled SecOC calculate_cmac.")
 
 from scapy.base_classes import Packet_metaclass
 from scapy.config import conf

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+
+# scapy.contrib.description = AUTOSAR Secure On-Board Communication
+# scapy.contrib.status = loads
+
+"""
+SecOC
+"""
+from collections import defaultdict
+
+from scapy.fields import (XByteField, X3BytesField, XIntField, PacketListField,
+                          FieldLenField, PacketLenField)
+from scapy.packet import Packet, Raw
+
+# Typing imports
+from typing import (
+    Dict,
+    Optional,
+    Type,
+    Callable,
+    Union,
+    Tuple
+)
+
+
+class PduPayloadField(PacketLenField):
+
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Packet
+                 guess_pkt_cls,  # type: Union[Callable[[Packet, bytes], Packet], Type[Packet]]  # noqa: E501
+                 length_from=None  # type: Optional[Callable[[Packet], int]]  # noqa: E501
+                 ):
+        # type: (...) -> None
+        super(PacketLenField, self).__init__(name, default, guess_pkt_cls)
+        self.length_from = length_from or (lambda x: 0)
+
+    def m2i(self, pkt, m):  # type: ignore
+        # type: (Optional[Packet], bytes) -> Packet
+        try:
+            # we want to set parent wherever possible
+            return self.cls(self, m, _parent=pkt)  # type: ignore
+        except TypeError:
+            return self.cls(self, m)
+
+
+class SecOC_PDU(Packet):
+    name = 'SecOC_PDU'
+    fields_desc = [
+        XIntField('pdu_id', 0),
+        FieldLenField('pdu_payload_len', None,
+                      fmt="I",
+                      length_of="pdu_payload",
+                      adjust=lambda pkt, x: x + 4),
+        PduPayloadField('pdu_payload',
+                        Raw(),
+                        guess_pkt_cls=lambda pkt, data: SecOC_PDU.get_pdu_payload_cls(pkt, data),  # noqa: E501
+                        length_from=lambda pkt: pkt.pdu_payload_len - 4),
+        XByteField("freshness_value", 0),
+        X3BytesField("message_authentication_code", 0)]
+
+    pdu_payload_cls_by_identifier: Dict[int, Type[Packet]] = {}
+    freshness_values_by_identifier: Dict[int, int] = defaultdict(int)
+    secret_keys_by_identifier: Dict[int, bytes] = {}
+
+    def post_dissect(self, s):  # type: (bytes) -> bytes
+        try:
+            SecOC_PDU.freshness_values_by_identifier[self.pdu_id] = self.freshness_value
+        except KeyError:
+            pass
+        return s
+
+    @staticmethod
+    def get_pdu_payload_cls(pkt: Packet,
+                            data: bytes
+                            ) -> Packet:
+        try:
+            cls = SecOC_PDU.pdu_payload_cls_by_identifier[pkt.pdu_id]
+            return cls(data)
+        except Exception:
+            pass
+        return Raw(data)
+
+    def extract_padding(self, s):
+        # type: (bytes) -> Tuple[bytes, Optional[bytes]]
+        return "", s
+
+
+class SecOC_PDUTransport(Packet):
+    """
+    Packet representing SecOC_PDUTransport containing multiple PDUs
+    """
+
+    # TODO: add dict to distinguish between secOC and standard PDU frames
+    name = 'SecOC_PDUTransport'
+    fields_desc = [
+        PacketListField("pdus", [SecOC_PDU()], pkt_cls=SecOC_PDU)
+    ]

--- a/test/contrib/automotive/autosar/pdu.uts
+++ b/test/contrib/automotive/autosar/pdu.uts
@@ -20,7 +20,7 @@ assert p.pdus == [PDU()]
 
 p = PDU()
 assert p.pdu_id == 0
-assert p.pdu_payload_len == 0
+assert p.pdu_payload_len == None
 
 = Build test pdu_id
 p = PDU(bytes(PDU(pdu_id=0x11)))

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -11,7 +11,13 @@
 
 = Load Contrib Layer
 
-load_contrib("automotive.autosar.secoc", globals_dict=globals())
+load_contrib("automotive.autosar.secoc")
+
+= Prepare SecOC keys
+
+SecOC_PDU.secoc_protected_pdus_by_identifier = [0, 1, 2, 3, 17, 18]
+SecOC_PDU.register_secoc_protected_pdu(0xdeadbeef)
+
 
 = Defaults test
 p = SecOC_PDUTransport()
@@ -40,7 +46,7 @@ assert p.pdu_id == 0
 assert p.pdu_payload_len == 12
 assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
 assert p.freshness_value == 0
-assert p.message_authentication_code == 0
+assert p.message_authentication_code == b"\x00\x00\x00"
 
 
 = Build test pdu_payload_len2
@@ -53,7 +59,7 @@ assert p.pdu_id == 0xdeadbeef
 assert p.pdu_payload_len == 12
 assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
 assert p.freshness_value == 42
-assert p.message_authentication_code == 0
+assert p.message_authentication_code == b"\x00\x00\x00"
 assert SecOC_PDU.freshness_values_by_identifier[0xdeadbeef] == 42
 
 
@@ -94,7 +100,7 @@ assert p1 == p2
 
 = Build SecOC_PDUTransport with one SecOC_PDU packet
 p1 = SecOC_PDUTransport(b'\x00\x00\x00\x01\x00\x00\x00\x08\xaa\xaa\xaa\xaa\x11\x22\x33\x44')
-p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(pdus=[SecOC_PDU(pdu_id=0x1, pdu_payload=Raw(b'\xaa\xaa\xaa\xaa'), freshness_value=0x11, message_authentication_code=0x223344)])))
+p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(pdus=[SecOC_PDU(pdu_id=0x1, pdu_payload=Raw(b'\xaa\xaa\xaa\xaa'), freshness_value=0x11, message_authentication_code=b"\x22\x33\x44")])))
 
 # Check if packets are the same
 assert p1 == p2

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -1,0 +1,103 @@
+% Regression tests for the SecOC_PDUTransport / SecOC_PDU layer
+
+
+# More information at http://www.secdev.org/projects/UTscapy/
+
+
+############
+############
+
++ SecOC_PDUTransport contrib tests
+
+= Load Contrib Layer
+
+load_contrib("automotive.autosar.secoc", globals_dict=globals())
+
+= Defaults test
+p = SecOC_PDUTransport()
+p.show()
+assert p.pdus == [SecOC_PDU()]
+
+p = SecOC_PDU()
+assert p.pdu_id == 0
+assert p.pdu_payload_len == None
+
+
+= Build test pdu_id
+p = SecOC_PDU(bytes(SecOC_PDU(pdu_id=0x11)))
+assert len(bytes(p)) == 12
+assert p.pdu_id == 0x11
+assert p.pdu_payload_len == 4
+
+
+= Build test pdu_payload_len
+p1 = bytes(SecOC_PDU(pdu_payload_len=12, pdu_payload=bytes.fromhex("1122334455667788")))
+print(p1.hex())
+p = SecOC_PDU(p1)
+p.show()
+assert len(p) == 20
+assert p.pdu_id == 0
+assert p.pdu_payload_len == 12
+assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
+assert p.freshness_value == 0
+assert p.message_authentication_code == 0
+
+
+= Build test pdu_payload_len2
+p1 = bytes(SecOC_PDU(pdu_id=0xdeadbeef, pdu_payload_len=12, pdu_payload=bytes.fromhex("1122334455667788"), freshness_value=42))
+print(p1.hex())
+p = SecOC_PDU(p1)
+p.show()
+assert len(p) == 20
+assert p.pdu_id == 0xdeadbeef
+assert p.pdu_payload_len == 12
+assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
+assert p.freshness_value == 42
+assert p.message_authentication_code == 0
+assert SecOC_PDU.freshness_values_by_identifier[0xdeadbeef] == 42
+
+
+= Build test id and payload len with data
+p = SecOC_PDU(bytes(SecOC_PDU(pdu_id=0x12, pdu_payload=b'\x22\x33\x22\x33')))
+assert len(p) == 16
+assert p.pdu_id == 0x12
+print(p.pdu_payload)
+p.show()
+assert p.pdu_payload_len == 8
+assert len(p.pdu_payload) == 4
+assert bytes(p.pdu_payload) == b'\x22\x33\x22\x33'
+
+
+= Build SecOC_PDUTransport with multiple SecOC_PDU packets
+p1 = SecOC_PDUTransport(
+    b'\x00\x00\x00\x01\x00\x00\x00\x05\x11\x00\x00\x00\x00'
+    b'\x00\x00\x00\x02\x00\x00\x00\x06\x11\x44\x00\x00\x00\x00'
+    b'\x00\x00\x00\x03\x00\x00\x00\x07\x11\x33\x91\x00\x00\x00\x00')
+
+# Check if fields are set correctly within SecOC_PDU list
+assert p1.pdus[0].pdu_id == 0x1
+assert p1.pdus[0].pdu_payload_len == 5
+assert p1.pdus[1].pdu_id == 0x2
+assert p1.pdus[1].pdu_payload_len == 6
+assert p1.pdus[2].pdu_id == 0x3
+assert p1.pdus[2].pdu_payload_len == 7
+
+p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(
+    pdus=[
+        SecOC_PDU(pdu_id=0x1,pdu_payload_len=5, pdu_payload=Raw(b'\x11')),
+        SecOC_PDU(pdu_id=0x2, pdu_payload_len=6, pdu_payload=Raw(b'\x11\x44')),
+        SecOC_PDU(pdu_id=0x3, pdu_payload_len=7, pdu_payload=Raw(b'\x11\x33\x91'))
+    ])))
+# Check if packets are the same
+assert p1 == p2
+
+
+= Build SecOC_PDUTransport with one SecOC_PDU packet
+p1 = SecOC_PDUTransport(b'\x00\x00\x00\x01\x00\x00\x00\x08\xaa\xaa\xaa\xaa\x11\x22\x33\x44')
+p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(pdus=[SecOC_PDU(pdu_id=0x1, pdu_payload=Raw(b'\xaa\xaa\xaa\xaa'), freshness_value=0x11, message_authentication_code=0x223344)])))
+
+# Check if packets are the same
+assert p1 == p2
+# Check if fields are set correctly within SecOC_PDU list
+assert p1.pdus[0].pdu_id == 0x1
+assert p1.pdus[0].pdu_payload_len == 8

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -25,7 +25,17 @@ class PDU_Payload(Packet):
         ByteField("c", 0)
     ]
 
+
+class PDU_Payload2(Packet):
+    fields_desc = [
+        ByteField("x", 0),
+        ByteField("y", 0),
+        ByteField("z", 0)
+    ]
+
+
 SecOC_PDUTransport.register_secoc_protected_pdu(32, PDU_Payload)
+SecOC_PDUTransport.register_secoc_protected_pdu(64, PDU_Payload2)
 
 
 = Defaults test
@@ -117,7 +127,7 @@ assert p1.pdus[0].pdu_id == 0x1
 assert p1.pdus[0].pdu_payload_len == 8
 
 
-= Build SecOC_PDUTransport with one SecOC_PDU packet
+= Build SecOC_PDUTransport with one SecOC_PDU packet and custom class
 p1 = SecOC_PDUTransport(b'\x00\x00\x00\x20\x00\x00\x00\x07\xaa\xbb\xcc\x11\x22\x33\x44')
 
 # Check if packets are the same
@@ -131,4 +141,54 @@ pdu.show()
 assert pdu.pdu_payload.a == 0xaa
 assert pdu.pdu_payload.b == 0xbb
 assert pdu.pdu_payload.c == 0xcc
+
+
+= Build SecOC_PDUTransport with multiple SecOC_PDU packets
+p1 = SecOC_PDUTransport(bytes.fromhex("00000020 00000007 aabbcc 11223344  00000040 00000007 ddeeff 55667788 000000ff 00000008 01234567 11223344 000000ff 00000008 01234567 11223344"))
+p1.show()
+# Check if packets are the same
+assert p1
+# Check if fields are set correctly within SecOC_PDU list
+assert p1.pdus[0].pdu_id == 0x20
+assert p1.pdus[1].pdu_id == 0x40
+assert p1.pdus[2].pdu_id == 0xff
+assert p1.pdus[3].pdu_id == 0xff
+assert p1.pdus[0].pdu_payload_len == 7
+assert p1.pdus[1].pdu_payload_len == 7
+assert p1.pdus[2].pdu_payload_len == 8
+assert p1.pdus[3].pdu_payload_len == 8
+assert p1.pdus[0].tmac == b"\x22\x33\x44"
+
+try:
+    assert p1.pdus[2].tmac == b"\x22\x33\x44"
+    assert False
+except AttributeError:
+    pass
+
+assert p1.pdus[1].tmac == b"\x66\x77\x88"
+
+pdu = p1.pdus[0]
+pdu.show()
+assert pdu.pdu_payload.a == 0xaa
+assert pdu.pdu_payload.b == 0xbb
+assert pdu.pdu_payload.c == 0xcc
+
+pdu = p1.pdus[1]
+pdu.show()
+assert pdu.pdu_payload.x == 0xdd
+assert pdu.pdu_payload.y == 0xee
+assert pdu.pdu_payload.z == 0xff
+
+pdu = p1.pdus[2]
+assert "PDU" in pdu.__class__.__name__
+assert pdu.payload.__class__.__name__ == "Raw"
+assert pdu.load == bytes.fromhex("0123456711223344")
+
+
+pdu = p1.pdus[3]
+assert "PDU" in pdu.__class__.__name__
+assert pdu.payload.__class__.__name__ == "Raw"
+assert pdu.load == bytes.fromhex("0123456711223344")
+
+
 

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -18,6 +18,15 @@ load_contrib("automotive.autosar.secoc")
 SecOC_PDU.secoc_protected_pdus_by_identifier = {0, 1, 2, 3, 17, 18}
 SecOC_PDU.register_secoc_protected_pdu(0xdeadbeef)
 
+class PDU_Payload(Packet):
+    fields_desc = [
+        ByteField("a", 0),
+        ByteField("b", 0),
+        ByteField("c", 0)
+    ]
+
+SecOC_PDUTransport.register_secoc_protected_pdu(32, PDU_Payload)
+
 
 = Defaults test
 p = SecOC_PDUTransport()
@@ -106,3 +115,20 @@ assert p1 == p2
 # Check if fields are set correctly within SecOC_PDU list
 assert p1.pdus[0].pdu_id == 0x1
 assert p1.pdus[0].pdu_payload_len == 8
+
+
+= Build SecOC_PDUTransport with one SecOC_PDU packet
+p1 = SecOC_PDUTransport(b'\x00\x00\x00\x20\x00\x00\x00\x07\xaa\xbb\xcc\x11\x22\x33\x44')
+
+# Check if packets are the same
+assert p1
+# Check if fields are set correctly within SecOC_PDU list
+assert p1.pdus[0].pdu_id == 0x20
+assert p1.pdus[0].pdu_payload_len == 7
+assert p1.pdus[0].tmac == b"\x22\x33\x44"
+pdu = p1.pdus[0]
+pdu.show()
+assert pdu.pdu_payload.a == 0xaa
+assert pdu.pdu_payload.b == 0xbb
+assert pdu.pdu_payload.c == 0xcc
+

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -15,7 +15,7 @@ load_contrib("automotive.autosar.secoc")
 
 = Prepare SecOC keys
 
-SecOC_PDU.secoc_protected_pdus_by_identifier = [0, 1, 2, 3, 17, 18]
+SecOC_PDU.secoc_protected_pdus_by_identifier = {0, 1, 2, 3, 17, 18}
 SecOC_PDU.register_secoc_protected_pdu(0xdeadbeef)
 
 
@@ -45,12 +45,12 @@ assert len(p) == 20
 assert p.pdu_id == 0
 assert p.pdu_payload_len == 12
 assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
-assert p.freshness_value == 0
-assert p.message_authentication_code == b"\x00\x00\x00"
+assert p.tfv == 0
+assert p.tmac == b"\x00\x00\x00"
 
 
 = Build test pdu_payload_len2
-p1 = bytes(SecOC_PDU(pdu_id=0xdeadbeef, pdu_payload_len=12, pdu_payload=bytes.fromhex("1122334455667788"), freshness_value=42))
+p1 = bytes(SecOC_PDU(pdu_id=0xdeadbeef, pdu_payload_len=12, pdu_payload=bytes.fromhex("1122334455667788"), tfv=42))
 print(p1.hex())
 p = SecOC_PDU(p1)
 p.show()
@@ -58,9 +58,8 @@ assert len(p) == 20
 assert p.pdu_id == 0xdeadbeef
 assert p.pdu_payload_len == 12
 assert bytes(p.pdu_payload) == bytes.fromhex("1122334455667788")
-assert p.freshness_value == 42
-assert p.message_authentication_code == b"\x00\x00\x00"
-assert SecOC_PDU.freshness_values_by_identifier[0xdeadbeef] == 42
+assert p.tfv == 42
+assert p.tmac == b"\x00\x00\x00"
 
 
 = Build test id and payload len with data
@@ -100,7 +99,7 @@ assert p1 == p2
 
 = Build SecOC_PDUTransport with one SecOC_PDU packet
 p1 = SecOC_PDUTransport(b'\x00\x00\x00\x01\x00\x00\x00\x08\xaa\xaa\xaa\xaa\x11\x22\x33\x44')
-p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(pdus=[SecOC_PDU(pdu_id=0x1, pdu_payload=Raw(b'\xaa\xaa\xaa\xaa'), freshness_value=0x11, message_authentication_code=b"\x22\x33\x44")])))
+p2 = SecOC_PDUTransport(bytes(SecOC_PDUTransport(pdus=[SecOC_PDU(pdu_id=0x1, pdu_payload=Raw(b'\xaa\xaa\xaa\xaa'), tfv=0x11, tmac=b"\x22\x33\x44")])))
 
 # Check if packets are the same
 assert p1 == p2


### PR DESCRIPTION
This PR adds a very basic implementation of AUTOSAR SecOC packets.

Basic therefore, because the actual implementation of the message authentication code calculation is left to the user, since there is no standard across OEMs.