### PR TITLE
tests: catch expected DNS deprecation warnings

### DIFF
--- a/test/scapy/layers/dns.uts
+++ b/test/scapy/layers/dns.uts
@@ -481,10 +481,17 @@ conf.max_list_count = old_max_list_count
 # Get through a list (should be pkt.an[0].rdata)
 c = b'\x01\x00^\x00\x00\xfb\x14\x0cv\x8f\xfe(\x08\x00E\x00\x01C\xe3\x91@\x00\xff\x11\xf4u\xc0\xa8\x00\xfe\xe0\x00\x00\xfb\x14\xe9\x14\xe9\x01/L \x00\x00\x84\x00\x00\x00\x00\x04\x00\x00\x00\x00\x05_raop\x04_tcp\x05local\x00\x00\x0c\x00\x01\x00\x00\x11\x94\x00\x1e\x1b140C768FFE28@Freebox Server\xc0\x0c\xc0(\x00\x10\x80\x01\x00\x00\x11\x94\x00\xa0\ttxtvers=1\x08vs=190.9\x04ch=2\x08sr=44100\x05ss=16\x08pw=false\x06et=0,1\x04ek=1\ntp=TCP,UDP\x13am=FreeboxServer1,2\ncn=0,1,2,3\x06md=0,2\x07sf=0x44\x0bft=0xBF0A00\x08sv=false\x07da=true\x08vn=65537\x04vv=2\xc0(\x00!\x80\x01\x00\x00\x00x\x00\x19\x00\x00\x00\x00\x13\x88\x10Freebox-Server-3\xc0\x17\xc1\x04\x00\x01\x80\x01\x00\x00\x00x\x00\x04\xc0\xa8\x00\xfe'
 pkt = Ether(c)
-assert pkt.an.rdata == b'140C768FFE28@Freebox Server._raop._tcp.local.'
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    assert pkt.an.rdata == b'140C768FFE28@Freebox Server._raop._tcp.local.'
+    assert len(w) == 1 and issubclass(w[-1].category, DeprecationWarning)
 
 # Set qd to None (should be qd=[])
-pkt = DNS(qr=1, qd=None, aa=1, rd=1)
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    pkt = DNS(qr=1, qd=None, aa=1, rd=1)
+    assert len(w) == 1 and issubclass(w[-1].category, DeprecationWarning)
+
 pkt = DNS(bytes(pkt))
 assert pkt.qd == []
 


### PR DESCRIPTION
to make it possible to run the tests with `-Werror`.

Fixes
```sh
>>> assert pkt.an.rdata == b'140C768FFE28@Freebox Server._raop._tcp.local.'
Traceback (most recent call last):
  File "<input>", line 2, in <module>
  File "scapy/layers/dns.py", line 1256, in __getattr__
    warnings.warn(
DeprecationWarning: The DNS fields 'qd', 'an', 'ns' and 'ar' are now PacketListField(s) !
```

It's a follow-up to dda902e829a51cc6237e253290c6871f30d7daf3