### PR TITLE
Add cert.uts and msnrpc.uts to cryptography tests

### DIFF
--- a/test/configs/cryptography.utsc
+++ b/test/configs/cryptography.utsc
@@ -1,16 +1,18 @@
 {
   "testfiles": [
-    "test/scapy/layers/tls/tls*.uts",
+    "test/contrib/macsec.uts",
     "test/scapy/layers/dot11.uts",
     "test/scapy/layers/ipsec.uts",
     "test/scapy/layers/kerberos.uts",
-    "test/contrib/macsec.uts"
+    "test/scapy/layers/msnrpc.uts",
+    "test/scapy/layers/tls/cert.uts",
+    "test/scapy/layers/tls/tls*.uts"
   ],
   "breakfailed": true,
   "onlyfailed": true,
   "preexec": {
     "test/contrib/*.uts": "load_contrib(\"%name%\")",
-    "test/tls*.uts": "load_layer(\"tls\")"
+    "test/scapy/layers/tls/*.uts": "load_layer(\"tls\")"
   },
   "kw_ko": [
     "mock",


### PR DESCRIPTION
- add `cert.uts` and `msnrpc.uts` to cryptography tests
- those tests include, among other things: certificate resign, AES-CFB8, etc.

I'm scared that https://github.com/secdev/scapy/issues/4470 is a regression not caused by us