### PR TITLE
STUN: Fix building binding response

### DIFF
--- a/scapy/contrib/stun.py
+++ b/scapy/contrib/stun.py
@@ -149,7 +149,7 @@ class XorIp(IPField):
     def i2m(self, pkt, x):
         if x is None:
             return b"\x00\x00\x00\x00"
-        return struct.pack(">i", struct.unpack(">i", inet_aton(x)) ^ MAGIC_COOKIE)
+        return struct.pack(">i", struct.unpack(">i", inet_aton(x))[0] ^ MAGIC_COOKIE)
 
 
 class STUNXorMappedAddress(STUNGenericTlv):

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -146,3 +146,20 @@ built = stun.build()
 parsed = STUN(built)
 
 assert parsed.build() == built
+
+= test STUN packet build with attributes
+stun = STUN(
+    stun_message_type="Binding success response",
+    transaction_id=0x3479476534635936316a796a,
+    attributes=[
+        STUNXorMappedAddress(xport=25000, xip="172.20.0.200"),
+        STUNUsername(length=37, username="Ht11MaRZHc4GOLJUsbu1R3YCs72HYN25:oNph"),
+        STUNMessageIntegrity(hmac_sha1=0x4b67036dfb65ca84d63bcac86c8d5981df657031),
+        STUNFingerprint(crc_32=0x4041e9c3)
+    ]
+)
+
+built = stun.build()
+parsed = STUN(built)
+
+assert parsed.build() == built


### PR DESCRIPTION
Building a binding success response with an XOR-MAPPED-ADDRESS attribute filed with:
```
  File "/home/simon/src/scapy/scapy/contrib/stun.py", line 152, in i2m
    return struct.pack(">i", struct.unpack(">i", inet_aton(x)) ^ MAGIC_COOKIE)
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
TypeError: While dissecting field 'attributes': While dissecting field 'xip': unsupported operand type(s) for ^: 'tuple' and 'int'
```

Fixed by properly handling the return value of struct.unpack (a tuple with one int).