### PR TITLE
Fix AF_PACKET protocol on raw L3 sends

### DIFF
--- a/scapy/arch/linux/__init__.py
+++ b/scapy/arch/linux/__init__.py
@@ -23,8 +23,8 @@ from scapy.compat import raw
 from scapy.consts import LINUX
 from scapy.arch.common import compile_filter, free_filter
 from scapy.config import conf
-from scapy.data import MTU, ETH_P_ALL, SOL_PACKET, SO_ATTACH_FILTER, \
-    SO_TIMESTAMPNS
+from scapy.data import MTU, ETH_P_ALL, ETH_P_IP, ETH_P_IPV6, SOL_PACKET, \
+    SO_ATTACH_FILTER, SO_TIMESTAMPNS
 from scapy.error import (
     ScapyInvalidPlatformException,
     Scapy_Exception,
@@ -201,6 +201,26 @@ def _flush_fd(fd):
             break
 
 
+def _guess_packet_protocol(sx, default):
+    # type: (bytes, int) -> int
+    if sx:
+        version = sx[0] >> 4
+        if version == 4:
+            return ETH_P_IP
+        if version == 6:
+            return ETH_P_IPV6
+    return default
+
+
+def _get_packet_protocol(x, sx, default):
+    # type: (Any, bytes, int) -> int
+    if isinstance(x, Packet):
+        proto = conf.l3types.layer2num.get(type(x))
+        if proto is not None:
+            return proto
+    return _guess_packet_protocol(sx, default)
+
+
 class L2Socket(SuperSocket):
     desc = "read/write packets at layer 2 using Linux PF_PACKET sockets"
 
@@ -293,6 +313,27 @@ class L2Socket(SuperSocket):
 
     def send(self, x):
         # type: (Packet) -> int
+        if self.lvl == 3:
+            sx = raw(x)
+            sdto = (
+                self.iface,
+                _get_packet_protocol(x, sx, self.type),
+            )
+            try:
+                x.sent_time = time.time()
+            except AttributeError:
+                pass
+            try:
+                if self.outs:
+                    return self.outs.sendto(sx, sdto)
+                return 0
+            except socket.error as msg:
+                if msg.errno == 22 and len(sx) < conf.min_pkt_size:
+                    sx += b"\x00" * (conf.min_pkt_size - len(sx))
+                    if self.outs:
+                        return self.outs.sendto(sx, sdto)
+                    return 0
+                raise
         try:
             return SuperSocket.send(self, x)
         except socket.error as msg:
@@ -350,11 +391,14 @@ class L3PacketSocket(L2Socket):
         iff = x.route()[0]
         if iff is None:
             iff = network_name(conf.iface)
+        elif isinstance(iff, NetworkInterface):
+            iff = network_name(iff)
         type_x = type(x)
+        sdto = (iff, conf.l3types.layer2num.get(type_x, self.type))
         if iff not in self.send_socks:
             self.send_socks[iff] = L3PacketSocket(
                 iface=iff,
-                type=conf.l3types.layer2num.get(type_x, self.type),
+                type=sdto[1],
                 filter=self.filter,
                 promisc=self.promisc,
             )
@@ -369,22 +413,28 @@ class L3PacketSocket(L2Socket):
             sx = bytes(sock.LL() / x)
         else:
             sx = bytes(x)
+        sdto = (iff, _get_packet_protocol(x, sx, sdto[1]))
         # Now send.
         try:
             x.sent_time = time.time()
         except AttributeError:
             pass
         try:
-            return fd.send(sx)
+            return fd.sendto(sx, sdto)
         except socket.error as msg:
             if msg.errno == 22 and len(sx) < conf.min_pkt_size:
-                return fd.send(
-                    sx + b"\x00" * (conf.min_pkt_size - len(sx))
+                return fd.sendto(
+                    sx + b"\x00" * (conf.min_pkt_size - len(sx)),
+                    sdto,
                 )
             elif conf.auto_fragment and msg.errno == 90:
                 i = 0
                 for p in x.fragment():
-                    i += fd.send(bytes(self.LL() / p))
+                    if sock.lvl == 2:
+                        sx = bytes(sock.LL() / p)
+                    else:
+                        sx = bytes(p)
+                    i += fd.sendto(sx, sdto)
                 return i
             else:
                 raise

--- a/test/linux.uts
+++ b/test/linux.uts
@@ -340,17 +340,90 @@ test_read_routes()
 
 from scapy.arch.linux import L3PacketSocket
 
-import socket
 from unittest import mock
 
 @mock.patch("scapy.arch.linux.socket.socket.sendto")
 def test_L3PacketSocket_sendto_python3(mock_sendto):
-    mock_sendto.side_effect = OSError(22, 2807)
+    mock_sendto.side_effect = [OSError(22, 2807), conf.min_pkt_size]
     l3ps = L3PacketSocket()
-    l3ps.send(IP(dst="8.8.8.8")/ICMP())
+    try:
+        assert l3ps.send(IP(dst="8.8.8.8")/ICMP()) == conf.min_pkt_size
+        assert mock_sendto.call_count == 2
+    finally:
+        l3ps.close()
     return True
 
 assert test_L3PacketSocket_sendto_python3()
+
+= AF_PACKET raw L3 send protocol
+~ linux
+
+from scapy.arch.linux import L2Socket, L3PacketSocket
+from scapy.compat import raw
+from scapy.data import ETH_P_ALL, ETH_P_IP, ETH_P_IPV6
+
+from unittest import mock
+
+def test_L3PacketSocket_sendto_ipv4_padding_protocol():
+    pkt = IP(dst="8.8.8.8")/ICMP()
+    pkt.route = lambda: ("ppp0", None, None)
+    sx = raw(pkt)
+    padded_sx = sx + b"\x00" * (conf.min_pkt_size - len(sx))
+    l3ps = object.__new__(L3PacketSocket)
+    l3ps.filter = None
+    l3ps.iface = "ppp0"
+    l3ps.LL = IP
+    l3ps.lvl = 3
+    l3ps.outs = mock.Mock()
+    l3ps.outs.sendto.side_effect = [OSError(22, 2807), len(padded_sx)]
+    l3ps.promisc = False
+    l3ps.send_socks = {"ppp0": l3ps}
+    l3ps.type = ETH_P_ALL
+    assert l3ps.send(pkt) == len(padded_sx)
+    assert l3ps.outs.sendto.mock_calls == [
+        mock.call(sx, ("ppp0", ETH_P_IP)),
+        mock.call(padded_sx, ("ppp0", ETH_P_IP)),
+    ]
+    return True
+
+def test_L3PacketSocket_sendto_ipv6_protocol():
+    pkt = IPv6(dst="ff02::1")/ICMPv6EchoRequest()
+    pkt.route = lambda: ("ppp0", None, None)
+    l3ps = object.__new__(L3PacketSocket)
+    l3ps.filter = None
+    l3ps.iface = "ppp0"
+    l3ps.LL = IPv6
+    l3ps.lvl = 3
+    l3ps.outs = mock.Mock()
+    l3ps.outs.sendto.return_value = len(raw(pkt))
+    l3ps.promisc = False
+    l3ps.send_socks = {"ppp0": l3ps}
+    l3ps.type = ETH_P_ALL
+    assert l3ps.send(pkt) == len(raw(pkt))
+    l3ps.outs.sendto.assert_called_once_with(
+        raw(pkt),
+        ("ppp0", ETH_P_IPV6),
+    )
+    return True
+
+def test_L2Socket_sendto_raw_l3_protocol():
+    pkt = IPv6(dst="ff02::1")/ICMPv6EchoRequest()
+    l2s = object.__new__(L2Socket)
+    l2s.iface = "ppp0"
+    l2s.lvl = 3
+    l2s.outs = mock.Mock()
+    l2s.outs.sendto.return_value = len(raw(pkt))
+    l2s.type = ETH_P_ALL
+    assert l2s.send(pkt) == len(raw(pkt))
+    l2s.outs.sendto.assert_called_once_with(
+        raw(pkt),
+        ("ppp0", ETH_P_IPV6),
+    )
+    return True
+
+assert test_L3PacketSocket_sendto_ipv4_padding_protocol()
+assert test_L3PacketSocket_sendto_ipv6_protocol()
+assert test_L2Socket_sendto_raw_l3_protocol()
 
 = Test _interface_selection
 ~ netaccess linux needs_root


### PR DESCRIPTION
### Description

Set the sockaddr_ll protocol explicitly when sending raw L3 packets through Linux AF_PACKET sockets. This prevents PPP/PPPoE drivers from seeing skb->protocol as 0 and dropping IPv4/IPv6 packets sent with send() or sendp().

Add Linux regression coverage for IPv4 padding retry and IPv6 protocol selection on L3PacketSocket and raw-L3 L2Socket paths.

Tested send and sendp can work on ppp0.

Fixes #4964

AI-Assisted: yes (OpenAI Codex)
