### PR TITLE
Fix PEP 639 license warnings & drop Python 3.7/3.8

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -83,15 +83,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12"]
         mode: [non_root]
         installmode: ['']
         flags: [" -K scanner"]
         allow-failure: ['false']
         include:
-          # Python 3.7
+          # Python 3.10
           - os: ubuntu-22.04
-            python: "3.7"
+            python: "3.10"
             mode: non_root
             flags: " -K scanner"
           # Linux root tests on last version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools>=62.0.0" ]
+requires = [ "setuptools>=77.0.0" ]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,8 +15,8 @@ maintainers = [
     { name="Guillaume VALADON" },
     { name="Nils WEISS" },
 ]
-license = { text="GPL-2.0-only" }
-requires-python = ">=3.7, <4"
+license = "GPL-2.0-only"
+requires-python = ">=3.9, <4"
 description = "Scapy: interactive packet manipulation tool"
 keywords = [ "network" ]
 classifiers = [
@@ -27,11 +27,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Telecommunications Industry",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@
 
 # Tox environments:
 # py{version}-{os}-{non_root,root}
-# In our testing, version can be 37 to 313 or py39 for pypy39
+# In our testing, version can be 39 to 313 or py39 for pypy39
 
 [tox]
 # minversion = 4.0
 skip_missing_interpreters = true
 # envlist = default when doing 'tox'
-envlist = py{37,38,39,310,311,312,313}-{linux,bsd,windows}-{non_root,root}
+envlist = py{39,310,311,312,313}-{linux,bsd,windows}-{non_root,root}
 
 # Main tests
 


### PR DESCRIPTION
Fixes #4849 

Shall we also add 3.14 support?