### PR TITLE
Remove orb()

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -10,7 +10,6 @@ Operating system specific functionality.
 import socket
 import sys
 
-from scapy.compat import orb
 from scapy.config import conf, _set_conf_sockets
 from scapy.consts import LINUX, SOLARIS, WINDOWS, BSD
 from scapy.data import (
@@ -72,7 +71,7 @@ from scapy.interfaces import (
 def str2mac(s):
     # Duplicated from scapy/utils.py for import reasons
     # type: (bytes) -> str
-    return ("%02x:" * 6)[:-1] % tuple(orb(x) for x in s)
+    return ("%02x:" * 6)[:-1] % tuple(s)
 
 
 def get_if_addr(iff):

--- a/scapy/asn1/asn1.py
+++ b/scapy/asn1/asn1.py
@@ -15,7 +15,7 @@ from scapy.config import conf
 from scapy.error import Scapy_Exception, warning
 from scapy.volatile import RandField, RandIP, GeneralizedTime
 from scapy.utils import Enum_metaclass, EnumElement, binrepr
-from scapy.compat import plain_str, bytes_encode, chb, orb
+from scapy.compat import plain_str, bytes_encode, chb
 
 from typing import (
     Any,
@@ -471,8 +471,8 @@ class ASN1_BIT_STRING(ASN1_Object[str]):
     def __setattr__(self, name, value):
         # type: (str, Any) -> None
         if name == "val_readable":
-            if isinstance(value, (str, bytes)):
-                val = "".join(binrepr(orb(x)).zfill(8) for x in value)
+            if isinstance(value, bytes):
+                val = "".join(binrepr(x).zfill(8) for x in value)
             else:
                 warning("Invalid val: should be bytes")
                 val = "<invalid val_readable>"

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -13,7 +13,7 @@ Basic Encoding Rules (BER) for ASN.1
 
 from scapy.config import conf
 from scapy.error import warning
-from scapy.compat import chb, orb, bytes_encode
+from scapy.compat import chb, bytes_encode
 from scapy.utils import binrepr, inet_aton, inet_ntoa
 from scapy.asn1.asn1 import (
     ASN1Tag,
@@ -129,7 +129,7 @@ def BER_len_enc(ll, size=0):
 
 def BER_len_dec(s):
     # type: (bytes) -> Tuple[int, bytes]
-    tmp_len = orb(s[0])
+    tmp_len = s[0]
     if not tmp_len & 0x80:
         return tmp_len, s[1:]
     tmp_len &= 0x7f
@@ -142,7 +142,7 @@ def BER_len_dec(s):
     ll = 0
     for c in s[1:tmp_len + 1]:
         ll <<= 8
-        ll |= orb(c)
+        ll |= c
     return ll, s[tmp_len + 1:]
 
 
@@ -164,7 +164,7 @@ def BER_num_dec(s, cls_id=0, max_pow=32):
         raise BER_Decoding_Error("BER_num_dec: got empty string", remaining=s)
     x = cls_id
     for i, c in enumerate(s):
-        c = orb(c)
+        c = c
         x <<= 7
         x |= c & 0x7f
         if not c & 0x80:
@@ -196,7 +196,7 @@ def BER_id_dec(s):
     # encoded in scapy's tag in order to reuse it for packet building.
     # Note that tags thus may have to be hard-coded with their extended
     # information, e.g. a SEQUENCE from asn1.py has a direct tag 0x20|16.
-    x = orb(s[0])
+    x = s[0]
     if x & 0x1f != 0x1f:
         # low-tag-number
         return x, s[1:]
@@ -213,7 +213,7 @@ def BER_id_enc(n):
     else:
         # high-tag-number
         s = BER_num_enc(n)
-        tag = orb(s[0])             # first byte, as an int
+        tag = s[0]                  # first byte, as an int
         tag &= 0x07                 # reset every bit from 8 to 4
         tag <<= 5                   # move back the info bits on top
         tag |= 0x1f                 # pad with 1s every bit from 5 to 1
@@ -464,11 +464,11 @@ class BERcodec_INTEGER(BERcodec_Object[int]):
         l, s, t = cls.check_type_check_len(s)
         x = 0
         if s:
-            if orb(s[0]) & 0x80:  # negative int
+            if s[0] & 0x80:  # negative int
                 x = -1
             for c in s:
                 x <<= 8
-                x |= orb(c)
+                x |= c
         return cls.asn1_object(x), t
 
 
@@ -490,13 +490,13 @@ class BERcodec_BIT_STRING(BERcodec_Object[str]):
         # /!\ the unused_bits information is lost after this decoding
         l, s, t = cls.check_type_check_len(s)
         if len(s) > 0:
-            unused_bits = orb(s[0])
+            unused_bits = s[0]
             if safe and unused_bits > 7:
                 raise BER_Decoding_Error(
                     "BERcodec_BIT_STRING: too many unused_bits advertised",
                     remaining=s
                 )
-            fs = "".join(binrepr(orb(x)).zfill(8) for x in s[1:])
+            fs = "".join(binrepr(x).zfill(8) for x in s[1:])
             if unused_bits > 0:
                 fs = fs[:-unused_bits]
             return cls.tag.asn1_object(fs), t

--- a/scapy/cbor/cborcodec.py
+++ b/scapy/cbor/cborcodec.py
@@ -31,7 +31,7 @@ from scapy.cbor.cbor import (
     CBOR_Object,
     _CBOR_ERROR,
 )
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.error import log_runtime
 
 
@@ -100,7 +100,7 @@ def CBOR_decode_head(s):
     if not s:
         raise CBOR_Codec_Decoding_Error("Empty CBOR data", remaining=s)
 
-    initial_byte = orb(s[0])
+    initial_byte = s[0]
     major_type = initial_byte >> 5
     additional_info = initial_byte & 0x1f
 
@@ -112,7 +112,7 @@ def CBOR_decode_head(s):
         if len(s) < 2:
             raise CBOR_Codec_Decoding_Error(
                 "Not enough bytes for 1-byte value", remaining=s)
-        return major_type, orb(s[1]), s[2:]
+        return major_type, s[1], s[2:]
     elif additional_info == 25:
         # 2-byte value follows
         if len(s) < 3:
@@ -562,7 +562,7 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
 
         # For major type 7, we need special handling because additional_info
         # encodes different things (simple values vs float sizes)
-        initial_byte = orb(s[0])
+        initial_byte = s[0]
         major_type = initial_byte >> 5
         additional_info = initial_byte & 0x1f
 
@@ -639,7 +639,7 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
                 if len(s) < 2:
                     raise CBOR_Codec_Decoding_Error(
                         "Not enough bytes for simple value", remaining=s)
-                return CBOR_SIMPLE_VALUE(orb(s[1])), s[2:]
+                return CBOR_SIMPLE_VALUE(s[1]), s[2:]
             else:
                 raise CBOR_Codec_Decoding_Error(
                     "Invalid additional info for major type 7: %d" % additional_info,
@@ -687,7 +687,7 @@ def _decode_cbor_item(s, safe=False):
     if not s:
         raise CBOR_Codec_Decoding_Error("Empty CBOR data", remaining=s)
 
-    initial_byte = orb(s[0])
+    initial_byte = s[0]
     major_type = initial_byte >> 5
 
     # Dispatch to appropriate codec based on major type

--- a/scapy/compat.py
+++ b/scapy/compat.py
@@ -19,7 +19,6 @@ from typing import (
     Optional,
     TypeVar,
     TYPE_CHECKING,
-    Union,
 )
 
 # Very important: will issue typing errors otherwise
@@ -37,7 +36,6 @@ __all__ = [
     'bytes_hex',
     'chb',
     'hex_bytes',
-    'orb',
     'plain_str',
     'raw',
     'StrEnum',
@@ -157,14 +155,6 @@ def chb(x):
     # type: (int) -> bytes
     """Same than chr() but encode as bytes."""
     return struct.pack("!B", x)
-
-
-def orb(x):
-    # type: (Union[int, str, bytes]) -> int
-    """Return ord(x) when not already an int."""
-    if isinstance(x, int):
-        return x
-    return ord(x)
 
 
 def bytes_hex(x):

--- a/scapy/contrib/automotive/ecu.py
+++ b/scapy/contrib/automotive/ecu.py
@@ -15,7 +15,6 @@ from collections import defaultdict
 from types import GeneratorType
 from threading import Lock
 
-from scapy.compat import orb
 from scapy.packet import Raw, Packet
 from scapy.plist import PacketList
 from scapy.sessions import DefaultSession
@@ -402,7 +401,7 @@ class Ecu(object):
         :return: Tuple as sort key
         """
         first_layer = cast(Packet, resp.key_response[0])  # type: ignore
-        service = orb(bytes(first_layer)[0])
+        service = bytes(first_layer)[0]
         return (service == 0x7f,
                 service,
                 0xffffffff - len(resp.states or []),

--- a/scapy/contrib/automotive/gm/gmlan.py
+++ b/scapy/contrib/automotive/gm/gmlan.py
@@ -32,7 +32,6 @@ from scapy.fields import (
 from scapy.packet import Packet, bind_layers, NoPayload
 from scapy.config import conf
 from scapy.contrib.isotp import ISOTP
-from scapy.compat import orb
 
 from typing import (  # noqa: F401
     Dict,
@@ -170,7 +169,7 @@ class GMLAN(ISOTP):
         # type: (...) -> type
         """Dispatch to the correct GMLAN service class in single layer mode."""
         if conf.contribs['GMLAN'].get('single_layer_mode', False) and len(_pkt) >= 1:
-            service = orb(_pkt[0])
+            service = _pkt[0]
             return cls._service_cls.get(service, cls)
         return cls
 

--- a/scapy/contrib/automotive/gm/gmlan_scanner.py
+++ b/scapy/contrib/automotive/gm/gmlan_scanner.py
@@ -13,7 +13,6 @@ import copy
 
 from collections import defaultdict
 
-from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.packet import Packet
 from scapy.config import conf
@@ -690,7 +689,7 @@ class GMLAN_RMBAEnumerator(GMLAN_Enumerator):
             ih = IntelHex()
             for tup in self.results_with_positive_response:
                 for i, b in enumerate(tup.resp.dataRecord):
-                    ih[tup.req.memoryAddress + i] = orb(b)
+                    ih[tup.req.memoryAddress + i] = b
 
             ih.tofile("RMBA_dump.hex", format="hex")
         except ImportError:

--- a/scapy/contrib/automotive/kwp.py
+++ b/scapy/contrib/automotive/kwp.py
@@ -27,7 +27,6 @@ from scapy.error import log_loading
 from scapy.utils import PeriodicSenderThread
 from scapy.plist import _PacketIterable  # noqa: F401
 from scapy.contrib.isotp import ISOTP
-from scapy.compat import orb
 
 from typing import (  # noqa: F401
     Any,
@@ -165,7 +164,7 @@ class KWP(ISOTP):
         # type: (bytes, Any, Any) -> type
         """Dispatch to the correct KWP service class in single layer mode."""
         if conf.contribs['KWP'].get('single_layer_mode', False) and len(_pkt) >= 1:
-            service = orb(_pkt[0])
+            service = _pkt[0]
             return cls._service_cls.get(service, cls)
         return cls
 

--- a/scapy/contrib/automotive/obd/obd.py
+++ b/scapy/contrib/automotive/obd/obd.py
@@ -19,7 +19,6 @@ from scapy.packet import NoPayload, bind_layers
 from scapy.config import conf
 from scapy.fields import XByteEnumField
 from scapy.contrib.isotp import ISOTP
-from scapy.compat import orb
 
 from typing import (  # noqa: F401
     Dict,
@@ -74,7 +73,7 @@ class OBD(ISOTP):
         # type: (...) -> type
         """Dispatch to the correct OBD service class in single layer mode."""
         if conf.contribs['OBD'].get('single_layer_mode', False) and len(_pkt) >= 1:
-            service = orb(_pkt[0])
+            service = _pkt[0]
             return cls._service_cls.get(service, cls)
         return cls
 

--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -15,7 +15,6 @@ from collections import defaultdict, OrderedDict
 from itertools import chain
 from typing import NamedTuple
 
-from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.error import Scapy_Exception
 from scapy.utils import make_lined_table, EDecimal, PeriodicSenderThread
@@ -761,7 +760,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         # type: (Optional[Packet], Union[Callable[[Packet], str], str]) -> str
         if response is None:
             return "Timeout"
-        elif orb(bytes(response)[0]) == 0x7f:
+        elif bytes(response)[0] == 0x7f:
             return self._get_negative_response_label(response)
         else:
             if isinstance(positive_case, str):
@@ -777,7 +776,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         # type: () -> List[EcuResponse]
         supported_resps = list()
         all_responses = [p for p in self._result_packets.values()
-                         if orb(bytes(p)[0]) & 0x40]
+                         if bytes(p)[0] & 0x40]
         for resp in all_responses:
             states = list(set([t.state for t in self.results_with_response
                                if t.resp == resp]))

--- a/scapy/contrib/automotive/someip.py
+++ b/scapy/contrib/automotive/someip.py
@@ -11,7 +11,7 @@ import struct
 
 from scapy.layers.inet import TCP, UDP
 from scapy.layers.inet6 import IP6Field
-from scapy.compat import raw, orb
+from scapy.compat import raw
 from scapy.config import conf
 from scapy.packet import (Packet, Raw, bind_top_down, bind_bottom_up,
                           bind_layers)
@@ -283,7 +283,7 @@ class SDEntry_EventGroup(_SDPacketBase):
 
 def _sdentry_class(payload, **kargs):
     TYPE_PAYLOAD_I = 0
-    pl_type = orb(payload[TYPE_PAYLOAD_I])
+    pl_type = payload[TYPE_PAYLOAD_I]
     cls = None
 
     if pl_type in SDENTRY_TYPE_SRV:
@@ -295,7 +295,7 @@ def _sdentry_class(payload, **kargs):
 
 
 def _sdoption_class(payload, **kargs):
-    pl_type = orb(payload[2])
+    pl_type = payload[2]
 
     cls = {
         SDOPTION_CFG_TYPE: SDOption_Config,

--- a/scapy/contrib/automotive/uds.py
+++ b/scapy/contrib/automotive/uds.py
@@ -20,7 +20,6 @@ from scapy.fields import ByteEnumField, StrField, ConditionalField, \
     FieldLenField, XStrFixedLenField, XStrLenField, FlagsField, PacketListField, \
     PacketField
 from scapy.packet import Packet, NoPayload, Raw, bind_layers
-from scapy.compat import orb
 from scapy.config import conf
 from scapy.utils import PeriodicSenderThread
 from scapy.contrib.isotp import ISOTP
@@ -163,7 +162,7 @@ class UDS(ISOTP):
         # type: (...) -> type
         """Dispatch to the correct UDS service class in single layer mode."""
         if conf.contribs['UDS'].get('single_layer_mode', False) and len(_pkt) >= 1:
-            service = orb(_pkt[0])
+            service = _pkt[0]
             return cls._service_cls.get(service, cls)
         return cls
 

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
 )
 
-from scapy.compat import orb
 from scapy.contrib.automotive import log_automotive
 from scapy.contrib.automotive.ecu import EcuState
 from scapy.contrib.automotive.scanner.configuration import \
@@ -1175,7 +1174,7 @@ class UDS_RMBASequentialEnumerator(UDS_RMBAEnumeratorABC):
             for tup in self.results_with_positive_response:
                 for i, b in enumerate(tup.resp.dataRecord):
                     addr = self.get_addr(tup.req)
-                    ih[addr + i] = orb(b)
+                    ih[addr + i] = b
 
             ih.tofile("RMBA_dump.hex", format="hex")
         except ImportError:

--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -25,7 +25,7 @@ from scapy.fields import (Field, BitField, BitEnumField, XBitField, ByteField,
 from scapy.layers.inet import TCP
 from scapy.layers.inet6 import IP6Field
 from scapy.config import conf, ConfClass
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.error import log_runtime
 
 
@@ -124,11 +124,11 @@ class BGPFieldIPv4(Field):
         return s + self.i2m(pkt, val)
 
     def getfield(self, pkt, s):
-        length = self.mask2iplen(orb(s[0])) + 1
+        length = self.mask2iplen(s[0]) + 1
         return s[length:], self.m2i(pkt, s[:length])
 
     def m2i(self, pkt, m):
-        mask = orb(m[0])
+        mask = m[0]
         mask2iplen_res = self.mask2iplen(mask)
         ip = b"".join(m[i + 1:i + 2] if i < mask2iplen_res else b"\x00" for i in range(4))  # noqa: E501
         return (mask, socket.inet_ntoa(ip))
@@ -168,11 +168,11 @@ class BGPFieldIPv6(Field):
         return s + self.i2m(pkt, val)
 
     def getfield(self, pkt, s):
-        length = self.mask2iplen(orb(s[0])) + 1
+        length = self.mask2iplen(s[0]) + 1
         return s[length:], self.m2i(pkt, s[:length])
 
     def m2i(self, pkt, m):
-        mask = orb(m[0])
+        mask = m[0]
         ip = b"".join(m[i + 1:i + 2] if i < self.mask2iplen(mask) else b"\x00" for i in range(16))  # noqa: E501
         return (mask, pton_ntop.inet_ntop(socket.AF_INET6, ip))
 
@@ -199,7 +199,7 @@ def detect_add_path_prefix46(s, max_bit_length):
     i = 0
     while i + 4 < len(s):
         i += 4
-        prefix_len = orb(s[i])
+        prefix_len = s[i]
         if prefix_len > max_bit_length:
             return False
         addr_len = (prefix_len + 7) // 8
@@ -207,12 +207,12 @@ def detect_add_path_prefix46(s, max_bit_length):
         if i > len(s):
             return False
         if prefix_len % 8:
-            if orb(s[i - 1]) & (0xFF >> (prefix_len % 8)):
+            if s[i - 1] & (0xFF >> (prefix_len % 8)):
                 return False
     # Must NOT be compatible with standard BGP
     i = 0
     while i + 4 < len(s):
-        prefix_len = orb(s[i])
+        prefix_len = s[i]
         if prefix_len == 0 and len(s) > 1:
             return True
         if prefix_len > max_bit_length:
@@ -222,7 +222,7 @@ def detect_add_path_prefix46(s, max_bit_length):
         if i > len(s):
             return True
         if prefix_len % 8:
-            if orb(s[i - 1]) & (0xFF >> (prefix_len % 8)):
+            if s[i - 1] & (0xFF >> (prefix_len % 8)):
                 return True
     return False
 
@@ -500,7 +500,7 @@ def _bgp_dispatcher(payload):
                 payload[:16] == _BGP_HEADER_MARKER:
 
             # Get BGP message type
-            message_type = orb(payload[18])
+            message_type = payload[18]
             if message_type == 4:
                 cls = _get_cls("BGPKeepAlive")
             else:
@@ -628,7 +628,7 @@ def _bgp_capability_dispatcher(payload):
     else:
         length = len(payload)
         if length >= _BGP_CAPABILITY_MIN_SIZE:
-            code = orb(payload[0])
+            code = payload[0]
             cls = _get_cls(_capabilities_objects.get(code, "BGPCapGeneric"))
 
     return cls
@@ -799,7 +799,7 @@ class BGPCapORFBlockPacketListField(PacketListField):
         while remain:
             # block length: afi (2 bytes) + reserved (1 byte) + safi (1 byte) +
             # orf_number (1 byte) + entries (2 bytes * orf_number)
-            orf_number = orb(remain[4])
+            orf_number = remain[4]
             entries_length = orf_number * 2
             current = remain[:5 + entries_length]
             remain = remain[5 + entries_length:]
@@ -920,7 +920,7 @@ class BGPOptParamPacketListField(PacketListField):
             remain, ret = s[:length], s[length:]
 
         while remain:
-            param_len = orb(remain[1])  # Get param length
+            param_len = remain[1]  # Get param length
             current = remain[:2 + param_len]
             remain = remain[2 + param_len:]
             packet = self.m2i(pkt, current)
@@ -1120,7 +1120,7 @@ class BGPPathAttrPacketListField(PacketListField):
         while remain:
             #
             # Get the path attribute flags
-            flags = orb(remain[0])
+            flags = remain[0]
 
             attr_len = 0
             if has_extended_length(flags):
@@ -1128,7 +1128,7 @@ class BGPPathAttrPacketListField(PacketListField):
                 current = remain[:4 + attr_len]
                 remain = remain[4 + attr_len:]
             else:
-                attr_len = orb(remain[2])
+                attr_len = remain[2]
                 current = remain[:3 + attr_len]
                 remain = remain[3 + attr_len:]
 
@@ -1181,7 +1181,7 @@ class ASPathSegmentPacketListField(PacketListField):
         while remain:
             #
             # Get the segment length
-            segment_length = orb(remain[1])
+            segment_length = remain[1]
 
             if bgp_module_conf.use_2_bytes_asn:
                 current = remain[:2 + segment_length * 2]
@@ -1894,7 +1894,7 @@ class MPReachNLRIPacketListField(PacketListField):
             if pkt.safi == 1:
                 # BGPNLRI_IPv6
                 while remain:
-                    mask = orb(remain[0])
+                    mask = remain[0]
                     length_in_bytes = (mask + 7) // 8
                     current = remain[:length_in_bytes + 1]
                     remain = remain[length_in_bytes + 1:]
@@ -2534,7 +2534,7 @@ class BGPORFEntryPacketListField(PacketListField):
                 # Address Prefix ORF
                 # Get the length, in bits, of the prefix
                 prefix_len = _bits_to_bytes_len(
-                    orb(remain[6])
+                    remain[6]
                 )
                 # flags (1 byte) + sequence (4 bytes) + min_len (1 byte) +
                 # max_len (1 byte) + mask_len (1 byte) + prefix_len
@@ -2558,7 +2558,7 @@ class BGPORFEntryPacketListField(PacketListField):
                 elif pkt.afi == 25:
                     # sequence (4 bytes) + min_len (1 byte) + max_len (1 byte) +  # noqa: E501
                     # rt (8 bytes) + import_rt (8 bytes)
-                    route_type = orb(remain[22])
+                    route_type = remain[22]
 
                     if route_type == 2:
                         # MAC / IP Advertisement Route

--- a/scapy/contrib/cdp.py
+++ b/scapy/contrib/cdp.py
@@ -34,7 +34,7 @@ from scapy.fields import (
 )
 from scapy.layers.inet import checksum
 from scapy.layers.l2 import SNAP
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.config import conf
 
 
@@ -173,7 +173,7 @@ class CDPAddrRecordIPv6(CDPAddrRecord):
 def _CDPGuessAddrRecord(p, **kargs):
     cls = conf.raw_layer
     if len(p) >= 2:
-        plen = orb(p[1])
+        plen = p[1]
         proto = p[2:plen + 2]
 
         if proto == _cdp_addrrecord_proto_ip:
@@ -402,11 +402,11 @@ class _CDPChecksum:
         This padding is only used for checksum computation.  The original
         packet should not be altered."""
         if len(pkt) % 2:
-            last_chr = orb(pkt[-1])
+            last_chr = pkt[-1]
             if last_chr <= 0x80:
                 return pkt[:-1] + b'\x00' + chb(last_chr)
             else:
-                return pkt[:-1] + b'\xff' + chb(orb(last_chr) - 1)
+                return pkt[:-1] + b'\xff' + chb(last_chr - 1)
         else:
             return pkt
 

--- a/scapy/contrib/diameter.py
+++ b/scapy/contrib/diameter.py
@@ -33,7 +33,7 @@ from scapy.fields import ConditionalField, EnumField, Field, FieldLenField, \
     XByteField, XIntField
 from scapy.layers.inet import TCP
 from scapy.layers.sctp import SCTPChunkData
-from scapy.compat import chb, orb, raw, bytes_hex, plain_str
+from scapy.compat import chb, raw, bytes_encode, bytes_hex, plain_str
 from scapy.error import warning
 from scapy.utils import inet_ntoa, inet_aton
 from scapy.pton_ntop import inet_pton, inet_ntop
@@ -307,8 +307,8 @@ class QoSFilterRule (StrLenField):        # Defined in 4.1.1 of RFC7155
 class ISDN (StrLenField):
     def i2repr(self, pkt, x):
         out = b''
-        for char in x:
-            c = orb(char)
+        for char in bytes_encode(x):
+            c = char
             out += chb(48 + (c & 15))  # convert second digit first
             v = (c & 240) >> 4
             if v != 15:
@@ -319,8 +319,8 @@ class ISDN (StrLenField):
         out = b''
         if x:
             fd = True     # waiting for first digit
-            for c in x:
-                digit = orb(c) - 48
+            for c in bytes_encode(x):
+                digit = c - 48
                 if fd:
                     val = digit
                 else:

--- a/scapy/contrib/eddystone.py
+++ b/scapy/contrib/eddystone.py
@@ -19,7 +19,6 @@ These beacons are used as building blocks for other systems:
 
 """
 
-from scapy.compat import orb
 from scapy.fields import IntField, SignedByteField, StrField, BitField, \
     StrFixedLenField, ShortField, FixedPointField, ByteEnumField
 from scapy.layers.bluetooth import EIR_Hdr, EIR_ServiceData16BitUUID, \
@@ -62,7 +61,7 @@ class EddystoneURLField(StrField):
         o = bytearray()
         p = 0
         while p < len(x):
-            c = orb(x[p])
+            c = x[p]
             if c == 46:  # "."
                 for k, v in EDDYSTONE_URL_TABLE.items():
                     if x.startswith(v, p):
@@ -84,7 +83,7 @@ class EddystoneURLField(StrField):
 
         o = bytearray()
         for c in x:
-            i = orb(c)
+            i = c
             r = EDDYSTONE_URL_TABLE.get(i)
             if r is None:
                 o.append(i)

--- a/scapy/contrib/esmc.py
+++ b/scapy/contrib/esmc.py
@@ -8,7 +8,6 @@
 from scapy.packet import Packet, bind_layers
 from scapy.fields import BitField, ByteField, XByteField, ShortField, XStrFixedLenField  # noqa: E501
 from scapy.contrib.slowprot import SlowProtocol
-from scapy.compat import orb
 
 
 class ESMC(Packet):
@@ -23,9 +22,9 @@ class ESMC(Packet):
     ]
 
     def guess_payload_class(self, payload):
-        if orb(payload[0]) == 1:
+        if payload[0] == 1:
             return QLTLV
-        if orb(payload[0]) == 2:
+        if payload[0] == 2:
             return EQLTLV
         return Packet.guess_payload_class(self, payload)
 

--- a/scapy/contrib/gtp.py
+++ b/scapy/contrib/gtp.py
@@ -19,7 +19,7 @@ Some IEs: 3GPP TS 24.008
 
 import struct
 
-from scapy.compat import chb, orb, bytes_encode
+from scapy.compat import chb, bytes_encode
 from scapy.config import conf
 from scapy.error import warning
 from scapy.fields import (
@@ -184,7 +184,7 @@ class TBCDByteField(StrFixedLenField):
     def m2i(self, pkt, val):
         ret = []
         for v in val:
-            byte = orb(v)
+            byte = v
             left = byte >> 4
             right = byte & 0xf
             if left == 0xf:
@@ -298,11 +298,11 @@ class GTPHeader(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 1:
-            if (orb(_pkt[0]) >> 5) & 0x7 == 2:
+            if (_pkt[0] >> 5) & 0x7 == 2:
                 from . import gtp_v2
                 return gtp_v2.GTPHeader
         if _pkt and len(_pkt) >= 8:
-            _gtp_type = orb(_pkt[1:2])
+            _gtp_type = _pkt[1]
             return GTPforcedTypes.get(_gtp_type, GTPHeader)
         return cls
 
@@ -323,7 +323,7 @@ class GTP_U_Header(GTPHeader):
             return GTPHeader.guess_payload_class(self, payload)
 
         if self.gtp_type == 255:
-            sub_proto = orb(payload[0])
+            sub_proto = payload[0]
             if sub_proto >= 0x45 and sub_proto <= 0x4e:
                 return IP
             elif (sub_proto & 0xf0) == 0x60:
@@ -426,7 +426,7 @@ class GTPPDUSessionContainer(Packet):
 
     def guess_payload_class(self, payload):
         if self.NextExtHdr == 0:
-            sub_proto = orb(payload[0])
+            sub_proto = payload[0]
             if sub_proto >= 0x45 and sub_proto <= 0x4e:
                 return IP
             elif (sub_proto & 0xf0) == 0x60:
@@ -610,7 +610,7 @@ class APNStrLenField(StrLenField):
         ret_s = b""
         tmp_s = s
         while tmp_s:
-            tmp_len = orb(tmp_s[0]) + 1
+            tmp_len = tmp_s[0] + 1
             if tmp_len > len(tmp_s):
                 warning("APN prematured end of character-string (size=%i, remaining bytes=%i)" % (tmp_len, len(tmp_s)))  # noqa: E501
             ret_s += tmp_s[1:tmp_len]
@@ -956,7 +956,7 @@ def IE_Dispatcher(s):
     if len(s) < 1:
         return Raw(s)
     # Get the IE type
-    ietype = orb(s[0])
+    ietype = s[0]
     cls = ietypecls.get(ietype, Raw)
 
     # if ietype greater than 128 are TLVs

--- a/scapy/contrib/gtp_v2.py
+++ b/scapy/contrib/gtp_v2.py
@@ -10,7 +10,6 @@
 import struct
 
 
-from scapy.compat import orb
 from scapy.data import IANA_ENTERPRISE_NUMBERS
 from scapy.fields import (
     BitEnumField,
@@ -298,7 +297,7 @@ def IE_Dispatcher(s):
     """Choose the correct Information Element class."""
 
     # Get the IE type
-    ietype = orb(s[0])
+    ietype = s[0]
     cls = ietypecls.get(ietype, Raw)
 
     # if ietype greater than 128 are TLVs
@@ -1018,7 +1017,7 @@ PCO_OPTION_CLASSES = {
 
 def PCO_option_dispatcher(s):
     """Choose the correct PCO element."""
-    option = orb(s[0])
+    option = s[0]
 
     cls = PCO_OPTION_CLASSES.get(option, Raw)
     return cls(s)
@@ -1267,7 +1266,7 @@ PCO_PROTOCOL_CLASSES = {
 
 def PCO_protocol_dispatcher(s):
     """Choose the correct PCO element."""
-    proto_num = orb(s[0]) * 256 + orb(s[1])
+    proto_num = s[0] * 256 + s[1]
     cls = PCO_PROTOCOL_CLASSES.get(proto_num, Raw)
     return cls(s)
 

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -22,7 +22,7 @@ import abc
 import re
 from io import BytesIO
 import struct
-from scapy.compat import raw, plain_str, hex_bytes, orb, chb, bytes_encode
+from scapy.compat import raw, plain_str, hex_bytes, chb, bytes_encode
 
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".
@@ -235,7 +235,7 @@ class AbstractUVarIntField(fields.Field):
         :raises: AssertionError
         """
         assert isinstance(fb, int) or len(fb) == 1
-        return (orb(fb) & self._max_value) == self._max_value
+        return (fb & self._max_value) == self._max_value
 
     def _parse_multi_byte(self, s):
         # type: (str) -> int
@@ -254,7 +254,7 @@ class AbstractUVarIntField(fields.Field):
 
         value = 0
         i = 1
-        byte = orb(s[i])
+        byte = s[i]
         # For CPU sake, stops at an arbitrary large number!
         max_value = 1 << 64
         # As long as the MSG is set, an another byte must be read
@@ -266,7 +266,7 @@ class AbstractUVarIntField(fields.Field):
                 )
             i += 1
             assert i < tmp_len, 'EINVAL: x: out-of-bound read: the string ends before the AbstractUVarIntField!'  # noqa: E501
-            byte = orb(s[i])
+            byte = s[i]
         value += byte << (7 * (i - 1))
         value += self._max_value
 
@@ -296,7 +296,7 @@ class AbstractUVarIntField(fields.Field):
         if self._detect_multi_byte(val[0]):
             ret = self._parse_multi_byte(val)
         else:
-            ret = orb(val[0]) & self._max_value
+            ret = val[0] & self._max_value
 
         assert ret >= 0
         return ret
@@ -392,7 +392,7 @@ class AbstractUVarIntField(fields.Field):
             return s[0] + chb((s[2] << self.size) + self._max_value) + self.i2m(pkt, val)[1:]  # noqa: E501
         # This AbstractUVarIntField is only one byte long; setting the prefix value  # noqa: E501
         # and appending the resulting byte to the string
-        return s[0] + chb((s[2] << self.size) + orb(self.i2m(pkt, val)))
+        return s[0] + chb((s[2] << self.size) + self.i2m(pkt, val))
 
     @staticmethod
     def _detect_bytelen_from_str(s):
@@ -410,7 +410,7 @@ class AbstractUVarIntField(fields.Field):
         tmp_len = len(s)
 
         i = 1
-        while orb(s[i]) & 0x80 > 0:
+        while s[i] & 0x80 > 0:
             i += 1
             assert i < tmp_len, 'EINVAL: s: out-of-bound read: unfinished AbstractUVarIntField detected'  # noqa: E501
         ret = i + 1
@@ -1011,7 +1011,7 @@ class HPackZString(HPackStringsInterface):
             return cls.static_huffman_code[-1]
         else:
             assert isinstance(c, int) or len(c) == 1
-        return cls.static_huffman_code[orb(c)]
+        return cls.static_huffman_code[c]
 
     @classmethod
     def huffman_encode(cls, s):
@@ -1142,7 +1142,7 @@ class HPackZString(HPackStringsInterface):
         i = 0
         ibl = len(s) * 8
         for c in s:
-            i = (i << 8) + orb(c)
+            i = (i << 8) + c
 
         ret = i, ibl
         assert ret[0] >= 0
@@ -1342,7 +1342,7 @@ class HPackHeaders(packet.Packet):
         """
         if s is None:
             return config.conf.raw_layer
-        fb = orb(s[0])
+        fb = s[0]
         if fb & 0x80 != 0:
             return HPackIndexedHdr
         if fb & 0x40 != 0:

--- a/scapy/contrib/http2.py
+++ b/scapy/contrib/http2.py
@@ -22,7 +22,7 @@ import abc
 import re
 from io import BytesIO
 import struct
-from scapy.compat import raw, plain_str, hex_bytes, chb, bytes_encode
+from scapy.compat import plain_str, chb, bytes_encode
 
 # Only required if using mypy-lang for static typing
 # Most symbols are used in mypy-interpreted "comments".
@@ -224,7 +224,7 @@ class AbstractUVarIntField(fields.Field):
         return x
 
     def _detect_multi_byte(self, fb):
-        # type: (str) -> bool
+        # type: (int) -> bool
         """ _detect_multi_byte returns whether the AbstractUVarIntField is represented on  # noqa: E501
           multiple bytes or not.
 
@@ -234,11 +234,10 @@ class AbstractUVarIntField(fields.Field):
         :return: bool: True if multibyte repr detected, else False.
         :raises: AssertionError
         """
-        assert isinstance(fb, int) or len(fb) == 1
         return (fb & self._max_value) == self._max_value
 
     def _parse_multi_byte(self, s):
-        # type: (str) -> int
+        # type: (bytes) -> int
         """ _parse_multi_byte parses x as a multibyte representation to get the
           int value of this AbstractUVarIntField.
 
@@ -274,7 +273,7 @@ class AbstractUVarIntField(fields.Field):
         return value
 
     def m2i(self, pkt, x):
-        # type: (Optional[packet.Packet], Union[str, Tuple[str, int]]) -> int
+        # type: (Optional[packet.Packet], Union[bytes, Tuple[bytes, int]]) -> int
         """
           A tuple is expected for the "x" param only if "size" is different than 8. If a tuple is received, some bits  # noqa: E501
           were consumed by another field. This field consumes the remaining bits, therefore the int of the tuple must  # noqa: E501
@@ -302,7 +301,7 @@ class AbstractUVarIntField(fields.Field):
         return ret
 
     def i2m(self, pkt, x):
-        # type: (Optional[packet.Packet], int) -> str
+        # type: (Optional[packet.Packet], int) -> bytes
         """
         :param packet.Packet|None pkt: unused.
         :param int x: the value to convert.
@@ -314,18 +313,16 @@ class AbstractUVarIntField(fields.Field):
         if x < self._max_value:
             return chb(x)
         else:
-            # The sl list join is a performance trick, because string
-            # concatenation is not efficient with Python immutable strings
-            sl = [chb(self._max_value)]
+            sl = [self._max_value]
             x -= self._max_value
             while x >= 0x80:
-                sl.append(chb(0x80 | (x & 0x7F)))
+                sl.append(0x80 | (x & 0x7F))
                 x >>= 7
-            sl.append(chb(x))
-            return b''.join(sl)
+            sl.append(x)
+            return bytes(sl)
 
     def any2i(self, pkt, x):
-        # type: (Optional[packet.Packet], Union[None, str, int]) -> Optional[int]  # noqa: E501
+        # type: (Optional[packet.Packet], Union[None, bytes, int]) -> Optional[int]  # noqa: E501
         """
           A "x" value as a string is parsed as a binary encoding of a UVarInt. An int is considered an internal value.  # noqa: E501
           None is returned as is.
@@ -358,7 +355,7 @@ class AbstractUVarIntField(fields.Field):
         return repr(self.i2h(pkt, x))
 
     def addfield(self, pkt, s, val):
-        # type: (Optional[packet.Packet], Union[str, Tuple[str, int, int]], int) -> str  # noqa: E501
+        # type: (Optional[packet.Packet], Union[bytes, Tuple[bytes, int, int]], int) -> str  # noqa: E501
         """
           An AbstractUVarIntField prefix always consumes the remaining bits
           of a BitField;if no current BitField is in use (no tuple in
@@ -389,14 +386,19 @@ class AbstractUVarIntField(fields.Field):
         # assert (8 - s[1]) == self.size, 'EINVAL: s: not enough bits remaining in current byte to read the prefix'  # noqa: E501
 
         if val >= self._max_value:
-            return s[0] + chb((s[2] << self.size) + self._max_value) + self.i2m(pkt, val)[1:]  # noqa: E501
+            return (
+                s[0] +
+                chb((s[2] << self.size) + self._max_value) +
+                self.i2m(pkt, val)[1:]
+            )
+
         # This AbstractUVarIntField is only one byte long; setting the prefix value  # noqa: E501
         # and appending the resulting byte to the string
-        return s[0] + chb((s[2] << self.size) + self.i2m(pkt, val))
+        return s[0] + chb((s[2] << self.size) + self.i2m(pkt, val)[0])
 
     @staticmethod
     def _detect_bytelen_from_str(s):
-        # type: (str) -> int
+        # type: (bytes) -> int
         """ _detect_bytelen_from_str returns the length of the machine
           representation of an AbstractUVarIntField starting at the beginning
           of s and which is assumed to expand over multiple bytes
@@ -639,15 +641,11 @@ class FieldUVarLenField(AbstractUVarIntField):
 
 class HPackStringsInterface(Sized, metaclass=abc.ABCMeta):  # type: ignore
     @abc.abstractmethod
-    def __str__(self):
+    def __bytes__(self):
         pass
 
-    def __bytes__(self):
-        r = self.__str__()
-        return bytes_encode(r)
-
     @abc.abstractmethod
-    def origin(self):
+    def origin(self) -> str:
         pass
 
     @abc.abstractmethod
@@ -663,15 +661,15 @@ class HPackLiteralString(HPackStringsInterface):
 
     def __init__(self, s):
         # type: (str) -> None
-        self._s = s
+        self._s = plain_str(s)
 
-    def __str__(self):
-        # type: () -> str
-        return self._s
+    def __bytes__(self):
+        # type: () -> bytes
+        return self._s.encode()
 
     def origin(self):
         # type: () -> str
-        return plain_str(self._s)
+        return self._s
 
     def __len__(self):
         # type: () -> int
@@ -999,7 +997,7 @@ class HPackZString(HPackStringsInterface):
 
     @classmethod
     def _huffman_encode_char(cls, c):
-        # type: (Union[str, EOS]) -> Tuple[int, int]
+        # type: (Union[int, EOS]) -> Tuple[int, int]
         """ huffman_encode_char assumes that the static_huffman_tree was
         previously initialized
 
@@ -1010,7 +1008,7 @@ class HPackZString(HPackStringsInterface):
         if isinstance(c, EOS):
             return cls.static_huffman_code[-1]
         else:
-            assert isinstance(c, int) or len(c) == 1
+            assert isinstance(c, int)
         return cls.static_huffman_code[c]
 
     @classmethod
@@ -1025,6 +1023,7 @@ class HPackZString(HPackStringsInterface):
         """
         i = 0
         ibl = 0
+        s = bytes_encode(s)
         for c in s:
             val, bl = cls._huffman_encode_char(c)
             i = (i << bl) + val
@@ -1076,7 +1075,9 @@ class HPackZString(HPackStringsInterface):
                 if isinstance(cur, type(None)):
                     raise AssertionError()
             elif isinstance(elmt, EOS):
-                raise InvalidEncodingException('Huffman decoder met the full EOS symbol')  # noqa: E501
+                raise InvalidEncodingException(
+                    'Huffman decoder met the full EOS symbol'
+                )
             elif isinstance(elmt, bytes):
                 interrupted = False
                 s.append(elmt)
@@ -1084,7 +1085,9 @@ class HPackZString(HPackStringsInterface):
                 cur_sym = 0
                 cur_sym_bl = 0
             else:
-                raise InvalidEncodingException('Should never happen, so incidentally it will')  # noqa: E501
+                raise InvalidEncodingException(
+                    'Should never happen, so incidentally it will'
+                )
             j += 1
 
         if interrupted:
@@ -1092,17 +1095,22 @@ class HPackZString(HPackStringsInterface):
             # symbol; this symbol must be, according to RFC7541 par5.2 the MSB
             # of the EOS symbol
             if cur_sym_bl > 7:
-                raise InvalidEncodingException('Huffman decoder is detecting padding longer than 7 bits')  # noqa: E501
+                raise InvalidEncodingException(
+                    'Huffman decoder is detecting padding longer than 7 bits'
+                )
             eos_symbol = cls.static_huffman_code[-1]
             eos_msb = eos_symbol[0] >> (eos_symbol[1] - cur_sym_bl)
             if eos_msb != cur_sym:
-                raise InvalidEncodingException('Huffman decoder is detecting unexpected padding format')  # noqa: E501
-        return b''.join(s)
+                raise InvalidEncodingException(
+                    'Huffman decoder is detecting unexpected padding format'
+                )
+        s = b''.join(s)
+        return s.decode()
 
     @classmethod
-    def huffman_conv2str(cls, bit_str, bit_len):
-        # type: (int, int) -> str
-        """ huffman_conv2str converts a bitstring of bit_len bitlength into a
+    def huffman_conv2bytes(cls, bit_str, bit_len):
+        # type: (int, int) -> bytes
+        """ huffman_conv2bytes converts a bitstring of bit_len bitlength into a
         binary string. It DOES NOT compress/decompress the bitstring!
 
         :param int bit_str: the bitstring to convert.
@@ -1119,14 +1127,12 @@ class HPackZString(HPackStringsInterface):
             bit_str <<= 8 - rem_bit
             byte_len += 1
 
-        # As usual the list/join tricks is a performance trick to build
-        # efficiently a Python string
-        s = []  # type: List[str]
+        s = []  # type: List[int]
         i = 0
         while i < byte_len:
-            s.insert(0, chb((bit_str >> (i * 8)) & 0xFF))
+            s.insert(0, (bit_str >> (i * 8)) & 0xFF)
             i += 1
-        return b''.join(s)
+        return bytes(s)
 
     @classmethod
     def huffman_conv2bitstring(cls, s):
@@ -1164,7 +1170,9 @@ class HPackZString(HPackStringsInterface):
             for idx in range(entry[1] - 1, -1, -1):
                 b = (entry[0] >> idx) & 1
                 if isinstance(parent[b], bytes):
-                    raise InvalidEncodingException('Huffman unique prefix violation :/')  # noqa: E501
+                    raise InvalidEncodingException(
+                        'Huffman unique prefix violation :/'
+                    )
                 if idx == 0:
                     parent[b] = chb(i) if i < 256 else EOS()
                 elif parent[b] is None:
@@ -1174,17 +1182,17 @@ class HPackZString(HPackStringsInterface):
 
     def __init__(self, s):
         # type: (str) -> None
-        self._s = s
-        i, ibl = type(self).huffman_encode(s)
-        self._encoded = type(self).huffman_conv2str(i, ibl)
+        self._s = plain_str(s)
+        i, ibl = type(self).huffman_encode(self._s)
+        self._encoded = type(self).huffman_conv2bytes(i, ibl)
 
-    def __str__(self):
-        # type: () -> str
+    def __bytes__(self):
+        # type: () -> bytes
         return self._encoded
 
     def origin(self):
         # type: () -> str
-        return plain_str(self._s)
+        return self._s
 
     def __len__(self):
         # type: () -> int
@@ -1194,12 +1202,18 @@ class HPackZString(HPackStringsInterface):
 class HPackStrLenField(fields.Field):
     """ HPackStrLenField is a StrLenField variant specialized for HTTP/2 HPack
 
-    This variant uses an internal representation that implements HPackStringsInterface.  # noqa: E501
+    This variant uses an internal representation that implements
+    HPackStringsInterface.
     """
     __slots__ = ['_length_from', '_type_from']
 
-    def __init__(self, name, default, length_from, type_from):
-        # type: (str, HPackStringsInterface, Callable[[packet.Packet], int], str) -> None  # noqa: E501
+    def __init__(
+        self,
+        name: str,
+        default: HPackStringsInterface,
+        length_from: Callable[[packet.Packet], int],
+        type_from: str,
+    ) -> None:
         super(HPackStrLenField, self).__init__(name, default)
         self._length_from = length_from
         self._type_from = type_from
@@ -1214,7 +1228,8 @@ class HPackStrLenField(fields.Field):
         """
         :param bool t: whether this string is a huffman compressed string.
         :param str s: the string to parse.
-        :return: HPackStringsInterface: either a HPackLiteralString or HPackZString, depending on t.  # noqa: E501
+        :return: HPackStringsInterface: either a HPackLiteralString or HPackZString,
+            depending on t.
         :raises: InvalidEncodingException
         """
         if t:
@@ -1225,10 +1240,10 @@ class HPackStrLenField(fields.Field):
     def getfield(self, pkt, s):
         # type: (packet.Packet, str) -> Tuple[str, HPackStringsInterface]
         """
-        :param packet.Packet pkt: the packet instance containing this field instance.  # noqa: E501
+        :param packet.Packet pkt: the packet instance containing this field instance.
         :param str s: the string to parse this field from.
-        :return: (str, HPackStringsInterface): the remaining string after this field was carved out & the extracted  # noqa: E501
-          value.
+        :return: (str, HPackStringsInterface): the remaining string after this field
+            was carved out & the extracted value.
         :raises: KeyError if "type_from" is not a field of pkt or its payloads.
         :raises: InvalidEncodingException
         """
@@ -1252,9 +1267,9 @@ class HPackStrLenField(fields.Field):
     def m2i(self, pkt, x):
         # type: (packet.Packet, str) -> HPackStringsInterface
         """
-        :param packet.Packet pkt: the packet instance containing this field instance.  # noqa: E501
+        :param packet.Packet pkt: the packet instance containing this field instance.
         :param str x: the string to parse.
-        :return: HPackStringsInterface: the internal type of the value parsed from x.  # noqa: E501
+        :return: HPackStringsInterface: the internal type of the value parsed from x.
         :raises: AssertionError
         :raises: InvalidEncodingException
         :raises: KeyError if _type_from is not one of pkt fields.
@@ -1262,14 +1277,19 @@ class HPackStrLenField(fields.Field):
         t = pkt.getfieldval(self._type_from)
         tmp_len = self._length_from(pkt)
 
-        assert t is not None and tmp_len is not None, 'Conversion from string impossible: no type or length specified'  # noqa: E501
+        assert t is not None and tmp_len is not None, \
+            'Conversion from string impossible: no type or length specified'
 
         return self._parse(t == 1, x[:tmp_len])
 
-    def any2i(self, pkt, x):
-        # type: (Optional[packet.Packet], Union[str, HPackStringsInterface]) -> HPackStringsInterface  # noqa: E501
+    def any2i(
+        self,
+        pkt: Optional[packet.Packet],
+        x: Union[str, HPackStringsInterface],
+    ) -> HPackStringsInterface:
         """
-        :param packet.Packet|None pkt: the packet instance containing this field instance.  # noqa: E501
+        :param packet.Packet|None pkt: the packet instance containing this field
+            instance.
         :param str|HPackStringsInterface x: the value to convert
         :return: HPackStringsInterface: the Scapy internal value for this field
         :raises: AssertionError, InvalidEncodingException
@@ -1281,8 +1301,8 @@ class HPackStrLenField(fields.Field):
         return x
 
     def i2m(self, pkt, x):
-        # type: (Optional[packet.Packet], HPackStringsInterface) -> str
-        return raw(x)
+        # type: (Optional[packet.Packet], HPackStringsInterface) -> bytes
+        return bytes(x)
 
     def i2len(self, pkt, x):
         # type: (Optional[packet.Packet], HPackStringsInterface) -> int
@@ -2107,7 +2127,9 @@ packet.bind_layers(H2Frame, H2ContinuationFrame, {'type': H2ContinuationFrame.ty
 
 #                                          HTTP/2 Connection Preface                                                   #  # noqa: E501
 # From RFC 7540 par3.5
-H2_CLIENT_CONNECTION_PREFACE = hex_bytes('505249202a20485454502f322e300d0a0d0a534d0d0a0d0a')  # noqa: E501
+H2_CLIENT_CONNECTION_PREFACE = bytes.fromhex(
+    '505249202a20485454502f322e300d0a0d0a534d0d0a0d0a'
+)
 
 
 ###############################################################################
@@ -2160,9 +2182,6 @@ class HPackHdrEntry(Sized):
             return "{} {}".format(self._name, self._value)
         else:
             return "{}: {}".format(self._name, self._value)
-
-    def __bytes__(self):
-        return bytes_encode(self.__str__())
 
 
 class HPackHdrTable(Sized):
@@ -2666,7 +2685,7 @@ class HPackHdrTable(Sized):
 
         sio = BytesIO(s.encode() if isinstance(s, str) else s)
 
-        base_frm_len = len(raw(H2Frame()))
+        base_frm_len = len(bytes(H2Frame()))
 
         ret = H2Seq()
         cur_frm = H2HeadersFrame()  # type: Union[H2HeadersFrame, H2ContinuationFrame]  # noqa: E501
@@ -2681,7 +2700,7 @@ class HPackHdrTable(Sized):
             new_hdr, new_hdr_len = self._convert_a_header_to_a_h2_header(
                 hdr_name, hdr_value, is_sensitive, should_index
             )
-            new_hdr_bin_len = len(raw(new_hdr))
+            new_hdr_bin_len = len(bytes(new_hdr))
 
             if register and isinstance(new_hdr, HPackLitHdrFldWithIncrIndexing):  # noqa: E501
                 self.register(new_hdr)
@@ -2695,7 +2714,7 @@ class HPackHdrTable(Sized):
                     (max_hdr_lst_sz != 0 and new_hdr_len > max_hdr_lst_sz)):
                 raise Exception('Header too long: {}'.format(hdr_name))
 
-            if (max_frm_sz < len(raw(cur_frm)) + base_frm_len + new_hdr_len or
+            if (max_frm_sz < len(bytes(cur_frm)) + base_frm_len + new_hdr_len or
                 (
                     max_hdr_lst_sz != 0 and
                     max_hdr_lst_sz < cur_hdr_sz + new_hdr_len
@@ -2718,7 +2737,7 @@ class HPackHdrTable(Sized):
         ret.frames.append(H2Frame(stream_id=stream_id, flags=flags) / cur_frm)
 
         if body:
-            base_data_frm_len = len(raw(H2DataFrame()))
+            base_data_frm_len = len(bytes(H2DataFrame()))
             sio = BytesIO(body)
             frgmt = sio.read(max_frm_sz - base_data_frm_len - base_frm_len)
             while frgmt:

--- a/scapy/contrib/isis.py
+++ b/scapy/contrib/isis.py
@@ -56,7 +56,7 @@ from scapy.layers.clns import network_layer_protocol_ids, register_cln_protocol
 from scapy.layers.inet6 import IP6ListField, IP6Field
 from scapy.utils import fletcher16_checkbytes
 from scapy.volatile import RandString, RandByte
-from scapy.compat import orb, hex_bytes
+from scapy.compat import hex_bytes
 
 EXT_VERSION = "v0.0.3"
 
@@ -74,7 +74,7 @@ def isis_str2area(s):
 
     numbytes = len(s[1:])
     fmt = "%02X" + (".%02X%02X" * (numbytes // 2)) + ("" if (numbytes % 2) == 0 else ".%02X")  # noqa: E501
-    return fmt % tuple(orb(x) for x in s)
+    return fmt % tuple(x for x in s)
 
 
 def isis_sysid2str(sysid):
@@ -82,7 +82,7 @@ def isis_sysid2str(sysid):
 
 
 def isis_str2sysid(s):
-    return ("%02X%02X." * 3)[:-1] % tuple(orb(x) for x in s)
+    return ("%02X%02X." * 3)[:-1] % tuple(x for x in s)
 
 
 def isis_nodeid2str(nodeid):
@@ -90,7 +90,7 @@ def isis_nodeid2str(nodeid):
 
 
 def isis_str2nodeid(s):
-    return "%s.%02X" % (isis_str2sysid(s[:-1]), orb(s[-1]))
+    return "%s.%02X" % (isis_str2sysid(s[:-1]), s[-1])
 
 
 def isis_lspid2str(lspid):
@@ -98,7 +98,7 @@ def isis_lspid2str(lspid):
 
 
 def isis_str2lspid(s):
-    return "%s-%02X" % (isis_str2nodeid(s[:-1]), orb(s[-1]))
+    return "%s-%02X" % (isis_str2nodeid(s[:-1]), s[-1])
 
 
 class _ISIS_IdFieldBase(Field):
@@ -225,7 +225,7 @@ class ISIS_CircuitTypeField(FlagsField):
 def _ISIS_GuessTlvClass_Helper(tlv_classes, defaultname, p, **kargs):
     cls = conf.raw_layer
     if len(p) >= 2:
-        tlvtype = orb(p[0])
+        tlvtype = p[0]
         clsname = tlv_classes.get(tlvtype, defaultname)
         cls = globals()[clsname]
 

--- a/scapy/contrib/isotp/isotp_packet.py
+++ b/scapy/contrib/isotp/isotp_packet.py
@@ -18,7 +18,7 @@ from typing import (
     cast,
 )
 
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.config import conf
 from scapy.error import Scapy_Exception
 from scapy.fields import BitField, FlagsField, StrLenField, \
@@ -246,9 +246,9 @@ class ISOTPHeader(CAN):
         if len(payload) < 1:
             return self.default_payload_class(payload)
 
-        t = (orb(payload[0]) & 0xf0) >> 4
+        t = (payload[0] & 0xf0) >> 4
         if t == 0:
-            length = (orb(payload[0]) & 0x0f)
+            length = (payload[0] & 0x0f)
             if length == 0:
                 return ISOTP_SF_FD
             else:
@@ -256,7 +256,7 @@ class ISOTPHeader(CAN):
         elif t == 1:
             if len(payload) < 2:
                 return self.default_payload_class(payload)
-            length = ((orb(payload[0]) & 0x0f) << 12) + orb(payload[1])
+            length = ((payload[0] & 0x0f) << 12) + payload[1]
             if length == 0:
                 return ISOTP_FF_FD
             else:

--- a/scapy/contrib/isotp/isotp_scanner.py
+++ b/scapy/contrib/isotp/isotp_scanner.py
@@ -23,7 +23,6 @@ from typing import (
     Union, Type,
 )
 
-from scapy.compat import orb
 from scapy.contrib.cansocket import PYTHON_CAN
 from scapy.contrib.isotp import ISOTPHeader_FD
 from scapy.contrib.isotp.isotp_packet import ISOTPHeader, ISOTPHeaderEA, \
@@ -151,8 +150,8 @@ def get_isotp_fc(
 
     try:
         index = 1 if extended else 0
-        isotp_pci = orb(packet.data[index]) >> 4
-        isotp_fc = orb(packet.data[index]) & 0x0f
+        isotp_pci = packet.data[index] >> 4
+        isotp_fc = packet.data[index] & 0x0f
         if isotp_pci == 3 and 0 <= isotp_fc <= 2:
             log_isotp.info("Found flow-control frame from identifier "
                            "0x%03x when testing identifier 0x%03x",
@@ -422,7 +421,7 @@ def generate_text_output(found_packets, extended_addressing=False, fd=False):
         if extended_addressing:
             send_id = pack // 256
             send_ext = pack - (send_id * 256)
-            ext_id = hex(orb(found_packets[pack][0].data[0]))
+            ext_id = hex(found_packets[pack][0].data[0])
             text += "\nSend to ID:             %s" \
                     "\nSend to extended ID:    %s" \
                     "\nReceived ID:            %s" \
@@ -479,7 +478,7 @@ def generate_code_output(found_packets, can_interface="iface",
         if extended_addressing:
             send_id = pack // 256
             send_ext = pack - (send_id * 256)
-            ext_id = orb(found_packets[pack][0].data[0])
+            ext_id = found_packets[pack][0].data[0]
             result += "ISOTPSocket(%s, tx_id=0x%x, rx_id=0x%x, padding=%s, " \
                       "ext_address=0x%x, rx_ext_address=0x%x, fd=%s, " \
                       "basecls=ISOTP)\n" % \
@@ -527,7 +526,7 @@ def generate_json_output(found_packets,  # type: Dict[int, Tuple[Packet, int]]
         if extended_addressing:
             source_id = pack >> 8
             source_ext = int(pack - (source_id * 256))
-            dest_ext = orb(pkt.data[0])
+            dest_ext = pkt.data[0]
             socket_list.append({"iface": can_interface,
                                 "tx_id": source_id,
                                 "ext_address": source_ext,
@@ -576,7 +575,7 @@ def generate_isotp_list(found_packets,  # type: Dict[int, Tuple[Packet, int]]
         if extended_addressing:
             source_id = pack >> 8
             source_ext = int(pack - (source_id * 256))
-            dest_ext = orb(pkt.data[0])
+            dest_ext = pkt.data[0]
             socket_list.append(ISOTPSocket(can_interface, tx_id=source_id,
                                            ext_address=source_ext,
                                            rx_id=dest_id,

--- a/scapy/contrib/ldp.py
+++ b/scapy/contrib/ldp.py
@@ -15,7 +15,6 @@ http://git.savannah.gnu.org/cgit/ldpscapy.git/snapshot/ldpscapy-5285b81d6e628043
 
 import struct
 
-from scapy.compat import orb
 from scapy.packet import Packet, bind_layers, bind_bottom_up
 from scapy.fields import (
     BitField,
@@ -79,9 +78,9 @@ class FecTLVField(StrField):
             # if x[0] == 1:
             #   list.append('Wildcard')
             # else:
-            # mask=orb(x[8*i+3])
+            # mask=x[8*i+3]
             # add=inet_ntoa(x[8*i+4:8*i+8])
-            mask = orb(x[3])
+            mask = x[3]
             nbroctets = mask // 8
             if mask % 8:
                 nbroctets += 1
@@ -230,7 +229,7 @@ class CommonHelloTLVField(StrField):
         list = []
         v = struct.unpack("!H", x[4:6])[0]
         list.append(v)
-        flags = orb(x[6])
+        flags = x[6]
         v = (flags & 0x80) >> 7
         list.append(v)
         v = (flags & 0x40) >> 6

--- a/scapy/contrib/lldp.py
+++ b/scapy/contrib/lldp.py
@@ -46,7 +46,7 @@ from scapy.fields import MACField, IPField, IP6Field, BitField, \
     BitScalingField
 from scapy.packet import Packet, bind_layers
 from scapy.data import ETHER_TYPES
-from scapy.compat import orb, bytes_int
+from scapy.compat import bytes_int
 
 LLDP_NEAREST_BRIDGE_MAC = '01:80:c2:00:00:0e'
 LLDP_NEAREST_NON_TPMR_BRIDGE_MAC = '01:80:c2:00:00:03'
@@ -154,7 +154,7 @@ class LLDPDU(Packet):
     def guess_payload_class(self, payload):
         # type is a 7-bit bitfield spanning bits 1..7 -> div 2
         try:
-            lldpdu_tlv_type = orb(payload[0]) // 2
+            lldpdu_tlv_type = payload[0] // 2
             class_type = LLDPDU_CLASS_TYPES.get(lldpdu_tlv_type, conf.raw_layer)
             if isinstance(class_type, list):
                 for cls in class_type:
@@ -762,7 +762,7 @@ class LLDPDUPowerViaMDI(LLDPDUGenericOrganisationSpecific):
         """
         match organization specific TLV
         """
-        return (orb(payload[5]) == 2 and orb(payload[1]) == 7
+        return (payload[5] == 2 and payload[1] == 7
                 and bytes_int(payload[2:5]) ==
                 LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3)
 
@@ -861,7 +861,7 @@ class LLDPDUPowerViaMDIDDL(LLDPDUPowerViaMDI):
         """
         match organization specific TLV
         """
-        return (orb(payload[5]) == 2 and orb(payload[1]) == 12
+        return (payload[5] == 2 and payload[1] == 12
                 and bytes_int(payload[2:5]) ==
                 LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3)
 
@@ -1041,7 +1041,7 @@ class LLDPDUPowerViaMDIType34(LLDPDUPowerViaMDIDDL):
         '''
         match organization specific TLV
         '''
-        return (orb(payload[5]) == 2 and orb(payload[1]) == 29
+        return (payload[5] == 2 and payload[1] == 29
                 and bytes_int(payload[2:5]) ==
                 LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3)
 
@@ -1176,7 +1176,7 @@ class LLDPDUPowerViaMDIMeasure(LLDPDUGenericOrganisationSpecific):
         '''
         match organization specific TLV
         '''
-        return (orb(payload[5]) == 8 and orb(payload[1]) == 26
+        return (payload[5] == 8 and payload[1] == 26
                 and bytes_int(payload[2:5]) ==
                 LLDPDUGenericOrganisationSpecific.ORG_UNIQUE_CODE_IEEE_802_3)
 

--- a/scapy/contrib/mac_control.py
+++ b/scapy/contrib/mac_control.py
@@ -30,7 +30,6 @@
 
 """
 
-from scapy.compat import orb
 from scapy.data import ETHER_TYPES
 from scapy.error import Scapy_Exception
 from scapy.fields import IntField, ByteField, ByteEnumField, ShortField, BitField  # noqa: E501
@@ -84,7 +83,7 @@ class MACControl(Packet):
     def guess_payload_class(self, payload):
 
         try:
-            op_code = (orb(payload[0]) << 8) + orb(payload[1])
+            op_code = (payload[0] << 8) + payload[1]
             return MAC_CTRL_CLASSES[op_code]
         except KeyError:
             pass

--- a/scapy/contrib/modbus.py
+++ b/scapy/contrib/modbus.py
@@ -17,7 +17,6 @@ from scapy.fields import XByteField, XShortField, StrLenField, ByteEnumField, \
     BitFieldLenField, ByteField, ConditionalField, EnumField, FieldListField, \
     ShortField, StrFixedLenField, XShortEnumField
 from scapy.layers.inet import TCP
-from scapy.utils import orb
 from scapy.config import conf
 from scapy.volatile import VolatileValue
 
@@ -867,10 +866,10 @@ class ModbusADURequest(Packet):
     ]
 
     def guess_payload_class(self, payload):
-        function_code = orb(payload[0])
+        function_code = payload[0]
 
         if function_code == 0x2B:
-            sub_code = orb(payload[1])
+            sub_code = payload[1]
             try:
                 return _mei_types_request[sub_code]
             except KeyError:
@@ -904,10 +903,10 @@ class ModbusADUResponse(Packet):
     ]
 
     def guess_payload_class(self, payload):
-        function_code = orb(payload[0])
+        function_code = payload[0]
 
         if function_code == 0x2B:
-            sub_code = orb(payload[1])
+            sub_code = payload[1]
             try:
                 return _mei_types_response[sub_code]
             except KeyError:

--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -20,7 +20,7 @@ from scapy.fields import (
 )
 from scapy.layers.inet import TCP
 from scapy.error import Scapy_Exception
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.volatile import RandNum
 from scapy.config import conf
 
@@ -50,7 +50,7 @@ class VariableFieldLenField(FieldLenField):
     def getfield(self, pkt, s):
         value = 0
         for offset, curbyte in enumerate(s):
-            curbyte = orb(curbyte)
+            curbyte = curbyte
             value += (curbyte & 127) * (128 ** offset)
             if curbyte & 128 == 0:
                 return s[offset + 1:], value

--- a/scapy/contrib/mqttsn.py
+++ b/scapy/contrib/mqttsn.py
@@ -20,7 +20,7 @@ from scapy.fields import BitField, BitEnumField, ByteField, ByteEnumField, \
     StrLenField, XByteEnumField
 from scapy.layers.inet import UDP
 from scapy.error import Scapy_Exception
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.volatile import RandNum
 import struct
 
@@ -91,13 +91,13 @@ class VariableFieldLenField(FieldLenField):
             return s + chb(val)
 
     def getfield(self, pkt, s):
-        if orb(s[0]) == 0x01:
+        if s[0] == 0x01:
             if len(s) < 3:
                 raise Scapy_Exception("%s: malformed length field" %
                                       self.__class__.__name__)
-            return s[3:], (orb(s[1]) << 8) | orb(s[2])
+            return s[3:], (s[1] << 8) | s[2]
         else:
-            return s[1:], orb(s[0])
+            return s[1:], s[0]
 
     def randval(self):
         return RandVariableFieldLen()

--- a/scapy/contrib/mysql.py
+++ b/scapy/contrib/mysql.py
@@ -39,7 +39,6 @@ resultset metadata/rows, or full command/authentication coverage.
 import struct
 from typing import Any, Optional, Tuple
 
-from scapy.compat import orb
 from scapy.fields import (
     ByteEnumField,
     ByteField,
@@ -227,7 +226,7 @@ def _read_lenenc_int(data: bytes) -> Tuple[int, int]:
     """Decode a MySQL length-encoded integer and return (value, consumed)."""
     if not data:
         return 0, 0
-    first = orb(data[0])
+    first = data[0]
     if first < 0xFB:
         return first, 1
     if first == 0xFC:
@@ -301,7 +300,7 @@ class MySQLByteLenStrField(Field[Any, Any]):
     def getfield(self, pkt: Packet, s: bytes) -> Tuple[bytes, Any]:
         if not s:
             return s, b""
-        length = orb(s[0])
+        length = s[0]
         return s[1 + length:], s[1:1 + length]
 
     def i2repr(self, pkt: Optional[Packet], val: Any) -> str:
@@ -626,7 +625,7 @@ class MySQLClientPacket(_MySQLPacket):
             if _capability(flags, CLIENT_PROTOCOL_41):
                 return MySQLHandshakeResponse41
         if payload:
-            command = orb(payload[0])
+            command = payload[0]
             if command == 0x03:
                 return MySQLComQuery
             if command in MYSQL_COMMANDS:
@@ -640,10 +639,10 @@ class MySQLServerPacket(_MySQLPacket):
     name = "MySQL Server Packet"
 
     def guess_payload_class(self, payload: bytes) -> type:
-        if payload and self.sequence_id == 0 and orb(payload[0]) == 0x0A:
+        if payload and self.sequence_id == 0 and payload[0] == 0x0A:
             return MySQLHandshakeV10
         if payload:
-            header = orb(payload[0])
+            header = payload[0]
             if header == 0x00:
                 if self.sequence_id == 1 and len(payload) == 12:
                     return MySQLStmtPrepareOK

--- a/scapy/contrib/openflow.py
+++ b/scapy/contrib/openflow.py
@@ -17,7 +17,7 @@ Specifications can be retrieved from https://www.opennetworking.org/
 import struct
 
 
-from scapy.compat import chb, orb, raw
+from scapy.compat import chb, raw
 from scapy.config import conf
 from scapy.error import warning
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, FieldLenField, FlagsField, IntEnumField, IntField, IPField, LongField, MACField, PacketField, PacketListField, ShortEnumField, ShortField, StrFixedLenField, X3BytesField, XBitField, XByteField, XIntField, XShortField  # noqa: E501
@@ -274,7 +274,7 @@ class OpenFlow(_ofp_header):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 2:
-            version = orb(_pkt[0])
+            version = _pkt[0]
             if version == 0x04:  # OpenFlow 1.3
                 from scapy.contrib.openflow3 import OpenFlow3
                 return OpenFlow3.dispatch_hook(_pkt, *args, **kargs)
@@ -283,20 +283,20 @@ class OpenFlow(_ofp_header):
                 # longer be used
                 # OpenFlow function may be called with a None
                 # self in OFPPacketField
-                of_type = orb(_pkt[1])
+                of_type = _pkt[1]
                 if of_type == 1:
-                    err_type = orb(_pkt[9])
+                    err_type = _pkt[9]
                     # err_type is a short int, but last byte is enough
                     if err_type == 255:
                         err_type = 65535
                     return ofp_error_cls[err_type]
                 elif of_type == 16:
-                    mp_type = orb(_pkt[9])
+                    mp_type = _pkt[9]
                     if mp_type == 255:
                         mp_type = 65535
                     return ofp_stats_request_cls[mp_type]
                 elif of_type == 17:
-                    mp_type = orb(_pkt[9])
+                    mp_type = _pkt[9]
                     if mp_type == 255:
                         mp_type = 65535
                     return ofp_stats_reply_cls[mp_type]

--- a/scapy/contrib/openflow3.py
+++ b/scapy/contrib/openflow3.py
@@ -19,7 +19,7 @@ import copy
 import struct
 
 
-from scapy.compat import orb, raw
+from scapy.compat import raw
 from scapy.config import conf
 from scapy.fields import BitEnumField, BitField, ByteEnumField, ByteField, \
     FieldLenField, FlagsField, IntEnumField, IntField, IPField, \
@@ -579,7 +579,7 @@ class OXMPacketListField(PacketListField):
         return val
 
     def m2i(self, pkt, s):
-        t = orb(s[2])
+        t = s[2]
         nrm_t = t - t % 2
         if nrm_t not in self.index:
             self.index.append(nrm_t)
@@ -587,7 +587,7 @@ class OXMPacketListField(PacketListField):
 
     @staticmethod
     def _get_oxm_length(s):
-        return orb(s[3])
+        return s[3]
 
     def addfield(self, pkt, s, val):
         return s + b"".join(raw(x) for x in self.i2m(pkt, val))
@@ -623,7 +623,7 @@ class OXMID(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 2:
-            t = orb(_pkt[2])
+            t = _pkt[2]
             return ofp_oxm_id_cls.get(t, Raw)
         return Raw
 
@@ -692,20 +692,20 @@ class OpenFlow3(OpenFlow):
             # port 6653 has been allocated by IANA, port 6633 should no
             # longer be used
             # OpenFlow3 function may be called with None self in OFPPacketField
-            of_type = orb(_pkt[1])
+            of_type = _pkt[1]
             if of_type == 1:
-                err_type = orb(_pkt[9])
+                err_type = _pkt[9]
                 # err_type is a short int, but last byte is enough
                 if err_type == 255:
                     err_type = 65535
                 return ofp_error_cls[err_type]
             elif of_type == 18:
-                mp_type = orb(_pkt[9])
+                mp_type = _pkt[9]
                 if mp_type == 255:
                     mp_type = 65535
                 return ofp_multipart_request_cls[mp_type]
             elif of_type == 19:
-                mp_type = orb(_pkt[9])
+                mp_type = _pkt[9]
                 if mp_type == 255:
                     mp_type = 65535
                 return ofp_multipart_reply_cls[mp_type]

--- a/scapy/contrib/ospf.py
+++ b/scapy/contrib/ospf.py
@@ -26,7 +26,6 @@ from scapy.fields import BitField, ByteEnumField, ByteField, \
 from scapy.layers.inet import IP, DestIPField
 from scapy.layers.inet6 import IPv6, in6_chksum
 from scapy.utils import fletcher16_checkbytes, checksum, inet_aton
-from scapy.compat import orb
 from scapy.config import conf
 
 EXT_VERSION = "v0.9.2"
@@ -254,7 +253,7 @@ def _LSAGuessPayloadClass(p, **kargs):
 
     cls = conf.raw_layer
     if len(p) >= 4:
-        typ = orb(p[3])
+        typ = p[3]
         clsname = _OSPF_LSclasses.get(typ, "Raw")
         cls = globals()[clsname]
     return cls(p, **kargs)

--- a/scapy/contrib/pfcp.py
+++ b/scapy/contrib/pfcp.py
@@ -12,7 +12,7 @@
 
 import struct
 
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.error import warning
 from scapy.fields import Field, BitEnumField, BitField, ByteEnumField, \
     ShortEnumField, ByteField, IntField, LongField, \
@@ -416,7 +416,7 @@ class APNStrLenField(StrLenField):
         ret_s = b""
         tmp_s = s
         while tmp_s:
-            tmp_len = orb(tmp_s[0]) + 1
+            tmp_len = tmp_s[0] + 1
             if tmp_len > len(tmp_s):
                 warning("APN prematured end of character-string (size=%i, remaining bytes=%i)" % (tmp_len, len(tmp_s)))  # noqa: E501
             ret_s += tmp_s[1:tmp_len]
@@ -468,7 +468,7 @@ def IE_Dispatcher(s):
     """Choose the correct Information Element class."""
 
     # Get the IE type
-    ietype = (orb(s[0]) * 256) + orb(s[1])
+    ietype = (s[0] * 256) + s[1]
     if ietype & 0x8000:
         return IE_EnterpriseSpecific(s)
 

--- a/scapy/contrib/pim.py
+++ b/scapy/contrib/pim.py
@@ -17,7 +17,6 @@ from scapy.fields import BitFieldLenField, BitField, BitEnumField, ByteField, \
 from scapy.layers.inet import IP
 from scapy.layers.inet6 import IPv6, in6_chksum, _IPv6ExtHdr
 from scapy.utils import checksum
-from scapy.compat import orb
 from scapy.config import conf
 from scapy.volatile import RandInt
 
@@ -75,7 +74,7 @@ class PIMv2Hdr(Packet):
 def _guess_pim_tlv_class(h_classes, default_key, pkt, **kargs):
     cls = conf.raw_layer
     if len(pkt) >= 2:
-        tlvtype = orb(pkt[1])
+        tlvtype = pkt[1]
         cls = h_classes.get(tlvtype, default_key)
     return cls(pkt, **kargs)
 

--- a/scapy/contrib/pnio_dcp.py
+++ b/scapy/contrib/pnio_dcp.py
@@ -6,7 +6,6 @@
 # scapy.contrib.description = Profinet DCP layer
 # scapy.contrib.status = loads
 
-from scapy.compat import orb
 from scapy.all import Packet, bind_layers, Padding
 from scapy.fields import (
     ByteEnumField,
@@ -459,8 +458,8 @@ def guess_dcp_block_class(packet, **kargs):
     :return: dcp block class
     """
     # packet = unicode(packet, "utf-8")
-    option = orb(packet[0])
-    suboption = orb(packet[1])
+    option = packet[0]
+    suboption = packet[1]
 
     # NOTE implement the other functions if needed
 

--- a/scapy/contrib/rpl_metrics.py
+++ b/scapy/contrib/rpl_metrics.py
@@ -19,7 +19,6 @@ RFC 6551 - Routing Metrics Used for Path Calculation in LLNs
 """
 
 import struct
-from scapy.compat import orb
 from scapy.packet import Packet
 from scapy.fields import ByteEnumField, ByteField, ShortField, BitField, \
     BitEnumField, FieldLenField, StrLenField, IntField
@@ -65,7 +64,7 @@ class DAGMCObjUnknown(Packet):
         Dispatch hook for DAGMC sub-fields
         """
         if _pkt:
-            opt_type = orb(_pkt[0])  # Option type
+            opt_type = _pkt[0]  # Option type
             if opt_type in DAGMC_CLS:
                 return DAGMC_CLS[opt_type]
         return cls

--- a/scapy/contrib/rtr.py
+++ b/scapy/contrib/rtr.py
@@ -23,7 +23,6 @@ from scapy.fields import IPField, IP6Field, StrLenField
 from scapy.fields import FieldLenField
 from scapy.fields import StrFixedLenField, ShortEnumField
 from scapy.layers.inet import TCP
-from scapy.compat import orb
 
 STATIC_SERIAL_NOTIFY_LENGTH = 12
 STATIC_SERIAL_QUERY_LENGTH = 12
@@ -317,8 +316,8 @@ class RTR(Packet):
           Attribution of correct type depending on version and pdu_type
         '''
         if _pkt and len(_pkt) >= 2:
-            version = orb(_pkt[0])
-            pdu_type = orb(_pkt[1])
+            version = _pkt[0]
+            pdu_type = _pkt[1]
             if version == 0:
                 return PDU_CLASS_VERSION_0[pdu_type]
             elif version == 1:

--- a/scapy/contrib/scada/iec104/__init__.py
+++ b/scapy/contrib/scada/iec104/__init__.py
@@ -43,7 +43,6 @@ from scapy.contrib.scada.iec104.iec104_fields import *  # noqa F403,F401
 from scapy.contrib.scada.iec104.iec104_information_elements import *  # noqa F403,F401
 from scapy.contrib.scada.iec104.iec104_information_objects import *  # noqa F403,F401
 
-from scapy.compat import orb
 from scapy.config import conf
 from scapy.error import warning, Scapy_Exception
 from scapy.fields import ByteField, BitField, ByteEnumField, PacketListField, \
@@ -221,8 +220,8 @@ def _iec104_apci_type_from_packet(data):
     see EN 60870-5-104:2006, sec. 5 (p. 13, fig. 6,7,8)
     """
 
-    oct_1 = orb(data[2])
-    oct_3 = orb(data[4])
+    oct_1 = data[2]
+    oct_3 = data[4]
 
     oct_1_bit_1 = bool(oct_1 & 1)
     oct_1_bit_2 = bool(oct_1 & 2)
@@ -232,7 +231,7 @@ def _iec104_apci_type_from_packet(data):
         if len(data) < 8:
             return IEC104_APDU_TYPE_UNKNOWN
 
-        is_seq_ioa = ((orb(data[7]) & 0x80) == 0x80)
+        is_seq_ioa = ((data[7] & 0x80) == 0x80)
 
         if is_seq_ioa:
             return IEC104_APDU_TYPE_I_SEQ_IOA
@@ -260,12 +259,12 @@ class IEC104_APDU(Packet):
         if payload_len < 6:
             return self.default_payload_class(payload)
 
-        if orb(payload[0]) != 0x68:
+        if payload[0] != 0x68:
             self.default_payload_class(payload)
 
         # the length field contains the number of bytes starting from the
         # first control octet
-        apdu_length = 2 + orb(payload[1])
+        apdu_length = 2 + payload[1]
 
         if payload_len < apdu_length:
             warning(
@@ -575,8 +574,8 @@ def _iec104_is_i_apdu_seq_ioa(payload):
     if len_payload < 6:
         return False
 
-    if orb(payload[0]) != 0x68 or (
-            orb(payload[1]) + 2) > len_payload or len_payload < 8:
+    if payload[0] != 0x68 or (
+            payload[1] + 2) > len_payload or len_payload < 8:
         return False
 
     return IEC104_APDU_TYPE_I_SEQ_IOA == _iec104_apci_type_from_packet(payload)
@@ -587,8 +586,8 @@ def _iec104_is_i_apdu_single_ioa(payload):
     if len_payload < 6:
         return False
 
-    if orb(payload[0]) != 0x68 or (
-            orb(payload[1]) + 2) > len_payload or len_payload < 8:
+    if payload[0] != 0x68 or (
+            payload[1] + 2) > len_payload or len_payload < 8:
         return False
 
     return IEC104_APDU_TYPE_I_SINGLE_IOA == _iec104_apci_type_from_packet(
@@ -599,7 +598,7 @@ def _iec104_is_u_apdu(payload):
     if len(payload) < 6:
         return False
 
-    if orb(payload[0]) != 0x68 or orb(payload[1]) != 4:
+    if payload[0] != 0x68 or payload[1] != 4:
         return False
 
     return IEC104_APDU_TYPE_U == _iec104_apci_type_from_packet(payload)
@@ -609,7 +608,7 @@ def _iec104_is_s_apdu(payload):
     if len(payload) < 6:
         return False
 
-    if orb(payload[0]) != 0x68 or orb(payload[1]) != 4:
+    if payload[0] != 0x68 or payload[1] != 4:
         return False
 
     return IEC104_APDU_TYPE_S == _iec104_apci_type_from_packet(payload)

--- a/scapy/contrib/scada/iec104/iec104_fields.py
+++ b/scapy/contrib/scada/iec104/iec104_fields.py
@@ -23,7 +23,6 @@
 """
 import struct
 
-from scapy.compat import orb
 from scapy.fields import Field, ThreeBytesField, BitField
 from scapy.volatile import RandSShort
 
@@ -106,8 +105,8 @@ class IEC104SequenceNumber(Field):
         return s + bytes(bytearray([b0, b1]))
 
     def getfield(self, pkt, s):
-        b0 = (orb(s[0]) & 0xfe) >> 1
-        b1 = orb(s[1])
+        b0 = (s[0] & 0xfe) >> 1
+        b1 = s[1]
 
         seq_num = b0 + (b1 << 7)
 

--- a/scapy/contrib/scada/pcom.py
+++ b/scapy/contrib/scada/pcom.py
@@ -23,7 +23,7 @@ from scapy.fields import XShortField, ByteEnumField, XByteField, \
     StrFixedLenField, StrLenField, LEShortField, \
     LEFieldLenField, XLE3BytesField, XLEShortField
 from scapy.volatile import RandShort
-from scapy.compat import bytes_encode, orb
+from scapy.compat import bytes_encode
 
 _protocol_modes = {0x65: "ascii", 0x66: "binary"}
 
@@ -101,7 +101,7 @@ class PCOMAscii(Packet):
         n = 0
         command = bytes_encode(command)
         for _, c in enumerate(command):
-            n += orb(c)
+            n += c
         return list(map(ord, hex(n % 256)[2:].zfill(2).upper()))
 
 

--- a/scapy/contrib/tacacs.py
+++ b/scapy/contrib/tacacs.py
@@ -21,7 +21,7 @@ from scapy.fields import ByteEnumField, ByteField, IntField
 from scapy.fields import FieldListField
 from scapy.fields import FieldLenField, ConditionalField, StrLenField
 from scapy.layers.inet import TCP
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.config import conf
 
 SECRET = 'test'
@@ -53,7 +53,7 @@ def obfuscate(pay, secret, session_id, version, seq):
 
     # Obf/Unobfuscation via XOR operation between plaintext and pad
 
-    return b"".join(chb(orb(pad[i]) ^ orb(pay[i])) for i in range(len(pay)))
+    return b"".join(chb(pad[i] ^ pay[i]) for i in range(len(pay)))
 
 
 TACACSPRIVLEVEL = {15: 'Root',

--- a/scapy/contrib/tcpao.py
+++ b/scapy/contrib/tcpao.py
@@ -9,7 +9,6 @@
 """Packet-processing utilities implementing RFC5925 and RFC5926"""
 
 import logging
-from scapy.compat import orb
 from scapy.layers.inet import IP, TCP
 from scapy.layers.inet import tcp_pseudoheader
 from scapy.layers.inet6 import IPv6
@@ -188,14 +187,14 @@ def build_message_from_packet(p, include_options=True, sne=0):
         doff = 5 + ((opt_len + 3) // 4)
     tcphdr_optend = doff * 4
     while pos < tcphdr_optend:
-        optnum = orb(th_bytes[pos])
+        optnum = th_bytes[pos]
         pos += 1
         if optnum == 0 or optnum == 1:
             if include_options:
                 result += bytearray([optnum])
             continue
 
-        optlen = orb(th_bytes[pos])
+        optlen = th_bytes[pos]
         pos += 1
         if pos + optlen - 2 > tcphdr_optend:
             logger.info("bad tcp option %d optlen %d beyond end-of-header",

--- a/scapy/contrib/tzsp.py
+++ b/scapy/contrib/tzsp.py
@@ -35,7 +35,6 @@
           - doesn't know the packet count tag (40 / 0x28)
 
 """
-from scapy.compat import orb
 from scapy.contrib.avs import AVSWLANHeader
 from scapy.error import warning, Scapy_Exception
 from scapy.fields import ByteField, ShortEnumField, IntField, FieldLenField, YesNoByteField  # noqa: E501
@@ -131,7 +130,7 @@ def _tzsp_handle_unknown_tag(payload, tag_type):
                 'treat remaining data as Raw', tag_type)
         return Raw
 
-    tag_data_length = orb(payload[1])
+    tag_data_length = payload[1]
 
     tag_data_fits_in_payload = (tag_data_length + 2) <= payload_len
     if not tag_data_fits_in_payload:
@@ -153,7 +152,7 @@ def _tzsp_guess_next_tag(payload):
         warning('missing payload')
         return None
 
-    tag_type = orb(payload[0])
+    tag_type = payload[0]
 
     try:
         tag_class_definition = _TZSP_TAG_CLASSES[tag_type]
@@ -166,7 +165,7 @@ def _tzsp_guess_next_tag(payload):
         return tag_class_definition
 
     try:
-        length = orb(payload[1])
+        length = payload[1]
     except IndexError:
         length = None
 

--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -9,7 +9,7 @@
 
 import struct
 
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.config import conf
 from scapy.data import (
     DLT_BLUETOOTH_LE_LL,
@@ -237,7 +237,7 @@ class BTLE(Packet):
 
         state = swapbits(init & 0xff) + (swapbits((init >> 8) & 0xff) << 8) + (swapbits((init >> 16) & 0xff) << 16)  # noqa: E501
         lfsr_mask = 0x5a6000
-        for i in (orb(x) for x in pdu):
+        for i in pdu:
             for j in range(8):
                 next_bit = (state ^ i) & 1
                 i >>= 1

--- a/scapy/layers/clns.py
+++ b/scapy/layers/clns.py
@@ -20,7 +20,6 @@ from scapy.config import conf
 from scapy.fields import ByteEnumField, PacketField
 from scapy.layers.l2 import LLC
 from scapy.packet import Packet, bind_top_down, bind_bottom_up
-from scapy.compat import orb
 
 network_layer_protocol_ids = {
     0x00: "Null",
@@ -54,7 +53,7 @@ def _create_cln_pdu(s, **kwargs):
     pdu_cls = conf.raw_layer
 
     if len(s) >= 1:
-        nlpid = orb(s[0])
+        nlpid = s[0]
         pdu_cls = _cln_protocols.get(nlpid, _GenericClnsPdu)
 
     return pdu_cls(s, **kwargs)

--- a/scapy/layers/dhcp.py
+++ b/scapy/layers/dhcp.py
@@ -25,7 +25,7 @@ import re
 
 from scapy.ansmachine import AnsweringMachine
 from scapy.base_classes import Net
-from scapy.compat import chb, orb, bytes_encode
+from scapy.compat import chb, bytes_encode
 from scapy.fields import (
     ByteEnumField,
     ByteField,
@@ -172,7 +172,7 @@ class ClasslessStaticRoutesField(Field):
     def m2i(self, pkt, x):
         # type: (Packet, bytes) -> str
         # b'\x20\x01\x02\x03\x04\t\x08\x07\x06' -> (1.2.3.4/32:9.8.7.6)
-        prefix = orb(x[0])
+        prefix = x[0]
 
         octets = (prefix + 7) // 8
         # Create the destination IP by using the number of octets
@@ -203,7 +203,7 @@ class ClasslessStaticRoutesField(Field):
         return struct.pack('b', prefix) + dest + router
 
     def getfield(self, pkt, s):
-        prefix = orb(s[0])
+        prefix = s[0]
         route_len = 5 + (prefix + 7) // 8
         return s[route_len:], self.m2i(pkt, s[:route_len])
 
@@ -433,7 +433,7 @@ class DHCPOptionsField(StrField):
                     vv = ",".join(repr(val) for val in v[1:])
                 s.append("%s=%s" % (v[0], vv))
             else:
-                s.append(sane(v))
+                s.append(sane(bytes_encode(v)))
         return "[%s]" % (" ".join(s))
 
     def getfield(self, pkt, s):
@@ -442,7 +442,7 @@ class DHCPOptionsField(StrField):
     def m2i(self, pkt, x):
         opt = []
         while x:
-            o = orb(x[0])
+            o = x[0]
             if o == 255:
                 opt.append("end")
                 x = x[1:]
@@ -451,18 +451,18 @@ class DHCPOptionsField(StrField):
                 opt.append("pad")
                 x = x[1:]
                 continue
-            if len(x) < 2 or len(x) < orb(x[1]) + 2:
+            if len(x) < 2 or len(x) < x[1] + 2:
                 opt.append(x)
                 break
             elif o in DHCPOptions:
                 f = DHCPOptions[o]
 
                 if isinstance(f, str):
-                    olen = orb(x[1])
+                    olen = x[1]
                     opt.append((f, x[2:olen + 2]))
                     x = x[olen + 2:]
                 else:
-                    olen = orb(x[1])
+                    olen = x[1]
                     lval = [f.name]
 
                     if olen == 0:
@@ -487,7 +487,7 @@ class DHCPOptionsField(StrField):
                     opt.append(otuple)
                     x = x[olen + 2:]
             else:
-                olen = orb(x[1])
+                olen = x[1]
                 opt.append((o, x[2:olen + 2]))
                 x = x[olen + 2:]
         return opt

--- a/scapy/layers/dhcp6.py
+++ b/scapy/layers/dhcp6.py
@@ -18,7 +18,7 @@ from scapy.ansmachine import AnsweringMachine
 from scapy.arch import get_if_hwaddr, in6_getifaddr
 from scapy.config import conf
 from scapy.data import EPOCH, ETHER_ANY
-from scapy.compat import raw, orb
+from scapy.compat import raw
 from scapy.error import warning
 from scapy.fields import BitField, ByteEnumField, ByteField, FieldLenField, \
     FlagsField, IntEnumField, IntField, MACField, \
@@ -66,7 +66,7 @@ dhcp6_cls_by_type = {1: "DHCP6_Solicit",
 def _dhcp6_dispatcher(x, *args, **kargs):
     cls = conf.raw_layer
     if len(x) >= 2:
-        cls = get_cls(dhcp6_cls_by_type.get(orb(x[0]), "Raw"), conf.raw_layer)
+        cls = get_cls(dhcp6_cls_by_type.get(x[0], "Raw"), conf.raw_layer)
     return cls(x, *args, **kargs)
 
 #############################################################################

--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -18,7 +18,7 @@ from zlib import crc32
 from scapy.config import conf, crypto_validator
 from scapy.data import ETHER_ANY, DLT_IEEE802_11, DLT_PRISM_HEADER, \
     DLT_IEEE802_11_RADIO
-from scapy.compat import raw, plain_str, orb, chb
+from scapy.compat import raw, plain_str, chb
 from scapy.packet import Packet, bind_layers, bind_top_down, NoPayload
 from scapy.fields import (
     BitEnumField,
@@ -1081,7 +1081,7 @@ class Dot11Elt(Packet):
         # This allows to introduce new Dot11Elt classes without breaking
         # previous code
         if len(s) >= 3:
-            length = orb(s[1])
+            length = s[1]
             if length > 0 and length <= 255:
                 self.info = s[2:2 + length]
         return s
@@ -1476,7 +1476,7 @@ class Dot11EltMicrosoftWPA(Dot11EltVendorSpecific):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            type_ = orb(_pkt[5])
+            type_ = _pkt[5]
             if type_ == 0x01:
                 # MS WPA IE
                 return Dot11EltMicrosoftWPA
@@ -1581,7 +1581,7 @@ class Dot11EltExtension(Dot11Elt):
             return cls
 
         if _pkt:
-            ext_id = orb(_pkt[2])
+            ext_id = _pkt[2]
             idcls = cls.registered_ext_ids.get(ext_id)
             if idcls is not None:
                 return idcls
@@ -2303,10 +2303,10 @@ class Dot11Encrypted(Packet):
         KEY_EXTIV = 0x20
         EXTIV_LEN = 8
         if _pkt and len(_pkt) >= 3:
-            if (orb(_pkt[3]) & KEY_EXTIV) and (len(_pkt) >= EXTIV_LEN):
-                if orb(_pkt[1]) == ((orb(_pkt[0]) | 0x20) & 0x7f):  # IS_TKIP
+            if (_pkt[3] & KEY_EXTIV) and (len(_pkt) >= EXTIV_LEN):
+                if _pkt[1] == ((_pkt[0] | 0x20) & 0x7f):  # IS_TKIP
                     return Dot11TKIP
-                elif orb(_pkt[2]) == 0:  # IS_CCMP
+                elif _pkt[2] == 0:  # IS_CCMP
                     return Dot11CCMP
                 else:
                     # Unknown encryption algorithm

--- a/scapy/layers/dot15d4.py
+++ b/scapy/layers/dot15d4.py
@@ -13,7 +13,7 @@ Wireless MAC according to IEEE 802.15.4.
 
 import struct
 
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.error import warning
 from scapy.config import conf
 
@@ -171,7 +171,7 @@ class Dot15d4FCS(Dot15d4):
         #   http://regregex.bbcmicro.net/crc-catalogue.htm#crc.cat.kermit
         crc = 0
         for i in range(0, len(data)):
-            c = orb(data[i])
+            c = data[i]
             q = (crc ^ c) & 15  # Do low-order 4 bits
             crc = (crc // 16) ^ (q * 4225)
             q = (crc ^ (c // 16)) & 15  # And high 4 bits

--- a/scapy/layers/eap.py
+++ b/scapy/layers/eap.py
@@ -41,7 +41,7 @@ from scapy.packet import (
 )
 from scapy.layers.l2 import SourceMACField, Ether, CookedLinux, GRE, SNAP
 from scapy.config import conf
-from scapy.compat import orb, chb
+from scapy.compat import chb
 
 #
 # EAPOL
@@ -256,9 +256,9 @@ class EAP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            c = orb(_pkt[0])
+            c = _pkt[0]
             if c in [1, 2] and len(_pkt) >= 5:
-                t = orb(_pkt[4])
+                t = _pkt[4]
                 return cls.registered_methods.get(t, cls)
         return cls
 
@@ -578,7 +578,7 @@ class MKAParamSet(Packet):
 
         cls = conf.raw_layer
         if _pkt is not None:
-            ptype = orb(_pkt[0])
+            ptype = _pkt[0]
             return globals().get(_param_set_cls.get(ptype), conf.raw_layer)
 
         return cls

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -40,7 +40,7 @@ from scapy.layers.l2 import (
     arpcachepoison,
     getmacbyip,
 )
-from scapy.compat import raw, chb, orb, bytes_encode, Optional
+from scapy.compat import raw, chb, bytes_encode, Optional
 from scapy.config import conf
 from scapy.fields import (
     BitEnumField,
@@ -160,7 +160,7 @@ class IPOption(Packet):
     @classmethod
     def dispatch_hook(cls, pkt=None, *args, **kargs):
         if pkt:
-            opt = orb(pkt[0]) & 0x1f
+            opt = pkt[0] & 0x1f
             if opt in cls.registered_ip_options:
                 return cls.registered_ip_options[opt]
         return cls
@@ -412,7 +412,7 @@ class TCPOptionsField(StrField):
     def m2i(self, pkt, x):
         opt = []
         while x:
-            onum = orb(x[0])
+            onum = x[0]
             if onum == 0:
                 opt.append(("EOL", None))
                 break
@@ -421,7 +421,7 @@ class TCPOptionsField(StrField):
                 x = x[1:]
                 continue
             try:
-                olen = orb(x[1])
+                olen = x[1]
             except IndexError:
                 olen = 0
             if olen < 2:
@@ -765,7 +765,7 @@ class TCP(Packet):
         if dataofs is None:
             opt_len = len(self.get_field("options").i2m(self, self.options))
             dataofs = 5 + ((opt_len + 3) // 4)
-            dataofs = (dataofs << 4) | orb(p[12]) & 0x0f
+            dataofs = (dataofs << 4) | p[12] & 0x0f
             p = p[:12] + chb(dataofs & 0xff) + p[13:]
         if self.chksum is None:
             if isinstance(self.underlayer, IP):

--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -21,7 +21,7 @@ from time import gmtime, strftime
 from scapy.arch import get_if_hwaddr
 from scapy.as_resolvers import AS_resolver_riswhois
 from scapy.base_classes import Gen, _ScopedIP
-from scapy.compat import chb, orb, raw, plain_str, bytes_encode
+from scapy.compat import chb, raw, plain_str, bytes_encode
 from scapy.consts import WINDOWS, OPENBSD
 from scapy.config import conf
 from scapy.data import (
@@ -295,7 +295,7 @@ class _IPv6GuessPayload:
 
     def default_payload_class(self, p):
         if self.nh == 58:  # ICMPv6
-            t = orb(p[0])
+            t = p[0]
             if len(p) > 2 and (t == 139 or t == 140):  # Node Info Query
                 return _niquery_guesser(p)
             if len(p) >= icmp6typesminhdrlen.get(t, float("inf")):  # Other ICMPv6 messages  # noqa: E501
@@ -305,8 +305,8 @@ class _IPv6GuessPayload:
                 return icmp6typescls.get(t, Raw)
             return Raw
         elif self.nh == 135 and len(p) > 3:  # Mobile IPv6
-            return _mip6_mhtype2cls.get(orb(p[2]), MIP6MH_Generic)
-        elif self.nh == 43 and orb(p[2]) == 4:  # Segment Routing header
+            return _mip6_mhtype2cls.get(p[2], MIP6MH_Generic)
+        elif self.nh == 43 and p[2] == 4:  # Segment Routing header
             return IPv6ExtHdrSegmentRouting
         return ipv6nhcls.get(self.nh, Raw)
 
@@ -347,7 +347,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
 
         if self.plen == 0 and self.nh == 0 and len(data) >= 8:
             # Extract Hop-by-Hop extension length
-            hbh_len = orb(data[1])
+            hbh_len = data[1]
             hbh_len = 8 + hbh_len * 8
 
             # Extract length from the Jumbogram option
@@ -357,7 +357,7 @@ class IPv6(_IPv6GuessPayload, Packet, IPTools):
             idx = 0
             offset = 4 * idx + 2
             while offset <= len(data):
-                opt_type = orb(data[offset])
+                opt_type = data[offset]
                 if opt_type == 0xc2:  # Jumbo option
                     jumbo_len = struct.unpack("I", data[offset + 2:offset + 2 + 4])[0]  # noqa: E501
                     break
@@ -513,7 +513,7 @@ class IPv46(IP, IPv6):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         if _pkt:
-            if orb(_pkt[0]) >> 4 == 6:
+            if _pkt[0] >> 4 == 6:
                 return IPv6
         elif kargs.get("version") == 6:
             return IPv6
@@ -781,7 +781,7 @@ class HBHOptUnknown(Packet):  # IPv6 Hop-By-Hop Option
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[0])  # Option type
+            o = _pkt[0]  # Option type
             if o in _hbhoptcls:
                 return _hbhoptcls[o]
         return cls
@@ -1826,7 +1826,7 @@ class _ICMPv6NDGuessPayload:
 
     def guess_payload_class(self, p):
         if len(p) > 1:
-            return icmp6ndoptscls.get(orb(p[0]), ICMPv6NDOptUnknown)
+            return icmp6ndoptscls.get(p[0], ICMPv6NDOptUnknown)
 
 
 # Beginning of ICMPv6 Neighbor Discovery Options.
@@ -2146,7 +2146,7 @@ class DomainNameListField(StrLenField):
 
     def i2m(self, pkt, x):
         def conditionalTrailingDot(z):
-            if z and orb(z[-1]) == 0:
+            if z and z[-1] == 0:
                 return z
             return z + b'\x00'
         # Build the encode names
@@ -2462,14 +2462,14 @@ def dnsrepr2names(x):
     res = []
     cur = b""
     while x:
-        tmp_len = orb(x[0])
+        tmp_len = x[0]
         x = x[1:]
         if not tmp_len:
             if cur and cur[-1:] == b'.':
                 cur = cur[:-1]
             res.append(cur)
             cur = b""
-            if x and orb(x[0]) == 0:  # single component
+            if x and x[0] == 0:  # single component
                 x = x[1:]
             continue
         if tmp_len & 0xc0:  # XXX TODO : work on that -- arno
@@ -2520,7 +2520,7 @@ class NIQueryDataField(StrField):
             # possible weird data extracted info
             res = []
             while val:
-                tmp_len = orb(val[0])
+                tmp_len = val[0]
                 val = val[1:]
                 if tmp_len == 0:
                     break
@@ -2804,7 +2804,7 @@ class ICMPv6NIReplyUnknown(ICMPv6NIReplyNOOP):
 
 def _niquery_guesser(p):
     cls = conf.raw_layer
-    type = orb(p[0])
+    type = p[0]
     if type == 139:  # Node Info Query specific stuff
         if len(p) > 6:
             qtype, = struct.unpack("!H", p[4:6])
@@ -2813,7 +2813,7 @@ def _niquery_guesser(p):
                    3: ICMPv6NIQueryIPv6,
                    4: ICMPv6NIQueryIPv4}.get(qtype, conf.raw_layer)
     elif type == 140:  # Node Info Reply specific stuff
-        code = orb(p[1])
+        code = p[1]
         if code == 0:
             if len(p) > 6:
                 qtype, = struct.unpack("!H", p[4:6])
@@ -3152,7 +3152,7 @@ class MIP6OptUnknown(_MIP6OptAlign):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         if _pkt:
-            o = orb(_pkt[0])  # Option type
+            o = _pkt[0]  # Option type
             if o in moboptcls:
                 return moboptcls[o]
         return cls

--- a/scapy/layers/ipsec.py
+++ b/scapy/layers/ipsec.py
@@ -40,7 +40,7 @@ import struct
 import warnings
 
 from scapy.config import conf, crypto_validator
-from scapy.compat import orb, raw
+from scapy.compat import raw
 from scapy.data import IP_PROTOS
 from scapy.error import log_loading
 from scapy.fields import (
@@ -500,8 +500,8 @@ class CryptAlgo(object):
                     raise IPSecIntegrityError(err)
 
         # extract padlen and nh
-        padlen = orb(data[-2])
-        nh = orb(data[-1])
+        padlen = data[-2]
+        nh = data[-1]
 
         # then use padlen to determine data and padding
         padding = data[len(data) - padlen - 2: len(data) - 2]

--- a/scapy/layers/llmnr.py
+++ b/scapy/layers/llmnr.py
@@ -21,7 +21,6 @@ from scapy.fields import (
     ShortField,
 )
 from scapy.packet import Packet, bind_layers, bind_bottom_up
-from scapy.compat import orb
 from scapy.layers.inet import UDP, DestIPField
 from scapy.layers.dns import (
     DNSCompressedPacket,
@@ -91,7 +90,7 @@ class _LLMNR(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if len(_pkt) >= 2:
-            if (orb(_pkt[2]) & 0x80):  # Response
+            if (_pkt[2] & 0x80):  # Response
                 return LLMNRResponse
             else:                  # Query
                 return LLMNRQuery

--- a/scapy/layers/lltd.py
+++ b/scapy/layers/lltd.py
@@ -21,7 +21,7 @@ from scapy.layers.l2 import Ether
 from scapy.layers.inet import IPField
 from scapy.layers.inet6 import IP6Field
 from scapy.data import ETHER_ANY
-from scapy.compat import orb, chb
+from scapy.compat import chb
 
 
 # Protocol layers
@@ -212,7 +212,7 @@ class LLTDQueryResp(Packet):
         if self.descs_count is None:
             # descs_count should be a FieldLenField but has an
             # unsupported format (14 bits)
-            flags = orb(pkt[0]) & 0xc0
+            flags = pkt[0] & 0xc0
             count = len(self.descs_list)
             pkt = chb(flags + (count >> 8)) + chb(count % 256) + pkt[2:]
         return pkt + pay
@@ -254,7 +254,7 @@ class LLTDQueryLargeTlvResp(Packet):
         if self.len is None:
             # len should be a FieldLenField but has an unsupported
             # format (14 bits)
-            flags = orb(pkt[0]) & 0xc0
+            flags = pkt[0] & 0xc0
             length = len(self.value)
             pkt = chb(flags + (length >> 8)) + chb(length % 256) + pkt[2:]
         return pkt + pay
@@ -294,7 +294,7 @@ class LLTDAttribute(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         if _pkt:
-            cmd = orb(_pkt[0])
+            cmd = _pkt[0]
         elif "type" in kargs:
             cmd = kargs["type"]
             if isinstance(cmd, str):

--- a/scapy/layers/ntp.py
+++ b/scapy/layers/ntp.py
@@ -44,7 +44,6 @@ from scapy.fields import (
 )
 from scapy.layers.inet import UDP
 from scapy.utils import lhex
-from scapy.compat import orb
 from scapy.config import conf
 
 
@@ -197,7 +196,7 @@ def _ntp_dispatcher(payload):
     else:
         length = len(payload)
         if length >= _NTP_PACKET_MIN_SIZE:
-            first_byte = orb(payload[0])
+            first_byte = payload[0]
             # Extract NTP mode
             mode = first_byte & 7
             return {6: NTPControl, 7: NTPPrivate}.get(mode, NTPHeader)

--- a/scapy/layers/ppp.py
+++ b/scapy/layers/ppp.py
@@ -13,7 +13,6 @@ import struct
 from scapy.config import conf
 from scapy.data import DLT_PPP, DLT_PPP_SERIAL, DLT_PPP_ETHER, \
     DLT_PPP_WITH_DIR
-from scapy.compat import orb
 from scapy.packet import Packet, bind_layers
 from scapy.layers.eap import EAP
 from scapy.layers.l2 import Ether, CookedLinux, GRE_PPTP
@@ -390,7 +389,7 @@ class PPP_IPCP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[0])
+            o = _pkt[0]
             return cls.registered_options.get(o, cls)
         return cls
 
@@ -464,7 +463,7 @@ class PPP_ECP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[0])
+            o = _pkt[0]
             return cls.registered_options.get(o, cls)
         return cls
 
@@ -525,7 +524,7 @@ class PPP_LCP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[0])
+            o = _pkt[0]
             if o in [1, 2, 3, 4]:
                 return PPP_LCP_Configure
             elif o in [5, 6]:
@@ -574,7 +573,7 @@ class PPP_LCP_Option(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[0])
+            o = _pkt[0]
             return cls.registered_options.get(o, cls)
         return cls
 
@@ -763,7 +762,7 @@ class PPP_PAP(Packet):
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         code = None
         if _pkt:
-            code = orb(_pkt[0])
+            code = _pkt[0]
         elif "code" in kargs:
             code = kargs["code"]
             if isinstance(code, str):
@@ -844,7 +843,7 @@ class PPP_CHAP(Packet):
     def dispatch_hook(cls, _pkt=None, *_, **kargs):
         code = None
         if _pkt:
-            code = orb(_pkt[0])
+            code = _pkt[0]
         elif "code" in kargs:
             code = kargs["code"]
             if isinstance(code, str):

--- a/scapy/layers/pptp.py
+++ b/scapy/layers/pptp.py
@@ -11,7 +11,6 @@ PPTP (Point to Point Tunneling Protocol)
 
 from scapy.packet import Packet, bind_layers
 from scapy.layers.inet import TCP
-from scapy.compat import orb
 from scapy.fields import ByteEnumField, FieldLenField, FlagsField, IntField, \
     IntEnumField, LenField, XIntField, ShortField, ShortEnumField, \
     StrFixedLenField, StrLenField, XShortField, XByteField
@@ -69,7 +68,7 @@ class PPTP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt:
-            o = orb(_pkt[9])
+            o = _pkt[9]
             return cls.registered_options.get(o, cls)
         return cls
 

--- a/scapy/layers/sctp.py
+++ b/scapy/layers/sctp.py
@@ -10,7 +10,7 @@ SCTP (Stream Control Transmission Protocol).
 
 import struct
 
-from scapy.compat import orb, raw
+from scapy.compat import raw
 from scapy.volatile import RandBin
 from scapy.config import conf
 from scapy.packet import Packet, bind_layers
@@ -113,7 +113,7 @@ crc32c_table = [
 def crc32c(buf):
     crc = 0xffffffff
     for c in buf:
-        crc = (crc >> 8) ^ crc32c_table[(crc ^ (orb(c))) & 0xFF]
+        crc = (crc >> 8) ^ crc32c_table[(crc ^ (c)) & 0xFF]
     crc = (~crc) & 0xffffffff
     # reverse endianness
     return struct.unpack(">I", struct.pack("<I", crc))[0]
@@ -128,8 +128,8 @@ def update_adler32(adler, buf):
     print(s1, s2)
 
     for c in buf:
-        print(orb(c))
-        s1 = (s1 + orb(c)) % BASE
+        print(c)
+        s1 = (s1 + c) % BASE
         s2 = (s2 + s1) % BASE
         print(s1, s2)
     return (s2 << 16) + s1
@@ -261,7 +261,7 @@ class _SCTPChunkGuessPayload:
         if len(p) < 4:
             return conf.padding_layer
         else:
-            t = orb(p[0])
+            t = p[0]
             return globals().get(sctpchunktypescls.get(t, "Raw"), conf.raw_layer)  # noqa: E501
 
 
@@ -327,7 +327,7 @@ class ChunkParamField(PacketListField):
     def m2i(self, p, m):
         cls = conf.raw_layer
         if len(m) >= 4:
-            t = orb(m[0]) * 256 + orb(m[1])
+            t = m[0] * 256 + m[1]
             cls = globals().get(sctpchunkparamtypescls.get(t, "Raw"), conf.raw_layer)  # noqa: E501
         return cls(m)
 

--- a/scapy/layers/sixlowpan.py
+++ b/scapy/layers/sixlowpan.py
@@ -51,7 +51,7 @@ Known Issues:
 import socket
 import struct
 
-from scapy.compat import chb, orb, raw
+from scapy.compat import chb, raw
 from scapy.data import ETHER_TYPES
 
 from scapy.packet import Packet, bind_layers, bind_top_down
@@ -528,7 +528,7 @@ def _extract_upperaddress(pkt, source=True):
         if addrmode == 3:  # Extended/long
             tmp_ip = LINK_LOCAL_PREFIX[0:8] + addr
             # Turn off the bit 7.
-            return tmp_ip[0:8] + struct.pack("B", (orb(tmp_ip[8]) ^ 0x2)) + tmp_ip[9:16]  # noqa: E501
+            return tmp_ip[0:8] + struct.pack("B", (tmp_ip[8] ^ 0x2)) + tmp_ip[9:16]  # noqa: E501
         elif addrmode == 2:  # Short
             return (
                 LINK_LOCAL_PREFIX[0:8] +

--- a/scapy/layers/tls/basefields.py
+++ b/scapy/layers/tls/basefields.py
@@ -11,7 +11,6 @@ upon the TLS version or ciphersuite, the packet has to provide a TLS context.
 import struct
 
 from scapy.fields import ByteField, ShortEnumField, ShortField, StrField
-from scapy.compat import orb
 
 _tls_type = {20: "change_cipher_spec",
              21: "alert",
@@ -203,7 +202,7 @@ class _TLSPadField(StrField):
             # because it's possible that the padding is followed by some data
             # from another TLS record (hence the last byte from s would not be
             # the last byte from the current record padding).
-            tmp_len = orb(s[pkt.padlen - 1])
+            tmp_len = s[pkt.padlen - 1]
             return s[tmp_len:], self.m2i(pkt, s[:tmp_len])
         return s, None
 

--- a/scapy/layers/tls/handshake.py
+++ b/scapy/layers/tls/handshake.py
@@ -34,7 +34,7 @@ from scapy.fields import (
     UTCTimeField,
 )
 
-from scapy.compat import hex_bytes, orb, raw
+from scapy.compat import hex_bytes, raw
 from scapy.config import conf, crypto_validator
 from scapy.packet import Packet, Raw, Padding
 from scapy.utils import randstring, repr_hex
@@ -104,7 +104,7 @@ class _TLSHandshake(_GenericTLSSessionInheritance):
         tmp_len = len(p)
         if self.msglen is None:
             l2 = tmp_len - 4
-            p = struct.pack("!I", (orb(p[0]) << 24) | l2) + p[4:]
+            p = struct.pack("!I", (p[0] << 24) | l2) + p[4:]
         return p + pay
 
     def guess_payload_class(self, p):
@@ -395,7 +395,7 @@ class TLS13ClientHello(_TLSHandshake):
         tmp_len = len(p)
         if self.msglen is None:
             sz = tmp_len - 4
-            p = struct.pack("!I", (orb(p[0]) << 24) | sz) + p[4:]
+            p = struct.pack("!I", (p[0] << 24) | sz) + p[4:]
         s = self.tls_session
         if self.ext:
             for e in self.ext:

--- a/scapy/layers/tls/keyexchange.py
+++ b/scapy/layers/tls/keyexchange.py
@@ -18,7 +18,6 @@ from scapy.error import warning
 from scapy.fields import ByteEnumField, ByteField, EnumField, FieldLenField, \
     FieldListField, PacketField, ShortEnumField, ShortField, \
     StrFixedLenField, StrLenField
-from scapy.compat import orb
 from scapy.packet import Packet, Raw, Padding
 from scapy.layers.tls.cert import PubKeyRSA, PrivKeyRSA
 from scapy.layers.tls.session import _GenericTLSSessionInheritance
@@ -662,7 +661,7 @@ _tls_server_ecdh_cls = {1: ServerECDHExplicitPrimeParams,
 def _tls_server_ecdh_cls_guess(m):
     if not m:
         return None
-    curve_type = orb(m[0])
+    curve_type = m[0]
     return _tls_server_ecdh_cls.get(curve_type, None)
 
 

--- a/scapy/layers/tls/record.py
+++ b/scapy/layers/tls/record.py
@@ -20,7 +20,7 @@ import struct
 from scapy.config import conf
 from scapy.error import log_runtime
 from scapy.fields import ByteEnumField, PacketListField, StrField
-from scapy.compat import raw, chb, orb
+from scapy.compat import raw, chb
 from scapy.utils import randstring
 from scapy.packet import Raw, Padding, bind_layers
 from scapy.layers.inet import TCP
@@ -84,7 +84,7 @@ class _TLSMsgListField(PacketListField):
         cls = Raw
         if pkt.type == 22:
             if len(m) >= 1:
-                msgtype = orb(m[0])
+                msgtype = m[0]
                 # If a version was agreed on by both client and server,
                 # we use it (tls_session.tls_version)
                 # Otherwise, if the client advertised for TLS 1.3, we try to
@@ -501,7 +501,7 @@ class TLS(_GenericTLSSessionInheritance):
                 #    hdr = hdr[:3] + struct.pack('!H', l-block_size)
 
                 # Extract padding ('pad' actually includes the trailing padlen)
-                padlen = orb(pfrag[-1]) + 1
+                padlen = pfrag[-1] + 1
                 mfrag, pad = pfrag[:-padlen], pfrag[-padlen:]
                 self.padlen = padlen
 

--- a/scapy/layers/tls/record_sslv2.py
+++ b/scapy/layers/tls/record_sslv2.py
@@ -11,7 +11,7 @@ import struct
 
 from scapy.config import conf
 from scapy.error import log_runtime
-from scapy.compat import orb, raw
+from scapy.compat import raw
 from scapy.packet import Raw
 from scapy.layers.tls.session import _GenericTLSSessionInheritance
 from scapy.layers.tls.record import _TLSMsgListField, TLS
@@ -36,7 +36,7 @@ class _SSLv2MsgListField(_TLSMsgListField):
     def m2i(self, pkt, m):
         cls = Raw
         if len(m) >= 1:
-            msgtype = orb(m[0])
+            msgtype = m[0]
             cls = _sslv2_handshake_cls.get(msgtype, Raw)
 
         if cls is Raw:
@@ -131,7 +131,7 @@ class SSLv2(TLS):
         # Extract padding
         padlen = 0
         if hdrlen == 3:
-            padlen = orb(s[2])
+            padlen = s[2]
         if padlen == 0:
             cfrag, pad = pfrag, b""
         else:

--- a/scapy/layers/tls/record_tls13.py
+++ b/scapy/layers/tls/record_tls13.py
@@ -16,7 +16,7 @@ See the TLS class documentation for more information.
 import struct
 
 from scapy.error import log_runtime, warning
-from scapy.compat import raw, orb
+from scapy.compat import raw
 from scapy.fields import ByteEnumField, PacketField, XStrField
 from scapy.layers.tls.session import _GenericTLSSessionInheritance
 from scapy.layers.tls.basefields import _TLSVersionField, _tls_version, \
@@ -140,7 +140,7 @@ class TLS13(_GenericTLSSessionInheritance):
         if len(s) < 5:
             raise Exception("Invalid record: header is too short.")
 
-        self.type = orb(s[0])
+        self.type = s[0]
         if (isinstance(self.tls_session.rcs.cipher, Cipher_NULL) or
                 self.type == 0x14):
             self.deciphered_len = None

--- a/scapy/layers/tls/tools.py
+++ b/scapy/layers/tls/tools.py
@@ -10,7 +10,7 @@ TLS helpers, provided as out-of-context methods.
 
 import struct
 
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.error import warning
 from scapy.fields import (ByteEnumField, ShortEnumField,
                           FieldLenField, StrLenField)
@@ -130,7 +130,7 @@ def _tls_del_pad(p):
         warning("Message format is invalid (padding)")
         return False
 
-    padlen = orb(p.data[-1])
+    padlen = p.data[-1]
     padsize = padlen + 1
 
     if p.len < padsize:

--- a/scapy/layers/vrrp.py
+++ b/scapy/layers/vrrp.py
@@ -11,7 +11,7 @@ VRRP (Virtual Router Redundancy Protocol).
 from scapy.packet import Packet, bind_layers
 from scapy.fields import BitField, ByteField, FieldLenField, FieldListField, \
     IPField, IP6Field, IntField, MultipleTypeField, StrField, XShortField
-from scapy.compat import chb, orb
+from scapy.compat import chb
 from scapy.layers.inet import IP, in4_chksum, checksum
 from scapy.layers.inet6 import IPv6, in6_chksum
 from scapy.error import warning
@@ -45,7 +45,7 @@ class VRRP(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 9:
-            ver_n_type = orb(_pkt[0])
+            ver_n_type = _pkt[0]
             if ver_n_type >= 48 and ver_n_type <= 57:  # Version == 3
                 return VRRPv3
         return VRRP
@@ -91,7 +91,7 @@ class VRRPv3(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=None, *args, **kargs):
         if _pkt and len(_pkt) >= 16:
-            ver_n_type = orb(_pkt[0])
+            ver_n_type = _pkt[0]
             if ver_n_type < 48 or ver_n_type > 57:  # Version != 3
                 return VRRP
         return VRRPv3

--- a/scapy/layers/x509.py
+++ b/scapy/layers/x509.py
@@ -133,7 +133,7 @@ class RSAPrivateKey(ASN1_Packet):
 class ValidationParms(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SEQUENCE(
-        ASN1F_BIT_STRING("seed", ""),
+        ASN1F_BIT_STRING("seed", b""),
         ASN1F_INTEGER("pgenCounter", 0),
     )
 
@@ -201,7 +201,7 @@ class ECParameters(ASN1_Packet):
 
 class ECDSAPublicKey(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
-    ASN1_root = ASN1F_BIT_STRING("ecPoint", "")
+    ASN1_root = ASN1F_BIT_STRING("ecPoint", b"")
 
 
 class ECDSAPrivateKey(ASN1_Packet):
@@ -250,7 +250,7 @@ class DHParameter(ASN1_Packet):
 
 class EdDSAPublicKey(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
-    ASN1_root = ASN1F_BIT_STRING("ecPoint", "")
+    ASN1_root = ASN1F_BIT_STRING("ecPoint", b"")
 
 
 class AlgorithmIdentifier(ASN1_Packet):
@@ -798,7 +798,7 @@ class X509_ExtSubjInfoAccess(ASN1_Packet):
 
 class X509_ExtNetscapeCertType(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
-    ASN1_root = ASN1F_BIT_STRING("netscapeCertType", "")
+    ASN1_root = ASN1F_BIT_STRING("netscapeCertType", b"")
 
 
 class X509_ExtComment(ASN1_Packet):
@@ -1014,7 +1014,7 @@ class ASN1F_X509_SubjectPublicKeyInfo(ASN1F_SEQUENCE):
                                      EdDSAPublicKey),
                         lambda pkt: pkt.signatureAlgorithm.algorithm.oidname in ["Ed25519", "Ed448"]),  # noqa: E501
                    ],
-                   ASN1F_BIT_STRING("subjectPublicKey", ""))]
+                   ASN1F_BIT_STRING("subjectPublicKey", b""))]
         ASN1F_SEQUENCE.__init__(self, *seq, **kargs)
 
 
@@ -1218,7 +1218,7 @@ class ASN1F_X509_Cert(ASN1F_SEQUENCE):
                         lambda pkt: "ecdsa" in pkt.signatureAlgorithm.algorithm.oidname.lower()),  # noqa: E501
                    ],
                    ASN1F_BIT_STRING("signatureValue",
-                                    "defaultsignature" * 2))]
+                                    b"defaultsignature" * 2))]
         ASN1F_SEQUENCE.__init__(self, *seq, **kargs)
 
 
@@ -1276,7 +1276,7 @@ class ASN1F_X509_CRL(ASN1F_SEQUENCE):
                         lambda pkt: "ecdsa" in pkt.signatureAlgorithm.algorithm.oidname.lower()),  # noqa: E501
                    ],
                    ASN1F_BIT_STRING("signatureValue",
-                                    "defaultsignature" * 2))]
+                                    b"defaultsignature" * 2))]
         ASN1F_SEQUENCE.__init__(self, *seq, **kargs)
 
 
@@ -1487,7 +1487,7 @@ class CMS_OriginatorPublicKey(ASN1_Packet):
         ASN1F_PACKET("algorithm",
                      X509_AlgorithmIdentifier(),
                      X509_AlgorithmIdentifier),
-        ASN1F_BIT_STRING("publicKey", ""),
+        ASN1F_BIT_STRING("publicKey", b""),
     )
 
 
@@ -1627,7 +1627,7 @@ class CMS_ContentInfo(ASN1_Packet):
                     lambda pkt: pkt.contentType.oidname == "id-envelopedData"
                 ),
             ],
-            ASN1F_BIT_STRING("content", "", explicit_tag=0xA0)
+            ASN1F_BIT_STRING("content", b"", explicit_tag=0xA0)
         )
     )
 
@@ -1662,7 +1662,7 @@ class PKCS10_CertificationRequest(ASN1_Packet):
                      PKCS10_CertificationRequestInfo),
         ASN1F_PACKET("signatureAlgorithm", X509_AlgorithmIdentifier(),
                      X509_AlgorithmIdentifier),
-        ASN1F_BIT_STRING("signature", ASN1F_BIT_STRING("", "")),
+        ASN1F_BIT_STRING("signature", b""),
     )
 
 
@@ -1777,7 +1777,7 @@ class CMC_ENROLLMENT_CSP_PROVIDER(ASN1_Packet):
     ASN1_root = ASN1F_SEQUENCE(
         ASN1F_INTEGER("KeySpec", 0),
         ASN1F_BMP_STRING("ProviderName", ""),
-        ASN1F_BIT_STRING("Signature", ""),
+        ASN1F_BIT_STRING("Signature", b""),
     )
 
 
@@ -1943,7 +1943,7 @@ class ASN1F_OCSP_BasicResponse(ASN1F_SEQUENCE):
                         lambda pkt: "ecdsa" in pkt.signatureAlgorithm.algorithm.oidname.lower()),  # noqa: E501
                    ],
                    ASN1F_BIT_STRING("signature",
-                                    "defaultsignature" * 2)),
+                                    b"defaultsignature" * 2)),
                ASN1F_optional(
                    ASN1F_SEQUENCE_OF("certs", None, X509_Cert,
                                      explicit_tag=0xa0))]

--- a/scapy/layers/zigbee.py
+++ b/scapy/layers/zigbee.py
@@ -12,7 +12,6 @@ ZigBee bindings for IEEE 802.15.4.
 
 import struct
 
-from scapy.compat import orb
 from scapy.packet import bind_layers, bind_bottom_up, Packet
 from scapy.fields import BitField, ByteField, XLEIntField, ConditionalField, \
     ByteEnumField, EnumField, BitEnumField, FieldListField, FlagsField, \
@@ -1447,7 +1446,7 @@ class ZEP2(Packet):
     @classmethod
     def dispatch_hook(cls, _pkt=b"", *args, **kargs):
         if _pkt and len(_pkt) >= 4:
-            v = orb(_pkt[2])
+            v = _pkt[2]
             if v == 1:
                 return ZEP1
             elif v == 2:

--- a/scapy/libs/rfc3961.py
+++ b/scapy/libs/rfc3961.py
@@ -44,7 +44,6 @@ import math
 import os
 import struct
 from scapy.compat import (
-    orb,
     chb,
     int_bytes,
     bytes_int,
@@ -726,7 +725,7 @@ class _DESCBC(_SimplifiedEncryptionProfile):
             # type: (List[int]) -> bytes
             temp = b""
             for i in range(len(deskey)):
-                t = (bin(orb(deskey[i]))[2:]).rjust(8, "0")
+                t = (bin(deskey[i])[2:]).rjust(8, "0")
                 if t[:7].count("1") % 2 == 0:
                     temp += chb(int(t[:7] + "1", 2))
                 else:
@@ -760,7 +759,7 @@ class _DESCBC(_SimplifiedEncryptionProfile):
             temp56 = list()
             # removeMSBits
             for byte in block:
-                temp56.append(orb(byte) & 0b01111111)
+                temp56.append(byte & 0b01111111)
 
             # reverse
             if odd is False:

--- a/scapy/modules/krack/crypto.py
+++ b/scapy/modules/krack/crypto.py
@@ -10,7 +10,7 @@ from zlib import crc32
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 from cryptography.hazmat.backends import default_backend
 
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.layers.dot11 import Dot11TKIP
 from scapy.utils import mac2str
 
@@ -291,7 +291,7 @@ def parse_TKIP_hdr(pkt):
     # 802.11i p. 46
     assert (TSC1 | 0x20) & 0x7f == WEPseed
 
-    TA = [orb(e) for e in mac2str(pkt.addr2)]
+    TA = [e for e in mac2str(pkt.addr2)]
     TSC = [TSC0, TSC1, TSC2, TSC3, TSC4, TSC5]
 
     return TSC, TA, payload
@@ -313,9 +313,9 @@ def build_TKIP_payload(data, iv, mac, tk):
     TKIP_hdr = chb(TSC1) + chb((TSC1 | 0x20) & 0x7f) + chb(TSC0) + chb(bitfield)  # noqa: E501
     TKIP_hdr += chb(TSC2) + chb(TSC3) + chb(TSC4) + chb(TSC5)
 
-    TA = [orb(e) for e in mac2str(mac)]
+    TA = [e for e in mac2str(mac)]
     TSC = [TSC0, TSC1, TSC2, TSC3, TSC4, TSC5]
-    TK = [orb(x) for x in tk]
+    TK = [x for x in tk]
 
     rc4_key = gen_TKIP_RC4_key(TSC, TA, TK)
     return TKIP_hdr + ARC4_encrypt(rc4_key, data)
@@ -324,7 +324,7 @@ def build_TKIP_payload(data, iv, mac, tk):
 def parse_data_pkt(pkt, tk):
     """Extract data from a WPA packet @pkt with temporal key @tk"""
     TSC, TA, data = parse_TKIP_hdr(pkt)
-    TK = [orb(x) for x in tk]
+    TK = [x for x in tk]
 
     rc4_key = gen_TKIP_RC4_key(TSC, TA, TK)
     return ARC4_decrypt(rc4_key, data)

--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -13,7 +13,7 @@ import random
 
 from scapy.data import KnowledgeBase, select_path
 from scapy.config import conf
-from scapy.compat import raw, orb
+from scapy.compat import raw
 from scapy.packet import NoPayload
 from scapy.layers.inet import IP, TCP, TCPOptions
 from scapy.layers.http import HTTP, HTTPRequest, HTTPResponse
@@ -126,7 +126,7 @@ class TCP_Signature(object):
         optlen = (tcp.dataofs << 2) - 20
         x = raw(tcp)[-optlen:]  # raw bytes of TCP options
         while x:
-            onum = orb(x[0])
+            onum = x[0]
             if onum == 0:
                 x = x[1:]
                 olayout += "eol+%i," % len(x)
@@ -138,7 +138,7 @@ class TCP_Signature(object):
                 olayout += "nop,"
                 continue
             try:
-                olen = orb(x[1])
+                olen = x[1]
             except IndexError:  # no room for length field
                 addq("bad")
                 break

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -40,7 +40,7 @@ from scapy.fields import (
     StrField,
 )
 from scapy.config import conf, _version_checker
-from scapy.compat import raw, orb, bytes_encode
+from scapy.compat import raw, bytes_encode
 from scapy.base_classes import BasePacket, Gen, SetGen, Packet_metaclass, \
     _CanvasDumpExtended
 from scapy.interfaces import _GlobInterfaceType
@@ -921,7 +921,7 @@ class Packet(
 
         def hexstr(x):
             # type: (bytes) -> str
-            return " ".join("%02x" % orb(c) for c in x)
+            return " ".join("%02x" % c for c in x)
 
         def make_dump_txt(x, y, txt):
             # type: (int, float, bytes) -> pyx.text.text

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 import socket
 import struct
 
-from scapy.compat import orb
 from scapy.config import conf
 from scapy.packet import Packet
 from scapy.pton_ntop import inet_pton
@@ -241,7 +240,7 @@ class TCPSession(IPSession):
             # Bidirectional
             def xor(x, y):
                 # type: (bytes, bytes) -> bytes
-                return bytes(orb(a) ^ orb(b) for a, b in zip(x, y))
+                return bytes(a ^ b for a, b in zip(x, y))
             return struct.pack("!4sH", xor(src, dst), pkt.dport ^ pkt.sport)
         else:
             # Uni-directional

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -41,7 +41,6 @@ from scapy.config import conf
 from scapy.consts import DARWIN, OPENBSD, WINDOWS
 from scapy.data import MTU, DLT_EN10MB, DLT_RAW
 from scapy.compat import (
-    orb,
     plain_str,
     chb,
     hex_bytes,
@@ -260,10 +259,10 @@ def _open_fifo(fd: Any, mode: str = "rb") -> IO[bytes]:
 
 
 def sane(x, color=False):
-    # type: (AnyStr, bool) -> str
+    # type: (bytes, bool) -> str
     r = ""
     for i in x:
-        j = orb(i)
+        j = i
         if (j < 32) or (j >= 127):
             if color:
                 r += conf.color_theme.not_printable(".")
@@ -320,7 +319,7 @@ def hexdump(p, dump=False):
         s += "%04x  " % i
         for j in range(16):
             if i + j < x_len:
-                s += "%02X " % orb(x[i + j])
+                s += "%02X " % x[i + j]
             else:
                 s += "   "
         s += " %s\n" % sane(x[i:i + 16], color=True)
@@ -370,7 +369,7 @@ def chexdump(p, dump=False):
     :return: a String only if dump=True
     """
     x = bytes_encode(p)
-    s = ", ".join("%#04x" % orb(x) for x in x)
+    s = ", ".join("%#04x" % x for x in x)
     if dump:
         return s
     else:
@@ -385,7 +384,7 @@ def hexstr(p, onlyasc=0, onlyhex=0, color=False):
     x = bytes_encode(p)
     s = []
     if not onlyasc:
-        s.append(" ".join("%02X" % orb(b) for b in x))
+        s.append(" ".join("%02X" % b for b in x))
     if not onlyhex:
         s.append(sane(x, color=color))
     return "  ".join(s)
@@ -394,7 +393,7 @@ def hexstr(p, onlyasc=0, onlyhex=0, color=False):
 def repr_hex(s):
     # type: (bytes) -> str
     """ Convert provided bitstring to a simple string of hex digits """
-    return "".join("%02x" % orb(x) for x in s)
+    return "".join("%02x" % x for x in s)
 
 
 @conf.commands.register
@@ -557,7 +556,7 @@ def hexdiff(
             if i + j < min(len(backtrackx), len(backtracky)):
                 if line[j]:
                     col = colorize[(linex[j] != liney[j]) * (doy - dox)]
-                    print(col("%02X" % orb(line[j])), end=' ')
+                    print(col("%02X" % line[j][0]), end=' ')
                     if linex[j] == liney[j]:
                         cl += sane(line[j], color=True)
                     else:
@@ -1819,7 +1818,7 @@ class RawPcapNgReader(RawPcapReader):
             if c == 9:
                 length = len(v)
                 if length == 1:
-                    tsresol = orb(v)
+                    tsresol = v[0]
                     options["tsresol"] = (2 if tsresol & 128 else 10) ** (
                         tsresol & 127
                     )

--- a/scapy/utils6.py
+++ b/scapy/utils6.py
@@ -22,7 +22,7 @@ from scapy.utils import (
     stror,
     strand,
 )
-from scapy.compat import orb, chb
+from scapy.compat import chb
 from scapy.pton_ntop import inet_pton, inet_ntop
 from scapy.volatile import RandMAC, RandBin
 from scapy.error import warning, Scapy_Exception
@@ -192,11 +192,11 @@ def in6_getAddrType(addr):
     addrType = 0
     # _Assignable_ Global Unicast Address space
     # is defined in RFC 3513 as those in 2000::/3
-    if ((orb(naddr[0]) & 0xE0) == 0x20):
+    if ((naddr[0] & 0xE0) == 0x20):
         addrType = (IPV6_ADDR_UNICAST | IPV6_ADDR_GLOBAL)
         if naddr[:2] == b' \x02':  # Mark 6to4 @
             addrType |= IPV6_ADDR_6TO4
-    elif orb(naddr[0]) == 0xff:  # multicast
+    elif naddr[0] == 0xff:  # multicast
         addrScope = paddr[3]
         if addrScope == '2':
             addrType = (IPV6_ADDR_LINKLOCAL | IPV6_ADDR_MULTICAST)
@@ -204,7 +204,7 @@ def in6_getAddrType(addr):
             addrType = (IPV6_ADDR_GLOBAL | IPV6_ADDR_MULTICAST)
         else:
             addrType = (IPV6_ADDR_GLOBAL | IPV6_ADDR_MULTICAST)
-    elif ((orb(naddr[0]) == 0xfe) and ((int(paddr[2], 16) & 0xC) == 0x8)):
+    elif ((naddr[0] == 0xfe) and ((int(paddr[2], 16) & 0xC) == 0x8)):
         addrType = (IPV6_ADDR_UNICAST | IPV6_ADDR_LINKLOCAL)
     elif paddr == "::1":
         addrType = IPV6_ADDR_LOOPBACK
@@ -265,7 +265,7 @@ def in6_ifaceidtomac(ifaceid_s):
     oui = first + ifaceid[1:3]
     end = ifaceid[5:]
     # Convert and reconstruct into a MAC Address
-    mac_bytes = ["%.02x" % orb(x) for x in list(oui + end)]
+    mac_bytes = ["%.02x" % x for x in list(oui + end)]
     return ":".join(mac_bytes)
 
 
@@ -461,7 +461,7 @@ def in6_getRandomizedIfaceId(ifaceid, previous=None):
     import hashlib
     s = hashlib.md5(s).digest()
     s1, s2 = s[:8], s[8:]
-    s1 = chb(orb(s1[0]) & (~0x04)) + s1[1:]  # set bit 6 to 0
+    s1 = chb(s1[0] & (~0x04)) + s1[1:]  # set bit 6 to 0
     bs1 = inet_ntop(socket.AF_INET6, b"\xff" * 8 + s1)[20:]
     bs2 = inet_ntop(socket.AF_INET6, b"\xff" * 8 + s2)[20:]
     return (bs1, bs2)
@@ -895,7 +895,7 @@ def in6_get_common_plen(a, b):
     tmpA = inet_pton(socket.AF_INET6, a)
     tmpB = inet_pton(socket.AF_INET6, b)
     for i in range(16):
-        mbits = matching_bits(orb(tmpA[i]), orb(tmpB[i]))
+        mbits = matching_bits(tmpA[i], tmpB[i])
         if mbits != 8:
             return 8 * i + mbits
     return 128

--- a/test/contrib/http2.uts
+++ b/test/contrib/http2.uts
@@ -228,11 +228,11 @@ assert s.origin() == string
 
 s = b"\xdeT'"
 i, ibl = h2.HPackZString.huffman_conv2bitstring(s)
-assert b'Test' == h2.HPackZString.huffman_decode(i, ibl)
+assert 'Test' == h2.HPackZString.huffman_decode(i, ibl)
 
 s = (b'\x18\xc61\x8cc' * 8191) + b'\x18\xc61\x8c\x7f'
 i, ibl = h2.HPackZString.huffman_conv2bitstring(s)
-assert b'a'*65535 == h2.HPackZString.huffman_decode(i, ibl)
+assert 'a'*65535 == h2.HPackZString.huffman_decode(i, ibl)
 
 assert(
     expect_exception(h2.InvalidEncodingException,

--- a/test/contrib/mqttsn.uts
+++ b/test/contrib/mqttsn.uts
@@ -774,14 +774,14 @@ try:
 except Scapy_Exception:
     pass
 
-b = '\x01'
+b = b'\x01'
 try:
     p = MQTTSN(b)   # expect Scapy_Exception
     assert false
 except Scapy_Exception:
     pass
 
-b = '\x01\x02'
+b = b'\x01\x02'
 try:
     p = MQTTSN(b)   # expect Scapy_Exception
     assert false

--- a/test/contrib/tcpao.uts
+++ b/test/contrib/tcpao.uts
@@ -28,7 +28,7 @@ def check(
     ):
         packet_bytes = fromhex(packet_hex)
         # sanity check for ip version
-        ipv = orb(packet_bytes[0]) >> 4
+        ipv = packet_bytes[0] >> 4
         if ipv == 4:
             p = IP(fromhex(packet_hex))
             assert p[IP].proto == socket.IPPROTO_TCP

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -595,9 +595,8 @@ hex_data = bytes_hex(monty_data)
 assert hex_data == b'53746f70212057686f20617070726f61636865732074686520427269646765206f66204465617468206d75737420616e73776572206d65207468657365207175657374696f6e732074687265652c202765726520746865206f746865722073696465206865207365652e'
 assert hex_bytes(hex_data) == monty_data
 
-= orb/chb
+= chb
 
-assert orb(b"\x01"[0]) == 1
 assert chb(1) == b"\x01"
 
 ############
@@ -863,7 +862,7 @@ except:
     pass
 
 = Test sane function
-sane("A\x00\xFFB") == "A..B"
+sane(b"A\x00\xFFB") == "A..B"
 
 = Test lhex function
 assert lhex(42) == "0x2a"
@@ -904,7 +903,7 @@ conf.color_theme = conf_color_theme
 chexdump(Ether(src="00:01:02:02:04:05"), dump=True) == "0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x02, 0x04, 0x05, 0x90, 0x00"
 
 = Test repr_hex function
-repr_hex("scapy") == "7363617079"
+repr_hex(b"scapy") == "7363617079"
 
 = Test hexstr function
 hexstr(b"A\x00\xFFB") == "41 00 FF 42  A..B"
@@ -1609,7 +1608,7 @@ assert o in [
 ]
 
 = ASN1 - ASN1_BIT_STRING
-a = ASN1_BIT_STRING("test", readable=True)
+a = ASN1_BIT_STRING(b"test", readable=True)
 a
 assert a.val == '01110100011001010111001101110100'
 assert raw(a) == b'\x03\x05\x00test'

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -248,11 +248,11 @@ for a in range(10):
     s1, s2
     tmp = inet_pton(socket.AF_INET6, "::" + s1)[8:]
     tmp
-    assert (orb(tmp[0]) & 0x04) == 0
+    assert (tmp[0] & 0x04) == 0
     s1, s2 = in6_getRandomizedIfaceId('20b:93ff:feeb:2d3', previous=s2)
     s1, s2
     tmp = inet_pton(socket.AF_INET6, "::" + s1)[8:]
-    assert (orb(tmp[0]) & 0x04) == 0
+    assert (tmp[0] & 0x04) == 0
 
 assert in6_getRandomizedIfaceId('20b:93ff:feeb:2d3', previous='d006:d540:db11:b092') == ('721f:11fa:3743:fc7f', '5946:5272:7fcc:108a')
 
@@ -2897,7 +2897,7 @@ a1, a2 = "2001:db8::1", "2001:db8::2"
 cookie = RandString(8)._fix()
 p1 = IPv6(src=a1, dst=a2)/MIP6MH_HoTI(cookie=cookie)
 p2 = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie=cookie)
-p2_ko = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie="".join(chr((orb(b'\xff') + 1) % 256)))
+p2_ko = IPv6(src=a2, dst=a1)/MIP6MH_HoT(cookie="".join(chr((0xff + 1) % 256)))
 assert p1.hashret() == p2.hashret() and p2.answers(p1) and not p1.answers(p2)
 assert p1.hashret() != p2_ko.hashret() and not p2_ko.answers(p1) and not p1.answers(p2_ko)
 

--- a/test/scapy/layers/tls/tls.uts
+++ b/test/scapy/layers/tls/tls.uts
@@ -897,7 +897,7 @@ assert isinstance(ske, TLSServerKeyExchange)
 p = ske.params
 assert isinstance(p, ServerECDHNamedCurveParams)
 assert p.named_curve == 0x0017
-assert orb(p.point[0]) == 4 and p.point[1:5] == b'\xc3\x9d\x1cD' and p.point[-4:] == b'X\x19\x03u'
+assert p.point[0] == 4 and p.point[1:5] == b'\xc3\x9d\x1cD' and p.point[-4:] == b'X\x19\x03u'
 assert ske.sig.sig_alg == 0x0601
 ske.sig.sig_val[:4] == b'y\x8aQ\x11' and ske.sig.sig_val[-4:] == b'`15\xef'
 


### PR DESCRIPTION
- remove `orb`, which was used for the Python 2 / Python 3 compatibility, but is no longer necessary.