### PR TITLE
packit: allow SHA-1 signatures when tests are run

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^# check$/a%check\\nOPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K scanner' .packit_rpm/scapy.spec"
+    - "sed -i '/^# check$/a%check\\nOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"


### PR DESCRIPTION
The "PrivKey class : resign cert" test fails on Fedora because SHA-1 signatures are deprecated there:
https://fedoraproject.org/wiki/SHA1SignaturesGuidance. Since it's Fedora-specific and the test failure is useful in terms of detecting it and deciding how to address it in programs that use scapy in environments like that it should be enough to allow SHA-1 signatures on Packit only.

Closes https://github.com/secdev/scapy/issues/4794

(The testsuite still fails there on big-endian machines but it's unrelated: https://github.com/secdev/scapy/issues/4793)