### PR TITLE
Fix in KNXnet/IP layer (KNX addresses handling)

### DIFF
--- a/scapy/contrib/knx.py
+++ b/scapy/contrib/knx.py
@@ -31,7 +31,7 @@ from scapy.fields import PacketField, MultipleTypeField, ByteField, XByteField, 
 from scapy.packet import Packet, bind_layers, bind_bottom_up, Padding
 from scapy.layers.inet import UDP
 
-### KNX CODES
+# KNX CODES
 
 # KNX Standard v2.1 - 03_08_02 p20
 SERVICE_IDENTIFIER_CODES = {
@@ -161,7 +161,7 @@ CEMI_PROPERTIES = {
 }
 
 
-### KNX SPECIFIC FIELDS
+# KNX SPECIFIC FIELDS
 
 # KNX Standard v2.1 - 03_05_01 p.17
 class KNXAddressField(ShortField):
@@ -171,13 +171,12 @@ class KNXAddressField(ShortField):
         return "%d.%d.%d" % ((x >> 12) & 0xf, (x >> 8) & 0xf, (x & 0xff))
 
     def any2i(self, pkt, x):
+        # Raises ValueError in x does not have format a/b/c
         if type(x) is str:
-            try:
-                a, b, c = map(int, x.split("."))
-                x = (a << 12) | (b << 8) | c
-            except:
-                raise ValueError(x)
+            a, b, c = map(int, x.split("."))
+            x = (a << 12) | (b << 8) | c
         return ShortField.any2i(self, pkt, x)
+
 
 # KNX Standard v2.1 - 03_05_01 p.18
 class KNXGroupField(ShortField):
@@ -185,16 +184,14 @@ class KNXGroupField(ShortField):
         return "%d/%d/%d" % ((x >> 11) & 0x1f, (x >> 8) & 0x7, (x & 0xff))
 
     def any2i(self, pkt, x):
+        # Raises ValueError in x does not have format a/b/c
         if type(x) is str:
-            try:
-                a, b, c = map(int, x.split("/"))
-                x = (a << 11) | (b << 8) | c
-            except:
-                raise ValueError(x)
+            a, b, c = map(int, x.split("/"))
+            x = (a << 11) | (b << 8) | c
         return ShortField.any2i(self, pkt, x)
 
 
-### KNX PLACEHOLDERS
+# KNX PLACEHOLDERS
 
 # KNX Standard v2.1 - 03_08_02 p21
 class HPAI(Packet):
@@ -251,7 +248,7 @@ class DIBSuppSvcFamilies(Packet):
         ConditionalField(
             PacketListField("service_family", ServiceFamily(), ServiceFamily,
                             length_from=lambda
-                                pkt: pkt.structure_length - 0x02),
+                            pkt: pkt.structure_length - 0x02),
             lambda pkt: pkt.structure_length > 0x02)
     ]
 
@@ -347,7 +344,7 @@ class LcEMI(Packet):
                  lambda pkt: pkt.address_type == 0)
             ],
             ShortField("destination_address", "")
-            ),
+        ),
         FieldLenField("npdu_length", 0x01, fmt="B", length_of="data"),
         # TPCI and APCI (2 byte made of 1+1+4+4+6 bits)
         BitEnumField("packet_type", 0, 1, {
@@ -357,7 +354,7 @@ class LcEMI(Packet):
         BitEnumField("sequence_type", 0, 1, {
             0: "unnumbered"
         }),
-        BitField("sequence_number", 0, 4), # Not used when sequence_type = unnumbered
+        BitField("sequence_number", 0, 4),  # Not used when sequence_type = unnumbered
         ConditionalField(BitEnumField("acpi", 2, 4, KNX_ACPI_CODES),
                          lambda pkt: pkt.packet_type == 0),
         ConditionalField(BitEnumField("service", 0, 2, KNX_SERVICE_CODES),
@@ -403,7 +400,7 @@ class CEMI(Packet):
     ]
 
 
-### KNX SERVICES
+# KNX SERVICES
 
 # KNX Standard v2.1 - 03_08_02 p28
 class KNXSearchRequest(Packet):
@@ -565,6 +562,7 @@ class KNXTunnelingACK(Packet):
         p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
         return p + pay
 
+
 class KNXRoutingIndication(Packet):
     name = "ROUTING_INDICATION"
     fields_desc = [
@@ -576,7 +574,7 @@ class KNXRoutingIndication(Packet):
         return p + pay
 
 
-### KNX FRAME
+# KNX FRAME
 
 # we made the choice to define a KNX service as a payload for a KNX Header
 # it could also be possible to define the body as a conditionnal PacketField
@@ -599,7 +597,7 @@ class KNX(Packet):
         return p + pay
 
 
-### LAYERS BINDING
+# LAYERS BINDING
 
 bind_bottom_up(UDP, KNX, dport=3671)
 bind_bottom_up(UDP, KNX, sport=3671)
@@ -626,7 +624,7 @@ bind_layers(KNX, KNXRoutingIndication, service_identifier=0x0530)
 # we could also define a new Packet class with no payload and inherit
 # every KNX packet from it :
 #
-#class _KNXBodyNoPayload(Packet):
+# class _KNXBodyNoPayload(Packet):
 #
 #    def extract_padding(self, s):
 #        return b"", None

--- a/scapy/contrib/knx.py
+++ b/scapy/contrib/knx.py
@@ -23,6 +23,7 @@ Currently, the module (partially) supports the following services :
 # scapy.contrib.description = KNX Protocol
 # scapy.contrib.status = loads
 
+import struct
 from scapy.fields import PacketField, MultipleTypeField, ByteField, XByteField, \
     ShortEnumField, ShortField, \
     ByteEnumField, IPField, StrFixedLenField, MACField, XBitField, \
@@ -204,7 +205,7 @@ class HPAI(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -236,7 +237,7 @@ class DIBDeviceInfo(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -253,7 +254,7 @@ class DIBSuppSvcFamilies(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -285,7 +286,7 @@ class CRI(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -300,7 +301,7 @@ class CRD(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -513,7 +514,7 @@ class KNXConfigurationRequest(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p[:4])).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p[:4])) + p[1:]
         return p + pay
 
 
@@ -528,7 +529,7 @@ class KNXConfigurationACK(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -544,7 +545,7 @@ class KNXTunnelingRequest(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p[:4])).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p[:4])) + p[1:]
         return p + pay
 
 
@@ -559,7 +560,7 @@ class KNXTunnelingACK(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         return p + pay
 
 
@@ -570,7 +571,7 @@ class KNXRoutingIndication(Packet):
     ]
 
     def post_build(self, p, pay):
-        p = (len(p[:4])).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p[:4])) + p[1:]
         return p + pay
 
 
@@ -591,9 +592,9 @@ class KNX(Packet):
 
     def post_build(self, p, pay):
         # computes header_length
-        p = (len(p)).to_bytes(1, byteorder='big') + p[1:]
+        p = struct.pack("!B", len(p)) + p[1:]
         # computes total_length
-        p = p[:-2] + (len(p) + len(pay)).to_bytes(2, byteorder='big')
+        p = p[:-2] + struct.pack("!H", len(p) + len(pay))
         return p + pay
 
 

--- a/scapy/contrib/knx.py
+++ b/scapy/contrib/knx.py
@@ -577,7 +577,7 @@ class KNXRoutingIndication(Packet):
 # KNX FRAME
 
 # we made the choice to define a KNX service as a payload for a KNX Header
-# it could also be possible to define the body as a conditionnal PacketField
+# it could also be possible to define the body as a conditional PacketField
 # contained after the header.
 
 class KNX(Packet):

--- a/test/contrib/knx.uts
+++ b/test/contrib/knx.uts
@@ -69,7 +69,42 @@ assert isinstance(p.payload, KNXTunnelingRequest)
 p = KNX(b'\x06\x10\x04!\x00\n\x04\x01\x00\x00')
 assert isinstance(p.payload, KNXTunnelingACK)
 
-+ Test layer binding
-= Destination port
++ Test KNX packet parsing
+= KNX Search Request
+pkt = KNX(b'\x06\x10\x02\x01\x00\x0e\x08\x01\x00\x00\x00\x00\x00\x00')
+assert pkt.service_identifier == 0x0201
+assert pkt.discovery_endpoint.ip_address == "0.0.0.0"
 
+= KNX Search response
+pkt = KNX(b'\x06\x10\x02\x02\x00F\x08\x01\x00\x00\x00\x00\x00\x006\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x02')
+assert pkt.service_identifier == 0x0202
+assert pkt.device_info.description_type == 1
 
++ Test KNX packet building
+= KNX Search Request
+pkt = KNX()/KNXSearchRequest()
+pkt.discovery_endpoint.ip_address = "192.168.1.1"
+assert raw(pkt) == b'\x06\x10\x02\x01\x00\x0e\x08\x01\xc0\xa8\x01\x01\x00\x00'
+
+= KNX Search Response
+pkt = KNX()/KNXSearchResponse()
+pkt.control_endpoint.port = 3671
+pkt.device_info.device_multicast_address = "224.0.23.12"
+pkt.device_info.device_mac_address = "ff:ff:ff:ff:ff:ff"
+
+assert raw(pkt) == b'\x06\x10\x02\x02\x00F\x08\x01\x00\x00\x00\x00\x0eW6\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xe0\x00\x17\x0c\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x02'
+
+= KNX Individual address parsing
+test_addr = DIBDeviceInfo()
+test_addr.knx_address = "1.1.1"
+assert test_addr.knx_address == 0x1101
+
+= CEMI individual address in a field that takes multiple types
+test_addr = CEMI(message_code=0x11) # L_Data.req
+test_addr.cemi_data.address_type = 0 # Individual address
+test_addr.cemi_data.destination_address = "1.1.1"
+
+= CEMI group address in a field that takes multiple types
+test_addr = CEMI(message_code=0x11) # L_Data.req
+test_addr.cemi_data.address_type = 1 # Group address
+test_addr.cemi_data.destination_address = "1/1/1"


### PR DESCRIPTION
This PR introduces a few changes to the KNXnet/IP layer, last updated in 2021:

* Fix validation and support issues on KNX individual addresses and KNX group addresses (see below)
* Add a few recognized KNX codes and supported types for MultipleTypeFields in complex packets
* Add basic and KNX address-related unit tests

I made the PR mainly to fix issues when building packets containing individual address (format 1.1.1) or group address (format 1/1/1) fields. The layer only supported either individual address or group address in a field, but some fields (for instance, in cEMI blocks) can take both formats. For instance, the code below used to raise a ValueError and is now valid.

```
test_addr = CEMI(message_code=0x11) # L_Data.req
test_addr.cemi_data.address_type = 0 # Individual address
test_addr.cemi_data.destination_address = "1.1.1"
```