### PR TITLE
fixed _TLSSignature show2

### DIFF
--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -170,7 +170,7 @@ class _TLSSignature(_GenericTLSSessionInheritance):
 
     def __init__(self, *args, **kargs):
         super(_TLSSignature, self).__init__(*args, **kargs)
-        if "sig_alg" not in kargs:
+        if self.sig_alg is None and "sig_alg" not in kargs:
             # Default sig_alg
             self.sig_alg = 0x0804
             if self.tls_session and self.tls_session.tls_version:


### PR DESCRIPTION
### I found that there is an issue with the show and show2 of _TLSSignature when using it. The expected sig_val for show2 should be "sha384+eccsa".
```from scapy.layers.tls.keyexchange import _TLSSignature
from scapy.all import raw
sig = _TLSSignature(sig_alg="sha384+ecdsa", sig_val=b"abcd")
sig.show()
sig.show2()
print(raw(sig).hex(), hex(sig.sig_alg))
```
```
###[ TLS Digital Signature ]###
  sig_alg   = sha384+ecdsa
  sig_len   = None
  sig_val   = b'abcd'

###[ TLS Digital Signature ]###
  sig_alg   = sha256+rsaepss
  sig_len   = 4
  sig_val   = b'abcd'

0503000461626364 0x503
```