### PR TITLE
Fix sr() on multiple interfaces and libpcap L3 sockets

### DIFF
--- a/scapy/arch/linux/__init__.py
+++ b/scapy/arch/linux/__init__.py
@@ -57,8 +57,8 @@ from scapy.arch.linux.rtnetlink import (  # noqa: F401
 # Typing imports
 from typing import (
     Any,
-    Callable,
     Dict,
+    List,
     NoReturn,
     Optional,
     Tuple,
@@ -322,6 +322,26 @@ class L2ListenSocket(L2Socket):
 class L3PacketSocket(L2Socket):
     desc = "read/write packets at layer 3 using Linux PF_PACKET sockets"
 
+    def __init__(self,
+                 iface=None,  # type: Optional[Union[str, NetworkInterface]]
+                 type=ETH_P_ALL,  # type: int
+                 promisc=None,  # type: Optional[Any]
+                 filter=None,  # type: Optional[Any]
+                 nofilter=0,  # type: int
+                 monitor=None,  # type: Optional[Any]
+                 ):
+        self.send_socks = {}
+        super(L3PacketSocket, self).__init__(
+            iface=iface,
+            type=type,
+            promisc=promisc,
+            filter=filter,
+            nofilter=nofilter,
+            monitor=monitor,
+        )
+        self.filter = filter
+        self.send_socks = {network_name(self.iface): self}
+
     def recv(self, x=MTU, **kwargs):
         # type: (int, **Any) -> Optional[Packet]
         pkt = SuperSocket.recv(self, x, **kwargs)
@@ -332,38 +352,68 @@ class L3PacketSocket(L2Socket):
 
     def send(self, x):
         # type: (Packet) -> int
+        # Select the file descriptor to send the packet on.
         iff = x.route()[0]
         if iff is None:
             iff = network_name(conf.iface)
-        sdto = (iff, self.type)
-        self.outs.bind(sdto)
-        sn = self.outs.getsockname()
-        ll = lambda x: x  # type: Callable[[Packet], Packet]
         type_x = type(x)
-        if type_x in conf.l3types:
-            sdto = (iff, conf.l3types.layer2num[type_x])
-        if sn[3] in conf.l2types:
-            ll = lambda x: conf.l2types.num2layer[sn[3]]() / x
-        if self.lvl == 3 and not issubclass(self.LL, type_x):
-            warning("Incompatible L3 types detected using %s instead of %s !",
-                    type_x, self.LL)
-            self.LL = type_x
-        sx = raw(ll(x))
-        x.sent_time = time.time()
+        if iff not in self.send_socks:
+            self.send_socks[iff] = L3PacketSocket(
+                iface=iff,
+                type=conf.l3types.layer2num.get(type_x, self.type),
+                filter=self.filter,
+                promisc=self.promisc,
+            )
+        sock = self.send_socks[iff]
+        fd = sock.outs
+        if sock.lvl == 3:
+            if not issubclass(sock.LL, type_x):
+                warning("Incompatible L3 types detected using %s instead of %s !",
+                        type_x, sock.LL)
+                sock.LL = type_x
+        if sock.lvl == 2:
+            sx = bytes(sock.LL() / x)
+        else:
+            sx = bytes(x)
+        # Now send.
         try:
-            return self.outs.sendto(sx, sdto)
+            x.sent_time = time.time()
+        except AttributeError:
+            pass
+        try:
+            return fd.send(sx)
         except socket.error as msg:
             if msg.errno == 22 and len(sx) < conf.min_pkt_size:
-                return self.outs.send(
+                return fd.send(
                     sx + b"\x00" * (conf.min_pkt_size - len(sx))
                 )
             elif conf.auto_fragment and msg.errno == 90:
                 i = 0
                 for p in x.fragment():
-                    i += self.outs.sendto(raw(ll(p)), sdto)
+                    i += fd.send(bytes(self.LL() / p))
                 return i
             else:
                 raise
+
+    @staticmethod
+    def select(sockets, remain=None):
+        # type: (List[SuperSocket], Optional[float]) -> List[SuperSocket]
+        socks = []  # type: List[SuperSocket]
+        for sock in sockets:
+            if isinstance(sock, L3PacketSocket):
+                socks += sock.send_socks.values()
+            else:
+                socks.append(sock)
+        return L2Socket.select(socks, remain=remain)
+
+    def close(self):
+        # type: () -> None
+        if self.closed:
+            return
+        super(L3PacketSocket, self).close()
+        for fd in self.send_socks.values():
+            if fd is not self:
+                fd.close()
 
 
 class VEthPair(object):

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -492,6 +492,8 @@ class IPv46(IP, IPv6):
     This class implements a dispatcher that is used to detect the IP version
     while parsing Raw IP pcap files.
     """
+    name = "IPv4/6"
+
     @classmethod
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         if _pkt:

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1285,7 +1285,7 @@ class AsyncSniffer(object):
                         for p in packets:
                             if lfilter and not lfilter(p):
                                 continue
-                            p.sniffed_on = sniff_sockets[s]
+                            p.sniffed_on = sniff_sockets.get(s, None)
                             # post-processing
                             self.count += 1
                             if store:

--- a/test/sendsniff.uts
+++ b/test/sendsniff.uts
@@ -359,3 +359,39 @@ if conf.use_pypy:
     tap0.close()
 else:
     del tap0
+
+#####
+#####
++ Test sr() on multiple interfaces
+
+= Setup multiple linux interfaces and ranges
+~ linux needs_root dbg
+
+import os
+exit_status = os.system("ip netns add blob0")
+exit_status |= os.system("ip netns add blob1")
+exit_status |= os.system("ip link add name scapy0.0 type veth peer name scapy0.1")
+exit_status |= os.system("ip link add name scapy1.0 type veth peer name scapy1.1")
+exit_status |= os.system("ip link set scapy0.1 netns blob0 up")
+exit_status |= os.system("ip link set scapy1.1 netns blob1 up")
+exit_status |= os.system("ip addr add 100.64.2.1/24 dev scapy0.0")
+exit_status |= os.system("ip addr add 100.64.3.1/24 dev scapy1.0")
+exit_status |= os.system("ip --netns blob0 addr add 100.64.2.2/24 dev scapy0.1")
+exit_status |= os.system("ip --netns blob1 addr add 100.64.3.2/24 dev scapy1.1")
+exit_status |= os.system("ip link set scapy0.0 up")
+exit_status |= os.system("ip link set scapy1.0 up")
+assert exit_status == 0
+
+conf.ifaces.reload()
+conf.route.resync()
+
+try:
+    pkts = sr(IP(dst=["100.64.2.2", "100.64.3.2"])/ICMP(), timeout=1)[0]
+    assert len(pkts) == 2
+    assert pkts[0].answer.src in ["100.64.2.2", "100.64.3.2"]
+    assert pkts[1].answer.src in ["100.64.2.2", "100.64.3.2"]
+finally:
+    e = os.system("ip netns del blob0")
+    e = os.system("ip netns del blob1")
+    conf.ifaces.reload()
+    conf.route.resync()


### PR DESCRIPTION
Currently you can `send()` on multiple interfaces, but not `sr()`.

This PR:

- fixes `sr` on multiple interfaces by allowing `L3socket*` to recursively spawn sockets on other interfaces if necessary
- fixes sending on tun-like interfaces through libpcap
