### PR TITLE
Type annotation bugfixes

### DIFF
--- a/scapy/arch/linux/rtnetlink.py
+++ b/scapy/arch/linux/rtnetlink.py
@@ -394,7 +394,7 @@ class ifinfomsg_rtattr(Packet):
 
 class ifinfomsg(Packet):
     fields_desc = [
-        ByteEnumField("ifi_family", 0, socket.AddressFamily),  # type: ignore
+        ByteEnumField("ifi_family", 0, socket.AddressFamily),
         ByteField("res", 0),
         Field("ifi_type", 0, fmt="=H"),
         Field("ifi_index", 0, fmt="=i"),
@@ -483,7 +483,7 @@ class ifaddrmsg_rtattr(Packet):
 
 class ifaddrmsg(Packet):
     fields_desc = [
-        ByteEnumField("ifa_family", 0, socket.AddressFamily),  # type: ignore
+        ByteEnumField("ifa_family", 0, socket.AddressFamily),
         ByteField("ifa_prefixlen", 0),
         FlagsField(
             "ifa_flags",
@@ -607,7 +607,7 @@ class rtmsg_rtattr(Packet):
 
 class rtmsg(Packet):
     fields_desc = [
-        ByteEnumField("rtm_family", 0, socket.AddressFamily),  # type: ignore
+        ByteEnumField("rtm_family", 0, socket.AddressFamily),
         ByteField("rtm_dst_len", 0),
         ByteField("rtm_src_len", 0),
         ByteField("rtm_tos", 0),

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -463,7 +463,7 @@ class Packet_metaclass(type):
                  *args,  # type: Any
                  **kargs  # type: Any
                  ):
-        # type: (...) -> 'Packet'
+        # type: (...) -> 'cls'
         if "dispatch_hook" in cls.__dict__:
             try:
                 cls = cls.dispatch_hook(*args, **kargs)

--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -463,7 +463,7 @@ class Packet_metaclass(type):
                  *args,  # type: Any
                  **kargs  # type: Any
                  ):
-        # type: (...) -> 'cls'
+        # type: (...) -> 'Packet'
         if "dispatch_hook" in cls.__dict__:
             try:
                 cls = cls.dispatch_hook(*args, **kargs)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2514,11 +2514,14 @@ class XBitField(BitField):
         return lhex(self.i2h(pkt, x))
 
 
+_EnumType = Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+
+
 class _EnumField(Field[Union[List[I], I], I]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[I]
-                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: _EnumType[I]
                  fmt="H",  # type: str
                  ):
         # type: (...) -> None
@@ -2647,7 +2650,7 @@ class CharEnumField(EnumField[str]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: str
-                 enum,  # type: Union[Dict[str, str], Dict[str, str], List[str], DADict[str, str], Type[Enum], Tuple[Callable[[str], str], Callable[[str], str]]]  # noqa: E501
+                 enum,  # type: _EnumType[str]
                  fmt="1s",  # type: str
                  ):
         # type: (...) -> None
@@ -2674,7 +2677,7 @@ class BitEnumField(_BitField[Union[List[int], int]], _EnumField[int]):
                  name,  # type: str
                  default,  # type:  Optional[int]
                  size,  # type:  int
-                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  **kwargs  # type: Any
                  ):
         # type: (...) -> None
@@ -2700,7 +2703,7 @@ class BitLenEnumField(BitLenField, _EnumField[int]):
                  name,  # type: str
                  default,  # type: Optional[int]
                  length_from,  # type: Callable[[Packet], int]
-                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  **kwargs,  # type: Any
                  ):
         # type: (...) -> None
@@ -2725,7 +2728,7 @@ class ShortEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(ShortEnumField, self).__init__(name, default, enum, "H")
@@ -2735,7 +2738,7 @@ class LEShortEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(LEShortEnumField, self).__init__(name, default, enum, "<H")
@@ -2745,7 +2748,7 @@ class LongEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(LongEnumField, self).__init__(name, default, enum, "Q")
@@ -2755,7 +2758,7 @@ class LELongEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(LELongEnumField, self).__init__(name, default, enum, "<Q")
@@ -2765,7 +2768,7 @@ class ByteEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(ByteEnumField, self).__init__(name, default, enum, "B")
@@ -2791,7 +2794,7 @@ class IntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(IntEnumField, self).__init__(name, default, enum, "I")
@@ -2801,7 +2804,7 @@ class SignedIntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(SignedIntEnumField, self).__init__(name, default, enum, "i")
@@ -2811,7 +2814,7 @@ class LEIntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         super(LEIntEnumField, self).__init__(name, default, enum, "<I")
@@ -2829,7 +2832,7 @@ class LE3BytesEnumField(LEThreeBytesField, _EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
+                 enum,  # type: _EnumType[int]
                  ):
         # type: (...) -> None
         _EnumField.__init__(self, name, default, enum)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -2647,7 +2647,7 @@ class CharEnumField(EnumField[str]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: str
-                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: Union[Dict[str, str], Dict[str, str], List[str], DADict[str, str], Type[Enum], Tuple[Callable[[str], str], Callable[[str], str]]]  # noqa: E501
                  fmt="1s",  # type: str
                  ):
         # type: (...) -> None
@@ -2674,7 +2674,7 @@ class BitEnumField(_BitField[Union[List[int], int]], _EnumField[int]):
                  name,  # type: str
                  default,  # type:  Optional[int]
                  size,  # type:  int
-                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  **kwargs  # type: Any
                  ):
         # type: (...) -> None
@@ -2700,7 +2700,7 @@ class BitLenEnumField(BitLenField, _EnumField[int]):
                  name,  # type: str
                  default,  # type: Optional[int]
                  length_from,  # type: Callable[[Packet], int]
-                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  **kwargs,  # type: Any
                  ):
         # type: (...) -> None
@@ -2725,7 +2725,7 @@ class ShortEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum,  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(ShortEnumField, self).__init__(name, default, enum, "H")
@@ -2735,7 +2735,7 @@ class LEShortEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(LEShortEnumField, self).__init__(name, default, enum, "<H")
@@ -2745,7 +2745,7 @@ class LongEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(LongEnumField, self).__init__(name, default, enum, "Q")
@@ -2755,7 +2755,7 @@ class LELongEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(LELongEnumField, self).__init__(name, default, enum, "<Q")
@@ -2765,7 +2765,7 @@ class ByteEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(ByteEnumField, self).__init__(name, default, enum, "B")
@@ -2791,7 +2791,7 @@ class IntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(IntEnumField, self).__init__(name, default, enum, "I")
@@ -2801,7 +2801,7 @@ class SignedIntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(SignedIntEnumField, self).__init__(name, default, enum, "i")
@@ -2811,7 +2811,7 @@ class LEIntEnumField(EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(LEIntEnumField, self).__init__(name, default, enum, "<I")
@@ -2829,7 +2829,7 @@ class LE3BytesEnumField(LEThreeBytesField, _EnumField[int]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[int]
-                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 enum  # type: Union[Dict[int, str], Dict[str, int], List[str], DADict[int, str], Type[Enum], Tuple[Callable[[int], str], Callable[[str], int]]]  # noqa: E501
                  ):
         # type: (...) -> None
         _EnumField.__init__(self, name, default, enum)

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1637,7 +1637,7 @@ class PacketListField(_PacketField[List[BasePacket]]):
             pkt_cls=None,  # type: Optional[Union[Callable[[bytes], Packet], Type[Packet]]]  # noqa: E501
             count_from=None,  # type: Optional[Callable[[Packet], int]]
             length_from=None,  # type: Optional[Callable[[Packet], int]]
-            next_cls_cb=None,  # type: Optional[Callable[[Packet, List[BasePacket], Optional[Packet], bytes], Type[Packet]]]  # noqa: E501
+            next_cls_cb=None,  # type: Optional[Callable[[Packet, List[BasePacket], Optional[Packet], bytes], Optional[Type[Packet]]]]  # noqa: E501
             max_count=None,  # type: Optional[int]
     ):
         # type: (...) -> None
@@ -2647,7 +2647,7 @@ class CharEnumField(EnumField[str]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: str
-                 enum,  # type: Union[Dict[str, str], Tuple[Callable[[str], str], Callable[[str], str]]]  # noqa: E501
+                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
                  fmt="1s",  # type: str
                  ):
         # type: (...) -> None
@@ -2670,8 +2670,14 @@ class CharEnumField(EnumField[str]):
 class BitEnumField(_BitField[Union[List[int], int]], _EnumField[int]):
     __slots__ = EnumField.__slots__
 
-    def __init__(self, name, default, size, enum, **kwargs):
-        # type: (str, Optional[int], int, Dict[int, str], **Any) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type:  Optional[int]
+                 size,  # type:  int
+                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 **kwargs  # type: Any
+                 ):
+        # type: (...) -> None
         _EnumField.__init__(self, name, default, enum)
         _BitField.__init__(self, name, default, size, **kwargs)
 
@@ -2694,7 +2700,7 @@ class BitLenEnumField(BitLenField, _EnumField[int]):
                  name,  # type: str
                  default,  # type: Optional[int]
                  length_from,  # type: Callable[[Packet], int]
-                 enum,  # type: Dict[int, str]
+                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
                  **kwargs,  # type: Any
                  ):
         # type: (...) -> None
@@ -2718,34 +2724,50 @@ class ShortEnumField(EnumField[int]):
 
     def __init__(self,
                  name,  # type: str
-                 default,  # type: int
-                 enum,  # type: Union[Dict[int, str], Dict[str, int], Tuple[Callable[[int], str], Callable[[str], int]], DADict[int, str]]  # noqa: E501
+                 default,  # type: Optional[int]
+                 enum,  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
                  ):
         # type: (...) -> None
         super(ShortEnumField, self).__init__(name, default, enum, "H")
 
 
 class LEShortEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, int, Union[Dict[int, str], List[str]]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(LEShortEnumField, self).__init__(name, default, enum, "<H")
 
 
 class LongEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, int, Union[Dict[int, str], List[str]]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(LongEnumField, self).__init__(name, default, enum, "Q")
 
 
 class LELongEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, int, Union[Dict[int, str], List[str]]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(LELongEnumField, self).__init__(name, default, enum, "<Q")
 
 
 class ByteEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, Optional[int], Dict[int, str]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(ByteEnumField, self).__init__(name, default, enum, "B")
 
 
@@ -2766,20 +2788,32 @@ class XByteEnumField(ByteEnumField):
 
 
 class IntEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, Optional[int], Dict[int, str]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(IntEnumField, self).__init__(name, default, enum, "I")
 
 
 class SignedIntEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, Optional[int], Dict[int, str]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(SignedIntEnumField, self).__init__(name, default, enum, "i")
 
 
 class LEIntEnumField(EnumField[int]):
-    def __init__(self, name, default, enum):
-        # type: (str, int, Dict[int, str]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         super(LEIntEnumField, self).__init__(name, default, enum, "<I")
 
 
@@ -2792,8 +2826,12 @@ class XShortEnumField(ShortEnumField):
 class LE3BytesEnumField(LEThreeBytesField, _EnumField[int]):
     __slots__ = EnumField.__slots__
 
-    def __init__(self, name, default, enum):
-        # type: (str, Optional[int], Dict[int, str]) -> None
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum  # type: Union[Dict[I, str], Dict[str, I], List[str], DADict[I, str], Type[Enum], Tuple[Callable[[I], str], Callable[[str], I]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
         _EnumField.__init__(self, name, default, enum)
         LEThreeBytesField.__init__(self, name, default)
 


### PR DESCRIPTION
This PR fixes two bugs in the type annotations:

1) Fix types in the constructor of various Enum fields. Enum fields accept a variety of specific formats to describe the Enum name - value mapping. The type annotations now list all the accepted types. The list is taken from the base class _EnumField line 2521

2) Fix the annotation of next_cls_cb in the PacketListField constructor. The comment on line 1700 shows the annotation correctly, but it was not correct in the actual function argument list.

No actual code was changes, only type annotations.