### PR TITLE
packit: no longer install mock

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -23,7 +23,6 @@ actions:
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: tcpdump' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: wireshark' .packit_rpm/scapy.spec"
-    - "sed -i '/^BuildArch/aBuildRequires: python3-mock' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-ipython' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-brotli' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-can' .packit_rpm/scapy.spec"


### PR DESCRIPTION
because it isn't used anymore.

It's a follow-up to 8ac13e7c15dc77a322959092d5847a1513ac6f33

(It was tested in https://download.copr.fedorainfracloud.org/results/packit/evverx-scapy-2/fedora-40-aarch64/07811671-scapy/builder-live.log.gz)