### PR TITLE
opc_da: fix STDOBJREF IPID and Fack selack field types

### DIFF
--- a/scapy/contrib/opc_da.py
+++ b/scapy/contrib/opc_da.py
@@ -37,6 +37,7 @@ from scapy.fields import (
     ConditionalField,
     Field,
     FieldLenField,
+    FieldListField,
     FlagsField,
     IntEnumField,
     IntField,
@@ -404,7 +405,7 @@ class STDOBJREF(Packet):
         LEIntField('cPublicRefs', 0),
         LELongField('OXID', 0),
         LELongField('OID', 0),
-        PacketField('IPID', None, UUIDField),
+        UUIDField('IPID', None, uuid_fmt=UUIDField.FORMAT_LE),
     ]
 
 
@@ -883,8 +884,8 @@ class OpcDaFack(Packet):
         IntField('maxFragSize', 0),
         ShortField('serialNum', 0),
         FieldLenField('selackLen', 0, count_of='selack', fmt="H"),
-        PacketListField('selack', None, IntField,
-                        count_from=lambda pkt:pkt.selackLen),
+        FieldListField('selack', [], IntField('', 0),
+                       count_from=lambda pkt: pkt.selackLen),
     ]
 
     def extract_padding(self, p):

--- a/test/contrib/opc_da.uts
+++ b/test/contrib/opc_da.uts
@@ -110,9 +110,18 @@ assert  elem1 == elem2
 # OpcDaCl_cancel
 # OpcDaCl_cancelLE
 
-# + Test Fack Packet
-# No example yet
-# OpcDaFack
++ Test Fack Packet
+= OpcDaFack
+opcDaFackPacket_Dissect = hex_bytes(b'0000000010000010000000080000010002aaaaaaaabbbbbbbb')
+fack = OpcDaFack(opcDaFackPacket_Dissect)
+assert fack.selackLen == 2
+assert fack.selack == [0xaaaaaaaa, 0xbbbbbbbb]
+assert raw(fack) == opcDaFackPacket_Dissect
+
+= OpcDaFackLE
+fackLE = OpcDaFackLE(opcDaFackPacket_Dissect)
+assert len(fackLE.selack) == 2
+assert raw(fackLE) == opcDaFackPacket_Dissect
 
 # + Test Cancel ack Packet
 # No example yet
@@ -180,3 +189,12 @@ elem2 = raw(ocDaAlter_contextLEPacket_Build)
 # + Test Orphaned Packet
 # No example yet
 # OpcDaOrphaned
+
++ Test STDOBJREF
+= STDOBJREF dissection
+stdObjRef_Dissect = hex_bytes(b'0100000002000000112233445566778899aabbccddeeff000102030405060708090a0b0c0d0e0f10')
+std = STDOBJREF(stdObjRef_Dissect)
+assert std.flags == 1
+assert std.cPublicRefs == 2
+assert str(std.IPID) == '04030201-0605-0807-090a-0b0c0d0e0f10'
+assert raw(std) == stdObjRef_Dissect


### PR DESCRIPTION
Two fields pass a field class where a packet class is expected.

`STDOBJREF.IPID` wraps `UUIDField` in a `PacketField`, so dissection dies:

```
>>> STDOBJREF(hex_bytes('0100000002000000112233445566778899aabbccddeeff000102030405060708090a0b0c0d0e0f10'))
TypeError: UUIDField.__init__() missing 1 required positional argument: 'default'
```

`_make_le` already special-cases `UUIDField`, so the field was meant to be used directly. `STDOBJREF` is little-endian only, hence `FORMAT_LE`.

`OpcDaFack.selack` passes `IntField` to a `PacketListField`. That one fails silently instead, with `selackLen=2` dissecting into a single `Raw` spanning both entries:

```
>>> OpcDaFack(hex_bytes('0000000010000010000000080000010002aaaaaaaabbbbbbbb')).selack
[<Raw  load=b'\xaa\xaa\xaa\xaa\xbb\xbb\xbb\xbb' |>]
```

A list of plain fields is `FieldListField`, which gives `[0xaaaaaaaa, 0xbbbbbbbb]`. `OpcDaFackLE` still builds and dissects.

Validated on Windows with Python 3.13. `UTscapy -t test/contrib/opc_da.uts -P "load_contrib('opc_da')"` gives 12 passed, 0 failed. The Fack section was a `# No example yet` placeholder and now holds real cases, plus one for STDOBJREF. `flake8 scapy/` and `mypy_check.py` (win32 and linux) are clean. The full `windows.utsc` campaign gives 96 failures, the same count and the same files as on master, all unrelated and caused by missing tcpdump, tshark and libpcap here.

The test vectors are hand-built from the field layout, not taken from a capture.
