### PR TITLE
Add ValueError to except in L2Socket.close()

### DIFF
--- a/scapy/arch/linux/__init__.py
+++ b/scapy/arch/linux/__init__.py
@@ -276,7 +276,7 @@ class L2Socket(SuperSocket):
         try:
             if self.promisc and getattr(self, "ins", None):
                 set_promisc(self.ins, self.iface, 0)
-        except (AttributeError, OSError):
+        except (AttributeError, OSError, ValueError):
             pass
         SuperSocket.close(self)
 


### PR DESCRIPTION
If the interface doesn't exist anymore, for whatever reason, a value error is thrown. 