### PR TITLE
Various SMB2 fixes

### DIFF
--- a/scapy/layers/smb2.py
+++ b/scapy/layers/smb2.py
@@ -4751,6 +4751,8 @@ class SMBStreamSocket(StreamSocket):
             and not smbh._decrypted
             # - MessageId is 0xFFFFFFFFFFFFFFFF
             and smbh.MID != 0xFFFFFFFFFFFFFFFF
+            # - Message is not ECHO request
+            and smbh.Command != 0x000D
             # - Status in the SMB2 header is STATUS_PENDING
             and smbh.Status != 0x00000103
         ):

--- a/scapy/layers/tftp.py
+++ b/scapy/layers/tftp.py
@@ -409,7 +409,7 @@ class TFTP_WRQ_server(Automaton):
 
     @ATMT.action(receive_data)
     def ack_data(self):
-        self.last_packet = self.l3 / TFTP_ACK(block=self.blk)
+        self.last_packet = self.l3 / TFTP_ACK(block=self.blk % 65536)
         self.send(self.last_packet)
 
     @ATMT.state()
@@ -516,11 +516,17 @@ class TFTP_RRQ_server(Automaton):
 
     @ATMT.action(file_not_found)
     def send_error(self):
-        self.send(self.l3 / TFTP_ERROR(errorcode=1, errormsg=TFTP_Error_Codes[1]))  # noqa: E501
+        self.send(self.l3 / TFTP_ERROR(
+            errorcode=1,
+            errormsg=TFTP_Error_Codes[1],
+        ))
 
     @ATMT.state()
     def SEND_FILE(self):
-        self.send(self.l3 / TFTP_DATA(block=self.blk) / self.data[(self.blk - 1) * self.blksize:self.blk * self.blksize])  # noqa: E501
+        self.send(
+            self.l3 / TFTP_DATA(block=self.blk % 65536) /
+            self.data[(self.blk - 1) * self.blksize:self.blk * self.blksize]
+        )
 
     @ATMT.timeout(SEND_FILE, 3)
     def timeout_waiting_ack(self):

--- a/scapy/modules/ldaphero.py
+++ b/scapy/modules/ldaphero.py
@@ -751,7 +751,7 @@ class LDAPHero:
             results = self.client.search(
                 baseObject=item,
                 scope=0,
-                attributes=["ntSecurityDescriptor"],
+                attributes=["nTSecurityDescriptor"],
                 controls=[
                     LDAP_Control(
                         controlType="1.2.840.113556.1.4.801",
@@ -776,6 +776,12 @@ class LDAPHero:
             nTSecurityDescriptor = SECURITY_DESCRIPTOR(
                 results[item]["nTSecurityDescriptor"][0]
             )
+        except KeyError:
+            self.tprint(
+                "Security Descriptor could NOT be read ! (Access denied?)",
+                tags=["error"],
+            )
+            return
         except LDAP_Exception as ex:
             self.tprint(
                 "Error parsing the Security Descriptor: " + str(ex),


### PR DESCRIPTION
- fix SMB credit computation
- fix SMB2.0.2 trying to use IOCTL
- do not recurse in StreamSocket
- do not check signature of echo requests (samba doesn't sign them)
- do not crash when security descriptor isn't available