### PR TITLE
Capture a possible ValueError when building the packet signature

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -344,7 +344,7 @@ class Packet_metaclass(type):
                                   default=f.default)
                 for f in dct["fields_desc"]
             ])
-        except (ImportError, AttributeError, KeyError):
+        except (ImportError, AttributeError, KeyError, ValueError):
             pass
         newcls = cast(Type['Packet'], type.__new__(cls, name, bases, dct))
         # Note: below can't be typed because we use attributes


### PR DESCRIPTION
When building Packets with complex field types, such as structures using . as separator in the field name, a ValueError may be raised when trying to build the Signature.

This was encountered during internal development of custom messages for an automotive protocol.
