### PR TITLE
Fix: Add type annotation and override PcapReader's __iter__ for mypy static type checking

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1623,6 +1623,10 @@ class PcapReader(RawPcapReader):
         # type: (int, **Any) -> Packet
         return self.read_packet(size=size, **kwargs)
 
+    def __iter__(self):
+        # type: () -> PcapReader
+        return self
+
     def __next__(self):  # type: ignore
         # type: () -> Packet
         try:


### PR DESCRIPTION
### Summary
Fixes a mypy type-checking issue where PcapReader's `__next__ `method was inferred to return a `tuple[bytes, PacketMetadata]` instead of a Packet due to inheriting `__iter__ `declaration of RawPcapReader.

### Changes
Overridden `__iter__()` method explicitly in PcapReader, with a type hint to indicate that PcapReader is an iterator over Packet objects.

**Note:** No test was added as no runtime behavior was changed.

fixes #4728
