### PR TITLE
Results.plot callback receive 2 args: (query,answer)

### DIFF
--- a/doc/scapy/usage.rst
+++ b/doc/scapy/usage.rst
@@ -1121,7 +1121,7 @@ We can easily plot some harvested values using Matplotlib. (Make sure that you h
 For example, we can observe the IP ID patterns to know how many distinct IP stacks are used behind a load balancer::
 
     >>> a, b = sr(IP(dst="www.target.com")/TCP(sport=[RandShort()]*1000))
-    >>> a.plot(lambda x:x[1].id)
+    >>> a.plot(lambda q,r: r.id)
     [<matplotlib.lines.Line2D at 0x2367b80d6a0>]
 
 .. image:: graphics/ipid.png


### PR DESCRIPTION
Fixes:

```python
>>> a.plot(lambda x:x[1].id)
File /home/isidro/ms/webserver/venv/lib/python3.13/site-packages/scapy/plist.py:288, in _PacketList.plot(self, f, lfilter, plot_xy, **kargs)
    286 # Get the list of packets
    287 if lfilter is None:
--> 288     lst_pkts = [f(*e) for e in self.res]
    289 else:
    290     lst_pkts = [f(*e) for e in self.res if lfilter(*e)]

TypeError: <lambda>() takes 1 positional argument but 2 were given
```

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [ ] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [ ] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

