### PR TITLE
Hsfz: Improve incorrect tester field naming.

### DIFF
--- a/scapy/contrib/automotive/bmw/hsfz.py
+++ b/scapy/contrib/automotive/bmw/hsfz.py
@@ -59,23 +59,31 @@ class HSFZ(Packet):
         IntField('length', None),
         ShortEnumField('control', 1, control_words),
         ConditionalField(
-            XByteField('source', 0), lambda p: p._hasaddrs()),
+            XByteField('source', 0), lambda p: p._has_srctgt_addrs()),
         ConditionalField(
-            XByteField('target', 0), lambda p: p._hasaddrs()),
+            XByteField('target', 0), lambda p: p._has_srctgt_addrs()),
+        ConditionalField(
+            XByteField('expected', 0), lambda p: p._has_exprecv_addrs()),
+        ConditionalField(
+            XByteField('received', 0), lambda p: p._has_exprecv_addrs()),
         ConditionalField(
             StrFixedLenField("identification_string",
                              None, None, lambda p: p.length),
             lambda p: p._hasidstring())
     ]
 
-    def _hasaddrs(self):
+    def _has_srctgt_addrs(self):
         # type: () -> bool
         # Address present in diagnostic_req_res, acknowledge_transfer,
-        # two byte length alive_check and incorrect_tester_address frames.
+        # and two byte length alive_check frames.
         return self.control == 0x01 or \
             self.control == 0x02 or \
-            (self.control == 0x12 and self.length == 2) or \
-            self.control == 0x40
+            (self.control == 0x12 and self.length == 2)
+
+    def _has_exprecv_addrs(self):
+        # type: () -> bool
+        # Address present in incorrect_tester_address frames.
+        return self.control == 0x40
 
     def _hasidstring(self):
         # type: () -> bool

--- a/test/contrib/automotive/bmw/hsfz.uts
+++ b/test/contrib/automotive/bmw/hsfz.uts
@@ -128,8 +128,8 @@ assert pkt.target == 0xf4
 pkt = HSFZ(bytes.fromhex("000000020040fff4"))
 assert pkt.length == 2
 assert pkt.control == 0x40
-assert pkt.source == 0xff
-assert pkt.target == 0xf4
+assert pkt.expected == 0xff
+assert pkt.received == 0xf4
 
 
 = Test HSFZSocket


### PR DESCRIPTION
<!-- This is just a checklist to guide you. You can remove it safely. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `cd test && ./run_tests` or `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
Based on https://gitlab.com/LarsVoelker/wireshark/-/commit/3c4a5165a69d371d2abae1f271fbd806f9a31819, I improved the naming of the fields for this particular command.

The protocol is getting a little bit more complex and it may be time for splitting it into layers if it keeps growing. Let me know what do you think about that and I may open a new PR with that changes if you think it may help.

Thanks!

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
