### PR TITLE
Test Python 3.7 on Ubuntu 22.04

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -78,12 +78,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         mode: [non_root]
         installmode: ['']
         flags: [" -K scanner"]
         allow-failure: ['false']
         include:
+          # Python 3.7
+          - os: ubuntu-22.04
+            python: "3.7"
+            mode: non_root
+            flags: " -K scanner"
           # Linux root tests
           - os: ubuntu-latest
             python: "3.12"


### PR DESCRIPTION
This PR fixes the unit tests for Python 3.7.