### PR TITLE
ci: actually run the tests on Packit again 

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^%check$/aOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K scanner' .packit_rpm/scapy.spec"
+    - "sed -i '/^%check$/aOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K netaccess -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"

--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^# check$/a%check\\nOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K scanner' .packit_rpm/scapy.spec"
+    - "sed -i '/^%check$/aOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"


### PR DESCRIPTION
The Fedora package added the "%check" section to the spec file to
perform an import check in
https://src.fedoraproject.org/rpms/scapy/c/878585466261f17c01516a653d19cf47022c2f9f?branch=rawhide
and it broke the upstream script where sed expected the "%check" section
to be commented out. This patch adjusts the sed command to run the tests
again.

The "netaccess" tests are turned off for now because they sporadically time out in some Packit jobs.
They can probably be brought back once Packit is stabilized.

It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/10153843/.
