### PR TITLE
ci: require the AI-Assisted tag only on commits done after 2026

### DIFF
--- a/.config/ci/check_commits.sh
+++ b/.config/ci/check_commits.sh
@@ -6,7 +6,7 @@
 # We copy Wireshark's contributing guide, thanks to them for the idea !
 # This script is inspired by https://gitlab.com/wireshark/wireshark/-/blob/master/.gitlab-ci.yml
 
-commits=$(git rev-list --no-merges --max-count=$((PR_FETCH_DEPTH - 1)) HEAD)
+commits=$(git rev-list --no-merges --after="2026-01-00T00:00:00" --max-count=$((PR_FETCH_DEPTH - 1)) HEAD)
 if [ -z "$commits" ]; then
     echo "No commit to check in PR. OK."
     exit 0


### PR DESCRIPTION
See https://github.com/secdev/scapy/pull/5002#issuecomment-4531328718