### PR TITLE
Fix select() on virtualized I/O on Windows

### DIFF
--- a/scapy/automaton.py
+++ b/scapy/automaton.py
@@ -113,6 +113,7 @@ def select_objects(inputs, remain):
             # in very few places but important (e.g. PcapReader), where we have
             # no valid fileno (and will stop on EOFError).
             results.add(i)
+            remain = 0
         else:
             events.append(i.fileno())
     if events:


### PR DESCRIPTION
- cache whether there are still packets in the queue on Windows sockets. This improves select() performance on windows, especially on socket startup
- this is especially critical on virtualized I/O (reproduced in a Windows VM), compared to a real windows machine.

fixes https://github.com/secdev/scapy/issues/4473