### PR TITLE
Parse layers with empty fields_desc

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -640,6 +640,7 @@ class L2CAP_Credit_Based_Reconfigure_Response(Packet):
 class ATT_Hdr(Packet):
     name = "ATT header"
     fields_desc = [XByteField("opcode", None), ]
+    dissect_empty_payload = True
 
 
 class ATT_Handle(Packet):
@@ -1675,6 +1676,7 @@ class HCI_Command_Hdr(Packet):
     fields_desc = [XBitField("ogf", 0, 6, tot_size=-2),
                    XBitField("ocf", 0, 10, end_tot_size=-2),
                    LenField("len", None, fmt="B"), ]
+    dissect_empty_payload = True
 
     def answers(self, other):
         return False

--- a/scapy/layers/bluetooth4LE.py
+++ b/scapy/layers/bluetooth4LE.py
@@ -310,6 +310,7 @@ class BTLE_DATA(Packet):
         BitEnumField("LLID", 0, 2, {1: "continue", 2: "start", 3: "control"}),
         ByteField("len", None),
     ]
+    dissect_empty_payload = True
 
     def post_build(self, p, pay):
         if self.len is None:
@@ -450,6 +451,7 @@ class BTLE_CTRL(Packet):
     fields_desc = [
         ByteEnumField("opcode", 0, BTLE_BTLE_CTRL_opcode)
     ]
+    dissect_empty_payload = True
 
 
 class LL_CONNECTION_UPDATE_IND(Packet):

--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -112,6 +112,7 @@ class Packet(
     show_indent = 1
     show_summary = True
     match_subclass = False
+    dissect_empty_payload = False
     class_dont_cache = {}  # type: Dict[Type[Packet], bool]
     class_packetfields = {}  # type: Dict[Type[Packet], Any]
     class_default_fields = {}  # type: Dict[Type[Packet], Dict[str, Any]]
@@ -1119,16 +1120,21 @@ class Packet(
 
         :param str s: the raw layer
         """
-        if s:
+        if s or self.dissect_empty_payload:
             if (
                 self.stop_dissection_after and
                 isinstance(self, self.stop_dissection_after)
             ):
                 # stop dissection here
+                if not s:
+                    return
                 p = conf.raw_layer(s, _internal=1, _underlayer=self)
                 self.add_payload(p)
                 return
             cls = self.guess_payload_class(s)
+            if not s and cls is conf.raw_layer:
+                # Don't add raw layer with empty payload
+                return
             try:
                 p = cls(
                     s,
@@ -1149,6 +1155,13 @@ class Packet(
                     if cls is not None:
                         raise
                 p = conf.raw_layer(s, _internal=1, _underlayer=self)
+            if not s:
+                # Check if parsed layer is also empty
+                try:
+                    if p.build():
+                        return
+                except Exception:
+                    return
             self.add_payload(p)
 
     def dissect(self, s):

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -1002,6 +1002,45 @@ b.mysummary()
 assert ATT_Read_By_Type_Request in b
 assert not Raw in b
 
+= ATT_Hdr - truncated payload is not completed with default values
+# Normal ATT_Error_Response
+b = hex_bytes("025e2009000500040001104c000a")
+c = HCI_Hdr(b)
+assert c[ATT_Error_Response].request == 0x10
+assert c[ATT_Error_Response].handle == 0x4c
+assert c[ATT_Error_Response].ecode == 0x0a
+assert raw(c) == b
+
+# ATT_Error_Response but without body
+b = hex_bytes("025e2005000100040001")
+c = HCI_Hdr(b)
+assert c[ATT_Hdr].opcode == 0x01
+assert ATT_Error_Response not in c
+assert not Raw in c
+assert raw(c) == b
+
+# ATT_Error_Response but with truncated body
+b = hex_bytes("025e2007000300040001104c")
+c = HCI_Hdr(b)
+assert c[ATT_Hdr].opcode == 0x01
+assert ATT_Error_Response not in c
+assert Raw in c
+assert raw(c) == b
+
+= ATT_Hdr - empty payload (ATT_Write_Response)
+c = HCI_Hdr(hex_bytes("025e2005000100040013"))
+assert c[ATT_Hdr].opcode == 0x13
+assert ATT_Write_Response in c
+assert not Raw in c
+
+= HCI_Command_Hdr - empty payload (HCI_Cmd_Reset)
+c = HCI_Hdr(hex_bytes("01030c00"))
+assert c[HCI_Command_Hdr].ogf == 0x03
+assert c[HCI_Command_Hdr].ocf == 0x03
+assert c[HCI_Command_Hdr].len == 0
+assert HCI_Cmd_Reset in c
+assert not Raw in c
+
 = ATT Read_By_Type_Response
 
 pkt = HCI_Hdr(hex_bytes('0248201b001700040009070200020300002a0400020500012a0600020700042a'))


### PR DESCRIPTION
### Description

I noticed some Bluetooth ATT layers aren't dissected.
For example, `025e2005000100040013` is a valid ATT write response packet with opcode `0x13`, but `ATT_Write_Response` is not present when you dissect it.
```
>>> HCI_Hdr(hex_bytes("025e2005000100040013"))
HCI_PHDR_Hdr / HCI ACL Data / HCI_ACL_Hdr / L2CAP_Hdr / ATT_Hdr
```

I think this is because [`Packet.do_dissect_payload`](https://github.com/secdev/scapy/blob/14001423f53cfa854c689f39126242ab4f10ca3c/scapy/packet.py#L1122) only dissects when the payload is not empty, but layers like `ATT_Write_Response` have no `fields_desc` because their opcode is dissected in the parent layer (`ATT_Hdr`).

### Fix

I added a `dissect_empty_payload` class attribute to the Packet class that forces `do_dissect_payload` to try to dissect an empty payload. The layer is only added if its empty as well:

```python
if not s:
    # Check if parsed layer is also empty
    try:
        if p.build():
            return
    except Exception:
        return
```

Otherwise, a layer with default values could be added after parsing an empty payload.
For example, `025e2005000100040001` is an ATT Error Response header with a missing body, but without this check an `ATT_Error_Response` layer with default values would be added even though there is no body.

I set `dissect_empty_payload` on `ATT_Hdr`, `HCI_Command_Hdr`, `BTLE_DATA`, and `BTLE_CTRL` because they all have sub-layers that would be ignored otherwise.

Instead of modifying `Packet`, an alternative would be to override `do_dissect_payload` in specific classes like `ATT_Hdr` so it dissects empty payloads, but then you have to keep this in sync with the implementation in Packet as well.

### Tests

I added tests that check whether `ATT_Write_Response` and `HCI_Cmd_Reset` now correctly include those layers when dissected.
I also added a test that makes sure a layer with default values isn't added when a payload is truncated.