### PR TITLE
Resolve race condition when starting AsyncSniffer

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1314,9 +1314,9 @@ class AsyncSniffer(object):
             self.stop_cb = stop_cb
 
         try:
+            self.continue_sniff = True
             if started_callback:
                 started_callback()
-            self.continue_sniff = True
 
             # Start timeout
             if timeout is not None:


### PR DESCRIPTION
When starting an `AsyncSniffer`, one can provide a `started_callback` which is called when the sniffer starts sniffing. After this callback has been called it can reasonably be assumed that the sniffer is indeed running and hence can be stopped.

We have existing automated tests using `AsyncSniffer` via a wrapping context manager, for convenience of writing those tests: when entering the context the sniffer is started and when leaving the context again the sniffer is stopped. The context manager waits until the callback is called before finishing its `__enter__`, with the callback signalling a `Barrier` to inform the context manager about this.

In particularly short tests, which almost immediately close the sniffer again, it turned out that this can cause the sniffer to hang or exceptions to be raised. This happens when the following events occurs, in this very order:

1. Our callback is called by the `AsyncSniffer`
2. Our callback signals the context manager
3. The context manager yields to the calling test
4. The test immediately decides to leave the context again
5. The context manager stops the `AsyncSniffer`
6. The `AsyncSniffer` thread sets `self.continue_sniff` to `True`

Note the thread switches: steps 1, 2 and 6 execute on the `AsyncSniffer` thread, steps 3 through 5 on the test's primary thread.

We can hit this race condition with fair reproducibility (tens of percents - no exact numbers known). Calling `started_callback` only after setting `self.continue_sniff` makes this entirely stable.

I have not included a test for this, as it is impossible hit this race condition anywhere near reliably (we have exacerbating conditions in our particular setup).