### PR TITLE
HKDF extract public API

### DIFF
--- a/scapy/layers/tls/crypto/hkdf.py
+++ b/scapy/layers/tls/crypto/hkdf.py
@@ -27,10 +27,14 @@ class TLS13_HKDF(object):
     @crypto_validator
     def extract(self, salt, ikm):
         h = self.hash
-        hkdf = HKDF(h, h.digest_size, salt, None, default_backend())
         if ikm is None:
             ikm = b"\x00" * h.digest_size
-        return hkdf._extract(ikm)
+        # cryptography 47.0.0 added this as a public API
+        if getattr(HKDF, "extract", None) is not None:
+            return HKDF.extract(h, salt, ikm)
+        else:
+            hkdf = HKDF(h, h.digest_size, salt, None, default_backend())
+            return hkdf._extract(ikm)
 
     @crypto_validator
     def expand(self, prk, info, L):


### PR DESCRIPTION
cryptography is refactoring some of our HKDF internals and we realized you're using a private API. We've promoted extract to public in v47. This isn't released yet, but we'll be removing that old private name in 49.0.0 so I wanted to get a PR over to you. refs https://github.com/pyca/cryptography/pull/13658