### PR TITLE
Fix  CDPMsgIPPrefix  in contrib.cdp when length is more than one IP address

### DIFF
--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -249,23 +249,19 @@ class CDPMsgIPGateway(CDPMsgGeneric):
                    ShortField("len", 8),
                    IPField("defaultgw", "192.168.0.1")]
 
-class CDPIPPrefixRecord(Packet):
-    name = "Prefixes"
+
+class IPPrefix(CDPMsgGeneric):
     fields_desc = [
-        IPField("prefix", "192.168.0.1"),
-        ByteField("plen", 24)]
-    def guess_payload_class(self, payload):
-        if len(payload) >= 5:
-            return CDPIPPrefixRecord
-        else:
-            return Raw
-            
+            IPField("Prefix", "192.168.0.1"),
+            ByteField("plen", 24)]
+
+
 class CDPMsgIPPrefix(CDPMsgGeneric):
     name = "IP Prefix"
     type = 0x0007
     fields_desc = [XShortEnumField("type", 0x0007, _cdp_tlv_types),
                    ShortField("len", 9),
-                   PacketListField("prefixes", [],CDPIPPrefixRecord, length_from=lambda p: p.len - 4)]
+                   PacketListField("prefixes", [], IPPrefix, length_from=lambda p: p.len - 4)]
 
 
 class CDPMsgProtoHello(CDPMsgGeneric):

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -252,8 +252,9 @@ class CDPMsgIPGateway(CDPMsgGeneric):
 
 class IPPrefix(CDPMsgGeneric):
     fields_desc = [
-            IPField("prefix", "192.168.0.1"),
-            ByteField("plen", 24)]
+        IPField("prefix", "192.168.0.1"),
+        ByteField("plen", 24),
+    ]
 
 
 class CDPMsgIPPrefix(CDPMsgGeneric):
@@ -261,7 +262,8 @@ class CDPMsgIPPrefix(CDPMsgGeneric):
     type = 0x0007
     fields_desc = [XShortEnumField("type", 0x0007, _cdp_tlv_types),
                    ShortField("len", 9),
-                   PacketListField("prefixes", [], IPPrefix, length_from=lambda p: p.len - 4)]
+                   PacketListField("prefixes", [], IPPrefix,
+                                   length_from=lambda p: p.len - 4)]
 
 
 class CDPMsgProtoHello(CDPMsgGeneric):

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -250,11 +250,14 @@ class CDPMsgIPGateway(CDPMsgGeneric):
                    IPField("defaultgw", "192.168.0.1")]
 
 
-class IPPrefix(CDPMsgGeneric):
+class CDPIPPrefix(Packet):
     fields_desc = [
         IPField("prefix", "192.168.0.1"),
         ByteField("plen", 24),
     ]
+
+    def guess_payload_class(self, p):
+        return conf.padding_layer
 
 
 class CDPMsgIPPrefix(CDPMsgGeneric):
@@ -262,7 +265,7 @@ class CDPMsgIPPrefix(CDPMsgGeneric):
     type = 0x0007
     fields_desc = [XShortEnumField("type", 0x0007, _cdp_tlv_types),
                    ShortField("len", 9),
-                   PacketListField("prefixes", [], IPPrefix,
+                   PacketListField("prefixes", [], CDPIPPrefix,
                                    length_from=lambda p: p.len - 4)]
 
 

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -249,14 +249,23 @@ class CDPMsgIPGateway(CDPMsgGeneric):
                    ShortField("len", 8),
                    IPField("defaultgw", "192.168.0.1")]
 
-
+class CDPIPPrefixRecord(Packet):
+    name = "Prefixes"
+    fields_desc = [
+        IPField("prefix", "192.168.0.1"),
+        ByteField("plen", 24)]
+    def guess_payload_class(self, payload):
+        if len(payload) >= 5:
+            return CDPIPPrefixRecord
+        else:
+            return Raw
+            
 class CDPMsgIPPrefix(CDPMsgGeneric):
     name = "IP Prefix"
     type = 0x0007
     fields_desc = [XShortEnumField("type", 0x0007, _cdp_tlv_types),
                    ShortField("len", 9),
-                   IPField("prefix", "192.168.0.1"),
-                   ByteField("plen", 24)]
+                   PacketListField("prefixes", [],CDPIPPrefixRecord, length_from=lambda p: p.len - 4)]
 
 
 class CDPMsgProtoHello(CDPMsgGeneric):

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -252,7 +252,7 @@ class CDPMsgIPGateway(CDPMsgGeneric):
 
 class IPPrefix(CDPMsgGeneric):
     fields_desc = [
-            IPField("Prefix", "192.168.0.1"),
+            IPField("prefix", "192.168.0.1"),
             ByteField("plen", 24)]
 
 


### PR DESCRIPTION
if the length of IP addresses prefixes was more than one address all the following content wasn't interpreted (Raw payload). This change seams to fix it

Here the capture with multiple addresses in the CDPIPPrefix
![CDP Wireshark](https://github.com/user-attachments/assets/3e76c186-9006-4809-8fb6-b9747327c4bb)

Here the cdp.py dissector before modification with the pcap showed before
![CDP IPPrefix length error](https://github.com/user-attachments/assets/67c17827-33eb-4b17-912b-44ce6e98e932)

Here the cdp.py dissector after modification with the same pcap
![CDP IPPrefix length error fix](https://github.com/user-attachments/assets/3098fc78-d495-4962-9833-58881c04d2d1)


That's my first participation, hope it can help