### PR TITLE
Fix: DHCPv6_am returns Reply instead of Solicit for DHCP6_Request

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1875,7 +1875,7 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
             client_duid = p[DHCP6OptClientId].duid
             resp = IPv6(src=self.src_addr, dst=req_src)
             resp /= UDP(sport=547, dport=546)
-            resp /= DHCP6_Solicit(trid=trid)
+            resp /= DHCP6_Reply(trid=trid)
             resp /= DHCP6OptServerId(duid=self.duid)
             resp /= DHCP6OptClientId(duid=client_duid)
 

--- a/test/scapy/layers/dhcp6.uts
+++ b/test/scapy/layers/dhcp6.uts
@@ -1626,3 +1626,15 @@ a.sport == 546 and a.dport == 547
 = DHCP6_AddrRegReply - Dispatch based on UDP port
 a=UDP(raw(UDP()/DHCP6_AddrRegReply()))
 isinstance(a.payload, DHCP6_AddrRegReply)
+
+############
+############
++ DHCP6_Reply - make_reply generates DHCP6_Reply and not DHCP6_Solicit in response to DHCP6_Request
+
+= DHCP6_Reply - Test that make_reply generates DHCP6_Reply and not DHCP6_Solicit in response to DHCP6_Request
+req = IPv6(src="fe80::1", dst="ff02::1:2")/UDP(sport=546, dport=547)/DHCP6_Request(trid=1)/DHCP6OptClientId(duid=2)
+am = DHCPv6_am()
+am.src_addr = "fe80::2"
+am.duid = 3
+reply = am.make_reply(req)
+reply.haslayer(DHCP6_Reply) and not reply.haslayer(DHCP6_Solicit)


### PR DESCRIPTION
### Summary

Fixes the bug where `DHCPv6_am.make_reply()` would return a `DHCP6_Solicit` message in response to a `DHCP6_Request`, which violates RFC 8415. The correct behavior is to send a `DHCP6_Reply`.

### Changes

- Replaced `DHCP6_Solicit` with `DHCP6_Reply` in the handler for `msgtype == 3`
- Added a test case to verify correct behavior

Closes: #4689
