### PR TITLE
bluetooth4LE: BTLE_ADV PDU_type enum typo fix

### DIFF
--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -283,7 +283,7 @@ class BTLE_ADV(Packet):
                                         2: "ADV_NONCONN_IND",
                                         3: "SCAN_REQ",
                                         4: "SCAN_RSP",
-                                        5: "CONNECT_REQ",
+                                        5: "CONNECT_IND",
                                         6: "ADV_SCAN_IND"}),
         XByteField("Length", None),
     ]


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->

The referenced documentation in the code shows a slightly different name. See below.

![imagen](https://github.com/user-attachments/assets/8158a10b-5bf9-4976-a98b-49d5ec1849a5)
