### PR TITLE
Use SourceMACField in ICMPv6NDOptSrcLLAddr

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -73,7 +73,14 @@ from scapy.layers.inet import (
     UDP,
     UDPerror,
 )
-from scapy.layers.l2 import CookedLinux, Ether, GRE, Loopback, SNAP
+from scapy.layers.l2 import (
+    CookedLinux,
+    Ether,
+    GRE,
+    Loopback,
+    SNAP,
+    SourceMACField,
+)
 from scapy.packet import bind_layers, Packet, Raw
 from scapy.sendrecv import sendp, sniff, sr, srp1
 from scapy.supersocket import SuperSocket
@@ -1831,7 +1838,7 @@ class ICMPv6NDOptSrcLLAddr(_ICMPv6NDGuessPayload, Packet):
     name = "ICMPv6 Neighbor Discovery Option - Source Link-Layer Address"
     fields_desc = [ByteField("type", 1),
                    ByteField("len", 1),
-                   MACField("lladdr", ETHER_ANY)]
+                   SourceMACField("lladdr")]
 
     def mysummary(self):
         return self.sprintf("%name% %lladdr%")

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -228,8 +228,6 @@ class SourceMACField(MACField):
         # type: (Optional[Packet], Optional[str]) -> str
         if x is None:
             iff = self.getif(pkt)
-            if iff is None:
-                iff = conf.iface
             if iff:
                 x = resolve_iface(iff).mac
             if x is None:


### PR DESCRIPTION
- properly default the lladdr
- it doesn't really make sense to default to `conf.iface` in this case