### PR TITLE
Kerberos improvements, bug fixes in LDAP

### DIFF
--- a/scapy/config.py
+++ b/scapy/config.py
@@ -619,11 +619,15 @@ class ExtsManager(importlib.abc.MetaPathFinder):
                 for k, v in distr.metadata.items() if k == 'Classifier'
             ):
                 try:
-                    pkg = next(
-                        k
-                        for k, v in importlib.metadata.packages_distributions().items()
-                        if distr.name in v
-                    )
+                    # Python 3.13 raises an internal warning when calling this
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings("ignore", category=DeprecationWarning)
+                        pkg = next(
+                            k
+                            for k, v in
+                            importlib.metadata.packages_distributions().items()
+                            if distr.name in v
+                        )
                 except KeyError:
                     pkg = distr.name
                 if pkg in self._loaded:

--- a/scapy/layers/dcerpc.py
+++ b/scapy/layers/dcerpc.py
@@ -1805,12 +1805,14 @@ class _NDRPacketField(_NDRValueOf, PacketField):
         return self.cls(m, ndr64=pkt.ndr64, ndrendian=pkt.ndrendian, _parent=pkt)
 
 
-# class _NDRPacketPadField(PadField):
-#     def padlen(self, flen, pkt):
-#         if pkt.ndr64:
-#             return -flen % self._align[1]
-#         else:
-#             return 0
+class _NDRPacketPadField(PadField):
+    # [MS-RPCE] 2.2.5.3.4.1 Structure with Trailing Gap
+    # Structures have extra alignment/padding in NDR64.
+    def padlen(self, flen, pkt):
+        if pkt.ndr64:
+            return -flen % self._align[1]
+        else:
+            return 0
 
 
 class NDRPacketField(NDRConstructedType, NDRAlign):
@@ -1819,9 +1821,7 @@ class NDRPacketField(NDRConstructedType, NDRAlign):
         self.fld = _NDRPacketField(name, default, pkt_cls=pkt_cls, **kwargs)
         NDRAlign.__init__(
             self,
-            # There is supposed to be padding after a struct in NDR64?
-            # _NDRPacketPadField(fld, align=pkt_cls.ALIGNMENT),
-            self.fld,
+            _NDRPacketPadField(self.fld, align=pkt_cls.ALIGNMENT),
             align=pkt_cls.ALIGNMENT,
         )
         NDRConstructedType.__init__(self, pkt_cls.fields_desc)

--- a/scapy/layers/ldap.py
+++ b/scapy/layers/ldap.py
@@ -1811,6 +1811,7 @@ class LDAP_Client(object):
             else:
                 port = 389
         sock = socket.socket()
+        self.timeout = timeout
         sock.settimeout(timeout)
         if self.verb:
             print(
@@ -2151,7 +2152,7 @@ class LDAP_Client(object):
         filter: str = "",
         scope=0,
         derefAliases=0,
-        sizeLimit=3000,
+        sizeLimit=300000,
         timeLimit=3000,
         attrsOnly=0,
         attributes: List[str] = [],
@@ -2202,7 +2203,7 @@ class LDAP_Client(object):
                                 controlType="1.2.840.113556.1.4.319",
                                 criticality=True,
                                 controlValue=LDAP_realSearchControlValue(
-                                    size=500,  # paging to 500 per 500
+                                    size=200,  # paging to 200 per 200
                                     cookie=cookie,
                                 ),
                             )
@@ -2211,7 +2212,7 @@ class LDAP_Client(object):
                         else []
                     )
                 ),
-                timeout=3,
+                timeout=self.timeout,
             )
             if LDAP_SearchResponseResultDone not in resp:
                 resp.show()
@@ -2294,7 +2295,7 @@ class LDAP_Client(object):
                 changes=changes,
             ),
             controls=controls,
-            timeout=3,
+            timeout=self.timeout,
         )
         if (
             LDAP_ModifyResponse not in resp.protocolOp
@@ -2341,7 +2342,7 @@ class LDAP_Client(object):
                 attributes=attributes,
             ),
             controls=controls,
-            timeout=3,
+            timeout=self.timeout,
         )
         if LDAP_AddResponse not in resp.protocolOp or resp.protocolOp.resultCode != 0:
             raise LDAP_Exception(
@@ -2382,7 +2383,7 @@ class LDAP_Client(object):
                 deleteoldrdn=deleteoldrdn,
             ),
             controls=controls,
-            timeout=3,
+            timeout=self.timeout,
         )
         if (
             LDAP_ModifyDNResponse not in resp.protocolOp

--- a/scapy/layers/msrpce/rpcclient.py
+++ b/scapy/layers/msrpce/rpcclient.py
@@ -490,6 +490,7 @@ class DCERPC_Client(object):
         ip,
         interface,
         port=None,
+        timeout=5,
         smb_kwargs={},
     ):
         """
@@ -527,7 +528,7 @@ class DCERPC_Client(object):
             else:
                 return
             # 2. connect to the SMB server
-            self.connect(ip, port=port, smb_kwargs=smb_kwargs)
+            self.connect(ip, port=port, timeout=timeout, smb_kwargs=smb_kwargs)
             # 3. open the new named pipe
             self.open_smbpipe(pipename)
         # Bind in RPC

--- a/scapy/layers/smbclient.py
+++ b/scapy/layers/smbclient.py
@@ -1229,7 +1229,7 @@ class smbclient(CLIUtil):
         )
         try:
             # Wrap with SMB_SOCKET
-            self.smbsock = SMB_SOCKET(self.sock)
+            self.smbsock = SMB_SOCKET(self.sock, timeout=self.timeout)
             # Wait for either the atmt to fail, or the smb_sock_ready to timeout
             _t = time.time()
             while True:


### PR DESCRIPTION
Various bug fixes:
- parsing of more kerberos errors in fast mode
- hide deprecation warnings on Python 3.13 (used internally in Python 3.13...)
- minor additions to [MS-DRSR]
- improvements to ticketer
- enable missing padding in NDR64 (that I really suspected should be enabled eventually, but yeah it needed)