### PR TITLE
tests: put LLDPDUPower tests in a separate test set

### DIFF
--- a/test/contrib/lldp.uts
+++ b/test/contrib/lldp.uts
@@ -371,6 +371,7 @@ try:
 except:
     assert False
 
++ Power via MDI
 ~ tshark
 
 = Define check_tshark function


### PR DESCRIPTION
to skip them when tshark isn't installed and `-K tshark` is passed.

Fixes
```
...
Traceback (most recent call last):
...
FileNotFoundError: Could not execute tshark, is it installed?
```

It's a follow-up to a28c08903412e9f21a48c869f3759596015c3383