### PR TITLE
Address TripleDES + Camellia deprecations

### DIFF
--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -215,12 +215,17 @@ if conf.crypto_valid:
         )
     except ImportError:
         decrepit_algorithms = algorithms
+
+    # cryptography's TripleDES can be used to simulate DES behavior
+    DES = lambda key: decrepit_algorithms.TripleDES(key * 3)
+    DES.key_sizes = decrepit_algorithms.TripleDES.key_sizes
+    DES.block_size = decrepit_algorithms.TripleDES.block_size
 else:
     log_loading.info("Can't import python-cryptography v1.7+. "
                      "Disabled IPsec encryption/authentication.")
     default_backend = None
     InvalidTag = Exception
-    Cipher = algorithms = modes = None
+    Cipher = algorithms = modes = DES = None
 
 ###############################################################################
 
@@ -573,9 +578,9 @@ if algorithms:
                                                  format_mode_iv=_salt_format_mode_iv)  # noqa: E501
 
     # Using a TripleDES cipher algorithm for DES is done by using the same 64
-    # bits key 3 times (done by cryptography when given a 64 bits key)
+    # bits key 3 times
     CRYPT_ALGOS['DES'] = CryptAlgo('DES',
-                                   cipher=decrepit_algorithms.TripleDES,
+                                   cipher=DES,
                                    mode=modes.CBC,
                                    key_size=(8,))
     CRYPT_ALGOS['3DES'] = CryptAlgo('3DES',

--- a/scapy/layers/tls/crypto/cipher_block.py
+++ b/scapy/layers/tls/crypto/cipher_block.py
@@ -33,6 +33,15 @@ if conf.crypto_valid:
     except ImportError:
         decrepit_algorithms = algorithms
 
+    # cryptography's TripleDES can be used to simulate DES behavior
+    DES = lambda key: decrepit_algorithms.TripleDES(key * 3)
+
+    try:
+        # cryptography > 47.0
+        Camellia = decrepit_algorithms.Camellia
+    except AttributeError:
+        Camellia = algorithms.Camellia
+
 
 _tls_block_cipher_algs = {}
 
@@ -134,7 +143,7 @@ if conf.crypto_valid:
         key_len = 32
 
     class Cipher_CAMELLIA_128_CBC(_BlockCipher):
-        pc_cls = algorithms.Camellia
+        pc_cls = Camellia
         pc_cls_mode = modes.CBC
         block_size = 16
         key_len = 16
@@ -149,13 +158,13 @@ _sslv2_block_cipher_algs = {}
 
 if conf.crypto_valid:
     class Cipher_DES_ECB(_BlockCipher):
-        pc_cls = decrepit_algorithms.TripleDES
+        pc_cls = staticmethod(DES)
         pc_cls_mode = modes.ECB
         block_size = 8
         key_len = 8
 
     class Cipher_DES_CBC(_BlockCipher):
-        pc_cls = decrepit_algorithms.TripleDES
+        pc_cls = staticmethod(DES)
         pc_cls_mode = modes.CBC
         block_size = 8
         key_len = 8

--- a/scapy/libs/rfc3961.py
+++ b/scapy/libs/rfc3961.py
@@ -97,8 +97,9 @@ except ImportError:
     raise ImportError("To use kerberos cryptography, you need to install cryptography.")
 
 
-# cryptography's TripleDES allow the usage of a 56bit key, which thus behaves like DES
-DES = decrepit_algorithms.TripleDES
+# cryptography's TripleDES can be used to simulate DES behavior
+def DES(key: bytes) -> decrepit_algorithms.TripleDES:
+    return decrepit_algorithms.TripleDES(key * 3)
 
 
 # https://go.microsoft.com/fwlink/?LinkId=186039


### PR DESCRIPTION
This PR addresses both TripleDES (see https://github.com/pyca/cryptography/pull/13928) and Camelia deprecation.

Those warnings will come with 47.0+