### PR TITLE
Add .idea to ignore Jetbrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.xml
 __pycache__/
 doc/scapy/_build
 doc/scapy/api
+.idea


### PR DESCRIPTION
- Added `.idea` to the `.gitignore` file to ignore project files created by JetBrains IDEs 
- No breaking changes introduced.