### PR TITLE
arch: import read_nameservers on illumos-based systems too

### DIFF
--- a/scapy/arch/solaris.py
+++ b/scapy/arch/solaris.py
@@ -18,7 +18,7 @@ socket.IPPROTO_GRE = 47
 # From sys/sockio.h and net/if.h
 SIOCGIFHWADDR = 0xc02069b9  # Get hardware address
 
-from scapy.arch.common import get_if_raw_addr  # noqa: F401, F403, E402
+from scapy.arch.common import get_if_raw_addr, read_nameservers  # noqa: F401, E402
 from scapy.arch.libpcap import *  # noqa: F401, F403, E402
 from scapy.arch.unix import *  # noqa: F401, F403, E402
 


### PR DESCRIPTION
to prevent it from failing there with:
```python
  ...
    from scapy.all import *
  File "/root/scapy/scapy/all.py", line 16, in <module>
    from scapy.arch import *
AttributeError: module 'scapy.arch' has no attribute 'read_nameservers'
```

With this patch applied run_scapy no longer fails and dns_resolve works as expected:
```python
>>> sys.platform
'sunos5'
>>> dns_resolve('example.com')
[<DNSRR  rrname=b'example.com.' type=A cacheflush=0 rclass=IN ttl=174 rdata=8.47.69.4 |>,
 <DNSRR  rrname=b'example.com.' type=A cacheflush=0 rclass=IN ttl=174 rdata=8.6.112.4 |>]
```

F403 isn't needed there (it was probably copied from the next line) so it was removed to avoid hitting E501 line too long (89 > 88 characters).

It's a follow-up to 528626a02c7bfa404a85857375da5f9b3203ebaa

AI-Assisted: no
