### PR TITLE
ci: trim the packit config a bit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -23,7 +23,6 @@ actions:
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: tcpdump' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: wireshark' .packit_rpm/scapy.spec"
-    - "sed -i '/^BuildArch/aBuildRequires: python3-tox-current-env' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-mock' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-ipython' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-brotli' .packit_rpm/scapy.spec"
@@ -34,7 +33,6 @@ actions:
     - "sed -i '/^BuildArch/aBuildRequires: python3-zstandard' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: samba' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: samba-client' .packit_rpm/scapy.spec"
-    - "sed -i 's/^\\(TOX_PARALLEL_NO_SPINNER=1 tox\\)/\\1 --current-env/' .config/ci/test.sh"
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
by dropping the tox-current-env kludge. The idea was to bypass virtual environments created by tox and use the system packages directly. It's no longer needed because tox itself isn't run anywhere any more on Packit and UTscapy is used instead.

I saw https://github.com/secdev/scapy/pull/4467/files#diff-847c419a134b4c8abecad34ccc6ceb6438986ec786ab32e848e830355727ded8L120 and was going to tweak the regexp but then I realized that `tox` is no longer used there so the tox-current-env kludge can be safely removed.

It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/7751295/. The fedora-rawhide-i386 job failed but it's unrelated to this change (I opened https://github.com/secdev/scapy/issues/4470)