### PR TITLE
DCE/RPC: various fixes

### DIFF
--- a/doc/scapy/layers/dcerpc.rst
+++ b/doc/scapy/layers/dcerpc.rst
@@ -313,7 +313,7 @@ There are extensions to the :class:`~scapy.layers.msrpce.rpcclient.DCERPC_Client
     client.negotiate_sessionkey(bytes.fromhex("77777777777777777777777777777777"))
     client.close()
 
-- the :class:`~scapy.layers.msrpce.msdcom.DCOM_Client` (unfinished)
+- the :class:`~scapy.layers.msrpce.msdcom.DCOM_Client`. More details are available in `DCOM <dcom.html>`_
 
 Server
 ------

--- a/scapy/layers/dcerpc.py
+++ b/scapy/layers/dcerpc.py
@@ -180,6 +180,8 @@ DCE_RPC_TRANSFER_SYNTAXES = {
 }
 DCE_RPC_INTERFACES_NAMES = {}
 DCE_RPC_INTERFACES_NAMES_rev = {}
+COM_INTERFACES_NAMES = {}
+COM_INTERFACES_NAMES_rev = {}
 
 
 class DCERPC_Transport(IntEnum):
@@ -1350,6 +1352,8 @@ def register_com_interface(name, uuid, opnums):
     # bind for build
     for opnum, operations in opnums.items():
         bind_top_down(DceRpc5Request, operations.request, opnum=opnum)
+    COM_INTERFACES_NAMES[uuid] = name
+    COM_INTERFACES_NAMES_rev[name.lower()] = uuid
 
 
 def find_com_interface(name) -> ComInterface:
@@ -2824,6 +2828,7 @@ class DceRpcSession(DefaultSession):
         self.sent_cont_ids = []
         self.cont_id = 0  # Currently selected context
         self.auth_context_id = 0  # Currently selected authentication context
+        self.assoc_group_id = 0  # Currently selected association group
         self.map_callid_opnum = {}
         self.frags = collections.defaultdict(lambda: b"")
         self.sniffsspcontexts = {}  # Unfinished contexts for passive
@@ -2869,6 +2874,8 @@ class DceRpcSession(DefaultSession):
                     finally:
                         self.sent_cont_ids = []
 
+                    self.assoc_group_id = pkt.assoc_group_id
+
                     # Endianness
                     self.ndrendian = {0: "big", 1: "little"}[pkt[DceRpc5].endian]
 
@@ -2878,18 +2885,20 @@ class DceRpcSession(DefaultSession):
         elif DceRpc5Request in pkt:
             # request => match opnum with callID
             opnum = pkt.opnum
+            uid = (self.assoc_group_id, pkt.call_id)
             if self.rpc_bind_is_com:
-                self.map_callid_opnum[pkt.call_id] = (
+                self.map_callid_opnum[uid] = (
                     opnum,
                     pkt[DceRpc5Request].payload.payload,
                 )
             else:
-                self.map_callid_opnum[pkt.call_id] = opnum, pkt[DceRpc5Request].payload
+                self.map_callid_opnum[uid] = opnum, pkt[DceRpc5Request].payload
         elif DceRpc5Response in pkt:
             # response => get opnum from table
+            uid = (self.assoc_group_id, pkt.call_id)
             try:
-                opnum, opts["request_packet"] = self.map_callid_opnum[pkt.call_id]
-                del self.map_callid_opnum[pkt.call_id]
+                opnum, opts["request_packet"] = self.map_callid_opnum[uid]
+                del self.map_callid_opnum[uid]
             except KeyError:
                 log_runtime.info("Unknown call_id %s in DCE/RPC session" % pkt.call_id)
         # Bind / Alter request/response specific
@@ -2912,7 +2921,7 @@ class DceRpcSession(DefaultSession):
         """
         Function to defragment DCE/RPC packets.
         """
-        uid = pkt.call_id
+        uid = (self.assoc_group_id, pkt.call_id)
         if pkt.pfc_flags.PFC_FIRST_FRAG and pkt.pfc_flags.PFC_LAST_FRAG:
             # Not fragmented
             return body

--- a/scapy/layers/ms_nrtp.py
+++ b/scapy/layers/ms_nrtp.py
@@ -712,7 +712,7 @@ def _member_type_infos_cb(pkt, lst, cur, remain):
     except StopIteration:
         return None
     typeEnum = BinaryTypeEnum(typeEnum)
-    # Return BinaryTypeEnum tainted with a pre-selected type.
+    # Return BinaryTypeEnum tainted with a preselected type.
     return functools.partial(
         NRBFAdditionalInfo,
         bintype=typeEnum,

--- a/scapy/layers/msrpce/msdcom.py
+++ b/scapy/layers/msrpce/msdcom.py
@@ -30,6 +30,7 @@ from scapy.fields import (
     PadField,
     StrLenField,
     StrNullFieldUtf16,
+    UUIDEnumField,
     UUIDField,
     XShortField,
     XStrFixedLenField,
@@ -37,6 +38,8 @@ from scapy.fields import (
 from scapy.volatile import RandUUID
 
 from scapy.layers.dcerpc import (
+    COM_INTERFACES_NAMES_rev,
+    COM_INTERFACES_NAMES,
     ComInterface,
     DCE_C_AUTHN_LEVEL,
     DCE_RPC_PROTOCOL_IDENTIFIERS,
@@ -445,7 +448,15 @@ class OBJREF(Packet):
     fields_desc = [
         XStrFixedLenField("signature", b"MEOW", length=4),  # :3
         LEIntField("flags", 0x04),
-        UUIDField("iid", IID_IActivationPropertiesIn, uuid_fmt=UUIDField.FORMAT_LE),
+        UUIDEnumField(
+            "iid",
+            IID_IActivationPropertiesIn,
+            (
+                COM_INTERFACES_NAMES.get,
+                lambda x: COM_INTERFACES_NAMES_rev.get(x.lower()),
+            ),
+            uuid_fmt=UUIDField.FORMAT_LE,
+        ),
     ]
 
 

--- a/scapy/layers/msrpce/msdcom.py
+++ b/scapy/layers/msrpce/msdcom.py
@@ -63,6 +63,7 @@ from scapy.layers.dcerpc import (
     NDRShortField,
     NDRSignedIntField,
     RPC_C_AUTHN,
+    RPC_C_IMP_LEVEL,
 )
 from scapy.utils import valid_ip6, valid_ip
 from scapy.layers.msrpce.rpcclient import DCERPC_Client, DCERPC_Transport
@@ -746,6 +747,7 @@ class OXID_Entry:
     def __init__(self):
         self.oxid: Optional[int] = None
         self.bindingInfo: Optional[Tuple[str, int]] = None
+        self.target_name: str = None
         self.authnHint: DCE_C_AUTHN_LEVEL = DCE_C_AUTHN_LEVEL.CONNECT
         self.version: Optional[COMVERSION] = None
         self.ipid_IRemUnknown: Optional[uuid.UUID] = None
@@ -788,6 +790,7 @@ class ObjectInstance:
         iface: ComInterface,
         ssp=None,
         auth_level=None,
+        impersonation_type=None,
         timeout=None,
         **kwargs,
     ):
@@ -799,6 +802,7 @@ class ObjectInstance:
 
         :param ssp: (optional) non default SSP to use to connect to the object exporter
         :param auth_level: (optional) non default authn level to use
+        :param impersonation_type: (optional) non default impersonation type to use
         :param timeout: (optional) timeout for the connection
         """
         # Look for this object's entry
@@ -828,6 +832,7 @@ class ObjectInstance:
             pkt=pkt,
             ssp=ssp,
             auth_level=auth_level,
+            impersonation_type=impersonation_type,
             timeout=timeout,
             **kwargs,
         )
@@ -868,6 +873,12 @@ class DCOM_Client(DCERPC_Client):
         # DCOM defaults to at least PKT_INTEGRITY
         if "auth_level" not in kwargs and "ssp" in kwargs:
             kwargs["auth_level"] = DCE_C_AUTHN_LEVEL.PKT_INTEGRITY
+
+        # DCOM_Client handles the activations.
+        # [MS-RPCE] sect 3.2.4.1.1.2 : "it MUST specify a default impersonation
+        # level of at leastRPC_C_IMPL_LEVEL_IMPERSONATE"
+        if "impersonation_type" not in kwargs and "ssp" in kwargs:
+            kwargs["impersonation_type"] = RPC_C_IMP_LEVEL.IMPERSONATE
 
         super(DCOM_Client, self).__init__(
             DCERPC_Transport.NCACN_IP_TCP,
@@ -919,7 +930,10 @@ class DCOM_Client(DCERPC_Client):
             raise ValueError("Must specify at least one interface !")
 
         # Bind IObjectExporter if not already
-        self.bind_or_alter(find_dcerpc_interface("IRemoteSCMActivator"))
+        self.bind_or_alter(
+            find_dcerpc_interface("IRemoteSCMActivator"),
+            target_name="rpcss/" + self.host,
+        )
 
         # [MS-DCOM] sect 3.1.2.5.2.3.3 - Issuing the Activation Request
 
@@ -1045,8 +1059,9 @@ class DCOM_Client(DCERPC_Client):
                 )
 
                 # Set RPC bindings from the activation request
-                binds, _ = _ParseStringArray(remoteReply.valueof("pdsaOxidBindings"))
+                binds, secs = _ParseStringArray(remoteReply.valueof("pdsaOxidBindings"))
                 entry.bindingInfo = self._ChoseRPCBinding(binds)
+                entry.target_name = self._CalculateTargetName(secs)
 
             if PropsOutInfo in prop:
                 # Information about the interfaces that the client requested
@@ -1236,6 +1251,21 @@ class DCOM_Client(DCERPC_Client):
                 return host, port
         raise ValueError("No valid bindings available !")
 
+    def _CalculateTargetName(self, secs: List[SECURITYBINDING]):
+        """
+        3.2.4.2 ORPC Invocations - Find SPN from aPrincName
+        """
+        if self.ssp is None or not secs:
+            return None
+
+        for sec in secs:
+            # "if the aPrincName field is nonempty"
+            if sec.wAuthnSvc == self.ssp.auth_type and sec.aPrincName:
+                return sec.aPrincName
+
+        # "if the aPrincName field is empty, the client MUST NOT specify an SPN"
+        return None
+
     def UnmarshallObjectReference(
         self, mifaceptr: MInterfacePointer, iid: ComInterface
     ):
@@ -1272,7 +1302,10 @@ class DCOM_Client(DCERPC_Client):
             client.connect(host, port=port)
 
         # Bind IObjectExporter if not already
-        client.bind_or_alter(find_dcerpc_interface("IObjectExporter"))
+        client.bind_or_alter(
+            find_dcerpc_interface("IObjectExporter"),
+            target_name="rpcss/" + self.host,
+        )
 
         try:
             # Perform ResolveOxid2
@@ -1304,8 +1337,9 @@ class DCOM_Client(DCERPC_Client):
         )
 
         # Set RPC bindings from the oxid request
-        binds, _ = _ParseStringArray(resp.valueof("ppdsaOxidBindings"))
+        binds, secs = _ParseStringArray(resp.valueof("ppdsaOxidBindings"))
         entry.bindingInfo = self._ChoseRPCBinding(binds)
+        entry.target_name = self._CalculateTargetName(secs)
 
         # Update the OXID table
         if entry.oxid not in self.OXID_table:
@@ -1353,6 +1387,7 @@ class DCOM_Client(DCERPC_Client):
         ipid: uuid.UUID,
         ssp=None,
         auth_level=None,
+        impersonation_type=None,
         timeout=5,
         **kwargs,
     ):
@@ -1364,6 +1399,7 @@ class DCOM_Client(DCERPC_Client):
 
         :param ssp: (optional) non default SSP to use to connect to the object exporter
         :param auth_level: (optional) non default authn level to use
+        :param impersonation_type: (optional) non default impersonation type to use
         :param timeout: (optional) timeout for the connection
         """
         # [MS-DCOM] sect 3.2.4.2
@@ -1396,6 +1432,7 @@ class DCOM_Client(DCERPC_Client):
                 DCERPC_Transport.NCACN_IP_TCP,
                 ssp=ssp or self.ssp,
                 auth_level=auth_level or oxid_entry.authnHint,
+                impersonation_type=impersonation_type or self.impersonation_type,
                 verb=self.verb,
             )
 
@@ -1406,7 +1443,10 @@ class DCOM_Client(DCERPC_Client):
             )
 
         # Bind the COM interface
-        resolver_entry.client.bind_or_alter(ipid_entry.iface)
+        resolver_entry.client.bind_or_alter(
+            ipid_entry.iface,
+            target_name=oxid_entry.target_name,
+        )
 
         # We need to set the NDR very late, after the bind
         pkt.ndr64 = resolver_entry.client.ndr64

--- a/scapy/layers/msrpce/msnrpc.py
+++ b/scapy/layers/msrpce/msnrpc.py
@@ -51,7 +51,6 @@ from scapy.layers.msrpce.raw.ms_nrpc import (
     PNETLOGON_CREDENTIAL,
 )
 
-
 if conf.crypto_valid:
     from cryptography.hazmat.primitives import hashes, hmac
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -70,7 +69,6 @@ else:
 from typing import (
     Optional,
 )
-
 
 # --- RFC
 
@@ -853,11 +851,12 @@ class NetlogonClient(DCERPC_Client):
             else:
                 self.ssp = self.sock.session.ssp = KerberosSSP(
                     UPN=UPN,
-                    SPN="netlogon/" + DC_FQDN,
                     PASSWORD=PASSWORD,
                     KEY=KEY,
                 )
-            if not self.bind_or_alter(self.interface):
+            # [MS-NRPC] note <185> "Windows uses netlogon/<hostname>"
+            target_name = "netlogon/" + DC_FQDN
+            if not self.bind_or_alter(self.interface, target_name=target_name):
                 raise ValueError("Bind failed !")
 
             # Send AuthenticateKerberos request

--- a/scapy/layers/msrpce/rpcclient.py
+++ b/scapy/layers/msrpce/rpcclient.py
@@ -347,6 +347,7 @@ class DCERPC_Client(object):
                     DceRpcSecVTCommand(SEC_VT_COMMAND_END=1)
                     / DceRpcSecVTPcontext(
                         InterfaceId=self.session.rpc_bind_interface.uuid,
+                        Version=self.session.rpc_bind_interface.if_version,
                         TransferSyntax="NDR64" if self.ndr64 else "NDR 2.0",
                         TransferVersion=1 if self.ndr64 else 2,
                     )

--- a/scapy/layers/msrpce/rpcclient.py
+++ b/scapy/layers/msrpce/rpcclient.py
@@ -7,6 +7,7 @@
 DCE/RPC client as per [MS-RPCE]
 """
 
+import collections
 import uuid
 import socket
 
@@ -101,7 +102,7 @@ class DCERPC_Client(object):
         ), "transport must be from DCERPC_Transport"
 
         # Counters
-        self.call_id = 0
+        self.call_ids = collections.defaultdict(lambda: 0)  # by assoc_group_id
         self.next_cont_id = 0  # next available context id
         self.next_auth_contex_id = 0  # next available auth context id
 
@@ -271,10 +272,10 @@ class DCERPC_Client(object):
 
         The DCE/RPC header is added automatically.
         """
-        self.call_id += 1
+        self.call_ids[self.session.assoc_group_id] += 1
         pkt = (
             DceRpc5(
-                call_id=self.call_id,
+                call_id=self.call_ids[self.session.assoc_group_id],
                 pfc_flags="PFC_FIRST_FRAG+PFC_LAST_FRAG",
                 endian=self.ndrendian,
                 auth_verifier=kwargs.pop("auth_verifier", None),
@@ -295,10 +296,10 @@ class DCERPC_Client(object):
 
         The DCE/RPC header is added automatically.
         """
-        self.call_id += 1
+        self.call_ids[self.session.assoc_group_id] += 1
         pkt = (
             DceRpc5(
-                call_id=self.call_id,
+                call_id=self.call_ids[self.session.assoc_group_id],
                 pfc_flags="PFC_FIRST_FRAG+PFC_LAST_FRAG",
                 endian=self.ndrendian,
                 auth_verifier=kwargs.pop("auth_verifier", None),
@@ -655,7 +656,6 @@ class DCERPC_Client(object):
             and respcls in resp
             and self._check_bind_context(interface, resp.results)
         ):
-            self.call_id = 0  # reset call id
             port = resp.sec_addr.port_spec.decode()
             ndr = self.session.ndr64 and "NDR64" or "NDR32"
             self.ndr64 = self.session.ndr64

--- a/scapy/layers/msrpce/rpcclient.py
+++ b/scapy/layers/msrpce/rpcclient.py
@@ -502,6 +502,7 @@ class DCERPC_Client(object):
         interface: Union[DceRpcInterface, ComInterface],
         reqcls,
         respcls,
+        target_name: Optional[str] = None,
     ) -> bool:
         """
         Internal: used to send a bind/alter request
@@ -560,7 +561,7 @@ class DCERPC_Client(object):
                         else 0
                     )
                 ),
-                target_name="host/" + self.host,
+                target_name=target_name or ("host/" + self.host),
             )
 
             if status not in [GSS_S_CONTINUE_NEEDED, GSS_S_COMPLETE]:
@@ -602,7 +603,7 @@ class DCERPC_Client(object):
                 self.sspcontext, token, status = self.ssp.GSS_Init_sec_context(
                     self.sspcontext,
                     input_token=resp.auth_verifier.auth_value,
-                    target_name="host/" + self.host,
+                    target_name=target_name or ("host/" + self.host),
                 )
 
             if status in [GSS_S_CONTINUE_NEEDED, GSS_S_COMPLETE]:
@@ -645,7 +646,7 @@ class DCERPC_Client(object):
                         self.sspcontext, token, status = self.ssp.GSS_Init_sec_context(
                             self.sspcontext,
                             input_token=resp.auth_verifier.auth_value,
-                            target_name="host/" + self.host,
+                            target_name=target_name or ("host/" + self.host),
                         )
             else:
                 log_runtime.error("GSS_Init_sec_context failed with %s !" % status)
@@ -704,23 +705,45 @@ class DCERPC_Client(object):
                     resp.show()
             return False
 
-    def bind(self, interface: Union[DceRpcInterface, ComInterface]) -> bool:
+    def bind(
+        self,
+        interface: Union[DceRpcInterface, ComInterface],
+        target_name: Optional[str] = None,
+    ) -> bool:
         """
         Bind the client to an interface
 
         :param interface: the DceRpcInterface object
         """
-        return self._bind(interface, DceRpc5Bind, DceRpc5BindAck)
+        return self._bind(
+            interface,
+            DceRpc5Bind,
+            DceRpc5BindAck,
+            target_name=target_name,
+        )
 
-    def alter_context(self, interface: Union[DceRpcInterface, ComInterface]) -> bool:
+    def alter_context(
+        self,
+        interface: Union[DceRpcInterface, ComInterface],
+        target_name: Optional[str] = None,
+    ) -> bool:
         """
         Alter context: post-bind context negotiation
 
         :param interface: the DceRpcInterface object
         """
-        return self._bind(interface, DceRpc5AlterContext, DceRpc5AlterContextResp)
+        return self._bind(
+            interface,
+            DceRpc5AlterContext,
+            DceRpc5AlterContextResp,
+            target_name=target_name,
+        )
 
-    def bind_or_alter(self, interface: Union[DceRpcInterface, ComInterface]) -> bool:
+    def bind_or_alter(
+        self,
+        interface: Union[DceRpcInterface, ComInterface],
+        target_name: Optional[str] = None,
+    ) -> bool:
         """
         Bind the client to an interface or alter the context if already bound
 
@@ -728,10 +751,10 @@ class DCERPC_Client(object):
         """
         if not self.session.rpc_bind_interface:
             # No interface is bound
-            return self.bind(interface)
+            return self.bind(interface, target_name=target_name)
         elif self.session.rpc_bind_interface != interface:
             # An interface is already bound
-            return self.alter_context(interface)
+            return self.alter_context(interface, target_name=target_name)
         return True
 
     def open_smbpipe(self, name: str):

--- a/scapy/layers/msrpce/rpcserver.py
+++ b/scapy/layers/msrpce/rpcserver.py
@@ -388,7 +388,7 @@ class DCERPC_Server(metaclass=_DCERPC_Server_metaclass):
                     self.session.out_pkt(
                         hdr
                         / cls(
-                            assoc_group_id=RandShort(),
+                            assoc_group_id=int(RandShort()),
                             sec_addr=DceRpc5PortAny(
                                 port_spec=port_spec,
                             ),

--- a/scapy/layers/ntlm.py
+++ b/scapy/layers/ntlm.py
@@ -1584,6 +1584,13 @@ class NTLMSSP(SSP):
                         if Context.flags & GSS_C_FLAGS.GSS_C_CONF_FLAG
                         else []
                     )
+                    + (
+                        [
+                            "NEGOTIATE_IDENTIFY",
+                        ]
+                        if Context.flags & GSS_C_FLAGS.GSS_C_IDENTIFY_FLAG
+                        else []
+                    )
                 ),
                 ProductMajorVersion=10,
                 ProductMinorVersion=0,


### PR DESCRIPTION
This PR does a bunch of things related to DCE/RPC:
- fixes https://github.com/secdev/scapy/issues/4900 by properly taking the association group id into account when computing the `call_id`. (BTW, contrary to what C706 says, it seems the group is also taken into account when using `alter context`, at least on windows)
- also register the names of [MS-DCOM] interfaces to have them shown nicely in OBJREF
- improve handling of impersonation type, also properly propagates it for NTLM
- generally a better and more per-spec handling of SPNs when it comes to DCOM
- fix the security trailer version being wrong which would lead in ACCESS_DENIED