### PR TITLE
ci: install scapy-rpc on Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,7 +17,7 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
-    - "sed -i '/^%check$/aOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K netaccess -K scanner' .packit_rpm/scapy.spec"
+    - "sed -i '/^%check$/apip3 install scapy-rpc\\nOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K netaccess -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: openssl' .packit_rpm/scapy.spec"


### PR DESCRIPTION
to prevent the tests from failing with
```
 ###(000)=[failed] [C706 MGMT] - Import layer
 ...
 ModuleNotFoundError: No module named 'scapy.layers.msrpce.raw.mgmt'

 ###(001)=[failed] [C706 MGMT] - Dissect rpc__mgmt_inq_if_ids_Response
 ...
 >>> pkt = rpc__mgmt_inq_if_ids_Response(DATA)
 NameError: name 'rpc__mgmt_inq_if_ids_Response' is not defined
```

scapy-rpc isn't packaged so it has to be installed using pip instead of Build-Requires as usual.

It's a follow-up to https://github.com/secdev/scapy/pull/4921.

It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/10159677/.