### PR TITLE
Remove ARP entry limitation

### DIFF
--- a/scapy/arch/bpf/pfroute.py
+++ b/scapy/arch/bpf/pfroute.py
@@ -935,8 +935,6 @@ class pfmsghdrs(Packet):
             "msgs",
             [],
             pfmsghdr,
-            # 65535 / len(pfmsghdr)
-            max_count=4096,
         ),
     ]
 


### PR DESCRIPTION
Fixes #4787 
I'm removing the hardcoded ARP cache entry limit on MacOS because it's causing Scapy to raise on import if the ARP cache is larger than 4096.



<details>
<summary>Import error traceback</summary>

```shell
(.env) mikedennis@CVX-Mac LANscape % python
Python 3.11.2 (main, Feb 16 2023, 02:55:59) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from scapy.sendrecv import srp
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/sendrecv.py", line 60, in <module>
    import scapy.route  # noqa: F401
    ^^^^^^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/route.py", line 250, in <module>
    conf.route = Route()
                 ^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/route.py", line 37, in __init__
    self.resync()
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/route.py", line 47, in resync
    self.routes = read_routes()
                  ^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/arch/bpf/pfroute.py", line 1011, in read_routes
    resp = _sr1_bsdsysctl(mib)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/arch/bpf/pfroute.py", line 988, in _sr1_bsdsysctl
    return pfmsghdrs(bytes(oldp))
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/base_classes.py", line 481, in __call__
    i.__init__(*args, **kargs)
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/packet.py", line 186, in __init__
    self.dissect(_pkt)
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/packet.py", line 1102, in dissect
    s = self.do_dissect(s)
        ^^^^^^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/packet.py", line 1040, in do_dissect
    s, fval = f.getfield(self, s)
              ^^^^^^^^^^^^^^^^^^^
  File "/Users/mikedennis/Documents/GitHub/LANscape/.env/lib/python3.11/site-packages/scapy/fields.py", line 1836, in getfield
    raise MaximumItemsCount(
scapy.fields.MaximumItemsCount: Maximum amount of items reached in PacketListField: 4096 (defaults to conf.max_list_count)
>>> exit()
```
</details>

MacOS uniquely caches failed/rejected ARP lookups, causing the list of entries in the cache to grow substantially larger than other OSes when preforming network scans across a large subnet.

If i run `ping 10.0.0.2`, which is a valid IP in my subnet but a host does not exist at that IP, my ARP cache will show:
```
? (10.0.0.2) at (incomplete) on en0 ifscope [ethernet]
```

This behavior is unique to MacOS, I have tested on Windows and various Linux distros and they will only show entries with corresponding MAC addresses.

In summary, Scapy's hardcoded ARP cache entry limit conflicts with the ARP caching behavior on MacOS.

> Note: im new to this repo and am open to suggestions on how to better implement a solution to this problem.

