### PR TITLE
hsfz: Fix acknowledgment transfer packet structure.

### DIFF
--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -59,14 +59,18 @@ class HSFZ(Packet):
         IntField('length', None),
         ShortEnumField('control', 1, control_words),
         ConditionalField(
-            XByteField('source', 0), lambda p: p.control == 1),
+            XByteField('source', 0), lambda p: p._hasaddrs()),
         ConditionalField(
-            XByteField('target', 0), lambda p: p.control == 1),
+            XByteField('target', 0), lambda p: p._hasaddrs()),
         ConditionalField(
             StrFixedLenField("identification_string",
                              None, None, lambda p: p.length),
             lambda p: p.control == 0x11)
     ]
+
+    def _hasaddrs(self):
+        # type: () -> bool
+        return self.control == 0x01 or self.control == 0x02
 
     def hashret(self):
         # type: () -> bytes

--- a/test/contrib/automotive/bmw/hsfz.uts
+++ b/test/contrib/automotive/bmw/hsfz.uts
@@ -76,6 +76,24 @@ assert pkt.control == 1
 assert pkt.securitySeed == b"0" * 0xfff00
 
 
+= Dissect diagnostic request
+
+pkt = HSFZ(hex_bytes("000000050001f41022f150"))
+assert pkt.length == 5
+assert pkt.control == 0x01
+assert pkt.source == 0xf4
+assert pkt.target == 0x10
+
+
+= Dissect acknowledgment transfer
+
+pkt = HSFZ(hex_bytes("000000050002f41022f150"))
+assert pkt.length == 5
+assert pkt.control == 0x02
+assert pkt.source == 0xf4
+assert pkt.target == 0x10
+
+
 = Dissect identification
 
 pkt = HSFZ(bytes.fromhex("000000320011444941474144523130424d574d4143374346436343463837393343424d5756494e5742413558373333333246483735373334"))


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
Fixes ACK packet structure in HSFZ.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
