### PR TITLE
Add tcp_reassemble function to DoIP

### DIFF
--- a/scapy/contrib/automotive/doip.py
+++ b/scapy/contrib/automotive/doip.py
@@ -38,6 +38,7 @@ from typing import (
     Union,
     Tuple,
     Optional,
+    Dict,
 )
 
 
@@ -259,6 +260,14 @@ class DoIP(Packet):
             return s[:self.payload_length - 4], None
         else:
             return b"", None
+
+    @classmethod
+    def tcp_reassemble(cls, data, metadata, session):
+        # type: (bytes, Dict[str, Any], Dict[str, Any]) -> Optional[Packet]
+        length = struct.unpack("!I", data[4:8])[0] + 8
+        if len(data) == length:
+            return DoIP(data)
+        return None
 
 
 bind_bottom_up(UDP, DoIP, sport=13400)

--- a/test/contrib/automotive/doip.uts
+++ b/test/contrib/automotive/doip.uts
@@ -381,6 +381,20 @@ assert req.hashret() == resp.hashret()
 assert resp[3].answers(req[3])
 assert not req[3].answers(resp[3])
 
+= TCPSession Test
+
+tmp_file = get_temp_file()
+
+wrpcap(tmp_file, [
+    IP(src="10.10.10.10", dst="10.10.10.11") / TCP(sport=61000, seq=1) / DoIP(payload_type=0x8001, payload_length=6) / b"\x3E",
+    IP(src="10.10.10.10", dst="10.10.10.11") / TCP(sport=61000, dport=13400, seq=14) / Raw(load=b"\xff")
+])
+
+pkts = sniff(offline=tmp_file, session=TCPSession)
+assert pkts[0].haslayer(UDS_TP)
+assert pkts[0].service == 0x3E
+
+
 + DoIP Communication tests
 
 = Load libraries


### PR DESCRIPTION
This PR adds the tcp_reassemble function to DoIP in order to support defragmentation of TCPSessions. 