### PR TITLE
DARWIN/MacOS patch to fix word alignment of netmask in sockaddr.sa_data and filter ARP entries

### DIFF
--- a/scapy/arch/bpf/pfroute.py
+++ b/scapy/arch/bpf/pfroute.py
@@ -401,15 +401,23 @@ class sockaddr(Packet):
             XStrLenField("sdl_pad", b"", length_from=lambda pkt: 16 - pkt.sa_len),
             lambda pkt: pkt.sa_len < 16 and pkt.sa_family == socket.AF_LINK,
         ),
-        # others
+        # others - only used for netmask, make alignment match sockaddr_in
+        ConditionalField(
+            StrFixedLenField("_sa_pad1", "", 2),
+            lambda pkt: pkt.sa_family
+            not in [
+                socket.AF_INET,
+                socket.AF_INET6,
+                socket.AF_LINK,
+            ],
+        ),
         ConditionalField(
             XStrLenField(
                 "sa_data",
                 "",
-                # NOTE: Darwin right-justifies netmask on 4 byte word alignment
+                # NOTE: Adjust length to 4 byte alignment.  Darwin sa_len is not always correct for simple math.
                 length_from=lambda pkt:
-                   ((pkt.sa_len+3)//4*4 - 2 if pkt.sa_len >= 2 else 0) if DARWIN else
-                     (pkt.sa_len - 2 if pkt.sa_len >= 2 else 0),
+                   ((pkt.sa_len+3)//4*4 - 4 if pkt.sa_len >= 2 else 0)
             ),
             lambda pkt: pkt.sa_family
             not in [
@@ -1023,12 +1031,13 @@ def read_routes():
         flags = msg.rtm_flags
         if not flags.RTF_UP:
             continue
-        if DARWIN and flags.RTF_WASCLONED and msg.rtm_parentflags.RTF_PRCLONING:
-            # OSX needs filtering
-            continue
-        if DARWIN and flags.RTF_HOST and not flags.RTF_BROADCAST:
-            # DARWIN includes the entire ARP table in the route response.  Remove it.
-            continue
+        if DARWIN:
+            if flags.RTF_WASCLONED and msg.rtm_parentflags.RTF_PRCLONING:
+                # OSX needs filtering
+                continue
+            if flags.RTF_HOST and not flags.RTF_BROADCAST:
+                # DARWIN includes the entire ARP table in the route response.  Remove it.
+                continue
         addrs = msg.rtm_addrs
         net = 0
         mask = 0xFFFFFFFF
@@ -1052,10 +1061,7 @@ def read_routes():
                 if nm.sa_family == socket.AF_INET:
                     mask = atol(nm.sin_addr)
                 elif nm.sa_family in [0x00, 0xFF]:  # NetBSD
-                    if DARWIN:
-                        mask = struct.unpack(">I", nm.sa_data[-4:].rjust(4, b"\x00"))[0]
-                    else:
-                        mask = struct.unpack("<I", nm.sa_data[:4].rjust(4, b"\x00"))[0]
+                    mask = struct.unpack(">I", nm.sa_data[:4].rjust(4, b"\x00"))[0]
                 else:
                     mask = int.from_bytes(nm.sa_data[:4], "big")
                 i += 1


### PR DESCRIPTION

-   [ ] I added unit tests or explained why they are not relevant
These changes deal with low-level parsing of an OS response and unit tests were not found.

-   [ ] I executed the regression tests (using `tox`)
I was unable to execute tox -e flake8.  AttributeError("module 'ast' has no attribute 'Str'")
This happened with requirements both <6.0.0 and current releases on 3.10.  Beyond scope of patch to identify issue, but there are only 11 lines of code involved that are formatted accordingly.

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
(1) Fixes incorrect parsing of routing tables on MacOS.  Issues with both word alignment and endian-ness.
(2) MacOS includes the entire ARP table within the route response.  This patch filters the entire route table except a host entry for the default route, which MacOS identifies as 'CONNECTED' and is not a straight forward filter.

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>
The nature of the conditional structure fields did not allow for evaluated conditions, therefore it required ternary within ternary.

<!-- if required - outline impacts on other parts of the library -->
Enables routing using route tables correctly on MacOS, which could impact software expecting them to only use default route.

Fixes #4894
