### PR TITLE
Request Registry Class

### DIFF
--- a/scapy/layers/windows/registry.py
+++ b/scapy/layers/windows/registry.py
@@ -499,6 +499,26 @@ class RRP_Client(DCERPC_Client):
             )
             raise ValueError(response.status)
 
+        if response.lpClassOut.Length > 2:
+            # There is a Class info stored. We need to
+            # get it by specifying the proper MaximumLength.
+            # By default the size is "2".
+            response = self.sr1_req(
+                BaseRegQueryInfoKey_Request(
+                    hKey=key_handle,
+                    lpClassIn=RPC_UNICODE_STRING(
+                        MaximumLength=response.lpClassOut.Length
+                    ),
+                ),
+                timeout=timeout,
+            )
+
+        if response.status != 0:
+            log_runtime.error(
+                "Got status %s while querying key info", hex(response.status)
+            )
+            raise ValueError(response.status)
+
         return response
 
     def get_key_security(
@@ -588,7 +608,6 @@ class RRP_Client(DCERPC_Client):
 
             index += 1
             results.append(response.lpNameOut.valueof("Buffer")[:-1].decode())
-
         return results
 
     def enum_values(


### PR DESCRIPTION
<!-- This is just a checklist to guide you. Please remove it if you check all items. -->

**Checklist:**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I unit tests are part of scapy-red
-   [x] I executed the regression tests (using `tox`)
-   [x] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->
The PR is fixing the information request to the class name of the registry. By default, we request a classname of 0b, but we need to re-request it with proper size if Windows returned >2B size.
