### PR TITLE
fields: fix i2len of 3-byte fields returning 4 instead of 3

### DIFF
--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -350,7 +350,7 @@ class ISIS_UnreservedBandwidthSubTlv(ISIS_GenericSubTlv):
 class ISIS_TEDefaultMetricSubTlv(ISIS_GenericSubTlv):
     name = "TE Default Metric SubTLV"
     fields_desc = [ByteEnumField("type", 18, _isis_subtlv_names_1),
-                   FieldLenField("len", None, length_of="temetric", adjust=lambda pkt, x:x - 1, fmt="B"),  # noqa: E501
+                   FieldLenField("len", None, length_of="temetric", fmt="B"),
                    ThreeBytesField("temetric", 1000)]
 
 

--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -1072,6 +1072,7 @@ class ThreeBytesField(Field[int, int]):
     def __init__(self, name, default):
         # type: (str, int) -> None
         Field.__init__(self, name, default, "!I")
+        self.sz = 3  # emits/consumes 3 bytes; keep i2len consistent for FieldLenField
 
     def addfield(self, pkt, s, val):
         # type: (Packet, bytes, Optional[int]) -> bytes
@@ -1092,6 +1093,7 @@ class LEThreeBytesField(ByteField):
     def __init__(self, name, default):
         # type: (str, Optional[int]) -> None
         Field.__init__(self, name, default, "<I")
+        self.sz = 3  # emits/consumes 3 bytes; keep i2len consistent for FieldLenField
 
     def addfield(self, pkt, s, val):
         # type: (Packet, bytes, Optional[int]) -> bytes

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -174,6 +174,18 @@ print(p.sprintf('%test1% %test2% %test3% %test4%'))
 assert p.sprintf('%test1% %test2% %test3% %test4%') == '0x123456 123456 0xfedbca 567890'
 assert repr(p.test1) == '1193046'
 
+# i2len must match the 3 bytes actually emitted, so FieldLenField(length_of=)
+# on a 3-byte field computes the right length.
+for cls in [ThreeBytesField, X3BytesField, LEThreeBytesField, XLE3BytesField, OUIField]:
+    f = cls('x', 0)
+    assert f.i2len(None, 0x010203) == len(f.addfield(None, b'', 0x010203)) == 3, cls
+
+class ThreeBytesTLV(Packet):
+    fields_desc = [ FieldLenField('len', None, length_of='oui', fmt='B'),
+                    OUIField('oui', 0x00000c) ]
+
+assert ThreeBytesTLV(raw(ThreeBytesTLV())).len == 3
+
 
 = NBytesField
 ~ field nbytesfield


### PR DESCRIPTION
### Problem

The 3-byte field types (`ThreeBytesField`, `X3BytesField`, `LEThreeBytesField`, `XLE3BytesField`, `OUIField`) report a length of **4** via `i2len()`, even though they serialize and consume exactly **3** bytes. So a `FieldLenField(length_of=<a 3-byte field>)` auto-computes a length one byte too large:

```python
from scapy.packet import Packet
from scapy.fields import FieldLenField, OUIField

class T(Packet):
    fields_desc = [FieldLenField("len", None, length_of="oui", fmt="B"),
                   OUIField("oui", 0x00000c)]

bytes(T())      # b'\x04\x00\x00\x0c'  -> len byte says 4, but OUI is 3 bytes on the wire
T(bytes(T())).len   # 4  (expected 3)
```

### Cause

`ThreeBytesField`/`LEThreeBytesField` pass a 4-byte struct format (`"!I"`/`"<I"`) to reuse `struct` for packing, then slice out 3 bytes in `addfield`/`getfield`. But `self.sz = struct.calcsize(fmt)` stays **4**, and the inherited `Field.i2len` returns `self.sz` — so `i2len` (4) disagrees with the bytes actually emitted (3), and `randval()` would also draw from a 32-bit range for a 24-bit field. The sibling `NBytesField` builds an exact-width format and is self-consistent.

### Fix

Set `self.sz = 3` in the two base classes so `i2len` (and `randval`) match the wire size. `addfield`/`getfield` use hardcoded 3-byte slices, so nothing else reads `sz` and build/dissect round-trip is unchanged (verified for all five classes).

### In-tree consumer (corrected)

There **is** one in-tree consumer, which my first push missed and CI caught: `ISIS_TEDefaultMetricSubTlv` wraps the 3-byte `temetric` field in a `FieldLenField` and, to compensate for the wrong `i2len`, subtracted 1 in an `adjust=` lambda to land back on the correct length of 3:

```python
FieldLenField("len", None, length_of="temetric", adjust=lambda pkt, x: x - 1, fmt="B")
```

With `i2len` now correct, that `-1` makes the sub-TLV length come out as **2**. This PR removes the workaround so the length stays 3. `test/contrib/isis.uts` (`LSP with Sub-TLVs`) exercises it end to end and passes again.

**Backward-compat note for out-of-tree layers:** any user layer that similarly compensated for the old `i2len` (an `adjust=` that subtracted 1 on a 3-byte field) will now be off by one and needs the same one-line cleanup. If you'd rather preserve the old `i2len == 4` behavior, say so and I'll close this.

### Testing

- `test/fields.uts` — added `i2len == emitted == 3` assertions for all five classes plus a `FieldLenField`+`OUIField` TLV; red before, green after. **PASSED=139 FAILED=0**.
- `test/contrib/isis.uts` — **PASSED=5 FAILED=0** (the `LSP with Sub-TLVs` roundtrip, which failed on the first push, now passes).
- Verified in an isolated worktree with `scapy.fields` importing from the checkout.

---

*Disclosure: found, written and verified by an AI coding agent (Claude Code) on this account (per the `AI-Assisted` commit trailer) — it wrote the repro, the fix and this description from running the code. I review every change and am accountable for it. Happy to adjust anything.*
