### PR TITLE
Fix sniffer join waiting indefinitely

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1400,9 +1400,8 @@ class AsyncSniffer(object):
         # type: (bool) -> Optional[PacketList]
         """Stops AsyncSniffer if not in async mode"""
         if self.running:
-            try:
-                self.stop_cb()
-            except AttributeError:
+            self.stop_cb()
+            if self.continue_sniff:
                 raise Scapy_Exception(
                     "Unsupported (offline or unsupported socket)"
                 )


### PR DESCRIPTION
When trying to stop a sniffer that was not already started, Scapy_Exception("Unsupported (offline or unsupported socket)") is no more raised and join() is waiting indefinitely.

Restore the previous stop_cb behavior.

Fixes: 6689da4cef ("Add missing type in AsyncSniffer (#4665)")

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [X] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [X] I squashed commits belonging together
-   [X] I added unit tests or explained why they are not relevant
-   [] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [X] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes #xxx <!-- (add issue number here if appropriate, else remove this line) -->
