### PR TITLE
Fix corruption of certain packets containing invalid TLS extension fields

### DIFF
--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -843,6 +843,6 @@ class _ExtensionsField(StrLenField):
                 cls = _tls_ext_early_data_cls.get(pkt.msgtype, TLS_Ext_Unknown)
             res.append(cls(m[:tmp_len + 4], tls_session=pkt.tls_session))
             m = m[tmp_len + 4:]
-        if len(m):
-            res.append(Raw(m))
+        if m:
+            res.append(conf.raw_layer(m))
         return res

--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -843,4 +843,6 @@ class _ExtensionsField(StrLenField):
                 cls = _tls_ext_early_data_cls.get(pkt.msgtype, TLS_Ext_Unknown)
             res.append(cls(m[:tmp_len + 4], tls_session=pkt.tls_session))
             m = m[tmp_len + 4:]
+        if len(m):
+            res.append(Raw(m))
         return res

--- a/test/scapy/layers/tls/tls.uts
+++ b/test/scapy/layers/tls/tls.uts
@@ -1561,6 +1561,11 @@ data = '1603031616020000660303602161b58e22f4966f18f9aa6afd5759f343935ed437cf09c5
 pkt = TLS(bytes.fromhex(data))
 assert [type(x) for x in pkt.msg] == [TLSServerHello, TLSCertificate, TLSCertificateStatus, TLSServerKeyExchange, TLSServerHelloDone]
 
+= Issue 3853
+data = hex_bytes("16030300360200002e030342615f0b32366c85b5de265ec99fd68c59079d9783dc2f547592fe12f4ab3fde00c02c000015ff01000100000e000000")
+tls_packet = TLS(data)
+assert raw(tls_packet) == data
+
 ###############################################################################
 ############################ Automaton behaviour ##############################
 ###############################################################################


### PR DESCRIPTION
Fixes #3853

Scapy's TLS layer corrupts packet data in some cases during dissection of TLS records containing invalid extension fields (extlen != len(ext)).

A corresponding unit test has been added as well.