### PR TITLE
Fix regression caused by #4847

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1418,7 +1418,7 @@ def dns_resolve(qname, qtype="A", raw=False, tcp=False, verbose=1, timeout=3, **
         return result
 
     kwargs.setdefault("timeout", timeout)
-    kwargs.setdefault("verbose", verbose)
+    kwargs.setdefault("verbose", 0)  # hide sr1() output
     res = None
     for nameserver in conf.nameservers:
         # Try all nameservers


### PR DESCRIPTION
2.6.1:
```python
>>> dns_resolve("google.com")
[<DNSRR  rrname=b'google.com.' type=A cacheflush=0 rclass=IN ttl=100 rdata=142.250.75.238 |>]
```

master (post #4847):
```python
>>> dns_resolve("google.com")
Begin emission

Finished sending 1 packets

Received 1 packets, got 1 answers, remaining 0 packets
[<DNSRR  rrname=b'google.com.' type=A cacheflush=0 rclass=IN ttl=100 rdata=142.250.75.238 |>]
```