### PR TITLE
Proposal: Set threaded to False in sr1.

### DIFF
--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -253,7 +253,7 @@ class SuperSocket(metaclass=_SuperSocket_metaclass):
         # if not explicitly specified by the user,
         # set threaded to False in sr1 to remove the overhead
         # for a Thread creation
-        kargs["threaded"] = kargs.get("threaded", False)
+        kargs.setdefault("threaded", False)
         ans = sendrecv.sndrcv(self, *args, **kargs)[0]  # type: SndRcvList
         if len(ans) > 0:
             pkt = ans[0][1]  # type: Packet

--- a/scapy/supersocket.py
+++ b/scapy/supersocket.py
@@ -250,6 +250,10 @@ class SuperSocket(metaclass=_SuperSocket_metaclass):
         """Send one packet and receive one answer
         """
         from scapy import sendrecv
+        # if not explicitly specified by the user,
+        # set threaded to False in sr1 to remove the overhead
+        # for a Thread creation
+        kargs["threaded"] = kargs.get("threaded", False)
         ans = sendrecv.sndrcv(self, *args, **kargs)[0]  # type: SndRcvList
         if len(ans) > 0:
             pkt = ans[0][1]  # type: Packet


### PR DESCRIPTION
If the user doesn't specifiy threaded, we should set it to False in sr1 to eliminate the overhead of a thread creation


@gpotter2 What do you think?