### PR TITLE
contrib/bluetooth_vsc_intel: Chip information commadns

### DIFF
--- a/scapy/contrib/bluetooth_vsc_intel.py
+++ b/scapy/contrib/bluetooth_vsc_intel.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+#
+# scapy.contrib.description = Intel Bluetooth HCI Vendor-Specific Commands
+# scapy.contrib.status = loads
+#
+# Information sources:
+# - Linux mainline ``drivers/bluetooth/btintel.c`` / ``btintel.h``
+
+from scapy.packet import Packet, bind_layers
+from scapy.fields import (
+    ByteField,
+    ByteEnumField,
+    FieldLenField,
+    LEMACField,
+    LEShortField,
+    PacketListField,
+    StrFixedLenField,
+    XStrLenField,
+)
+
+from scapy.layers.bluetooth import (
+    HCI_Command_Hdr,
+    HCI_Event_Command_Complete,
+)
+
+_intel_hw_variant = {
+    0x07: "WP", 0x08: "StP", 0x0b: "SfP", 0x0c: "WsP", 0x11: "JfP",
+    0x12: "ThP", 0x13: "HrP", 0x14: "CcP", 0x17: "TyP", 0x18: "Slr",
+    0x19: "Slr-F", 0x1b: "Mgr", 0x1c: "GaP", 0x1d: "BzrU", 0x1e: "Bzr",
+    0x1f: "ScP", 0x20: "ScP2", 0x21: "ScP2-F", 0x22: "BzrIW",
+}
+
+_intel_image_type = {
+    0x01: "bootloader",
+    0x02: "iml",
+    0x03: "operational",
+}
+
+_intel_tlv_type = {
+    0x10: "cnvi_top", 0x11: "cnvr_top", 0x12: "cnvi_bt", 0x13: "cnvr_bt",
+    0x14: "cnvi_otp", 0x15: "cnvr_otp", 0x16: "dev_rev_id",
+    0x17: "usb_vendor_id", 0x18: "usb_product_id", 0x19: "pcie_vendor_id",
+    0x1a: "pcie_device_id", 0x1b: "pcie_subsystem_id", 0x1c: "image_type",
+    0x1d: "time_stamp", 0x1e: "build_type", 0x1f: "build_num",
+    0x20: "fw_build_product", 0x21: "fw_build_hw", 0x22: "fw_step",
+    0x23: "bt_spec", 0x24: "mfg_name", 0x25: "hci_rev", 0x26: "lmp_subver",
+    0x27: "otp_patch_ver", 0x28: "secure_boot", 0x29: "key_from_hdr",
+    0x2a: "otp_lock", 0x2b: "api_lock", 0x2c: "debug_lock", 0x2d: "min_fw",
+    0x2e: "limited_cce", 0x2f: "sbe_type", 0x30: "otp_bdaddr",
+    0x31: "unlocked_state", 0x32: "git_sha1", 0x50: "fw_id",
+}
+
+_intel_exception_type = {
+    0x00: "system"
+}
+
+
+class HCI_Cmd_VSC_Intel_Read_Version(Packet):
+    """
+    Intel Read Version (OCF 0x005, opcode 0xFC05).
+
+    An empty ``param`` requests the legacy fixed reply.
+    A ``param=0xFF`` requests the TLV reply used by modern CNVi controllers.
+    """
+    name = "Intel Read Version"
+    fields_desc = [
+        ByteField("param", 0xFF),
+    ]
+
+
+class HCI_Cmd_VSC_Intel_Read_Boot_Params(Packet):
+    """Intel Read Boot Params (OCF 0x00D, opcode 0xFC0D). Empty body."""
+    name = "Intel Read Boot Params"
+
+
+class HCI_Cmd_VSC_Intel_Read_Debug_Features(Packet):
+    """Intel Read Debug Features (OCF 0x0A6, opcode 0xFCA6)."""
+    name = "Intel Read Debug Features"
+    fields_desc = [
+        ByteField("page_no", 1),
+    ]
+
+
+class HCI_Cmd_VSC_Intel_Exception_Info(Packet):
+    """
+    Intel Exception Info (OCF 0x022, opcode 0xFC22).
+
+    Issued by the driver after a hardware-error event to fetch the exception
+    string.
+    """
+    name = "Intel Exception Info"
+    fields_desc = [
+        ByteEnumField("type", 0, _intel_exception_type),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Intel_Version_TLV(Packet):
+    """One ``intel_version_tlv`` record: type, length, value."""
+    name = "Intel Version TLV"
+    fields_desc = [
+        ByteEnumField("type", 0, _intel_tlv_type),
+        FieldLenField("len", None, length_of="value", fmt="B"),
+        XStrLenField("value", b"", length_from=lambda pkt: pkt.len),
+    ]
+
+    def extract_padding(self, s):
+        return b"", s
+
+
+class HCI_Cmd_Complete_VSC_Intel_Read_Version(Packet):
+    """
+    Read Version (0xFC05) command complete.
+    """
+    name = "Intel Read Version (TLV) complete"
+    fields_desc = [
+        PacketListField("tlvs", [], HCI_Cmd_Complete_VSC_Intel_Version_TLV,
+                        length_from=lambda pkt: pkt.underlayer.underlayer.len - 4),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Intel_Read_Boot_Params(Packet):
+    """
+    Read Boot Params (0xFC0D) command complete.
+
+    Reports the secure-boot / OTP / API / debug lock state.
+    """
+    name = "Intel Read Boot Params complete"
+    fields_desc = [
+        ByteField("otp_format", 0),
+        ByteField("otp_content", 0),
+        ByteField("otp_patch", 0),
+        LEShortField("dev_revid", 0),
+        ByteField("secure_boot", 0),
+        ByteField("key_from_hdr", 0),
+        ByteField("key_type", 0),
+        ByteField("otp_lock", 0),
+        ByteField("api_lock", 0),
+        ByteField("debug_lock", 0),
+        LEMACField("otp_bdaddr", None),
+        ByteField("min_fw_build_nn", 0),
+        ByteField("min_fw_build_cw", 0),
+        ByteField("min_fw_build_yy", 0),
+        ByteField("limited_cce", 0),
+        ByteField("unlocked_state", 0),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Intel_Read_Debug_Features(Packet):
+    """
+    Read Debug Features (0xFCA6) command complete.
+
+    ``page1`` is the 128-bit feature mask.
+    ``page1[0] & 0x3f`` gates coredump and telemetry.
+    """
+    name = "Intel Read Debug Features complete"
+    fields_desc = [
+        ByteField("page_no", 1),
+        StrFixedLenField("page1", b"\x00" * 16, 16),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Intel_Exception_Info(Packet):
+    """
+    Exception Info (0xFC22) command complete: a fixed 12-byte exception string.
+    """
+    name = "Intel Exception Info complete"
+    fields_desc = [
+        StrFixedLenField("exception", b"\x00" * 12, 12),
+    ]
+
+
+bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Intel_Read_Version, ogf=0x3F, ocf=0x005)
+bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Intel_Read_Boot_Params, ogf=0x3F, ocf=0x00D)
+bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Intel_Read_Debug_Features, ogf=0x3F, ocf=0x0A6)
+bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Intel_Exception_Info, ogf=0x3F, ocf=0x022)
+
+bind_layers(HCI_Event_Command_Complete, HCI_Cmd_Complete_VSC_Intel_Read_Version,
+            opcode=0xFC05)
+bind_layers(HCI_Event_Command_Complete, HCI_Cmd_Complete_VSC_Intel_Read_Boot_Params,
+            opcode=0xFC0D)
+bind_layers(HCI_Event_Command_Complete, HCI_Cmd_Complete_VSC_Intel_Read_Debug_Features,
+            opcode=0xFCA6)
+bind_layers(HCI_Event_Command_Complete, HCI_Cmd_Complete_VSC_Intel_Exception_Info,
+            opcode=0xFC22)

--- a/test/contrib/bluetooth_vsc_intel.uts
+++ b/test/contrib/bluetooth_vsc_intel.uts
@@ -1,0 +1,102 @@
+% Intel Bluetooth Vendor-Specific Command (VSC) tests
+# test/run_tests -P "load_contrib('bluetooth_vsc_intel')" -t test/contrib/bluetooth_vsc_intel.uts
+
++ Load the Intel VSC contrib module
+
+= Load the contrib module
+from scapy.layers.bluetooth import *
+load_contrib("bluetooth_vsc_intel")
+from scapy.contrib.bluetooth_vsc_intel import *
+
+
++ Intel Read Version (OCF 0x005 / opcode 0xFC05)
+
+= Build the TLV-form request (param 0xFF)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Intel_Read_Version()
+assert cmd.ogf == 0x3f
+assert cmd.ocf == 0x005
+assert cmd.opcode == 0xfc05
+assert cmd.param == 0xff
+assert raw(cmd) == bytes.fromhex("05fc01ff")
+
+= Dissect a live TLV Read Version reply (8087:0037, BlazarU, bootloader mode)
+# 04(evt) 0e(cmd complete) len=5e num=01 op=05fc status=00 <22 TLV records>
+evt = HCI_Hdr(bytes.fromhex(
+    "040e5e0105fc00100430090800110410190002120400371d00150232041602000017028780"
+    "180237001c01011d0212161e01011f04ea3f00002701002801012901002a01002b01012c01"
+    "002d03010a0e2e01002f0101300645590ba994d4310100"))
+assert HCI_Cmd_Complete_VSC_Intel_Read_Version in evt
+assert evt[HCI_Event_Command_Complete].status == 0
+cc = evt[HCI_Cmd_Complete_VSC_Intel_Read_Version]
+assert len(cc.tlvs) == 22
+tl = {t.type: t.value for t in cc.tlvs}
+# cnvi_bt -> hw_variant 0x1d (BlazarU)
+cnvi_bt = int.from_bytes(tl[0x12], "little")
+assert (cnvi_bt >> 16) & 0x3f == 0x1d
+# image_type bootloader, lock posture as read from the wire
+assert tl[0x1c] == b"\x01"        # image_type = bootloader
+assert tl[0x28] == b"\x01"        # secure_boot = 1
+assert tl[0x2a] == b"\x00"        # otp_lock = 0
+assert tl[0x2b] == b"\x01"        # api_lock = 1
+assert tl[0x2c] == b"\x00"        # debug_lock = 0
+assert tl[0x30] == bytes.fromhex("45590ba994d4")   # otp_bdaddr (LE)
+# TLV enum name resolves
+assert cc.tlvs[0].sprintf("%type%") == "cnvi_top"
+
+= TLV reply round-trips
+assert raw(evt) == bytes.fromhex(
+    "040e5e0105fc00100430090800110410190002120400371d00150232041602000017028780"
+    "180237001c01011d0212161e01011f04ea3f00002701002801012901002a01002b01012c01"
+    "002d03010a0e2e01002f0101300645590ba994d4310100")
+
+
++ Intel Read Boot Params (OCF 0x00D / opcode 0xFC0D)
+
+= Build the request (empty body)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Intel_Read_Boot_Params()
+assert cmd.opcode == 0xfc0d
+assert raw(cmd) == bytes.fromhex("0dfc00")
+
+= Dissect a boot-params reply, exposing the lock posture and BD_ADDR
+# num=01 op=0dfc status=00 then struct intel_boot_params (22 B)
+evt = HCI_Hdr(bytes.fromhex("040e1a010dfc00") +
+              bytes.fromhex("0000003412010000000100" "45590ba994d4" "0102030000"))
+bp = evt[HCI_Cmd_Complete_VSC_Intel_Read_Boot_Params]
+assert bp.dev_revid == 0x1234
+assert bp.secure_boot == 1
+assert bp.api_lock == 1
+assert bp.debug_lock == 0
+assert bp.otp_bdaddr == "d4:94:a9:0b:59:45"    # LEMACField reverses the LE bytes
+assert raw(evt) == bytes.fromhex("040e1a010dfc00") + \
+    bytes.fromhex("0000003412010000000100" "45590ba994d4" "0102030000")
+
+
++ Intel Read Debug Features (OCF 0x0A6 / opcode 0xFCA6)
+
+= Build the request (page_no)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Intel_Read_Debug_Features()
+assert cmd.opcode == 0xfca6
+assert cmd.page_no == 1
+assert raw(cmd) == bytes.fromhex("a6fc0101")
+
+= Dissect a debug-features reply (page_no + 16-byte mask)
+evt = HCI_Hdr(bytes.fromhex("040e13 01 a6fc 00".replace(" ", "")) +
+              b"\x01" + bytes.fromhex("3f000000000000000000000000000000"))
+df = evt[HCI_Cmd_Complete_VSC_Intel_Read_Debug_Features]
+assert df.page_no == 1
+assert df.page1[0] == 0x3f      # page1[0] & 0x3f -> coredump/telemetry gate
+assert len(df.page1) == 16
+
+
++ Intel Exception Info (OCF 0x022 / opcode 0xFC22)
+
+= Build the request (type)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Intel_Exception_Info()
+assert cmd.opcode == 0xfc22
+assert raw(cmd) == bytes.fromhex("22fc0100")
+
+= Dissect an exception-info reply (12-byte string)
+evt = HCI_Hdr(bytes.fromhex("040e0f0122fc00") + b"CRASH\x00\x00\x00\x00\x00\x00\x00")
+ei = evt[HCI_Cmd_Complete_VSC_Intel_Exception_Info]
+assert ei.exception[:5] == b"CRASH"
+assert len(ei.exception) == 12


### PR DESCRIPTION
<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->
<!-- (add issue number here if appropriate, else remove this line) -->

Context on bluetooth vendor commands: https://github.com/secdev/scapy/issues/4864

Added Intel Bluetooth vendor commands for reading information about the connected controller.