### PR TITLE
tree-wide: replace utcnow and utcfromtimestamp

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -68,7 +68,7 @@ def _version_from_git_archive():
         return _parse_tag(tag)
     elif tstamp:
         # archived revision is not tagged, use the commit date
-        d = datetime.datetime.utcfromtimestamp(int(tstamp))
+        d = datetime.datetime.fromtimestamp(int(tstamp), datetime.timezone.utc)
         return d.strftime('%Y.%m.%d')
 
     raise ValueError("invalid git archive format")
@@ -162,7 +162,9 @@ def _version():
     # Fallback
     try:
         # last resort, use the modification date of __init__.py
-        d = datetime.datetime.utcfromtimestamp(os.path.getmtime(__file__))
+        d = datetime.datetime.fromtimestamp(
+            os.path.getmtime(__file__), datetime.timezone.utc
+        )
         return d.strftime('%Y.%m.%d')
     except Exception:
         pass

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -434,7 +434,7 @@ class _HTTPContent(Packet):
                     # Add Content-Length anyways
                     val = str(len(self.payload or b""))
                 elif f.name == "Date" and isinstance(self, HTTPResponse):
-                    val = datetime.datetime.utcnow().strftime(
+                    val = datetime.datetime.now(datetime.timezone.utc).strftime(
                         '%a, %d %b %Y %H:%M:%S GMT'
                     )
                 else:

--- a/scapy/layers/kerberos.py
+++ b/scapy/layers/kerberos.py
@@ -2643,7 +2643,7 @@ class KerberosClient(Automaton):
         return kdcreq
 
     def as_req(self):
-        now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+        now_time = datetime.now(timezone.utc).replace(microsecond=0)
 
         kdc_req = self._base_kdc_req(now_time=now_time)
         kdc_req.addresses = [
@@ -2690,7 +2690,7 @@ class KerberosClient(Automaton):
         return asreq
 
     def tgs_req(self):
-        now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+        now_time = datetime.now(timezone.utc).replace(microsecond=0)
 
         kdc_req = self._base_kdc_req(now_time=now_time)
 
@@ -3836,7 +3836,7 @@ class KerberosSSP(SSP):
                 authenticator=EncryptedData(),
             )
             # Build the authenticator
-            now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+            now_time = datetime.now(timezone.utc).replace(microsecond=0)
             Context.KrbSessionKey = Key.random_to_key(
                 self.SKEY_TYPE,
                 os.urandom(16),
@@ -3929,7 +3929,7 @@ class KerberosSSP(SSP):
                 # The client MUST generate an additional AP exchange reply message
                 # exactly as the server would as the final message to send to the
                 # server.
-                now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+                now_time = datetime.now(timezone.utc).replace(microsecond=0)
                 cli_ap_rep = KRB_AP_REP(encPart=EncryptedData())
                 cli_ap_rep.encPart.encrypt(
                     Context.STSessionKey,
@@ -4018,7 +4018,7 @@ class KerberosSSP(SSP):
                 # Required but not provided. Return an error
                 self._setup_u2u()
                 Context.U2U = True
-                now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+                now_time = datetime.now(timezone.utc).replace(microsecond=0)
                 err = KRB_GSSAPI_Token(
                     innerToken=KRB_InnerToken(
                         TOK_ID=b"\x03\x00",
@@ -4039,7 +4039,7 @@ class KerberosSSP(SSP):
                 tkt = ap_req.ticket.encPart.decrypt(self.KEY)
             except ValueError as ex:
                 warning("KerberosSSP: %s (bad KEY?)" % ex)
-                now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+                now_time = datetime.now(timezone.utc).replace(microsecond=0)
                 err = KRB_GSSAPI_Token(
                     innerToken=KRB_InnerToken(
                         TOK_ID=b"\x03\x00",

--- a/scapy/modules/ticketer.py
+++ b/scapy/modules/ticketer.py
@@ -645,7 +645,7 @@ class Ticketer:
         duration = kwargs.get(
             "duration", int(self._prompt("Expires in (h) [10]: ") or "10")
         )
-        now_time = datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc)
+        now_time = datetime.now(timezone.utc).replace(microsecond=0)
         rand = random.SystemRandom()
         key = Key.random_to_key(
             EncryptionType.AES256_CTS_HMAC_SHA1_96, rand.randbytes(32)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -5136,10 +5136,10 @@ assert pl[1][Ether].dst == '00:22:33:44:55:66'
 = _version()
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 version_filename = os.path.join(scapy._SCAPY_PKG_DIR, "VERSION")
-mtime = datetime.utcfromtimestamp(os.path.getmtime(scapy.__file__))
+mtime = datetime.fromtimestamp(os.path.getmtime(scapy.__file__), timezone.utc)
 version = "2.0.0"
 with open(version_filename, "w") as fd:
     fd.write(version)

--- a/test/scapy/layers/kerberos.uts
+++ b/test/scapy/layers/kerberos.uts
@@ -1266,7 +1266,7 @@ def fake_choice(x):
     return x[0]
 
 date_mock = mock.MagicMock()
-date_mock.utcnow.return_value = datetime(2024, 3, 5, 16, 52, 55, 424801)
+date_mock.now.side_effect = lambda tz=None: datetime(2024, 3, 5, 16, 52, 55, 424801, tz)
 
 _patches = [
     # Patch all the random


### PR DESCRIPTION
They were deprecated in https://github.com/python/cpython/issues/103857.

Closes https://github.com/secdev/scapy/issues/4460