### PR TITLE
do not fail on linux < 4.12

### DIFF
--- a/scapy/arch/linux/rtnetlink.py
+++ b/scapy/arch/linux/rtnetlink.py
@@ -715,7 +715,11 @@ def _sr1_rtrequest(pkt: Packet) -> List[Packet]:
     # Configure socket
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 32768)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1048576)
-    sock.setsockopt(SOL_NETLINK, NETLINK_EXT_ACK, 1)
+    try:
+        sock.setsockopt(SOL_NETLINK, NETLINK_EXT_ACK, 1)  # this is only supported after Linux 4.12
+    except OSError:
+        log_loading.warning("Failed to read the routes using RTNETLINK !")
+        return []
     sock.bind((0, 0))  # bind to kernel
     sock.setsockopt(SOL_NETLINK, NETLINK_GET_STRICT_CHK, 1)
     # Request routes


### PR DESCRIPTION
I was getting this error after https://github.com/secdev/scapy/pull/4352 was merged:
```
  File "/usr/lib/python3.11/site-packages/scapy/layers/snmp.py", line 20, in <module>
    from scapy.layers.inet import UDP, IP, ICMP
  File "/usr/lib/python3.11/site-packages/scapy/layers/inet.py", line 20, in <module>
    from scapy.ansmachine import AnsweringMachine
  File "/usr/lib/python3.11/site-packages/scapy/ansmachine.py", line 20, in <module>
    from scapy.arch import get_if_addr
  File "/usr/lib/python3.11/site-packages/scapy/arch/__init__.py", line 189, in <module>
    _set_conf_sockets()  # Apply config
    ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/scapy/config.py", line 826, in _set_conf_sockets
    conf.ifaces.reload()
  File "/usr/lib/python3.11/site-packages/scapy/interfaces.py", line 253, in reload
    self._reload_provs()
  File "/usr/lib/python3.11/site-packages/scapy/interfaces.py", line 249, in _reload_provs
    self._load(prov.reload(), prov)
               ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/scapy/interfaces.py", line 51, in reload
    return self.load()
           ^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/scapy/arch/linux/__init__.py", line 173, in load
    for iface in _get_if_list().values():
                 ^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/scapy/arch/linux/rtnetlink.py", line 790, in _get_if_list
    results = _sr1_rtrequest(
              ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/scapy/arch/linux/rtnetlink.py", line 718, in _sr1_rtrequest
    sock.setsockopt(SOL_NETLINK, NETLINK_EXT_ACK, 1)
OSError: [Errno 92] Protocol not available
```
