### PR TITLE
[DOC] Fix malformed :param directive in HTTP2.gen_txt_repr docstring

### DIFF
--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -2454,7 +2454,7 @@ class HPackHdrTable(Sized):
 
         :param H2Frame|list of HPackHeaders hdrs: the list of headers to
           convert to textual representation.
-        :param bool: whether incremental headers should be added to the dynamic
+        :param bool register: whether incremental headers should be added to the dynamic
           table as we generate the text representation
         :return: str: the textual representation of the provided headers
         :raises: AssertionError


### PR DESCRIPTION
<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

The docstring for HTTP2.gen_txt_repr documents its second argument with :param bool:, which names the type (bool) rather than the parameter. The actual parameter is register (signature: gen_txt_repr(self, hdrs, register=True)), so register was effectively undocumented and the directive was malformed. Corrected to :param bool register:, matching the Sphinx :param <type> <name>: style already used for hdrs on the line above. Docs only, no behaviour change.

