### PR TITLE
LL_VERSION_IND Subversion field should be little-endian

### DIFF
--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -541,7 +541,7 @@ class LL_VERSION_IND(Packet):
     fields_desc = [
         ByteEnumField("version", 8, BTLE_Versions),
         LEShortEnumField("company", 0, BTLE_Corp_IDs),
-        XShortField("subversion", 0)
+        XLEShortField("subversion", 0)
     ]
 
 


### PR DESCRIPTION
<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

The Subversion field of LL_VERSION_IND is little-endian (like most other fields). However currently it's being parsed as big-endian. This change fixes the definition to be little-endian.

![image](https://github.com/user-attachments/assets/4c416a44-15eb-40d4-9701-a354730e9dde)