### PR TITLE
contrib/bluetooth_vsc_barrot: Chip information commands

### DIFF
--- a/scapy/contrib/bluetooth_vsc_barrot.py
+++ b/scapy/contrib/bluetooth_vsc_barrot.py
@@ -11,9 +11,11 @@
 from scapy.packet import Packet, bind_layers
 from scapy.fields import (
     ByteField,
+    StrFixedLenField,
     XLEShortField,
     XLEIntField,
     XStrField,
+    XStrFixedLenField,
     XStrLenField,
 )
 
@@ -31,12 +33,22 @@ class HCI_Cmd_VSC_Barrot(Packet):
     fields_desc = [XLEShortField("cmd", 0)]
 
 
-class HCI_Evt_VSC_Barrot_Command_Complete(Packet):
+class HCI_Cmd_VSC_Barrot_Read_Chip_Version(Packet):
     """
-    Barrot vendor-specific Command Complete body (opcode 0xFC80).
+    Barrot Read Chip Version (cmd 0x01).
+
+    Returns the chip model, firmware date, flash id and feature flags.
     """
-    name = "Barrot Vendor Specific Command Complete"
-    fields_desc = [XLEShortField("cmd", 0)]
+    name = "Barrot Read Chip Version"
+
+
+class HCI_Cmd_VSC_Barrot_Read_Signature(Packet):
+    """
+    Barrot Read Signature (cmd 0x03).
+
+    Returns a 32-byte chip signature.
+    """
+    name = "Barrot Read Signature"
 
 
 class HCI_Cmd_VSC_Barrot_Flash_Write(Packet):
@@ -67,6 +79,39 @@ class HCI_Cmd_VSC_Barrot_Flash_Read(Packet):
     ]
 
 
+class HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version(Packet):
+    """
+    Read Chip Version (cmd 0x01) command complete.
+
+    ``version`` packs the chip model in hex digits (0x08051A02 -> "BR8051A02").
+    """
+    name = "Barrot Read Chip Version complete"
+    fields_desc = [
+        StrFixedLenField("magic", b"BRT", 3),
+        ByteField("config_type", 0),
+        XLEIntField("version", 0),
+        XLEIntField("fw_date", 0),
+        XLEIntField("esm_type", 0),
+        XLEIntField("run_mode", 0),
+        XLEIntField("features", 0),
+        XLEShortField("flash_id", 0),
+    ]
+
+
+class HCI_Cmd_Complete_VSC_Barrot_Read_Signature(Packet):
+    """Read Signature (cmd 0x03) command complete: the 32-byte signature."""
+    name = "Barrot Read Signature complete"
+    fields_desc = [XStrFixedLenField("signature", b"\x00" * 32, 32)]
+
+
+class HCI_Evt_VSC_Barrot_Command_Complete(Packet):
+    """
+    Barrot vendor-specific Command Complete body (opcode 0xFC80).
+    """
+    name = "Barrot Vendor Specific Command Complete"
+    fields_desc = [XLEShortField("cmd", 0)]
+
+
 class HCI_Cmd_Complete_VSC_Barrot_Flash_Read(Packet):
     """Flash Read (cmd 0x12) command complete: the ``length`` bytes read."""
     name = "Barrot Flash Read complete"
@@ -77,10 +122,16 @@ class HCI_Cmd_Complete_VSC_Barrot_Flash_Read(Packet):
 
 
 bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Barrot, ogf=0x3F, ocf=0x080)
-bind_layers(HCI_Event_Command_Complete, HCI_Evt_VSC_Barrot_Command_Complete,
-            opcode=0xFC80)
-
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Read_Chip_Version, cmd=0x01)
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Read_Signature, cmd=0x03)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Write, cmd=0x11)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Read, cmd=0x12)
+
+bind_layers(HCI_Event_Command_Complete, HCI_Evt_VSC_Barrot_Command_Complete,
+            opcode=0xFC80)
+bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
+            HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version, cmd=0x01)
+bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
+            HCI_Cmd_Complete_VSC_Barrot_Read_Signature, cmd=0x03)
 bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
             HCI_Cmd_Complete_VSC_Barrot_Flash_Read, cmd=0x12)

--- a/test/contrib/bluetooth_vsc_barrot.uts
+++ b/test/contrib/bluetooth_vsc_barrot.uts
@@ -83,3 +83,49 @@ evt = HCI_Hdr(bytes.fromhex("040e0a0180fc000f0011223344"))
 assert HCI_Evt_VSC_Barrot_Command_Complete in evt
 assert evt[HCI_Evt_VSC_Barrot_Command_Complete].cmd == 0x0f
 assert HCI_Cmd_Complete_VSC_Barrot_Flash_Read not in evt
+
+
++ Barrot Read Chip Version (cmd 0x01)
+
+= Read chip version build (no arguments; id set by the subcommand layer)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Read_Chip_Version()
+assert cmd.opcode == 0xfc80
+assert cmd.cmd == 0x01
+# 80fc(op) 02(len) 0100(cmd id LE)
+assert raw(cmd) == b'\x80\xfc\x02\x01\x00'
+
+= Dissect a real Read Chip Version command complete (BR8051A02)
+# captured live from a BR8051A02: magic "BRT", version 0x08051a02, flash_id 0x8512
+evt = HCI_Hdr(bytes.fromhex("040e220180fc00010042525401021a05084af66d9502000000000000000000000012850000"))
+assert HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version in evt
+assert evt[HCI_Event_Command_Complete].status == 0
+v = evt[HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version]
+assert v.magic == b"BRT"
+assert v.config_type == 0x01
+assert v.version == 0x08051a02
+assert v.fw_date == 0x956df64a
+assert v.esm_type == 0x00000002
+assert v.flash_id == 0x8512
+
+= Read chip version build + dissect round-trip
+v = HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version(version=0x08551a01, flash_id=0x1234)
+p = HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version(raw(v))
+assert p.magic == b"BRT"
+assert p.version == 0x08551a01
+assert p.flash_id == 0x1234
+
+
++ Barrot Read Signature (cmd 0x03)
+
+= Read signature build (no arguments)
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Read_Signature()
+assert cmd.cmd == 0x03
+assert raw(cmd) == b'\x80\xfc\x02\x03\x00'
+
+= Dissect a real Read Signature command complete (32-byte signature)
+evt = HCI_Hdr(bytes.fromhex("040e260180fc00030026f71f00cf59b76f7ba01712190f208052300712d2d12c169a3b57b193632026"))
+assert HCI_Cmd_Complete_VSC_Barrot_Read_Signature in evt
+assert evt[HCI_Event_Command_Complete].status == 0
+sig = evt[HCI_Cmd_Complete_VSC_Barrot_Read_Signature].signature
+assert len(sig) == 32
+assert sig == bytes.fromhex("26f71f00cf59b76f7ba01712190f208052300712d2d12c169a3b57b193632026")


### PR DESCRIPTION
AI-Assisted: no

<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->
<!-- (add issue number here if appropriate, else remove this line) -->

New Barrot vendor commands to get chip and firmware information.