### PR TITLE
fields: preserve containers when copying fields

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -314,39 +314,12 @@ class _FieldContainer(object):
 
     def copy(self):
         # type: () -> Any
-        def _copy_attr(attr):
-            # type: (Any) -> Any
-            if hasattr(attr, "copy"):
-                return attr.copy()
-            return attr
-
-        cls = self.__class__
-        other = cls.__new__(cls)
-
-        if hasattr(self, "__dict__"):
-            other.__dict__ = {
-                key: _copy_attr(value)
-                for key, value in self.__dict__.items()
-            }
-
-        copied_slots = set()
-        for base in cls.__mro__:
-            slots = base.__dict__.get("__slots__", ())
-            if isinstance(slots, str):
-                slots = (slots,)
-            for slot in slots:
-                if slot in ("__dict__", "__weakref__") or slot in copied_slots:
-                    continue
-                slot_descriptor = base.__dict__.get(slot)
-                if getattr(cls, slot, None) is not slot_descriptor:
-                    continue
-                copied_slots.add(slot)
-                try:
-                    value = getattr(self, slot)
-                except AttributeError:
-                    continue
-                setattr(other, slot, _copy_attr(value))
-
+        other = self.__class__.__new__(self.__class__)
+        for slot in self.__slots__:
+            val = object.__getattribute__(self, slot)
+            if hasattr(val, "copy"):
+                val = val.copy()
+            object.__setattr__(other, slot, val)
         return other
 
     def __setattr__(self, attr, value):
@@ -354,6 +327,9 @@ class _FieldContainer(object):
         try:
             object.__setattr__(self, attr, value)
         except AttributeError as ex:
+            for cls in type(self).__mro__:
+                if attr in cls.__dict__:
+                    raise ex
             try:
                 fld = object.__getattribute__(self, "fld")
             except AttributeError:

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -312,6 +312,54 @@ class _FieldContainer(object):
     """
     __slots__ = ["fld"]
 
+    def copy(self):
+        # type: () -> Any
+        def _copy_attr(attr):
+            # type: (Any) -> Any
+            if hasattr(attr, "copy"):
+                return attr.copy()
+            return attr
+
+        cls = self.__class__
+        other = cls.__new__(cls)
+
+        if hasattr(self, "__dict__"):
+            other.__dict__ = {
+                key: _copy_attr(value)
+                for key, value in self.__dict__.items()
+            }
+
+        copied_slots = set()
+        for base in cls.__mro__:
+            slots = base.__dict__.get("__slots__", ())
+            if isinstance(slots, str):
+                slots = (slots,)
+            for slot in slots:
+                if slot in ("__dict__", "__weakref__") or slot in copied_slots:
+                    continue
+                slot_descriptor = base.__dict__.get(slot)
+                if getattr(cls, slot, None) is not slot_descriptor:
+                    continue
+                copied_slots.add(slot)
+                try:
+                    value = getattr(self, slot)
+                except AttributeError:
+                    continue
+                setattr(other, slot, _copy_attr(value))
+
+        return other
+
+    def __setattr__(self, attr, value):
+        # type: (str, Any) -> None
+        try:
+            object.__setattr__(self, attr, value)
+        except AttributeError as ex:
+            try:
+                fld = object.__getattribute__(self, "fld")
+            except AttributeError:
+                raise ex
+            setattr(fld, attr, value)
+
     def __getattr__(self, attr):
         # type: (str) -> Any
         return getattr(self.fld, attr)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -15,6 +15,34 @@
 #Field("foo", None, fmt="I").getfield(None, b"\x12\x34\x56\x78ABCD")
 #assert  _ == ("ABCD",0x12345678) 
 
+= FieldContainer copy
+~ core field
+
+field_container = Emph(ByteField("foo", 0))
+field_container_copy = field_container.copy()
+
+assert type(field_container_copy) is Emph
+assert type(field_container_copy.fld) is ByteField
+assert field_container_copy.fld is not field_container.fld
+assert field_container_copy.name == "foo"
+assert field_container_copy.default == 0
+
+class TEST_FIELD_CONTAINER_COPY_SOURCE(Packet):
+    fields_desc = [Emph(ByteField("foo", 0))]
+
+class TEST_FIELD_CONTAINER_COPY_TARGET(Packet):
+    fields_desc = [TEST_FIELD_CONTAINER_COPY_SOURCE, ByteField("bar", 0)]
+    foo = 7
+
+source_field = TEST_FIELD_CONTAINER_COPY_SOURCE.fields_desc[0]
+target_field = TEST_FIELD_CONTAINER_COPY_TARGET.fields_desc[0]
+
+assert type(target_field) is Emph
+assert type(target_field.fld) is ByteField
+assert target_field.fld is not source_field.fld
+assert target_field.default == 7
+assert source_field.default == 0
+
 
 = ConditionnalField class
 ~ core field


### PR DESCRIPTION
## Summary

Fix copying of `_FieldContainer` instances so wrappers such as `Emph` remain wrappers instead of being replaced by their contained field.

The root cause was that `_FieldContainer` delegated missing attributes to `fld`, so `container.copy()` resolved to `container.fld.copy()` when the container class did not define its own `copy()` method. This also affected packet field copying when `fields_desc` references another packet class and overrides a copied field default.

Fixes #4657.

## Changes

- Add `_FieldContainer.copy()` to copy the container instance and its stored attributes.
- Delegate unsupported attribute assignment to the contained field, matching the existing read delegation needed by field default replacement.
- Add a regression test for direct `Emph(...).copy()` and the packet-metaclass copy path from the issue.

## Validation

- `python3 -m scapy.tools.UTscapy -t test/fields.uts -N -qq -f xUnit -o /tmp/scapy-fields.xml`
- `/tmp/scapy-flake8-venv/bin/flake8 scapy/`

Note: `tox` is not installed in this local environment, so flake8 was run through a temporary venv using the repository-pinned `flake8<6.0.0` version.
