### PR TITLE
Support for Scope Identifiers in IP addresses for multicast/link-local support

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -252,6 +252,31 @@ Now that we know how to manipulate packets. Let's see how to send them. The send
     Sent 1 packets.
     <PacketList: TCP:0 UDP:0 ICMP:0 Other:1>
 
+.. _multicast:
+
+Multicast on layer 3: Scope Identifiers
+---------------------------------------
+
+.. index::
+   single: Multicast
+
+.. note:: This feature is only available since Scapy 2.6.0.
+
+If you try to use multicast addresses (IPv4) or link-local addresses (IPv6), you'll notice that Scapy follows the routing table and takes the first entry. In order to specify which interface to use when looking through the routing table, Scapy supports scope identifiers (similar to RFC6874 but for both IPv6 and IPv4).
+
+.. code:: python
+
+    >>> conf.checkIPaddr = False  # answer IP will be != from the one we requested
+    # send on interface 'eth0'
+    >>> sr(IP(dst="224.0.0.1%eth0")/ICMP(), multi=True)
+    >>> sr(IPv6(dst="ff02::1%eth0")/ICMPv6EchoRequest(), multi=True)
+
+You can use both ``%eth0`` format or ``%15`` (the interface id) format. You can query those using ``conf.ifaces``.
+
+.. note::
+
+   Behind the scene, calling ``IP(dst="224.0.0.1%eth0")`` creates a ``ScopedIP`` object that contains ``224.0.0.1`` on the scope of the interface ``eth0``. If you are using an interface object (for instance ``conf.iface``), you can also craft that object. For instance::
+        >>> pkt = IP(dst=ScopedIP("224.0.0.1", scope=conf.iface))/ICMP()
 
 Fuzzing
 -------
@@ -1488,8 +1513,23 @@ NBNS Query Request (find by NetbiosName)
 
 .. code::
 
-    >>> conf.checkIPaddr = False  # Mandatory because we are using a broadcast destination
+    >>> conf.checkIPaddr = False  # Mandatory because we are using a broadcast destination and receiving unicast
     >>> sr1(IP(dst="192.168.0.255")/UDP()/NBNSHeader()/NBNSQueryRequest(QUESTION_NAME="DC1"))
+
+mDNS Query Request
+------------------
+
+For instance, find all spotify connect devices.
+
+.. code::
+
+    >>> # For interface 'eth0'
+    >>> ans, _ = sr(IPv6(dst="ff02::fb%eth0")/UDP(sport=5353, dport=5353)/DNS(rd=0, qd=[DNSQR(qname='_spotify-connect._tcp.local', qtype="PTR")]), multi=True, timeout=2)
+    >>> ans.show()
+
+.. note::
+
+    As you can see, we used a scope identifier (``%eth0``) to specify on which interface we want to use the above multicast IP.
 
 Advanced traceroute
 -------------------

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -37,8 +37,13 @@ from scapy.pton_ntop import inet_ntop, inet_pton
 from scapy.utils import inet_aton, inet_ntoa, lhex, mac2str, str2mac, EDecimal
 from scapy.utils6 import in6_6to4ExtractAddr, in6_isaddr6to4, \
     in6_isaddrTeredo, in6_ptop, Net6, teredoAddrExtractInfo
-from scapy.base_classes import Gen, Net, BasePacket, Field_metaclass
-from scapy.error import warning
+from scapy.base_classes import (
+    _ScopedIP,
+    BasePacket,
+    Field_metaclass,
+    Net,
+    ScopedIP,
+)
 
 # Typing imports
 from typing import (
@@ -848,7 +853,10 @@ class IPField(Field[Union[str, Net], bytes]):
         # type: (Optional[Packet], Union[AnyStr, List[AnyStr]]) -> Any
         if isinstance(x, bytes):
             x = plain_str(x)  # type: ignore
-        if isinstance(x, str):
+        if isinstance(x, _ScopedIP):
+            return x
+        elif isinstance(x, str):
+            x = ScopedIP(x)
             try:
                 inet_aton(x)
             except socket.error:
@@ -893,6 +901,8 @@ class IPField(Field[Union[str, Net], bytes]):
 
     def i2repr(self, pkt, x):
         # type: (Optional[Packet], Union[str, Net]) -> str
+        if isinstance(x, _ScopedIP) and x.scope:
+            return repr(x)
         r = self.resolve(self.i2h(pkt, x))
         return r if isinstance(r, str) else repr(r)
 
@@ -902,29 +912,16 @@ class IPField(Field[Union[str, Net], bytes]):
 
 
 class SourceIPField(IPField):
-    __slots__ = ["dstname"]
-
-    def __init__(self, name, dstname):
-        # type: (str, Optional[str]) -> None
+    def __init__(self, name):
+        # type: (str) -> None
         IPField.__init__(self, name, None)
-        self.dstname = dstname
 
     def __findaddr(self, pkt):
-        # type: (Packet) -> str
+        # type: (Packet) -> Optional[str]
         if conf.route is None:
             # unused import, only to initialize conf.route
             import scapy.route  # noqa: F401
-        dst = ("0.0.0.0" if self.dstname is None
-               else getattr(pkt, self.dstname) or "0.0.0.0")
-        if isinstance(dst, (Gen, list)):
-            r = {
-                conf.route.route(str(daddr))
-                for daddr in dst
-            }  # type:  Set[Tuple[str, str, str]]
-            if len(r) > 1:
-                warning("More than one possible route for %r" % (dst,))
-            return min(r)[1]
-        return conf.route.route(dst)[1]
+        return pkt.route()[1] or conf.route.route()[1]
 
     def i2m(self, pkt, x):
         # type: (Optional[Packet], Optional[Union[str, Net]]) -> bytes
@@ -945,18 +942,21 @@ class IP6Field(Field[Optional[Union[str, Net6]], bytes]):
         Field.__init__(self, name, default, "16s")
 
     def h2i(self, pkt, x):
-        # type: (Optional[Packet], Optional[str]) -> str
+        # type: (Optional[Packet], Any) -> str
         if isinstance(x, bytes):
             x = plain_str(x)
-        if isinstance(x, str):
+        if isinstance(x, _ScopedIP):
+            return x
+        elif isinstance(x, str):
+            x = ScopedIP(x)
             try:
-                x = in6_ptop(x)
+                x = ScopedIP(in6_ptop(x), scope=x.scope)
             except socket.error:
                 return Net6(x)  # type: ignore
         elif isinstance(x, tuple):
             if len(x) != 2:
                 raise ValueError("Invalid IPv6 format")
-            return Net6(*x)
+            return Net6(*x)  # type: ignore
         elif isinstance(x, list):
             x = [self.h2i(pkt, n) for n in x]
         return x  # type: ignore
@@ -990,6 +990,8 @@ class IP6Field(Field[Optional[Union[str, Net6]], bytes]):
             elif in6_isaddr6to4(x):   # print encapsulated address
                 vaddr = in6_6to4ExtractAddr(x)
                 return "%s [6to4 GW: %s]" % (self.i2h(pkt, x), vaddr)
+            elif isinstance(x, _ScopedIP) and x.scope:
+                return repr(x)
         r = self.i2h(pkt, x)          # No specific information to return
         return r if isinstance(r, str) else repr(r)
 
@@ -999,36 +1001,27 @@ class IP6Field(Field[Optional[Union[str, Net6]], bytes]):
 
 
 class SourceIP6Field(IP6Field):
-    __slots__ = ["dstname"]
-
-    def __init__(self, name, dstname):
-        # type: (str, str) -> None
+    def __init__(self, name):
+        # type: (str) -> None
         IP6Field.__init__(self, name, None)
-        self.dstname = dstname
+
+    def __findaddr(self, pkt):
+        # type: (Packet) -> Optional[str]
+        if conf.route6 is None:
+            # unused import, only to initialize conf.route
+            import scapy.route6  # noqa: F401
+        return pkt.route()[1]
 
     def i2m(self, pkt, x):
         # type: (Optional[Packet], Optional[Union[str, Net6]]) -> bytes
-        if x is None:
-            dst = ("::" if self.dstname is None else
-                   getattr(pkt, self.dstname) or "::")
-            iff, x, nh = conf.route6.route(dst)
+        if x is None and pkt is not None:
+            x = self.__findaddr(pkt)
         return super(SourceIP6Field, self).i2m(pkt, x)
 
     def i2h(self, pkt, x):
         # type: (Optional[Packet], Optional[Union[str, Net6]]) -> str
-        if x is None:
-            if conf.route6 is None:
-                # unused import, only to initialize conf.route6
-                import scapy.route6  # noqa: F401
-            dst = ("::" if self.dstname is None else getattr(pkt, self.dstname))  # noqa: E501
-            if isinstance(dst, (Gen, list)):
-                r = {conf.route6.route(str(daddr))
-                     for daddr in dst}
-                if len(r) > 1:
-                    warning("More than one possible route for %r" % (dst,))
-                x = min(r)[1]
-            else:
-                x = conf.route6.route(dst)[1]
+        if x is None and pkt is not None:
+            x = self.__findaddr(pkt)
         return super(SourceIP6Field, self).i2h(pkt, x)
 
 

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -48,7 +48,7 @@ class HSRPmd5(Packet):
         ByteEnumField("algo", 0, {1: "MD5"}),
         ByteField("padding", 0x00),
         XShortField("flags", 0x00),
-        SourceIPField("sourceip", None),
+        SourceIPField("sourceip"),
         XIntField("keyid", 0x00),
         StrFixedLenField("authdigest", b"\00" * 16, 16)]
 

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -20,7 +20,7 @@ from time import gmtime, strftime
 
 from scapy.arch import get_if_hwaddr
 from scapy.as_resolvers import AS_resolver_riswhois
-from scapy.base_classes import Gen
+from scapy.base_classes import Gen, _ScopedIP
 from scapy.compat import chb, orb, raw, plain_str, bytes_encode
 from scapy.consts import WINDOWS
 from scapy.config import conf
@@ -149,7 +149,7 @@ def neighsol(addr, src, iface, timeout=1, chainCC=0):
 def getmacbyip6(ip6, chainCC=0):
     # type: (str, int) -> Optional[str]
     """
-    Returns the MAC address used to reach a given IPv6 address.
+    Returns the MAC address of the next hop used to reach a given IPv6 address.
 
     neighborCache.get() method is used on instantiated neighbor cache.
     Resolution mechanism is described in associated doc string.
@@ -319,15 +319,18 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
                    ShortField("plen", None),
                    ByteEnumField("nh", 59, ipv6nh),
                    ByteField("hlim", 64),
-                   SourceIP6Field("src", "dst"),  # dst is for src @ selection
+                   SourceIP6Field("src"),
                    DestIP6Field("dst", "::1")]
 
     def route(self):
         """Used to select the L2 address"""
         dst = self.dst
-        if isinstance(dst, Gen):
+        scope = None
+        if isinstance(dst, (Net6, _ScopedIP)):
+            scope = dst.scope
+        if isinstance(dst, (Gen, list)):
             dst = next(iter(dst))
-        return conf.route6.route(dst)
+        return conf.route6.route(dst, dev=scope)
 
     def mysummary(self):
         return "%s > %s (%i)" % (self.src, self.dst, self.nh)

--- a/scapy/libs/ethertypes.py
+++ b/scapy/libs/ethertypes.py
@@ -35,6 +35,8 @@
  */
 """
 
+# To quote Python's get-pip:
+
 # Hi There!
 #
 # You may be wondering what this giant blob of binary data here is, you might

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -61,7 +61,7 @@ QUOTES = [
      "the wires and in the waves.", "Jean-Claude Van Damme"),
     ("We are in France, we say Skappee. OK? Merci.", "Sebastien Chabal"),
     ("Wanna support scapy? Star us on GitHub!", "Satoshi Nakamoto"),
-    ("What is dead may never die!", "Python 2"),
+    ("I'll be back.", "Python 2"),
 ]
 
 

--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -220,7 +220,7 @@ class Route6:
         self.ipv6_ifaces.add(iff)
 
     def route(self, dst="", dev=None, verbose=conf.verb):
-        # type: (str, Optional[Any], int) -> Tuple[str, str, str]
+        # type: (str, Optional[str], int) -> Tuple[str, str, str]
         """
         Provide best route to IPv6 destination address, based on Scapy
         internal routing table content.
@@ -254,7 +254,7 @@ class Route6:
 
         # Choose a valid IPv6 interface while dealing with link-local addresses
         if dev is None and (in6_islladdr(dst) or in6_ismlladdr(dst)):
-            dev = conf.iface  # default interface
+            dev = str(conf.iface)  # default interface
 
             # Check if the default interface supports IPv6!
             if dev not in self.ipv6_ifaces and self.ipv6_ifaces:
@@ -309,7 +309,7 @@ class Route6:
                 if verbose:
                     warning("No route found for IPv6 destination %s "
                             "(no default route?)", dst)
-                return (conf.loopback_name, "::", "::")
+                return (dev or conf.loopback_name, "::", "::")
 
         # Sort with longest prefix first then use metrics as a tie-breaker
         paths.sort(key=lambda x: (-x[0], x[1]))

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -14,6 +14,7 @@ import re
 import socket
 import subprocess
 import time
+import warnings
 
 from scapy.compat import plain_str
 from scapy.data import ETH_P_ALL
@@ -452,12 +453,14 @@ def _send(x,  # type: _PacketIterable
 
 @conf.commands.register
 def send(x,  # type: _PacketIterable
-         iface=None,  # type: Optional[_GlobInterfaceType]
          **kargs  # type: Any
          ):
     # type: (...) -> Optional[PacketList]
     """
     Send packets at layer 3
+
+    This determines the interface (or L2 source to use) based on the routing
+    table: conf.route / conf.route6
 
     :param x: the packets
     :param inter: time (in s) between two packets (default 0)
@@ -467,11 +470,18 @@ def send(x,  # type: _PacketIterable
     :param realtime: check that a packet was sent before sending the next one
     :param return_packets: return the sent packets
     :param socket: the socket to use (default is conf.L3socket(kargs))
-    :param iface: the interface to send the packets on
     :param monitor: (not on linux) send in monitor mode
     :returns: None
     """
-    iface, ipv6 = _interface_selection(iface, x)
+    if "iface" in kargs:
+        # Warn that it isn't used.
+        warnings.warn(
+            "'iface' has no effect on L3 I/O send(). For multicast/link-local "
+            "see https://scapy.readthedocs.io/en/latest/usage.html#multicast",
+            SyntaxWarning,
+        )
+        del kargs["iface"]
+    iface, ipv6 = _interface_selection(x)
     return _send(
         x,
         lambda iface: iface.l3socket(ipv6),
@@ -649,10 +659,7 @@ def _parse_tcpreplay_result(stdout_b, stderr_b, argv):
         return {}
 
 
-def _interface_selection(iface,  # type: Optional[_GlobInterfaceType]
-                         packet  # type: _PacketIterable
-                         ):
-    # type: (...) -> Tuple[NetworkInterface, bool]
+def _interface_selection(packet: _PacketIterable) -> Tuple[NetworkInterface, bool]:
     """
     Select the network interface according to the layer 3 destination
     """
@@ -664,21 +671,17 @@ def _interface_selection(iface,  # type: Optional[_GlobInterfaceType]
             ipv6 = True
         except (ValueError, OSError):
             pass
-    if iface is None:
-        try:
-            iff = resolve_iface(_iff or conf.iface)
-        except AttributeError:
-            iff = None
-        return iff or conf.iface, ipv6
-
-    return resolve_iface(iface), ipv6
+    try:
+        iff = resolve_iface(_iff or conf.iface)
+    except AttributeError:
+        iff = None
+    return iff or conf.iface, ipv6
 
 
 @conf.commands.register
 def sr(x,  # type: _PacketIterable
        promisc=None,  # type: Optional[bool]
        filter=None,  # type: Optional[str]
-       iface=None,  # type: Optional[_GlobInterfaceType]
        nofilter=0,  # type: int
        *args,  # type: Any
        **kargs  # type: Any
@@ -686,8 +689,19 @@ def sr(x,  # type: _PacketIterable
     # type: (...) -> Tuple[SndRcvList, PacketList]
     """
     Send and receive packets at layer 3
+
+    This determines the interface (or L2 source to use) based on the routing
+    table: conf.route / conf.route6
     """
-    iface, ipv6 = _interface_selection(iface, x)
+    if "iface" in kargs:
+        # Warn that it isn't used.
+        warnings.warn(
+            "'iface' has no effect on L3 I/O sr(). For multicast/link-local "
+            "see https://scapy.readthedocs.io/en/latest/usage.html#multicast",
+            SyntaxWarning,
+        )
+        del kargs["iface"]
+    iface, ipv6 = _interface_selection(x)
     s = iface.l3socket(ipv6)(
         promisc=promisc, filter=filter,
         iface=iface, nofilter=nofilter,
@@ -702,7 +716,18 @@ def sr1(*args, **kargs):
     # type: (*Any, **Any) -> Optional[Packet]
     """
     Send packets at layer 3 and return only the first answer
+
+    This determines the interface (or L2 source to use) based on the routing
+    table: conf.route / conf.route6
     """
+    if "iface" in kargs:
+        # Warn that it isn't used.
+        warnings.warn(
+            "'iface' has no effect on L3 I/O sr1(). For multicast/link-local "
+            "see https://scapy.readthedocs.io/en/latest/usage.html#multicast",
+            SyntaxWarning,
+        )
+        del kargs["iface"]
     ans, _ = sr(*args, **kargs)
     if ans:
         return cast(Packet, ans[0][1])
@@ -926,13 +951,23 @@ def srflood(x,  # type: _PacketIterable
     # type: (...) -> Tuple[SndRcvList, PacketList]
     """Flood and receive packets at layer 3
 
+    This determines the interface (or L2 source to use) based on the routing
+    table: conf.route / conf.route6
+
     :param prn:      function applied to packets received
     :param unique:   only consider packets whose print
     :param nofilter: put 1 to avoid use of BPF filters
     :param filter:   provide a BPF filter
-    :param iface:    listen answers only on the given interface
     """
-    iface, ipv6 = _interface_selection(iface, x)
+    if "iface" in kargs:
+        # Warn that it isn't used.
+        warnings.warn(
+            "'iface' has no effect on L3 I/O srflood(). For multicast/link-local "
+            "see https://scapy.readthedocs.io/en/latest/usage.html#multicast",
+            SyntaxWarning,
+        )
+        del kargs["iface"]
+    iface, ipv6 = _interface_selection(x)
     s = iface.l3socket(ipv6)(
         promisc=promisc, filter=filter,
         iface=iface, nofilter=nofilter,
@@ -946,7 +981,6 @@ def srflood(x,  # type: _PacketIterable
 def sr1flood(x,  # type: _PacketIterable
              promisc=None,  # type: Optional[bool]
              filter=None,  # type: Optional[str]
-             iface=None,  # type: Optional[_GlobInterfaceType]
              nofilter=0,  # type: int
              *args,  # type: Any
              **kargs  # type: Any
@@ -954,13 +988,24 @@ def sr1flood(x,  # type: _PacketIterable
     # type: (...) -> Optional[Packet]
     """Flood and receive packets at layer 3 and return only the first answer
 
+    This determines the interface (or L2 source to use) based on the routing
+    table: conf.route / conf.route6
+
     :param prn:      function applied to packets received
     :param verbose:  set verbosity level
     :param nofilter: put 1 to avoid use of BPF filters
     :param filter:   provide a BPF filter
     :param iface:    listen answers only on the given interface
     """
-    iface, ipv6 = _interface_selection(iface, x)
+    if "iface" in kargs:
+        # Warn that it isn't used.
+        warnings.warn(
+            "'iface' has no effect on L3 I/O sr1flood(). For multicast/link-local "
+            "see https://scapy.readthedocs.io/en/latest/usage.html#multicast",
+            SyntaxWarning,
+        )
+        del kargs["iface"]
+    iface, ipv6 = _interface_selection(x)
     s = iface.l3socket(ipv6)(
         promisc=promisc, filter=filter,
         nofilter=nofilter, iface=iface,

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -139,7 +139,7 @@ assert r == b"FOO\x01\x02\x03\x04"
 = SourceIPField
 ~ core field
 defaddr = conf.route.route('0.0.0.0')[1]
-class Test(Packet): fields_desc = [SourceIPField("sourceip", None)]
+class Test(Packet): fields_desc = [SourceIPField("sourceip")]
 
 assert Test().sourceip == defaddr
 assert Test(raw(Test())).sourceip == defaddr

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -63,6 +63,53 @@ if exit_status == 0:
 else:
     assert True
 
+
+= Test scoped interface addresses
+~ linux needs_root
+
+import os
+exit_status = os.system("ip link add name scapy0 type dummy")
+exit_status = os.system("ip link add name scapy1 type dummy")
+exit_status |= os.system("ip addr add 192.0.2.1/24 dev scapy0")
+exit_status |= os.system("ip addr add 192.0.3.1/24 dev scapy1")
+exit_status |= os.system("ip link set scapy0 address 00:01:02:03:04:05 multicast on up")
+exit_status |= os.system("ip link set scapy1 address 06:07:08:09:10:11 multicast on up")
+assert exit_status == 0
+
+conf.ifaces.reload()
+conf.route.resync()
+conf.route6.resync()
+
+conf.route6
+
+try:
+    # IPv4
+    a = Ether()/IP(dst="224.0.0.1%scapy0")
+    assert a[Ether].src == "00:01:02:03:04:05"
+    assert a[IP].src == "192.0.2.1"
+    b = Ether()/IP(dst="224.0.0.1%scapy1")
+    assert b[Ether].src == "06:07:08:09:10:11"
+    assert b[IP].src == "192.0.3.1"
+    c = Ether()/IP(dst="224.0.0.1/24%scapy1")
+    assert c[Ether].src == "06:07:08:09:10:11"
+    assert c[IP].src == "192.0.3.1"
+    # IPv6
+    a = Ether()/IPv6(dst="ff02::fb%scapy0")
+    assert a[Ether].src == "00:01:02:03:04:05"
+    assert a[IPv6].src == "fe80::201:2ff:fe03:405"
+    b = Ether()/IPv6(dst="ff02::fb%scapy1")
+    assert b[Ether].src == "06:07:08:09:10:11"
+    assert b[IPv6].src == "fe80::407:8ff:fe09:1011"
+    c = Ether()/IPv6(dst="ff02::fb/30%scapy1")
+    assert c[Ether].src == "06:07:08:09:10:11"
+    assert c[IPv6].src == "fe80::407:8ff:fe09:1011"
+finally:
+    exit_status = os.system("ip link del scapy0")
+    exit_status = os.system("ip link del scapy1")
+    conf.ifaces.reload()
+    conf.route.resync()
+    conf.route6.resync()
+
 = catch loopback device missing
 ~ linux needs_root
 
@@ -310,7 +357,7 @@ assert test_L3PacketSocket_sendto_python3()
 
 import os
 from scapy.sendrecv import _interface_selection
-assert _interface_selection(None, IP(dst="8.8.8.8")/UDP()) == (conf.iface, False)
+assert _interface_selection(IP(dst="8.8.8.8")/UDP()) == (conf.iface, False)
 exit_status = os.system("ip link add name scapy0 type dummy")
 exit_status = os.system("ip addr add 192.0.2.1/24 dev scapy0")
 exit_status = os.system("ip addr add fc00::/24 dev scapy0")
@@ -318,8 +365,8 @@ exit_status = os.system("ip link set scapy0 up")
 conf.ifaces.reload()
 conf.route.resync()
 conf.route6.resync()
-assert _interface_selection(None, IP(dst="192.0.2.42")/UDP()) == ("scapy0", False)
-assert _interface_selection(None, IPv6(dst="fc00::ae0d")/UDP()) == ("scapy0", True)
+assert _interface_selection(IP(dst="192.0.2.42")/UDP()) == ("scapy0", False)
+assert _interface_selection(IPv6(dst="fc00::ae0d")/UDP()) == ("scapy0", True)
 exit_status = os.system("ip link del name dev scapy0")
 conf.ifaces.reload()
 conf.route.resync()


### PR DESCRIPTION
This PR does a few changes to how Scapy handles IP addresses, in order to properly support link-layer / multicast scopes on L3. In particular:
- add implicit multicast routes in Linux when the interface supports multicast (note: on Windows, those routes are explicitly provided by the OS so no change was required)
- add support for a RFC6874-like scope identifier. One can now do:
```python
pkt1 = IPv6(dst="ff02::fb%eth0")
pkt2 = IPv6(dst="ff02::fb%eth1")
assert pkt1.src != pkt2.src
# etc.
pkt3 = IP(dst="224.0.0.1%eth0")
```
The interface is then taken into account when calling `route()`. This enables support for multicast addresses using L3-functions (send, sr, etc.) as it also automatically choses the correct source addresses.
- The above behavior is allowed through the introduction of a hidden `ScopedIP` (**I'm open to some other name**) class/function that returns a `str` that has a secret `scope` attribute (in order to remember the interface)
- Deprecate the `iface` attribute of L3 functions. It was already mostly doing *nothing*, as L3sockets already implement chosing the proper interface when sending. This was confusing.
- remove the second attribute of `SourceIPField` and `SourceIP6Field`. The code path was generally a duplicate since those packets already implement a `route()` function.

### Demo (see doc)

```python
conf.checkIPaddr = False
sr(IPv6(dst="ff02::2%eth0")/ICMPv6EchoRequest(), multi=True)
sr(IPv6(dst="ff02::2%eth1")/ICMPv6EchoRequest(), multi=True)
```

### Other changes

- extend https://github.com/secdev/scapy/pull/4481 to support scoped identifiers