### PR TITLE
Fix DNSRRTSIG length fields not auto-computing

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -1138,11 +1138,11 @@ class DNSRRTSIG(_DNSRRdummy):
                    DNSStrField("algo_name", "hmac-sha1"),
                    TimeSignedField("time_signed", 0),
                    ShortField("fudge", 0),
-                   FieldLenField("mac_len", 20, fmt="!H", length_of="mac_data"),  # noqa: E501
+                   FieldLenField("mac_len", None, fmt="!H", length_of="mac_data"),  # noqa: E501
                    StrLenField("mac_data", "", length_from=lambda pkt: pkt.mac_len),  # noqa: E501
                    ShortField("original_id", 0),
                    ShortField("error", 0),
-                   FieldLenField("other_len", 0, fmt="!H", length_of="other_data"),  # noqa: E501
+                   FieldLenField("other_len", None, fmt="!H", length_of="other_data"),  # noqa: E501
                    StrLenField("other_data", "", length_from=lambda pkt: pkt.other_len)  # noqa: E501
                    ]
 

--- a/test/scapy/layers/dns_dnssec.uts
+++ b/test/scapy/layers/dns_dnssec.uts
@@ -132,11 +132,20 @@ t.type == 16 and t.rdlen == 312 and t.rdata[0][:5] == b"Scapy" and t.rdata[1][-1
 
 = DNSRRTSIG basic instantiation
 t = DNSRRTSIG()
-raw(t) == b"\x00\x00\xfa\x00\x01\x00\x00\x00\x00\x00\x1b\thmac-sha1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00"
+raw(t) == b"\x00\x00\xfa\x00\x01\x00\x00\x00\x00\x00\x1b\thmac-sha1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 = DNSRRTSIG(), check parameters
 t = DNSRRTSIG(rrname="SAMPLE-ALG.EXAMPLE.", time_signed=853804800, fudge=300)
-raw(t) == b"\nSAMPLE-ALG\x07EXAMPLE\x00\x00\xfa\x00\x01\x00\x00\x00\x00\x00\x1b\thmac-sha1\x00\x00\x002\xe4\x07\x00\x01,\x00\x14\x00\x00\x00\x00\x00\x00"
+raw(t) == b"\nSAMPLE-ALG\x07EXAMPLE\x00\x00\xfa\x00\x01\x00\x00\x00\x00\x00\x1b\thmac-sha1\x00\x00\x002\xe4\x07\x00\x01,\x00\x00\x00\x00\x00\x00\x00\x00"
+
+= DNSRRTSIG mac_len/other_len auto-computed, round-trips
+# Regression: mac_len/other_len defaulted to a hardcoded 20/0 instead of None,
+# so FieldLenField never auto-computed and a non-empty MAC did not round-trip
+# (the length prefix stayed 20, truncating the MAC to 20 bytes on re-dissect).
+t = DNSRRTSIG(mac_data=b"M" * 32, other_data=b"O" * 6)
+raw_t = raw(t)
+p = DNSRRTSIG(raw_t)
+p.mac_len == 32 and p.other_len == 6 and p.mac_data == b"M" * 32 and p.other_data == b"O" * 6 and raw(p) == raw_t
 
 = TimeField methods
 


### PR DESCRIPTION
### Description

`DNSRRTSIG` declares its two `FieldLenField` length prefixes with hardcoded defaults — `mac_len=20` and `other_len=0` — instead of `None`. `FieldLenField` only auto-computes the length from its `length_of` target when the value is `None`, so these prefixes were frozen and never matched the real `mac_data` / `other_data`, breaking the build/dissect round-trip.

Even the zero-argument default can't re-parse its own bytes:

```python
>>> from scapy.layers.dns import DNSRRTSIG
>>> b = bytes(DNSRRTSIG())
>>> DNSRRTSIG(b)
struct.error: unpack requires a buffer of 2 bytes
```

`mac_len` is 20 but `mac_data` is empty, so on dissect the `mac_data` `StrLenField` consumes the 20 bytes belonging to the trailing fields, and the next `getfield` unpacks past the buffer. With a real MAC (e.g. a 32-byte HMAC-SHA256), the length prefix stays 20 and 12 bytes of the MAC are silently truncated on the wire.

Every other `FieldLenField` in `dns.py` — `DNSRROPT.rdlen`, `DNSRRNAPTR`'s `flags_len`/`services_len`/`regexp_len`, and the header counts — uses `None`. `DNSRROPT(rdata=...)` round-trips correctly for exactly that reason, which confirms `None` is the intended pattern and the literal `20`/`0` are the defect.

**Fix:** set `mac_len` and `other_len` defaults to `None` so they auto-compute like their siblings (2 lines).

### Tests

Two existing `dns_dnssec.uts` assertions had baked in the buggy `\x14` (mac_len=20 with an empty MAC); corrected to `\x00`, and added a round-trip case asserting a 32-byte MAC + 6-byte `other_data` survive build→dissect (`mac_len`/`other_len` auto-compute to 32/6). The new case is red before the fix and green after. `dns.uts` (31) and `dns_dnssec.uts` pass; `flake8` clean and `mypy` unchanged vs baseline.

*AI assistance:* prepared with Claude Code (Claude Opus 4.8) — disclosed via the `AI-Assisted: yes (Claude Opus 4.8)` commit trailer. I reproduced the crash, verified the round-trip fix against the sibling `FieldLenField`s, corrected the bug-baked test expectations, and reviewed every line before opening.
