### PR TITLE
Add missing timeout in HTTP_Client request, in sr1() call

### DIFF
--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -905,7 +905,7 @@ class HTTP_Client(object):
         while True:
             # Perform the request.
             try:
-                resp = self.sr1(req)
+                resp = self.sr1(req, timeout=timeout)
             except Exception:
                 # Socket has died, restart.
                 self._sockinfo = None


### PR DESCRIPTION
When performing HTTP request with HTTP_Client, request() mehod stucks in sr1() when the request is to a non HTTP port, e.g. HTTPS port. This happens even when timeout parameter is passed to request() method.

To fix this, I added timeout parameter passing to sr1() call to TCP socket. This prevents request() from stucking when timeout is passed as argument.