### PR TITLE
PCAPNG: Adding SHB Options

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2403,6 +2403,9 @@ class RawPcapNgWriter(GenericRawPcapWriter):
 
     def __init__(self,
                  filename,  # type: str
+                 shb_hardware=None,  # type: Optional[str]
+                 shb_os=None,  # type: Optional[str]
+                 shb_userapp=None,  # type: Optional[str]
                  ):
         # type: (...) -> None
 
@@ -2415,6 +2418,10 @@ class RawPcapNgWriter(GenericRawPcapWriter):
         # tcpdump only support little-endian in PCAPng files
         self.endian = "<"
         self.endian_magic = b"\x4d\x3c\x2b\x1a"
+
+        self.shb_hardware = shb_hardware
+        self.shb_os = shb_os
+        self.shb_userapp = shb_userapp
 
         self.filename = filename
         self.f = open(filename, "wb", 4096)
@@ -2482,6 +2489,24 @@ class RawPcapNgWriter(GenericRawPcapWriter):
         block_shb += struct.pack(self.endian + "H", 0)
         # Section Length
         block_shb += struct.pack(self.endian + "q", -1)
+
+        # Add Hardware Name Option (2), if exists
+        if self.shb_hardware is not None:
+            block_shb += struct.pack(self.endian + "HH", 0x0002, len(self.shb_hardware))
+            block_shb += self.shb_hardware.encode()
+            block_shb = self._add_padding(block_shb)
+
+        # Add OS Name Option (3), if exists
+        if self.shb_os is not None:
+            block_shb += struct.pack(self.endian + "HH", 0x0003, len(self.shb_os))
+            block_shb += self.shb_os.encode()
+            block_shb = self._add_padding(block_shb)
+
+        # Add User Application Name Option (4), if exists
+        if self.shb_userapp is not None:
+            block_shb += struct.pack(self.endian + "HH", 0x0004, len(self.shb_userapp))
+            block_shb += self.shb_userapp.encode()
+            #block_shb = self._add_padding(block_shb)
 
         self.f.write(self.build_block(block_type, block_shb))
 

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1749,7 +1749,7 @@ class RawPcapNgReader(RawPcapReader):
             raise Scapy_Exception("PcapNg: Invalid Section Header Block "
                                   " options (too short)")
         self._read_block_tail(blocklen)
-        self._read_options(options)
+        self.shb_options = self._read_options(options)
 
     def _read_packet(self, size=MTU):  # type: ignore
         # type: (int) -> Tuple[bytes, RawPcapNgReader.PacketMetadata]
@@ -2506,7 +2506,7 @@ class RawPcapNgWriter(GenericRawPcapWriter):
         if self.shb_userapp is not None:
             block_shb += struct.pack(self.endian + "HH", 0x0004, len(self.shb_userapp))
             block_shb += self.shb_userapp.encode()
-            #block_shb = self._add_padding(block_shb)
+            block_shb = self._add_padding(block_shb)
 
         self.f.write(self.build_block(block_type, block_shb))
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2158,15 +2158,18 @@ l = rdpcap(tmpfile)
 assert b"Scapy" in l[0][Raw].load
 assert l[0].time == ts
 
-= Write a pcapng with SHB options
+= Write and read back a pcapng with SHB options
 
 tmpfile = get_temp_file(autoext=".pcapng")
 r = RawPcapNgWriter(tmpfile, shb_hardware="hardware", shb_os="os", shb_userapp="userapp")
 r._write_block_shb()
 r.f.close()
 
-# without a reader not much we can check
-assert os.stat(tmpfile).st_size == 60
+reader = RawPcapNgReader(tmpfile)
+assert reader.shb_options.get(2) == b"hardware"
+assert reader.shb_options.get(3) == b"os"
+assert reader.shb_options.get(4) == b"userapp"
+reader.close()
 
 = Check wrpcapng()
 

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2158,6 +2158,16 @@ l = rdpcap(tmpfile)
 assert b"Scapy" in l[0][Raw].load
 assert l[0].time == ts
 
+= Write a pcapng with SHB options
+
+tmpfile = get_temp_file(autoext=".pcapng")
+r = RawPcapNgWriter(tmpfile, shb_hardware="hardware", shb_os="os", shb_userapp="userapp")
+r._write_block_shb()
+r.f.close()
+
+# without a reader not much we can check
+assert os.stat(tmpfile).st_size == 60
+
 = Check wrpcapng()
 
 tmpfile = get_temp_file(autoext=".pcapng")


### PR DESCRIPTION
This patch allows to initialize the PcapNgWriter with Hardware, OS, and User Application. This information is written to the pcapng SHB.