### PR TITLE
Fix sniff timeout when libpcap select returns readable with no packets

### DIFF
--- a/scapy/contrib/isotp/isotp_utils.py
+++ b/scapy/contrib/isotp/isotp_utils.py
@@ -345,11 +345,14 @@ class ISOTPSession(DefaultSession):
             basecls=kwargs.pop("basecls", ISOTP))
         super(ISOTPSession, self).__init__(*args, **kwargs)
 
-    def recv(self, sock: SuperSocket) -> Iterator[Packet]:
+    def recv(self, sock: SuperSocket, nonblock: bool = False) -> Iterator[Packet]:
         """
         Will be called by sniff() to ask for a packet
         """
-        pkt = sock.recv()
+        if nonblock and hasattr(sock, "nonblock_recv"):
+            pkt = sock.nonblock_recv()
+        else:
+            pkt = sock.recv()
         if not pkt:
             return
         self.m.feed(pkt)

--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -1336,7 +1336,11 @@ class AsyncSniffer(object):
                     # The session object is passed the socket to call recv() on,
                     # and may perform additional processing (ip defrag, etc.)
                     try:
-                        packets = session.recv(s)
+                        packets = session.recv(
+                            s,
+                            nonblock=timeout is not None and
+                            hasattr(s, "nonblock_recv"),
+                        )
                         # A session can return multiple objects
                         for p in packets:
                             if lfilter and not lfilter(p):

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -51,11 +51,14 @@ class DefaultSession(object):
             return self.supersession.process(pkt)
         return pkt
 
-    def recv(self, sock: 'SuperSocket') -> Iterator[Packet]:
+    def recv(self, sock: 'SuperSocket', nonblock: bool = False) -> Iterator[Packet]:
         """
         Will be called by sniff() to ask for a packet
         """
-        pkt = sock.recv()
+        if nonblock and hasattr(sock, "nonblock_recv"):
+            pkt = sock.nonblock_recv()
+        else:
+            pkt = sock.recv()
         if not pkt:
             return
         pkt = self.process(pkt)
@@ -407,11 +410,14 @@ class TCPSession(IPSession):
             return pkt
         return None
 
-    def recv(self, sock: 'SuperSocket') -> Iterator[Packet]:
+    def recv(self, sock: 'SuperSocket', nonblock: bool = False) -> Iterator[Packet]:
         """
         Will be called by sniff() to ask for a packet
         """
-        pkt = sock.recv(stop_dissection_after=self.stop_dissection_after)
+        if nonblock and hasattr(sock, "nonblock_recv"):
+            pkt = sock.nonblock_recv()
+        else:
+            pkt = sock.recv(stop_dissection_after=self.stop_dissection_after)
         # Now handle TCP reassembly
         if self.app:
             while pkt is not None:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2061,6 +2061,45 @@ o.send(REFPACKET)
 pkts = sniff(opened_socket=[o], timeout=3)
 assert len(pkts) == 10
 
+= sniff timeout with select-ready but empty pcap socket (#4590)
+
+import time
+from scapy.automaton import ObjectPipe
+from scapy.supersocket import SuperSocket
+
+class PcapLikeSocket(SuperSocket):
+    def __init__(self):
+        self.ins = ObjectPipe(name="pcap_like_socket")
+        self.outs = None
+        self.recv_called = False
+
+    def recv(self, x=65535, **kwargs):
+        self.recv_called = True
+        time.sleep(60)
+        return None
+
+    def nonblock_recv(self, x=65535):
+        return None
+
+    @staticmethod
+    def select(sockets, remain=None):
+        return list(sockets)
+
+    def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        self.ins.close()
+
+sock = PcapLikeSocket()
+t0 = time.monotonic()
+pkts = sniff(opened_socket=sock, timeout=1, count=1)
+elapsed = time.monotonic() - t0
+assert not sock.recv_called, "blocking recv must not be used with timeout"
+assert elapsed < 3, "sniff should stop on timeout, got %.1fs" % elapsed
+assert len(pkts) == 0
+sock.close()
+
 = GH issue 3306
 ~ netaccess needs_root
 


### PR DESCRIPTION
## Summary
- When `sniff(..., timeout=N)` uses a libpcap socket, `select` may report the capture fd as readable even when no BPF-matched packets are available; a blocking `pcap_next_ex` in `recv()` could then stall past the sniff timeout (same class as #74).
- Timed sniff loops now call `nonblock_recv()` when the socket supports it, via a `nonblock` flag on session `recv()`.
- Adds a mock regression test that simulates libpcap always returning the socket from `select` while `nonblock_recv()` yields no packet.

Fixes #4590

## Test plan
- [x] New regression test: `sniff timeout with select-ready but empty pcap socket (#4590)` in `test/regression.uts`
- [x] Manual verification: mock socket completes within ~1s with `timeout=1`, blocking `recv()` never called
- [ ] CI (UTscapy on Linux with libpcap)


Made with [Cursor](https://cursor.com)