### PR TITLE
ci: drop downstream import check

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,6 +19,7 @@ actions:
     - "rm -fv .packit_rpm/sources"
     # Drop all downstream patches to prevent them from interfering with upstream builds
     - "sed -ri '/^Patch[0-9]+\\:.+\\.patch/d' .packit_rpm/scapy.spec"
+    - "sed -i '/^%pyproject_check_import/d' .packit_rpm/scapy.spec"
     - "sed -i '/^%check$/apip3 install scapy-rpc\\nOPENSSL_ENABLE_SHA1_SIGNATURES=1 OPENSSL_CONF=$(python3 ./.config/ci/openssl.py) ./test/run_tests -c test/configs/linux.utsc -K ci_only -K netaccess -K scanner' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: can-utils' .packit_rpm/scapy.spec"
     - "sed -i '/^BuildArch/aBuildRequires: libpcap' .packit_rpm/scapy.spec"


### PR DESCRIPTION
to prevent it from interfering with the upstream CI.

The import check was added recently in
https://src.fedoraproject.org/rpms/scapy/c/878585466261f17c01516a653d19cf47022c2f9f?branch=rawhide and it started failing when https://github.com/secdev/scapy/pull/4975 was merged with
<details>
<summary>ModuleNotFoundError: No module named 'winreg'</summary>

```
+ /usr/bin/python3 -sP /usr/lib/rpm/redhat/import_all_modules.py \
  -f /builddir/build/BUILD/scapy-2.7.0-build/scapy-2.7.0-1.20260423030854887593.pr2.57.g5d1727ff.fc43.x86_64-pyproject-modules \
  -e scapy.arch.bpf.core -e scapy.arch.bpf.supersocket -e scapy.arch.windows \
  -e scapy.arch.windows.native -e scapy.arch.windows.structures \
  -e scapy.contrib.cansocket_python_can -e scapy.tools.generate_bluetooth \
  -e scapy.tools.generate_ethertypes -e scapy.tools.generate_manuf \
  -e scapy.tools.scapy_pyannotate -e scapy.libs.winpcapy
...
Check import: scapy.arch.windows.sspi
Traceback (most recent call last):
  File "/usr/lib/rpm/redhat/import_all_modules.py", line 106, in import_modules
    importlib.import_module(module)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib64/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
  File "/builddir/build/BUILD/scapy-2.7.0-build/BUILDROOT/usr/lib/python3.14/site-packages/scapy/arch/windows/__init__.py", line 18, in <module>
    import winreg
ModuleNotFoundError: No module named 'winreg'
```
</details>

Since it can't keep up with upstream PRs it can be trimmed.

Big endian builds are back to normal
(https://forge.fedoraproject.org/infra/ansible/pulls/3316) and left intact.

Closes https://github.com/secdev/scapy/issues/4979

It was tested in https://copr.fedorainfracloud.org/coprs/packit/evverx-scapy-2/build/10426205/

<!-- This is a checklist of actions required to have a PR reviewed. You should include it and fill it accordingly. (You may only remove it if you check all items and you are a well-known contributor.) -->

**Checklist :**

-   [x] If you are new to Scapy: I have checked [CONTRIBUTING.md](https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md) (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [x] I added unit tests or explained why they are not relevant
-   [x] I executed the regression tests (using `tox`)
-   [ ] If the PR is still not finished, please create a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
-   [ ] This PR uses (partially) AI-generated code. If so:
    - [ ] I ensured the generated code follows the internal concepts of scapy
    - [ ] This PR has a test coverage > 90%
    - [ ] I reviewed every generated line
    - [ ] If this PR contains more than 500 lines of code (excluding unit tests) I considered splitting this PR.
     - [ ] I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

**I understand that failing to mention the use of AI may result in a ban. (We do not forbid it, but you must play fair. Be warned !)**

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is ->>

<!-- if required - outline impacts on other parts of the library -->

fixes https://github.com/secdev/scapy/issues/4979 <!-- (add issue number here if appropriate, else remove this line) -->
