### PR TITLE
tests: filter out non-ICMP packets in the tun test

### DIFF
--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -96,7 +96,7 @@ conf.route6.resync()
 def cb():
     send(IP(dst="192.0.2.2")/ICMP(seq=(1,3)))
 
-t = AsyncSniffer(opened_socket=tun0, lfilter=lambda x: IP in x, started_callback=cb, count=3)
+t = AsyncSniffer(opened_socket=tun0, lfilter=lambda x: ICMP in x, started_callback=cb, count=3)
 t.start()
 t.join(timeout=3)
 


### PR DESCRIPTION
When systemd-resolved with its LLMNR/mDNS responders enabled is run it starts sending its probes as soon as the tun interface pops up:
```
00:36:36.643708 IP c > igmp.mcast.net: igmp v3 report, 2 group record(s)
00:36:36.644530 IP c.mdns > mdns.mcast.net.mdns: 0 [1n] ANY (QM)? c.local. (44)
00:36:36.645307 IP c.llmnr > 224.0.0.252.llmnr: UDP, length 22
```
and that interferes with the test. Since the test is interested in ICMP packets only it can safely skip everything else.

Fixes:
```
 #(006)=[failed] Send ping packets from Linux into Scapy
 ...
 assert len(icmp4_sequences) == 3
 AssertionError
```

(The tap test seems to fail too but as far as I can see it has something to do with cd01ec12 (according to `git bisect`). I'll try to take a closer look later. As far as I can tell src candidates in `conf.route6` are different from what the test expects there)