### PR TITLE
fix: set ICMPv6TimeExceeded length for RFC4884 extensions

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1018,9 +1018,15 @@ class _ICMPExtensionField(TrailerField):
     def getfield(self, pkt, s):
         # RFC4884 section 5.2 says if the ICMP packet length
         # is >144 then ICMP extensions start at byte 137.
+        length = getattr(pkt, "length", 0) or 0
         if len(pkt.original) < 144:
+            if not length:
+                return s, None
+            offset = length * 8
+        else:
+            offset = 136 + len(s) - len(pkt.original)
+        if offset > len(s):
             return s, None
-        offset = 136 + len(s) - len(pkt.original)
         data = s[offset:]
         # Validate checksum
         if checksum(data) == data[3:5]:
@@ -1059,6 +1065,25 @@ def _ICMP_extpad_post_dissection(self, pkt):
         if isinstance(pad, conf.padding_layer):
             pad.underlayer.remove_payload()
             pkt.extpad = pad.load
+
+
+def _icmp4884_prepare_ext_build(pkt, p, pay, length_offset):
+    # RFC4884: set length and pad original datagram when extensions are used
+    if pkt.ext is None:
+        return p, pay
+    if pkt.extpad in (None, b"", ""):
+        padding_index = pay.rindex(bytes(pkt.ext))
+        payload_len = len(pay[:padding_index])
+        padding_len = (8 - payload_len % 8) % 8
+        if payload_len + padding_len < 128:
+            padding_len = 128 - payload_len
+        padding = b"\x00" * padding_len
+        pay = pay[:padding_index] + padding + pay[padding_index:]
+    if pkt.length in (None, 0):
+        ext_index = pay.rindex(bytes(pkt.ext))
+        length = len(pay[:ext_index]) // 8
+        p = p[:length_offset] + chb(length) + p[length_offset + 1:]
+    return p, pay
 
 
 icmptypes = {0: "echo-reply",

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -62,6 +62,7 @@ from scapy.fields import (
     XShortField,
 )
 from scapy.layers.inet import (
+    _icmp4884_prepare_ext_build,
     _ICMPExtensionField,
     _ICMPExtensionPadField,
     _ICMP_extpad_post_dissection,
@@ -1509,6 +1510,10 @@ class ICMPv6TimeExceeded(_ICMPv6Error):
                    _ICMPExtensionPadField(),
                    _ICMPExtensionField()]
     post_dissection = _ICMP_extpad_post_dissection
+
+    def post_build(self, p, pay):
+        p, pay = _icmp4884_prepare_ext_build(self, p, pay, length_offset=4)
+        return _ICMPv6.post_build(self, p, pay)
 
 
 # The default pointer value is set to the next header field of

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -365,8 +365,27 @@ a[ICMPv6PacketTooBig][TCPerror].chksum == b.chksum
 
 
 ########### ICMPv6TimeExceeded Class ################################
-# To be done but not critical. Same mechanisms and format as 
-# previous ones.
+
+= ICMPv6TimeExceeded extension - length field build (GH4353)
+
+pkt = IPv6() / ICMPv6TimeExceeded(ext=ICMPExtension_Header()) / IPv6() / ICMPv6EchoRequest()
+raw = bytes(pkt)
+pkt2 = IPv6(raw)
+assert pkt2[ICMPv6TimeExceeded].length == 16
+
+= ICMPv6TimeExceeded extension - Ether round-trip (GH4353)
+
+pkt = Ether() / IPv6() / ICMPv6TimeExceeded(ext=ICMPExtension_Header()) / IPv6() / ICMPv6EchoRequest()
+pkt = Ether(bytes(pkt))
+assert pkt[ICMPv6TimeExceeded].length == 16
+
+= ICMPv6TimeExceeded extension - rebuild stability (GH4353)
+
+pkt = IPv6() / ICMPv6TimeExceeded(ext=ICMPExtension_Header()) / IPv6() / ICMPv6EchoRequest()
+raw = bytes(pkt)
+pkt2 = IPv6(raw)
+assert isinstance(pkt2[ICMPv6TimeExceeded].ext, ICMPExtension_Header)
+assert bytes(pkt2) == raw
 
 ########### ICMPv6ParamProblem Class ################################
 # See previous note


### PR DESCRIPTION
## Summary
- Automatically set the RFC 4884 `length` field when building `ICMPv6TimeExceeded` messages with ICMP extension headers
- Pad the original datagram to at least 128 octets before the extension structure
- Dissect extensions in shorter ICMP messages when `length` is present

Fixes #4353

## Test plan
- [x] Issue reproduction: `ICMPv6TimeExceeded(ext=ICMPExtension_Header())` round-trip sets `length == 16`
- [x] Ether-wrapped round-trip from issue report
- [x] Rebuild stability (`bytes()` → parse → `bytes()`)
- [x] Existing IPv4 ICMP extension tests (`test/scapy/layers/inet.uts`)
- [x] New GH4353 tests in `test/scapy/layers/inet6.uts`

Made with [Cursor](https://cursor.com)