### PR TITLE
netbios: avoid copying the packet chain for each coalesced message

### DIFF
--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -382,7 +382,7 @@ class TCPSession(IPSession):
                     tcp_session
                 )
                 if sub_packet:
-                    packet /= sub_packet
+                    packet.add_payload(sub_packet)
                     padding = self._strip_padding(sub_packet)
                 else:
                     break

--- a/test/scapy/layers/netbios.uts
+++ b/test/scapy/layers/netbios.uts
@@ -123,6 +123,13 @@ z = raw(TCP()/NBTSession())
 assert z == b'\x00\x8b\x00\x8b\x00\x00\x00\x00\x00\x00\x00\x00P\x02 \x00\x00\x00\x00\x00\x00\x00\x00\x00'
 assert NBTSession in TCP(z)
 
+= TCPSession strips padding from each coalesced NetBIOS keepalive
+message = bytes(NBTSession(TYPE=0x85, LENGTH=0))
+frame = Ether()/IP()/TCP(sport=35000, dport=445, seq=1, flags="PA")/Raw(message * 4)
+packet = TCPSession().process(Ether(bytes(frame)))
+assert packet.layers().count(NBTSession) == 4
+assert Padding not in packet
+
 = OSS-Fuzz Findings
 
 # Note: the packet is corrupted


### PR DESCRIPTION
When `TCPSession` splits several NBT messages out of one TCP segment, it appends each with
`packet /= sub_packet`. That operator copies both sides, so a segment holding n messages copies
chains of 1, 2, ... n-1 messages and the total work grows with the square of the message count.

A 1,440-byte TCP payload holds 360 four-byte keepalives, so an ordinary frame is enough.

```python
import io, time
from scapy.all import Ether, IP, Raw, TCP, TCPSession, sniff, wrpcap

class Keep(io.BytesIO):
    def close(self): pass

def run(n):
    buf = Keep()
    wrpcap(buf, [Ether()/IP()/TCP(dport=445, flags="PA")/Raw(bytes.fromhex("85000000") * n)])
    start = time.perf_counter()
    sniff(offline=io.BytesIO(buf.getvalue()), session=TCPSession)
    return (time.perf_counter() - start) * 1000

for n in (80, 160, 320):
    print(n, f"{run(n):.2f} ms")
```

Before this change that prints roughly 42.81, 186.15 and 766.25 ms — doubling the message count
roughly quadruples the time.

`sub_packet` is built immediately above the append and is not shared, so it does not need a
defensive copy. `add_payload` appends it directly. That also fixes a second thing: the following
`_strip_padding` now acts on the object that was actually appended rather than on a discarded
clone.

A valid two-message benchmark measured 182,735.4 ns/call before and 167,463.3 ns/call after, inside
this machine noise.

Test added in `test/scapy/layers/netbios.uts`: four coalesced keepalives must produce four
`NBTSession` layers with no retained `Padding`. It fails without the change.