### PR TITLE
bluetooth_vsc_barrot: Read/Write from memory bus

### DIFF
--- a/scapy/contrib/bluetooth_vsc_barrot.py
+++ b/scapy/contrib/bluetooth_vsc_barrot.py
@@ -51,6 +51,32 @@ class HCI_Cmd_VSC_Barrot_Read_Signature(Packet):
     name = "Barrot Read Signature"
 
 
+class HCI_Cmd_VSC_Barrot_Bus_Write(Packet):
+    """
+    Barrot Bus Write (cmd 0x0E).
+
+    Writes ``data`` to arbitrary memory bus ``address``
+    """
+    name = "Barrot Bus Write"
+    fields_desc = [
+        XLEIntField("address", 0),
+        XStrField("data", b"")
+    ]
+
+
+class HCI_Cmd_VSC_Barrot_Bus_Read(Packet):
+    """
+    Barrot Bus Read (cmd 0x0F)
+
+    Reads ``length`` bytes from memory bus ``address``.
+    """
+    name = "Barrot Bus Read"
+    fields_desc = [
+        XLEIntField("address", 0),
+        ByteField("length", 0)
+    ]
+
+
 class HCI_Cmd_VSC_Barrot_Flash_Write(Packet):
     """
     Barrot Flash Write (cmd 0x11).
@@ -79,6 +105,14 @@ class HCI_Cmd_VSC_Barrot_Flash_Read(Packet):
     ]
 
 
+class HCI_Evt_VSC_Barrot_Command_Complete(Packet):
+    """
+    Barrot vendor-specific Command Complete body (opcode 0xFC80).
+    """
+    name = "Barrot Vendor Specific Command Complete"
+    fields_desc = [XLEShortField("cmd", 0)]
+
+
 class HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version(Packet):
     """
     Read Chip Version (cmd 0x01) command complete.
@@ -104,12 +138,14 @@ class HCI_Cmd_Complete_VSC_Barrot_Read_Signature(Packet):
     fields_desc = [XStrFixedLenField("signature", b"\x00" * 32, 32)]
 
 
-class HCI_Evt_VSC_Barrot_Command_Complete(Packet):
-    """
-    Barrot vendor-specific Command Complete body (opcode 0xFC80).
-    """
-    name = "Barrot Vendor Specific Command Complete"
-    fields_desc = [XLEShortField("cmd", 0)]
+class HCI_Cmd_Complete_VSC_Barrot_Bus_Read(Packet):
+    """Bus Read (cmd 0x0F) command complete: the ``length`` bytes read from
+    the memory bus."""
+    name = "Barrot Bus Read complete"
+    fields_desc = [
+        XStrLenField("data", b"",
+                     length_from=lambda p: p.underlayer.underlayer.underlayer.len - 6)
+    ]
 
 
 class HCI_Cmd_Complete_VSC_Barrot_Flash_Read(Packet):
@@ -124,6 +160,8 @@ class HCI_Cmd_Complete_VSC_Barrot_Flash_Read(Packet):
 bind_layers(HCI_Command_Hdr, HCI_Cmd_VSC_Barrot, ogf=0x3F, ocf=0x080)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Read_Chip_Version, cmd=0x01)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Read_Signature, cmd=0x03)
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Bus_Write, cmd=0x0E)
+bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Bus_Read, cmd=0x0F)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Write, cmd=0x11)
 bind_layers(HCI_Cmd_VSC_Barrot, HCI_Cmd_VSC_Barrot_Flash_Read, cmd=0x12)
 
@@ -133,5 +171,7 @@ bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
             HCI_Cmd_Complete_VSC_Barrot_Read_Chip_Version, cmd=0x01)
 bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
             HCI_Cmd_Complete_VSC_Barrot_Read_Signature, cmd=0x03)
+bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
+            HCI_Cmd_Complete_VSC_Barrot_Bus_Read, cmd=0x0F)
 bind_layers(HCI_Evt_VSC_Barrot_Command_Complete,
             HCI_Cmd_Complete_VSC_Barrot_Flash_Read, cmd=0x12)

--- a/test/contrib/bluetooth_vsc_barrot.uts
+++ b/test/contrib/bluetooth_vsc_barrot.uts
@@ -129,3 +129,87 @@ assert evt[HCI_Event_Command_Complete].status == 0
 sig = evt[HCI_Cmd_Complete_VSC_Barrot_Read_Signature].signature
 assert len(sig) == 32
 assert sig == bytes.fromhex("26f71f00cf59b76f7ba01712190f208052300712d2d12c169a3b57b193632026")
++ Barrot Bus Write (cmd 0x0E)
+
+= Bus write build + dissect
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Bus_Write(address=0x20000000, data=b'\xaa\xbb')
+assert cmd.opcode == 0xfc80
+assert cmd.cmd == 0x0e
+r = raw(cmd)
+# 80fc(op) 08(len) 0e00(cmd id LE) 00000020(addr LE) aabb(data)
+assert r == b'\x80\xfc\x08\x0e\x00\x00\x00\x00\x20\xaa\xbb'
+p = HCI_Command_Hdr(r)
+assert HCI_Cmd_VSC_Barrot_Bus_Write in p
+assert p[HCI_Cmd_VSC_Barrot_Bus_Write].address == 0x20000000
+assert p[HCI_Cmd_VSC_Barrot_Bus_Write].data == b'\xaa\xbb'
+= Bus write of a single byte keeps the length byte in sync
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Bus_Write(address=0x1234, data=b'\x5a')
+r = raw(cmd)
+# len = 2 (cmd id) + 4 (addr) + 1 (data) = 7
+assert r[2] == 0x07
+p = HCI_Command_Hdr(r)
+assert p[HCI_Cmd_VSC_Barrot_Bus_Write].address == 0x1234
+assert p[HCI_Cmd_VSC_Barrot_Bus_Write].data == b'\x5a'
+
+= Bus write with an empty payload
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Bus_Write(address=0x0)
+r = raw(cmd)
+assert r == b'\x80\xfc\x06\x0e\x00\x00\x00\x00\x00'
+p = HCI_Command_Hdr(r)
+assert p[HCI_Cmd_VSC_Barrot_Bus_Write].data == b''
+
+
++ Barrot Bus Read (cmd 0x0F)
+
+= Bus read build + dissect
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Bus_Read(address=0x20000000, length=0x04)
+assert cmd.opcode == 0xfc80
+assert cmd.cmd == 0x0f
+r = raw(cmd)
+# 80fc(op) 07(len) 0f00(cmd id LE) 00000020(addr LE) 04(length)
+assert r == b'\x80\xfc\x07\x0f\x00\x00\x00\x00\x20\x04'
+p = HCI_Command_Hdr(r)
+assert HCI_Cmd_VSC_Barrot_Bus_Read in p
+assert p[HCI_Cmd_VSC_Barrot_Bus_Read].address == 0x20000000
+assert p[HCI_Cmd_VSC_Barrot_Bus_Read].length == 0x04
+
+= Bus read of a full 0xFF-byte request at address 0
+cmd = HCI_Command_Hdr() / HCI_Cmd_VSC_Barrot() / HCI_Cmd_VSC_Barrot_Bus_Read(address=0x0, length=0xFF)
+r = raw(cmd)
+assert r == b'\x80\xfc\x07\x0f\x00\x00\x00\x00\x00\xff'
+p = HCI_Command_Hdr(r)
+assert p[HCI_Cmd_VSC_Barrot_Bus_Read].length == 0xFF
+
+= Bus read defaults
+cmd = HCI_Cmd_VSC_Barrot_Bus_Read()
+assert cmd.address == 0
+assert cmd.length == 0
+assert raw(cmd) == b'\x00\x00\x00\x00\x00'
+
+
++ Barrot Bus Read command complete (opcode 0xFC80, echoed cmd 0x0F)
+
+= Dissect a bus read Command Complete carrying 4 data bytes
+# 04(evt) 0e(cmd complete) len=0a num=01 op=80fc status=00 cmd=0f00 data=deadbeef
+evt = HCI_Hdr(bytes.fromhex("040e0a0180fc000f00deadbeef"))
+assert HCI_Cmd_Complete_VSC_Barrot_Bus_Read in evt
+assert evt[HCI_Event_Command_Complete].status == 0
+assert evt[HCI_Evt_VSC_Barrot_Command_Complete].cmd == 0x0f
+assert evt[HCI_Cmd_Complete_VSC_Barrot_Bus_Read].data == bytes.fromhex("deadbeef")
+
+= Dissect a single-byte bus read result
+# event param len = 7 -> 1 data byte after the echoed cmd id
+evt = HCI_Hdr(bytes.fromhex("040e070180fc000f00ab"))
+assert evt[HCI_Cmd_Complete_VSC_Barrot_Bus_Read].data == b"\xab"
+
+= Dissect a bus read result with the maximum event payload (0xF9 data bytes)
+data = bytes(range(0xF9))
+evt = HCI_Hdr(bytes.fromhex("040eff0180fc000f00") + data)
+assert evt[HCI_Cmd_Complete_VSC_Barrot_Bus_Read].data == data
+
+= A non-bus-read command complete does not mis-parse as a bus read body
+# echoed cmd id 0x12 (flash read) must not bind to the bus-read complete class
+evt = HCI_Hdr(bytes.fromhex("040e0a0180fc00120011223344"))
+assert HCI_Evt_VSC_Barrot_Command_Complete in evt
+assert evt[HCI_Evt_VSC_Barrot_Command_Complete].cmd == 0x12
+assert HCI_Cmd_Complete_VSC_Barrot_Bus_Read not in evt


### PR DESCRIPTION
AI-Assisted: no

### Description
Barrot HCI Vendor commands to read/write memory bus addresses.