### PR TITLE
DNS - correct rr type `0` to be in line with RFC

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -72,7 +72,7 @@ from typing import (
 
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 dnstypes = {
-    0: "ANY",
+    0: "RESERVED",
     1: "A", 2: "NS", 3: "MD", 4: "MF", 5: "CNAME", 6: "SOA", 7: "MB", 8: "MG",
     9: "MR", 10: "NULL", 11: "WKS", 12: "PTR", 13: "HINFO", 14: "MINFO",
     15: "MX", 16: "TXT", 17: "RP", 18: "AFSDB", 19: "X25", 20: "ISDN",


### PR DESCRIPTION
**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

set DNS rr type `0` label to "RESERVED", per latest IANA + RFC
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4

see https://github.com/secdev/scapy/pull/4416#issuecomment-2166780436

[NO_TRAIN]::