### PR TITLE
http: re-check Basic credentials on every request

### DIFF
--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -1292,6 +1292,8 @@ class HTTP_Server(Automaton):
 
     @ATMT.receive_condition(SERVE)
     def new_request(self, pkt):
+        if self.basic:
+            raise self.AUTH(pkt)
         raise self.SERVE(pkt)
 
     # DEV: overwrite this function

--- a/test/scapy/layers/http.uts
+++ b/test/scapy/layers/http.uts
@@ -408,6 +408,31 @@ with run_httpserver(mech=HTTP_AUTH_MECHS.NONE):
 
 assert html == "<!doctype html><html><body><h1>OK</h1></body></html>"
 
+= HTTP - HTTP_Server authenticates every Basic request on a reused connection
+~ http-client
+
+import base64
+import http.client
+
+headers = {
+    "Authorization": "Basic " + base64.b64encode(b"user:password").decode(),
+}
+
+with run_httpserver(mech=HTTP_AUTH_MECHS.BASIC, BASIC_IDENTITIES={"user": "password"}):
+    client = http.client.HTTPConnection("127.0.0.1", 8080, timeout=2)
+    try:
+        client.request("GET", "/", headers=headers)
+        first_response = client.getresponse()
+        first_status = first_response.status
+        first_response.read()
+        client.request("GET", "/")
+        second_status = client.getresponse().status
+    finally:
+        client.close()
+
+assert first_status == 200
+assert second_status == 401
+
 + Test HTTPS client/server
 
 = HTTPS - HTTPS_client asks HTTPS_server with NTLMSSP and CBT


### PR DESCRIPTION


HTTP Basic authentication is defined per request: every request carries its own `Authorization`
header and is meant to be checked on its own. `HTTP_Server` checks it once per connection instead.
This brings it in line with how the scheme works.

`HTTP_Server` is Scapy's HTTP answering automaton. When it is started with `basic=True` it asks for
a username and password, and a request without them gets a `401` challenge instead of a response
([`scapy/layers/http.py:1161-1172`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/http.py#L1161-L1172)).

A request that carries the right credentials moves the connection into the `SERVE` state
([`scapy/layers/http.py:1200-1225`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/http.py#L1200-L1225)),
and the connection stays there. Every later request on the same socket is handed straight back to
`SERVE` without looking for an `Authorization` header
([`scapy/layers/http.py:1293-1295`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/http.py#L1293-L1295)):

```python
@ATMT.receive_condition(SERVE)
def new_request(self, pkt):
    raise self.SERVE(pkt)
```

So authentication is checked once per TCP connection rather than once per request. HTTP/1.1 keeps
connections open and reuses them, so a second request with no credentials at all is answered.

For a client that opens its own connection this is mostly a correctness wart: the same client keeps
the access it already authenticated for, and nobody else gets in.

It matters more when the connection is not the client's own. Anyone testing through a reverse proxy
or a connection pool — the usual way of putting a server behind something — can have one backend
connection carry requests from more than one person. Then the second person is served on the first
person's credentials, and the server never asks. That is worth fixing even though reaching it takes
a specific setup.

The change routes each request on an authenticated connection back through the existing credential
parser:

```diff
 @ATMT.receive_condition(SERVE)
 def new_request(self, pkt):
+    if self.basic:
+        raise self.AUTH(pkt)
     raise self.SERVE(pkt)
```

A valid credential still reaches `SERVE`; a missing or wrong one gets the `401` it would have got
on the first request. Authentication schemes other than Basic are untouched and keep their
connection-scoped behaviour.

The added test in `test/scapy/layers/http.uts` sends a valid Basic request and then a request with
no headers on one `http.client.HTTPConnection`, and asserts `200` followed by `401`. Reverting the
production change makes that test fail. With the change, all 21 HTTP tests pass, and import,
flake8, Linux and Windows mypy, and codespell are clean.

The valid state transition measured 150.9 ns per call before the change and 151.5 ns after. That
+0.4% difference is too small to separate from normal run-to-run variation, so no performance claim
is made in either direction.