### PR TITLE
bluetooth: Add EIR service solicitation types

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -1219,6 +1219,30 @@ class EIR_Device_ID(EIR_Element):
     ]
 
 
+class EIR_ServiceSolicitation16BitUUID(EIR_Element):
+    name = "EIR Service Solicitation - 16-bit UUID"
+    fields_desc = [
+        XLEShortField("svc_uuid", None)
+    ]
+
+    def extract_padding(self, s):
+        # Needed to end each EIR_Element packet and make PacketListField work.
+        plen = EIR_Element.length_from(self) - 2
+        return s[:plen], s[plen:]
+
+
+class EIR_ServiceSolicitation128BitUUID(EIR_Element):
+    name = "EIR Service Solicitation - 128-bit UUID"
+    fields_desc = [
+        UUIDField('svc_uuid', None, uuid_fmt=UUIDField.FORMAT_REV)
+    ]
+
+    def extract_padding(self, s):
+        # Needed to end each EIR_Element packet and make PacketListField work.
+        plen = EIR_Element.length_from(self) - 2
+        return s[:plen], s[plen:]
+
+
 class EIR_ServiceData16BitUUID(EIR_Element):
     name = "EIR Service Data - 16-bit UUID"
     fields_desc = [
@@ -2341,6 +2365,8 @@ bind_layers(EIR_Hdr, EIR_SecureSimplePairingHashC192, type=0x0e)
 bind_layers(EIR_Hdr, EIR_SecureSimplePairingRandomizerR192, type=0x0f)
 bind_layers(EIR_Hdr, EIR_SecurityManagerOOBFlags, type=0x11)
 bind_layers(EIR_Hdr, EIR_PeripheralConnectionIntervalRange, type=0x12)
+bind_layers(EIR_Hdr, EIR_ServiceSolicitation16BitUUID, type=0x14)
+bind_layers(EIR_Hdr, EIR_ServiceSolicitation128BitUUID, type=0x15)
 bind_layers(EIR_Hdr, EIR_ServiceData16BitUUID, type=0x16)
 bind_layers(EIR_Hdr, EIR_ServiceData32BitUUID, type=0x20)
 bind_layers(EIR_Hdr, EIR_ServiceData128BitUUID, type=0x21)

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -547,6 +547,13 @@ except TypeError:
 else:
     assert False, "expected exception"
 
+= Parse EIR_ServiceSolicitation16BitUUID and EIR_ServiceSolicitation128BitUUID
+
+d = hex_bytes("043e29020100013d1ef10747d81d0319000002010603140d181115d0002d121e4b0fa4994eceb531f40579aa") 
+p = HCI_Hdr(d)
+assert p[EIR_ServiceSolicitation16BitUUID].svc_uuid == 0x180d
+assert p[EIR_ServiceSolicitation128BitUUID].svc_uuid == UUID('7905f431-b5ce-4e99-a40f-4b1e122d00d0')
+
 = Parse EIR_ServiceData16BitUUID
 
 d = hex_bytes("043e1902010001abcdef7da97f0d020102030350fe051650fee6c2ac")


### PR DESCRIPTION
**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

Add new Bluetooth EIR types :)
