### PR TITLE
ci: modernize solaris config

### DIFF
--- a/test/configs/solaris.utsc
+++ b/test/configs/solaris.utsc
@@ -2,6 +2,8 @@
   "testfiles": [
     "test/*.uts",
     "test/scapy/layers/*.uts",
+    "test/scapy/layers/tls/*.uts",
+    "test/scapy/layers/msrpce/*.uts",
     "test/contrib/automotive/*.uts",
     "test/contrib/automotive/obd/*.uts",
     "test/contrib/automotive/scanner/*.uts",
@@ -17,15 +19,13 @@
     "test/windows.uts",
     "test/contrib/automotive/ecu_am.uts",
     "test/contrib/automotive/gm/gmlanutils.uts",
-    "test/contrib/isotp.uts",
     "test/contrib/isotpscan.uts"
   ],
   "onlyfailed": true,
+  "extensions": ["scapy-rpc"],
   "preexec": {
     "test/contrib/*.uts": "load_contrib(\"%name%\")",
-    "test/cert.uts": "load_layer(\"tls\")",
-    "test/sslv2.uts": "load_layer(\"tls\")",
-    "test/tls*.uts": "load_layer(\"tls\")"
+    "test/scapy/layers/tls/*.uts": "load_layer(\"tls\")"
   },
   "kw_ko": [
     "osx",


### PR DESCRIPTION
test/contrib/isotp.uts is dropped to prevent the tests from failing with
```
━ UTScapy - Scapy 2.7.1rc1.post58 - 3.13.13
 └ Loaded config file ./test/configs/solaris.utsc
ERROR: Cannot remove test/contrib/isotp.uts from test files
```
It's a follow-up to 386d7fa4d811b35364ca325353123685ac84c4dd where that
file was removed.

TLS-related tests are adjusted
It's a follow-up to 219f2febd8456c440988b329b44c1dbcd0e47d0d where the
TLS tests were moved to test/scapy/layers/tls

scapy-rpc tests are added

AI-Assisted: no

It was tested in https://github.com/evverx/avahi/actions/runs/29078009229/job/86313970280?pr=3. A couple of tests failed there but those failures probably indicate bugs and need looking into. I went down a really deep rabbit hole there where MAC addresses aren't extracted correctly with use_pcap=True because the PF_LINK addresses aren't cast to sockaddr_dl (on *BSD as well) so those failures can be related to that (or not).
