### PR TITLE
hsfz: vehicle ident string is only present in replays with non zero len.

### DIFF
--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -65,7 +65,7 @@ class HSFZ(Packet):
         ConditionalField(
             StrFixedLenField("identification_string",
                              None, None, lambda p: p.length),
-            lambda p: p.control == 0x11)
+            lambda p: p.control == 0x11 and p.length != 0)
     ]
 
     def hashret(self):

--- a/test/contrib/automotive/bmw/hsfz.uts
+++ b/test/contrib/automotive/bmw/hsfz.uts
@@ -88,6 +88,11 @@ assert pkt.length == 50
 assert pkt.control == 0x11
 assert b"BMW" in pkt.identification_string
 
+pkt = UDP(hex_bytes("e9811a9b000ea98f000000000011"))
+assert pkt.length == 0
+assert pkt.control == 0x11
+
+
 = Test HSFZSocket
 
 


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
During initial discovery, it is common to see UDP HSFZ frames with no vehicle identification string as a way to request replies from vehiles.

Do not populate the field if length of HSFZ len is zero.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
