### PR TITLE
Removed unnecessary Cancel ACK's field

### DIFF
--- a/scapy/contrib/ltp.py
+++ b/scapy/contrib/ltp.py
@@ -171,13 +171,6 @@ class LTP(Packet):
                                        15, _ltp_cancel_reasons),
                          lambda x: x.flags == 14),
         #
-        # Cancellation Acknowldgements
-        #
-        ConditionalField(SDNV2("CancelAckToBlockSender", 0),
-                         lambda x: x.flags == 13),
-        ConditionalField(SDNV2("CancelAckToBlockReceiver", 0),
-                         lambda x: x.flags == 15),
-        #
         # Finally, trailing extensions
         #
         PacketListField("TrailerExtensions", [], LTPex, count_from=lambda x: x.TrailerExtensionCount)  # noqa: E501


### PR DESCRIPTION
Removed unnecessary ConditionalFields CancelAckToBlockSender and CancelAckToBlockReceiver from LTP segments following RFC 5326 Section 3.2.4.

https://www.rfc-editor.org/rfc/rfc5326.html#page-20

fixes #4591
