### PR TITLE
bpf: adjust bpf_ts on FreeBSD

### DIFF
--- a/scapy/arch/bpf/supersocket.py
+++ b/scapy/arch/bpf/supersocket.py
@@ -66,10 +66,11 @@ else:
 _NANOTIME = FREEBSD  # Kinda disappointing availability TBH
 
 if _NANOTIME:
+    # https://github.com/freebsd/freebsd-src/blob/aea4240ef5834fb4a47f80c659c80f902cb4bb06/sys/net/bpf.h#L206-L209
     class bpf_timeval(ctypes.Structure):
         # actually a bpf_timespec
-        _fields_ = [("tv_sec", ctypes.c_ulong),
-                    ("tv_nsec", ctypes.c_ulong)]
+        _fields_ = [("tv_sec", ctypes.c_int64),
+                    ("tv_nsec", ctypes.c_uint64)]
 elif NETBSD:
     class bpf_timeval(ctypes.Structure):
         _fields_ = [("tv_sec", ctypes.c_ulong),


### PR DESCRIPTION
to get scapy to capture packets on both 32-bit and 64-bit machines.

The bpf_ts structure contains two 64-bit fields:
https://github.com/freebsd/freebsd-src/blob/aea4240ef5834fb4a47f80c659c80f902cb4bb06/sys/net/bpf.h#L206-L209
```
struct bpf_ts {
	bpf_int64	bt_sec;		/* seconds */
	bpf_u_int64	bt_frac;	/* fraction */
};
```
and it has been this way since it was introduced in https://github.com/freebsd/freebsd-src/commit/547d94bde34f99a8068431bc4cf680ee9dbb1816 back in 2010.
```
Introduce new time stamp 'struct bpf_ts' and header 'struct bpf_xhdr'.
The new time stamp has both 64-bit second and fractional parts.  bpf_xhdr
has this time stamp instead of 'struct timeval' for bh_tstamp.  The new
structures let us use bh_tstamp of same size on both 32-bit and 64-bit
platforms without adding additional shims for 32-bit binaries.
```

It was tested on FreeBSD 14.4-RELEASE/i386 and 15.1-RELEASE-p2/amd64.
