### PR TITLE
Fwdmachine fix and doc

### DIFF
--- a/scapy/fwdmachine.py
+++ b/scapy/fwdmachine.py
@@ -86,9 +86,10 @@ class ForwardMachine:
     Methods to override:
 
     :func xfrmcs: a function to call when forwarding a packet from the 'client' to
-        the server. If it returns True, the packet is forwarded as it. If it
-        returns False or None, the packet is discarded. If it returns a
-        packet, this packet is forwarded instead of the original packet.
+        the server. If it raises a FORWARD exception, the packet is forwarded as it. If
+        it raises a DROP Exception, the packet is discarded. If it raises a
+        FORWARD_REPLACE(pkt) exception, then pkt is forwarded instead of the original
+        packet.
     :func xfrmsc: same as xfrmcs for packets forwarded from the 'server' to the
         'client'.
     """


### PR DESCRIPTION
This PR:
* fixes a type error when writing a certificate to disk in ForwardMachine
* fixes the documentation of the ForwardMachine class to match the current implementation (which expects derived classes to raise exceptions rather than return values)

Thanks for considering it for merging.