### PR TITLE
Clean up remains of field_pos_list

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -694,8 +694,6 @@ class Packet(
         # type: () -> bytes
         """
         Create the default layer regarding fields_desc dict
-
-        :param field_pos_list:
         """
         if self.raw_packet_cache is not None and \
                 self.raw_packet_cache_fields is not None:
@@ -2008,7 +2006,7 @@ class Raw(Packet):
 class Padding(Raw):
     name = "Padding"
 
-    def self_build(self, field_pos_list=None):
+    def self_build(self):
         # type: (Optional[Any]) -> bytes
         return b""
 


### PR DESCRIPTION
The field is no longer used anywhere, but it was still in a function doc and as an argument for Padding.self_build.
