### PR TITLE
Bluetooth: L2CAP signaling channel: better default id, because 0 is a invalid id per the spec

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -330,7 +330,7 @@ class L2CAP_CmdHdr(Packet):
                                   24: "credit_based_conn_resp",
                                   25: "credit_based_reconf_req",
                                   26: "credit_based_reconf_resp"}),
-        ByteField("id", 0),
+        ByteField("id", 1),
         LEShortField("len", None)]
 
     def post_build(self, p, pay):


### PR DESCRIPTION
Per the Bluetooth 5.4 spec page 1043: "Signaling identifier 0x00 is an invalid identifier and shall never be used in any command."

The use of an id field of 0 here forces a scapy user to override the field instead of just using it as is for the first packet.