### PR TITLE
Fix deprecation warnings in dot15d4 and gtp tests

### DIFF
--- a/test/contrib/gtp.uts
+++ b/test/contrib/gtp.uts
@@ -22,17 +22,17 @@ a = GTPHeader(raw(GTP_U_Header()/GTPPDUSessionContainer(QFI=3)))
 assert isinstance(a, GTP_U_Header)
 assert a[GTP_U_Header].E == 1 and a[GTP_U_Header].next_ex == 0x85
 assert a[GTPPDUSessionContainer].ExtHdrLen == 1
-assert a[GTPPDUSessionContainer].P == 0 and a[GTPPDUSessionContainer].R == 0
+assert a[GTPPDUSessionContainer].PPP == 0 and a[GTPPDUSessionContainer].RQI == 0
 assert a[GTPPDUSessionContainer].QFI == 3
 assert a[GTPPDUSessionContainer].NextExtHdr == 0
 
 = GTP_U_Header with PDU Session Container with QFI/PPI
 
-a = GTPHeader(raw(GTP_U_Header()/GTPPDUSessionContainer(type=0, QFI=3, P=1, PPI=6)))
+a = GTPHeader(raw(GTP_U_Header()/GTPPDUSessionContainer(type=0, QFI=3, PPP=1, PPI=6)))
 assert isinstance(a, GTP_U_Header)
 assert a[GTP_U_Header].E == 1 and a[GTP_U_Header].next_ex == 0x85
 assert a[GTPPDUSessionContainer].ExtHdrLen == 2
-assert a[GTPPDUSessionContainer].P == 1 and a[GTPPDUSessionContainer].R == 0
+assert a[GTPPDUSessionContainer].PPP == 1 and a[GTPPDUSessionContainer].RQI == 0
 assert a[GTPPDUSessionContainer].QFI == 3 and a[GTPPDUSessionContainer].PPI == 6
 assert a[GTPPDUSessionContainer].NextExtHdr == 0
 assert a[GTPPDUSessionContainer].type == 0
@@ -55,7 +55,7 @@ assert isinstance(a[GTP_U_Header].payload, PPP)
 = GTPPDUSessionContainer(), dissect
 h = 'fa163ed6de7bfa163ed82b9408004500008400000000fe114b560a0a2e010a0a2efe086808680070000034ff006000000001fa163e850200ff800000000045000054074d00004001fb490a0a31fe0a0a32010000325600930001c444ca5f00000000759e0a0000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637'
 gtp = Ether(hex_bytes(h))
-gtp[GTP_U_Header].ExtHdrLen == 2 and gtp[GTP_U_Header].padding == b'\x00\x00\x00' and gtp[GTP_U_Header][IP].src == '10.10.49.254' and gtp[GTP_U_Header][IP][ICMP].type == 0 and gtp[GTP_U_Header].type == 0 and gtp[GTP_U_Header].qmp == 0 and gtp[GTP_U_Header].P == 1 and gtp[GTP_U_Header].R == 1 and gtp[GTP_U_Header].QFI == 63 and gtp[GTP_U_Header].PPI == 4
+gtp[GTP_U_Header].ExtHdrLen == 2 and gtp[GTP_U_Header].padding == b'\x00\x00\x00' and gtp[GTP_U_Header][IP].src == '10.10.49.254' and gtp[GTP_U_Header][IP][ICMP].type == 0 and gtp[GTP_U_Header].type == 0 and gtp[GTP_U_Header].QMP == 0 and gtp[GTP_U_Header].PPP == 1 and gtp[GTP_U_Header].RQI == 1 and gtp[GTP_U_Header].QFI == 63 and gtp[GTP_U_Header].PPI == 4
 
 = GTPPDUSessionContainer with padding
 data = b'\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x08\x00E\x00\x00^\x00\x01\x00\x00@\x11|\x8c\x7f\x00\x00\x01\x7f\x00\x00\x01\x08h\x08h\x00J\xed^4\xff\x00:\x00\x00\x00\x00\x00\x00\x00\x85\x04\x08\xbf\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00E\x00\x00&\x00\x01\x00\x00@\x11|\xc4\x7f\x00\x00\x01\x7f\x00\x00\x01\x005\x005\x00\x12\x01^ffffffffff000'

--- a/test/scapy/layers/dot15d4.uts
+++ b/test/scapy/layers/dot15d4.uts
@@ -195,10 +195,10 @@ lowpan_frag_iphc = LoWPAN_IPHC(lowpan_iphc)
 assert IPv6 in lowpan_frag_iphc
 assert lowpan_frag_iphc.load == b'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http'
 
-p = LoWPAN_IPHC(tf=0x0, flowlabel=0x8, _nhField=0x3a, _hopLimit=64)/IPv6(dst="aaaa::11:22ff:fe33:4455", src="aaaa::1")/ICMPv6EchoRequest()
+p = LoWPAN_IPHC(tf=0x0, flowlabel=0x8, nhField=0x3a, hopLimit=64)/IPv6(dst="aaaa::11:22ff:fe33:4455", src="aaaa::1")/ICMPv6EchoRequest()
 p = LoWPAN_IPHC(raw(p))
 assert ICMPv6EchoRequest in p
-assert p.destinyAddr == "aaaa::11:22ff:fe33:4455"
+assert p.dst == "aaaa::11:22ff:fe33:4455"
 
 q = LoWPAN_IPHC(tf=0x0)
 assert raw(q) == b'`\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -356,24 +356,24 @@ assert raw(ipv6_tcp_http) == raw(ipv6)
 = SixLoWPAN - Advanced 1
 
 packet = LoWPAN_IPHC(b"\x7b\x49\x3a\x02\x01\xff\x02\x02\x02\x87\x00\x02\x0b\x00\x00\x00\x00\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x12\x74\x02\x00\x02\x02\x02")
-assert packet._nhField == 0x3a
+assert packet.nhField == 0x3a
 assert packet.src == "::"
 assert packet.dst == "ff02::1:ff02:202"
 
 = SixLoWPAN - Advanced 2
 
 packet = SixLoWPAN(b"\x7b\x49\x3a\x02\x01\xff\x01\x01\x01\x87\x00\x57\xe6\x00\x00\x00\x00\xaa\xaa\x00\x00\x00\x00\x00\x00\x02\x12\x74\x01\x00\x01\x01\x01")
-assert packet._nhField == 0x3a
-assert packet.sourceAddr == "::"
-assert packet.destinyAddr == "ff02::1:ff01:101"
+assert packet.nhField == 0x3a
+assert packet.src == "::"
+assert packet.dst == "ff02::1:ff01:101"
 
 = SixLoWPAN - Advanced 3
 
 packet = Ether()/IP()/UDP()/ZEP2()/Dot15d4(fcf_srcaddrmode=2)/Dot15d4Data(src_addr=0x0)/b"\x7b\x33\x3a\x88\x00\x3c\xb9\x60\x00\x00\x00\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x12\x74\x02\x00\x02\x02\x02\x02\x02\x00\x12\x74\x02\x00\x02\x02\x02\x00\x00\x00\x00\x00\x00"
 packet = Ether(raw(packet))
 packet.show2()
-assert packet.sourceAddr == 'fe80::ff:fe00:0'
-assert packet.destinyAddr == 'fe80::ff:fe00:ffff'
+assert packet[LoWPAN_IPHC].src == 'fe80::ff:fe00:0'
+assert packet[LoWPAN_IPHC].dst == 'fe80::ff:fe00:ffff'
 
 = SixLoWPAN - Using ICMP
 
@@ -390,7 +390,7 @@ assert packet.sam == 0x3
 assert packet.m == False
 assert packet.dac == True
 assert packet.dam == 0x2
-assert packet._nhField == 0x3a
+assert packet.nhField == 0x3a
 
 = LoWPAN_IPHC - Extracted packet
 icmp = Ether()/IP()/UDP()/ZEP2()/Dot15d4(fcf_srcaddrmode=2)/Dot15d4Data(src_addr=0xFFFF)/b"\x7b\x3b\x3a\x01\x86\x00\xd3\xfd\x80\x00\x00\xc8\x00\x05\x7e\x40\x00\x00\x00\x00\x03\x04\x40\xc0\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\xaa\xaa\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x01\x00\x00\x00\x00\x05\x00\x01\x02\x02\x12\x13\xff\xfe\x14\x15\x16\x7b\x66\x6f\x6e\x74\x2d"
@@ -457,10 +457,10 @@ assert packet[IPv6].hlim == 255
 #TODO: Context Test
 
 = SixLoWPAN - Check Source Address
-packet = SixLoWPAN()/LoWPAN_IPHC(sam = 0, sac = 0, destinyAddr='ff02::1a')/IPv6(hlim=65, src="aaaa::1", dst="ff02::1a")/ICMPv6EchoRequest()
+packet = SixLoWPAN()/LoWPAN_IPHC(sam = 0, sac = 0, dst='ff02::1a')/IPv6(hlim=65, src="aaaa::1", dst="ff02::1a")/ICMPv6EchoRequest()
 packet = SixLoWPAN(raw(packet))
-assert packet.sourceAddr == "aaaa::1"
-assert packet.destinyAddr == "ff02::1a"
+assert packet.src == "aaaa::1"
+assert packet.dst == "ff02::1a"
 
 = SixLoWPAN over Ethernet
 # See https://github.com/secdev/scapy/issues/2716
@@ -484,7 +484,7 @@ pkt_2 = Ether(ack_frame)
 pkt_3 = Ether(router_adv)
 
 assert ZEP2 in pkt_1
-assert pkt_1[LoWPAN_IPHC].sourceAddr == "fe80::ff:fe00:5566"
+assert pkt_1[LoWPAN_IPHC].src == "fe80::ff:fe00:5566"
 
 assert ZEP2 in pkt_2
 assert Dot15d4Ack in pkt_2
@@ -507,8 +507,8 @@ assert packet.sam == 0x2
 assert packet.m == 0x0
 assert packet.dac == 0x1
 assert packet.dam == 0x03
-assert packet._nhField == 0x06
-assert packet._hopLimit == 128
+assert packet.nhField == 0x06
+assert packet.hopLimit == 128
 
 = SixLoWPAN - Using ETH 2
 
@@ -524,8 +524,8 @@ assert packet.sam == 0x3
 assert packet.m == 0x0
 assert packet.dac == 0x1
 assert packet.dam == 0x02
-assert packet._nhField == 0x06
-assert packet._hopLimit == 128
+assert packet.nhField == 0x06
+assert packet.hopLimit == 128
 
 = SixLoWPAN - Using ETH 3
 
@@ -540,8 +540,8 @@ assert packet.sam == 0x2
 assert packet.m == 0x0
 assert packet.dac == 0x1
 assert packet.dam == 0x03
-assert packet._nhField == 0x06
-assert packet._hopLimit == 128
+assert packet.nhField == 0x06
+assert packet.hopLimit == 128
 packet.show2()
 
 


### PR DESCRIPTION
(It should hopefully make it easier to flip `-Werror` eventually and spot interesting warnings like
```sh
/builddir/build/BUILD/scapy-2.5.0-build/scapy-2.5.0/scapy/layers/smbserver.py:960: DeprecationWarning: pathlib.PurePath.is_reserved() is deprecated and scheduled for removal in Python 3.15. Use os.path.isreserved() to detect reserved paths on Windows.
  if path.is_reserved():
```
)

Fixes warnings like
```
$ python3 -Werror -Xdev -m scapy.tools.UTscapy -t test/scapy/layers/dot15d4.uts
..
>>> p = LoWPAN_IPHC(tf=0x0, flowlabel=0x8, _nhField=0x3a, _hopLimit=64)/IPv6(dst="aaaa::11:22ff:fe33:4455", src="aaaa::1")/ICMPv6EchoRequest()
scapy-2.5.0/scapy/packet.py:443: DeprecationWarning: _nhField has been deprecated in favor of nhField since 2.4.4 !
  warnings.warn(
scapy-2.5.0/scapy/packet.py:443: DeprecationWarning: _hopLimit has been deprecated in favor of hopLimit since 2.4.4 !
```

It's a follow-up to https://github.com/secdev/scapy/commit/f28c11096c6f641ff5b6f98d9f810ee4909efc0d

Fixes warnings like
```
$ python3 -Werror -Xdev -m scapy.tools.UTscapy -P 'load_contrib("gtp")' -t test/contrib/gtp.uts
...
>>> assert a[GTPPDUSessionContainer].P == 0 and a[GTPPDUSessionContainer].R == 0
scapy-2.5.0/scapy/packet.py:443: DeprecationWarning: P has been deprecated in favor of PPP since 2.4.5 !
  warnings.warn(
scapy-2.5.0/scapy/packet.py:443: DeprecationWarning: R has been deprecated in favor of RQI since 2.4.5 !
  warnings.warn(
```

It's a follow-up to https://github.com/secdev/scapy/commit/dcd54d59c94b83632b74e268e8b14026cbcd67c8