### PR TITLE
Use ClassVar for Packet.fields_desc type hint

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -55,6 +55,7 @@ from scapy.libs.test_pyx import PYX
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     Iterator,
     List,
@@ -105,7 +106,7 @@ class Packet(
         "process_information"
     ]
     name = None
-    fields_desc = []  # type: List[AnyField]
+    fields_desc = []  # type: ClassVar[List[AnyField]]
     deprecated_fields = {}  # type: Dict[str, Tuple[str, str]]
     overload_fields = {}  # type: Dict[Type[Packet], Dict[str, Any]]
     payload_guess = []  # type: List[Tuple[Dict[str, Any], Type[Packet]]]


### PR DESCRIPTION
## Summary
- import `ClassVar` in `scapy.packet`
- annotate `Packet.fields_desc` as `ClassVar[List[AnyField]]`
- keep runtime behavior unchanged

Closes #4991

## Checks
- `python3 -m py_compile scapy/packet.py`
- `git diff --check`

Not run locally:
- `tox -e flake8` (`tox` resolves to a broken pyenv-win shim; `python3 -m tox` is not installed)
- `tox -e mypy` (same tox issue)
- `python3 -m ruff check --select RUF012 scapy/packet.py` (`ruff` is not installed)