### PR TITLE
BPF filter: fix memory leak

### DIFF
--- a/scapy/arch/bpf/core.py
+++ b/scapy/arch/bpf/core.py
@@ -14,7 +14,7 @@ import socket
 import struct
 
 from scapy.arch.bpf.consts import BIOCSETF, BIOCSETIF
-from scapy.arch.common import compile_filter
+from scapy.arch.common import compile_filter, free_filter
 from scapy.config import conf
 from scapy.consts import LINUX
 from scapy.error import Scapy_Exception
@@ -76,6 +76,8 @@ def attach_filter(fd, bpf_filter, iface):
     ret = fcntl.ioctl(fd, BIOCSETF, bp)
     if ret < 0:
         raise Scapy_Exception("Can't attach the BPF filter !")
+    # Free
+    free_filter(bp)
 
 
 def in6_getifaddr():

--- a/scapy/arch/common.py
+++ b/scapy/arch/common.py
@@ -132,6 +132,14 @@ def compile_filter(filter_exp,  # type: str
     return bpf
 
 
+def free_filter(bp: bpf_program) -> None:
+    """
+    Free a bpf_program created with compile_filter
+    """
+    from scapy.libs.winpcapy import pcap_freecode
+    pcap_freecode(ctypes.byref(bp))
+
+
 #######
 # DNS #
 #######

--- a/scapy/arch/linux/__init__.py
+++ b/scapy/arch/linux/__init__.py
@@ -21,7 +21,7 @@ import time
 
 from scapy.compat import raw
 from scapy.consts import LINUX
-from scapy.arch.common import compile_filter
+from scapy.arch.common import compile_filter, free_filter
 from scapy.config import conf
 from scapy.data import MTU, ETH_P_ALL, SOL_PACKET, SO_ATTACH_FILTER, \
     SO_TIMESTAMPNS
@@ -130,13 +130,14 @@ def attach_filter(sock, bpf_filter, iface):
     if conf.use_pypy and sys.pypy_version_info <= (7, 3, 2):  # type: ignore
         # PyPy < 7.3.2 has a broken behavior
         # https://foss.heptapod.net/pypy/pypy/-/issues/3298
-        bp = struct.pack(  # type: ignore
+        fp = struct.pack(
             'HL',
             bp.bf_len, ctypes.addressof(bp.bf_insns.contents)
         )
     else:
-        bp = sock_fprog(bp.bf_len, bp.bf_insns)  # type: ignore
-    sock.setsockopt(socket.SOL_SOCKET, SO_ATTACH_FILTER, bp)
+        fp = sock_fprog(bp.bf_len, bp.bf_insns)  # type: ignore
+    sock.setsockopt(socket.SOL_SOCKET, SO_ATTACH_FILTER, fp)
+    free_filter(bp)
 
 
 def set_promisc(s, iff, val=1):


### PR DESCRIPTION
The `bpf_program` created with `compile_filter` was never freed.

fix https://github.com/secdev/scapy/issues/4698