### PR TITLE
ci: install cbor2 on Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -28,6 +28,7 @@ actions:
     - "sed -i '/^BuildArch/aBuildRequires: python3-ipython' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-brotli' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-can' .packit_rpm/scapy.spec"
+    - "sed -i '/^BuildArch/aBuildRequires: python3-cbor2' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-coverage' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-cryptography' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: python3-tkinter' .packit_rpm/scapy.spec"


### PR DESCRIPTION
to prevent the newly introduced CBOR tests from failing with:
```
 ###(090)=[failed] Interop: Large unsigned integer

 >>> large_int = 18446744073709551615  # 2^64 - 1
 >>> encoded = cbor2.dumps(large_int)
 NameError: name 'cbor2' is not defined
```
and so on.

It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/10238626/