### PR TITLE
ci: drop all downstream patches on Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -17,6 +17,8 @@ actions:
     - "git clone https://src.fedoraproject.org/rpms/scapy .packit_rpm --depth=1"
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
+    # Drop all downstream patches to prevent them from interfering with upstream builds
+    - "sed -ri '/^Patch[0-9]+\\:.+\\.patch/d' .packit_rpm/scapy.spec"
     - "sed -i '/^%check$/apip3 install scapy-rpc\\nOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K netaccess -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"


### PR DESCRIPTION
to prevent them from interfering with upstream builds. For example https://github.com/secdev/scapy/pull/4924 failed with
```
+ cd scapy-2.7.0
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ /usr/lib/rpm/rpmuncompress /builddir/build/SOURCES/scapy-2.7.0-rhel9.patch
+ /usr/bin/patch -p1 -s --fuzz=0 --no-backup-if-mismatch -f
1 out of 1 hunk FAILED -- saving rejects to file pyproject.toml.rej
error: Bad exit status from /var/tmp/rpm-tmp.HHeMZC (%prep)
```
It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/10163905/