### PR TITLE
bluetooth_vsc_barrot: Read and write memory vendor commands

### DIFF
--- a/scapy/contrib/bluetooth_vsc_barrot.py
+++ b/scapy/contrib/bluetooth_vsc_barrot.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+#
+# scapy.contrib.description = Barrot Bluetooth HCI Vendor-Specific Commands
+# scapy.contrib.status = loads
+#
+# Information sources:
+# - https://github.com/tryger/barrot-tools/
+
+from scapy.packet import Packet, bind_layers
+from scapy.fields import (
+    ByteField,
+    XLEShortField,
+    XLEIntField,
+    XStrField,
+    XStrLenField,
+)
+
+from scapy.layers.bluetooth import (
+    HCI_Command_Hdr,
+    HCI_Event_Command_Complete,
+)
+
+
+class HCI_Cmd_VSC_Barrot(Packet):
+    """
+    Barrot vendor-specific command wrapper (opcode 0xFC80).
+    """
+    name = "Barrot Vendor Specific Command"
+    fields_desc = [XLEShortField("cmd", 0)]
+
+
+class HCI_Evt_VSC_Barrot_Command_Complete(Packet):
+    """
+    Barrot vendor-specific Command Complete body (opcode 0xFC80).
+    """
+    name = "Barrot Vendor Specific Command Complete"
+    fields_desc = [XLEShortField("cmd", 0)]
+
+
+class HCI_Cmd_VSC_Barrot_Flash_Write(Packet):
+    """
+    Barrot Flash Write (cmd 0x11).
+
+    Writes ``data`` to the flash offset ``address``. On a write-protected device
+    the firmware reports success (status 0x00) but does not change the flash.
+    """
+    name = "Barrot Flash Write"
+    fields_desc = [
+        XLEIntField("address", 0),
+        XStrField("data", b""),
+    ]
+
+
+class HCI_Cmd_VSC_Barrot_Flash_Read(Packet):
+    """
+    Barrot Flash Read (cmd 0x12).
+
+    Reads ``length`` bytes (1..0xF0) from the flash offset ``address``.
+    Only reads the SPI flash storage memory.
+    """
+    name = "Barrot Flash Read"
+    fields_desc = [
+        XLEIntField("address", 0),
+        ByteField("length", 0),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Barrot_Flash_Read(Packet):
+    """Flash Read (cmd 0x12) command complete: the ``length`` bytes read."""
+    name = "Barrot Flash Read complete"
+    fields_desc = [
+        XStrLenField("data", b"",
+                     length_from=lambda p: p.underlayer.underlayer.underlayer.len - 6)
+    ]
+
+
+bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Barrot, ogf=0x3F, ocf=0x080)
+bind_layers(HCI_Event_Command_Complete, HCI_Evt_VSC_Barrot_Command_Complete,
+            opcode=0xFC80)
+
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Write, cmd=0x11)
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Read, cmd=0x12)
+bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
+            HCI_Cmd_Complete_VSC_Barrot_Flash_Read, cmd=0x12)

--- a/test/contrib/bluetooth_vsc_barrot.uts
+++ b/test/contrib/bluetooth_vsc_barrot.uts
@@ -1,0 +1,85 @@
+% Barrot Bluetooth Vendor-Specific Command (VSC) tests
+# test/run_tests -P "load_contrib('bluetooth_vsc_barrot')" -t test/contrib/bluetooth_vsc_barrot.uts
+
++ Load the Barrot VSC contrib module
+
+= Load the contrib module
+from scapy.layers.bluetooth import *
+load_contrib("bluetooth_vsc_barrot")
+from scapy.contrib.bluetooth_vsc_barrot import *
+
+
++ Barrot command wrapper (opcode 0xFC80)
+
+= All Barrot VSCs share opcode 0xFC80 and select the subcommand with a 16-bit id
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Flash_Read(address=0x0, length=0x0)
+assert cmd.ogf == 0x3f
+assert cmd.ocf == 0x080
+assert cmd.opcode == 0xfc80
+assert cmd.cmd == 0x12
+
+
++ Barrot Flash Read (cmd 0x12)
+
+= Flash read build + dissect
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Flash_Read(address=0x1000, length=0x10)
+assert cmd.opcode == 0xfc80
+r = raw(cmd)
+# 80fc(op) 07(len) 1200(cmd id LE) 00100000(addr LE) 10(length)
+assert r == b'\x80\xfc\x07\x12\x00\x00\x10\x00\x00\x10'
+p = HCI_Command_Hdr(r)
+assert HCI_Cmd_VSC_Barrot_Flash_Read in p
+assert p[HCI_Cmd_VSC_Barrot_Flash_Read].address == 0x1000
+assert p[HCI_Cmd_VSC_Barrot_Flash_Read].length == 0x10
+
+= Flash read at the flash base with the maximum single-request length (0xF0)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Flash_Read(address=0x0, length=0xF0)
+r = raw(cmd)
+assert r == b'\x80\xfc\x07\x12\x00\x00\x00\x00\x00\xf0'
+p = HCI_Command_Hdr(r)
+assert p[HCI_Cmd_VSC_Barrot_Flash_Read].length == 0xF0
+
+
++ Barrot Flash Write (cmd 0x11)
+
+= Flash write build + dissect
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Flash_Write(address=0x2000, data=b'\xaa\xbb')
+assert cmd.opcode == 0xfc80
+r = raw(cmd)
+# 80fc(op) 08(len) 1100(cmd id LE) 00200000(addr LE) aabb(data)
+assert r == b'\x80\xfc\x08\x11\x00\x00\x20\x00\x00\xaa\xbb'
+p = HCI_Command_Hdr(r)
+assert HCI_Cmd_VSC_Barrot_Flash_Write in p
+assert p[HCI_Cmd_VSC_Barrot_Flash_Write].address == 0x2000
+assert p[HCI_Cmd_VSC_Barrot_Flash_Write].data == b'\xaa\xbb'
+
+= Flash write of a full 128-byte chunk keeps the length byte in sync
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Flash_Write(address=0x0, data=b'\x00' * 128)
+r = raw(cmd)
+# len = 2 (cmd id) + 4 (addr) + 128 (data) = 134 = 0x86
+assert r[2] == 0x86
+p = HCI_Command_Hdr(r)
+assert len(p[HCI_Cmd_VSC_Barrot_Flash_Write].data) == 128
+
+
++ Barrot Flash Read command complete (opcode 0xFC80, echoed cmd 0x12)
+
+= Dissect a Command Complete carrying 4 data bytes
+# 04(evt) 0e(cmd complete) len=0a num=01 op=80fc status=00 cmd=1200 data=deadbeef
+evt = HCI_Hdr(bytes.fromhex("040e0a0180fc001200deadbeef"))
+assert HCI_Cmd_Complete_VSC_Barrot_Flash_Read in evt
+assert evt[HCI_Event_Command_Complete].status == 0
+assert evt[HCI_Evt_VSC_Barrot_Command_Complete].cmd == 0x12
+assert evt[HCI_Cmd_Complete_VSC_Barrot_Flash_Read].data == bytes.fromhex("deadbeef")
+
+= Dissect a single-byte flash read result
+# event param len = 7 -> 1 data byte after the echoed cmd id
+evt = HCI_Hdr(bytes.fromhex("040e070180fc001200ab"))
+assert evt[HCI_Cmd_Complete_VSC_Barrot_Flash_Read].data == b"\xab"
+
+= A non-flash-read command complete does not mis-parse as a flash read body
+# echoed cmd id 0x0f (bus read) must not bind to the flash-read complete class
+evt = HCI_Hdr(bytes.fromhex("040e0a0180fc000f0011223344"))
+assert HCI_Evt_VSC_Barrot_Command_Complete in evt
+assert evt[HCI_Evt_VSC_Barrot_Command_Complete].cmd == 0x0f
+assert HCI_Cmd_Complete_VSC_Barrot_Flash_Read not in evt


### PR DESCRIPTION
AI-Assisted: no

<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
Context on bluetooth vendor commands: https://github.com/secdev/scapy/issues/4864

Added Barrot Bluetooth vendor commands for reading and writing Bluetooth flash memory.