### PR TITLE
fixed a runtime bug when the cert attribute doesn't exists

### DIFF
--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -1006,11 +1006,11 @@ class TLS13Certificate(_TLSHandshake):
         connection_end = self.tls_session.connection_end
         if connection_end == "client":
             if self.certs:
-                sc = [x.cert[1] for x in self.certs]
+                sc = [x.cert[1] for x in self.certs if hasattr(x, 'cert')]
                 self.tls_session.server_certs = sc
         else:
             if self.certs:
-                cc = [x.cert[1] for x in self.certs]
+                cc = [x.cert[1] for x in self.certs if hasattr(x, 'cert')]
                 self.tls_session.client_certs = cc
 
 


### PR DESCRIPTION
When running this test: https://gist.github.com/Frank-Buss/c27c663f79ccd1eeb6d74f7795f8bdde it generates this error:
```
  File "/home/frank/tmp/scapy/scapy/packet.py", line 1883, in getfield_and_val
    raise AttributeError(attr)
AttributeError: cert
```
This PR fixes it. Not sure about the underlying reason, the TLS packets might be broken. Maybe better to fix it elsewhere or show a warning message as well, but this works at least.