### PR TITLE
Chown when Scapy is run with sudo

### DIFF
--- a/scapy/main.py
+++ b/scapy/main.py
@@ -129,9 +129,38 @@ def _read_config_file(cf, _globals=globals(), _locals=locals(),
             return
         # We have a default ! set it
         try:
-            cf_path.parent.mkdir(parents=True, exist_ok=True)
+            if not cf_path.parent.exists():
+                cf_path.parent.mkdir(parents=True, exist_ok=True)
+                if (
+                    not WINDOWS and
+                    "SUDO_UID" in os.environ and
+                    "SUDO_GID" in os.environ
+                ):
+                    # Was started with sudo. Still, chown to the user.
+                    try:
+                        os.chown(
+                            cf_path.parent,
+                            int(os.environ["SUDO_UID"]),
+                            int(os.environ["SUDO_GID"]),
+                        )
+                    except Exception:
+                        pass
             with cf_path.open("w") as fd:
                 fd.write(default)
+            if (
+                not WINDOWS and
+                "SUDO_UID" in os.environ and
+                "SUDO_GID" in os.environ
+            ):
+                # Was started with sudo. Still, chown to the user.
+                try:
+                    os.chown(
+                        cf_path,
+                        int(os.environ["SUDO_UID"]),
+                        int(os.environ["SUDO_GID"]),
+                    )
+                except Exception:
+                    pass
             log_loading.debug("Config file [%s] created with default.", cf)
         except OSError:
             log_loading.warning("Config file [%s] could not be created.", cf,


### PR DESCRIPTION
- minor bugfix: when scapy is ran with sudo, create the files as the user