### PR TITLE
hsfz: Improve alive check dissection.

### DIFF
--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -65,12 +65,23 @@ class HSFZ(Packet):
         ConditionalField(
             StrFixedLenField("identification_string",
                              None, None, lambda p: p.length),
-            lambda p: p.control == 0x11 and p.length != 0)
+            lambda p: p._hasidstring())
     ]
 
     def _hasaddrs(self):
         # type: () -> bool
-        return self.control == 0x01 or self.control == 0x02
+        # Address present in diagnostic_req_res, acknowledge_transfer and
+        # two byte length alive_check frames.
+        return self.control == 0x01 or \
+            self.control == 0x02 or \
+            (self.control == 0x12 and self.length == 2)
+
+    def _hasidstring(self):
+        # type: () -> bool
+        # ID string is present in some vehicle_ident_data frames and in
+        # long alive_check grames.
+        return (self.control == 0x11 and self.length != 0) or \
+            (self.control == 0x12 and self.length > 2)
 
     def hashret(self):
         # type: () -> bytes

--- a/test/contrib/automotive/bmw/hsfz.uts
+++ b/test/contrib/automotive/bmw/hsfz.uts
@@ -111,8 +111,20 @@ assert pkt.length == 0
 assert pkt.control == 0x11
 
 
-= Test HSFZSocket
+= Dissect alive check
+pkt = HSFZ(bytes.fromhex("000000200012444941474144523130424d5756494e5858585858585858585858585858585858"))
+assert pkt.length == 32
+assert pkt.control == 0x12
+assert b"BMW" in pkt.identification_string
 
+pkt = HSFZ(bytes.fromhex("00000002001200f4"))
+assert pkt.length == 2
+assert pkt.control == 0x12
+assert pkt.source == 0x00
+assert pkt.target == 0xf4
+
+
+= Test HSFZSocket
 
 server_up = threading.Event()
 def server():


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->

Improve HSFZ alive check packet dissection.

I am not a thousend percent on the short alive check frames structure (having addresses) but that is the best idea I've got regarding those two bytes...
