### PR TITLE
Fix typos in comments (excpect, incremeted, explaination)

### DIFF
--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -391,7 +391,7 @@ class DHCP6OptIAAddress(_DHCP6OptGuessPayload):    # RFC 8415 sect 21.6
                    IntEnumField("validlft", 0, {0xffffffff: "infinity"}),
                    # last field IAaddr-options is not defined in the
                    # reference document. We copy what wireshark does: read
-                   # more dhcp6 options and excpect failures
+                   # more dhcp6 options and expect failures
                    PacketListField("iaaddropts", [],
                                    _DHCP6OptGuessPayloadElt,
                                    length_from=lambda pkt: pkt.optlen - 24)]

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -1296,7 +1296,7 @@ def fragment6(pkt, fragSize):
 
     remain = fragPartStr
     res = []
-    fragOffset = 0     # offset, incremeted during creation
+    fragOffset = 0     # offset, incremented during creation
     fragId = random.randint(0, 0xffffffff)  # random id ...
     if fragHeader.id is not None:  # ... except id provided by user
         fragId = fragHeader.id
@@ -4232,7 +4232,7 @@ bind_layers(Ether, IPv6, type=0x86dd)
 bind_layers(CookedLinux, IPv6, proto=0x86dd)
 bind_layers(GRE, IPv6, proto=0x86dd)
 bind_layers(SNAP, IPv6, code=0x86dd)
-# AF_INET6 values are platform-dependent. For a detailed explaination, read
+# AF_INET6 values are platform-dependent. For a detailed explanation, read
 # https://github.com/the-tcpdump-group/libpcap/blob/f98637ad7f086a34c4027339c9639ae1ef842df3/gencode.c#L3333-L3354  # noqa: E501
 if WINDOWS:
     bind_layers(Loopback, IPv6, type=0x18)


### PR DESCRIPTION
Fix three spelling mistakes in code comments found by codespell:

- `scapy/layers/dhcp6.py`: `excpect` → `expect`
- `scapy/layers/inet6.py`: `incremeted` → `incremented`
- `scapy/layers/inet6.py`: `explaination` → `explanation`

All changes are in comments only — no functional code was modified.