### PR TITLE
Decrypt TLS messages if a private key is available

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -1108,6 +1108,8 @@ class Conf(ConfClass):
     )
     #: Dictionary containing parsed NSS Keys
     tls_nss_keys: Dict[str, bytes] = None
+    #: PrivKeyRSA object used to decrypt TLS sessions
+    tls_rsa_private_key = None
     #: When TCPSession is used, parse DCE/RPC sessions automatically.
     #: This should be used for passive sniffing.
     dcerpc_session_enable = False

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -22,6 +22,7 @@ from scapy.pton_ntop import inet_pton
 from scapy.sessions import TCPSession
 from scapy.utils import repr_hex, strxor
 from scapy.layers.inet import TCP
+from scapy.layers.tls.cert import PrivKeyRSA
 from scapy.layers.tls.crypto.compression import Comp_NULL
 from scapy.layers.tls.crypto.hkdf import TLS13_HKDF
 from scapy.layers.tls.crypto.prf import PRF
@@ -1027,6 +1028,8 @@ class _GenericTLSSessionInheritance(Packet):
                     if s:
                         if conf.tls_nss_keys is not None:
                             s.nss_keys = conf.tls_nss_keys
+                        if isinstance(conf.tls_rsa_private_key, PrivKeyRSA):
+                            s.server_rsa_key = conf.tls_rsa_private_key
                         if s.dport == self.tls_session.dport:
                             self.tls_session = s
                         else:
@@ -1034,6 +1037,8 @@ class _GenericTLSSessionInheritance(Packet):
                     else:
                         if conf.tls_nss_keys is not None:
                             self.tls_session.nss_keys = conf.tls_nss_keys
+                        if isinstance(conf.tls_rsa_private_key, PrivKeyRSA):
+                            self.tls_session.server_rsa_key = conf.tls_rsa_private_key
                         conf.tls_sessions.add(self.tls_session)
             if self.tls_session.connection_end == "server":
                 srk = conf.tls_sessions.server_rsa_key

--- a/test/scapy/layers/tls/tls.uts
+++ b/test/scapy/layers/tls/tls.uts
@@ -1586,6 +1586,18 @@ assert b"z2|gxarIKOxt,G1d>.Q2MzGY[k@" in packets[13].msg[0].data
 
 conf = bck_conf
 
+= pcap file & a RSA private key
+
+bck_conf = conf
+conf.tls_session_enable = True
+conf.tls_rsa_private_key = scapy_path("test/scapy/layers/tls/pki/srv_key.pem")
+
+packets = rdpcap(scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.pcap"))
+assert b"GET /secret.txt HTTP/1.0\n" in packets[11].msg[0].data
+assert b"z2|gxarIKOxt,G1d>.Q2MzGY[k@" in packets[13].msg[0].data
+
+conf = bck_conf
+
 = pcapng file with a Decryption Secrets Block
 ~ tshark linux
 


### PR DESCRIPTION
This PR adds a convenient way to decrypt TLS messages using a RSA private key.