### PR TITLE
Radius: Add timestamp attribute

### DIFF
--- a/scapy/layers/radius.py
+++ b/scapy/layers/radius.py
@@ -435,6 +435,11 @@ class RadiusAttr_Acct_Output_Gigawords(_RadiusAttrIntValue):
     val = 53
 
 
+class RadiusAttr_Event_Timestamp(_RadiusAttrIntValue):
+    """RFC 2869"""
+    val = 55
+
+
 class RadiusAttr_Egress_VLANID(_RadiusAttrIntValue):
     """RFC 4675"""
     val = 56


### PR DESCRIPTION
**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)

Recently I was using Scapy to parse and create some radius packets. 
I have noticed not all attributes are implemented in the radius module, more specifically it was lacking one very common attribute and so I decided to add it -> Event Timestamp. It is taken from RFC 2869.
