### PR TITLE
MQTT: do not crash when MQTTPublish has no underlayer

### DIFF
--- a/scapy/contrib/mqtt.py
+++ b/scapy/contrib/mqtt.py
@@ -198,12 +198,13 @@ class MQTTPublish(Packet):
         StrLenField("topic", "",
                     length_from=lambda pkt: pkt.length),
         ConditionalField(ShortField("msgid", None),
-                         lambda pkt: (pkt.underlayer.QOS == 1 or
-                                      pkt.underlayer.QOS == 2)),
+                         lambda pkt: pkt.underlayer is not None and
+                         pkt.underlayer.QOS in (1, 2)),
         StrLenField("value", "",
-                    length_from=lambda pkt: pkt.underlayer.len - pkt.length - 2
-                    if pkt.underlayer.QOS == 0 else
-                    pkt.underlayer.len - pkt.length - 4)
+                    length_from=lambda pkt: 0 if pkt.underlayer is None else
+                    (pkt.underlayer.len - pkt.length - 2
+                     if pkt.underlayer.QOS == 0 else
+                     pkt.underlayer.len - pkt.length - 4))
     ]
 
 

--- a/test/contrib/mqtt.uts
+++ b/test/contrib/mqtt.uts
@@ -187,3 +187,10 @@ assert MQTTUnsubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/
 = MQTTSubscribe
 u = MQTT(b'\x82\x10\x00\x01\x00\x03\x61\x2F\x62\x02\x00\x03\x63\x2F\x64\x00')
 assert MQTTSubscribe in u and len(u.topics) == 2 and u.topics[1].topic == b"c/d"
+
+= MQTTPublish without underlayer does not crash
+p = MQTTPublish()
+p.show()
+assert p.topic == b""
+assert p.value == b""
+assert p.msgid is None


### PR DESCRIPTION
Fixes #5071.

`MQTTPublish` reads `QOS` and `len` from `pkt.underlayer` in the `msgid` condition and the `value` length callback. Building or displaying a publish packet with no underlayer (`MQTTPublish().show()`) raised `AttributeError: 'NoneType' object has no attribute 'QOS'`.

Both callbacks now treat a missing underlayer as QoS 0 / empty payload, which matches how a standalone publish is constructed. Existing layered build/dissect tests are unchanged.

Repro that used to crash:

```python
from scapy.contrib.mqtt import MQTTPublish
MQTTPublish().show()
```

`./test/run_tests -P "load_contrib('mqtt')" -t test/contrib/mqtt.uts` — 25 passed.