### PR TITLE
Fix LOCAL_PREF attribute flag

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -1070,7 +1070,7 @@ attributes_flags = {
     2: 0x40,    # AS_PATH
     3: 0x40,    # NEXT_HOP
     4: 0x80,    # MULTI_EXIT_DISC
-    5: 0x40,    # LOCAL_PREF
+    5: 0x00,    # LOCAL_PREF
     6: 0x40,    # ATOMIC_AGGREGATE
     7: 0xc0,    # AGGREGATOR
     8: 0xc0,    # COMMUNITIES (RFC 1997)


### PR DESCRIPTION
<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

fix `LOCAL_PERF` attribute flag

According to [RFC 4271 Section 5.1.5](https://datatracker.ietf.org/doc/html/rfc4271#section-5.1.5), the LOCAL_PREF attribute (type code 5) is a well-known discretionary attribute that is **not transitive**. However, Scapy was incorrectly setting the transitive bit (0x40) for this attribute.

<!-- if required - outline impacts on other parts of the library -->

fixes #4882  <!-- (add issue number here if appropriate, else remove this line) -->
