### PR TITLE
Use Sequence[Packet] in _PacketIterable instead of List

### DIFF
--- a/scapy/plist.py
+++ b/scapy/plist.py
@@ -10,7 +10,7 @@ PacketList: holds several packets and allows to do operations on them.
 
 import os
 from collections import defaultdict
-from typing import NamedTuple
+from typing import Sequence, NamedTuple
 
 from scapy.config import conf
 from scapy.base_classes import (
@@ -780,7 +780,7 @@ class PacketList(_PacketList[Packet],
 
 
 _PacketIterable = Union[
-    List[Packet],
+    Sequence[Packet],
     Packet,
     SetGen[Packet],
     _PacketList[Packet]


### PR DESCRIPTION
The `Sequence` type only requires a read-only list of `Packet` and is covariant. With `List[Packet]` the following simple code fails on mypy:

```
pl = [Ether() / IP() / UDP() for _ in range(10)]
wrpcap("tmp.pcap", pl)
```

This happens because `Packet.__div__` cleverly returns `Self` so `pl` is a `List[Ether]` which is incompatible with `List[Packet]`.

We can't actually turn `_PacketIterable` into `Iterable[Packet]` because `__len__` is used.