### PR TITLE
Dot11: fix type using {} instead of []

### DIFF
--- a/scapy/layers/dot11.py
+++ b/scapy/layers/dot11.py
@@ -734,7 +734,7 @@ class Dot11(Packet):
         _Dot11MacField("addr1", ETHER_ANY, 1),
         ConditionalField(
             _Dot11MacField("addr2", ETHER_ANY, 2),
-            lambda pkt: (pkt.type not in {1, 3} or
+            lambda pkt: (pkt.type not in [1, 3] or
                          pkt.subtype in [0x4, 0x5, 0x6, 0x8, 0x9, 0xa, 0xb, 0xe, 0xf]),
         ),
         ConditionalField(
@@ -742,7 +742,7 @@ class Dot11(Packet):
             lambda pkt: (pkt.type in [0, 2] or
                          ((pkt.type, pkt.subtype) == (1, 6) and pkt.cfe == 6)),
         ),
-        ConditionalField(LEShortField("SC", 0), lambda pkt: pkt.type not in {1, 3}),
+        ConditionalField(LEShortField("SC", 0), lambda pkt: pkt.type not in [1, 3]),
         ConditionalField(
             _Dot11MacField("addr4", ETHER_ANY, 4),
             lambda pkt: (pkt.type == 2 and

--- a/test/scapy/layers/dot11.uts
+++ b/test/scapy/layers/dot11.uts
@@ -23,6 +23,11 @@ raw_data = raw(pkt)
 expected = b'\x05\x12'
 assert raw_data[2:4] == b'\x05\x12', f"Encoded Dot11 ID field is {raw_data[2:4]}, expected {repr(expected)}."
 
+= Dot11 - build with fuzz
+# GH5070
+Dot11(type=RandInt())
+fuzz(Dot11())
+
 = Dot11 - dissection
 p = Dot11(s)
 Dot11 in p and p.addr3 == "00:00:00:00:00:00"


### PR DESCRIPTION
fixes https://github.com/secdev/scapy/issues/5070