### PR TITLE
OpenBSD: fix tests and disallow LibreSSL

### DIFF
--- a/scapy/contrib/automotive/autosar/secoc.py
+++ b/scapy/contrib/automotive/autosar/secoc.py
@@ -16,7 +16,7 @@ if conf.crypto_valid:
     from cryptography.hazmat.primitives import cmac
     from cryptography.hazmat.primitives.ciphers import algorithms
 else:
-    log_loading.info("Can't import python-cryptography v1.7+. "
+    log_loading.info("Can't import python-cryptography v2.0+. "
                      "Disabled SecOC calculate_cmac.")
 
 from scapy.config import conf

--- a/scapy/contrib/macsec.py
+++ b/scapy/contrib/macsec.py
@@ -33,7 +33,7 @@ if conf.crypto_valid:
         modes,
     )
 else:
-    log_loading.info("Can't import python-cryptography v1.7+. "
+    log_loading.info("Can't import python-cryptography v2.0+. "
                      "Disabled MACsec encryption/authentication.")
 
 

--- a/scapy/contrib/psp.py
+++ b/scapy/contrib/psp.py
@@ -65,7 +65,7 @@ if conf.crypto_valid:
         aead,
     )
 else:
-    log_loading.info("Can't import python-cryptography v1.7+. "
+    log_loading.info("Can't import python-cryptography v2.0+. "
                      "Disabled PSP encryption/authentication.")
 
 ###############################################################################

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -73,7 +73,7 @@ if conf.crypto_valid:
         decrepit_algorithms = algorithms
 else:
     default_backend = Ciphers = algorithms = decrepit_algorithms = None
-    log_loading.info("Can't import python-cryptography v1.7+. Disabled WEP decryption/encryption. (Dot11)")  # noqa: E501
+    log_loading.info("Can't import python-cryptography v2.0+. Disabled WEP decryption/encryption. (Dot11)")  # noqa: E501
 
 
 #########

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -19,8 +19,17 @@ from scapy.utils import checksum, do_graph, incremental_label, \
     linehexdump, strxor, whois, colgen
 from scapy.ansmachine import AnsweringMachine
 from scapy.base_classes import Gen, Net, _ScopedIP
-from scapy.data import ETH_P_IP, ETH_P_ALL, DLT_RAW, DLT_RAW_ALT, DLT_IPV4, \
-    IP_PROTOS, TCP_SERVICES, UDP_SERVICES
+from scapy.consts import OPENBSD
+from scapy.data import (
+    ETH_P_IP,
+    ETH_P_ALL,
+    DLT_RAW,
+    DLT_RAW_ALT,
+    DLT_IPV4,
+    IP_PROTOS,
+    TCP_SERVICES,
+    UDP_SERVICES,
+)
 from scapy.layers.l2 import (
     CookedLinux,
     Dot3,
@@ -1358,6 +1367,8 @@ bind_layers(UDP, GRE, dport=4754)
 conf.l2types.register(DLT_RAW, IP)
 conf.l2types.register_num2layer(DLT_RAW_ALT, IP)
 conf.l2types.register(DLT_IPV4, IP)
+if OPENBSD:
+    conf.l2types.register_num2layer(228, IP)
 
 conf.l3types.register(ETH_P_IP, IP)
 conf.l3types.register_num2layer(ETH_P_ALL, IP)

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -22,7 +22,7 @@ from scapy.arch import get_if_hwaddr
 from scapy.as_resolvers import AS_resolver_riswhois
 from scapy.base_classes import Gen, _ScopedIP
 from scapy.compat import chb, orb, raw, plain_str, bytes_encode
-from scapy.consts import WINDOWS
+from scapy.consts import WINDOWS, OPENBSD
 from scapy.config import conf
 from scapy.data import (
     DLT_IPV6,
@@ -4213,6 +4213,8 @@ conf.l2types.register(31, IPv6)
 conf.l2types.register(DLT_IPV6, IPv6)
 conf.l2types.register(DLT_RAW, IPv46)
 conf.l2types.register_num2layer(DLT_RAW_ALT, IPv46)
+if OPENBSD:
+    conf.l2types.register_num2layer(229, IPv6)
 
 bind_layers(Ether, IPv6, type=0x86dd)
 bind_layers(CookedLinux, IPv6, proto=0x86dd)

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -221,7 +221,7 @@ if conf.crypto_valid:
     DES.key_sizes = decrepit_algorithms.TripleDES.key_sizes
     DES.block_size = decrepit_algorithms.TripleDES.block_size
 else:
-    log_loading.info("Can't import python-cryptography v1.7+. "
+    log_loading.info("Can't import python-cryptography v2.0+. "
                      "Disabled IPsec encryption/authentication.")
     default_backend = None
     InvalidTag = Exception

--- a/scapy/layers/tls/__init__.py
+++ b/scapy/layers/tls/__init__.py
@@ -91,5 +91,5 @@ from scapy.config import conf
 if not conf.crypto_valid:
     import logging
     log_loading = logging.getLogger("scapy.loading")
-    log_loading.info("Can't import python-cryptography v1.7+. "
+    log_loading.info("Can't import python-cryptography v2.0+. "
                      "Disabled PKI & TLS crypto-related features.")

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -533,7 +533,7 @@ if len(routes6) > 2 and not WINDOWS:
     # Identify routes to fe80::/64
     assert sum(1 for r in routes6 if r[0] == "::1" and r[4] == ["::1"]) >= 1
     if len(iflist) >= 2:
-        assert sum(1 for r in routes6 if ll_route.match(r[0]) and r[1] == 64) >= 1
+        assert sum(1 for r in routes6 if ll_route.match(r[0])) >= 1
         try:
             # Identify a route to a node IPv6 link-local address
             assert sum(1 for r in routes6 if in6_islladdr(r[0]) and r[1] == 128) >= 1
@@ -2941,11 +2941,12 @@ class BSDLoader:
         for p in self.patches:
             p.start()        
         return pfroute
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, type, value, traceback):
         for p in self.loadpatches:
             p.stop()
         for p in self.patches:
             p.stop()
+        importlib.reload(scapy.arch.bpf.pfroute)
 
 
 = OpenBSD 7.5 amd64 - read_routes()

--- a/test/tuntap.uts
+++ b/test/tuntap.uts
@@ -37,10 +37,10 @@ assert p.addr_family == 2
 assert isinstance(p.payload, IP)
 
 p = DarwinUtunPacketInfo()/IPv6()
-assert p.addr_family == 30
+assert p.addr_family == socket.AF_INET6
 
 p = DarwinUtunPacketInfo(raw(p))
-assert p.addr_family == 30
+assert p.addr_family == socket.AF_INET6
 assert isinstance(p.payload, IPv6)
 
 #######


### PR DESCRIPTION
This:
- disables cryptography usage when LibreSSL is detected. See https://github.com/pyca/cryptography/issues/14048. See the link alex posted, in some cases it's up to **50.000 times** slower. It seems to be a wontfix from the mail thread, so we're just disabling it.
- fixes other tests on OpenBSD