### PR TITLE
Refactoring of SecOC Layer and implementation for SecOC over CANFD

### DIFF
--- a/scapy/contrib/automotive/autosar/pdu.py
+++ b/scapy/contrib/automotive/autosar/pdu.py
@@ -36,7 +36,6 @@ class PDU(Packet):
 class PDUTransport(Packet):
     """
     Packet representing PDUTransport containing multiple PDUs
-    FIXME: Support CAN messages as well.
     """
     name = 'PDUTransport'
     fields_desc = [

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -4,13 +4,11 @@
 # Copyright (C) Nils Weiss <nils@we155.de>
 
 # scapy.contrib.description = AUTOSAR Secure On-Board Communication
-# scapy.contrib.status = loads
+# scapy.contrib.status = library
 
 """
 SecOC
 """
-import struct
-
 from scapy.config import conf
 from scapy.error import log_loading
 
@@ -21,74 +19,35 @@ else:
     log_loading.info("Can't import python-cryptography v1.7+. "
                      "Disabled SecOC calculate_cmac.")
 
-from scapy.base_classes import Packet_metaclass
 from scapy.config import conf
-from scapy.contrib.automotive.autosar.pdu import PDU
-from scapy.fields import (XByteField, XIntField, PacketListField,
-                          FieldLenField, PacketLenField, XStrFixedLenField)
+from scapy.fields import PacketLenField
 from scapy.packet import Packet, Raw
 
 # Typing imports
 from typing import (
-    Any,
     Callable,
     Dict,
     Optional,
     Set,
-    Tuple,
     Type,
 )
 
 
-class PduPayloadField(PacketLenField):
-
-    __slots__ = ["guess_pkt_cls"]
-
-    def __init__(self,
-                 name,  # type: str
-                 default,  # type: Packet
-                 guess_pkt_cls,  # type: Callable[[Packet, bytes], Packet]  # noqa: E501
-                 length_from=None  # type: Optional[Callable[[Packet], int]]  # noqa: E501
-                 ):
-        # type: (...) -> None
-        super(PacketLenField, self).__init__(name, default, Raw)
-        self.length_from = length_from or (lambda x: 0)
-        self.guess_pkt_cls = guess_pkt_cls
-
-    def m2i(self, pkt, m):  # type: ignore
-        # type: (Optional[Packet], bytes) -> Packet
-        return self.guess_pkt_cls(pkt, m)
-
-
-class SecOC_PDU(Packet):
-    name = 'SecOC_PDU'
-    fields_desc = [
-        XIntField('pdu_id', 0),
-        FieldLenField('pdu_payload_len', None,
-                      fmt="I",
-                      length_of="pdu_payload",
-                      adjust=lambda pkt, x: x + 4),
-        PduPayloadField('pdu_payload',
-                        Raw(),
-                        guess_pkt_cls=lambda pkt, data: SecOC_PDU.get_pdu_payload_cls(pkt, data),  # noqa: E501
-                        length_from=lambda pkt: pkt.pdu_payload_len - 4),
-        XByteField("tfv", 0),  # truncated freshness value
-        XStrFixedLenField("tmac", None, length=3)]  # truncated message authentication code # noqa: E501
+class SecOCMixin:
 
     pdu_payload_cls_by_identifier: Dict[int, Type[Packet]] = dict()
     secoc_protected_pdus_by_identifier: Set[int] = set()
 
     def secoc_authenticate(self) -> None:
-        self.tfv = struct.unpack(">B", self.get_secoc_freshness_value()[-1:])[0]
-        self.tmac = self.get_message_authentication_code()[0:3]
+        raise NotImplementedError
 
     def secoc_verify(self) -> bool:
-        return self.get_message_authentication_code()[0:3] == self.tmac
+        raise NotImplementedError
 
     def get_secoc_payload(self) -> bytes:
         """Override this method for customization
         """
-        return self.pdu_payload
+        raise NotImplementedError
 
     def get_secoc_key(self) -> bytes:
         """Override this method for customization
@@ -123,56 +82,34 @@ class SecOC_PDU(Packet):
     @classmethod
     def unregister_secoc_protected_pdu(cls, pdu_id: int) -> None:
         cls.secoc_protected_pdus_by_identifier.remove(pdu_id)
-        del cls.secret_keys_by_identifier[pdu_id]
+        del cls.pdu_payload_cls_by_identifier[pdu_id]
 
     @classmethod
-    def dispatch_hook(cls, s=None, *_args, **_kwds):
-        # type: (Optional[bytes], Any, Any) -> Packet_metaclass
-        """dispatch_hook determines if PDU is protected by SecOC.
-        If PDU is protected, SecOC_PDU will be returned, otherwise AutoSAR PDU
-        will be returned.
-        """
-        if s is None:
-            return SecOC_PDU
-        if len(s) < 4:
-            return Raw
-        identifier = struct.unpack('>I', s[0:4])[0]
-        if identifier in cls.secoc_protected_pdus_by_identifier:
-            return SecOC_PDU
-        else:
-            return PDU
-
-    @staticmethod
-    def get_pdu_payload_cls(pkt: Packet,
+    def get_pdu_payload_cls(cls,
+                            pkt: Packet,
                             data: bytes
                             ) -> Packet:
         try:
-            cls = SecOC_PDU.pdu_payload_cls_by_identifier[pkt.pdu_id]
+            klass = cls.pdu_payload_cls_by_identifier[pkt.pdu_id]
         except KeyError:
-            cls = conf.raw_layer
-        return cls(data, _parent=pkt)
-
-    def extract_padding(self, s):
-        # type: (bytes) -> Tuple[bytes, Optional[bytes]]
-        return b"", s
+            klass = conf.raw_layer
+        return klass(data, _parent=pkt)
 
 
-class SecOC_PDUTransport(Packet):
-    """
-    Packet representing SecOC_PDUTransport containing multiple PDUs
-    """
+class PduPayloadField(PacketLenField):
+    __slots__ = ["guess_pkt_cls"]
 
-    name = 'SecOC_PDUTransport'
-    fields_desc = [
-        PacketListField("pdus", [SecOC_PDU()], pkt_cls=SecOC_PDU)
-    ]
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Packet
+                 guess_pkt_cls,  # type: Callable[[Packet, bytes], Packet]  # noqa: E501
+                 length_from=None  # type: Optional[Callable[[Packet], int]]  # noqa: E501
+                 ):
+        # type: (...) -> None
+        super(PacketLenField, self).__init__(name, default, Raw)
+        self.length_from = length_from or (lambda x: 0)
+        self.guess_pkt_cls = guess_pkt_cls
 
-    @staticmethod
-    def register_secoc_protected_pdu(pdu_id: int,
-                                     pdu_payload_cls: Type[Packet] = Raw
-                                     ) -> None:
-        SecOC_PDU.register_secoc_protected_pdu(pdu_id, pdu_payload_cls)
-
-    @staticmethod
-    def unregister_secoc_protected_pdu(pdu_id: int) -> None:
-        SecOC_PDU.unregister_secoc_protected_pdu(pdu_id)
+    def m2i(self, pkt, m):  # type: ignore
+        # type: (Optional[Packet], bytes) -> Packet
+        return self.guess_pkt_cls(pkt, m)

--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -84,17 +84,6 @@ class SecOCMixin:
         cls.secoc_protected_pdus_by_identifier.remove(pdu_id)
         del cls.pdu_payload_cls_by_identifier[pdu_id]
 
-    @classmethod
-    def get_pdu_payload_cls(cls,
-                            pkt: Packet,
-                            data: bytes
-                            ) -> Packet:
-        try:
-            klass = cls.pdu_payload_cls_by_identifier[pkt.pdu_id]
-        except KeyError:
-            klass = conf.raw_layer
-        return klass(data, _parent=pkt)
-
 
 class PduPayloadField(PacketLenField):
     __slots__ = ["guess_pkt_cls"]

--- a/scapy/contrib/automotive/autosar/secoc_canfd.py
+++ b/scapy/contrib/automotive/autosar/secoc_canfd.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+
+# scapy.contrib.description = AUTOSAR Secure On-Board Communication PDUs
+# scapy.contrib.status = loads
+
+"""
+SecOC PDU
+"""
+import struct
+
+from scapy.contrib.automotive.autosar.secoc import SecOCMixin, PduPayloadField
+from scapy.base_classes import Packet_metaclass
+from scapy.fields import (XByteField, FieldLenField, XStrFixedLenField,
+                          FlagsField, XBitField, ShortField)
+from scapy.layers.can import CANFD
+from scapy.packet import Raw
+
+# Typing imports
+from typing import (
+    Any,
+    Optional,
+    Tuple,
+)
+
+
+class SecOC_CANFD(CANFD, SecOCMixin):
+    name = 'SecOC_CANFD'
+    fields_desc = [
+        FlagsField('flags', 0, 3, ['error',
+                                   'remote_transmission_request',
+                                   'extended']),
+        XBitField('identifier', 0, 29),
+        FieldLenField('length', None, length_of='pdu_payload',
+                      fmt='B', adjust=lambda pkt, x: x + 4),
+        FlagsField('fd_flags', 4, 8, [
+            'bit_rate_switch', 'error_state_indicator', 'fd_frame']),
+        ShortField('reserved', 0),
+        PduPayloadField('pdu_payload',
+                        Raw(),
+                        guess_pkt_cls=lambda pkt, data: SecOC_CANFD.get_pdu_payload_cls(pkt, data),  # noqa: E501
+                        length_from=lambda pkt: pkt.length - 4),
+        XByteField("tfv", 0),  # truncated freshness value
+        XStrFixedLenField("tmac", None, length=3)]  # truncated message authentication code # noqa: E501
+
+    def secoc_authenticate(self) -> None:
+        self.tfv = struct.unpack(">B", self.get_secoc_freshness_value()[-1:])[0]
+        self.tmac = self.get_message_authentication_code()[0:3]
+
+    def secoc_verify(self) -> bool:
+        return self.get_message_authentication_code()[0:3] == self.tmac
+
+    def get_secoc_payload(self) -> bytes:
+        """Override this method for customization
+        """
+        return bytes(self.pdu_payload)
+
+    @classmethod
+    def dispatch_hook(cls, s=None, *_args, **_kwds):
+        # type: (Optional[bytes], Any, Any) -> Packet_metaclass
+        """dispatch_hook determines if PDU is protected by SecOC.
+        If PDU is protected, SecOC_PDU will be returned, otherwise AutoSAR PDU
+        will be returned.
+        """
+        if s is None:
+            return SecOC_CANFD
+        if len(s) < 4:
+            return Raw
+        identifier = struct.unpack('>I', s[0:4])[0] & 0x1FFFFFFF
+        if identifier in cls.secoc_protected_pdus_by_identifier:
+            return SecOC_CANFD
+        else:
+            return CANFD
+
+    def extract_padding(self, s):
+        # type: (bytes) -> Tuple[bytes, Optional[bytes]]
+        return b"", s

--- a/scapy/contrib/automotive/autosar/secoc_canfd.py
+++ b/scapy/contrib/automotive/autosar/secoc_canfd.py
@@ -11,12 +11,13 @@ SecOC PDU
 """
 import struct
 
+from scapy.config import conf
 from scapy.contrib.automotive.autosar.secoc import SecOCMixin, PduPayloadField
 from scapy.base_classes import Packet_metaclass
 from scapy.fields import (XByteField, FieldLenField, XStrFixedLenField,
                           FlagsField, XBitField, ShortField)
 from scapy.layers.can import CANFD
-from scapy.packet import Raw
+from scapy.packet import Raw, Packet
 
 # Typing imports
 from typing import (
@@ -73,6 +74,17 @@ class SecOC_CANFD(CANFD, SecOCMixin):
             return SecOC_CANFD
         else:
             return CANFD
+
+    @classmethod
+    def get_pdu_payload_cls(cls,
+                            pkt: Packet,
+                            data: bytes
+                            ) -> Packet:
+        try:
+            klass = cls.pdu_payload_cls_by_identifier[pkt.identifier]
+        except KeyError:
+            klass = conf.raw_layer
+        return klass(data, _parent=pkt)
 
     def extract_padding(self, s):
         # type: (bytes) -> Tuple[bytes, Optional[bytes]]

--- a/scapy/contrib/automotive/autosar/secoc_pdu.py
+++ b/scapy/contrib/automotive/autosar/secoc_pdu.py
@@ -11,6 +11,7 @@ SecOC PDU
 """
 import struct
 
+from scapy.config import conf
 from scapy.contrib.automotive.autosar.secoc import SecOCMixin, PduPayloadField
 from scapy.base_classes import Packet_metaclass
 from scapy.contrib.automotive.autosar.pdu import PDU
@@ -70,6 +71,17 @@ class SecOC_PDU(Packet, SecOCMixin):
             return SecOC_PDU
         else:
             return PDU
+
+    @classmethod
+    def get_pdu_payload_cls(cls,
+                            pkt: Packet,
+                            data: bytes
+                            ) -> Packet:
+        try:
+            klass = cls.pdu_payload_cls_by_identifier[pkt.pdu_id]
+        except KeyError:
+            klass = conf.raw_layer
+        return klass(data, _parent=pkt)
 
     def extract_padding(self, s):
         # type: (bytes) -> Tuple[bytes, Optional[bytes]]

--- a/scapy/contrib/automotive/autosar/secoc_pdu.py
+++ b/scapy/contrib/automotive/autosar/secoc_pdu.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Nils Weiss <nils@we155.de>
+
+# scapy.contrib.description = AUTOSAR Secure On-Board Communication PDUs
+# scapy.contrib.status = loads
+
+"""
+SecOC PDU
+"""
+import struct
+
+from scapy.contrib.automotive.autosar.secoc import SecOCMixin, PduPayloadField
+from scapy.base_classes import Packet_metaclass
+from scapy.contrib.automotive.autosar.pdu import PDU
+from scapy.fields import (XByteField, XIntField, PacketListField,
+                          FieldLenField, XStrFixedLenField)
+from scapy.packet import Packet, Raw
+
+# Typing imports
+from typing import (
+    Any,
+    Optional,
+    Tuple,
+    Type,
+)
+
+
+class SecOC_PDU(Packet, SecOCMixin):
+    name = 'SecOC_PDU'
+    fields_desc = [
+        XIntField('pdu_id', 0),
+        FieldLenField('pdu_payload_len', None,
+                      fmt="I",
+                      length_of="pdu_payload",
+                      adjust=lambda pkt, x: x + 4),
+        PduPayloadField('pdu_payload',
+                        Raw(),
+                        guess_pkt_cls=lambda pkt, data: SecOC_PDU.get_pdu_payload_cls(pkt, data),  # noqa: E501
+                        length_from=lambda pkt: pkt.pdu_payload_len - 4),
+        XByteField("tfv", 0),  # truncated freshness value
+        XStrFixedLenField("tmac", None, length=3)]  # truncated message authentication code # noqa: E501
+
+    def secoc_authenticate(self) -> None:
+        self.tfv = struct.unpack(">B", self.get_secoc_freshness_value()[-1:])[0]
+        self.tmac = self.get_message_authentication_code()[0:3]
+
+    def secoc_verify(self) -> bool:
+        return self.get_message_authentication_code()[0:3] == self.tmac
+
+    def get_secoc_payload(self) -> bytes:
+        """Override this method for customization
+        """
+        return self.pdu_payload
+
+    @classmethod
+    def dispatch_hook(cls, s=None, *_args, **_kwds):
+        # type: (Optional[bytes], Any, Any) -> Packet_metaclass
+        """dispatch_hook determines if PDU is protected by SecOC.
+        If PDU is protected, SecOC_PDU will be returned, otherwise AutoSAR PDU
+        will be returned.
+        """
+        if s is None:
+            return SecOC_PDU
+        if len(s) < 4:
+            return Raw
+        identifier = struct.unpack('>I', s[0:4])[0]
+        if identifier in cls.secoc_protected_pdus_by_identifier:
+            return SecOC_PDU
+        else:
+            return PDU
+
+    def extract_padding(self, s):
+        # type: (bytes) -> Tuple[bytes, Optional[bytes]]
+        return b"", s
+
+
+class SecOC_PDUTransport(Packet):
+    """
+    Packet representing SecOC_PDUTransport containing multiple PDUs
+    """
+
+    name = 'SecOC_PDUTransport'
+    fields_desc = [
+        PacketListField("pdus", [SecOC_PDU()], pkt_cls=SecOC_PDU)
+    ]
+
+    @staticmethod
+    def register_secoc_protected_pdu(pdu_id: int,
+                                     pdu_payload_cls: Type[Packet] = Raw
+                                     ) -> None:
+        SecOC_PDU.register_secoc_protected_pdu(pdu_id, pdu_payload_cls)
+
+    @staticmethod
+    def unregister_secoc_protected_pdu(pdu_id: int) -> None:
+        SecOC_PDU.unregister_secoc_protected_pdu(pdu_id)

--- a/test/contrib/automotive/autosar/secoc.uts
+++ b/test/contrib/automotive/autosar/secoc.uts
@@ -11,7 +11,7 @@
 
 = Load Contrib Layer
 
-load_contrib("automotive.autosar.secoc")
+load_contrib("automotive.autosar.secoc_pdu")
 
 = Prepare SecOC keys
 

--- a/test/scapy/layers/can.uts
+++ b/test/scapy/layers/can.uts
@@ -1484,3 +1484,51 @@ nan = [x for x in li if math.isnan(x)]
 
 assert len(nan) >= 0
 assert abs(len(gz) - len(lz)) < (testlen // 10)
+
++ SECOC CANFD
+
+= Load SecOC_CANFD
+
+load_contrib("automotive.autosar.secoc_canfd", globals_dict=globals())
+
+
+= Test SecOC_CANFD build
+
+#SecOC_CANFD.register_secoc_protected_pdu(0x123)
+
+pkt = SecOC_CANFD(identifier=0x123, pdu_payload=bytes.fromhex("1122334455667788AABBCCDDEEFF0011"))
+pkt.show2()
+canfd = CANFD(bytes(pkt))
+canfd.show2()
+pkt = SecOC_CANFD(bytes(pkt))
+
+assert pkt.identifier == canfd.identifier
+assert pkt.data == canfd.data
+assert pkt.length == canfd.length
+
+SecOC_CANFD.register_secoc_protected_pdu(0x123)
+
+pkt = CANFD(identifier=0x123, data=bytes.fromhex("1122334455667788AABBCCDDEEFF001122334455"))
+canfd = CANFD(bytes(pkt))
+canfd.show2()
+pkt = SecOC_CANFD(bytes(pkt))
+pkt.show2()
+
+assert pkt.identifier == canfd.identifier
+assert bytes(pkt.pdu_payload) == bytes(canfd.data)[:-4]
+assert pkt.length == canfd.length
+assert pkt.tfv == 0x22
+assert pkt.tmac == b"\x33\x44\x55"
+
+pkt.secoc_authenticate()
+
+assert pkt.tfv == 0
+assert pkt.tmac != b"\x33\x44\x55"
+
+if conf.crypto_valid:
+    from cryptography.hazmat.primitives import cmac
+    from cryptography.hazmat.primitives.ciphers import algorithms
+    c = cmac.CMAC(algorithms.AES128(b"\x00" * 16))
+    c.update(bytes.fromhex("1122334455667788AABBCCDDEEFF0011") + bytes.fromhex("00000000"))
+    mac = c.finalize()
+    assert pkt.tmac == mac[:3]


### PR DESCRIPTION
This PR 

- moves the SecOC relevant code into it's own library file.
- adds an Implementation for SecOC over CANFD

