### PR TITLE
Fix IP.Summary() crash when dst is RandIP()

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -586,6 +586,8 @@ class IP(Packet, IPTools):
         if conf.route is None:
             # unused import, only to initialize conf.route
             import scapy.route  # noqa: F401
+        if not isinstance(dst, (str, bytes, int)):
+            dst = str(dst)
         return conf.route.route(dst, dev=scope)
 
     def hashret(self):

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -92,6 +92,12 @@ pkts = sniff(offline=pkts, session=IPSession)
 assert len(pkts) == 2
 assert pkts[1].load == b"X" * 1500
 
+= IPSession - summary with RandIP() does not crash
+
+pkt = IP(dst=RandIP())
+s = pkt.summary()
+assert isinstance(s, str)
+
 = StringBuffer
 
 buffer = StringBuffer()


### PR DESCRIPTION
**Changes:**

- Prevent `IP.summary()` from crashing on randomized destinations
- Add UTScapy regression test covering this case

Fix #4883
