### PR TITLE
Port V2G to Scapy

### DIFF
--- a/scapy/contrib/automotive/v2g.py
+++ b/scapy/contrib/automotive/v2g.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+
+#  V2GInjector is a tool to penetrate V2G network through PowerLine, monitor and inject traffic
+# Copyright (C) 2019 Sebastien Dudek (@FlUxIuS)
+
+# scapy.contrib.description = ISO 15118 V2G Transport Protocol and SECC Discovery
+# scapy.contrib.status = loads
+
+import struct
+
+from scapy.fields import (
+    ByteField,
+    FieldLenField,
+    IntField,
+    IP6Field,
+    ShortEnumField,
+    ShortField,
+    StrLenField,
+)
+from scapy.layers.inet import TCP, UDP
+from scapy.packet import Packet, bind_bottom_up, bind_layers
+
+V2GTP_PAYLOAD_TYPES = {
+    0x8001: "EXI",
+}
+
+SECC_TYPES = {
+    0x9000: "SECC_RequestMessage",
+    0x9001: "SECC_ResponseMessage",
+}
+
+
+class V2GTP(Packet):
+    name = "V2GTP"
+    fields_desc = [
+        ByteField("Version", 0x01),
+        ByteField("Invers", 0xfe),
+        ShortEnumField("PayloadType", 0x8001, V2GTP_PAYLOAD_TYPES),
+        FieldLenField("PayloadLen", 0, count_of="Payload", fmt="!I"),
+        StrLenField("Payload", "", length_from=lambda pkt: pkt.PayloadLen),
+    ]
+
+    def post_build(self, pkt, pay):
+        # type: (bytes, bytes) -> bytes
+        payload = self.Payload or pay
+        if self.PayloadLen == 0 and payload:
+            pkt = pkt[:4] + struct.pack("!I", len(payload)) + pkt[8:]
+        if self.Payload:
+            return pkt
+        return pkt + pay
+
+
+class SECC_RequestMessage(Packet):
+    name = "SECC_RequestMessage"
+    fields_desc = [
+        ByteField("SecurityProtocol", 0x0),
+        ByteField("TransportProtocol", 0x0),
+    ]
+
+
+class SECC_ResponseMessage(Packet):
+    name = "SECC_ResponseMessage"
+    fields_desc = [
+        IP6Field("TargetAddress", "::"),
+        ShortField("TargetPort", 0),
+        ByteField("SecurityProtocol", 0x0),
+        ByteField("TransportProtocol", 0x0),
+    ]
+
+
+class SECC(Packet):
+    name = "SECC"
+    fields_desc = [
+        ByteField("Version", 0x01),
+        ByteField("Inversion", 0xfe),
+        ShortEnumField("SECCType", 0, SECC_TYPES),
+        IntField("PayloadLen", 0),
+    ]
+
+    def post_build(self, pkt, pay):
+        # type: (bytes, bytes) -> bytes
+        if self.PayloadLen == 0 and pay:
+            pkt = pkt[:4] + struct.pack("!I", len(pay)) + pkt[8:]
+        return pkt + pay
+
+
+bind_bottom_up(UDP, SECC, sport=15118)
+bind_bottom_up(UDP, SECC, dport=15118)
+bind_layers(UDP, SECC, sport=15118, dport=15118)
+
+bind_bottom_up(TCP, V2GTP, sport=15118)
+bind_bottom_up(TCP, V2GTP, dport=15118)
+bind_layers(TCP, V2GTP, sport=15118, dport=15118)
+
+bind_layers(SECC, SECC_RequestMessage, SECCType=0x9000)
+bind_layers(SECC, SECC_ResponseMessage, SECCType=0x9001)

--- a/scapy/contrib/automotive/v2g.py
+++ b/scapy/contrib/automotive/v2g.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # This file is part of Scapy
 # See https://scapy.net/ for more information
-
-#  V2GInjector is a tool to penetrate V2G network through PowerLine, monitor and inject traffic
 # Copyright (C) 2019 Sebastien Dudek (@FlUxIuS)
 
 # scapy.contrib.description = ISO 15118 V2G Transport Protocol and SECC Discovery

--- a/test/contrib/automotive/v2g.uts
+++ b/test/contrib/automotive/v2g.uts
@@ -1,0 +1,62 @@
+% Regression tests for the ISO 15118 V2G layer
+
++ V2G contrib tests
+
+= Load Contrib Layer
+
+load_contrib("automotive.v2g", globals_dict=globals())
+
+= V2GTP defaults
+
+p = V2GTP()
+assert p.Version == 0x01
+assert p.Invers == 0xfe
+assert p.PayloadType == 0x8001
+assert p.PayloadLen == 0
+assert p.Payload == b""
+
+= V2GTP build and dissect
+
+payload = b"\x01\x02\x03\x04"
+p = V2GTP(Payload=payload)
+raw_pkt = bytes(p)
+assert raw_pkt == b"\x01\xfe\x80\x01\x00\x00\x00\x04" + payload
+assert V2GTP(raw_pkt).Payload == payload
+
+= SECC request defaults
+
+p = SECC(SECCType=0x9000) / SECC_RequestMessage()
+assert p[SECC].Version == 0x01
+assert p[SECC].Inversion == 0xfe
+assert p[SECC].SECCType == 0x9000
+assert p[SECC_RequestMessage].SecurityProtocol == 0x0
+assert p[SECC_RequestMessage].TransportProtocol == 0x0
+
+= SECC request build and dissect
+
+p = SECC(SECCType=0x9000, PayloadLen=2) / SECC_RequestMessage(SecurityProtocol=0x10, TransportProtocol=0x00)
+raw_pkt = bytes(p)
+assert raw_pkt == b"\x01\xfe\x90\x00\x00\x00\x00\x02\x10\x00"
+assert SECC(raw_pkt)[SECC_RequestMessage].SecurityProtocol == 0x10
+
+= SECC response build and dissect
+
+p = SECC(SECCType=0x9001, PayloadLen=20) / SECC_ResponseMessage(
+    TargetAddress="fe80::1",
+    TargetPort=49152,
+    SecurityProtocol=0x10,
+    TransportProtocol=0x00,
+)
+raw_pkt = bytes(p)
+assert SECC(raw_pkt)[SECC_ResponseMessage].TargetPort == 49152
+assert SECC(raw_pkt)[SECC_ResponseMessage].TargetAddress == "fe80::1"
+
+= UDP binding on port 15118
+
+p = UDP(sport=15118, dport=15118) / SECC(SECCType=0x9000, PayloadLen=2) / SECC_RequestMessage()
+assert p[SECC].SECCType == 0x9000
+
+= TCP binding on port 15118
+
+p = TCP(sport=49152, dport=15118) / V2GTP(Payload=b"\xde\xad\xbe\xef")
+assert p[V2GTP].Payload == b"\xde\xad\xbe\xef"


### PR DESCRIPTION
This moves the layers from V2GInjector to Scapy Mainline. 

@FlUxIuS are you OK with changing the license to GPLv2 only for this file? 

AI-Assisted: yes (Cursor AI)