### PR TITLE
packit: set up OPENSSL_CONF properly

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^# check$/a%check\\n./test/run_tests -c test/configs/linux.utsc -K scanner' .packit_rpm/scapy.spec"
+    - "sed -i '/^# check$/a%check\\nOPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"


### PR DESCRIPTION
openssl got updated on Fedora Rawhide and its defaults are no longer compatible with the test suite. `.config/ci/openssl.py` sets it up and gets the tests to pass there.

Closes https://github.com/secdev/scapy/issues/4470

( it was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/7818676/ )