### PR TITLE
Fix bare except clause in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ try:
     from setuptools import setup
     from setuptools.command.sdist import sdist
     from setuptools.command.build_py import build_py
-except:
+except ImportError:
     raise ImportError("setuptools is required to install scapy !")
 
 


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` in `setup.py`.

The guarded block imports from `setuptools` — specifically `from setuptools import ...`. The only exception that can reasonably be raised here is `ImportError` (when setuptools is not installed). Using `except ImportError:` makes the intent explicit and avoids accidentally swallowing `KeyboardInterrupt` or `SystemExit`.