### PR TITLE
Hack: patch setuptools < 77 to support modern licenses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
     { name="Guillaume VALADON" },
     { name="Nils WEISS" },
 ]
-license = { text="GPL-2.0-only" }
+license = "GPL-2.0-only"
 requires-python = ">=3.7, <4"
 description = "Scapy: interactive packet manipulation tool"
 keywords = [ "network" ]
@@ -27,7 +27,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
     "Intended Audience :: Telecommunications Industry",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This PR is a hack to support old setuptools with the new license format.

- fixes https://github.com/secdev/scapy/issues/4849
- replaces https://github.com/secdev/scapy/pull/4924

See https://github.com/pypa/setuptools/issues/4903 for more details. This should allow us to keep 3.7 support after all. @evverx what do you think?

As dumb as it is,[ Python 3.7 is still Scapy's biggest usage](https://pypistats.org/packages/scapy),  by far.
<img width="1564" height="420" alt="image" src="https://github.com/user-attachments/assets/dcd48d0b-68b1-42cd-a767-09ce0b26d859" />
