### PR TITLE
SSH: fix _ComaStrField length calculation

### DIFF
--- a/scapy/layers/ssh.py
+++ b/scapy/layers/ssh.py
@@ -62,6 +62,9 @@ class _ComaStrField(StrLenField):
     def i2m(self, pkt, x):
         return super(_ComaStrField, self).i2m(pkt, b",".join(x))
 
+    def i2len(self, pkt, x):
+        return len(self.i2m(pkt, x))
+
 
 class SSHString(Packet):
     fields_desc = [

--- a/test/scapy/layers/ssh.uts
+++ b/test/scapy/layers/ssh.uts
@@ -35,3 +35,45 @@ assert pkts[10].pay.H_hash.value.data.key.value == b"\xef\xecj=~\xe4Y'\xe9\xad\x
 
 assert isinstance(pkts[10][SSH:2].pay, SSHNewKeys)
 assert isinstance(pkts[12].pay, SSHNewKeys)
+
+= ComaStrField encode/decode
+
+import struct
+from scapy.layers.ssh import _ComaStrField
+
+csf = _ComaStrField("names", [])
+
+# m2i splits on commas
+assert csf.m2i(None, b"curve25519-sha256,diffie-hellman-group14-sha256") == \
+    [b"curve25519-sha256", b"diffie-hellman-group14-sha256"]
+
+# i2m joins with commas
+assert csf.i2m(None, [b"curve25519-sha256", b"diffie-hellman-group14-sha256"]) == \
+    b"curve25519-sha256,diffie-hellman-group14-sha256"
+
+# single element, no comma
+assert csf.m2i(None, b"ssh-ed25519") == [b"ssh-ed25519"]
+assert csf.i2m(None, [b"ssh-ed25519"]) == b"ssh-ed25519"
+
+# empty string <-> single empty-name list
+assert csf.m2i(None, b"") == [b""]
+assert csf.i2m(None, [b""]) == b""
+
+# round trips
+names = [b"a", b"b", b"c"]
+assert csf.m2i(None, csf.i2m(None, names)) == names
+raw = b"x,y,z"
+assert csf.i2m(None, csf.m2i(None, raw)) == raw
+
+# through NameList length
+nl = NameList(names=[b"curve25519-sha256"])
+raw = bytes(nl)
+assert struct.unpack("!I", raw[:4])[0] == len(b"curve25519-sha256"), \
+    "NameList length field encodes item count instead of byte length"
+
+# Multi-name list
+nl2 = NameList(names=[b"curve25519-sha256", b"diffie-hellman-group14-sha256"])
+raw2 = bytes(nl2)
+expected = b"curve25519-sha256,diffie-hellman-group14-sha256"
+assert raw2[4:] == expected
+assert struct.unpack("!I", raw2[:4])[0] == len(expected)


### PR DESCRIPTION
> AI-Assisted: yes (Claude Sonnet 4.6)

Hi everyone,

This PR fixes SSH `_ComaStrField` length calculation.

`_ComaStrField` is used in `NameList` which is used with `SSHKexInit`:

Reproduce:
```python
from scapy.layers.ssh import SSHKexInit, NameList

kex = SSHKexInit(kex_algorithms=NameList(names=[b"curve25519-sha256"]))
SSHKexInit(bytes(kex))  # <- error
```

```
>>> bytes(NameList(names=[b"curve25519-sha256"]))
b'\x00\x00\x00\x01curve25519-sha256'
                 ^
                 |
         incorrect length
```

The current implementation considers `names` as list and not bytes and return `1` for `length` in this example.