### PR TITLE
Fix crash with StreamSocket and TLS

### DIFF
--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -1167,8 +1167,11 @@ class _GenericTLSSessionInheritance(Packet):
             length = struct.unpack("!H", data[3:5])[0] + 5
             if len(data) >= length:
                 # get the underlayer as it is used to populate tls_session
-                underlayer = metadata["original"][TCP].copy()
-                underlayer.remove_payload()
+                if metadata.get("original", None) is None:
+                    underlayer = TCP()
+                else:
+                    underlayer = metadata["original"][TCP].copy()
+                    underlayer.remove_payload()
                 # eventually get the tls_session now for TLS.dispatch_hook
                 tls_session = None
                 if conf.tls_session_enable:

--- a/scapy/layers/tls/session.py
+++ b/scapy/layers/tls/session.py
@@ -1167,11 +1167,10 @@ class _GenericTLSSessionInheritance(Packet):
             length = struct.unpack("!H", data[3:5])[0] + 5
             if len(data) >= length:
                 # get the underlayer as it is used to populate tls_session
-                if metadata.get("original", None) is None:
-                    underlayer = TCP()
-                else:
-                    underlayer = metadata["original"][TCP].copy()
-                    underlayer.remove_payload()
+                if "original" not in metadata:
+                    return cls(data)
+                underlayer = metadata["original"][TCP].copy()
+                underlayer.remove_payload()
                 # eventually get the tls_session now for TLS.dispatch_hook
                 tls_session = None
                 if conf.tls_session_enable:


### PR DESCRIPTION
Bug found during ScapyCon. Is it worth a test?

This script crashes before applying the PR:
```
import socket

from scapy.all import *


load_layer("tls")

sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.connect(("secdev.org", 443))

ssck = StreamSocket(sock, TLS)

ssck.send(TLS(msg=TLSClientHello()))
msg = ssck.recv()
msg.show()
```