### PR TITLE
Positional maxsplit is deprecated in 3.13+

### DIFF
--- a/scapy/contrib/rtsp.py
+++ b/scapy/contrib/rtsp.py
@@ -72,7 +72,7 @@ class RTSPRequest(_HTTPContent):
     def do_dissect(self, s):
         first_line, body = _dissect_headers(self, s)
         try:
-            method, uri, version = re.split(rb"\s+", first_line, 2)
+            method, uri, version = re.split(rb"\s+", first_line, maxsplit=2)
             self.setfieldval("Method", method)
             self.setfieldval("Request_Uri", uri)
             self.setfieldval("Version", version)
@@ -116,7 +116,7 @@ class RTSPResponse(_HTTPContent):
     def do_dissect(self, s):
         first_line, body = _dissect_headers(self, s)
         try:
-            Version, Status, Reason = re.split(rb"\s+", first_line, 2)
+            Version, Status, Reason = re.split(rb"\s+", first_line, maxsplit=2)
             self.setfieldval("Version", Version)
             self.setfieldval("Status_Code", Status)
             self.setfieldval("Reason_Phrase", Reason)

--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -529,7 +529,7 @@ class HTTPRequest(_HTTPContent):
         """From the HTTP packet string, populate the scapy object"""
         first_line, body = _dissect_headers(self, s)
         try:
-            Method, Path, HTTPVersion = re.split(br"\s+", first_line, 2)
+            Method, Path, HTTPVersion = re.split(br"\s+", first_line, maxsplit=2)
             self.setfieldval('Method', Method)
             self.setfieldval('Path', Path)
             self.setfieldval('Http_Version', HTTPVersion)
@@ -573,7 +573,7 @@ class HTTPResponse(_HTTPContent):
         ''' From the HTTP packet string, populate the scapy object '''
         first_line, body = _dissect_headers(self, s)
         try:
-            HTTPVersion, Status, Reason = re.split(br"\s+", first_line, 2)
+            HTTPVersion, Status, Reason = re.split(br"\s+", first_line, maxsplit=2)
             self.setfieldval('Http_Version', HTTPVersion)
             self.setfieldval('Status_Code', Status)
             self.setfieldval('Reason_Phrase', Reason)


### PR DESCRIPTION
- positional `maxsplit` for the `re` module functions is deprecated in Python 3.13+: https://docs.python.org/3.13/whatsnew/3.13.html#new-deprecations