### PR TITLE
libpcap: make L3socket send() follow routing

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -746,7 +746,7 @@ def pcap_service_stop(askadmin=True):
 if conf.use_pcap:
     _orig_open_pcap = libpcap.open_pcap
 
-    def open_pcap(iface,  # type: Union[str, NetworkInterface]
+    def open_pcap(device,  # type: Union[str, NetworkInterface]
                   *args,  # type: Any
                   **kargs  # type: Any
                   ):
@@ -754,7 +754,7 @@ if conf.use_pcap:
         """open_pcap: Windows routine for creating a pcap from an interface.
         This function is also responsible for detecting monitor mode.
         """
-        iface = cast(NetworkInterface_Win, resolve_iface(iface))
+        iface = cast(NetworkInterface_Win, resolve_iface(device))
         iface_network_name = iface.network_name
         if not iface:
             raise Scapy_Exception(

--- a/scapy/libs/winpcapy.py
+++ b/scapy/libs/winpcapy.py
@@ -398,6 +398,12 @@ try:
     pcap_statustostr = _lib.pcap_statustostr
     pcap_statustostr.restype = STRING
     pcap_statustostr.argtypes = [c_int]
+
+    # int pcap_set_buffer_size(pcap_t *p, int buffer_size)
+    # set the buffer size for a not-yet-activated capture handle
+    pcap_set_buffer_size = _lib.pcap_set_buffer_size
+    pcap_set_buffer_size.restype = c_int
+    pcap_set_buffer_size.argtypes = [POINTER(pcap_t), c_int]
 except AttributeError:
     pass
 


### PR DESCRIPTION
This makes the L3pcapSocket behave similarly to the other L3*Socket(s).

In a L3 socket, the destination is used to chose the interface to send the packet on. This means that Scapy should be able to created another pcap file descriptor if the currently bound one isn't on the proper interface.
