### PR TITLE
Net: honor the scope argument

### DIFF
--- a/scapy/base_classes.py
+++ b/scapy/base_classes.py
@@ -216,8 +216,8 @@ class Net(Gen[str]):
             raise Scapy_Exception("Wildcards are no longer accepted in %s()" %
                                   self.__class__.__name__)
         self.scope = None
-        if "%" in net:
-            net = ScopedIP(net)
+        if "%" in net or scope is not None:
+            net = ScopedIP(net, scope=scope)
         if isinstance(net, _ScopedIP):
             self.scope = net.scope
         if stop is None:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -3853,6 +3853,21 @@ assert Net("1.2.3.0/24") == Net("1.2.3.0", "1.2.3.255")
 
 assert hash(Net("1.2.3.0/24")) == hash(Net("1.2.3.0", "1.2.3.255"))
 
+= Net with a scope identifier
+
+iface = conf.iface.network_name
+
+# The scope may be passed inline or as an argument, and both must be stored.
+# Do not compare Net objects here: Net.__eq__ ignores .scope.
+assert Net("224.0.0.1%%%s" % iface).scope == iface
+assert Net("224.0.0.1", scope=iface).scope == iface
+assert Net("224.0.0.1/24", scope=iface).scope == iface
+assert Net("224.0.0.1", "224.0.0.9", scope=iface).scope == iface
+assert Net("224.0.0.1").scope is None
+
+# The scope is carried over to every address the Net generates.
+assert list(Net("224.0.0.0/31", scope=iface))[1].scope == iface
+
 = Net using name
 ~ netaccess
 


### PR DESCRIPTION
### Description

`Net.__init__` takes a `scope` argument and never reads it. The form printed in `Net`'s own docstring returns an unscoped object:

```python
>>> Net("224.0.0.1", scope=conf.iface).scope
None            # expected 'eth0'
>>> Net("224.0.0.1%eth0").scope
'eth0'
```

`__iter__` copies `self.scope` onto every address it yields, so a `Net` built with `scope=` yields plain addresses and packets built from it leave through the default interface rather than the requested one. `Net6` inherits `__init__`, so IPv6 behaves the same way.

The argument arrived with scope support in #4461. That commit wired `scope` into the signature, into `__iter__`, into `__repr__` and into `__hash__`, but not into the body of `__init__`. This patch hands it to `ScopedIP`, which does the interface resolution and keeps the existing precedence where an inline `%` overrides the argument.

No test could have caught this. `Net.__eq__` does not look at `scope`, so `Net("224.0.0.1", scope=iface) == Net("224.0.0.1%iface")` holds whether or not the argument works. The new test asserts on `.scope` itself for that reason, across the mask form, the start/stop form and the addresses a `Net` generates.

One related thing I did not touch: `__hash__` includes `scope` but `__eq__` does not, so `Net("224.0.0.1%eth0")` and `Net("224.0.0.1")` compare equal with different hashes, which makes them distinct keys in a dict. Fixing that shifts comparison semantics, so it seemed worth a separate discussion.
