### PR TITLE
Explicitly set registerVal max count to 123 to override global limit

### DIFF
--- a/scapy/contrib/modbus.py
+++ b/scapy/contrib/modbus.py
@@ -102,7 +102,8 @@ class ModbusPDU03ReadHoldingRegistersResponse(Packet):
                                     adjust=lambda pkt, x: x * 2),
                    FieldListField("registerVal", [0x0000],
                                   ShortField("", 0x0000),
-                                  count_from=lambda pkt: pkt.byteCount)]
+                                  count_from=lambda pkt: pkt.byteCount,
+                                  max_count=123)]
 
 
 class ModbusPDU03ReadHoldingRegistersError(Packet):


### PR DESCRIPTION
Added `max_count=123` to the `FieldListField` for the `registerVal` field to override the global `conf.max_list_count =100`


fixes #4573
