### PR TITLE
Add .NET Remoting / .NET Binary Formatter

### DIFF
--- a/doc/scapy/layers/dotnet.rst
+++ b/doc/scapy/layers/dotnet.rst
@@ -1,0 +1,18 @@
+.NET Protocols
+==============
+
+Scapy implements a few .NET specific protocols. Those protocols are a bit uncommon, but it can be useful to try to understand what's sent by .NET applications, or for more offensive purposes (issues with .NET deserialization for instance).
+
+.NET Remoting
+-------------
+
+Implemented under ``ms_nrtp``, you can load it using::
+
+    from scapy.layers.ms_nrtp import *
+
+This supports:
+
+- The .NET remote protocol: ``NRTP*`` classes
+- The .NET Binary Formatter: ``NRBF*`` classes
+
+For instance you can try to parse a .NET Remoting payload generated using ysoserial with the ``NRBF()`` to analyse what it's doing.

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -3882,9 +3882,9 @@ class UUIDEnumField(UUIDField, _EnumField[UUID]):
         return _EnumField.i2repr(self, pkt, x)
 
 
-class BitExtendedField(Field[Optional[int], bytes]):
+class BitExtendedField(Field[Optional[int], int]):
     """
-    Bit Extended Field
+    Low E Bit Extended Field
 
     This type of field has a variable number of bytes. Each byte is defined
     as follows:
@@ -3900,101 +3900,44 @@ class BitExtendedField(Field[Optional[int], bytes]):
 
     __slots__ = ["extension_bit"]
 
-    def prepare_byte(self, x):
-        # type: (int) -> int
-        # Moves the forwarding bit to the LSB
-        x = int(x)
-        fx_bit = (x & 2**self.extension_bit) >> self.extension_bit
-        lsb_bits = x & 2**self.extension_bit - 1
-        msb_bits = x >> (self.extension_bit + 1)
-        x = (msb_bits << (self.extension_bit + 1)) + (lsb_bits << 1) + fx_bit
-        return x
-
-    def str2extended(self, x=b""):
-        # type: (bytes) -> Tuple[bytes, Optional[int]]
-        # For convenience, we reorder the byte so that the forwarding
-        # bit is always the LSB. We then apply the same algorithm
-        # whatever the real forwarding bit position
-
-        # First bit is the stopping bit at zero
-        bits = 0b0
-        end = None
-
-        # We retrieve 7 bits.
-        # If "forwarding bit" is 1 then we continue on another byte
-        i = 0
-        for c in bytearray(x):
-            c = self.prepare_byte(c)
-            bits = bits << 7 | (int(c) >> 1)
-            if not int(c) & 0b1:
-                end = x[i + 1:]
-                break
-            i = i + 1
-        if end is None:
-            # We reached the end of the data but there was no
-            # "ending bit". This is not normal.
-            return b"", None
-        else:
-            return end, bits
-
-    def extended2str(self, x):
-        # type: (Optional[int]) -> bytes
-        if x is None:
-            return b""
-        x = int(x)
-        s = []
-        LSByte = True
-        FX_Missing = True
-        bits = 0b0
-        i = 0
-        while (x > 0 or FX_Missing):
-            if i == 8:
-                # End of byte
-                i = 0
-                s.append(bits)
-                bits = 0b0
-                FX_Missing = True
-            else:
-                if i % 8 == self.extension_bit:
-                    # This is extension bit
-                    if LSByte:
-                        bits = bits | 0b0 << i
-                        LSByte = False
-                    else:
-                        bits = bits | 0b1 << i
-                    FX_Missing = False
-                else:
-                    bits = bits | (x & 0b1) << i
-                    x = x >> 1
-                # Still some bits
-                i = i + 1
-        s.append(bits)
-
-        result = "".encode()
-        for x in s[:: -1]:
-            result = result + struct.pack(">B", x)
-        return result
-
     def __init__(self, name, default, extension_bit):
         # type: (str, Optional[Any], int) -> None
         Field.__init__(self, name, default, "B")
+        assert extension_bit in [7, 0]
         self.extension_bit = extension_bit
-
-    def i2m(self, pkt, x):
-        # type: (Optional[Any], Optional[int]) -> bytes
-        return self.extended2str(x)
-
-    def m2i(self, pkt, x):
-        # type: (Optional[Any], bytes) -> Optional[int]
-        return self.str2extended(x)[1]
 
     def addfield(self, pkt, s, val):
         # type: (Optional[Packet], bytes, Optional[int]) -> bytes
-        return s + self.i2m(pkt, val)
+        val = self.i2m(pkt, val)
+        if not val:
+            return s + b"\0"
+        rv = b""
+        mask = 1 << self.extension_bit
+        shift = (self.extension_bit + 1) % 8
+        while val:
+            bv = (val & 0x7F) << shift
+            val = val >> 7
+            if val:
+                bv |= mask
+            rv += struct.pack("!B", bv)
+        return s + rv
 
     def getfield(self, pkt, s):
         # type: (Optional[Any], bytes) -> Tuple[bytes, Optional[int]]
-        return self.str2extended(s)
+        val = 0
+        smask = 1 << self.extension_bit
+        mask = 0xFF & ~ (1 << self.extension_bit)
+        shift = (self.extension_bit + 1) % 8
+        i = 0
+        while s:
+            val |= ((s[0] & mask) >> shift) << (7 * i)
+            if (s[0] & smask) == 0:  # extension bit is 0
+                # end
+                s = s[1:]
+                break
+            s = s[1:]
+            i += 1
+        return s, self.m2i(pkt, val)
 
 
 class LSBExtendedField(BitExtendedField):

--- a/scapy/layers/ms_nrtp.py
+++ b/scapy/layers/ms_nrtp.py
@@ -1,0 +1,1038 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Gabriel Potter
+
+"""
+.NET RemoTing Protocol
+
+This implements:
+- [MS-NRTP] - .NET Remoting Core Protocol
+- [MS-NRBF] - .NET Remoting Binary Format
+"""
+
+import enum
+import functools
+import struct
+
+from scapy.automaton import Automaton, ATMT
+from scapy.config import conf
+from scapy.main import interact
+from scapy.fields import (
+    ByteEnumField,
+    ByteField,
+    ConditionalField,
+    FieldLenField,
+    FieldListField,
+    FlagsField,
+    LEIntField,
+    LELongField,
+    LEShortEnumField,
+    LEShortField,
+    LESignedIntField,
+    LESignedLongField,
+    LESignedShortField,
+    LenField,
+    MSBExtendedField,
+    MultipleTypeField,
+    PacketField,
+    PacketListField,
+    SignedByteField,
+    StrField,
+    StrFixedLenField,
+    StrLenField,
+    StrLenFieldUtf16,
+)
+from scapy.packet import Packet
+from scapy.supersocket import StreamSocket
+
+
+# [MS-NRTP] sect 2.2.3.2.1
+
+
+class CountedString(Packet):
+    fields_desc = [
+        ByteEnumField(
+            "StringEncoding",
+            0,
+            {
+                0: "Unicode",
+                1: "UTF8",
+            },
+        ),
+        FieldLenField("Length", None, fmt="<I", count_of="StringData"),
+        MultipleTypeField(
+            [
+                (
+                    StrLenFieldUtf16(
+                        "StringData", "", length_from=lambda pkt: pkt.Length
+                    ),
+                    lambda pkt: pkt.StringEncoding == 0,
+                ),
+                (
+                    StrLenField("StringData", "", length_from=lambda pkt: pkt.Length),
+                    lambda pkt: pkt.StringEncoding == 1,
+                ),
+            ],
+            StrLenField("StringData", "", length_from=lambda pkt: pkt.Length),
+        ),
+    ]
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+CountedStringField = lambda name: PacketField(name, CountedString(), CountedString)
+
+# [MS-NRTP] sect 2.2.3.1.4
+
+NRTP_HeaderDataFormat = {
+    0: "Void",
+    1: "CountedString",
+    2: "Byte",
+    3: "Uint16",
+    4: "Int32",
+}
+
+# [MS-NRTP] sect 2.2.3.3.3.1
+
+
+class NRTPHeader(Packet):
+    fields_desc = [
+        LEShortEnumField(
+            "HeaderToken",
+            0,
+            {
+                0: "End",
+                1: "Custom",
+                2: "StatusCode",
+                3: "StatusPhrase",
+                4: "RequestUri",
+                5: "CloseConnection",
+                6: "ContentType",
+            },
+        ),
+    ]
+
+    registered_headers = {}
+
+    @classmethod
+    def register_variant(cls, id=None):
+        cls.registered_headers[cls.HeaderToken.default] = cls
+
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt and len(_pkt) >= 2:
+            return cls.registered_headers.get(
+                struct.unpack("<H", _pkt[:2])[0], NRTPUnknownHeader
+            )
+        return cls
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRTP] sect 2.2.3.3.3.1
+
+
+class NRTPEndHeader(NRTPHeader):
+    HeaderToken = 0
+    fields_desc = [
+        NRTPHeader,
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.2
+
+
+class NRTPCustomHeader(NRTPHeader):
+    HeaderToken = 1
+    fields_desc = [
+        NRTPHeader,
+        CountedStringField("HeaderName"),
+        CountedStringField("HeaderValue"),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.3
+
+
+class NRTPStatusCodeHeader(NRTPHeader):
+    HeaderToken = 2
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 3, NRTP_HeaderDataFormat),
+        LEShortField("StatusCodeValue", 0),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.4
+
+
+class NRTPStatusPhraseHeader(NRTPHeader):
+    HeaderToken = 3
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 1, NRTP_HeaderDataFormat),
+        CountedStringField("StatusPhraseValue"),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.5
+
+
+class NRTPRequestUriHeader(NRTPHeader):
+    HeaderToken = 4
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 1, NRTP_HeaderDataFormat),
+        CountedStringField("UriValue"),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.6
+
+
+class NRTPCloseConnectionHeader(NRTPHeader):
+    HeaderToken = 5
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 0, NRTP_HeaderDataFormat),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.7
+
+
+class NRTPContentTypeHeader(NRTPHeader):
+    HeaderToken = 6
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 1, NRTP_HeaderDataFormat),
+        CountedStringField("ContentTypeValue"),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.3.8
+
+
+class NRTPUnknownHeader(NRTPHeader):
+    HeaderToken = 7
+    fields_desc = [
+        NRTPHeader,
+        ByteEnumField("DataType", 0, NRTP_HeaderDataFormat),
+        MultipleTypeField(
+            [
+                (
+                    StrFixedLenField("DataValue", b"", length=0),
+                    lambda pkt: pkt.DataType == 0,
+                ),
+                (
+                    CountedStringField("DataValue"),
+                    lambda pkt: pkt.DataType == 1,
+                ),
+                (
+                    StrFixedLenField("DataValue", b"", length=1),
+                    lambda pkt: pkt.DataType == 2,
+                ),
+                (
+                    LEShortField("DataValue", 0),
+                    lambda pkt: pkt.DataType == 3,
+                ),
+                (
+                    LEIntField("DataValue", 0),
+                    lambda pkt: pkt.DataType == 4,
+                ),
+            ],
+            StrField("DataValue", b""),
+        ),
+    ]
+
+
+# [MS-NRTP] sect 2.2.3.3.1
+
+
+class NRTPSingleMessageContent(Packet):
+    name = "NRTP Single Message Content"
+    fields_desc = [
+        StrFixedLenField("ProtocolId", b"\x2e\x4E\x45\x54", 4),
+        ByteField("MajorVersion", 1),
+        ByteField("MinorVersion", 0),
+        LEShortEnumField(
+            "OperationType",
+            0,
+            {
+                0: "Request",
+                1: "OneWayRequest",
+                2: "Reply",
+            },
+        ),
+        LEShortEnumField(
+            "ContentDistribution",
+            0,
+            {
+                0: "Not chunked",
+                1: "Chunked",
+            },
+        ),
+        ConditionalField(
+            LenField("Length", None, fmt="<I"), lambda pkt: pkt.ContentDistribution == 0
+        ),
+        PacketListField(
+            "Headers",
+            [NRTPEndHeader()],
+            None,
+            next_cls_cb=lambda pkt, lst, cur, remain: (
+                None if isinstance(cur, NRTPEndHeader) else NRTPHeader
+            ),
+        ),
+    ]
+
+    @classmethod
+    def tcp_reassemble(cls, data, metadata, session):
+        if not data:
+            return None
+        # Recover Length if available
+        length = metadata.get("length", None)
+        if length is None and len(data) >= 14:
+            cd = struct.unpack("<H", data[8:10])[0]
+            if cd == 0:
+                # Not chunked
+                length = struct.unpack("<I", data[10:14])[0]
+                metadata["length"] = length
+        if length is None:
+            return cls(data)
+        # Parse only the header packet
+        pkt = cls(data, stop_dissection_after=Packet)
+        # Is it complete?
+        if pkt.payload and len(pkt.payload) >= length:
+            # Get content-type
+            try:
+                content_type = next(
+                    x.ContentTypeValue.StringData
+                    for x in pkt.Headers
+                    if x.HeaderToken == 6
+                )
+                session["content_type"] = content_type
+            except StopIteration:
+                # Not in this packet. Do we know it from the session?
+                content_type = session.get("content_type", None)
+                if not content_type:
+                    return pkt
+            # We have a content-type. Parse it.
+            if content_type == b"application/octet-stream":
+                # pkt.payload is NRBF.
+                pkt.payload = NRBF(bytes(pkt.payload))
+            return pkt
+        return None
+
+
+# [MS-NRBF] .NET Remoting Binary Format
+
+
+class MSBExtendedFieldLen(MSBExtendedField):
+    __slots__ = FieldLenField.__slots__
+
+    def __init__(self, name, default, length_of=None):
+        FieldLenField.__init__(self, name, default, length_of=length_of)
+        super(MSBExtendedFieldLen, self).__init__(name, default)
+
+    i2m = FieldLenField.i2m
+
+
+# [MS-NRBF] sect 2.1.1.6
+
+
+class NRBFLengthPrefixedString(Packet):
+    fields_desc = [
+        MSBExtendedFieldLen("Length", None, length_of="String"),
+        StrLenField("String", b"", length_from=lambda pkt: pkt.Length),
+    ]
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRBF] sect 2.1.1.8
+
+
+class NRBFClassTypeInfo(Packet):
+    fields_desc = [
+        PacketField("TypeName", NRBFLengthPrefixedString(), NRBFLengthPrefixedString),
+        LESignedIntField("LibraryId", 0),
+    ]
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRBF] sect 2.1.2.3
+
+
+class PrimitiveTypeEnum(enum.IntEnum):
+    Boolean = 1
+    Byte = 2
+    Char = 2
+    Decimal = 5
+    Double = 6
+    Int16 = 7
+    Int32 = 8
+    Int64 = 9
+    SByte = 10
+    Single = 11
+    TimeSpan = 12
+    DateTime = 13
+    UInt16 = 14
+    UInt32 = 15
+    UInt64 = 16
+    Null = 17
+    String = 18
+
+
+# [MS-NRBF] sect 2.1.2.2
+
+
+class BinaryTypeEnum(enum.IntEnum):
+    Primitive = 0
+    String = 1
+    Object = 2
+    SystemClass = 3
+    Class = 4
+    ObjectArray = 5
+    StringArray = 6
+    PrimitiveArray = 7
+
+
+# [MS-NRBF] sect 2.2.2.1
+
+
+class NRBFValueWithCode(Packet):
+    fields_desc = [
+        ByteEnumField("PrimitiveType", 0, PrimitiveTypeEnum),
+        MultipleTypeField(
+            [
+                (ByteField("Value", 0), lambda pkt: pkt.PrimitiveType in [1, 2, 3, 4]),
+                (LESignedShortField("Value", 0), lambda pkt: pkt.PrimitiveType == 7),
+                (LESignedIntField("Value", 0), lambda pkt: pkt.PrimitiveType == 8),
+                (LESignedLongField("Value", 0), lambda pkt: pkt.PrimitiveType == 9),
+                (SignedByteField("Value", 0), lambda pkt: pkt.PrimitiveType == 10),
+                (LEShortField("Value", 0), lambda pkt: pkt.PrimitiveType == 14),
+                (LEIntField("Value", 0), lambda pkt: pkt.PrimitiveType == 15),
+                (LELongField("Value", 0), lambda pkt: pkt.PrimitiveType == 16),
+                (
+                    PacketField(
+                        "Value", NRBFLengthPrefixedString(), NRBFLengthPrefixedString
+                    ),
+                    lambda pkt: pkt.PrimitiveType == 18,
+                ),
+            ],
+            StrFixedLenField("Value", b"", length=0),
+        ),
+    ]
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRBF] sect 2.2.2.2
+
+
+class NRBFStringValueWithCode(NRBFValueWithCode):
+    PrimitiveType = 18
+
+
+StringValueWithCode = lambda name: PacketField(
+    name, NRBFStringValueWithCode(), NRBFStringValueWithCode
+)
+
+
+# [MS-NRBF] sect 2.2.2.3
+
+
+class NRBFArrayOfValueWithCode(Packet):
+    fields_desc = [
+        FieldLenField("Length", None, fmt="<I", count_of="ListOfValueWithCode"),
+        PacketListField(
+            "ListOfValueWithCode",
+            [],
+            NRBFValueWithCode,
+            count_from=lambda pkt: pkt.Length,
+        ),
+    ]
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# Generic record type
+
+NRBF_RecordTypeEnumeration = {
+    0: "SerializedStreamHeader",
+    1: "ClassWithId",
+    2: "SystemClassWithMembers",
+    3: "ClassWithMembers",
+    4: "SystemClassWithMembersAndTypes",
+    5: "ClassWithMembersAndTypes",
+    6: "BinaryObjectString",
+    7: "BinaryArray",
+    8: "MemberPrimitiveTyped",
+    9: "MemberReference",
+    10: "ObjectNull",
+    11: "MessageEnd",
+    12: "BinaryLibrary",
+    13: "ObjectNullMultiple256",
+    14: "ObjectNullMultiple",
+    15: "ArraySinglePrimitive",
+    16: "ArraySingleObject",
+    17: "ArraySingleString",
+    21: "MethodCall",
+    22: "MethodReturn",
+}
+
+
+class NRBFRecord(Packet):
+    fields_desc = [
+        ByteEnumField("RecordTypeEnum", 255, NRBF_RecordTypeEnumeration),
+    ]
+
+    registered_records = {}
+
+    @classmethod
+    def register_variant(cls, id=None):
+        cls.registered_records[cls.RecordTypeEnum.default] = cls
+
+    @classmethod
+    def dispatch_hook(cls, _pkt=None, *args, **kargs):
+        if _pkt:
+            return cls.registered_records.get(_pkt[0], NRBFRecord)
+        return cls
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRBF] sect 2.2.3.1
+
+_NRBF_MessageFlags = {
+    0x00000001: "NoArgs",
+    0x00000002: "ArgsInline",
+    0x00000004: "ArgsIsArray",
+    0x00000008: "ArgsInArray",
+    0x00000010: "NoContext",
+    0x00000020: "ContextInline",
+    0x00000040: "ContextInArray",
+    0x00000080: "MethodSignatureInArray",
+    0x00000100: "PropertiesInArray",
+    0x00000200: "NoReturnValue",
+    0x00000400: "ReturnValueVoid",
+    0x00000800: "ReturnValueInline",
+    0x00001000: "ReturnValueInArray",
+    0x00002000: "ExceptionInArray",
+    0x00008000: "GenericMethod",
+}
+
+
+class NRBFBinaryMethodCall(NRBFRecord):
+    RecordTypeEnum = 21
+    fields_desc = [
+        NRBFRecord,
+        FlagsField("MessageEnum", 0, -32, _NRBF_MessageFlags),
+        StringValueWithCode("MethodName"),
+        StringValueWithCode("TypeName"),
+        ConditionalField(
+            StringValueWithCode("CallContext"),
+            lambda pkt: pkt.MessageEnum.ContextInline,
+        ),
+        ConditionalField(
+            PacketField("Args", NRBFArrayOfValueWithCode(), NRBFArrayOfValueWithCode),
+            lambda pkt: pkt.MessageEnum.ArgsInline,
+        ),
+    ]
+
+
+# [MS-NRBF] sect 2.2.3.3
+
+
+class NRBFBinaryMethodReturn(NRBFRecord):
+    RecordTypeEnum = 22
+    fields_desc = [
+        NRBFRecord,
+        FlagsField("MessageEnum", 0, -32, _NRBF_MessageFlags),
+        ConditionalField(
+            PacketField("ReturnValue", NRBFValueWithCode(), NRBFValueWithCode),
+            lambda pkt: pkt.MessageEnum.ReturnValueInline,
+        ),
+        ConditionalField(
+            StringValueWithCode("CallContext"),
+            lambda pkt: pkt.MessageEnum.ContextInline,
+        ),
+        ConditionalField(
+            PacketField("Args", NRBFArrayOfValueWithCode(), NRBFArrayOfValueWithCode),
+            lambda pkt: pkt.MessageEnum.ArgsInline,
+        ),
+    ]
+
+
+# [MS-NRBF] sect 2.3 - Class Records
+
+# A generic packet use for Member data
+
+
+def _members_cb(pkt, lst, cur, remain):
+    index = len(lst) + (1 if cur is not None else 0)
+    if index >= pkt.MemberCount:
+        return None
+    if hasattr(pkt, "BinaryTypeEnums"):
+        if index < len(pkt.BinaryTypeEnums):
+            typeEnum = pkt.BinaryTypeEnums[index]
+            if typeEnum == BinaryTypeEnum.Primitive:
+                # Get AdditionalInfo to get the matching primitive type.
+                primitiveType = pkt.AdditionalInfos[
+                    sum(
+                        1
+                        for x in pkt.BinaryTypeEnums[:index]
+                        if x
+                        not in [
+                            BinaryTypeEnum.String,
+                            BinaryTypeEnum.Object,
+                            BinaryTypeEnum.ObjectArray,
+                            BinaryTypeEnum.StringArray,
+                        ]
+                    )
+                ].Value
+                return functools.partial(
+                    NRBFMemberPrimitiveUnTyped,
+                    type=PrimitiveTypeEnum(primitiveType),
+                )
+    return NRBFRecord
+
+
+class _NRBFMembers(Packet):
+    fields_desc = [
+        PacketListField(
+            "Members",
+            [],
+            None,
+            next_cls_cb=_members_cb,
+        )
+    ]
+
+
+# [MS-NRBF] sect 2.3.1.1
+
+
+class NRBFClassInfo(Packet):
+    fields_desc = [
+        LESignedIntField("ObjectId", 0),
+        PacketField("Name", NRBFLengthPrefixedString(), NRBFLengthPrefixedString),
+        FieldLenField("MemberCount", None, fmt="<i", count_of="MemberNames"),
+        PacketListField(
+            "MemberNames",
+            [],
+            NRBFLengthPrefixedString,
+            count_from=lambda pkt: pkt.MemberCount,
+        ),
+    ]
+
+
+# [MS-NRBF] sect 2.3.1.2
+
+
+class NRBFAdditionalInfo(Packet):
+    __slots__ = ["type"]
+
+    fields_desc = [
+        MultipleTypeField(
+            [
+                (
+                    ByteEnumField("Value", 0, PrimitiveTypeEnum),
+                    lambda pkt: pkt.type
+                    in [
+                        BinaryTypeEnum.Primitive,
+                        BinaryTypeEnum.PrimitiveArray,
+                    ],
+                ),
+                (
+                    PacketField(
+                        "Value", NRBFLengthPrefixedString(), NRBFLengthPrefixedString
+                    ),
+                    lambda pkt: pkt.type == BinaryTypeEnum.SystemClass,
+                ),
+                (
+                    PacketField("Value", NRBFClassTypeInfo(), NRBFClassTypeInfo),
+                    lambda pkt: pkt.type == BinaryTypeEnum.Class,
+                ),
+            ],
+            StrFixedLenField("Value", b"", length=0),
+        ),
+    ]
+
+    def __init__(self, _pkt=None, **kwargs):
+        self.type = kwargs.pop("type", BinaryTypeEnum.Primitive)
+        assert isinstance(self.type, BinaryTypeEnum)
+        super(NRBFAdditionalInfo, self).__init__(_pkt, **kwargs)
+
+    def clone_with(self, *args, **kwargs):
+        pkt = super(NRBFAdditionalInfo, self).clone_with(*args, **kwargs)
+        pkt.type = self.type
+        return pkt
+
+    def copy(self):
+        pkt = super(NRBFAdditionalInfo, self).copy()
+        pkt.type = self.type
+        return pkt
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+def _member_type_infos_cb(pkt, lst, cur, remain):
+    """
+    Returns a NRBFAdditionalInfo with the type selected.
+    """
+    # Get the next member of 'BinaryTypeEnums'
+    index = len(lst) + (1 if cur is not None else 0)
+    try:
+        typeEnum = next(
+            y
+            for i, y in enumerate(
+                x
+                for x in pkt.BinaryTypeEnums
+                if x
+                not in [
+                    # Some types are ignored (see table in [MS-NRBF] sect 2.3.1.2)
+                    BinaryTypeEnum.String,
+                    BinaryTypeEnum.Object,
+                    BinaryTypeEnum.ObjectArray,
+                    BinaryTypeEnum.StringArray,
+                ]
+            )
+            if i >= index
+        )
+    except StopIteration:
+        return None
+    typeEnum = BinaryTypeEnum(typeEnum)
+    # Return BinaryTypeEnum tainted with a pre-selected type.
+    return functools.partial(
+        NRBFAdditionalInfo,
+        type=typeEnum,
+    )
+
+
+class NRBFMemberTypeInfo(Packet):
+    fields_desc = [
+        FieldListField(
+            "BinaryTypeEnums",
+            [],
+            ByteEnumField("", 0, BinaryTypeEnum),
+            count_from=lambda pkt: pkt.MemberCount,
+        ),
+        PacketListField(
+            "AdditionalInfos",
+            [],
+            None,
+            next_cls_cb=_member_type_infos_cb,
+        ),
+    ]
+
+
+# [MS-NRBF] 2.3.2.5
+
+
+class NRBFClassWithId(NRBFRecord):
+    RecordTypeEnum = 1
+    fields_desc = [
+        NRBFRecord,
+        LESignedIntField("ObjectId", 0),
+        LESignedIntField("MetadataId", 0),
+    ]
+
+
+# [MS-NRBF] sect 2.5.2
+
+
+class NRBFMemberPrimitiveUnTyped(Packet):
+    __slots__ = ["type"]
+
+    fields_desc = [
+        NRBFValueWithCode.fields_desc[1],
+    ]
+
+    def __init__(self, _pkt=None, **kwargs):
+        self.type = kwargs.pop("type", PrimitiveTypeEnum.Byte)
+        assert isinstance(self.type, PrimitiveTypeEnum)
+        super(NRBFMemberPrimitiveUnTyped, self).__init__(_pkt, **kwargs)
+
+    def clone_with(self, *args, **kwargs):
+        pkt = super(NRBFMemberPrimitiveUnTyped, self).clone_with(*args, **kwargs)
+        pkt.type = self.type
+        return pkt
+
+    def copy(self):
+        pkt = super(NRBFMemberPrimitiveUnTyped, self).copy()
+        pkt.type = self.type
+        return pkt
+
+    @property
+    def PrimitiveType(self):
+        return self.type
+
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
+
+# [MS-NRBF] sect 2.3.2.1
+
+
+class NRBFClassWithMembersAndTypes(NRBFRecord):
+    RecordTypeEnum = 5
+    fields_desc = [
+        NRBFRecord,
+        NRBFClassInfo,
+        NRBFMemberTypeInfo,
+        LESignedIntField("LibraryId", 0),
+        _NRBFMembers,
+    ]
+
+
+# [MS-NRBF] sect 2.3.2.3
+
+
+class NRBFSystemClassWithMembersAndTypes(NRBFRecord):
+    RecordTypeEnum = 4
+    fields_desc = [
+        NRBFRecord,
+        NRBFClassInfo,
+        NRBFMemberTypeInfo,
+        _NRBFMembers,
+    ]
+
+
+# [MS-NRBF] sect 2.3.2.4
+
+
+class NRBFSystemClassWithMembers(NRBFRecord):
+    RecordTypeEnum = 2
+    fields_desc = [
+        NRBFRecord,
+        NRBFClassInfo,
+        _NRBFMembers,
+    ]
+
+
+# [MS-NRBF] sect 2.4.2.1
+
+
+class ArrayInfo(Packet):
+    fields_desc = [LEIntField("ObjectId", 0), LEIntField("Length", None)]
+
+
+# [MS-NRBF] sect 2.4.3.2
+
+
+class NRBFArraySingleObject(NRBFRecord):
+    RecordTypeEnum = 16
+    Length = 1
+    fields_desc = [
+        NRBFRecord,
+        ArrayInfo,
+    ]
+
+
+# [MS-NRBF] sect 2.4.3.3
+
+
+def _values_singleprim_cb(pkt, lst, cur, remain):
+    index = len(lst) + (1 if cur is not None else 0)
+    if index >= pkt.Length:
+        return None
+    return functools.partial(
+        NRBFMemberPrimitiveUnTyped,
+        type=PrimitiveTypeEnum(pkt.PrimitiveTypeEnum),
+    )
+
+
+class NRBFArraySinglePrimitive(NRBFRecord):
+    RecordTypeEnum = 15
+    fields_desc = [
+        NRBFRecord,
+        ArrayInfo,
+        ByteEnumField("PrimitiveTypeEnum", 0, PrimitiveTypeEnum),
+        MultipleTypeField(
+            [
+                (
+                    StrLenField("Values", [], length_from=lambda pkt: pkt.Length),
+                    lambda pkt: pkt.PrimitiveTypeEnum == PrimitiveTypeEnum.Byte,
+                )
+            ],
+            PacketListField(
+                "Values",
+                [],
+                next_cls_cb=_values_singleprim_cb,
+                max_count=1000,
+            ),
+        ),
+    ]
+
+    def post_build(self, p, pay):
+        if self.Length is None:
+            p = p[:5] + struct.pack("<I", len(self.Values)) + p[9:]
+        return p + pay
+
+
+# [MS-NRBF] sect 2.5.1
+
+
+class NRBFMemberPrimitiveTyped(NRBFRecord):
+    RecordTypeEnum = 9
+    fields_desc = [
+        NRBFRecord,
+        NRBFValueWithCode,
+    ]
+
+
+# [MS-NRBF] sect 2.5.3
+
+
+class NRBFMemberReference(NRBFRecord):
+    RecordTypeEnum = 9
+    fields_desc = [
+        NRBFRecord,
+        LEIntField("IdRef", 0),
+    ]
+
+
+# [MS-NRBF] sect 2.5.4
+
+
+class NRBFObjectNull(NRBFRecord):
+    RecordTypeEnum = 10
+    fields_desc = [
+        NRBFRecord,
+    ]
+
+
+# [MS-NRBF] sect 2.5.7
+
+
+class NRBFBinaryObjectString(NRBFRecord):
+    RecordTypeEnum = 6
+    fields_desc = [
+        NRBFRecord,
+        LEIntField("ObjectId", 0),
+        PacketField("Value", NRBFLengthPrefixedString(), NRBFLengthPrefixedString),
+    ]
+
+
+# [MS-NRBF] sect 2.6.1
+
+
+class NRBFSerializationHeader(NRBFRecord):
+    RecordTypeEnum = 0
+    fields_desc = [
+        NRBFRecord,
+        LESignedIntField("RootID", 1),
+        LESignedIntField("HeaderId", 0),
+        LESignedIntField("MajorVersion", 1),
+        LESignedIntField("MinorVersion", 0),
+    ]
+
+
+# [MS-NRBF] sect 2.6.2
+
+
+class NRBFBinaryLibrary(NRBFRecord):
+    RecordTypeEnum = 12
+    fields_desc = [
+        NRBFRecord,
+        LESignedIntField("LibraryId", 0),
+        PacketField(
+            "LibraryName", NRBFLengthPrefixedString(), NRBFLengthPrefixedString
+        ),
+    ]
+
+
+# [MS-NRBF] sect 2.6.3
+
+
+class NRBFMessageEnd(NRBFRecord):
+    RecordTypeEnum = 11
+    fields_desc = [
+        NRBFRecord,
+    ]
+
+
+# NRBF is a list of records
+
+
+def _nrbf_records_cls(pkt, lst, cur, remain):
+    # Detect end
+    if isinstance(cur, NRBFMessageEnd):
+        return None
+    return NRBFRecord
+
+
+class NRBF(Packet):
+    # This is the same structure as what is returned by ysoserial.net
+    fields_desc = [
+        PacketListField(
+            "records",
+            [NRBFMessageEnd()],
+            None,
+            max_count=1000,
+            next_cls_cb=_nrbf_records_cls,
+        )
+    ]
+
+    def default_payload_class(self, _):
+        return conf.padding_layer
+
+
+# Automatons
+
+
+class NRTP_Server(Automaton):
+    """
+    NRTP server to send a single payload.
+    """
+
+    pkt_cls = NRTPSingleMessageContent
+    socketcls = StreamSocket
+
+    def __init__(self, PAYLOAD, verb=True, *args, **kwargs):
+        self.PAYLOAD = PAYLOAD
+        self.verb = verb
+        if "sock" not in kwargs:
+            raise ValueError(
+                "NMF_Server cannot be started directly ! Use NMF_Server.spawn"
+            )
+        Automaton.__init__(
+            self,
+            *args,
+            **kwargs,
+        )
+
+    @ATMT.state(initial=1)
+    def BEGIN(self):
+        pass
+
+    @ATMT.state(error=1)
+    def FAILURE(self, error):
+        return error
+
+    @ATMT.receive_condition(BEGIN)
+    def should_send_response(self, pkt):
+        if NRTPSingleMessageContent in pkt:
+            raise self.END().action_parameters(pkt)
+
+    @ATMT.action(should_send_response)
+    def send_response(self, pkt):
+        self.send(NRTPSingleMessageContent(OperationType="Reply") / self.PAYLOAD)
+
+    @ATMT.state(final=1)
+    def END(self):
+        pass
+
+
+if __name__ == "__main__":
+    interact(mydict=globals(), mybanner="Scapy [MS-NRTP] addon")

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -2112,120 +2112,27 @@ assert bytes(y) != bytes(y)
 
 ############
 ############
-+ BitExtendedField
-
-= BitExtendedField: simple test
-
-class DebugPacket(Packet):
-    fields_desc = [
-        BitExtendedField("val", None, extension_bit=0)
-    ]
-
-a = DebugPacket(val=1234)
-assert a.val == 1234
-
-= BitExtendedField i2m: corner values
-* 7 bits of data = 0
-import codecs
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.i2m(None, 0)
-    r = int(codecs.encode(r, 'hex'), 16)
-    assert r == 0
-
-* 7 bits of data = 1
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.i2m(None, 0b1111111)
-    r = int(codecs.encode(r, 'hex'), 16)
-    assert r == 0xff - 2**i
-
-= BitExtendedField i2m: field expansion
-* If there is 8 bits of data, we need to add a byte
-m = BitExtendedField("foo", None, extension_bit=0)
-r = m.i2m(None, 0b10000000)
-r = int(codecs.encode(r, 'hex'), 16)
-assert r == 0x0300
-
-= BitExtendedField i2m: test all FX bit positions
-* Data is 0b10000001 (129) and all str values are precomputed
-data_129 = {
-    "extended": 129,
-    "int_with_fx": [770, 769, 1281, 2305, 4353, 8449, 16641, 33025],
-    "str_with_fx" : []
-}
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.i2m(None, data_129["extended"])
-    data_129["str_with_fx"].append(r)
-    r = int(codecs.encode(r, 'hex'), 16)
-    assert r == data_129["int_with_fx"][i]
-
-= BitExtendedField m2i: test all FX bit positions
-* Data is 0b10000001 (129) and all str values are precomputed
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.m2i(None, data_129["str_with_fx"][i])
-    assert r == data_129["extended"]
-
-= BitExtendedField m2i: stop at FX zero
-* 1 byte of zeroes (FX stop) then 1 byte of ones : ignore 2nd byte
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.m2i(None, b'\x00\xff')
-    assert r == 0
-
-= BitExtendedField m2i: multiple bytes
-* 0b00000011 0b11111110 --> 0xff
-data_254 = {
-    "extended": 0xff,
-    "str_with_fx" : [b'\x03\xfe', b'\x03\xfd', b'\x05\xfb', b'\x09\xf7', b'\x11\xef', b'\x21\xdf', b'\x41\xbf', b'\x81\x7f']
-}
-for i in range(len(data_254['str_with_fx'])):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.m2i(None, data_254["str_with_fx"][i])
-    assert r == data_254['extended']
-
-= BitExtendedField m2i: invalid field with no stopping bit
-* 1 byte of one (no FX stop) shall return an error
-for i in range(8):
-    m = BitExtendedField("foo", None, extension_bit=i)
-    r = m.m2i(None, b'\xff')
-    assert r == None
-
 = LSBExtendedField
-* Test i2m and m2i
-data_129 = {
-    "extended": 129,
-    "int_with_fx": 770,
-    "str_with_fx" : None
-}
-m = LSBExtendedField("foo", None)
-r = m.i2m(None, data_129["extended"])
-data_129["str_with_fx"] = r
-r = int(codecs.encode(r, 'hex'), 16)
-assert r == data_129["int_with_fx"]
+* Test addfield and getfield
 
-m = LSBExtendedField("foo", None)
-r = m.m2i(None, data_129["str_with_fx"])
-assert r == data_129["extended"]
+f = LSBExtendedField("a", 0)
+
+assert f.addfield(None, b"", 1) == b"\x02"
+assert f.addfield(None, b"", 127) == b"\xfe"
+assert f.addfield(None, b"", 128) == b"\x01\x02"
+assert f.addfield(None, b"", 536) == b"1\x08"
+assert f.addfield(None, b"", 16383) == b"\xff\xfe"
 
 = MSBExtendedField
 * Test i2m and m2i
-data_129 = {
-    "extended": 129,
-    "int_with_fx": 33025,
-    "str_with_fx" : None
-}
-m = MSBExtendedField("foo", None)
-r = m.i2m(None, data_129["extended"])
-data_129["str_with_fx"] = r
-r = int(codecs.encode(r, 'hex'), 16)
-assert r == data_129["int_with_fx"]
 
-m = MSBExtendedField("foo", None)
-r = m.m2i(None, data_129["str_with_fx"])
-assert r == data_129["extended"]
+f = MSBExtendedField("a", 0)
+
+assert f.addfield(None, b"", 1) == b"\x01"
+assert f.addfield(None, b"", 127) == b"\x7f"
+assert f.addfield(None, b"", 128) == b"\x80\x01"
+assert f.addfield(None, b"", 536) == b"\x98\x04"
+assert f.addfield(None, b"", 16383) == b"\xff\x7f"
 
 
 ############

--- a/test/scapy/layers/msnrtp.uts
+++ b/test/scapy/layers/msnrtp.uts
@@ -1,0 +1,155 @@
+% MS-NRTP tests
+
++ [MS-NRTP]
+
+= [MS-NRBF] parse .NET Binary Format
+
+from scapy.layers.ms_nrtp import *
+
+data = b'\x00\x01\x00\x00\x00\xff\xff\xff\xff\x01\x00\x00\x00\x00\x00\x00\x00\x0c\x02\x00\x00\x00NSystem.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\x05\x01\x00\x00\x00\x13System.Data.DataSet\n\x00\x00\x00\x16DataSet.RemotingFormat\x13DataSet.DataSetName\x11DataSet.Namespace\x0eDataSet.Prefix\x15DataSet.CaseSensitive\x12DataSet.LocaleLCID\x1aDataSet.EnforceConstraints\x1aDataSet.ExtendedProperties\x14DataSet.Tables.Count\x10DataSet.Tables_0\x04\x01\x01\x01\x00\x00\x00\x02\x00\x07\x1fSystem.Data.SerializationFormat\x02\x00\x00\x00\x01\x08\x01\x08\x02\x02\x00\x00\x00\x05\xfd\xff\xff\xff\x1fSystem.Data.SerializationFormat\x01\x00\x00\x00\x07value__\x00\x08\x02\x00\x00\x00\x01\x00\x00\x00\x06\x04\x00\x00\x00\x00\t\x04\x00\x00\x00\t\x04\x00\x00\x00\x00\t\x04\x00\x00\x00\n\x01\x00\x00\x00\t\x05\x00\x00\x00\x0f\x05\x00\x00\x00\x07\x00\x00\x00\x02TRIMMED\x0b'
+
+pkt = NRBF(data)
+assert len(pkt.records) == 5
+
+assert isinstance(pkt.records[0], NRBFSerializationHeader)
+assert pkt.records[0].RootID == 1
+assert pkt.records[0].HeaderId == -1
+
+assert pkt.records[1].LibraryId == 2
+assert pkt.records[1].LibraryName.String == b'System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+
+assert pkt.records[2].ObjectId == 1
+assert pkt.records[2].MemberCount == 10
+assert len(pkt.records[2].MemberNames) == 10
+assert pkt.records[2].MemberNames[9].String == b"DataSet.Tables_0"
+assert pkt.records[2].AdditionalInfos[0].Value.TypeName.String == b"System.Data.SerializationFormat"
+assert pkt.records[2].AdditionalInfos[1].Value == PrimitiveTypeEnum.Boolean
+assert pkt.records[2].AdditionalInfos[5].Value == PrimitiveTypeEnum.Byte
+assert pkt.records[2].Members[0].Members[0].Value == 1
+assert isinstance(pkt.records[2].Members[1], NRBFBinaryObjectString)
+assert isinstance(pkt.records[2].Members[2], NRBFMemberReference)
+assert isinstance(pkt.records[2].Members[3], NRBFMemberReference)
+assert isinstance(pkt.records[2].Members[4], NRBFMemberPrimitiveUnTyped)
+assert isinstance(pkt.records[2].Members[7], NRBFObjectNull)
+assert isinstance(pkt.records[2].Members[9], NRBFMemberReference)
+assert pkt.records[2].Members[9].IdRef == 5
+
+assert pkt.records[3].ObjectId == 5
+assert pkt.records[3].Values == b"TRIMMED"
+
+assert isinstance(pkt.records[4], NRBFMessageEnd)
+
+= [MS-NRBF] build .NET Binary Format
+
+pkt = NRBF(
+    records=[
+        NRBFSerializationHeader(HeaderId=-1),
+        NRBFBinaryLibrary(
+            LibraryId=2,
+            LibraryName=NRBFLengthPrefixedString(
+                String=b"System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            ),
+        ),
+        NRBFClassWithMembersAndTypes(
+            ObjectId=1,
+            Name=NRBFLengthPrefixedString(String=b"System.Data.DataSet"),
+            MemberCount=10,
+            MemberNames=[
+                NRBFLengthPrefixedString(String=b"DataSet.RemotingFormat"),
+                NRBFLengthPrefixedString(String=b"DataSet.DataSetName"),
+                NRBFLengthPrefixedString(String=b"DataSet.Namespace"),
+                NRBFLengthPrefixedString(String=b"DataSet.Prefix"),
+                NRBFLengthPrefixedString(String=b"DataSet.CaseSensitive"),
+                NRBFLengthPrefixedString(String=b"DataSet.LocaleLCID"),
+                NRBFLengthPrefixedString(String=b"DataSet.EnforceConstraints"),
+                NRBFLengthPrefixedString(String=b"DataSet.ExtendedProperties"),
+                NRBFLengthPrefixedString(String=b"DataSet.Tables.Count"),
+                NRBFLengthPrefixedString(String=b"DataSet.Tables_0"),
+            ],
+            BinaryTypeEnums=[
+                BinaryTypeEnum.Class,
+                BinaryTypeEnum.String,
+                BinaryTypeEnum.String,
+                BinaryTypeEnum.String,
+                BinaryTypeEnum.Primitive,
+                BinaryTypeEnum.Primitive,
+                BinaryTypeEnum.Primitive,
+                BinaryTypeEnum.Object,
+                BinaryTypeEnum.Primitive,
+                BinaryTypeEnum.PrimitiveArray,
+            ],
+            AdditionalInfos=[
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.SystemClass,
+                    Value=NRBFClassTypeInfo(
+                        TypeName=NRBFLengthPrefixedString(
+                            String=b"System.Data.SerializationFormat"
+                        ),
+                        LibraryId=2,
+                    )
+                ),
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.Primitive,
+                    Value=PrimitiveTypeEnum.Boolean,
+                ),
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.Primitive,
+                    Value=PrimitiveTypeEnum.Int32,
+                ),
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.Primitive,
+                    Value=PrimitiveTypeEnum.Boolean,
+                ),
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.Primitive,
+                    Value=PrimitiveTypeEnum.Int32,
+                ),
+                NRBFAdditionalInfo(
+                    type=BinaryTypeEnum.PrimitiveArray,
+                    Value=PrimitiveTypeEnum.Byte,
+                ),
+            ],
+            LibraryId=2,
+            Members=[
+                NRBFClassWithMembersAndTypes(
+                    ObjectId=-3,
+                    Name=NRBFLengthPrefixedString(
+                        String=b"System.Data.SerializationFormat"
+                    ),
+                    MemberNames=[
+                        NRBFLengthPrefixedString(String=b"value__"),
+                    ],
+                    BinaryTypeEnums=[BinaryTypeEnum.Primitive],
+                    AdditionalInfos=[
+                        NRBFAdditionalInfo(type=BinaryTypeEnum.Primitive,
+                                           Value=PrimitiveTypeEnum.Int32),
+                    ],
+                    LibraryId=2,
+                    Members=[
+                        NRBFMemberPrimitiveUnTyped(type=PrimitiveTypeEnum.Int32, Value=1)
+                    ],
+                ),
+                NRBFBinaryObjectString(
+                    ObjectId=4,
+                    Value=NRBFLengthPrefixedString(String=b""),
+                ),
+                NRBFMemberReference(IdRef=4),
+                NRBFMemberReference(IdRef=4),
+                NRBFMemberPrimitiveUnTyped(type=PrimitiveTypeEnum.Boolean, Value=0),
+                NRBFMemberPrimitiveUnTyped(type=PrimitiveTypeEnum.Int32, Value=1033),
+                NRBFMemberPrimitiveUnTyped(type=PrimitiveTypeEnum.Boolean, Value=0),
+                NRBFObjectNull(),
+                NRBFMemberPrimitiveUnTyped(type=PrimitiveTypeEnum.Int32, Value=1),
+                NRBFMemberReference(IdRef=5),
+            ],
+        ),
+        NRBFArraySinglePrimitive(
+            ObjectId=5,
+            PrimitiveTypeEnum=PrimitiveTypeEnum.Byte,
+            Values=b"TRIMMED",
+        ),
+        NRBFMessageEnd(),
+    ]
+)
+
+assert bytes(pkt) == data


### PR DESCRIPTION
No one asked for it..

- .Net Remoting support per [MS-NRTP]. Includes a small server
- .Net Remoting Binary Formatter support per [MS-NRBF]
- Rewrite MSBExtendedField and actually use them (they were unused fields, with very ugly code)

Those protocols are deprecated because they are very unsafe.. One more reason to have it in Scapy.