### PR TITLE
Minor QoL fixes

### DIFF
--- a/scapy/layers/smbserver.py
+++ b/scapy/layers/smbserver.py
@@ -26,6 +26,7 @@ import time
 from scapy.arch import get_if_addr
 from scapy.automaton import ATMT, Automaton
 from scapy.config import conf
+from scapy.consts import WINDOWS
 from scapy.error import log_runtime, log_interactive
 from scapy.volatile import RandUUID
 
@@ -1058,7 +1059,7 @@ class SMB_Server(Automaton):
         # Note: symbolic links are currently unsupported.
         if root not in path.parents and path != root:
             raise FileNotFoundError
-        if path.is_reserved():
+        if WINDOWS and path.is_reserved():
             raise FileNotFoundError
         if not path.exists():
             if create and createOptions:

--- a/scapy/main.py
+++ b/scapy/main.py
@@ -985,6 +985,8 @@ def interact(mydict=None, argv=None, mybanner=None, loglevel=logging.INFO):
                 cfg.InteractiveShellEmbed.term_title = False
             cfg.HistoryAccessor.hist_file = conf.histfile
             cfg.InteractiveShell.banner1 = banner
+            if conf.verb < 2:
+                cfg.InteractiveShellEmbed.enable_tip = False
             # configuration can thus be specified here.
             _kwargs = {}
             if conf.interactive_shell == "ptipython":


### PR DESCRIPTION
- Remove warning in smbserver on Python 3.13+
- Disable IPython tips in `-H` mode