### PR TITLE
netbios: key the NBNS resolver cache by name

### DIFF
--- a/scapy/layers/netbios.py
+++ b/scapy/layers/netbios.py
@@ -456,7 +456,7 @@ def nbns_resolve(
     qname = NBNSQueryRequest.QUESTION_NAME.any2i(None, qname)
 
     # Check cache
-    cache_ident = qname + b"raw" if raw else b""
+    cache_ident = (qname, raw)
     result = _nbns_cache.get(cache_ident)
     if result:
         return result

--- a/test/scapy/layers/netbios.uts
+++ b/test/scapy/layers/netbios.uts
@@ -137,3 +137,32 @@ with no_debug_dissector():
     raw_packet = b'E\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x05\x00\x00\x00'
     packet = NBNSQueryResponse(raw_packet)
     assert packet.summary() == "NBNSQueryResponse"
+
+= nbns_resolve caches default results by query name
+~ mock
+
+from unittest import mock
+from scapy.layers.netbios import _nbns_cache, nbns_resolve
+
+_nbns_queries = []
+_nbns_cache.flush()
+
+def _answer_nbns(requests, **kwargs):
+    packet = requests[0] if isinstance(requests, list) else requests
+    name = packet.QUESTION_NAME
+    _nbns_queries.append(name)
+    address = "203.0.113.66" if name == b"ALPHA" else "192.0.2.44"
+    return NBNSHeader(RESPONSE=1, NM_FLAGS=0x50, ANCOUNT=1) / NBNSQueryResponse(
+        RR_NAME=name,
+        ADDR_ENTRY=[NBNS_ADD_ENTRY(NB_ADDRESS=address)],
+    )
+
+try:
+    with mock.patch("scapy.layers.netbios.sr1", side_effect=_answer_nbns), mock.patch(
+        "scapy.layers.netbios.conf.route.get_if_bcast", return_value=["192.0.2.255"]
+    ):
+        assert nbns_resolve("ALPHA", iface="test") == ["203.0.113.66"]
+        assert nbns_resolve("BETA", iface="test") == ["192.0.2.44"]
+    assert _nbns_queries == [b"ALPHA", b"BETA"]
+finally:
+    _nbns_cache.flush()


### PR DESCRIPTION


`nbns_resolve()` looks up a NetBIOS name on the local network and caches what it gets back, so a
repeated lookup for the same name does not send another query.

The cache key is built at
[`scapy/layers/netbios.py:455-462`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/netbios.py#L455-L462):

```python
cache_ident = qname + b"raw" if raw else b""
```

Python applies `+` before the conditional, so this reads as `(qname + b"raw") if raw else b""`. The
name is part of the key only when the caller passes `raw=True`. `raw` defaults to `False`, so every
ordinary lookup is stored and retrieved under the same empty key `b""`.

The first ordinary lookup in a process therefore populates the cache for all of them. A later
lookup for a different name returns the first name's address
([the result is stored under that shared key at
`scapy/layers/netbios.py:505-515`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/netbios.py#L505-L515)),
and no query goes out, so nothing on the network reveals that the wrong answer was used. Anything
built on `nbns_resolve()` is then pointed at the wrong host.

The change keys the cache by both the name and the result mode:

```diff
-    cache_ident = qname + b"raw" if raw else b""
+    cache_ident = (qname, raw)
```

Repeated lookups of one name are still cache hits. Different names now miss and reach the network,
which is the behaviour the cache was meant to have.

The added regression test asserts that a second lookup for a different name returns that name's own
address and that a query was sent for it. Restoring the old expression makes the test fail. With
the change the NetBIOS suite passes 11 of 11, and import, flake8, Linux and Windows mypy, and
codespell are clean.

A cache hit measured 462.6 ns per call before the change and 489.2 ns after. That +5.8% cost is
larger than this benchmark's run-to-run variation, so it is reported rather than dismissed. It buys
a tuple key in place of a byte string on the hit path; the lookups that previously "hit" for the
wrong name were returning an incorrect answer, so the comparison is against work that was not
correct to skip.