### PR TITLE
Draft: add SNAC flag to inet6

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -2208,7 +2208,7 @@ class ICMPv6ND_RA(_ICMPv6NDGuessPayload, _ICMPv6):
                    BitField("H", 0, 1),
                    BitEnumField("prf", 1, 2, icmp6ndraprefs),  # RFC 4191
                    BitField("P", 0, 1),
-                   BitField("S", 0, 1),
+                   BitField("S", 0, 1), # draft-ietf-6man-snac-router-ra-flag-03
                    BitField("res", 0, 1),
                    ShortField("routerlifetime", 1800),
                    IntField("reachabletime", 0),


### PR DESCRIPTION
<!-- This is just a checklist to guide you. Please remove it if you check all items. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests (using `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

add a recent flag mainly added for 6loWPAN networks like Thread https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-11

I have not added tests as it is 0 in most cases unless there is a border router on the network, also its neighbouring flag, NDP Proxy, is also not tested.

A long with the tox test(which i have not been able to run), I had modified the version in the virtual environment of the project I'm working on and can confirm it behaves as expected on network packets

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->