### PR TITLE
DNS - change rr 0 to IANA standard, ALL -> ANY

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -72,7 +72,7 @@ from typing import (
 
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 dnstypes = {
-    0: "ANY",
+    0: "RESERVED",
     1: "A", 2: "NS", 3: "MD", 4: "MF", 5: "CNAME", 6: "SOA", 7: "MB", 8: "MG",
     9: "MR", 10: "NULL", 11: "WKS", 12: "PTR", 13: "HINFO", 14: "MINFO",
     15: "MX", 16: "TXT", 17: "RP", 18: "AFSDB", 19: "X25", 20: "ISDN",
@@ -91,7 +91,7 @@ dnstypes = {
 }
 
 
-dnsqtypes = {251: "IXFR", 252: "AXFR", 253: "MAILB", 254: "MAILA", 255: "ALL"}
+dnsqtypes = {251: "IXFR", 252: "AXFR", 253: "MAILB", 254: "MAILA", 255: "ANY"}
 dnsqtypes.update(dnstypes)
 dnsclasses = {1: 'IN', 2: 'CS', 3: 'CH', 4: 'HS', 255: 'ANY'}
 


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
This PR updates the DNS resource record types:
 - changes `0` to RESERVED, per https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4 and https://www.rfc-editor.org/rfc/rfc6895.html#section-3.1
 - updates ID 255 from `ALL` keyword to `ANY`

my justification for this is:
 - https://www.rfc-editor.org/rfc/rfc6895.html#section-3.1 mentions the QTYPE as `* (ALL/ANY)`. `ANY` is the actual rtype keyword mapped to id 255, and referenced by [`RFC 8482`](https://www.rfc-editor.org/rfc/rfc8482.html)
 - using ALL as an rtype in a query is non-standard and not even supported in Cloudflare DNS API (even though Google DNS will respond to ALL).
 
The current mapping of type `0` is in from the beginning: https://github.com/secdev/scapy/blob/bb2ddd8ef0416706e645595b6b5484ee4f409ad3/scapy/layers/dns.py#L222

[NO_TRAIN]::