### PR TITLE
contrib/hicp: terminate Configure fields on the correct delimiter

### DIFF
--- a/scapy/contrib/hicp.py
+++ b/scapy/contrib/hicp.py
@@ -98,7 +98,7 @@ class HICPConfigure(Packet):
         return "".join(p).encode('utf-8') + b"\x00" + pay
 
     def do_dissect(self, s):
-        res = match(".*: ([^;]+);", s.decode('utf-8'))
+        res = match(": ([^;]+);", s.decode('utf-8'))
         if res:
             self.target = TO_MACFIELD(res.group(1))
         s = s[len(self.target) + 3:]

--- a/test/contrib/hicp.uts
+++ b/test/contrib/hicp.uts
@@ -75,6 +75,10 @@ assert(pkt.target == "aa:aa:aa:aa:aa:aa")
 assert(pkt.ip_address == "255.255.255.255")
 assert(pkt.hostname == b"llama")
 
+= Keep a later value delimiter out of the target field
+pkt = HICP(b"Configure: aa-aa-aa-aa-aa-aa;HN = llama: one;\x00")
+assert(pkt.target == "aa:aa:aa:aa:aa:aa")
+
 + HICP Configure response
 = Build and dissect successful response to configure request
 


### PR DESCRIPTION
The Configure field terminated on `!` rather than the `;` the format requires, so each field
re-scanned the rest of the packet and parsing cost grew with the square of the delimiter count.

Using the required `;` removes the repeated suffix scans.

Test added in `test/contrib/hicp.uts`.