### PR TITLE
Fix xdg folder permission check for cases when privileges were dropped

### DIFF
--- a/scapy/main.py
+++ b/scapy/main.py
@@ -68,17 +68,18 @@ QUOTES = [
 def _probe_xdg_folder(var, default, *cf):
     # type: (str, str, *str) -> Optional[pathlib.Path]
     path = pathlib.Path(os.environ.get(var, default))
-    if not path.exists():
-        # ~ folder doesn't exist. Create according to spec
-        # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-        # "If, when attempting to write a file, the destination directory is
-        # non-existent an attempt should be made to create it with permission 0700."
-        try:
+    try:
+        if not path.exists():
+            # ~ folder doesn't exist. Create according to spec
+            # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+            # "If, when attempting to write a file, the destination directory is
+            # non-existent an attempt should be made to create it with permission 0700."
             path.mkdir(mode=0o700, exist_ok=True)
-        except Exception:
-            # There is a gazillion ways this can fail. Most notably,
-            # a read-only fs.
-            return None
+    except Exception:
+        # There is a gazillion ways this can fail. Most notably, a read-only fs or no
+        # permissions to even check for folder to exist (e.x. privileges were dropped
+        # before scapy was started).
+        return None
     return path.joinpath(*cf).resolve()
 
 


### PR DESCRIPTION
If privileges for scapy were dropped, but username remain unchanged, path.exist() would trigger an exception. Fix that by moving whole if statement under try-except.

**Checklist:**

-   [X] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [X] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
         Tests are not relevant because it is extremely hard to write a proper test for that behaviour. 
-   [X] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [X] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

Fixes #4618
