### PR TITLE
[DNS] add NAPTR RRs

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1111,11 +1111,32 @@ class DNSRRTSIG(_DNSRRdummy):
                    ]
 
 
+class DNSRRNAPTR(_DNSRRdummy):
+    name = "DNS NAPTR Record"
+    fields_desc = [DNSStrField("rrname", ""),
+                   ShortEnumField("type", 35, dnstypes),
+                   ShortEnumField("rclass", 1, dnsclasses),
+                   IntField("ttl", 0),
+                   ShortField("rdlen", None),
+                   BitField('order', 0, 16),  # ok
+                   BitField('preference', 0, 16),  # ok
+                   FieldLenField('flags_len', 0, fmt="!B", length_of="flags"),
+                   StrLenField('flags', b"", length_from=lambda pkt: pkt.flags_len),
+                   FieldLenField('service_len', 0, fmt="!B", length_of="services"),
+                   StrLenField('services', b"",
+                               length_from=lambda pkt: pkt.service_len),
+                   FieldLenField('regexp_len', 0, fmt="!B", length_of='regexp'),
+                   StrLenField('regexp', b"", length_from=lambda pkt: pkt.regexp_len),
+                   DNSStrField('replacement', b""),
+                   ]
+
+
 DNSRR_DISPATCHER = {
     6: DNSRRSOA,         # RFC 1035
     13: DNSRRHINFO,      # RFC 1035
     15: DNSRRMX,         # RFC 1035
     33: DNSRRSRV,        # RFC 2782
+    35: DNSRRNAPTR,      # RFC 2915
     41: DNSRROPT,        # RFC 1671
     43: DNSRRDS,         # RFC 4034
     46: DNSRRRSIG,       # RFC 4034

--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1112,22 +1112,23 @@ class DNSRRTSIG(_DNSRRdummy):
 
 
 class DNSRRNAPTR(_DNSRRdummy):
-    name = "DNS NAPTR Record"
+    name = "DNS NAPTR Resource Record"
     fields_desc = [DNSStrField("rrname", ""),
                    ShortEnumField("type", 35, dnstypes),
-                   ShortEnumField("rclass", 1, dnsclasses),
+                   BitField("cacheflush", 0, 1),  # mDNS RFC 6762
+                   BitEnumField("rclass", 1, 15, dnsclasses),
                    IntField("ttl", 0),
                    ShortField("rdlen", None),
-                   BitField('order', 0, 16),  # ok
-                   BitField('preference', 0, 16),  # ok
-                   FieldLenField('flags_len', 0, fmt="!B", length_of="flags"),
-                   StrLenField('flags', b"", length_from=lambda pkt: pkt.flags_len),
-                   FieldLenField('service_len', 0, fmt="!B", length_of="services"),
-                   StrLenField('services', b"",
-                               length_from=lambda pkt: pkt.service_len),
-                   FieldLenField('regexp_len', 0, fmt="!B", length_of='regexp'),
-                   StrLenField('regexp', b"", length_from=lambda pkt: pkt.regexp_len),
-                   DNSStrField('replacement', b""),
+                   ShortField("order", 0),
+                   ShortField("preference", 0),
+                   FieldLenField("flags_len", None, fmt="!B", length_of="flags"),
+                   StrLenField("flags", "", length_from=lambda pkt: pkt.flags_len),
+                   FieldLenField("services_len", None, fmt="!B", length_of="services"),
+                   StrLenField("services", "",
+                               length_from=lambda pkt: pkt.services_len),
+                   FieldLenField("regexp_len", None, fmt="!B", length_of="regexp"),
+                   StrLenField("regexp", "", length_from=lambda pkt: pkt.regexp_len),
+                   DNSStrField("replacement", ""),
                    ]
 
 

--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -273,6 +273,17 @@ assert DNSRR(raw(rr)).rdata == []
 rr = DNSRR(rrname='scapy', type='TXT', rdata=[])
 assert raw(rr) == b
 
+= DNS record type 35 (NAPTR)
+
+b = b'\x00\x00#\x00\x01\x00\x00\x00\x00\x00+\x00\n\x00d\x01u\x07E2U+sip\x1b!^.*$!sip:info@example.com!\x00'
+
+p = DNSRRNAPTR(b)
+assert p.order == 10 and p.preference == 100 and p.flags == b'u' and p.services == b'E2U+sip'
+assert p.regexp == b'!^.*$!sip:info@example.com!' and p.replacement == b'.'
+
+p = DNSRRNAPTR(order=10, preference=100, flags="u", services="E2U+sip", regexp="!^.*$!sip:info@example.com!")
+assert raw(p) == b
+
 = DNS record type 39 (DNAME)
 
 b = b'\x05local\x00\x00\x27\x00\x01\x00\x00\x00\x00\x00\x07\x05local\x00'


### PR DESCRIPTION
I took https://github.com/secdev/scapy/pull/4453, made it consistent with the other RRs, added some tests and fixed a bug those tests exposed (the lengths of "flags", "services" and "regexp" weren't computed correctly when they were instantiated because their default lengths were 0 instead of None)

closes #4453 