### PR TITLE
fix: bounds-check hexdiff() offset-skip loop to prevent IndexError

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -530,7 +530,7 @@ def hexdiff(
         if dox:
             xd = y
             j = 0
-            while not linex[j]:
+            while j < len(linex) and not linex[j]:
                 j += 1
                 xd -= 1
             print(colorize[doy - dox]("%04x" % xd), end=' ')
@@ -541,7 +541,7 @@ def hexdiff(
         if doy:
             yd = y
             j = 0
-            while not liney[j]:
+            while j < len(liney) and not liney[j]:
                 j += 1
                 yd -= 1
             print(colorize[doy - dox]("%04x" % yd), end=' ')

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -978,6 +978,11 @@ assert expected_ret2 in ret2
 hexdiff(b"abc", IP() / TCP())
 hexdiff(IP() / TCP(), b"abc")
 
+# Test that hexdiff does not crash on a 16-byte row that is entirely a gap
+# on one side (GH #5034)
+
+hexdiff(b"B" * 9 + b"\x08", b"A" + b"\x08" + b"A" * 23, algo="difflib")
+
 = Test mysummary functions - Ether
 
 p = Ether(dst="ff:ff:ff:ff:ff:ff", src="ff:ff:ff:ff:ff:ff", type=0x9000)


### PR DESCRIPTION
## Summary

`hexdiff()` raises `IndexError: list index out of range` when the difflib alignment (`algo='difflib'`) produces a 16-byte display row that is entirely a "gap" on one side (a run of >=16 aligned insertions/deletions). The loop that skips leading empty cells to compute the row's starting offset had no bounds check and walked off the end of the row.

Fixes #5034

## Changes

- `scapy/utils.py`: added `j < len(linex)` / `j < len(liney)` bounds checks to the two offset-skip `while` loops in `hexdiff()`, so the loop stops once it reaches the end of a fully-gapped row instead of indexing past it.
- `test/regression.uts`: added a regression test using the minimal reproduction from the issue (`hexdiff(b"B"*9 + b"\x08", b"A" + b"\x08" + b"A"*23, algo="difflib")`), which previously raised `IndexError` and now completes without crashing.

AI-Assisted: yes (Claude Sonnet 5)