### PR TITLE
WIP ICMP Extension Header bugfixes

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1003,27 +1003,18 @@ class _ICMPExtensionField(TrailerField):
 
     def getfield(self, pkt, s):
         # RFC4884 section 5.2 says if the ICMP packet length
-        # is >144 then ICMP extensions start at byte 137.
+        # is >144 then ICMP extensions start at least at byte 137.
         if len(pkt.original) < 144:
             return s, None
-        offset = 136 + len(s) - len(pkt.original)
+        if pkt.length == 0:
+            return s, None
+        offset = pkt.length * 4   # original padded datagram len
         data = s[offset:]
         # Validate checksum
         if checksum(data) == data[3:5]:
             return s, None  # failed
         # Dissect
         return s[:offset], ICMPExtension_Header(data)
-
-    def addfield(self, pkt, s, val):
-        if val is None:
-            return s
-        data = bytes(val)
-        # Calc how much padding we need, not how much we deserve
-        pad = 136 - len(pkt.payload) - len(s)
-        if pad < 0:
-            warning("ICMPExtension_Header is after the 136th octet of ICMP.")
-            return data
-        return super(_ICMPExtensionField, self).addfield(pkt, s, b"\x00" * pad + data)
 
 
 class _ICMPExtensionPadField(TrailerField):
@@ -1201,6 +1192,18 @@ class ICMP(Packet):
     post_dissection = _ICMP_extpad_post_dissection
 
     def post_build(self, p, pay):
+        if self.ext is not None and self.extpad in [None, b""]:
+            padding_index = pay.rindex(bytes(self.ext))
+            payload_len = len(pay[:padding_index])
+            padding_len = (4 - payload_len % 4) % 4
+            if payload_len + padding_len < 128:
+                padding_len = 128 - payload_len
+            padding = b"\x00" * padding_len
+            pay = pay[:padding_index] + padding + pay[padding_index:]
+        if self.ext is not None and self.length in [None, 0]:
+            ext_index = pay.rindex(bytes(self.ext))
+            length = len(pay[:ext_index]) // 4
+            p = p[:5] + chb(length) + p[6:]
         p += pay
         if self.chksum is None:
             ck = checksum(p)


### PR DESCRIPTION
Continuing my work with ICMP Extension Header started with this issue GH-4281, I noticed that there are more bugs or missing mechanisms (like GH-4353).

I don't have enough time to do all things at once, also it would be nice to discuss some details during implementation to fulfill your expectations and met coding style.

I started with IPv4 variant, in incoming future it would be necessary to implement similar changes for IPv6.

At this moment I fixed:

- [x] Setting `length` attribute when extension header is present and field is not set.

> The length attribute MUST be specified when the ICMP Extension Structure is appended to the above mentioned ICMP messages.

- [x] Accept payload longer than 128 octets.

> When the ICMP Extension Structure is appended to an ICMP message and that ICMP message contains an "original datagram" field, the "original datagram" field MUST contain at least 128 octets.

To be done:

- [ ] Set IPv6 `length` field.
- [ ] Write tests with more scenarios and longer payloads.

RFC for reference - [RFC 4884: Extended ICMP to Support Multi-Part Messages](https://datatracker.ietf.org/doc/html/rfc4884).