### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Codecov Status](https://codecov.io/gh/secdev/scapy/branch/master/graph/badge.svg)](https://codecov.io/gh/secdev/scapy) <!-- ignore_ppi -->
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/30ee6772bb264a689a2604f5cdb0437b)](https://app.codacy.com/gh/secdev/scapy/dashboard) <!-- ignore_ppi -->
 [![PyPI Version](https://img.shields.io/pypi/v/scapy.svg)](https://pypi.python.org/pypi/scapy/)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/s/secdev/scapy.svg)](https://inspect.software/software/secdev/scapy)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](LICENSE)
 [![Join the chat at https://gitter.im/secdev/scapy](https://badges.gitter.im/secdev/scapy.svg)](https://gitter.im/secdev/scapy) <!-- ignore_ppi -->
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/secdev/scapy), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
