### PR TITLE
HTTP: fix forwarding of HEAD sessions

### DIFF
--- a/scapy/fwdmachine.py
+++ b/scapy/fwdmachine.py
@@ -414,6 +414,7 @@ class ForwardMachine:
         # Wrap the sockets
         sock = self.sockcls(sock, self.cls)
         ss = self.sockcls(ss, self.cls)
+        sock.streamsession = ss.streamsession
         try:
             while True:
                 # Listen on both ends of the connection

--- a/test/scapy/layers/http.uts
+++ b/test/scapy/layers/http.uts
@@ -90,11 +90,11 @@ assert HTTPRequest in a[3]
 assert a[3].Method == b"HEAD"
 assert a[3].User_Agent == b'curl/7.88.1'
 
-assert HTTPResponse in a[6]
-assert a[6].Content_Type == b'text/html; charset=UTF-8'
-assert a[6].Expires == b'Mon, 01 Apr 2024 22:25:38 GMT'
-assert a[6].Reason_Phrase == b'Moved Permanently'
-assert a[6].X_Frame_Options == b"SAMEORIGIN"
+assert HTTPResponse in a[5]
+assert a[5].Content_Type == b'text/html; charset=UTF-8'
+assert a[5].Expires == b'Mon, 01 Apr 2024 22:25:38 GMT'
+assert a[5].Reason_Phrase == b'Moved Permanently'
+assert a[5].X_Frame_Options == b"SAMEORIGIN"
 
 = HTTP build with 'chunked' content type
 


### PR DESCRIPTION
- proper handling of HEAD in HTTP sessions
- fix session being always null when using the ForwardMachine