### PR TITLE
Small HTTP session fixes

### DIFF
--- a/scapy/layers/l2.py
+++ b/scapy/layers/l2.py
@@ -158,7 +158,11 @@ def getmacbyip(ip, chainCC=0):
     # Check the routing table
     iff, _, gw = conf.route.route(ip)
 
-    # Broadcast case
+    # Limited broadcast
+    if ip == "255.255.255.255":
+        return "ff:ff:ff:ff:ff:ff"
+
+    # Directed broadcast
     if (iff == conf.loopback_name) or (ip in conf.route.get_if_bcast(iff)):
         return "ff:ff:ff:ff:ff:ff"
 

--- a/test/scapy/layers/http.uts
+++ b/test/scapy/layers/http.uts
@@ -79,11 +79,11 @@ assert HTTPRequest in a[3]
 assert a[3].Method == b"HEAD"
 assert a[3].User_Agent == b'curl/7.88.1'
 
-assert HTTPResponse in a[5]
-assert a[5].Content_Type == b'text/html; charset=UTF-8'
-assert a[5].Expires == b'Mon, 01 Apr 2024 22:25:38 GMT'
-assert a[5].Reason_Phrase == b'Moved Permanently'
-assert a[5].X_Frame_Options == b"SAMEORIGIN"
+assert HTTPResponse in a[6]
+assert a[6].Content_Type == b'text/html; charset=UTF-8'
+assert a[6].Expires == b'Mon, 01 Apr 2024 22:25:38 GMT'
+assert a[6].Reason_Phrase == b'Moved Permanently'
+assert a[6].X_Frame_Options == b"SAMEORIGIN"
 
 = HTTP build with 'chunked' content type
 
@@ -214,7 +214,7 @@ filename = scapy_path("/test/pcaps/http_tcp_psh.pcap.gz")
 
 pkts = sniff(offline=filename, session=TCPSession)
 
-assert len(pkts) == 15
+assert len(pkts) == 14
 # Verify a split header exists in the packet
 assert pkts[5].User_Agent == b'example_user_agent'
 


### PR DESCRIPTION
- https://github.com/secdev/scapy/pull/4307 is broken. Revert it and find some similar, still shitty workaround
- fix HTTP url being badly parsed in HTTP_Client
- I don't know why it's here, but also includes a fix of Limited broadcast... (lost stash or something)