### PR TITLE
asn1: decode BER integers with int.from_bytes

### DIFF
--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -462,12 +462,7 @@ class BERcodec_INTEGER(BERcodec_Object[int]):
                ):
         # type: (...) -> Tuple[ASN1_Object[int], bytes]
         l, s, t = cls.check_type_check_len(s)
-        # Convert the content octets in one go. Shifting a growing Python
-        # integer one octet at a time costs more with every octet already
-        # accumulated, so decoding was quadratic in the encoded width: a sender
-        # could multiply parsing cost by padding any INTEGER with leading sign
-        # octets, in any protocol that uses BER. int.from_bytes performs the
-        # same two's-complement conversion in a single pass.
+        # One pass: shifting a growing integer per octet was quadratic in width.
         return cls.asn1_object(int.from_bytes(s, "big", signed=True)), t
 
 

--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -462,14 +462,13 @@ class BERcodec_INTEGER(BERcodec_Object[int]):
                ):
         # type: (...) -> Tuple[ASN1_Object[int], bytes]
         l, s, t = cls.check_type_check_len(s)
-        x = 0
-        if s:
-            if s[0] & 0x80:  # negative int
-                x = -1
-            for c in s:
-                x <<= 8
-                x |= c
-        return cls.asn1_object(x), t
+        # Convert the content octets in one go. Shifting a growing Python
+        # integer one octet at a time costs more with every octet already
+        # accumulated, so decoding was quadratic in the encoded width: a sender
+        # could multiply parsing cost by padding any INTEGER with leading sign
+        # octets, in any protocol that uses BER. int.from_bytes performs the
+        # same two's-complement conversion in a single pass.
+        return cls.asn1_object(int.from_bytes(s, "big", signed=True)), t
 
 
 class BERcodec_BOOLEAN(BERcodec_INTEGER):

--- a/scapy/layers/kerberos.py
+++ b/scapy/layers/kerberos.py
@@ -374,10 +374,22 @@ _KRB_S_TYPES = {
 }
 
 
+class _KRBInt32Field(ASN1F_enum_INTEGER):
+    def m2i(self, pkt, s):
+        s = self._apply_tagging_dec(s, pkt, _fname=self.name)
+        codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
+        if codec.check_type_get_len(s)[0] > 5:
+            raise BER_Decoding_Error(
+                "Kerberos integer is wider than 32 bits", remaining=s
+            )
+        dec = codec.safedec if self.flexible_tag else codec.dec
+        return dec(s, context=self.context, **self._codec_kwargs(pkt))
+
+
 class EncryptedData(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SEQUENCE(
-        ASN1F_enum_INTEGER("etype", 0x17, _KRB_E_TYPES, explicit_tag=0xA0),
+        _KRBInt32Field("etype", 0x17, _KRB_E_TYPES, explicit_tag=0xA0),
         ASN1F_optional(UInt32("kvno", None, explicit_tag=0xA1)),
         ASN1F_STRING("cipher", "", explicit_tag=0xA2),
     )

--- a/scapy/layers/kerberos.py
+++ b/scapy/layers/kerberos.py
@@ -374,22 +374,10 @@ _KRB_S_TYPES = {
 }
 
 
-class _KRBInt32Field(ASN1F_enum_INTEGER):
-    def m2i(self, pkt, s):
-        s = self._apply_tagging_dec(s, pkt, _fname=self.name)
-        codec = self.ASN1_tag.get_codec(pkt.ASN1_codec)
-        if codec.check_type_get_len(s)[0] > 5:
-            raise BER_Decoding_Error(
-                "Kerberos integer is wider than 32 bits", remaining=s
-            )
-        dec = codec.safedec if self.flexible_tag else codec.dec
-        return dec(s, context=self.context, **self._codec_kwargs(pkt))
-
-
 class EncryptedData(ASN1_Packet):
     ASN1_codec = ASN1_Codecs.BER
     ASN1_root = ASN1F_SEQUENCE(
-        _KRBInt32Field("etype", 0x17, _KRB_E_TYPES, explicit_tag=0xA0),
+        ASN1F_enum_INTEGER("etype", 0x17, _KRB_E_TYPES, explicit_tag=0xA0),
         ASN1F_optional(UInt32("kvno", None, explicit_tag=0xA1)),
         ASN1F_STRING("cipher", "", explicit_tag=0xA2),
     )

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1503,11 +1503,6 @@ assert pkt.json() == '{"length": null, "id": 0, "qr": 0, "opcode": 0, "aa": 0, "
 pkt = KRB_AP_REP(bytes(KRB_AP_REP(encPart=EncryptedData())))
 assert pkt.command() == "KRB_AP_REP(pvno=ASN1_INTEGER(5), msgType=ASN1_INTEGER(15), encPart=EncryptedData(etype=ASN1_INTEGER(23), kvno=None, cipher=ASN1_STRING(b'')))"
 
-= KRB AP REP rejects encryption type wider than Int32
-wide = KerberosTCPHeader(hex_bytes("000000206f1e301ca003020105a10302010fa210300ea0080206010101010101a2020400"))
-assert Raw in wide
-assert KRB_AP_REP not in wide
-
 = Test json(à with ASN.1 packet
 
 assert pkt.json() == '{"pvno": {"type": "ASN1_INTEGER", "value": "5"}, "msgType": {"type": "ASN1_INTEGER", "value": "15"}, "encPart": {"etype": {"type": "ASN1_INTEGER", "value": "23"}, "kvno": null, "cipher": {"type": "ASN1_STRING", "value": ""}}}'
@@ -4379,6 +4374,44 @@ try:
     assert False
 except BER_Decoding_Error:
     pass
+
+
+= Decode an INTEGER with one bulk numeric conversion
+
+from builtins import int as builtin_int
+import scapy.asn1.ber as ber_module
+
+class _CountingIntMeta(type):
+    # The decode path also asks isinstance(tag, int), so the stand-in has to
+    # answer that the way the real int would.
+    def __instancecheck__(cls, obj):
+        return isinstance(obj, builtin_int)
+
+class CountingInt(builtin_int, metaclass=_CountingIntMeta):
+    calls = 0
+    @classmethod
+    def from_bytes(cls, value, byteorder, signed=False):
+        CountingInt.calls += 1
+        return builtin_int.from_bytes(value, byteorder, signed=signed)
+
+wide = b"\x02\x08" + b"\x01" * 8
+ber_module.int = CountingInt
+try:
+    decoded, remainder = BERcodec_INTEGER.do_dec(wide)
+finally:
+    del ber_module.int
+
+assert decoded.val == builtin_int.from_bytes(b"\x01" * 8, "big", signed=True)
+assert remainder == b""
+assert CountingInt.calls == 1
+
+= Decode INTEGER boundary values
+
+assert BERcodec_INTEGER.do_dec(b"\x02\x01\x7f")[0].val == 127
+assert BERcodec_INTEGER.do_dec(b"\x02\x01\x80")[0].val == -128
+assert BERcodec_INTEGER.do_dec(b"\x02\x02\x00\x80")[0].val == 128
+assert BERcodec_INTEGER.do_dec(b"\x02\x01\xff")[0].val == -1
+assert BERcodec_INTEGER.do_dec(b"\x02\x00")[0].val == 0
 
 
 = BER tests - 2

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -1503,6 +1503,11 @@ assert pkt.json() == '{"length": null, "id": 0, "qr": 0, "opcode": 0, "aa": 0, "
 pkt = KRB_AP_REP(bytes(KRB_AP_REP(encPart=EncryptedData())))
 assert pkt.command() == "KRB_AP_REP(pvno=ASN1_INTEGER(5), msgType=ASN1_INTEGER(15), encPart=EncryptedData(etype=ASN1_INTEGER(23), kvno=None, cipher=ASN1_STRING(b'')))"
 
+= KRB AP REP rejects encryption type wider than Int32
+wide = KerberosTCPHeader(hex_bytes("000000206f1e301ca003020105a10302010fa210300ea0080206010101010101a2020400"))
+assert Raw in wide
+assert KRB_AP_REP not in wide
+
 = Test json(à with ASN.1 packet
 
 assert pkt.json() == '{"pvno": {"type": "ASN1_INTEGER", "value": "5"}, "msgType": {"type": "ASN1_INTEGER", "value": "15"}, "encPart": {"etype": {"type": "ASN1_INTEGER", "value": "23"}, "kvno": null, "cipher": {"type": "ASN1_STRING", "value": ""}}}'


### PR DESCRIPTION
`BERcodec_INTEGER.do_dec` builds the value by shifting a Python integer left one octet at a time at
[`scapy/asn1/ber.py:464-471`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/asn1/ber.py#L464-L471).
Each shift copies the whole accumulated integer, so the cost of an octet rises with the number of
octets already read and decoding is quadratic in the encoded width.

Nothing in BER limits that width, so any protocol using it can be made to spend the time. A sender
pads an INTEGER with leading sign octets, which do not change the value, and the parser does the
work anyway. Kerberos `EncryptedData.etype` is one way in; it is not the only one.

Measured on one machine, decoding one INTEGER:

| content octets | before | after |
|---|---|---|
| 4,000 | 1.42 ms | 0.002 ms |
| 16,000 | 18.5 ms | 0.009 ms |
| 64,000 | 304 ms | 0.032 ms |
| 256,000 | 5,013 ms | 0.137 ms |

Quadratic before, linear after.

`int.from_bytes(s, "big", signed=True)` performs the same two's-complement conversion in one pass.
The two agree on every input tested, including the empty string, single octets on both sides of the
sign boundary, and 20,000 random byte strings.

**This replaces the first version of this pull request, which added an `Int32` width check to
Kerberos.** @gpotter2 was right that the problem is generic rather than Kerberos-specific, so
`scapy/layers/kerberos.py` is untouched now. Nothing is rejected that was accepted before — wide
integers still parse, just cheaply — which also means certificates and other legitimately large
INTEGER values are unaffected.

The regression test counts that the conversion happens once rather than once per octet, following
the `BitLenField` test added in #5108. It fails on the unmodified revision.
