### PR TITLE
contrib/http3: add HTTP/3 framing + SETTINGS helper with UTscapy tests

### DIFF
--- a/scapy/contrib/http3.py
+++ b/scapy/contrib/http3.py
@@ -1,113 +1,170 @@
 # SPDX-License-Identifier: GPL-2.0-only
 """
-HTTP/3 (RFC 9114) framing — minimal contrib layer.
+HTTP/3 (RFC 9114) framing — contrib layer.
 
-This provides a thin "frame" abstraction used by HTTP/3 on top of QUIC streams:
+This provides a "frame" abstraction used by HTTP/3 on top of QUIC streams:
   - frame type: QUIC varint
   - frame length: QUIC varint
-  - frame payload: raw bytes (opaque here)
+  - frame payload: raw bytes (opaque here, with helpers for a few control frames)
 
-It is intentionally framing-only: it does not implement QPACK or parse HEADERS.
-
-Typical uses:
-  - dissecting **decrypted** HTTP/3 stream data (e.g., after TLS/QUIC decryption)
-  - crafting small synthetic H3 test vectors
+Focus: practical crafting/inspection of **decrypted** HTTP/3 stream data. No QPACK.
 
 Examples
 --------
->>> from scapy.contrib.http3 import H3Frame, h3_parse_frames, h3_parse_settings
->>> # Build a DATA frame (type=0x00) with "abc"
->>> f = H3Frame(type=0x00, length=3, data=b"abc")
->>> raw(f)
+>>> from scapy.contrib.http3 import (
+...     H3Frame, h3_parse_frames, h3_iterparse, h3_parse_settings,
+...     h3_build_data, h3_build_headers, h3_build_settings,
+...     h3_build_goaway, h3_parse_goaway,
+...     h3_build_priority_update_req, h3_build_priority_update_push,
+...     h3_parse_priority_update,
+... )
+>>> raw(h3_build_data(b"abc"))
 b'\\x00\\x03abc'
 
->>> # Length can be auto-filled from data if left to 0
->>> H3Frame(type=0x01, data=b'\\x01\\x02').build()
-b'\\x01\\x02\\x01\\x02'
+>>> # Concatenated frames
+>>> blob = raw(h3_build_data(b"abc")) + raw(h3_build_headers(b"\\x82"))
+>>> [(fr.type, fr.length) for fr in h3_parse_frames(blob)]
+[(0, 3), (1, 1)]
 
->>> # Parse a blob of concatenated frames
->>> blob = b'\\x00\\x03abc' + b'\\x01\\x01Z'
->>> frames = h3_parse_frames(blob)
->>> [ (fr.type, fr.length, bytes(fr.data)) for fr in frames ]
-[(0, 3, b'abc'), (1, 1, b'Z')]
-
->>> # SETTINGS helper (payload is varint-id/varint-value pairs)
->>> # id=0x1 -> 0x100 (256) encodes as 0x41 0x00 ; id=0x3 -> 0x40 (64) as 0x40 0x40
->>> settings_payload = b'\\x01\\x41\\x00' + b'\\x03\\x40\\x40'
->>> h3_parse_settings(settings_payload)
+>>> # SETTINGS (varint pairs)
+>>> sp = b'\\x01\\x41\\x00' + b'\\x03\\x40\\x40'  # (1->256),(3->64)
+>>> h3_parse_settings(sp)
 [(1, 256), (3, 64)]
+>>> raw(h3_build_settings([(1,256),(3,64)]))
+b'\\x04\\x04\\x01A\\x00\\x03@@'
+
+>>> # GOAWAY (identifier as a varint)
+>>> f = h3_build_goaway(1234)
+>>> h3_parse_goaway(bytes(H3Frame(raw(f)).data))
+1234
 """
 
-from typing import List, Tuple
+from typing import Iterable, Iterator, List, Tuple
 
 from scapy.packet import Packet
 from scapy.fields import StrLenField
 from scapy.layers.quic import QuicVarIntField
+from scapy.config import conf
 
-# --- H3 frame type constants (subset) ---
-H3_DATA                  = 0x00
-H3_HEADERS               = 0x01
-H3_CANCEL_PUSH           = 0x03
-H3_SETTINGS              = 0x04
-H3_GOAWAY                = 0x07
-H3_PRIORITY_UPDATE_REQ   = 0x0F
-H3_PRIORITY_UPDATE_PUSH  = 0x10
+
+# --- H3 frame type constants (subset from RFC 9114 §7) ---
+H3_DATA                 = 0x00
+H3_HEADERS              = 0x01
+H3_CANCEL_PUSH          = 0x03
+H3_SETTINGS             = 0x04
+H3_PUSH_PROMISE         = 0x05
+H3_GOAWAY               = 0x07
+H3_PRIORITY_UPDATE_REQ  = 0x0F
+H3_PRIORITY_UPDATE_PUSH = 0x10
+
+_H3_TYPE_NAMES = {
+    H3_DATA: "DATA",
+    H3_HEADERS: "HEADERS",
+    H3_CANCEL_PUSH: "CANCEL_PUSH",
+    H3_SETTINGS: "SETTINGS",
+    H3_PUSH_PROMISE: "PUSH_PROMISE",
+    H3_GOAWAY: "GOAWAY",
+    H3_PRIORITY_UPDATE_REQ: "PRIORITY_UPDATE(Request)",
+    H3_PRIORITY_UPDATE_PUSH: "PRIORITY_UPDATE(Push)",
+}
 
 
 class H3Frame(Packet):
+    """
+    Generic HTTP/3 frame.
+
+    Notes:
+      - 'data' is kept opaque (except for helpers below) to stay flexible.
+      - Length is auto-fixed from 'data' in post_build.
+      - extract_padding() ensures chained frames dissect cleanly.
+    """
     name = "H3Frame"
     fields_desc = [
         QuicVarIntField("type", 0),
         QuicVarIntField("length", 0),
-        # keep "data" (not "payload") to avoid clashing with Packet.payload
         StrLenField("data", b"", length_from=lambda p: p.length),
     ]
 
     def post_build(self, p, pay):
-        # If user didn't set length (or set it to 0) but provided data,
-        # recompute the header using the actual data length.
-        if (self.length in (None, 0)) and self.data:
-            t = self.getfieldval("type")
-            d = self.getfieldval("data") or b""
-            p = H3Frame(type=t, length=len(d), data=d).build()
+        d = self.getfieldval("data") or b""
+        want_len = len(d)
+        cur_len = int(self.getfieldval("length") or 0)
+        if want_len != cur_len:
+            t = int(self.getfieldval("type") or 0)
+            f = QuicVarIntField("tmp", 0)
+            hdr = f.addfield(None, b"", t) + f.addfield(None, b"", want_len)
+            p = hdr + d
         return p + pay
 
+    def mysummary(self):
+        tname = _H3_TYPE_NAMES.get(self.type, f"0x{self.type:x}")
+        return f"H3Frame {tname} len={self.length}"
+
+    def extract_padding(self, s):
+        dlen = int(self.length or 0)
+        if dlen > len(s):
+            dlen = len(s)
+        return s[:dlen], s[dlen:]
+
+
+# ---------- Varint-at-offset + bulk/streaming parsers ----------
 
 def _quic_varint_decode_at(buf: bytes, i: int) -> Tuple[int, int]:
-    """
-    Decode one QUIC varint located at buf[i:], using Scapy's QuicVarIntField.
-    Returns (value, next_index).
-    """
     fld = QuicVarIntField("tmp", 0)
     rest, val = fld.getfield(None, buf[i:])
     next_i = len(buf) - len(rest)
     return val, next_i
 
 
-def h3_parse_frames(blob: bytes):
-    """
-    Parse a concatenated frames blob into a list of H3Frame.
-    Raises ValueError on truncation.
-    """
-    out = []
+def h3_parse_frames(blob: bytes) -> List[H3Frame]:
+    out: List[H3Frame] = []
     i = 0
-    while i < len(blob):
-        tmp = H3Frame(blob[i:])
-        header_only = H3Frame(type=tmp.type, length=tmp.length).build()
-        hdr_len = len(header_only)
-        end = i + hdr_len + tmp.length
-        if end > len(blob):
+    L = len(blob)
+    while i < L:
+        try:
+            ftype, j = _quic_varint_decode_at(blob, i)
+            flen,  k = _quic_varint_decode_at(blob, j)
+        except Exception as e:
+            raise ValueError(f"Invalid H3 frame header at {i}: {e!r}")
+        end = k + flen
+        if end > L:
             raise ValueError("H3 frame truncated")
         out.append(H3Frame(blob[i:end]))
         i = end
     return out
 
 
+def h3_iterparse(chunks: Iterable[bytes]) -> Iterator[H3Frame]:
+    """
+    Incrementally parse frames from an iterable of byte chunks.
+    Yields H3Frame as soon as a full frame is available.
+    """
+    buf = bytearray()
+    for chunk in chunks:
+        if not chunk:
+            continue
+        buf += chunk
+        # Try to peel as many frames as possible from the front
+        while True:
+            if not buf:
+                break
+            try:
+                ftype, j = _quic_varint_decode_at(buf, 0)
+                flen,  k = _quic_varint_decode_at(buf, j)
+            except Exception:
+                # Not enough for header yet
+                break
+            end = k + flen
+            if end > len(buf):
+                # Not enough for payload yet
+                break
+            yield H3Frame(bytes(buf[:end]))
+            del buf[:end]
+
+
+# ---------- SETTINGS encode/decode ----------
+
 def h3_parse_settings(payload: bytes) -> List[Tuple[int, int]]:
-    """
-    Parse a SETTINGS payload (sequence of varint-id / varint-value pairs) and
-    return a list of (setting_id, value). Silently stops on first truncated pair.
-    """
     res: List[Tuple[int, int]] = []
     i = 0
     L = len(payload)
@@ -122,19 +179,96 @@ def h3_parse_settings(payload: bytes) -> List[Tuple[int, int]]:
     return res
 
 
+def h3_build_settings_pairs(pairs: Iterable[Tuple[int, int]]) -> bytes:
+    f = QuicVarIntField("tmp", 0)
+    out = b""
+    for sid, sval in pairs:
+        out += f.addfield(None, b"", int(sid))
+        out += f.addfield(None, b"", int(sval))
+    return out
+
+
+# ---------- Convenience frame builders (DATA/HEADERS/SETTINGS) ----------
+
+def h3_build_data(data: bytes) -> H3Frame:
+    return H3Frame(type=H3_DATA, data=bytes(data))
+
+
+def h3_build_headers(block: bytes) -> H3Frame:
+    return H3Frame(type=H3_HEADERS, data=bytes(block))
+
+
+def h3_build_settings(pairs: Iterable[Tuple[int, int]]) -> H3Frame:
+    payload = h3_build_settings_pairs(pairs)
+    return H3Frame(type=H3_SETTINGS, data=payload)
+
+
+# ---------- Control-frame helpers: GOAWAY & PRIORITY_UPDATE ----------
+
+def h3_build_goaway(identifier: int) -> H3Frame:
+    f = QuicVarIntField("tmp", 0)
+    pay = f.addfield(None, b"", int(identifier))
+    return H3Frame(type=H3_GOAWAY, data=pay)
+
+
+def h3_parse_goaway(payload: bytes) -> int:
+    _, ident = QuicVarIntField("tmp", 0).getfield(None, payload)
+    return int(ident)
+
+
+def h3_build_priority_update_req(element_id: int, value: bytes) -> H3Frame:
+    """
+    PRIORITY_UPDATE(request-stream): payload = varint(element_id) + field-value-bytes.
+    We don't parse the field-value semantics here (opaque per RFC 9218).
+    """
+    f = QuicVarIntField("tmp", 0)
+    pay = f.addfield(None, b"", int(element_id)) + bytes(value or b"")
+    return H3Frame(type=H3_PRIORITY_UPDATE_REQ, data=pay)
+
+
+def h3_build_priority_update_push(push_id: int, value: bytes) -> H3Frame:
+    f = QuicVarIntField("tmp", 0)
+    pay = f.addfield(None, b"", int(push_id)) + bytes(value or b"")
+    return H3Frame(type=H3_PRIORITY_UPDATE_PUSH, data=pay)
+
+
+def h3_parse_priority_update(payload: bytes) -> Tuple[int, bytes]:
+    """
+    Parse PRIORITY_UPDATE payload into (id, value_bytes).
+    (For request variant: id = element-id; for push variant: id = push-id)
+    """
+    rest, ident = QuicVarIntField("tmp", 0).getfield(None, payload)
+    consumed = len(payload) - len(rest)
+    return int(ident), payload[consumed:]
+
+
 __all__ = [
+    # Types
     "H3Frame",
+    # Parsers
     "h3_parse_frames",
+    "h3_iterparse",
     "h3_parse_settings",
+    "h3_parse_goaway",
+    "h3_parse_priority_update",
+    # Builders
+    "h3_build_settings_pairs",
+    "h3_build_data",
+    "h3_build_headers",
+    "h3_build_settings",
+    "h3_build_goaway",
+    "h3_build_priority_update_req",
+    "h3_build_priority_update_push",
+    # Constants
     "H3_DATA",
     "H3_HEADERS",
     "H3_SETTINGS",
     "H3_GOAWAY",
     "H3_CANCEL_PUSH",
+    "H3_PUSH_PROMISE",
     "H3_PRIORITY_UPDATE_REQ",
     "H3_PRIORITY_UPDATE_PUSH",
 ]
 
 # Register contrib (so UTScapy `-P "load_contrib('http3')"` works)
-from scapy.config import conf
 conf.contribs["http3"] = "scapy.contrib.http3"

--- a/scapy/contrib/http3.py
+++ b/scapy/contrib/http3.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: GPL-2.0-only
+"""
+HTTP/3 (RFC 9114) framing — minimal contrib layer.
+
+This provides a thin "frame" abstraction used by HTTP/3 on top of QUIC streams:
+  - frame type: QUIC varint
+  - frame length: QUIC varint
+  - frame payload: raw bytes (opaque here)
+
+It is intentionally framing-only: it does not implement QPACK or parse HEADERS.
+
+Typical uses:
+  - dissecting **decrypted** HTTP/3 stream data (e.g., after TLS/QUIC decryption)
+  - crafting small synthetic H3 test vectors
+
+Examples
+--------
+>>> from scapy.contrib.http3 import H3Frame, h3_parse_frames, h3_parse_settings
+>>> # Build a DATA frame (type=0x00) with "abc"
+>>> f = H3Frame(type=0x00, length=3, data=b"abc")
+>>> raw(f)
+b'\\x00\\x03abc'
+
+>>> # Length can be auto-filled from data if left to 0
+>>> H3Frame(type=0x01, data=b'\\x01\\x02').build()
+b'\\x01\\x02\\x01\\x02'
+
+>>> # Parse a blob of concatenated frames
+>>> blob = b'\\x00\\x03abc' + b'\\x01\\x01Z'
+>>> frames = h3_parse_frames(blob)
+>>> [ (fr.type, fr.length, bytes(fr.data)) for fr in frames ]
+[(0, 3, b'abc'), (1, 1, b'Z')]
+
+>>> # SETTINGS helper (payload is varint-id/varint-value pairs)
+>>> # id=0x1 -> 0x100 (256) encodes as 0x41 0x00 ; id=0x3 -> 0x40 (64) as 0x40 0x40
+>>> settings_payload = b'\\x01\\x41\\x00' + b'\\x03\\x40\\x40'
+>>> h3_parse_settings(settings_payload)
+[(1, 256), (3, 64)]
+"""
+
+from typing import List, Tuple
+
+from scapy.packet import Packet
+from scapy.fields import StrLenField
+from scapy.layers.quic import QuicVarIntField
+
+# --- H3 frame type constants (subset) ---
+H3_DATA                  = 0x00
+H3_HEADERS               = 0x01
+H3_CANCEL_PUSH           = 0x03
+H3_SETTINGS              = 0x04
+H3_GOAWAY                = 0x07
+H3_PRIORITY_UPDATE_REQ   = 0x0F
+H3_PRIORITY_UPDATE_PUSH  = 0x10
+
+
+class H3Frame(Packet):
+    name = "H3Frame"
+    fields_desc = [
+        QuicVarIntField("type", 0),
+        QuicVarIntField("length", 0),
+        # keep "data" (not "payload") to avoid clashing with Packet.payload
+        StrLenField("data", b"", length_from=lambda p: p.length),
+    ]
+
+    def post_build(self, p, pay):
+        # If user didn't set length (or set it to 0) but provided data,
+        # recompute the header using the actual data length.
+        if (self.length in (None, 0)) and self.data:
+            t = self.getfieldval("type")
+            d = self.getfieldval("data") or b""
+            p = H3Frame(type=t, length=len(d), data=d).build()
+        return p + pay
+
+
+def _quic_varint_decode_at(buf: bytes, i: int) -> Tuple[int, int]:
+    """
+    Decode one QUIC varint located at buf[i:], using Scapy's QuicVarIntField.
+    Returns (value, next_index).
+    """
+    fld = QuicVarIntField("tmp", 0)
+    rest, val = fld.getfield(None, buf[i:])
+    next_i = len(buf) - len(rest)
+    return val, next_i
+
+
+def h3_parse_frames(blob: bytes):
+    """
+    Parse a concatenated frames blob into a list of H3Frame.
+    Raises ValueError on truncation.
+    """
+    out = []
+    i = 0
+    while i < len(blob):
+        tmp = H3Frame(blob[i:])
+        header_only = H3Frame(type=tmp.type, length=tmp.length).build()
+        hdr_len = len(header_only)
+        end = i + hdr_len + tmp.length
+        if end > len(blob):
+            raise ValueError("H3 frame truncated")
+        out.append(H3Frame(blob[i:end]))
+        i = end
+    return out
+
+
+def h3_parse_settings(payload: bytes) -> List[Tuple[int, int]]:
+    """
+    Parse a SETTINGS payload (sequence of varint-id / varint-value pairs) and
+    return a list of (setting_id, value). Silently stops on first truncated pair.
+    """
+    res: List[Tuple[int, int]] = []
+    i = 0
+    L = len(payload)
+    while i < L:
+        try:
+            sid, j = _quic_varint_decode_at(payload, i)
+            sval, k = _quic_varint_decode_at(payload, j)
+        except Exception:
+            break
+        res.append((sid, sval))
+        i = k
+    return res
+
+
+__all__ = [
+    "H3Frame",
+    "h3_parse_frames",
+    "h3_parse_settings",
+    "H3_DATA",
+    "H3_HEADERS",
+    "H3_SETTINGS",
+    "H3_GOAWAY",
+    "H3_CANCEL_PUSH",
+    "H3_PRIORITY_UPDATE_REQ",
+    "H3_PRIORITY_UPDATE_PUSH",
+]
+
+# Register contrib (so UTScapy `-P "load_contrib('http3')"` works)
+from scapy.config import conf
+conf.contribs["http3"] = "scapy.contrib.http3"

--- a/test/contrib/http3.uts
+++ b/test/contrib/http3.uts
@@ -3,23 +3,33 @@
 + Basic round-trip
 
 = DATA frame round-trip
-f = H3Frame(type=0x00, length=3, data=b"abc")
+f = h3_build_data(b"abc")
 assert raw(f) == b"\x00\x03abc"
 g = H3Frame(raw(f))
-assert g.type == 0x00 and g.length == 3 and bytes(g.data) == b"abc"
+assert g.type == H3_DATA and g.length == 3 and bytes(g.data) == b"abc"
 
-= Length auto-fill when left to 0
-f2 = H3Frame(type=0x01, data=b"\x01\x02")
-assert raw(f2) == b"\x01\x02\x01\x02"
+= Length auto-fill when left to 0 (manual build path)
+f2 = H3Frame(type=H3_HEADERS, data=b"\x82")
+assert raw(f2) == b"\x01\x01\x82"
 g2 = H3Frame(raw(f2))
-assert g2.type == 0x01 and g2.length == 2 and bytes(g2.data) == b"\x01\x02"
+assert g2.type == H3_HEADERS and g2.length == 1 and bytes(g2.data) == b"\x82"
 
 = Concatenated frames parse
-blob = b"\x00\x03abc" + b"\x01\x01Z"
+blob = raw(h3_build_data(b"abc")) + raw(h3_build_headers(b"\x82"))
 frames = h3_parse_frames(blob)
 assert len(frames) == 2
-assert frames[0].type == 0x00 and frames[0].length == 3 and bytes(frames[0].data) == b"abc"
-assert frames[1].type == 0x01 and frames[1].length == 1 and bytes(frames[1].data) == b"Z"
+assert frames[0].type == H3_DATA and frames[0].length == 3 and bytes(frames[0].data) == b"abc"
+assert frames[1].type == H3_HEADERS and frames[1].length == 1 and bytes(frames[1].data) == b"\x82"
+
++ Streaming parser
+
+= h3_iterparse yields frames as chunks arrive
+chunks = [raw(h3_build_data(b"abc"))[:2],
+          raw(h3_build_data(b"abc"))[2:] + raw(h3_build_headers(b"\x82"))]
+out = list(h3_iterparse(chunks))
+assert len(out) == 2
+assert out[0].type == H3_DATA and bytes(out[0].data) == b"abc"
+assert out[1].type == H3_HEADERS and bytes(out[1].data) == b"\x82"
 
 + SETTINGS helper
 
@@ -28,3 +38,43 @@ assert frames[1].type == 0x01 and frames[1].length == 1 and bytes(frames[1].data
 settings_payload = b"\x01\x41\x00" + b"\x03\x40\x40"
 pairs = h3_parse_settings(settings_payload)
 assert pairs == [(1, 256), (3, 64)]
+
+= Build SETTINGS frame from pairs and round-trip
+sf = h3_build_settings([(1, 256), (3, 64)])
+assert sf.type == H3_SETTINGS
+sp = H3Frame(raw(sf))
+assert sp.type == H3_SETTINGS
+assert h3_parse_settings(bytes(sp.data)) == [(1, 256), (3, 64)]
+
++ GOAWAY
+
+= GOAWAY round-trip
+gw = h3_build_goaway(1234)
+gw2 = H3Frame(raw(gw))
+assert gw2.type == H3_GOAWAY
+assert h3_parse_goaway(bytes(gw2.data)) == 1234
+
++ PRIORITY_UPDATE
+
+= PRIORITY_UPDATE (request) round-trip
+pu = h3_build_priority_update_req(5, b"u=1")
+pu2 = H3Frame(raw(pu))
+assert pu2.type == H3_PRIORITY_UPDATE_REQ
+pid, val = h3_parse_priority_update(bytes(pu2.data))
+assert pid == 5 and val == b"u=1"
+
+= PRIORITY_UPDATE (push) round-trip
+pp = h3_build_priority_update_push(9, b"i=2")
+pp2 = H3Frame(raw(pp))
+assert pp2.type == H3_PRIORITY_UPDATE_PUSH
+pid2, val2 = h3_parse_priority_update(bytes(pp2.data))
+assert pid2 == 9 and val2 == b"i=2"
+
++ Unknown frame passthrough
+
+= Build unknown type and ensure it parses cleanly
+unk = H3Frame(type=0x21, data=b"\xDE\xAD\xBE\xEF")
+# 0x21 encodes on 1 byte (prefix 00); length 4 encodes on 1 byte too
+assert raw(unk) == b"\x21\x04\xde\xad\xbe\xef" or raw(unk) == b"\x21\x04\xDE\xAD\xBE\xEF"
+unk2 = H3Frame(raw(unk))
+assert unk2.type == 0x21 and unk2.length == 4 and bytes(unk2.data) == b"\xDE\xAD\xBE\xEF"

--- a/test/contrib/http3.uts
+++ b/test/contrib/http3.uts
@@ -1,0 +1,30 @@
+% HTTP/3 contrib tests
+
++ Basic round-trip
+
+= DATA frame round-trip
+f = H3Frame(type=0x00, length=3, data=b"abc")
+assert raw(f) == b"\x00\x03abc"
+g = H3Frame(raw(f))
+assert g.type == 0x00 and g.length == 3 and bytes(g.data) == b"abc"
+
+= Length auto-fill when left to 0
+f2 = H3Frame(type=0x01, data=b"\x01\x02")
+assert raw(f2) == b"\x01\x02\x01\x02"
+g2 = H3Frame(raw(f2))
+assert g2.type == 0x01 and g2.length == 2 and bytes(g2.data) == b"\x01\x02"
+
+= Concatenated frames parse
+blob = b"\x00\x03abc" + b"\x01\x01Z"
+frames = h3_parse_frames(blob)
+assert len(frames) == 2
+assert frames[0].type == 0x00 and frames[0].length == 3 and bytes(frames[0].data) == b"abc"
+assert frames[1].type == 0x01 and frames[1].length == 1 and bytes(frames[1].data) == b"Z"
+
++ SETTINGS helper
+
+= Parse SETTINGS payload (two pairs)
+# id=0x1 -> 0x100 (256) encodes as 0x41 0x00 ; id=0x3 -> 0x40 (64) as 0x40 0x40
+settings_payload = b"\x01\x41\x00" + b"\x03\x40\x40"
+pairs = h3_parse_settings(settings_payload)
+assert pairs == [(1, 256), (3, 64)]


### PR DESCRIPTION
_This module is for HTTP/3 (RFC 9114) framing, building on Scapy’s existing QUIC support._

**Features**
- H3Frame class: parses/builds HTTP/3 frames (type, length, data) using QUIC varints.
- h3_parse_frames(blob): parses concatenated frames from decrypted H3 stream data.
- h3_iterparse(chunks): streaming parser for incremental frame parsing.
- h3_parse_settings(payload): helper for SETTINGS frame payloads, returns (setting_id, value) pairs.
- Builders for DATA, HEADERS, SETTINGS, GOAWAY, and PRIORITY_UPDATE frames.
- Constants for common frame types (H3_DATA, H3_HEADERS, H3_SETTINGS, etc.).

**Tests**
- Added UTscapy campaign (`test/contrib/http3.uts`) covering:
  - Round-trip encode/decode of DATA/HEADERS frames
  - Auto-fill of frame length when omitted
  - Concatenated frame parsing
  - Streaming parser (`h3_iterparse`)
  - SETTINGS frame parsing + build/round-trip
  - GOAWAY + PRIORITY_UPDATE round-trip helpers
  - Unknown frame passthrough
