### PR TITLE
Stun improvements

### DIFF
--- a/scapy/contrib/stun.py
+++ b/scapy/contrib/stun.py
@@ -149,7 +149,7 @@ class XorIp(IPField):
     def i2m(self, pkt, x):
         if x is None:
             return b"\x00\x00\x00\x00"
-        return struct.pack(">i", struct.unpack(">i", inet_aton(x)) ^ MAGIC_COOKIE)
+        return struct.pack(">i", struct.unpack(">i", inet_aton(x))[0] ^ MAGIC_COOKIE)
 
 
 class STUNXorMappedAddress(STUNGenericTlv):

--- a/scapy/contrib/stun.py
+++ b/scapy/contrib/stun.py
@@ -193,6 +193,25 @@ class STUNXorMappedAddress(STUNGenericTlv):
     ]
 
 
+class STUNMappedAddress(STUNGenericTlv):
+    name = "STUN Mapped Address"
+
+    fields_desc = [
+        XShortField("type", 0x0001),
+        FieldLenField("length", None, length_of="ip", adjust=lambda pkt, x: x + 4),
+        ByteField("RESERVED", 0),
+        ByteEnumField("address_family", 1, _xor_mapped_address_family),
+        ShortField("port", 0),
+        MultipleTypeField(
+            [
+                (IPField("ip", "127.0.0.1"), lambda pkt: pkt.address_family == 1),
+                (IP6Field("ip", "::1"), lambda pkt: pkt.address_family == 2),
+            ],
+            IPField("ip", "127.0.0.1"),
+        ),
+    ]
+
+
 class STUNUseCandidate(STUNGenericTlv):
     name = "STUN Use Candidate"
 
@@ -235,6 +254,7 @@ class STUNGoogNetworkInfo(STUNGenericTlv):
 
 
 _stun_tlv_class = {
+    0x0001: STUNMappedAddress,
     0x0006: STUNUsername,
     0x0008: STUNMessageIntegrity,
     0x0020: STUNXorMappedAddress,

--- a/scapy/contrib/stun.py
+++ b/scapy/contrib/stun.py
@@ -20,7 +20,7 @@ import itertools
 
 from scapy.layers.inet import UDP, TCP
 from scapy.config import conf
-from scapy.packet import Packet, bind_layers
+from scapy.packet import Packet, bind_bottom_up, bind_top_down
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.fields import (
     BitField,
@@ -307,5 +307,10 @@ class STUN(Packet):
         return pkt
 
 
-bind_layers(UDP, STUN, dport=3478)
-bind_layers(TCP, STUN, dport=3478)
+bind_bottom_up(UDP, STUN, sport=3478)
+bind_bottom_up(UDP, STUN, dport=3478)
+bind_top_down(UDP, STUN, sport=3478, dport=3478)
+
+bind_bottom_up(TCP, STUN, sport=3478)
+bind_bottom_up(TCP, STUN, dport=3478)
+bind_top_down(TCP, STUN, sport=3478, dport=3478)

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -78,7 +78,7 @@ assert parsed.length == 44
 assert parsed.magic_cookie == 0x2112A442
 assert parsed.transaction_id == 0xcfacb2a43aa2de5a9d56d85a, parsed.transaction_id
 assert parsed.attributes == [
-      STUNXorMappedAddress(xport=40480, xip="172.20.0.42"),
+      STUNXorMappedAddress(length=8, xport=40480, xip="172.20.0.42"),
       STUNMessageIntegrity(hmac_sha1=0xb71fc9235897c802e3fff8e3d889fa41428d967d),
       STUNFingerprint(crc_32=0xea9b6559)
 ]
@@ -99,13 +99,32 @@ assert STUN.stun_message_type.i2repr(None, parsed.stun_message_type) == "Binding
 assert parsed.length == 88
 assert parsed.magic_cookie == 0x2112A442
 assert parsed.transaction_id == 0x3479476534635936316a796a, parsed.transaction_id
-assert parsed.attributes[0] == STUNXorMappedAddress(xport=25000, xip="172.20.0.200"), parsed.attributes
+assert parsed.attributes[0] == STUNXorMappedAddress(length=8, xport=25000, xip="172.20.0.200"), parsed.attributes
 assert parsed.attributes == [
-      STUNXorMappedAddress(xport=25000, xip="172.20.0.200"),
+      STUNXorMappedAddress(length=8, xport=25000, xip="172.20.0.200"),
       STUNUsername(length=37, username="Ht11MaRZHc4GOLJUsbu1R3YCs72HYN25:oNph"),
       STUNMessageIntegrity(hmac_sha1=0x4b67036dfb65ca84d63bcac86c8d5981df657031),
       STUNFingerprint(crc_32=0x4041e9c3)
 ]
+
+= test STUN binding success response IPv6
+
+raw = b"\x01\x01\x00\x18\x21\x12\xa4\x42\x91\x1b\x25\x32\x99\x8d\xa0\x1c" \
+      b"\xf9\xd0\x53\xd9\x00\x20\x00\x14\x00\x02\x3c\xd7\x21\x12\xa4\x42" \
+      b"\x91\x1b\x25\x32\x99\x8d\xa0\x1c\xf9\xd0\x53\xd8"
+
+parsed = STUN(raw)
+assert parsed.RESERVED == 0x00, parsed.RESERVED
+assert STUN.stun_message_type.i2repr(None, parsed.stun_message_type) == "Binding success response"
+assert parsed.length == 24
+assert parsed.magic_cookie == 0x2112A442
+assert parsed.transaction_id == 0x911b2532998da01cf9d053d9, parsed.transaction_id
+assert len(parsed.attributes) == 1, len(parsed.attributes)
+assert parsed.attributes[0].type == 0x0020, parsed.attributes[0].type
+assert parsed.attributes[0].length == 20, parsed.attributes[0].length
+assert parsed.attributes[0].address_family == 0x02, parsed.attributes[0].address_family
+assert parsed.attributes[0].xport == 7621, parsed.attributes[0].xport
+assert parsed.attributes[0].xip == "::1", parsed.attributes[0].xip
 
 = test STUN binding indication 1
 
@@ -163,3 +182,18 @@ built = stun.build()
 parsed = STUN(built)
 
 assert parsed.build() == built
+
+= test STUN packet build IPv6
+
+stun = STUN(
+    stun_message_type="Binding success response",
+    transaction_id=0x911b2532998da01cf9d053d9,
+    attributes=[
+        STUNXorMappedAddress(xport=7621, address_family="IPv6", xip="::1")
+    ]
+)
+built = stun.build()
+parsed = STUN(built)
+
+assert parsed.build() == built
+assert parsed.attributes[0].length == 20

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -146,3 +146,20 @@ built = stun.build()
 parsed = STUN(built)
 
 assert parsed.build() == built
+
+= test STUN packet build with attributes
+stun = STUN(
+    stun_message_type="Binding success response",
+    transaction_id=0x3479476534635936316a796a,
+    attributes=[
+        STUNXorMappedAddress(xport=25000, xip="172.20.0.200"),
+        STUNUsername(length=37, username="Ht11MaRZHc4GOLJUsbu1R3YCs72HYN25:oNph"),
+        STUNMessageIntegrity(hmac_sha1=0x4b67036dfb65ca84d63bcac86c8d5981df657031),
+        STUNFingerprint(crc_32=0x4041e9c3)
+    ]
+)
+
+built = stun.build()
+parsed = STUN(built)
+
+assert parsed.build() == built

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -126,6 +126,24 @@ assert parsed.attributes[0].address_family == 0x02, parsed.attributes[0].address
 assert parsed.attributes[0].xport == 7621, parsed.attributes[0].xport
 assert parsed.attributes[0].xip == "::1", parsed.attributes[0].xip
 
+= test STUN classic binding success response
+
+raw = b"\x01\x01\x00\x0c\x37\x06\xd1\x4d\x38\x3a\xd6\xc8\x40\x5e\x17\x9a" \
+      b"\x93\x92\xea\xa8\x00\x01\x00\x08\x00\x01\x0d\x14\xc0\xa8\x00\x05"
+
+parsed = STUN(raw)
+assert parsed.RESERVED == 0x00, parsed.RESERVED
+assert STUN.stun_message_type.i2repr(None, parsed.stun_message_type) == "Binding success response"
+assert parsed.length == 12
+assert parsed.magic_cookie == 0x3706d14d
+assert parsed.transaction_id == 0x383ad6c8405e179a9392eaa8, parsed.transaction_id
+assert len(parsed.attributes) == 1, len(parsed.attributes)
+assert parsed.attributes[0].type == 0x0001, parsed.attributes[0].type
+assert parsed.attributes[0].length == 8, parsed.attributes[0].length
+assert parsed.attributes[0].address_family == 0x01, parsed.attributes[0].address_family
+assert parsed.attributes[0].port == 3348, parsed.attributes[0].port
+assert parsed.attributes[0].ip == "192.168.0.5", parsed.attributes[0].ip
+
 = test STUN binding indication 1
 
 raw = b"\x00\x11\x00\x08\x21\x12\xa4\x42\x29\x3d\x68\x7b\x0f\xbc\x44\x7c" \

--- a/test/contrib/stun.uts
+++ b/test/contrib/stun.uts
@@ -215,3 +215,28 @@ parsed = STUN(built)
 
 assert parsed.build() == built
 assert parsed.attributes[0].length == 20
+
+= test STUN bottom up binding 1
+
+udp = UDP(sport=62049, dport=3478) / STUN()
+built = udp.build()
+parsed = UDP(built)
+
+assert type(parsed.payload) == STUN, parsed.show(dump=True)
+
+= test STUN bottom up binding 2
+
+udp = UDP(sport=3478, dport=62049) / STUN(stun_message_type="Binding error response")
+built = udp.build()
+parsed = UDP(built)
+
+assert type(parsed.payload) == STUN, parsed.show(dump=True)
+
+= test STUN top down binding
+
+udp = UDP() / STUN()
+built = udp.build()
+parsed = UDP(built)
+
+assert parsed.sport == 3478, parsed.sport
+assert parsed.dport == 3478, parsed.dport


### PR DESCRIPTION
Various STUN improvements:
- Fix building binding response (was #4700)
- Support IPv6 in binding response
- Support MAPPED-ADDRESS attribute
- Fix UDP/TCP layer binding

Added test cases for all the changes.