### PR TITLE
Fixed wrong IKEv2 gw_id_type in IKEv2_Notify for Redirect Payloads

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -767,7 +767,7 @@ class IKEv2_Notify(IKEv2_Payload):
             MultipleTypeField(
                 [
                     (IPField("gw_id", "127.0.0.1"), lambda x: x.gw_id_type == 1),
-                    (IP6Field("gw_id", "::1"), lambda x: x.gw_id_type == 5),
+                    (IP6Field("gw_id", "::1"), lambda x: x.gw_id_type == 2),
                 ],
                 StrLenField("gw_id", "", length_from=lambda x: x.gw_id_len)
             ),


### PR DESCRIPTION
Pull Request for open Issue: https://github.com/secdev/scapy/issues/4486