### PR TITLE
Support Multiple Comments in Packet Object

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -101,7 +101,7 @@ class Packet(
         "direction", "sniffed_on",
         # handle snaplen Vs real length
         "wirelen",
-        "comment",
+        "comments",
         "process_information"
     ]
     name = None
@@ -179,7 +179,7 @@ class Packet(
         self.wirelen = None  # type: Optional[int]
         self.direction = None  # type: Optional[int]
         self.sniffed_on = None  # type: Optional[_GlobInterfaceType]
-        self.comment = None  # type: Optional[bytes]
+        self.comments = None  # type: Optional[List[bytes]]
         self.process_information = None  # type: Optional[Dict[str, Any]]
         self.stop_dissection_after = stop_dissection_after
         if _pkt:
@@ -222,6 +222,25 @@ class Packet(
         Optional[int],
         Optional[bytes],
     ]
+
+    @property
+    def comment(self):
+        # type: () -> Optional[bytes]
+        """Get the comment of the packet"""
+        if self.comments is not None and len(self.comments) > 0:
+            return self.comments[-1]
+
+    @comment.setter
+    def comment(self, value):
+        """
+        Set the comment of the packet.
+        If value is None, it will clear the comments.
+        """
+        # type: (Optional[bytes]) -> None
+        if value is not None:
+            self.comments = [value]
+        else:
+            self.comments = None
 
     def __reduce__(self):
         # type: () -> Tuple[Type[Packet], Tuple[bytes], Packet._PickleType]
@@ -435,7 +454,7 @@ class Packet(
         clone.payload = self.payload.copy()
         clone.payload.add_underlayer(clone)
         clone.time = self.time
-        clone.comment = self.comment
+        clone.comments = self.comments
         clone.direction = self.direction
         clone.sniffed_on = self.sniffed_on
         return clone
@@ -1145,7 +1164,7 @@ class Packet(
             self.raw_packet_cache_fields
         )
         pkt.wirelen = self.wirelen
-        pkt.comment = self.comment
+        pkt.comments = self.comments
         pkt.sniffed_on = self.sniffed_on
         pkt.direction = self.direction
         if payload is not None:

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -227,8 +227,8 @@ class Packet(
     def comment(self):
         # type: () -> Optional[bytes]
         """Get the comment of the packet"""
-        if self.comments is not None and len(self.comments) > 0:
-            return self.comments[-1]
+        if self.comments and len(self.comments):
+            return self.comments[0]
         return None
 
     @comment.setter

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -229,14 +229,15 @@ class Packet(
         """Get the comment of the packet"""
         if self.comments is not None and len(self.comments) > 0:
             return self.comments[-1]
+        return None
 
     @comment.setter
     def comment(self, value):
+        # type: (Optional[bytes]) -> None
         """
         Set the comment of the packet.
         If value is None, it will clear the comments.
         """
-        # type: (Optional[bytes]) -> None
         if value is not None:
             self.comments = [value]
         else:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2383,7 +2383,7 @@ class RawPcapWriter(GenericRawPcapWriter):
                       comment=None,  # type: Optional[bytes]
                       ifname=None,  # type: Optional[bytes]
                       direction=None,  # type: Optional[int]
-                      comments=None,  # type: Optional[List[bytes]
+                      comments=None,  # type: Optional[List[bytes]]
                       ):
         # type: (...) -> None
         """

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1648,7 +1648,7 @@ class RawPcapNgReader(RawPcapReader):
     PacketMetadata = collections.namedtuple("PacketMetadataNg",  # type: ignore
                                             ["linktype", "tsresol",
                                              "tshigh", "tslow", "wirelen",
-                                             "comment", "ifname", "direction",
+                                             "ifname", "direction",
                                              "process_information", "comments", ])
 
     def __init__(self, filename, fdesc=None, magic=None):  # type: ignore
@@ -1901,7 +1901,6 @@ class RawPcapNgReader(RawPcapReader):
                             "(%d/%d) !" % (proc_index, len(self.process_information)))
 
         comments = options.get(1, None)
-        comment = comments[-1] if comments is not None and len(comments) > 0 else None
         epb_flags_raw = options.get(2, None)
         if epb_flags_raw:
             epb_flags_raw = cast(bytes, epb_flags_raw)
@@ -1925,7 +1924,6 @@ class RawPcapNgReader(RawPcapReader):
                                                tshigh=tshigh,
                                                tslow=tslow,
                                                wirelen=wirelen,
-                                               comment=comment,
                                                ifname=ifname,
                                                direction=direction,
                                                process_information=process_information,
@@ -1953,7 +1951,6 @@ class RawPcapNgReader(RawPcapReader):
                                                tshigh=None,
                                                tslow=None,
                                                wirelen=wirelen,
-                                               comment=None,
                                                ifname=None,
                                                direction=None,
                                                process_information={},
@@ -1978,7 +1975,6 @@ class RawPcapNgReader(RawPcapReader):
                                                tshigh=tshigh,
                                                tslow=tslow,
                                                wirelen=wirelen,
-                                               comment=None,
                                                ifname=None,
                                                direction=None,
                                                process_information={},
@@ -2084,7 +2080,7 @@ class PcapNgReader(RawPcapNgReader, PcapReader):
         rp = super(PcapNgReader, self)._read_packet(size=size)
         if rp is None:
             raise EOFError
-        s, (linktype, tsresol, tshigh, tslow, wirelen, comment, ifname, direction, process_information, comments) = rp  # noqa: E501
+        s, (linktype, tsresol, tshigh, tslow, wirelen, ifname, direction, process_information, comments) = rp  # noqa: E501
         try:
             cls = conf.l2types.num2layer[linktype]  # type: Type[Packet]
             p = cls(s, **kwargs)  # type: Packet
@@ -2101,8 +2097,6 @@ class PcapNgReader(RawPcapNgReader, PcapReader):
             p.time = EDecimal((tshigh << 32) + tslow) / tsresol
         p.wirelen = wirelen
         p.comments = comments
-        if p.comments is None:
-            p.comment = comment
         p.direction = direction
         p.process_information = process_information.copy()
         if ifname is not None:

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1648,8 +1648,8 @@ class RawPcapNgReader(RawPcapReader):
     PacketMetadata = collections.namedtuple("PacketMetadataNg",  # type: ignore
                                             ["linktype", "tsresol",
                                              "tshigh", "tslow", "wirelen",
-                                             "ifname", "direction",
-                                             "process_information", "comments", ])
+                                             "comments", "ifname", "direction",
+                                             "process_information", ])
 
     def __init__(self, filename, fdesc=None, magic=None):  # type: ignore
         # type: (str, IO[bytes], bytes) -> None
@@ -2083,7 +2083,7 @@ class PcapNgReader(RawPcapNgReader, PcapReader):
         rp = super(PcapNgReader, self)._read_packet(size=size)
         if rp is None:
             raise EOFError
-        s, (linktype, tsresol, tshigh, tslow, wirelen, ifname, direction, process_information, comments) = rp  # noqa: E501
+        s, (linktype, tsresol, tshigh, tslow, wirelen, comments, ifname, direction, process_information) = rp  # noqa: E501
         try:
             cls = conf.l2types.num2layer[linktype]  # type: Type[Packet]
             p = cls(s, **kwargs)  # type: Packet

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1649,7 +1649,7 @@ class RawPcapNgReader(RawPcapReader):
                                             ["linktype", "tsresol",
                                              "tshigh", "tslow", "wirelen",
                                              "comments", "ifname", "direction",
-                                             "process_information", ])
+                                             "process_information"])
 
     def __init__(self, filename, fdesc=None, magic=None):  # type: ignore
         # type: (str, IO[bytes], bytes) -> None

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1651,7 +1651,7 @@ class RawPcapNgReader(RawPcapReader):
                                              "comment", "ifname", "direction",
                                              "process_information", "comments", ])
 
-    def __init__(self, filename, fdesc=None, magic=None, comments=None):  # type: ignore
+    def __init__(self, filename, fdesc=None, magic=None):  # type: ignore
         # type: (str, IO[bytes], bytes, List[bytes]) -> None
         self.filename = filename
         self.f = fdesc
@@ -1675,7 +1675,6 @@ class RawPcapNgReader(RawPcapReader):
         }
         self.endian = "!"  # Will be overwritten by first SHB
         self.process_information = []  # type: List[Dict[str, Any]]
-        self.comments = comments
 
         if magic != b"\x0a\x0d\x0d\x0a":  # PcapNg:
             raise Scapy_Exception(

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2122,7 +2122,6 @@ class GenericPcapWriter(object):
                       usec=None,  # type: Optional[int]
                       caplen=None,  # type: Optional[int]
                       wirelen=None,  # type: Optional[int]
-                      comment=None,  # type: Optional[bytes]
                       ifname=None,  # type: Optional[bytes]
                       direction=None,  # type: Optional[int]
                       comments=None,  # type: Optional[List[bytes]]
@@ -2206,7 +2205,6 @@ class GenericPcapWriter(object):
         if wirelen is None:
             wirelen = caplen
 
-        comment = getattr(packet, "comment", None)
         comments = getattr(packet, "comments", None)
         ifname = getattr(packet, "sniffed_on", None)
         direction = getattr(packet, "direction", None)
@@ -2222,7 +2220,6 @@ class GenericPcapWriter(object):
             rawpkt,
             sec=f_sec, usec=usec,
             caplen=caplen, wirelen=wirelen,
-            comment=comment,
             ifname=ifname,
             direction=direction,
             linktype=linktype,
@@ -2378,7 +2375,6 @@ class RawPcapWriter(GenericRawPcapWriter):
                       usec=None,  # type: Optional[int]
                       caplen=None,  # type: Optional[int]
                       wirelen=None,  # type: Optional[int]
-                      comment=None,  # type: Optional[bytes]
                       ifname=None,  # type: Optional[bytes]
                       direction=None,  # type: Optional[int]
                       comments=None,  # type: Optional[List[bytes]]
@@ -2614,7 +2610,6 @@ class RawPcapNgWriter(GenericRawPcapWriter):
                       usec=None,  # type: Optional[int]
                       caplen=None,  # type: Optional[int]
                       wirelen=None,  # type: Optional[int]
-                      comment=None,  # type: Optional[bytes]
                       ifname=None,  # type: Optional[bytes]
                       direction=None,  # type: Optional[int]
                       comments=None,  # type: Optional[List[bytes]]

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1802,7 +1802,7 @@ class RawPcapNgReader(RawPcapReader):
                         "%d !" % len(options))
                 raise EOFError
             if code != 0 and 4 + length <= len(options):
-                if code in [1, 2988, 2989, 19372, 19373]:
+                if code in [1, 2988, 2989, 19372, 19373]:  # https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html#name-options-format
                     if code not in opts:
                         opts[code] = []
                     cast(List[bytes], opts[code]).append(options[4:4 + length])

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2094,11 +2094,9 @@ class PcapNgReader(RawPcapNgReader, PcapReader):
         if tshigh is not None:
             p.time = EDecimal((tshigh << 32) + tslow) / tsresol
         p.wirelen = wirelen
-        p.comment = comment
-        if comments is not None:
-            comments.remove(comment)
-            if len(comments) > 0:
-                p.comments = comments
+        p.comments = comments
+        if p.comments is None:
+            p.comment = comment
         p.direction = direction
         p.process_information = process_information.copy()
         if ifname is not None:
@@ -2595,8 +2593,8 @@ class RawPcapNgWriter(GenericRawPcapWriter):
         # Options
         opts = b''
         if comments is not None and len(comments) > 0:
-            for comment in comments:
-                comment = bytes_encode(comment)
+            for c in comments:
+                comment = bytes_encode(c)
                 opts += struct.pack(self.endian + "HH", 1, len(comment))
                 # Pad Option Value to 32 bits
                 opts += self._add_padding(comment)

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2250,6 +2250,12 @@ wrpcapng(tmpfile, p)
 l = rdpcap(tmpfile)
 assert l[0].comment == p.comment
 
+p = Ether() / IPv6() / TCP()
+p.comments = [b"Hello!", b"Scapy!", b"Pcapng!"]
+wrpcapng(tmpfile, p)
+l = rdpcap(tmpfile)
+assert l[0].comments == p.comments
+
 = rdpcap on fifo
 ~ linux
 f = get_temp_file()


### PR DESCRIPTION
The [pcapng format specification](https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-05.html#name-options-format) explicitly allows for multiple comments to be associated with a packet via repeated opt_comment fields. This change brings Scapy closer to that standard, making it easier to work with multi-comment pcapng traces and enabling richer annotations in packet analysis.

<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
