### PR TITLE
Update utils.py to forward size parameter in RawPcapnpReader

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1786,7 +1786,7 @@ class RawPcapNgReader(RawPcapReader):
 
         """
         while True:
-            res = self._read_block()
+            res = self._read_block(size=size)
             if res is not None:
                 return res
 


### PR DESCRIPTION
I found this little flaw when reading packages from a pcap that was captured on a different device. This fixed the issue of raw data being truncated. If there is a good reason to ignore the size in here lmk

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
RawPcapNgReader will now forward size to lower level parsing, allowing for configuration to trickle down
Default state is not touched.
Unit tests should ideally not be effected by this

<!-- if required - outline impacts on other parts of the library -->
There should be no impact in other parts of the library