### PR TITLE
TLS Extension EarlyDataIndicationTicket name field change

### DIFF
--- a/scapy/layers/tls/extensions.py
+++ b/scapy/layers/tls/extensions.py
@@ -576,7 +576,7 @@ class TLS_Ext_EarlyDataIndication(TLS_Ext_Unknown):
 
 
 class TLS_Ext_EarlyDataIndicationTicket(TLS_Ext_Unknown):
-    name = "TLS Extension - Ticket Early Data Info"
+    name = "TLS Extension - Early Data Indication Ticket"
     fields_desc = [ShortEnumField("type", 0x2a, _tls_ext),
                    MayEnd(ShortField("len", None)),
                    IntField("max_early_data_size", 0)]


### PR DESCRIPTION
The TLS_Ext_EarlyDataIndicationTicket name was "TLS Extension - Ticket Early Data Info" which is the name for the TLX_Ext_TicketEarlyDataInfo class so I changed the name field of the TLS_Ext_EarlyDataIndicationTicket to "TLS Extension - Early Data Indication Ticket" to differentiate it from the other class. I assume the creation of this extension class was copied and pasted from the TicketEarlyDataInfo class and the creator just forgot to switch the name.