### PR TITLE
inet6: parse node-information address lists without suffix copies

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -2726,22 +2726,30 @@ class NIReplyDataField(StrField):
         elif qtype == 3:  # IPv6 addresses with TTLs
             # XXX TODO : get the real length
             res = []
-            while len(s) >= 20:  # 4 + 16
-                ttl = struct.unpack("!I", s[:4])[0]
-                ip = inet_ntop(socket.AF_INET6, s[4:20])
+            if len(s) < 40:
+                if len(s) < 20:
+                    return s, (3, res)
+                ttl, addr = struct.unpack("!I16s", s[:20])
+                return s[20:], (3, [(ttl, inet_ntop(socket.AF_INET6, addr))])
+            end = len(s) - len(s) % 20
+            for ttl, addr in struct.iter_unpack("!I16s", memoryview(s)[:end]):
+                ip = inet_ntop(socket.AF_INET6, addr)
                 res.append((ttl, ip))
-                s = s[20:]
-            return s, (3, res)
+            return s[end:], (3, res)
 
         elif qtype == 4:  # IPv4 addresses with TTLs
             # XXX TODO : get the real length
             res = []
-            while len(s) >= 8:  # 4 + 4
-                ttl = struct.unpack("!I", s[:4])[0]
-                ip = inet_ntop(socket.AF_INET, s[4:8])
+            if len(s) < 16:
+                if len(s) < 8:
+                    return s, (4, res)
+                ttl, addr = struct.unpack("!I4s", s[:8])
+                return s[8:], (4, [(ttl, inet_ntop(socket.AF_INET, addr))])
+            end = len(s) - len(s) % 8
+            for ttl, addr in struct.iter_unpack("!I4s", memoryview(s)[:end]):
+                ip = inet_ntop(socket.AF_INET, addr)
                 res.append((ttl, ip))
-                s = s[8:]
-            return s, (4, res)
+            return s[end:], (4, res)
         else:
             # XXX TODO : implement me and deal with real length
             return b"", (0, s)

--- a/test/scapy/layers/inet6.uts
+++ b/test/scapy/layers/inet6.uts
@@ -1814,6 +1814,28 @@ s = raw(IPv6()/ICMPv6NIReplyIPv4(data=[(2807, "192.168.0.1")]))
 p = IPv6(s)
 ICMPv6NIReplyIPv4 in p and p.data == [(2807, "192.168.0.1")]
 
+= ICMPv6NIReply address lists do not copy the unparsed suffix
+class SliceBoundedBytes(bytes):
+    max_width = 0
+    def __getitem__(self, item):
+        value = super().__getitem__(item)
+        if isinstance(item, slice):
+            SliceBoundedBytes.max_width = max(SliceBoundedBytes.max_width, len(value))
+            value = SliceBoundedBytes(value)
+        return value
+
+inputs = (
+    (ICMPv6NIReplyIPv4(), bytes.fromhex("00000000c0000201") * 4),
+    (ICMPv6NIReplyIPv6(), bytes.fromhex("0000000020010db8000000000000000000000001") * 4),
+)
+for packet, data in inputs:
+    field = packet.get_field("data")
+    remaining, values = field.getfield(packet, SliceBoundedBytes(data))
+    assert remaining == b""
+    assert len(values[1]) == 4
+
+assert SliceBoundedBytes.max_width <= 16
+
 
 ############
 ############


### PR DESCRIPTION
The default ICMPv6 dissector selects a node-information reply class from attacker-controlled type
and qtype values at
[`scapy/layers/inet6.py:2805-2822`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/inet6.py#L2805-L2822).
For qtypes 3 and 4, `NIReplyDataField.getfield()` removes every address by slicing the full
unconsumed suffix at
[`scapy/layers/inet6.py:2711-2744`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/inet6.py#L2711-L2744).

From 2,000 to 8,000 address records, median parsing grew from 0.83 ms to 6.87 ms, with a 1.73
exponent and a 5.2% noise floor. Patched times were 0.50 ms to 2.04 ms, with a 1.06 exponent and a
14.0% noise floor.

This change preserves the zero- and one-record paths, then uses `struct.iter_unpack()` over a
`memoryview` and slices the remainder once. The focused count-and-remainder regression failed on
the unmodified revision and passed with the patch.
