### PR TITLE
Bluetooth: Make EIR_AdvertisingInterval variable length

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -56,6 +56,7 @@ from scapy.fields import (
     XLEIntField,
     LEMACField,
     BitEnumField,
+    LEThreeBytesField,
 )
 from scapy.supersocket import SuperSocket
 from scapy.sendrecv import sndrcv
@@ -1266,7 +1267,19 @@ class EIR_PublicTargetAddress(EIR_Element):
 class EIR_AdvertisingInterval(EIR_Element):
     name = "Advertising Interval"
     fields_desc = [
-        LEShortField("advertising_interval", 0)
+        MultipleTypeField(
+            [
+                (ByteField("advertising_interval", 0),
+                 lambda p: p.underlayer.len - 1 == 1),
+                (LEShortField("advertising_interval", 0),
+                 lambda p: p.underlayer.len - 1 == 2),
+                (LEThreeBytesField("advertising_interval", 0),
+                 lambda p: p.underlayer.len - 1 == 3),
+                (LEIntField("advertising_interval", 0),
+                 lambda p: p.underlayer.len - 1 == 4),
+            ],
+            LEShortField("advertising_interval", 0)
+        )
     ]
 
 

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -481,6 +481,10 @@ p = HCI_Event_Hdr(hex_bytes('3e23020100002e4961121110170201060f0954656c655361742
 assert EIR_AdvertisingInterval in p
 assert p[EIR_AdvertisingInterval].advertising_interval == 400
 
+p = BTLE(hex_bytes('d6be898e20234fe761e5b754021a1803030a18020ace12fffa07104a2b010000000054b7e561e74f00000000'))
+assert EIR_AdvertisingInterval in p
+assert p[EIR_AdvertisingInterval].advertising_interval == 24
+
 = Parse EIR_LEBluetoothDeviceAddress
 p = HCI_Event_Hdr(hex_bytes("3e2a02010000d93519d7ba4c1e0201020affc4000734151317fd80081b00d93519d7ba4c0303b9fe020ad4ad"))
 assert EIR_LEBluetoothDeviceAddress in p


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

This should fix https://github.com/secdev/scapy/issues/4625
