### PR TITLE
Dot11ReassoResp inherits from _Dot11EltUtils

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -1597,8 +1597,11 @@ class Dot11ReassoReq(_Dot11EltUtils):
                    MACField("current_AP", ETHER_ANY)]
 
 
-class Dot11ReassoResp(Dot11AssoResp):
+class Dot11ReassoResp(_Dot11EltUtils):
     name = "802.11 Reassociation Response"
+    fields_desc = [FlagsField("cap", 0, 16, capability_list),
+                   LEShortField("status", 0),
+                   LEShortField("AID", 0)]
 
 
 class Dot11ProbeReq(_Dot11EltUtils):


### PR DESCRIPTION
fmt = ('{Dot11ReassoResp: Reassosiaction capabilities: %Dot11ReassoResp.cap%}'
'{Dot11AssoResp: Association capabilities: %Dot11AssoResp.cap%}')

pkt.sprintf(fmt)