### PR TITLE
Fix cryptography deprecation warnings

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -63,8 +63,16 @@ from scapy.sendrecv import sniff, sendp
 if conf.crypto_valid:
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
+
+    try:
+        # cryptography > 43.0
+        from cryptography.hazmat.decrepit.ciphers import (
+            algorithms as decrepit_algorithms,
+        )
+    except ImportError:
+        decrepit_algorithms = algorithms
 else:
-    default_backend = Ciphers = algorithms = None
+    default_backend = Ciphers = algorithms = decrepit_algorithms = None
     log_loading.info("Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption. (Dot11)")  # noqa: E501
 
 
@@ -1876,7 +1884,7 @@ class Dot11WEP(Dot11Encrypted):
             key = conf.wepkey
         if key and conf.crypto_valid:
             d = Cipher(
-                algorithms.ARC4(self.iv + key.encode("utf8")),
+                decrepit_algorithms.ARC4(self.iv + key.encode("utf8")),
                 None,
                 default_backend(),
             ).decryptor()
@@ -1901,7 +1909,7 @@ class Dot11WEP(Dot11Encrypted):
             else:
                 icv = p[4:8]
             e = Cipher(
-                algorithms.ARC4(self.iv + key.encode("utf8")),
+                decrepit_algorithms.ARC4(self.iv + key.encode("utf8")),
                 None,
                 default_backend(),
             ).encryptor()

--- a/scapy/layers/kerberos.py
+++ b/scapy/layers/kerberos.py
@@ -3519,7 +3519,12 @@ class KerberosSSP(SSP):
                 tok.root.Data = strrot(Data, tok.root.RRC)
                 return msgs, tok
         elif Context.KrbSessionKey.etype in [23, 24]:  # RC4
-            from scapy.libs.rfc3961 import Hmac_MD5, Cipher, algorithms, _rfc1964pad
+            from scapy.libs.rfc3961 import (
+                Cipher,
+                Hmac_MD5,
+                _rfc1964pad,
+                decrepit_algorithms,
+            )
 
             # Build token
             seq = struct.pack(">I", Context.SendSeqNum)
@@ -3560,7 +3565,7 @@ class KerberosSSP(SSP):
             # 4. Populate token + encrypt
             if confidentiality:
                 # 'encrypt' is requested
-                rc4 = Cipher(algorithms.ARC4(Kcrypt), mode=None).encryptor()
+                rc4 = Cipher(decrepit_algorithms.ARC4(Kcrypt), mode=None).encryptor()
                 tok.root.CONFOUNDER = rc4.update(Confounder)
                 Data = rc4.update(ToEncrypt)
                 # Split encrypted data
@@ -3581,7 +3586,7 @@ class KerberosSSP(SSP):
                 Kseq = Hmac_MD5(Kss).digest(b"\x00\x00\x00\x00")
             Kseq = Hmac_MD5(Kseq).digest(tok.root.SGN_CKSUM)
             # 6. Encrypt 'SND_SEQ'
-            rc4 = Cipher(algorithms.ARC4(Kseq), mode=None).encryptor()
+            rc4 = Cipher(decrepit_algorithms.ARC4(Kseq), mode=None).encryptor()
             tok.root.SND_SEQ = rc4.update(tok.root.SND_SEQ)
             # 7. Include 'InitialContextToken pseudo ASN.1 header'
             tok = KRB_GSSAPI_Token(
@@ -3684,7 +3689,12 @@ class KerberosSSP(SSP):
                     msgs[0].data = Data
                 return msgs
         elif Context.KrbSessionKey.etype in [23, 24]:  # RC4
-            from scapy.libs.rfc3961 import Hmac_MD5, Cipher, algorithms, _rfc1964pad
+            from scapy.libs.rfc3961 import (
+                Cipher,
+                Hmac_MD5,
+                _rfc1964pad,
+                decrepit_algorithms,
+            )
 
             # Drop wrapping
             tok = signature.innerToken
@@ -3703,7 +3713,7 @@ class KerberosSSP(SSP):
                 Kseq = Hmac_MD5(Kss).digest(b"\x00\x00\x00\x00")
             Kseq = Hmac_MD5(Kseq).digest(tok.root.SGN_CKSUM)
             # 2. Decrypt 'SND_SEQ'
-            rc4 = Cipher(algorithms.ARC4(Kseq), mode=None).encryptor()
+            rc4 = Cipher(decrepit_algorithms.ARC4(Kseq), mode=None).encryptor()
             seq = rc4.update(tok.root.SND_SEQ)[:4]
             # 3. Compute the 'Kcrypt' key
             Klocal = strxor(Kss, len(Kss) * b"\xf0")
@@ -3716,7 +3726,7 @@ class KerberosSSP(SSP):
             # 4. Decrypt
             if confidentiality:
                 # 'encrypt' was requested
-                rc4 = Cipher(algorithms.ARC4(Kcrypt), mode=None).encryptor()
+                rc4 = Cipher(decrepit_algorithms.ARC4(Kcrypt), mode=None).encryptor()
                 Confounder = rc4.update(tok.root.CONFOUNDER)
                 Data = rc4.update(ToDecrypt)
                 # Split encrypted data

--- a/scapy/libs/rfc3961.py
+++ b/scapy/libs/rfc3961.py
@@ -878,14 +878,18 @@ class _DES3CBC(_SimplifiedEncryptionProfile):
     def basic_encrypt(cls, key, plaintext):
         # type: (bytes, bytes) -> bytes
         assert len(plaintext) % 8 == 0
-        des3 = Cipher(algorithms.TripleDES(key), modes.CBC(b"\0" * 8)).encryptor()
+        des3 = Cipher(
+            decrepit_algorithms.TripleDES(key), modes.CBC(b"\0" * 8)
+        ).encryptor()
         return des3.update(bytes(plaintext))
 
     @classmethod
     def basic_decrypt(cls, key, ciphertext):
         # type: (bytes, bytes) -> bytes
         assert len(ciphertext) % 8 == 0
-        des3 = Cipher(algorithms.TripleDES(key), modes.CBC(b"\0" * 8)).decryptor()
+        des3 = Cipher(
+            decrepit_algorithms.TripleDES(key), modes.CBC(b"\0" * 8)
+        ).decryptor()
         return des3.update(bytes(ciphertext))
 
 
@@ -1083,7 +1087,7 @@ class _RC4(_EncryptionAlgorithmProfile):
         else:
             kie = ki
         ke = Hmac_MD5(kie).digest(cksum)
-        rc4 = Cipher(algorithms.ARC4(ke), mode=None).decryptor()
+        rc4 = Cipher(decrepit_algorithms.ARC4(ke), mode=None).decryptor()
         basic_plaintext = rc4.update(bytes(basic_ctext))
         exp_cksum = Hmac_MD5(ki).digest(basic_plaintext)
         ok = _mac_equal(cksum, exp_cksum)


### PR DESCRIPTION
Updates to use the decrepit module from cryptography when available (for 43+)

fixes https://github.com/secdev/scapy/issues/4508