### PR TITLE
802.11: Rename unaccessible flags in FCfield

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -708,7 +708,7 @@ class Dot11(Packet):
             [
                 (
                     FlagsField("FCfield", 0, 4,
-                               ["pw-mgt", "MD", "protected", "order"]),
+                               ["pw_mgt", "MD", "protected", "order"]),
                     lambda pkt: (pkt.type, pkt.subtype) == (1, 6)
                 ),
                 (
@@ -718,8 +718,8 @@ class Dot11(Packet):
                 )
             ],
             FlagsField("FCfield", 0, 8,
-                       ["to-DS", "from-DS", "MF", "retry",
-                        "pw-mgt", "MD", "protected", "order"])
+                       ["to_DS", "from_DS", "MF", "retry",
+                        "pw_mgt", "MD", "protected", "order"])
         ),
         ConditionalField(
             BitField("FCfield_bw", 0, 3),
@@ -746,7 +746,7 @@ class Dot11(Packet):
         ConditionalField(
             _Dot11MacField("addr4", ETHER_ANY, 4),
             lambda pkt: (pkt.type == 2 and
-                         pkt.FCfield & 3 == 3),  # from-DS+to-DS
+                         pkt.FCfield & 3 == 3),  # from_DS+to_DS
         )
     ]
 
@@ -2116,7 +2116,7 @@ iwconfig wlan0 mode managed
         tcp = p.getlayer(TCP)
         pay = raw(tcp.payload)
         p[IP].underlayer.remove_payload()
-        p.FCfield = "from-DS"
+        p.FCfield = "from_DS"
         p.addr1, p.addr2 = p.addr2, p.addr1
         p /= IP(src=ip.dst, dst=ip.src)
         p /= TCP(sport=tcp.dport, dport=tcp.sport,

--- a/scapy/modules/krack/automaton.py
+++ b/scapy/modules/krack/automaton.py
@@ -332,7 +332,7 @@ class KrackAP(Automaton):
         ])
 
     def send_wpa_enc(self, data, iv, seqnum, dest, mic_key,
-                     key_idx=0, additionnal_flag=["from-DS"],
+                     key_idx=0, additionnal_flag=["from_DS"],
                      encrypt_key=None):
         """Send an encrypted packet with content @data, using IV @iv,
         sequence number @seqnum, MIC key @mic_key
@@ -551,7 +551,7 @@ class KrackAP(Automaton):
             addr1=self.client,
             addr2=self.mac,
             addr3=self.mac,
-            FCfield='from-DS',
+            FCfield='from_DS',
             SC=(next(self.seq_num) << 4),
         )
         rep /= LLC(dsap=0xaa, ssap=0xaa, ctrl=3)
@@ -595,7 +595,7 @@ class KrackAP(Automaton):
             addr1=self.client,
             addr2=self.mac,
             addr3=self.mac,
-            FCfield='from-DS',
+            FCfield='from_DS',
             SC=(next(self.seq_num) << 4),
         )
 
@@ -652,7 +652,7 @@ class KrackAP(Automaton):
                 addr1=self.client,
                 addr2=self.mac,
                 addr3=self.mac,
-                FCfield='from-DS',
+                FCfield='from_DS',
                 SC=(next(self.seq_num) << 4),
                 subtype=0,
                 type="Data",

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -261,7 +261,7 @@ def check_WiFi_am_reply(packet):
     assert isinstance(packet, list) and len(packet) == 2
     assert TCP in packet[0] and Raw in packet[0] and raw(packet[0][Raw]) == b"5c4pY"
 
-test_WiFi_am(Dot11(FCfield="to-DS")/IP()/TCP()/"Scapy",
+test_WiFi_am(Dot11(FCfield="to_DS")/IP()/TCP()/"Scapy",
              check_WiFi_am_reply,
              iffrom="scapy0", ifto="scapy1", replace="5c4pY", pattern="Scapy")
 

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -99,6 +99,7 @@ assert raw(PPI()/Dot11(type=2, subtype=8, FCfield=0x40)/Dot11QoS()/Dot11WEP()) =
 conf.wepkey = "test123"
 a = PPI(b'\x00\x00\x08\x00i\x00\x00\x00\x88@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x008(^a')
 assert a[Dot11QoS][Dot11WEP].icv == 942169697
+assert not a[Dot11].FCfield.to_DS
 
 = Dot11TKIP - dissection
 


### PR DESCRIPTION
This fixes https://github.com/secdev/scapy/issues/4628.
Those fields can't be accessed as normal flags, names shouldn't contain a -...