### PR TITLE
Remove weird un-scapy like default for Ether

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1666,7 +1666,7 @@ class DNS_am(AnsweringMachine):
                 resp[Ether].src, resp[Ether].dst = None, req[Ether].src
             else:
                 resp[Ether].src, resp[Ether].dst = (
-                    None if req[Ether].dst in "ff:ff:ff:ff:ff:ff" else req[Ether].dst,
+                    None if req[Ether].dst == "ff:ff:ff:ff:ff:ff" else req[Ether].dst,
                     req[Ether].src,
                 )
         from scapy.layers.inet6 import IPv6

--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -195,7 +195,7 @@ class DestMACField(MACField):
     def i2h(self, pkt, x):
         # type: (Optional[Packet], Optional[str]) -> str
         if x is None and pkt is not None:
-            x = "None (resolved on build)"
+            x = None
         return super(DestMACField, self).i2h(pkt, x)
 
     def i2m(self, pkt, x):


### PR DESCRIPTION
- it feels really weird for `Ether().dst` to be weird shit. Just return `None` it's fine.