### PR TITLE
netbios: parse every address entry in a name query response

### DIFF
--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -198,6 +198,9 @@ class NBNS_ADD_ENTRY(Packet):
         IPField("NB_ADDRESS", "127.0.0.1")
     ]
 
+    def default_payload_class(self, payload):
+        return conf.padding_layer
+
 
 class NBNSQueryResponse(Packet):
     name = "NBNS query response"

--- a/test/scapy/layers/netbios.uts
+++ b/test/scapy/layers/netbios.uts
@@ -40,6 +40,29 @@ assert z.RR_NAME == b'POTATO'
 assert z.ADDR_ENTRY[0].G == 0
 assert z.ADDR_ENTRY[0].NB_ADDRESS == "192.168.1.65"
 
+= NBNSQueryResponse - name registered on several addresses
+
+# RFC1002 sect 4.2.13: RDATA holds one {NB_FLAGS, NB_ADDRESS} pair per address
+# the name answers on, and RDLENGTH spans all of them.
+
+data = b'/S\x85\x80\x00\x00\x00\x01\x00\x00\x00\x00 FAEPFEEBFEEPCACACACACACACACACAAA\x00\x00 \x00\x01\x00\x03\xf4\x80\x00\x0c\x00\x00\xc0\xa8\x01A\x00\x00\xc0\xa8\x01B'
+z = NBNSHeader(data)
+assert z.RDLENGTH == 12
+assert len(z.ADDR_ENTRY) == 2
+assert [x.NB_ADDRESS for x in z.ADDR_ENTRY] == ["192.168.1.65", "192.168.1.66"]
+assert raw(z) == data
+
+z = NBNSHeader()/NBNSQueryResponse(RR_NAME="FRED", ADDR_ENTRY=[NBNS_ADD_ENTRY(NB_ADDRESS="192.168.0.13"), NBNS_ADD_ENTRY(NB_ADDRESS="192.168.0.14")])
+pkt = NBNSHeader(raw(z))
+assert pkt.RDLENGTH == 12
+assert [x.NB_ADDRESS for x in pkt.ADDR_ENTRY] == ["192.168.0.13", "192.168.0.14"]
+
+# RDLENGTH bounds the list: what follows the record is not an address entry
+
+pkt = NBNSHeader(data + b'\xde\xad\xbe\xef')
+assert len(pkt.ADDR_ENTRY) == 2
+assert raw(pkt) == data + b'\xde\xad\xbe\xef'
+
 = NBNSQueryResponse answers NBNSQueryRequest
 
 req = IP(ihl=5, len=78, proto=17, chksum=8562, src='172.19.0.7', dst='172.19.0.255')/UDP(sport=137, dport=137, len=58, chksum=62101)/NBNSHeader(NM_FLAGS=17, QDCOUNT=1)/NBNSQueryRequest(QUESTION_NAME=b'Loremipsumdolor', SUFFIX=17217)


### PR DESCRIPTION
## The bug

`NBNSQueryResponse.ADDR_ENTRY` is a `PacketListField` bounded by `RDLENGTH`, but
`NBNS_ADD_ENTRY` defines neither `extract_padding` nor `default_payload_class`.
`PacketListField.getfield` moves on to the next element only when the one it just
dissected left a `Padding` behind (`scapy/fields.py:1838-1848`); otherwise it sets
`remain = b""` and the loop ends. The first entry therefore takes the rest of RDATA
as a `Raw` payload and the list holds exactly one element, whatever `RDLENGTH` says.

On master (`b36473a`), a response carrying two addresses:

```
>>> z = NBNSHeader(data)
>>> z.RDLENGTH
12
>>> len(z.ADDR_ENTRY)
1
>>> [x.NB_ADDRESS for x in z.ADDR_ENTRY]
['192.168.1.65']
>>> z.ADDR_ENTRY[0].payload
<Raw  load=b'\x00\x00\xc0\xa8\x01B' |>
```

`data` is the POTATO name query response already in
`test/scapy/layers/netbios.uts`, with a second address entry appended and
`RDLENGTH` adjusted. I do not have a capture of a real multi-address answer.

RFC 1002 sect 4.2.13 describes RDATA as "a sequence of zero or more ADDR_ENTRY
records. Each ADDR_ENTRY record represents an owner of a name. For group names there
may be multiple entries. However, the list may be incomplete due to packet size
limitations." Querying a group name, a 0x1C domain controller name for instance, is
the case that answers with several.

The consequence reaches the API: `nbns_resolve()` builds its return value with
`[x.NB_ADDRESS for x in res.ADDR_ENTRY]`, so a caller gets one address out of however
many were answered. Nothing raises.

## The fix

Give `NBNS_ADD_ENTRY` the `default_payload_class` that
`NBNSNodeStatusResponseService` already carries further down the same file. That
class is the structural counterpart, its `NODE_NAME` list works, and the existing
node status test already asserts five entries come back from it. The omission looks
like an oversight rather than a decision.

Bytes are untouched. `raw()` reproduces the input before and after the change,
including when trailing data follows the record, so this changes how the record is
presented and not what is written.

## Verification

Full Windows suite, same machine, master versus this branch:

```
master:  6161 passed / 96 failed
branch:  6162 passed / 96 failed
```

The 96 are pre-existing here and environmental (no tshark, no tcpdump, no loopback
adapter, no `scapy-rpc` extension). I diffed the failing set by name: identical on
both sides, nothing new and nothing fixed by accident. The one extra pass is the new
test.

Reverting only the source change and keeping the test fails exactly the new case, so
it binds to the defect and not to the implementation:

```
###(002)=[failed] NBNSQueryResponse - name registered on several addresses
>>> assert len(z.ADDR_ENTRY) == 2
AssertionError
```

`flake8 scapy/`, `mypy_check.py linux`, `mypy_check.py win32` and `codespell` all
exit 0.

Beyond the test I checked `RDLENGTH` values that lie in both directions, an
`RDLENGTH` that is not a multiple of 6, `RDLENGTH` 0, and the OSS-Fuzz sample already
in the test file. None of them raises and `raw()` reproduces the input in every case.
Where RDATA does not divide into whole entries the remainder comes back as a `Raw` in
the list, and `RDLENGTH` 0 gives an empty list.

## One thing worth flagging

`conf.max_list_count` (100) now applies to `ADDR_ENTRY`. The collapse made it
unreachable before, so a response claiming more than 100 entries used to yield one
entry and now drops back to `Raw`. `NBNSNodeStatusResponse.NODE_NAME` behaves the
same way at 101 entries and `DNS` raises `MaximumItemsCount` in the same situation,
so this puts `ADDR_ENTRY` in the regime the other list fields are already in. `raw()`
round-trips in that case too.

## Scope

I left the other layers alone. `ICMPv6MLReport2.records` and
`HCI_Cmd_LE_Set_Extended_Advertise_Enable.sets` collapse the same way, three and two
elements coming back as one, and there are further candidates I have not verified.
Those are separate changes. Happy to follow up if you want them.
