### PR TITLE
Make Dot11EltVendorSpecific packet extensible

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1452,10 +1452,10 @@ class Dot11EltVendorSpecific(Dot11Elt):
     def register_variant(cls):  # XXX: We do not accept id, but our super-class does
         oui = cls.oui.default
         if not oui:
-            # This is us, register ourselves in the super-class.
-            # TODO: Is there a better way to check?
+            # This is Dot11EltVendorSpecific, register it in the super-class.
             super().register_variant()
-        if oui not in cls.registered_ouis:
+        elif oui not in cls.registered_ouis:
+            # Sub-Vendor (e.g. Dot11EltMicrosoftWPA)
             cls.registered_ouis[oui] = cls
 
 

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1451,6 +1451,10 @@ class Dot11EltVendorSpecific(Dot11Elt):
     @classmethod
     def register_variant(cls):  # XXX: We do not accept id, but our super-class does
         oui = cls.oui.default
+        if not oui:
+            # This is us, register ourselves in the super-class.
+            # TODO: Is there a better way to check?
+            super().register_variant()
         if oui not in cls.registered_ouis:
             cls.registered_ouis[oui] = cls
 

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1449,7 +1449,7 @@ class Dot11EltVendorSpecific(Dot11Elt):
     registered_ouis = {}
 
     @classmethod
-    def register_variant(cls):  # XXX: We do not accept id, but our super-class does
+    def register_variant(cls):
         oui = cls.oui.default
         if not oui:
             # This is Dot11EltVendorSpecific, register it in the super-class.

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1452,7 +1452,7 @@ class Dot11EltVendorSpecific(Dot11Elt):
     def register_variant(cls):  # XXX: We do not accept id, but our super-class does
         oui = cls.oui.default
         if oui not in cls.registered_ouis:
-            cls.registered_ouis[id] = cls
+            cls.registered_ouis[oui] = cls
 
 
 class Dot11EltMicrosoftWPA(Dot11EltVendorSpecific):


### PR DESCRIPTION
See #4659

This commit allows the `Dot11EltVendorSpecific` packet to dispatch to its subclasses based on their OUI, with the same idiom that the parent `Dot11Elt` uses to select subclasses based on their ID already:

https://github.com/secdev/scapy/blob/c15a670926185f6ddb9b3330ed1f947ff6f14b92/scapy/layers/dot11.py#L1057-L1074

This is just a rough sketch, so feedback very welcome; is the approach heading in the right direction? :)
