### PR TITLE
Dot11EltVHTOperation, Dot11EltOBSS and Dot11EltCSA do not use the match_subclass class variable.

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1450,6 +1450,7 @@ class Dot11EltMicrosoftWPA(Dot11EltVendorSpecific):
 
 class Dot11EltCSA(Dot11Elt):
     name = "802.11 CSA Element"
+    match_subclass = True
     fields_desc = [
         ByteEnumField("ID", 37, _dot11_id_enum),
         ByteField("len", 3),
@@ -1463,6 +1464,7 @@ class Dot11EltCSA(Dot11Elt):
 
 class Dot11EltOBSS(Dot11Elt):
     name = "802.11 OBSS Scan Parameters Element"
+    match_subclass = True
     fields_desc = [
         ByteEnumField("ID", 74, _dot11_id_enum),
         ByteField("len", 14),
@@ -1492,6 +1494,7 @@ class Dot11VHTOperationInfo(Packet):
 
 class Dot11EltVHTOperation(Dot11Elt):
     name = "802.11 VHT Operation Element"
+    match_subclass = True
     fields_desc = [
         ByteEnumField("ID", 192, _dot11_id_enum),
         ByteField("len", 5),

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -763,3 +763,18 @@ assert pkt[Dot11EltVHTOperation].VHT_Operation_Info
 assert pkt[Dot11EltVHTOperation].VHT_Operation_Info.channel_width == 1
 assert pkt[Dot11EltVHTOperation].VHT_Operation_Info.channel_center0 == 42
 assert pkt[Dot11EltVHTOperation].VHT_Operation_Info.channel_center1 == 50
+
+= Dot11EltVHTOperation in isolation
+
+pkt = Dot11EltVHTOperation(b'\xc0\x05\x01*2\x00\x00')
+assert pkt[Dot11Elt::{"ID": 192}].len == 5
+
+= Dot11EltOBSS in isolation
+
+pkt = Dot11EltOBSS(b'J\x0e\x14\x00\n\x00,\x01\xc8\x00\x14\x00\x05\x00\x19\x00')
+assert pkt[Dot11Elt::{"ID": 74}].len == 14
+
+= Dot11EltCSA in isolation
+
+pkt = Dot11EltCSA(b'%\x03\x01\x0b\x05')
+assert pkt[Dot11Elt::{"ID": 37}].len == 3


### PR DESCRIPTION
Dot11EltVHTOperation, Dot11EltOBSS and Dot11EltCSA do not use the 'match_subclass' class variable, which seemingly implies that search for the given IE via:

pkt[Dot11Elt::{'ID': <ID>}]

will not work in some cases.

Fix is to enable match_subclass, with additional 'isolation' unit tests added for these IEs.

Fixes broken searching of the three mentioned IEs when searching via the Dot11Elt class.

fixes #4483
