### PR TITLE
Kerberos: support FAST

### DIFF
--- a/scapy/libs/rfc3961.py
+++ b/scapy/libs/rfc3961.py
@@ -1383,6 +1383,18 @@ class Key(object):
         return ep.random_to_key(seed)
 
     @classmethod
+    def new_random_key(cls, etype):
+        # type: (EncryptionType) -> Key
+        """
+        Generates a seed then calls random-to-key
+        """
+        try:
+            ep = _enctypes[etype]
+        except ValueError:
+            raise ValueError("Unknown etype '%s'" % etype)
+        return cls.random_to_key(etype, os.urandom(ep.seedsize))
+
+    @classmethod
     def string_to_key(cls, etype, string, salt, params=None):
         # type: (EncryptionType, bytes, bytes, Optional[bytes]) -> Key
         """


### PR DESCRIPTION
- add support for Kerberos FAST:
  - in the client
  - in ticketer via `armor_with=`
- supports AS-REQ FAST, and both the "implicit" and "explicit" modes of TGS-REQ FAST

```
t = Ticketer()
t.request_tgt("Win10$@domain.local", key=Key(EncryptionType.AES256_CTS_HMAC_SHA1_96, bytes.fromhex("XXXXXX.....")))
t.request_tgt("Administrator@domain.local", armor_with=0)
```