### PR TITLE
dns: add EDNS0 Padding option

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -439,7 +439,7 @@ class DNSTextField(StrLenField):
 
 edns0types = {0: "Reserved", 1: "LLQ", 2: "UL", 3: "NSID", 4: "Owner",
               5: "DAU", 6: "DHU", 7: "N3U", 8: "edns-client-subnet", 10: "COOKIE",
-              15: "Extended DNS Error"}
+              12: "Padding", 15: "Extended DNS Error"}
 
 
 class _EDNS0Dummy(Packet):
@@ -626,6 +626,16 @@ class EDNS0COOKIE(_EDNS0Dummy):
                                 length_from=lambda pkt: max(0, pkt.optlen - 8))]
 
 
+# RFC 7830 - EDNS0 Padding Option
+
+class EDNS0PADDING(_EDNS0Dummy):
+    name = "DNS EDNS0 Padding"
+    fields_desc = [ShortEnumField("optcode", 12, edns0types),
+                   FieldLenField("optlen", None, length_of="padding", fmt="!H"),
+                   StrLenField("padding", "",
+                               length_from=lambda pkt: pkt.optlen)]
+
+
 # RFC 8914 - Extended DNS Errors
 
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes
@@ -681,6 +691,7 @@ EDNS0OPT_DISPATCHER = {
     7: EDNS0N3U,
     8: EDNS0ClientSubnet,
     10: EDNS0COOKIE,
+    12: EDNS0PADDING,
     15: EDNS0ExtendedDNSError,
 }
 

--- a/test/scapy/layers/dns_edns0.uts
+++ b/test/scapy/layers/dns_edns0.uts
@@ -182,6 +182,31 @@ assert p.client_cookie == b'\x01' * 8
 assert p.server_cookie == b'\x02' * 16
 
 
++ EDNS0 - Padding
+
+= Basic instantiation & dissection
+
+b = b'\x00\x0c\x00\x00'
+
+p = EDNS0PADDING()
+assert raw(p) == b
+
+p = EDNS0PADDING(b)
+assert p.optcode == 12
+assert p.optlen == 0
+assert p.padding == b''
+
+b = b'\x00\x0c\x00\x03\x00\x01\x02'
+
+p = EDNS0PADDING(padding=b'\x00\x01\x02')
+assert raw(p) == b
+
+p = EDNS0PADDING(b)
+assert p.optcode == 12
+assert p.optlen == 3
+assert p.padding == b'\x00\x01\x02'
+
+
 + EDNS0 - Extended DNS Error
 
 = Basic instantiation & dissection


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7830 specifies the EDNS(0) "Padding" option, which allows DNS clients and servers to pad request and response messages by a variable number of octets.

It was cross-checked with TShark
```
>>> tdecode(Ether()/IP()/UDP()/DNS(ar=[DNSRROPT(rdata=[EDNS0PADDING(padding=b'\x00')])]))
...
            Option: PADDING
                Option Code: PADDING (12)
                Option Length: 1
                Option Data: 00
                Padding: 00
```