### PR TITLE
bluetooth: parse every advertising set in Set_Extended_Advertise_Enable

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -2272,6 +2272,9 @@ class Extended_Advertise_Set(Packet):
                    LEShortField('duration', 0),
                    ByteField('max_events', 0)]
 
+    def extract_padding(self, s):
+        return b'', s
+
 
 class HCI_Cmd_LE_Set_Extended_Advertise_Enable(Packet):
     name = 'HCI_LE_Set_Extended_Advertising_Enable'

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -1169,3 +1169,24 @@ assert p[HCI_Mon_Index_Info].manufacturer == 0x131
 p = HCI_Mon_Pcap_Hdr(hex_bytes("ffff000c426c7565746f6f74682073756273797374656d2076657273696f6e20322e323200"))
 assert HCI_Mon_System_Note in p
 assert p[HCI_Mon_System_Note].note == b'Bluetooth subsystem version 2.22'
+
+= HCI_Cmd_LE_Set_Extended_Advertise_Enable - multiple advertising sets
+
+p = HCI_Cmd_LE_Set_Extended_Advertise_Enable(hex_bytes("01020164000502c8000a"))
+assert p.num_sets == 2
+assert len(p.sets) == 2
+assert p.sets[0].handle == 1
+assert p.sets[0].duration == 100
+assert p.sets[0].max_events == 5
+assert p.sets[1].handle == 2
+assert p.sets[1].duration == 200
+assert p.sets[1].max_events == 10
+assert raw(p) == hex_bytes("01020164000502c8000a")
+
+= HCI_Cmd_LE_Set_Extended_Advertise_Enable - single advertising set
+
+p = HCI_Cmd_LE_Set_Extended_Advertise_Enable(hex_bytes("010101640005"))
+assert p.num_sets == 1
+assert len(p.sets) == 1
+assert p.sets[0].handle == 1
+assert raw(p) == hex_bytes("010101640005")


### PR DESCRIPTION
`HCI_Cmd_LE_Set_Extended_Advertise_Enable.sets` returns a single entry no matter what `num_sets` says.

`Extended_Advertise_Set` does not override `extract_padding`, so the first set claims the following sets as its payload and `PacketListField` finds nothing left to parse.

```
>>> p = HCI_Cmd_LE_Set_Extended_Advertise_Enable(hex_bytes("01020164000502c8000a"))
>>> p.num_sets, len(p.sets)
(2, 1)
>>> bytes(p.sets[0].payload)
b'\x02\xc8\x00\n'
```

After the change `len(p.sets) == 2` and the second set reads `handle=2 duration=200 max_events=10`. Rebuilding returns the same bytes either way. `HCI_LE_Meta_Extended_Advertising_Report` already carries the same `extract_padding` further down the module.

Validated on Windows with Python 3.13. `UTscapy -t test/scapy/layers/bluetooth.uts` gives 90 passed, 0 failed, with two cases added for two sets and one set. `flake8 scapy/` and `mypy_check.py` (win32 and linux) are clean. The full `windows.utsc` campaign gives 96 failures, the same count and the same files as on master, all unrelated and caused by missing tcpdump, tshark and libpcap here.
