### PR TITLE
FIX: Correct DHCPv6 option addition method

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -1817,13 +1817,13 @@ DHCPv6_am.parse_options( dns="2001:500::1035", domain="localdomain, local",
                 reqopts = query[DHCP6OptOptReq].reqopts
                 for o, opt in self.dhcpv6_options.items():
                     if o in reqopts:
-                        answer /= opt
+                        answer.add_payload(opt.copy())
             else:
                 # advertise everything we have available
                 # Should not happen has clients MUST include
                 # and ORO in requests (sec 18.1.1)   -- arno
                 for o, opt in self.dhcpv6_options.items():
-                    answer /= opt
+                    answer.add_payload(opt.copy())
 
         if msgtype == 1:  # SOLICIT (See Sect 17.1 and 17.2 of RFC 3315)
 


### PR DESCRIPTION
## Problem Description
DHCPv6 server responses are missing critical options like `DHCP6OptDNSServers` and `DHCP6OptDNSDomains` due to incorrect option addition method.

## Issue with the Original Code `answer /= opt`

In Python, `answer /= opt` is equivalent to `answer = answer / opt`. This is a **rebinding operation**:
- Creates a new packet object (appending `opt` as payload to the original `answer`)
- Rebinds the local variable `answer` to this new object

Critical problem:
- `answer` is a function parameter (passed by object reference)
- Rebinding parameter variables **does not affect the original object outside the function**
- Even though options appear added inside the function, the external `answer` still points to the unmodified original object
- Results in **lost options** in the final response

## Why the Fixed Code `answer.add_payload(opt.copy())` Works

Key improvements:
1. **In-place modification**:
   - `add_payload()` directly modifies the original `answer` object's payload field
   - No new object creation or variable rebinding occurs

2. **Safe object handling**:
   - `opt.copy()` prevents unintended side effects by:
     - Avoiding reference modification of the original option object
     - Ensuring clean payload attachment

3. **Correct scope propagation**:
   - Modifications are immediately reflected in the external `answer` object
   - Options are successfully preserved in the final DHCPv6 response

## Solution
Replace the division assignment operator with in-place modification:
- **Before**: `answer /= opt`
- **After**: `answer.add_payload(opt.copy())`
