### PR TITLE
Parse ATT_Read_By_Group_Type_Response fields

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -11,7 +11,6 @@ Bluetooth layers, sockets and send/receive functions.
 """
 
 import ctypes
-import functools
 import socket
 import struct
 import select
@@ -734,15 +733,10 @@ class ATT_Read_By_Type_Request(Packet):
 
 
 class ATT_Handle_Variable(Packet):
-    __slots__ = ["val_length"]
     fields_desc = [XLEShortField("handle", 0),
                    XStrLenField(
                        "value", 0,
-                       length_from=lambda pkt: pkt.val_length)]
-
-    def __init__(self, _pkt=b"", val_length=2, **kwargs):
-        self.val_length = val_length
-        Packet.__init__(self, _pkt, **kwargs)
+                       length_from=lambda pkt: pkt and pkt.parent.len - 2 or 0)]
 
     def extract_padding(self, s):
         return b"", s
@@ -751,20 +745,7 @@ class ATT_Handle_Variable(Packet):
 class ATT_Read_By_Type_Response(Packet):
     name = "Read By Type Response"
     fields_desc = [ByteField("len", 4),
-                   PacketListField(
-                       "handles", [],
-                       next_cls_cb=lambda pkt, *args: (
-                           pkt._next_cls_cb(pkt, *args)
-                       ))]
-
-    @classmethod
-    def _next_cls_cb(cls, pkt, lst, p, remain):
-        if len(remain) >= pkt.len:
-            return functools.partial(
-                ATT_Handle_Variable,
-                val_length=pkt.len - 2
-            )
-        return None
+                   PacketListField("handles", [], ATT_Handle_Variable)]
 
 
 class ATT_Read_Request(Packet):
@@ -795,16 +776,11 @@ class ATT_Read_By_Group_Type_Request(Packet):
 
 
 class ATT_Group_Handle_Variable(Packet):
-    __slots__ = ["val_length"]
     fields_desc = [XLEShortField("handle", 0),
                    XLEShortField("group_end_handle", 0),
                    XStrLenField(
                        "value", 0,
-                       length_from=lambda pkt: pkt.val_length)]
-
-    def __init__(self, _pkt=b"", val_length=2, **kwargs):
-        self.val_length = val_length
-        Packet.__init__(self, _pkt, **kwargs)
+                       length_from=lambda pkt: pkt and pkt.parent.len - 4 or 0)]
 
     def extract_padding(self, s):
         return b"", s
@@ -813,20 +789,7 @@ class ATT_Group_Handle_Variable(Packet):
 class ATT_Read_By_Group_Type_Response(Packet):
     name = "Read By Group Type Response"
     fields_desc = [ByteField("len", 4),
-                   PacketListField(
-                       "handles", [],
-                       next_cls_cb=lambda pkt, *args: (
-                           pkt._next_cls_cb(pkt, *args)
-                       ))]
-
-    @classmethod
-    def _next_cls_cb(cls, pkt, lst, p, remain):
-        if len(remain) >= pkt.len:
-            return functools.partial(
-                ATT_Group_Handle_Variable,
-                val_length=pkt.len - 4
-            )
-        return None
+                   PacketListField("handles", [], ATT_Group_Handle_Variable)]
 
 
 class ATT_Write_Request(Packet):

--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -794,10 +794,39 @@ class ATT_Read_By_Group_Type_Request(Packet):
                    XLEShortField("uuid", 0), ]
 
 
+class ATT_Group_Handle_Variable(Packet):
+    __slots__ = ["val_length"]
+    fields_desc = [XLEShortField("handle", 0),
+                   XLEShortField("group_end_handle", 0),
+                   XStrLenField(
+                       "value", 0,
+                       length_from=lambda pkt: pkt.val_length)]
+
+    def __init__(self, _pkt=b"", val_length=2, **kwargs):
+        self.val_length = val_length
+        Packet.__init__(self, _pkt, **kwargs)
+
+    def extract_padding(self, s):
+        return b"", s
+
+
 class ATT_Read_By_Group_Type_Response(Packet):
     name = "Read By Group Type Response"
-    fields_desc = [XByteField("length", 0),
-                   StrField("data", ""), ]
+    fields_desc = [ByteField("len", 4),
+                   PacketListField(
+                       "handles", [],
+                       next_cls_cb=lambda pkt, *args: (
+                           pkt._next_cls_cb(pkt, *args)
+                       ))]
+
+    @classmethod
+    def _next_cls_cb(cls, pkt, lst, p, remain):
+        if len(remain) >= pkt.len:
+            return functools.partial(
+                ATT_Group_Handle_Variable,
+                val_length=pkt.len - 4
+            )
+        return None
 
 
 class ATT_Write_Request(Packet):

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -1016,6 +1016,23 @@ pkt.handles[0].value == b'\x02\x03\x00\x00*'
 pkt.handles[1].value == b'\x02\x05\x00\x01*'
 pkt.handles[2].value == b'\x02\x07\x00\x04*'
 
+= ATT Read_By_Group_Type_Response
+pkt = HCI_Hdr(hex_bytes('025e20180014000400110601000700001808000b0001180c0010000a18'))
+
+assert pkt[ATT_Read_By_Group_Type_Response].len == 6
+assert len(pkt.handles) == 3
+assert pkt.handles[0].handle == 0x1
+assert pkt.handles[1].handle == 0x8
+assert pkt.handles[2].handle == 0xc
+
+assert pkt.handles[0].group_end_handle == 0x7
+assert pkt.handles[1].group_end_handle == 0xb
+assert pkt.handles[2].group_end_handle == 0x10
+
+assert pkt.handles[0].value == b'\x00\x18'
+assert pkt.handles[1].value == b'\x01\x18'
+assert pkt.handles[2].value == b'\x0a\x18'
+
 = SM_Security_Request
 pkt = HCI_Hdr(hex_bytes('0200260600020006000b0d'))
 assert SM_Security_Request in pkt

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -1002,8 +1002,14 @@ b.mysummary()
 assert ATT_Read_By_Type_Request in b
 assert not Raw in b
 
-= ATT Read_By_Type_Response
+= ATT Read_By_Type_Request
+pkt = HCI_Hdr(hex_bytes('025e000b00070004000808000b000328'))
 
+assert pkt[ATT_Read_By_Type_Request].start == 0x8
+assert pkt[ATT_Read_By_Type_Request].end == 0xb
+assert pkt[ATT_Read_By_Type_Request].uuid == 0x2803
+
+= ATT Read_By_Type_Response
 pkt = HCI_Hdr(hex_bytes('0248201b001700040009070200020300002a0400020500012a0600020700042a'))
 
 assert pkt[ATT_Read_By_Type_Response].len == 7
@@ -1015,6 +1021,13 @@ assert pkt.handles[2].handle == 0x6
 pkt.handles[0].value == b'\x02\x03\x00\x00*'
 pkt.handles[1].value == b'\x02\x05\x00\x01*'
 pkt.handles[2].value == b'\x02\x07\x00\x04*'
+
+= ATT Read_By_Group_Type_Request
+pkt = HCI_Hdr(hex_bytes('025e000b0007000400100100ffff0028'))
+
+assert pkt[ATT_Read_By_Group_Type_Request].start == 0x1
+assert pkt[ATT_Read_By_Group_Type_Request].end == 0xffff
+assert pkt[ATT_Read_By_Group_Type_Request].uuid == 0x2800
 
 = ATT Read_By_Group_Type_Response
 pkt = HCI_Hdr(hex_bytes('025e20180014000400110601000700001808000b0001180c0010000a18'))


### PR DESCRIPTION
### Description

- Parses the attribute data list in `ATT_Read_By_Group_Type_Response` packets into `ATT_Group_Handle_Variable`.
- Adds tests for `ATT_Read_By_Type_Request`, `ATT_Read_By_Group_Type_Request`, and `ATT_Read_By_Group_Type_Response`.