### PR TITLE
Follow semver: change dev version -> post

### DIFF
--- a/scapy/__init__.py
+++ b/scapy/__init__.py
@@ -30,12 +30,12 @@ def _parse_tag(tag):
 
     Example::
 
-        v2.3.2-346-g164a52c075c8 -> '2.3.2.dev346'
+        v2.3.2-346-g164a52c075c8 -> '2.3.2.post346'
     """
     match = re.match('^v?(.+?)-(\\d+)-g[a-f0-9]+$', tag)
     if match:
-        # remove the 'v' prefix and add a '.devN' suffix
-        return '%s.dev%s' % (match.group(1), match.group(2))
+        # remove the 'v' prefix and add a '.postN' suffix
+        return '%s.post%s' % (match.group(1), match.group(2))
     else:
         match = re.match('^v?([\\d\\.]+(rc\\d+)?)$', tag)
         if match:
@@ -93,13 +93,13 @@ def _version_from_git_describe():
     The tag prefix (``v``) and the git commit sha1 (``-g164a52c075c8``) are
     removed if present.
 
-    If the current directory is not exactly on the tag, a ``.devN`` suffix is
+    If the current directory is not exactly on the tag, a ``.postN`` suffix is
     appended where N is the number of commits made after the last tag.
 
     Example::
 
         >>> _version_from_git_describe()
-        '2.3.2.dev346'
+        '2.3.2.post346'
 
     :raises CalledProcessError: if git is unavailable
     :return: Scapy's latest tag

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -32,7 +32,7 @@ class FakeModule2(object):
     __version__ = "5.143.3.12"
 
 class FakeModule3(object):
-    __version__ = "v2.4.2.dev42"
+    __version__ = "v2.4.2.post42"
 
 from scapy.config import _version_checker
 
@@ -67,7 +67,7 @@ with mock.patch('scapy.subprocess.Popen', return_value=b):
         except ValueError:
             pass
 
-assert GitModuleScapy.__version__ == '2.4.5rc1.dev261'
+assert GitModuleScapy.__version__ == '2.4.5rc1.post261'
 assert _version_checker(GitModuleScapy, (2, 4, 5))
 
 = List layers


### PR DESCRIPTION
A very long time ago someone (can't find the issue) noted that we are using semver wrong (dev is BEFORE a release). They're actually right + it is useful to fix this as it allows someone to require a post release in their dependencies.