### PR TITLE
Use Vendor IntEnum in place of Vendor IDs

### DIFF
--- a/scapy/contrib/rtps/common_types.py
+++ b/scapy/contrib/rtps/common_types.py
@@ -12,6 +12,7 @@ Real-Time Publish-Subscribe Protocol (RTPS) dissection
 # scapy.contrib.status = library
 
 import struct
+from enum import IntEnum
 
 from scapy.fields import (
     _FieldContainer,
@@ -277,29 +278,53 @@ class ProtocolVersionPacket(Packet):
         return b"", p
 
 
+class Vendor(IntEnum):
+    UNKNOWN = 0x0000,
+    RTI_CONNEXT = 0x0101,
+    ADLINK_OPENSPLICE = 0x0102,
+    OCI_OPENDDS = 0x0103,
+    MILSOFT_MIL = 0x0104,
+    KONGSBERG_INTERCOM = 0x0105,
+    TWINOAKS_COREDX = 0x0106,
+    LAKOTA = 0x0107,
+    ICOUP = 0x0108,
+    ETRI_DIAMOND = 0x0109,
+    RTI_CONNEXT_MICRO = 0x010A,
+    ADLINK_VORTEXCAFE = 0x010B,
+    PRISMTECH = 0x010C,
+    ADLINK_VORTEXLITE = 0x010D,
+    TECHNICOLOR_QEO = 0x010E,
+    EPROSIMA_FASTDDS = 0x010F,
+    ECLIPSE_CYCLONE = 0x0110,
+    GURUMNETWORKS_GURUM = 0x0111,
+    ATOSTEK_RUSTDDS = 0x0112,
+    NANJINGZHENRONG_ZRDDS = 0x0113,
+    S2E_DUST = 0x0114
+
+
 _rtps_vendor_ids = {
-    0x0000: "VENDOR_ID_UNKNOWN (0x0000)",
-    0x0101: "Real-Time Innovations, Inc. (RTI) - Connext DDS",
-    0x0102: "ADLink Ltd. - OpenSplice DDS",
-    0x0103: "Object Computing Inc. (OCI) - OpenDDS",
-    0x0104: "MilSoft - Mil-DDS",
-    0x0105: "Kongsberg - InterCOM DDS",
-    0x0106: "Twin Oaks Computing, Inc. - CoreDX DDS",
-    0x0107: "Lakota Technical Solutions, Inc.",
-    0x0108: "ICOUP Consulting",
-    0x0109: "Electronics and Telecommunication Research Institute (ETRI) - Diamond DDS",
-    0x010A: "Real-Time Innovations, Inc. (RTI) - Connext DDS Micro",
-    0x010B: "ADLink Ltd. - VortexCafe",
-    0x010C: "PrismTech Ltd",
-    0x010D: "ADLink Ltd. - Vortex Lite",
-    0x010E: "Technicolor - Qeo",
-    0x010F: "eProsima - FastRTPS, FastDDS",
-    0x0110: "Eclipse Foundation - Cyclone DDS",
-    0x0111: "Gurum Networks, Inc. - GurumDDS",
-    0x0112: "Atostek - RustDDS",
-    0x0113: "Nanjing Zhenrong Software Technology Co. \
+    Vendor.UNKNOWN: "VENDOR_ID_UNKNOWN (0x0000)",
+    Vendor.RTI_CONNEXT: "Real-Time Innovations, Inc. (RTI) - Connext DDS",
+    Vendor.ADLINK_OPENSPLICE: "ADLink Ltd. - OpenSplice DDS",
+    Vendor.OCI_OPENDDS: "Object Computing Inc. (OCI) - OpenDDS",
+    Vendor.MILSOFT_MIL: "MilSoft - Mil-DDS",
+    Vendor.KONGSBERG_INTERCOM: "Kongsberg - InterCOM DDS",
+    Vendor.TWINOAKS_COREDX: "Twin Oaks Computing, Inc. - CoreDX DDS",
+    Vendor.LAKOTA: "Lakota Technical Solutions, Inc.",
+    Vendor.ICOUP: "ICOUP Consulting",
+    Vendor.ETRI_DIAMOND: "Electronics and Telecommunication Research Institute (ETRI) - Diamond DDS",
+    Vendor.RTI_CONNEXT_MICRO: "Real-Time Innovations, Inc. (RTI) - Connext DDS Micro",
+    Vendor.ADLINK_VORTEXCAFE: "ADLink Ltd. - VortexCafe",
+    Vendor.PRISMTECH: "PrismTech Ltd",
+    Vendor.ADLINK_VORTEXLITE: "ADLink Ltd. - Vortex Lite",
+    Vendor.TECHNICOLOR_QEO: "Technicolor - Qeo",
+    Vendor.EPROSIMA_FASTDDS: "eProsima - FastRTPS, FastDDS",
+    Vendor.ECLIPSE_CYCLONE: "Eclipse Foundation - Cyclone DDS",
+    Vendor.GURUMNETWORKS_GURUM: "Gurum Networks, Inc. - GurumDDS",
+    Vendor.ATOSTEK_RUSTDDS: "Atostek - RustDDS",
+    Vendor.NANJINGZHENRONG_ZRDDS: "Nanjing Zhenrong Software Technology Co. \
         - Zhenrong Data Distribution Service (ZRDDS)",
-    0x0114: "S2E Software Systems B.V. - Dust DDS",
+    Vendor.S2E_DUST: "S2E Software Systems B.V. - Dust DDS",
 }
 
 

--- a/test/contrib/rtps.uts
+++ b/test/contrib/rtps.uts
@@ -476,3 +476,41 @@ p1 = RTPS(
 assert p0.build() == d
 assert p1.build() == d
 assert p0 == p1
+
++ Test Vendor IntEnum
+= import Vendor IntEnum
+from scapy.contrib.rtps.common_types import Vendor
+
+= VendorIdPacket declaration
+vendor_id_pkt = VendorIdPacket(vendor_id=Vendor)
+
+= Test with previous test case
+d = b"\x52\x54\x50\x53\x02\x02\x01\x0f\x01\x0f\x45\xd2\xb3\xf5\x58\xb9" \
+    b"\x01\x00\x00\x00\x06\x03\x18\x00\x00\x00\x03\xc7\x00\x00\x03\xc2" \
+    b"\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+p0 = RTPS(d)
+
+p1 = RTPS(
+    protocolVersion=ProtocolVersionPacket(major=2, minor=2),
+    vendorId=VendorIdPacket(vendor_id=Vendor.EPROSIMA_FASTDDS),
+    guidPrefix=GUIDPrefixPacket(
+        hostId=0x010f45d2, appId=0xb3f558b9, instanceId=0x01000000
+    ),
+    magic=b"RTPS",
+) / RTPSMessage(
+    submessages=[
+        RTPSSubMessage_ACKNACK(
+            submessageId=6,
+            submessageFlags=3,
+            octetsToNextHeader=0x18,
+            reader_id=b'\x00\x00\x03\xc7',
+            writer_id=b'\x00\x00\x03\xc2',
+            readerSNState=b'\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00',
+            count=1
+        )
+    ]
+)
+
+assert p0.build() == d
+assert p1.build() == d
+assert p0 == p1


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

This PR creates an `IntEnum` called `Vendor` and updates the `_rtps_vendor_ids` to use the `Vendor`. This way, the codebase remains unaffected by these changes while developers can freely use `Vendor` rather than the raw hexadecimal value. An example of this usage is in `rtps.uts`.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #4692 <!-- (add issue number here if appropriate, else remove this line) -->
