### PR TITLE
bpv7: Bundle Protocol v7 contrib with RFC validation

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -193,6 +193,23 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+
+  cbor2-interop:
+    name: cbor2 interoperability (Python 3.12)
+    runs-on: ubuntu-latest
+    needs: [commit, spdx]
+    steps:
+      - name: Checkout Scapy
+        uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install tox
+        run: pip install tox
+      - name: Run cbor2 differential tests
+        run: tox -e cbor2
+
   cryptography:
     name: pyca/cryptography test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ follow the instructions to install them.
 
 ## Packaging status
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/scapy.svg?columns=4&exclude_unsupported=1&header=
-)](https://repology.org/project/scapy/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/scapy.svg?columns=4&exclude_unsupported=1)](https://repology.org/project/scapy/versions)
 
 ## License
 

--- a/scapy/cbor/__init__.py
+++ b/scapy/cbor/__init__.py
@@ -21,15 +21,21 @@ from scapy.cbor.cbor import (
     CBOR_TEXT_STRING,
     CBOR_ARRAY,
     CBOR_MAP,
+    CBORMapData,
     CBOR_SEMANTIC_TAG,
     CBOR_SIMPLE_VALUE,
     CBOR_FALSE,
     CBOR_TRUE,
     CBOR_NULL,
     CBOR_UNDEFINED,
+    CBOR_UNDEFINED_VALUE,
+    CBOR_NO_ITEM,
     CBOR_FLOAT,
+    CBORFloatValue,
     CBOR_DECODING_ERROR,
     RandCBORObject,
+    CBORTagValue,
+    CBORSimpleValue,
 )
 
 from scapy.cbor.cborcodec import (
@@ -45,8 +51,12 @@ from scapy.cbor.cborcodec import (
 )
 
 from scapy.cbor.cborfields import (
+    CBORBuildResult,
+    CBORParseResult,
     CBORF_element,
     CBORF_field,
+    CBORF_ANY,
+    CBOR_ABSENT,
     CBORF_UNSIGNED_INTEGER,
     CBORF_NEGATIVE_INTEGER,
     CBORF_INTEGER,
@@ -56,12 +66,19 @@ from scapy.cbor.cborfields import (
     CBORF_NULL,
     CBORF_UNDEFINED,
     CBORF_FLOAT,
+    CBORF_SEQUENCE,
+    CBORF_SEQUENCE_OF,
     CBORF_ARRAY,
     CBORF_ARRAY_OF,
+    CBORF_ARRAY_INDEFINITE,
     CBORF_MAP,
     CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_ENUM,
+    CBORF_UNSIGNED_FLAGS,
     CBORF_optional,
+    CBORF_CONDITIONAL,
     CBORF_PACKET,
+    CBORF_BYTE_STRING_PACKET,
 )
 
 __all__ = [
@@ -81,14 +98,20 @@ __all__ = [
     "CBOR_TEXT_STRING",
     "CBOR_ARRAY",
     "CBOR_MAP",
+    "CBORMapData",
     "CBOR_SEMANTIC_TAG",
     "CBOR_SIMPLE_VALUE",
     "CBOR_FALSE",
     "CBOR_TRUE",
     "CBOR_NULL",
     "CBOR_UNDEFINED",
+    "CBOR_UNDEFINED_VALUE",
+    "CBOR_NO_ITEM",
     "CBOR_FLOAT",
+    "CBORFloatValue",
     "CBOR_DECODING_ERROR",
+    "CBORTagValue",
+    "CBORSimpleValue",
     # Random/Fuzzing
     "RandCBORObject",
     # Codec classes
@@ -101,9 +124,14 @@ __all__ = [
     "CBORcodec_MAP",
     "CBORcodec_SEMANTIC_TAG",
     "CBORcodec_SIMPLE_AND_FLOAT",
+    # Result types
+    "CBORBuildResult",
+    "CBORParseResult",
     # Field base classes
     "CBORF_element",
     "CBORF_field",
+    "CBORF_ANY",
+    "CBOR_ABSENT",
     # Scalar fields
     "CBORF_UNSIGNED_INTEGER",
     "CBORF_NEGATIVE_INTEGER",
@@ -115,11 +143,18 @@ __all__ = [
     "CBORF_UNDEFINED",
     "CBORF_FLOAT",
     # Structured fields
+    "CBORF_SEQUENCE",
+    "CBORF_SEQUENCE_OF",
     "CBORF_ARRAY",
     "CBORF_ARRAY_OF",
+    "CBORF_ARRAY_INDEFINITE",
     "CBORF_MAP",
     "CBORF_SEMANTIC_TAG",
     # Complex fields
+    "CBORF_UNSIGNED_ENUM",
+    "CBORF_UNSIGNED_FLAGS",
     "CBORF_optional",
+    "CBORF_CONDITIONAL",
     "CBORF_PACKET",
+    "CBORF_BYTE_STRING_PACKET",
 ]

--- a/scapy/cbor/cbor.py
+++ b/scapy/cbor/cbor.py
@@ -7,7 +7,10 @@ CBOR (Concise Binary Object Representation) - RFC 8949
 Following the ASN.1 paradigm
 """
 
+import copy
+import math
 import random
+import struct
 from typing import (
     Any,
     Dict,
@@ -296,11 +299,12 @@ class CBOR_Object_metaclass(type):
             'Type[CBOR_Object[Any]]',
             super(CBOR_Object_metaclass, cls).__new__(cls, name, bases, dct)
         )
-        try:
-            c.tag.register_cbor_object(c)
-        except Exception:
-            # Some objects may not have tags yet
-            log_runtime.warning("Failed to register CBOR object %r" % c)
+        if c.tag is not None:
+            try:
+                c.tag.register_cbor_object(c)
+            except Exception:
+                # Some objects may not have tags yet
+                log_runtime.exception("Failed to register CBOR object %r" % c)
         return c
 
 
@@ -346,7 +350,26 @@ class CBOR_Object(Generic[_K], metaclass=CBOR_Object_metaclass):
 
     def __eq__(self, other):
         # type: (Any) -> bool
-        return bool(self.val == other)
+        if isinstance(other, CBOR_Object):
+            return (
+                type(self) is type(other)
+                and self.val == other.val
+            )
+        return NotImplemented
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return NotImplemented
+        return not equal
+
+    def __hash__(self):
+        # type: () -> int
+        try:
+            return hash((type(self), self.val))
+        except TypeError:
+            return hash((type(self), id(self)))
 
 
 #######################
@@ -367,6 +390,11 @@ class CBOR_NEGATIVE_INTEGER(CBOR_Object[int]):
 class CBOR_BYTE_STRING(CBOR_Object[bytes]):
     """CBOR byte string (major type 2)"""
     tag = CBOR_MajorTypes.BYTE_STRING
+
+    def __repr__(self):
+        # type: () -> str
+        hexval = self.val.hex() if self.val else ''
+        return "<%s[h'%s']>" % (self.__class__.__name__, hexval)
 
 
 class CBOR_TEXT_STRING(CBOR_Object[str]):
@@ -389,14 +417,202 @@ class CBOR_ARRAY(CBOR_Object[List[Any]]):
         return s
 
 
-class CBOR_MAP(CBOR_Object[Dict[Any, Any]]):
-    """CBOR map (major type 5)"""
+class CBORMapData(object):
+    """Ordered CBOR map pairs with typed dict-like access for scalar keys.
+
+    Preserves full CBOR key objects for faithful ``enc()`` round-trips while
+    still supporting ``map_data['name']`` / ``'name' in map_data`` for the
+    common scalar-key cases used by existing tests.
+
+    Lookup uses ``(type(key), key)`` identity so CBOR/Python values that
+    compare equal under ``==`` but differ by type (``1`` vs ``True``) remain
+    distinct.
+    """
+
+    __slots__ = ("_pairs",)
+
+    def __init__(self, pairs=None):
+        # type: (Optional[List[Tuple[Any, Any]]]) -> None
+        self._pairs = list(pairs or [])
+
+    def cbor_pairs(self):
+        # type: () -> List[Tuple[Any, Any]]
+        return list(self._pairs)
+
+    def copy(self):
+        # type: () -> CBORMapData
+        return copy.deepcopy(self)
+
+    def __copy__(self):
+        # type: () -> CBORMapData
+        return self.copy()
+
+    def __deepcopy__(self, memo):
+        # type: (Dict[int, Any]) -> CBORMapData
+        return CBORMapData(copy.deepcopy(self._pairs, memo))
+
+    def __len__(self):
+        # type: () -> int
+        return len(self._pairs)
+
+    def __iter__(self):
+        # type: () -> Any
+        return iter(self.keys())
+
+    @staticmethod
+    def _float_key_identity(val, encoded=None):
+        # type: (float, Optional[bytes]) -> Tuple[Any, ...]
+        """Identity that distinguishes +0.0 / -0.0 and NaN payloads."""
+        fval = float(val)
+        if math.isnan(fval):
+            if encoded is not None:
+                return (float, "nan", bytes(encoded))
+            return (float, "nan", struct.pack(">d", fval))
+        # struct.pack preserves the IEEE sign bit so +0.0 != -0.0.
+        return (float, "f", struct.pack(">d", fval))
+
+    @staticmethod
+    def _key_identity(key):
+        # type: (Any) -> Tuple[Any, ...]
+        """Return a typed identity for map-key lookup."""
+        if isinstance(key, CBOR_Object):
+            # Normalize CBOR wrappers to the native Python type they encode.
+            if isinstance(key, (CBOR_TRUE, CBOR_FALSE)):
+                return (bool, bool(key.val))
+            if isinstance(key, CBOR_NULL):
+                return (type(None), None)
+            if isinstance(key, CBOR_UNDEFINED):
+                from scapy.cbor.cbor import CBOR_UNDEFINED_VALUE
+                return (type(CBOR_UNDEFINED_VALUE), CBOR_UNDEFINED_VALUE)
+            if isinstance(key, CBOR_UNSIGNED_INTEGER):
+                return (int, int(key.val))
+            if isinstance(key, CBOR_NEGATIVE_INTEGER):
+                return (int, int(key.val))
+            if isinstance(key, CBOR_FLOAT):
+                return CBORMapData._float_key_identity(
+                    key.val, getattr(key, "_encoded", None)
+                )
+            if isinstance(key, CBOR_BYTE_STRING):
+                return (bytes, bytes(key.val))
+            if isinstance(key, CBOR_TEXT_STRING):
+                return (str, str(key.val))
+            if isinstance(key, CBOR_ARRAY):
+                return (list, key)
+            if isinstance(key, CBOR_MAP):
+                return (CBORMapData, key)
+            if isinstance(key, CBOR_SEMANTIC_TAG):
+                return (CBOR_SEMANTIC_TAG, key.val)
+            if isinstance(key, CBOR_SIMPLE_VALUE):
+                return (CBOR_SIMPLE_VALUE, key.val)
+            return (type(key), key.val)
+        # bool is a subclass of int; float includes CBORFloatValue.
+        if isinstance(key, bool):
+            return (bool, key)
+        if isinstance(key, float):
+            encoded = getattr(key, "cbor_encoded", None)
+            return CBORMapData._float_key_identity(key, encoded)
+        if isinstance(key, int):
+            return (int, key)
+        return (type(key), key)
+
+    def keys(self):
+        # type: () -> List[Any]
+        out = []  # type: List[Any]
+        for key, _value in self._pairs:
+            out.append(key.val if isinstance(key, CBOR_Object) else key)
+        return out
+
+    def values(self):
+        # type: () -> List[Any]
+        return [value for _key, value in self._pairs]
+
+    def items(self):
+        # type: () -> List[Tuple[Any, Any]]
+        return [
+            (key.val if isinstance(key, CBOR_Object) else key, value)
+            for key, value in self._pairs
+        ]
+
+    def __contains__(self, key):
+        # type: (Any) -> bool
+        try:
+            self[key]
+            return True
+        except KeyError:
+            return False
+
+    def __getitem__(self, key):
+        # type: (Any) -> Any
+        want = self._key_identity(key)
+        matches = []  # type: List[Any]
+        for map_key, value in self._pairs:
+            if self._key_identity(map_key) == want:
+                matches.append(value)
+        if not matches:
+            raise KeyError(key)
+        if len(matches) > 1:
+            raise KeyError("Ambiguous CBOR map key %r" % (key,))
+        return matches[0]
+
+    def get(self, key, default=None):
+        # type: (Any, Any) -> Any
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        if isinstance(other, dict):
+            # Do not use dict(self.items()): Python collapses True/1 (and
+            # similar) as equal keys, which is not the CBOR data model.
+            if len(other) != len(self._pairs):
+                return False
+            other_items = list(other.items())
+            used = [False] * len(other_items)
+            for map_key, value in self._pairs:
+                want = self._key_identity(map_key)
+                matched = False
+                for idx, (other_key, other_value) in enumerate(other_items):
+                    if used[idx]:
+                        continue
+                    if self._key_identity(other_key) != want:
+                        continue
+                    if value != other_value:
+                        return False
+                    used[idx] = True
+                    matched = True
+                    break
+                if not matched:
+                    return False
+            return True
+        if isinstance(other, CBORMapData):
+            return self._pairs == other._pairs
+        return NotImplemented
+
+    def __repr__(self):
+        # type: () -> str
+        return "CBORMapData(%r)" % (self.items(),)
+
+
+class CBOR_MAP(CBOR_Object[Any]):
+    """CBOR map (major type 5).
+
+    Decoded maps use :class:`CBORMapData` (ordered pairs). Manually
+    constructed maps may still use a plain ``dict``.
+    """
     tag = CBOR_MajorTypes.MAP
 
     def strshow(self, lvl=0):
         # type: (int) -> str
         s = ("  " * lvl) + ("# CBOR_MAP:") + "\n"
-        for k, v in self.val.items():
+        if isinstance(self.val, CBORMapData):
+            items = self.val.cbor_pairs()
+        elif isinstance(self.val, dict):
+            items = list(self.val.items())
+        else:
+            items = list(self.val)
+        for k, v in items:
             s += ("  " * (lvl + 1)) + "Key: "
             if hasattr(k, 'strshow'):
                 s += k.strshow(0).strip() + "\n"
@@ -456,9 +672,142 @@ class CBOR_UNDEFINED(CBOR_Object[None]):
         super(CBOR_UNDEFINED, self).__init__(None)
 
 
+class CBORTagValue(object):
+    """Packet-field internal representation of a CBOR semantic tag."""
+    __slots__ = ("tag", "value")
+
+    def __init__(self, tag, value):
+        # type: (int, Any) -> None
+        self.tag = int(tag)
+        self.value = value
+
+    def __repr__(self):
+        # type: () -> str
+        return "CBORTagValue(tag=%r, value=%r)" % (self.tag, self.value)
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        return (
+            isinstance(other, CBORTagValue) and
+            self.tag == other.tag and
+            self.value == other.value
+        )
+
+    def __hash__(self):
+        # type: () -> int
+        return hash((self.tag, self.value))
+
+
+class CBORSimpleValue(object):
+    """Packet-field internal representation of a CBOR simple value."""
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        # type: (int) -> None
+        self.value = int(value)
+
+    def __repr__(self):
+        # type: () -> str
+        return "CBORSimpleValue(%r)" % self.value
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        return isinstance(other, CBORSimpleValue) and self.value == other.value
+
+    def __hash__(self):
+        # type: () -> int
+        return hash(self.value)
+
+
+class _CBORUndefined(object):
+    """Sentinel for CBOR undefined (distinct from Python ``None`` / null)."""
+
+    def __repr__(self):
+        # type: () -> str
+        return "CBOR_UNDEFINED"
+
+    def __bool__(self):
+        # type: () -> bool
+        return False
+
+    def __copy__(self):
+        # type: () -> _CBORUndefined
+        return self
+
+    def __deepcopy__(self, memo):
+        # type: (dict) -> _CBORUndefined
+        return self
+
+
+CBOR_UNDEFINED_VALUE = _CBORUndefined()
+
+
+class _CBORNoItem(object):
+    """Structural sentinel: sequence ended without consuming input."""
+
+    def __repr__(self):
+        # type: () -> str
+        return "CBOR_NO_ITEM"
+
+    def __copy__(self):
+        # type: () -> _CBORNoItem
+        return self
+
+    def __deepcopy__(self, memo):
+        # type: (dict) -> _CBORNoItem
+        return self
+
+
+CBOR_NO_ITEM = _CBORNoItem()
+
+
 class CBOR_FLOAT(CBOR_Object[float]):
     """CBOR floating-point number (major type 7)"""
     tag = CBOR_MajorTypes.SIMPLE_AND_FLOAT
+
+    def __init__(self, val, encoded=None):
+        # type: (float, Optional[bytes]) -> None
+        CBOR_Object.__init__(self, val)
+        # Exact received float encoding when known; preferred width when None.
+        self._encoded = encoded
+
+    def enc(self, codec=None):
+        # type: (Any) -> bytes
+        if self._encoded is not None:
+            return self._encoded
+        return super(CBOR_FLOAT, self).enc(codec)
+
+
+class CBORFloatValue(float):
+    """Native float that optionally retains the exact CBOR encoding.
+
+    Used by :class:`~scapy.cbor.cborfields.CBORF_FLOAT` and
+    :class:`~scapy.cbor.cborfields.CBORF_ANY` so dissected half / single /
+    double (and NaN payloads) survive field storage and rebuild when the
+    packet raw cache is cleared, until the value is replaced by a plain
+    ``float``.
+    """
+
+    __slots__ = ("_cbor_encoded",)
+
+    def __new__(cls, value, encoded=None):
+        # type: (float, Optional[bytes]) -> CBORFloatValue
+        self = float.__new__(cls, value)
+        object.__setattr__(self, "_cbor_encoded", encoded)
+        return self
+
+    @property
+    def cbor_encoded(self):
+        # type: () -> Optional[bytes]
+        return getattr(self, "_cbor_encoded", None)
+
+    def __copy__(self):
+        # type: () -> CBORFloatValue
+        return CBORFloatValue(float(self), self.cbor_encoded)
+
+    def __deepcopy__(self, memo):
+        # type: (dict) -> CBORFloatValue
+        return self.__copy__()
 
 
 class _CBOR_ERROR(CBOR_Object[Union[bytes, CBOR_Object[Any]]]):

--- a/scapy/cbor/cborcodec.py
+++ b/scapy/cbor/cborcodec.py
@@ -35,6 +35,9 @@ from scapy.compat import chb
 from scapy.error import log_runtime
 
 
+MAX_CBOR_NESTING = 128
+
+
 ##################
 #  CBOR encoding #
 ##################
@@ -42,6 +45,10 @@ from scapy.error import log_runtime
 
 class CBOR_Exception(Exception):
     pass
+
+
+class CBOR_INDEFINITE(object):
+    """Marker returned by :func:`CBOR_decode_head` for indefinite-length items."""
 
 
 class CBOR_Codec_Encoding_Error(CBOR_Encoding_Error):
@@ -74,6 +81,15 @@ def CBOR_encode_head(major_type, value):
     Encode CBOR initial byte and additional info.
     Format: 3 bits major type + 5 bits additional info
     """
+    if value is None:
+        raise CBOR_Codec_Encoding_Error(
+            "Indefinite length requires CBOR_encode_indefinite_head")
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CBOR_Codec_Encoding_Error(
+            "CBOR head value must be an integer, got %r" % (value,))
+    if value < 0 or value > 0xFFFFFFFFFFFFFFFF:
+        raise CBOR_Codec_Encoding_Error(
+            "CBOR head value out of uint64 range: %r" % (value,))
     if value < 24:
         # Value fits in 5 bits
         return chb((major_type << 5) | value)
@@ -91,14 +107,56 @@ def CBOR_encode_head(major_type, value):
         return chb((major_type << 5) | 27) + struct.pack(">Q", value)
 
 
+def CBOR_encode_indefinite_head(major_type):
+    # type: (int) -> bytes
+    """Encode a CBOR indefinite-length header (additional info 31)."""
+    if major_type not in (2, 3, 4, 5):
+        raise CBOR_Codec_Encoding_Error(
+            "Indefinite length not allowed for major type %d" % major_type
+        )
+    return chb((major_type << 5) | 31)
+
+
+def CBOR_encode_break():
+    # type: () -> bytes
+    """Encode the CBOR break stop code (0xff)."""
+    return b'\xff'
+
+
+def _cbor_buf_bytes(buf):
+    # type: (Any) -> bytes
+    """Materialize a bytes/memoryview slice as ``bytes``."""
+    if isinstance(buf, bytes):
+        return buf
+    if isinstance(buf, memoryview):
+        return buf.tobytes()
+    return bytes(buf)
+
+
+def cbor_is_break(s):
+    # type: (Any) -> bool
+    """Return whether *s* begins with a CBOR break byte."""
+    return bool(s) and s[0] == 0xff
+
+
+def cbor_consume_break(s):
+    # type: (Any) -> Any
+    """Consume a leading CBOR break byte from *s*."""
+    if not cbor_is_break(s):
+        raise CBOR_Codec_Decoding_Error(
+            "Expected break byte (0xff)", remaining=_cbor_buf_bytes(s))
+    return s[1:]
+
+
 def CBOR_decode_head(s):
-    # type: (bytes) -> Tuple[int, int, bytes]
+    # type: (Any) -> Tuple[int, Union[int, CBOR_INDEFINITE], Any]
     """
     Decode CBOR initial byte and additional info.
     Returns: (major_type, value, remaining_bytes)
     """
     if not s:
-        raise CBOR_Codec_Decoding_Error("Empty CBOR data", remaining=s)
+        raise CBOR_Codec_Decoding_Error(
+            "Empty CBOR data", remaining=_cbor_buf_bytes(s))
 
     initial_byte = s[0]
     major_type = initial_byte >> 5
@@ -111,32 +169,360 @@ def CBOR_decode_head(s):
         # 1-byte value follows
         if len(s) < 2:
             raise CBOR_Codec_Decoding_Error(
-                "Not enough bytes for 1-byte value", remaining=s)
+                "Not enough bytes for 1-byte value",
+                remaining=_cbor_buf_bytes(s))
         return major_type, s[1], s[2:]
     elif additional_info == 25:
         # 2-byte value follows
         if len(s) < 3:
             raise CBOR_Codec_Decoding_Error(
-                "Not enough bytes for 2-byte value", remaining=s)
+                "Not enough bytes for 2-byte value",
+                remaining=_cbor_buf_bytes(s))
         value = struct.unpack(">H", s[1:3])[0]
         return major_type, value, s[3:]
     elif additional_info == 26:
         # 4-byte value follows
         if len(s) < 5:
             raise CBOR_Codec_Decoding_Error(
-                "Not enough bytes for 4-byte value", remaining=s)
+                "Not enough bytes for 4-byte value",
+                remaining=_cbor_buf_bytes(s))
         value = struct.unpack(">I", s[1:5])[0]
         return major_type, value, s[5:]
     elif additional_info == 27:
         # 8-byte value follows
         if len(s) < 9:
             raise CBOR_Codec_Decoding_Error(
-                "Not enough bytes for 8-byte value", remaining=s)
+                "Not enough bytes for 8-byte value",
+                remaining=_cbor_buf_bytes(s))
         value = struct.unpack(">Q", s[1:9])[0]
         return major_type, value, s[9:]
+    elif additional_info == 31:
+        if major_type in (0, 1, 6):
+            raise CBOR_Codec_Decoding_Error(
+                "Indefinite length not allowed for major type %d" %
+                major_type, remaining=_cbor_buf_bytes(s))
+        if major_type in (2, 3, 4, 5):
+            return major_type, CBOR_INDEFINITE, s[1:]
+        raise CBOR_Codec_Decoding_Error(
+            "Indefinite length not allowed for major type %d" %
+            major_type, remaining=_cbor_buf_bytes(s))
+    elif additional_info in (28, 29, 30):
+        raise CBOR_Codec_Decoding_Error(
+            "Reserved additional info: %d" % additional_info,
+            remaining=_cbor_buf_bytes(s))
     else:
         raise CBOR_Codec_Decoding_Error(
-            "Invalid additional info: %d" % additional_info, remaining=s)
+            "Invalid additional info: %d" % additional_info,
+            remaining=_cbor_buf_bytes(s))
+
+
+def cbor_argument_is_shortest(additional_info, value):
+    # type: (int, Union[int, CBOR_INDEFINITE]) -> bool
+    """Return True when *additional_info* is the shortest encoding for *value*."""
+    if value is CBOR_INDEFINITE:
+        return additional_info == 31
+    if additional_info < 24:
+        return True
+    if additional_info == 24:
+        return value >= 24
+    if additional_info == 25:
+        return value >= 256
+    if additional_info == 26:
+        return value >= 65536
+    if additional_info == 27:
+        return value >= (1 << 32)
+    return additional_info == 31
+
+
+def _cbor_float_from_bits(ai, bits):
+    # type: (int, int) -> float
+    if ai == 25:
+        sign = (bits >> 15) & 0x1
+        exponent = (bits >> 10) & 0x1f
+        fraction = bits & 0x3ff
+        if exponent == 0:
+            if fraction == 0:
+                return -0.0 if sign else 0.0
+            return ((-1) ** sign) * (fraction / 1024.0) * (2 ** -14)
+        if exponent == 31:
+            return float("nan") if fraction else (
+                float("-inf") if sign else float("inf")
+            )
+        return ((-1) ** sign) * (1.0 + fraction / 1024.0) * (2 ** (exponent - 15))
+    if ai == 26:
+        return struct.unpack(">f", struct.pack(">I", bits))[0]
+    return struct.unpack(">d", struct.pack(">Q", bits))[0]
+
+
+def _cbor_float_to_half_bits(value):
+    # type: (float) -> Optional[int]
+    """Return IEEE binary16 bits when *value* round-trips exactly."""
+    import math
+    if math.isnan(value):
+        # Callers that care about NaN payloads must use bit-pattern helpers.
+        return 0x7E00
+    sign = 0x8000 if math.copysign(1.0, value) < 0 else 0
+    if math.isinf(value):
+        return sign | 0x7C00
+    if value == 0.0:
+        return sign
+    value = abs(value)
+    bits64, = struct.unpack(">Q", struct.pack(">d", value))
+    exp64 = ((bits64 >> 52) & 0x7FF) - 1023
+    mant64 = bits64 & ((1 << 52) - 1)
+    if exp64 > 15:
+        return None
+    if exp64 < -14:
+        # Subnormal half
+        shift = -14 - exp64 + 42  # 52 - 10
+        if shift > 52:
+            return None
+        mant = ((mant64 | (1 << 52)) >> shift) if exp64 != -1023 else 0
+        half = mant & 0x3FF
+        preferred = math.copysign(value, -1.0 if sign else 1.0)
+        if _cbor_float_from_bits(25, sign | half) != preferred:
+            # Compare absolute then restore sign via copysign on left side
+            decoded = _cbor_float_from_bits(25, sign | half)
+            if decoded != math.copysign(abs(value), -1.0 if sign else 1.0):
+                return None
+        return sign | half
+    half_exp = exp64 + 15
+    half_mant = mant64 >> 42
+    # Reject if discarded mantissa bits are nonzero (not exact).
+    if mant64 & ((1 << 42) - 1):
+        return None
+    bits = sign | (half_exp << 10) | half_mant
+    decoded = _cbor_float_from_bits(25, bits)
+    if decoded != math.copysign(abs(value), -1.0 if sign else 1.0):
+        return None
+    return bits
+
+
+def _cbor_nan_preferred_ai(ai, bits):
+    # type: (int, int) -> int
+    """Preferred float AI for a NaN, based on the original bit pattern.
+
+    RFC 8949 prefers a shorter NaN only when zero-padding the shorter
+    significand reconstructs the original NaN payload.
+    """
+    if ai == 25:
+        return 25
+    if ai == 26:
+        # binary32 NaN: 1+8+23. Prefer half when low 13 significand bits are 0.
+        mant = int(bits) & 0x7FFFFF
+        if mant and (mant & ((1 << 13) - 1)) == 0:
+            return 25
+        return 26
+    if ai == 27:
+        # binary64 NaN: 1+11+52.
+        mant = int(bits) & ((1 << 52) - 1)
+        if mant == 0:
+            # Infinity, not NaN — caller should not use this helper.
+            return 27
+        # Prefer half when only the top 10 significand bits are used.
+        if (mant & ((1 << 42) - 1)) == 0:
+            return 25
+        # Prefer single when only the top 23 significand bits are used.
+        if (mant & ((1 << 29) - 1)) == 0:
+            return 26
+        return 27
+    return ai
+
+
+def _cbor_preferred_float_ai(value):
+    # type: (float) -> int
+    """Return the preferred float AI (25/26/27) for a numeric *value*."""
+    import math
+    if math.isnan(value):
+        # Without the original payload bits, only the quiet binary16 NaN is a
+        # safe generic preference. Encoded-width checks use bit patterns.
+        return 25
+    if _cbor_float_to_half_bits(value) is not None:
+        return 25
+    try:
+        single = struct.unpack(">f", struct.pack(">f", value))[0]
+    except (OverflowError, struct.error):
+        return 27
+    if single == value or (math.isinf(single) and math.isinf(value)):
+        return 26
+    return 27
+
+
+def _cbor_preferred_float_ai_from_encoded(ai, bits):
+    # type: (int, int) -> int
+    """Preferred float AI using the original encoded width and bit pattern."""
+    import math
+    float_val = _cbor_float_from_bits(ai, bits)
+    if math.isnan(float_val):
+        return _cbor_nan_preferred_ai(ai, bits)
+    return _cbor_preferred_float_ai(float_val)
+
+
+def cbor_find_non_deterministic(s, allow_indefinite=True, base_offset=0):
+    # type: (bytes, bool, int) -> List[Tuple[int, str]]
+    """Scan *s* for non-shortest CBOR argument encodings.
+
+    Returns a list of ``(absolute_offset, message)`` issues. Indefinite-length
+    items are accepted only when *allow_indefinite* is true (e.g. a BPv7
+    bundle outer array). Callers that require definite-length encoding
+    (primary/canonical blocks per RFC 9171) must pass ``False``.
+    """
+    issues = []  # type: List[Tuple[int, str]]
+    index = [0]
+
+    def _walk():
+        # type: () -> None
+        start = index[0]
+        if start >= len(s):
+            raise CBOR_Codec_Decoding_Error(
+                "Empty CBOR data", remaining=s[start:])
+        initial = s[start]
+        if initial == 0xff:
+            issues.append((
+                base_offset + start,
+                "Standalone break byte (0xff)",
+            ))
+            index[0] = start + 1
+            return
+        major = initial >> 5
+        ai = initial & 0x1f
+        pos = start + 1
+        if ai < 24:
+            value = ai  # type: Union[int, CBOR_INDEFINITE]
+        elif ai == 24:
+            if pos + 1 > len(s):
+                raise CBOR_Codec_Decoding_Error(
+                    "Not enough bytes for 1-byte value", remaining=s[start:])
+            value = s[pos]
+            pos += 1
+        elif ai == 25:
+            if pos + 2 > len(s):
+                raise CBOR_Codec_Decoding_Error(
+                    "Not enough bytes for 2-byte value", remaining=s[start:])
+            value = struct.unpack(">H", s[pos:pos + 2])[0]
+            pos += 2
+        elif ai == 26:
+            if pos + 4 > len(s):
+                raise CBOR_Codec_Decoding_Error(
+                    "Not enough bytes for 4-byte value", remaining=s[start:])
+            value = struct.unpack(">I", s[pos:pos + 4])[0]
+            pos += 4
+        elif ai == 27:
+            if pos + 8 > len(s):
+                raise CBOR_Codec_Decoding_Error(
+                    "Not enough bytes for 8-byte value", remaining=s[start:])
+            value = struct.unpack(">Q", s[pos:pos + 8])[0]
+            pos += 8
+        elif ai == 31:
+            value = CBOR_INDEFINITE
+        else:
+            raise CBOR_Codec_Decoding_Error(
+                "Invalid additional info: %d" % ai, remaining=s[start:])
+        index[0] = pos
+
+        # Major type 7: simple values and floats. Check float preferred width.
+        if major == 7:
+            if ai == 24 and isinstance(value, int) and value < 32:
+                issues.append((
+                    base_offset + start,
+                    "Non-shortest CBOR simple value encoding "
+                    "(AI=24, value=%d)" % value,
+                ))
+            if ai in (25, 26, 27) and value is not CBOR_INDEFINITE:
+                preferred = _cbor_preferred_float_ai_from_encoded(ai, int(value))
+                if preferred is not None and preferred < ai:
+                    issues.append((
+                        base_offset + start,
+                        "Non-shortest CBOR float encoding (AI=%d, preferred AI=%d)"
+                        % (ai, preferred),
+                    ))
+            return
+
+        if value is CBOR_INDEFINITE:
+            if not allow_indefinite:
+                issues.append((
+                    base_offset + start,
+                    "Indefinite-length item is not allowed",
+                ))
+            if major in (2, 3):
+                while index[0] < len(s) and not cbor_is_break(s[index[0]:]):
+                    _walk()
+                if index[0] >= len(s) or not cbor_is_break(s[index[0]:]):
+                    raise CBOR_Codec_Decoding_Error(
+                        "Expected break byte (0xff)", remaining=s[index[0]:])
+                index[0] += 1
+                return
+            if major == 4:
+                while index[0] < len(s) and not cbor_is_break(s[index[0]:]):
+                    _walk()
+                if index[0] >= len(s) or not cbor_is_break(s[index[0]:]):
+                    raise CBOR_Codec_Decoding_Error(
+                        "Expected break byte (0xff)", remaining=s[index[0]:])
+                index[0] += 1
+                return
+            if major == 5:
+                key_encodings = []  # type: List[bytes]
+                while index[0] < len(s) and not cbor_is_break(s[index[0]:]):
+                    key_start = index[0]
+                    _walk()
+                    key_encodings.append(bytes(s[key_start:index[0]]))
+                    _walk()
+                if index[0] >= len(s) or not cbor_is_break(s[index[0]:]):
+                    raise CBOR_Codec_Decoding_Error(
+                        "Expected break byte (0xff)", remaining=s[index[0]:])
+                index[0] += 1
+                if key_encodings != sorted(key_encodings):
+                    issues.append((
+                        base_offset + start,
+                        "CBOR map keys are not in bytewise lexicographic order",
+                    ))
+                return
+            raise CBOR_Codec_Decoding_Error(
+                "Indefinite length not allowed for major type %d" % major,
+                remaining=s[start:],
+            )
+
+        if not cbor_argument_is_shortest(ai, value):
+            issues.append((
+                base_offset + start,
+                "Non-shortest CBOR argument encoding (AI=%d, value=%r)"
+                % (ai, value),
+            ))
+
+        if major in (2, 3):
+            length = int(value)
+            if index[0] + length > len(s):
+                raise CBOR_Codec_Decoding_Error(
+                    "Truncated byte/text string", remaining=s[start:])
+            index[0] += length
+            return
+        if major == 4:
+            for _ in range(int(value)):
+                _walk()
+            return
+        if major == 5:
+            key_encodings = []  # type: List[bytes]
+            for _ in range(int(value)):
+                key_start = index[0]
+                _walk()
+                key_encodings.append(bytes(s[key_start:index[0]]))
+                _walk()
+            if key_encodings != sorted(key_encodings):
+                issues.append((
+                    base_offset + start,
+                    "CBOR map keys are not in bytewise lexicographic order",
+                ))
+            return
+        if major == 6:
+            _walk()
+            return
+
+    try:
+        _walk()
+    except CBOR_Codec_Decoding_Error:
+        # Malformed input is reported by normal decoding, not this checker.
+        pass
+    return issues
 
 
 #    [ CBOR codec classes ]    #
@@ -189,7 +575,7 @@ class CBORcodec_Object(Generic[_K], metaclass=CBORcodec_metaclass):
                ):
         # type: (...) -> Tuple[CBOR_Object[Any], bytes]
         """Decode CBOR data using automatic dispatch based on major type."""
-        return _decode_cbor_item(s, safe=safe)
+        return _decode_cbor_item(s, safe=False, depth=_depth)
 
     @classmethod
     def dec(cls,
@@ -199,10 +585,11 @@ class CBORcodec_Object(Generic[_K], metaclass=CBORcodec_metaclass):
             _depth=0,  # type: int
             ):
         # type: (...) -> Tuple[Union[_CBOR_ERROR, CBOR_Object[_K]], bytes]
+        # Nested decoding must raise so safedec only wraps the outermost item.
         if not safe:
-            return cls.do_dec(s, context, safe, _depth=_depth)
+            return cls.do_dec(s, context, False, _depth=_depth)
         try:
-            return cls.do_dec(s, context, safe, _depth=_depth)
+            return cls.do_dec(s, context, False, _depth=_depth)
         except CBOR_Codec_Decoding_Error as e:
             return CBOR_DECODING_ERROR(s, exc=e), b""
         except CBOR_Error as e:
@@ -244,6 +631,9 @@ class CBORcodec_UNSIGNED_INTEGER(CBORcodec_Object[int]):
             raise CBOR_Codec_Encoding_Error(
                 "Cannot encode negative value as unsigned integer. "
                 "Use CBOR_NEGATIVE_INTEGER for negative values.")
+        if i > 0xFFFFFFFFFFFFFFFF:
+            raise CBOR_Codec_Encoding_Error(
+                "Unsigned integer exceeds uint64 range")
         return CBOR_encode_head(0, i)
 
     @classmethod
@@ -276,6 +666,9 @@ class CBORcodec_NEGATIVE_INTEGER(CBORcodec_Object[int]):
             raise CBOR_Codec_Encoding_Error(
                 "Cannot encode non-negative value as negative integer. "
                 "Use CBOR_UNSIGNED_INTEGER for non-negative values.")
+        if i < -(1 << 64):
+            raise CBOR_Codec_Encoding_Error(
+                "Negative integer below CBOR int64 range")
         # CBOR negative integer: -1 - n
         return CBOR_encode_head(1, -1 - i)
 
@@ -324,11 +717,36 @@ class CBORcodec_BYTE_STRING(CBORcodec_Object[bytes]):
             raise CBOR_Codec_Decoding_Error(
                 "Expected major type 2 (byte string), got %d" % major_type,
                 remaining=s)
+        if length is CBOR_INDEFINITE:
+            chunks = []  # type: List[bytes]
+            while True:
+                if cbor_is_break(remainder):
+                    remainder = cbor_consume_break(remainder)
+                    break
+                chunk_mt, chunk_len, remainder = CBOR_decode_head(remainder)
+                if chunk_mt != 2:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Indefinite byte string chunk must be major type 2",
+                        remaining=remainder)
+                if chunk_len is CBOR_INDEFINITE:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Nested indefinite byte string", remaining=remainder)
+                if len(remainder) < chunk_len:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough bytes for byte string chunk: "
+                        "expected %d, got %d" %
+                        (chunk_len, len(remainder)), remaining=remainder)
+                chunks.append(_cbor_buf_bytes(remainder[:chunk_len]))
+                remainder = remainder[chunk_len:]
+            return cls.cbor_object(b"".join(chunks)), remainder
         if len(remainder) < length:
             raise CBOR_Codec_Decoding_Error(
                 "Not enough bytes for byte string: expected %d, got %d" %
-                (length, len(remainder)), remaining=s)
-        return cls.cbor_object(remainder[:length]), remainder[length:]
+                (length, len(remainder)), remaining=_cbor_buf_bytes(s))
+        return (
+            cls.cbor_object(_cbor_buf_bytes(remainder[:length])),
+            remainder[length:],
+        )
 
 
 class CBORcodec_TEXT_STRING(CBORcodec_Object[str]):
@@ -360,15 +778,44 @@ class CBORcodec_TEXT_STRING(CBORcodec_Object[str]):
             raise CBOR_Codec_Decoding_Error(
                 "Expected major type 3 (text string), got %d" % major_type,
                 remaining=s)
+        if length is CBOR_INDEFINITE:
+            decoded_chunks = []  # type: List[str]
+            while True:
+                if cbor_is_break(remainder):
+                    remainder = cbor_consume_break(remainder)
+                    break
+                chunk_mt, chunk_len, remainder = CBOR_decode_head(remainder)
+                if chunk_mt != 3:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Indefinite text string chunk must be major type 3",
+                        remaining=remainder)
+                if chunk_len is CBOR_INDEFINITE:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Nested indefinite text string", remaining=remainder)
+                if len(remainder) < chunk_len:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough bytes for text string chunk: "
+                        "expected %d, got %d" %
+                        (chunk_len, len(remainder)), remaining=remainder)
+                chunk_bytes = _cbor_buf_bytes(remainder[:chunk_len])
+                remainder = remainder[chunk_len:]
+                try:
+                    decoded_chunks.append(chunk_bytes.decode('utf-8'))
+                except UnicodeDecodeError as e:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Invalid UTF-8 in text string chunk: %s" % str(e),
+                        remaining=_cbor_buf_bytes(s))
+            return cls.cbor_object("".join(decoded_chunks)), remainder
         if len(remainder) < length:
             raise CBOR_Codec_Decoding_Error(
                 "Not enough bytes for text string: expected %d, got %d" %
-                (length, len(remainder)), remaining=s)
+                (length, len(remainder)), remaining=_cbor_buf_bytes(s))
         try:
-            text = remainder[:length].decode('utf-8')
+            text = _cbor_buf_bytes(remainder[:length]).decode('utf-8')
         except UnicodeDecodeError as e:
             raise CBOR_Codec_Decoding_Error(
-                "Invalid UTF-8 in text string: %s" % str(e), remaining=s)
+                "Invalid UTF-8 in text string: %s" % str(e),
+                remaining=_cbor_buf_bytes(s))
         return cls.cbor_object(text), remainder[length:]
 
 
@@ -381,10 +828,12 @@ class CBORcodec_ARRAY(CBORcodec_Object[List[Any]]):
         # type: (Union[List[Any], CBOR_Object[List[Any]]]) -> bytes
         from scapy.cbor.cbor import CBOR_Object
         array = obj.val if isinstance(obj, CBOR_Object) else obj
-        result = CBOR_encode_head(4, len(array))
-        for item in array:
-            result += CBORcodec_Object.encode_cbor_item(item)
-        return result
+        parts = [CBOR_encode_head(4, len(array))]
+        parts.extend(
+            CBORcodec_Object.encode_cbor_item(item)
+            for item in array
+        )
+        return b"".join(parts)
 
     @classmethod
     def do_dec(cls,
@@ -402,31 +851,54 @@ class CBORcodec_ARRAY(CBORcodec_Object[List[Any]]):
                 remaining=s)
 
         items = []
-        for _ in range(length):
-            if not remainder:
-                raise CBOR_Codec_Decoding_Error(
-                    "Not enough items in array", remaining=s)
-            item, remainder = CBORcodec_Object.decode_cbor_item(
-                remainder, safe=safe)
-            items.append(item)
+        if length is CBOR_INDEFINITE:
+            while True:
+                if cbor_is_break(remainder):
+                    remainder = cbor_consume_break(remainder)
+                    break
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough items in array", remaining=s)
+                item, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                items.append(item)
+        else:
+            for _ in range(length):
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough items in array", remaining=s)
+                item, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                items.append(item)
 
         return cls.cbor_object(items), remainder
 
 
-class CBORcodec_MAP(CBORcodec_Object[Dict[Any, Any]]):
-    """CBOR map codec (major type 5)"""
+class CBORcodec_MAP(CBORcodec_Object[Any]):
+    """CBOR map codec (major type 5).
+
+    Maps are stored as an ordered list of ``(key, value)`` CBOR objects so
+    that unhashable keys and distinct CBOR items that collide under Python
+    equality (``1`` vs ``True``) round-trip faithfully.
+    """
     tag = CBOR_MajorTypes.MAP
 
     @classmethod
     def enc(cls, obj):
-        # type: (Union[Dict[Any, Any], CBOR_Object[Dict[Any, Any]]]) -> bytes
-        from scapy.cbor.cbor import CBOR_Object
+        # type: (Any) -> bytes
+        from scapy.cbor.cbor import CBOR_Object, CBORMapData
         mapping = obj.val if isinstance(obj, CBOR_Object) else obj
-        result = CBOR_encode_head(5, len(mapping))
-        for key, value in mapping.items():
-            result += CBORcodec_Object.encode_cbor_item(key)
-            result += CBORcodec_Object.encode_cbor_item(value)
-        return result
+        if isinstance(mapping, CBORMapData):
+            pairs = mapping.cbor_pairs()
+        elif isinstance(mapping, dict):
+            pairs = list(mapping.items())
+        else:
+            pairs = list(mapping)
+        parts = [CBOR_encode_head(5, len(pairs))]
+        for key, value in pairs:
+            parts.append(CBORcodec_Object.encode_cbor_item(key))
+            parts.append(CBORcodec_Object.encode_cbor_item(value))
+        return b"".join(parts)
 
     @classmethod
     def do_dec(cls,
@@ -435,7 +907,8 @@ class CBORcodec_MAP(CBORcodec_Object[Dict[Any, Any]]):
                safe=False,  # type: bool
                _depth=0,  # type: int
                ):
-        # type: (...) -> Tuple[CBOR_Object[Dict[Any, Any]], bytes]
+        # type: (...) -> Tuple[CBOR_Object[Any], bytes]
+        from scapy.cbor.cbor import CBORMapData
         cls.check_string(s)
         major_type, length, remainder = CBOR_decode_head(s)
         if major_type != 5:
@@ -443,26 +916,53 @@ class CBORcodec_MAP(CBORcodec_Object[Dict[Any, Any]]):
                 "Expected major type 5 (map), got %d" % major_type,
                 remaining=s)
 
-        mapping = {}
-        for _ in range(length):
-            if not remainder:
-                raise CBOR_Codec_Decoding_Error(
-                    "Not enough key-value pairs in map", remaining=s)
-            key, remainder = CBORcodec_Object.decode_cbor_item(
-                remainder, safe=safe)
-            if not remainder:
-                raise CBOR_Codec_Decoding_Error(
-                    "Map key without value", remaining=s)
-            value, remainder = CBORcodec_Object.decode_cbor_item(
-                remainder, safe=safe)
-            # Convert key to hashable type if it's a CBOR object
-            if isinstance(key, CBOR_Object):
-                key_val = key.val
-            else:
-                key_val = key
-            mapping[key_val] = value
+        pairs = []  # type: List[Tuple[Any, Any]]
+        seen_keys = set()  # type: set[bytes]
 
-        return cls.cbor_object(mapping), remainder
+        def _add_pair(key, value):
+            # type: (Any, Any) -> None
+            # CBOR_FLOAT preserves received wire bytes in enc(), so distinct
+            # float/NaN encodings remain distinct while semantic duplicates
+            # (e.g. 1 vs 0x18 0x01) still collapse via preferred encoding.
+            key_wire = CBORcodec_Object.encode_cbor_item(key)
+            if key_wire in seen_keys:
+                raise CBOR_Codec_Decoding_Error(
+                    "Duplicate CBOR map key: %r" % (key,),
+                    remaining=s)
+            seen_keys.add(key_wire)
+            pairs.append((key, value))
+
+        if length is CBOR_INDEFINITE:
+            while True:
+                if cbor_is_break(remainder):
+                    remainder = cbor_consume_break(remainder)
+                    break
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough key-value pairs in map", remaining=s)
+                key, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Map key without value", remaining=s)
+                value, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                _add_pair(key, value)
+        else:
+            for _ in range(length):
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Not enough key-value pairs in map", remaining=s)
+                key, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                if not remainder:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Map key without value", remaining=s)
+                value, remainder = CBORcodec_Object.decode_cbor_item(
+                    remainder, safe=False, depth=_depth + 1)
+                _add_pair(key, value)
+
+        return cls.cbor_object(CBORMapData(pairs)), remainder
 
 
 class CBORcodec_SEMANTIC_TAG(CBORcodec_Object[Tuple[int, Any]]):
@@ -475,9 +975,13 @@ class CBORcodec_SEMANTIC_TAG(CBORcodec_Object[Tuple[int, Any]]):
         from scapy.cbor.cbor import CBOR_Object
         tagged_item = obj.val if isinstance(obj, CBOR_Object) else obj
         tag_num, item = tagged_item
-        result = CBOR_encode_head(6, tag_num)
-        result += CBORcodec_Object.encode_cbor_item(item)
-        return result
+        if tag_num < 0 or tag_num > 0xFFFFFFFFFFFFFFFF:
+            raise CBOR_Codec_Encoding_Error(
+                "Semantic tag number out of uint64 range")
+        return (
+            CBOR_encode_head(6, tag_num)
+            + CBORcodec_Object.encode_cbor_item(item)
+        )
 
     @classmethod
     def do_dec(cls,
@@ -499,7 +1003,7 @@ class CBORcodec_SEMANTIC_TAG(CBORcodec_Object[Tuple[int, Any]]):
                 "Tag without following item", remaining=s)
 
         item, remainder = CBORcodec_Object.decode_cbor_item(
-            remainder, safe=safe)
+            remainder, safe=False, depth=_depth + 1)
         return cls.cbor_object((tag_num, item)), remainder
 
 
@@ -536,11 +1040,26 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
         elif val is None:
             return chb(0xf6)  # null
         elif isinstance(val, float):
-            # Encode as double precision (8 bytes)
+            # Preferred serialization (RFC 8949): shortest float that
+            # preserves the numeric value. Received non-preferred widths are
+            # preserved via packet raw caches, not by this encoder.
+            ai = _cbor_preferred_float_ai(val)
+            if ai == 25:
+                half = _cbor_float_to_half_bits(val)
+                if half is not None:
+                    return chb(0xf9) + struct.pack(">H", half)
+                ai = 26
+            if ai == 26:
+                try:
+                    return chb(0xfa) + struct.pack(">f", val)
+                except (OverflowError, struct.error):
+                    pass
             return chb(0xfb) + struct.pack(">d", val)
         elif isinstance(val, int) and 0 <= val <= 23:
             # Simple value 0-23
             return CBOR_encode_head(7, val)
+        elif isinstance(val, int) and 32 <= val <= 255:
+            return b"\xf8" + chb(val)
         else:
             raise CBOR_Codec_Encoding_Error(
                 "Cannot encode value as simple/float: %r" % val)
@@ -615,21 +1134,21 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
                     (1 + fraction / 1024.0) *
                     (2 ** (exponent - 15)))
 
-            return CBOR_FLOAT(float_val), remainder
+            return CBOR_FLOAT(float_val, encoded=_cbor_buf_bytes(s[:3])), remainder
         elif additional_info == 26:
             # Single precision float (4 bytes)
             if len(s) < 5:
                 raise CBOR_Codec_Decoding_Error(
                     "Not enough bytes for single float", remaining=s)
             float_val = struct.unpack(">f", s[1:5])[0]
-            return CBOR_FLOAT(float_val), s[5:]
+            return CBOR_FLOAT(float_val, encoded=_cbor_buf_bytes(s[:5])), s[5:]
         elif additional_info == 27:
             # Double precision float (8 bytes)
             if len(s) < 9:
                 raise CBOR_Codec_Decoding_Error(
                     "Not enough bytes for double float", remaining=s)
             float_val = struct.unpack(">d", s[1:9])[0]
-            return CBOR_FLOAT(float_val), s[9:]
+            return CBOR_FLOAT(float_val, encoded=_cbor_buf_bytes(s[:9])), s[9:]
         elif additional_info < 24:
             # Simple value 0-23
             return CBOR_SIMPLE_VALUE(additional_info), s[1:]
@@ -639,7 +1158,13 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
                 if len(s) < 2:
                     raise CBOR_Codec_Decoding_Error(
                         "Not enough bytes for simple value", remaining=s)
-                return CBOR_SIMPLE_VALUE(s[1]), s[2:]
+                simple = s[1]
+                if simple < 32:
+                    raise CBOR_Codec_Decoding_Error(
+                        "Two-byte simple-value encoding below 32 "
+                        "is not well-formed",
+                        remaining=s)
+                return CBOR_SIMPLE_VALUE(simple), s[2:]
             else:
                 raise CBOR_Codec_Decoding_Error(
                     "Invalid additional info for major type 7: %d" % additional_info,
@@ -652,10 +1177,29 @@ class CBORcodec_SIMPLE_AND_FLOAT(CBORcodec_Object[Union[int, float, bool, None]]
 def _encode_cbor_item(item):
     # type: (Any) -> bytes
     """Encode a Python value to CBOR bytes"""
-    from scapy.cbor.cbor import CBOR_Object
+    from scapy.cbor.cbor import (
+        CBOR_Object,
+        CBOR_UNDEFINED,
+        CBOR_UNDEFINED_VALUE,
+        CBORMapData,
+        CBORTagValue,
+        CBORSimpleValue,
+        CBOR_SIMPLE_VALUE,
+    )
 
     if isinstance(item, CBOR_Object):
         return item.enc()
+    elif item is CBOR_UNDEFINED_VALUE:
+        return CBOR_UNDEFINED().enc()
+    elif isinstance(item, CBORTagValue):
+        return (
+            CBOR_encode_head(6, item.tag) +
+            _encode_cbor_item(item.value)
+        )
+    elif isinstance(item, CBORSimpleValue):
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(CBOR_SIMPLE_VALUE(item.value))
+    elif isinstance(item, CBORMapData):
+        return CBORcodec_MAP.enc(item)
     elif isinstance(item, bool):
         # Must check bool before int (bool is subclass of int)
         return CBORcodec_SIMPLE_AND_FLOAT.enc(item)
@@ -673,6 +1217,9 @@ def _encode_cbor_item(item):
     elif isinstance(item, dict):
         return CBORcodec_MAP.enc(item)
     elif isinstance(item, float):
+        encoded = getattr(item, "cbor_encoded", None)
+        if encoded is not None:
+            return encoded
         return CBORcodec_SIMPLE_AND_FLOAT.enc(item)
     elif item is None:
         return CBORcodec_SIMPLE_AND_FLOAT.enc(None)
@@ -681,37 +1228,159 @@ def _encode_cbor_item(item):
             "Cannot encode type: %s" % type(item))
 
 
-def _decode_cbor_item(s, safe=False):
-    # type: (bytes, bool) -> Tuple[CBOR_Object[Any], bytes]
-    """Decode CBOR bytes to a CBOR_Object"""
+def _encode_cbor_map_deterministic(pairs):
+    # type: (Any) -> bytes
+    """Encode map pairs in RFC 8949 core-deterministic key order."""
+    encoded_pairs = []  # type: List[Tuple[bytes, bytes]]
+    for key, value in pairs:
+        key_bytes = _encode_cbor_item_deterministic(key)
+        value_bytes = _encode_cbor_item_deterministic(value)
+        encoded_pairs.append((key_bytes, value_bytes))
+    encoded_pairs.sort(key=lambda item: item[0])
+    parts = [CBOR_encode_head(5, len(encoded_pairs))]
+    for key_bytes, value_bytes in encoded_pairs:
+        parts.append(key_bytes)
+        parts.append(value_bytes)
+    return b"".join(parts)
+
+
+def _encode_cbor_item_deterministic(item):
+    # type: (Any) -> bytes
+    """Encode a Python value using RFC 8949 core-deterministic rules.
+
+    Unlike :func:`_encode_cbor_item`, map keys at every nesting level are
+    sorted by their deterministic encoded bytes. Intended for schema-driven
+    rebuild paths such as preserved unknown ``CBORF_MAP`` members.
+
+    :class:`~scapy.cbor.cbor.CBOR_Object` wrappers are accepted and reduced to
+    native values (preferred float encoding, deterministic nested maps).
+    """
+    from scapy.cbor.cbor import (
+        CBOR_Object,
+        CBOR_ARRAY,
+        CBOR_MAP,
+        CBOR_SEMANTIC_TAG,
+        CBOR_SIMPLE_VALUE,
+        CBOR_UNDEFINED,
+        CBOR_UNDEFINED_VALUE,
+        CBORMapData,
+        CBORTagValue,
+        CBORSimpleValue,
+    )
+
+    if isinstance(item, CBOR_Object):
+        if isinstance(item, CBOR_UNDEFINED):
+            return CBOR_UNDEFINED().enc()
+        if isinstance(item, CBOR_ARRAY):
+            return _encode_cbor_item_deterministic(list(item.val))
+        if isinstance(item, CBOR_MAP):
+            if isinstance(item.val, CBORMapData):
+                return _encode_cbor_map_deterministic(item.val.cbor_pairs())
+            if isinstance(item.val, list):
+                return _encode_cbor_map_deterministic(item.val)
+            return _encode_cbor_map_deterministic(list(item.val.items()))
+        if isinstance(item, CBOR_SEMANTIC_TAG):
+            tag_num, inner = item.val
+            return (
+                CBOR_encode_head(6, tag_num)
+                + _encode_cbor_item_deterministic(inner)
+            )
+        if isinstance(item, CBOR_SIMPLE_VALUE):
+            return CBORcodec_SIMPLE_AND_FLOAT.enc(item)
+        return _encode_cbor_item_deterministic(item.val)
+    if item is CBOR_UNDEFINED_VALUE:
+        return CBOR_UNDEFINED().enc()
+    if isinstance(item, CBORTagValue):
+        return (
+            CBOR_encode_head(6, item.tag)
+            + _encode_cbor_item_deterministic(item.value)
+        )
+    if isinstance(item, CBORSimpleValue):
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(CBOR_SIMPLE_VALUE(item.value))
+    if isinstance(item, CBORMapData):
+        return _encode_cbor_map_deterministic(item.cbor_pairs())
+    if isinstance(item, dict):
+        return _encode_cbor_map_deterministic(list(item.items()))
+    if isinstance(item, list):
+        encoded_items = [
+            _encode_cbor_item_deterministic(element) for element in item
+        ]
+        return CBOR_encode_head(4, len(encoded_items)) + b"".join(encoded_items)
+    if isinstance(item, bool):
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(item)
+    if isinstance(item, int):
+        if item >= 0:
+            return CBORcodec_UNSIGNED_INTEGER.enc(item)
+        return CBORcodec_NEGATIVE_INTEGER.enc(item)
+    if isinstance(item, bytes):
+        return CBORcodec_BYTE_STRING.enc(item)
+    if isinstance(item, str):
+        return CBORcodec_TEXT_STRING.enc(item)
+    if isinstance(item, float):
+        # Preserve dissected wire (e.g. NaN payloads) when known; otherwise
+        # fall back to preferred-width encoding.
+        encoded = getattr(item, "cbor_encoded", None)
+        if encoded is not None:
+            return encoded
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(item)
+    if item is None:
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(None)
+    raise CBOR_Codec_Encoding_Error(
+        "Cannot deterministically encode type: %s" % type(item)
+    )
+
+
+def _decode_cbor_item(s, safe=False, depth=0):
+    # type: (Any, bool, int) -> Tuple[CBOR_Object[Any], Any]
+    """Decode CBOR bytes to a CBOR_Object.
+
+    Top-level callers may pass ``bytes`` (or a subclass). Decoding then works
+    on a ``memoryview`` so unread suffixes are not recopied per item.
+    """
+    if depth > MAX_CBOR_NESTING:
+        raise CBOR_Codec_Decoding_Error(
+            "Maximum CBOR nesting depth exceeded",
+            remaining=_cbor_buf_bytes(s))
+    if not isinstance(s, memoryview):
+        obj, rem = _decode_cbor_item(memoryview(s), safe=False, depth=depth)
+        return obj, _cbor_buf_bytes(rem) if isinstance(rem, memoryview) else rem
     if not s:
-        raise CBOR_Codec_Decoding_Error("Empty CBOR data", remaining=s)
+        raise CBOR_Codec_Decoding_Error(
+            "Empty CBOR data", remaining=_cbor_buf_bytes(s))
+
+    if cbor_is_break(s):
+        raise CBOR_Codec_Decoding_Error(
+            "Standalone break byte (0xff)", remaining=_cbor_buf_bytes(s))
 
     initial_byte = s[0]
     major_type = initial_byte >> 5
 
     # Dispatch to appropriate codec based on major type
     if major_type == 0:
-        return CBORcodec_UNSIGNED_INTEGER.dec(s, safe=safe)
+        return CBORcodec_UNSIGNED_INTEGER.dec(s, safe=False, _depth=depth)
     elif major_type == 1:
-        return CBORcodec_NEGATIVE_INTEGER.dec(s, safe=safe)
+        return CBORcodec_NEGATIVE_INTEGER.dec(s, safe=False, _depth=depth)
     elif major_type == 2:
-        return CBORcodec_BYTE_STRING.dec(s, safe=safe)
+        return CBORcodec_BYTE_STRING.dec(s, safe=False, _depth=depth)
     elif major_type == 3:
-        return CBORcodec_TEXT_STRING.dec(s, safe=safe)
+        return CBORcodec_TEXT_STRING.dec(s, safe=False, _depth=depth)
     elif major_type == 4:
-        return CBORcodec_ARRAY.dec(s, safe=safe)
+        return CBORcodec_ARRAY.dec(s, safe=False, _depth=depth)
     elif major_type == 5:
-        return CBORcodec_MAP.dec(s, safe=safe)
+        return CBORcodec_MAP.dec(s, safe=False, _depth=depth)
     elif major_type == 6:
-        return CBORcodec_SEMANTIC_TAG.dec(s, safe=safe)
+        return CBORcodec_SEMANTIC_TAG.dec(s, safe=False, _depth=depth)
     elif major_type == 7:
-        return CBORcodec_SIMPLE_AND_FLOAT.dec(s, safe=safe)
+        return CBORcodec_SIMPLE_AND_FLOAT.dec(s, safe=False, _depth=depth)
     else:
         raise CBOR_Codec_Decoding_Error(
-            "Invalid major type: %d" % major_type, remaining=s)
+            "Invalid major type: %d" % major_type,
+            remaining=_cbor_buf_bytes(s))
 
 
 # Add helper methods to CBORcodec_Object
 CBORcodec_Object.encode_cbor_item = staticmethod(_encode_cbor_item)
+CBORcodec_Object.encode_cbor_item_deterministic = staticmethod(
+    _encode_cbor_item_deterministic
+)
 CBORcodec_Object.decode_cbor_item = staticmethod(_decode_cbor_item)

--- a/scapy/cbor/cborfields.py
+++ b/scapy/cbor/cborfields.py
@@ -1401,12 +1401,14 @@ class CBORF_SEQUENCE_OF(CBORF_field[List[Any]]):
 
     Preferred constructors (ASN1F_SEQUENCE_OF / PacketListField style)::
 
-        CBORF_SEQUENCE_OF("items", [], cls=MyPacket)
-        CBORF_SEQUENCE_OF("items", [], cls=CBORF_UNSIGNED_INTEGER)
+        CBORF_SEQUENCE_OF("items", [], pkt_cls=MyPacket)
+        CBORF_SEQUENCE_OF("items", [], pkt_cls=CBORF_UNSIGNED_INTEGER)
         CBORF_SEQUENCE_OF("items", [], next_cls_cb=choose_next)
 
-    ``pkt_cls`` is accepted as an alias of ``cls`` for PacketListField
-    familiarity. Pass only one of ``cls`` / ``pkt_cls`` / ``next_cls_cb``.
+    ``pkt_cls`` may be a :class:`CBOR_Packet` subclass or a
+    :class:`CBORF_field` class/instance. Do not use a ``cls=`` keyword:
+    :class:`~typing.Generic` reserves that name on Python 3.7.
+    Pass only one of ``pkt_cls`` / ``next_cls_cb``.
     """
     CBOR_tag = None
     islist = 1
@@ -1414,8 +1416,7 @@ class CBORF_SEQUENCE_OF(CBORF_field[List[Any]]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Any
-                 cls=None,  # type: _ARRAY_T
-                 pkt_cls=None,  # type: Optional[Type[Packet]]
+                 pkt_cls=None,  # type: _ARRAY_T
                  next_cls_cb=None,  # type: Optional[Callable[..., Optional[Type[Packet]]]]  # noqa: E501
                  ):
         # type: (...) -> None
@@ -1425,16 +1426,14 @@ class CBORF_SEQUENCE_OF(CBORF_field[List[Any]]):
         self.holds_packets = 0
 
         if next_cls_cb is not None:
-            if cls is not None or pkt_cls is not None:
+            if pkt_cls is not None:
                 raise ValueError(
-                    "Pass only next_cls_cb, or only cls/pkt_cls"
+                    "Pass only next_cls_cb, or only pkt_cls"
                 )
             self.next_cls_cb = next_cls_cb
             self.holds_packets = 1
         else:
-            if cls is not None and pkt_cls is not None:
-                raise ValueError("Pass only one of cls or pkt_cls")
-            chosen = pkt_cls if pkt_cls is not None else cls
+            chosen = pkt_cls
             if isinstance(chosen, type) and issubclass(chosen, CBORF_field) or \
                     isinstance(chosen, CBORF_field):
                 if isinstance(chosen, type):
@@ -1447,7 +1446,7 @@ class CBORF_SEQUENCE_OF(CBORF_field[List[Any]]):
                 self.holds_packets = 1
             else:
                 raise ValueError(
-                    "Provide cls, pkt_cls, or next_cls_cb"
+                    "Provide pkt_cls or next_cls_cb"
                 )
         super(CBORF_SEQUENCE_OF, self).__init__(name, default)
 
@@ -1579,10 +1578,12 @@ class CBORF_ARRAY_OF(CBORF_field[List[Any]]):
 
     Preferred constructors::
 
-        CBORF_ARRAY_OF("items", [], cls=MyPacket)
-        CBORF_ARRAY_OF("items", [], cls=CBORF_UNSIGNED_INTEGER)
+        CBORF_ARRAY_OF("items", [], pkt_cls=MyPacket)
+        CBORF_ARRAY_OF("items", [], pkt_cls=CBORF_UNSIGNED_INTEGER)
 
-    ``pkt_cls`` is accepted as an alias of ``cls``. Pass only one of them.
+    ``pkt_cls`` may be a :class:`CBOR_Packet` subclass or a
+    :class:`CBORF_field` class/instance. Do not use a ``cls=`` keyword:
+    :class:`~typing.Generic` reserves that name on Python 3.7.
     """
     CBOR_tag = CBOR_MajorTypes.ARRAY
     islist = 1
@@ -1590,15 +1591,12 @@ class CBORF_ARRAY_OF(CBORF_field[List[Any]]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Any
-                 cls=None,  # type: _ARRAY_T
-                 pkt_cls=None,  # type: Optional[Type[Packet]]
+                 pkt_cls=None,  # type: _ARRAY_T
                  ):
         # type: (...) -> None
-        if cls is not None and pkt_cls is not None:
-            raise ValueError("Pass only one of cls or pkt_cls")
-        chosen = pkt_cls if pkt_cls is not None else cls
+        chosen = pkt_cls
         if chosen is None:
-            raise ValueError("Provide cls or pkt_cls")
+            raise ValueError("Provide pkt_cls")
         if isinstance(chosen, type) and issubclass(chosen, CBORF_field) or \
                 isinstance(chosen, CBORF_field):
             if isinstance(chosen, type):
@@ -1610,7 +1608,7 @@ class CBORF_ARRAY_OF(CBORF_field[List[Any]]):
             self.cls = cast("Type[CBOR_Packet]", chosen)
             self.holds_packets = 1
         else:
-            raise ValueError("cls must be a CBORF_field or CBOR_Packet")
+            raise ValueError("pkt_cls must be a CBORF_field or CBOR_Packet")
         super(CBORF_ARRAY_OF, self).__init__(name, default)
 
     def any2i(self, pkt, x):
@@ -2165,17 +2163,20 @@ class CBORF_PACKET(CBORF_field['CBOR_Packet']):
     CBOR field that encapsulates a nested :class:`CBOR_Packet`.
 
     The nested packet is encoded as-is (its ``CBOR_root.build()`` output)
-    and decoded by instantiating ``cls`` from the current byte stream.
+    and decoded by instantiating ``pkt_cls`` from the current byte stream.
+
+    Use ``pkt_cls=`` (or a positional third argument). A ``cls=`` keyword
+    conflicts with :class:`~typing.Generic` on Python 3.7.
     """
     holds_packets = 1
 
     def __init__(self,
                  name,  # type: str
                  default,  # type: Optional[CBOR_Packet]
-                 cls,  # type: Type[CBOR_Packet]
+                 pkt_cls,  # type: Type[CBOR_Packet]
                  ):
         # type: (...) -> None
-        self.cls = cls
+        self.cls = pkt_cls
         super(CBORF_PACKET, self).__init__(name, default)
 
     def _parse_packet_item(self, pkt, s):

--- a/scapy/cbor/cborfields.py
+++ b/scapy/cbor/cborfields.py
@@ -5,32 +5,50 @@
 """
 Classes that implement CBOR (Concise Binary Object Representation) data
 structures as packet fields.  Modelled after scapy/asn1fields.py.
+
+Public leaf/compound hooks follow Scapy/ASN.1 style (``any2i`` / ``i2m`` /
+``m2i``, ``build`` / ``dissect``). Compounds additionally use
+``build_result`` / ``dissect_result`` so unframed sequences and array
+budgeting can return an item count for raw-cache fidelity; callers outside
+this module should prefer ``build`` / ``dissect``.
 """
 
 import copy
 
-from functools import reduce
+from dataclasses import dataclass
 
 from scapy.cbor.cbor import (
     CBOR_Decoding_Error,
-    CBOR_Error,
+    CBOR_Encoding_Error,
     CBOR_MajorTypes,
     CBOR_Object,
     CBOR_UNSIGNED_INTEGER,
     CBOR_NEGATIVE_INTEGER,
     CBOR_BYTE_STRING,
     CBOR_TEXT_STRING,
+    CBOR_ARRAY,
     CBOR_SEMANTIC_TAG,
     CBOR_FALSE,
     CBOR_TRUE,
     CBOR_NULL,
     CBOR_UNDEFINED,
+    CBOR_UNDEFINED_VALUE,
+    CBOR_NO_ITEM,
     CBOR_FLOAT,
+    CBOR_MAP,
+    CBOR_SIMPLE_VALUE,
+    CBORTagValue,
+    CBORSimpleValue,
 )
 from scapy.cbor.cborcodec import (
     CBOR_Codec_Decoding_Error,
+    CBOR_INDEFINITE,
     CBOR_decode_head,
     CBOR_encode_head,
+    CBOR_encode_indefinite_head,
+    CBOR_encode_break,
+    cbor_is_break,
+    cbor_consume_break,
     CBORcodec_Object,
     CBORcodec_UNSIGNED_INTEGER,
     CBORcodec_NEGATIVE_INTEGER,
@@ -38,7 +56,8 @@ from scapy.cbor.cborcodec import (
     CBORcodec_TEXT_STRING,
     CBORcodec_SIMPLE_AND_FLOAT,
 )
-from scapy.base_classes import BasePacket
+from scapy.error import log_runtime
+from scapy.packet import Packet
 from scapy.volatile import (
     RandChoice,
     RandFloat,
@@ -47,10 +66,11 @@ from scapy.volatile import (
     RandField,
 )
 
-from scapy import packet
+from scapy import packet, fields, config
 
 from typing import (
     Any,
+    Callable,
     Dict,
     Generic,
     List,
@@ -71,8 +91,170 @@ class CBORF_badsequence(Exception):
     pass
 
 
+class CBOR_Type_Mismatch(CBOR_Decoding_Error):
+    """Raised when a CBOR field encounters an unexpected major type."""
+
+
+@dataclass(frozen=True)
+class CBORBuildResult(object):
+    """Encoded CBOR bytes and how many top-level items they contain."""
+    data: bytes = b""
+    items: int = 0
+
+
+@dataclass(frozen=True)
+class CBORParseResult(object):
+    """Decoded value, unconsumed input, and items consumed."""
+    value: Any = None
+    remaining: bytes = b""
+    items: int = 0
+
+
+# Sentinel for an optional field that was not present on the wire.
+# Distinct from Python ``None``, which encodes CBOR null for CBORF_ANY.
+# Identity must survive copy/deepcopy used by Packet default caches.
+
+
+class _CBORAbsent(object):
+    def __repr__(self):
+        # type: () -> str
+        return "CBOR_ABSENT"
+
+    def __copy__(self):
+        # type: () -> _CBORAbsent
+        return self
+
+    def __deepcopy__(self, memo):
+        # type: (dict) -> _CBORAbsent
+        return self
+
+
+CBOR_ABSENT = _CBORAbsent()
+
+
+def cbor_item_span(s):
+    # type: (bytes) -> Tuple[bytes, bytes]
+    """Split *s* into the first well-formed CBOR item and the remainder."""
+    _obj, remain = CBORcodec_Object.decode_cbor_item(s)
+    if remain:
+        return s[:-len(remain)], remain
+    return s, b""
+
+
+def _encode_exactly_one_cbor_item(val, context="value"):
+    # type: (Any, str) -> bytes
+    """Serialize *val* and require it to be exactly one well-formed CBOR item.
+
+    Used by packet-valued fields so Raw/bytes/Packet fallbacks cannot claim
+    ``items=1`` while emitting multiple or malformed CBOR items.
+    """
+    if hasattr(val, "cbor_build_result"):
+        result = val.cbor_build_result()
+        if result.items != 1:
+            raise CBOR_Encoding_Error(
+                "%s must encode exactly one top-level CBOR item, "
+                "but encoded %d"
+                % (getattr(type(val), "__name__", context), result.items)
+            )
+        data = result.data
+    else:
+        data = bytes(val)
+    try:
+        item, remaining = cbor_item_span(data)
+    except Exception as exc:
+        raise CBOR_Encoding_Error(
+            "%s did not encode a well-formed CBOR item: %s"
+            % (context, exc)
+        )
+    if remaining:
+        raise CBOR_Encoding_Error(
+            "%s encoded more than one top-level CBOR item"
+            % context
+        )
+    if item != data:
+        raise CBOR_Encoding_Error(
+            "%s encoded a CBOR item that does not cover the full payload"
+            % context
+        )
+    return data
+
+
+def _cbor_attach_parent(parent, child):
+    # type: (Optional[Packet], Any) -> Any
+    """Attach *child* as a field-contained packet of *parent* (Scapy parent)."""
+    if child is not None and parent is not None and hasattr(child, "add_parent"):
+        child.add_parent(parent)
+    return child
+
+
+def _cbor_packet_from_bytes(cls, data, parent):
+    # type: (Type[Packet], bytes, Optional[Packet]) -> Packet
+    """Instantiate a nested packet with Scapy field-parent ownership."""
+    return cls(data, _parent=parent)  # type: ignore
+
+
+def cbor_object_to_python(obj):
+    # type: (Any) -> Any
+    """Convert a :class:`CBOR_Object` tree to native Python values."""
+    if not isinstance(obj, CBOR_Object):
+        return obj
+    if isinstance(obj, CBOR_UNDEFINED):
+        return CBOR_UNDEFINED_VALUE
+    if isinstance(obj, CBOR_ARRAY):
+        return [cbor_object_to_python(item) for item in obj.val]
+    if isinstance(obj, CBOR_MAP):
+        # Preserve an explicit map wrapper so rebuild cannot confuse maps
+        # with arrays of pairs.
+        from scapy.cbor.cbor import CBORMapData
+        if isinstance(obj.val, CBORMapData):
+            pairs = obj.val.cbor_pairs()
+        elif isinstance(obj.val, list):
+            pairs = obj.val
+        else:
+            pairs = list(obj.val.items())
+        return CBORMapData([
+            (cbor_object_to_python(k), cbor_object_to_python(v))
+            for k, v in pairs
+        ])
+    if isinstance(obj, CBOR_SEMANTIC_TAG):
+        tag_num, item = obj.val
+        return CBORTagValue(tag_num, cbor_object_to_python(item))
+    if isinstance(obj, CBOR_SIMPLE_VALUE):
+        return CBORSimpleValue(obj.val)
+    if isinstance(obj, CBOR_FLOAT):
+        from scapy.cbor.cbor import CBORFloatValue
+        return CBORFloatValue(obj.val, encoded=getattr(obj, "_encoded", None))
+    return obj.val
+
+
 class CBORF_element(object):
-    pass
+    """Base class for CBOR packet field elements."""
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        data = self.build(pkt)
+        return CBORBuildResult(data, self.min_items(pkt))
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        remaining = self.dissect(pkt, s)
+        return CBORParseResult(remaining=remaining, items=self.max_items(pkt))
+
+    def build(self, pkt):
+        # type: (CBOR_Packet) -> bytes
+        raise NotImplementedError
+
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        raise NotImplementedError
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
 
 
 ##########################
@@ -80,35 +262,29 @@ class CBORF_element(object):
 ##########################
 
 _I = TypeVar('_I')  # Internal storage
-_A = TypeVar('_A')  # CBOR object
 
 
-class CBORF_field(CBORF_element, Generic[_I, _A]):
+class CBORF_field(CBORF_element, Generic[_I]):
+    """Base class for CBOR items in packet fields.
+
+    Packet fields store native Python values (``int``, ``bytes``, ``str``,
+    ``bool``, ``float``, ``list``, ``dict``, ``None``).
+    """
     holds_packets = 0
     islist = 0
+    ismutable = False
+    allows_none = False
     CBOR_tag = None  # type: Optional[Any]
 
     def __init__(self,
                  name,  # type: str
-                 default,  # type: Optional[_A]
+                 default,  # type: Optional[_I]
                  ):
         # type: (...) -> None
         self.name = name
-        if default is None:
-            self.default = default  # type: Optional[_A]
-        else:
-            self.default = self._wrap(default)
         self.owners = []  # type: List[Type[CBOR_Packet]]
-
-    def _wrap(self, val):
-        # type: (Any) -> _A
-        """Return a CBOR object wrapping *val*.
-
-        The base implementation is a pass-through cast; subclasses override
-        this to convert a raw Python value to the appropriate CBOR object
-        type (e.g. :class:`~scapy.cbor.cbor.CBOR_UNSIGNED_INTEGER`).
-        """
-        return cast(_A, val)
+        # Mirror Scapy Field: normalize defaults through any2i().
+        self.default = self.any2i(None, default)
 
     def register_owner(self, cls):
         # type: (Type[CBOR_Packet]) -> None
@@ -122,77 +298,170 @@ class CBORF_field(CBORF_element, Generic[_I, _A]):
         # type: (CBOR_Packet, _I) -> Any
         return x
 
+    def h2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> _I
+        return cast(_I, x)
+
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[_A, bytes]
-        raise NotImplementedError("Subclasses must implement m2i")
+        # type: (CBOR_Packet, bytes) -> Tuple[_I, bytes]
+        raise NotImplementedError(
+            "Subclasses must implement m2i for %s" % type(self))
+
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        """Encode a native Python value to CBOR bytes.
+
+        Prefer overriding :meth:`i2m` in new code; ``encode_value`` remains
+        the shared leaf encoder used by the default :meth:`i2m`.
+        """
+        raise NotImplementedError(
+            "Subclasses must implement encode_value for %s" % type(self))
 
     def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Union[bytes, _I, _A]) -> bytes
-        if x is None:
-            return b""
-        if isinstance(x, CBOR_Object):
-            return x.enc()
-        return self._encode(x)
-
-    def _encode(self, x):
-        # type: (Any) -> bytes
-        """Encode a raw Python value to CBOR bytes."""
-        raise NotImplementedError("Subclasses must implement _encode")
+        # type: (CBOR_Packet, Any) -> bytes
+        """Convert internal value to CBOR wire bytes (Scapy build hook)."""
+        if isinstance(x, fields.RawVal):
+            data = bytes(x)
+            try:
+                item, remaining = cbor_item_span(data)
+            except Exception as exc:
+                raise CBOR_Encoding_Error(
+                    "RawVal for %r is not well-formed CBOR: %s"
+                    % (self.name, exc)
+                )
+            if remaining or item != data:
+                raise CBOR_Encoding_Error(
+                    "RawVal for %r must contain exactly one CBOR item"
+                    % self.name
+                )
+            return data
+        # Do not special-case None here: for CBORF_ANY, None is CBOR null.
+        # Absent/optional skipping is handled in build_result().
+        return self.encode_value(x)
 
     def any2i(self, pkt, x):
         # type: (CBOR_Packet, Any) -> _I
-        return cast(_I, x)
+        if x is CBOR_ABSENT or x is CBOR_UNDEFINED_VALUE or x is CBOR_NO_ITEM:
+            return cast(_I, x)
+        if isinstance(x, CBOR_Object):
+            x = cbor_object_to_python(x)
+        return self.h2i(pkt, x)
 
     def extract_packet(self,
                        cls,  # type: Type[CBOR_Packet]
                        s,  # type: bytes
-                       _underlayer=None,  # type: Optional[CBOR_Packet]
+                       _parent=None,  # type: Optional[CBOR_Packet]
                        ):
         # type: (...) -> Tuple[CBOR_Packet, bytes]
         try:
-            c = cls(s, _underlayer=_underlayer)
+            c = cls(s, _parent=_parent)
         except CBORF_badsequence:
-            c = packet.Raw(s, _underlayer=_underlayer)  # type: ignore
-        cpad = c.getlayer(packet.Raw)
+            c = packet.Raw(s, _parent=_parent)  # type: ignore
+        craw = c.getlayer(config.conf.raw_layer)
+        cpad = c.getlayer(config.conf.padding_layer)
         s = b""
+        if craw is not None:
+            s = craw.load
+            if craw.underlayer:
+                del craw.underlayer.payload
         if cpad is not None:
             s = cpad.load
             if cpad.underlayer:
                 del cpad.underlayer.payload
         return c, s
 
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        val = pkt.getfieldval(self.name)
+        if val is None:
+            if self.allows_none:
+                return CBORBuildResult(b"", 0)
+            raise CBOR_Encoding_Error(
+                "Required field %r is None" % self.name)
+        return CBORBuildResult(self.i2m(pkt, val), 1)
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        val, remain = self.m2i(pkt, s)
+        self.set_val(pkt, val)
+        return CBORParseResult(remaining=remain, items=1)
+
+    def parse_value(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        """Decode a free value without assigning it onto *pkt*."""
+        val, remain = self.m2i(pkt, s)
+        return CBORParseResult(value=val, remaining=remain, items=1)
+
+    def build_value(self, pkt, value):
+        # type: (CBOR_Packet, Any) -> CBORBuildResult
+        """Encode *value* without reading it from *pkt* fields."""
+        return CBORBuildResult(
+            data=self.i2m(pkt, self.any2i(pkt, value)),
+            items=1,
+        )
+
     def build(self, pkt):
         # type: (CBOR_Packet) -> bytes
-        return self.i2m(pkt, getattr(pkt, self.name))
+        return self.build_result(pkt).data
 
     def dissect(self, pkt, s):
         # type: (CBOR_Packet, bytes) -> bytes
-        v, s = self.m2i(pkt, s)
-        self.set_val(pkt, v)
-        return s
+        return self.dissect_result(pkt, s).remaining
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
 
     def do_copy(self, x):
         # type: (Any) -> Any
-        if isinstance(x, list):
-            x = x[:]
-            for i in range(len(x)):
-                if isinstance(x[i], BasePacket):
-                    x[i] = x[i].copy()
+        if x is CBOR_ABSENT or x is CBOR_UNDEFINED_VALUE or x is CBOR_NO_ITEM:
             return x
+        if isinstance(x, list):
+            return copy.deepcopy(x)
         if hasattr(x, "copy"):
-            return x.copy()
-        return x
+            try:
+                return x.copy()
+            except TypeError:
+                pass
+        return copy.deepcopy(x)
 
     def set_val(self, pkt, val):
         # type: (CBOR_Packet, Any) -> None
-        setattr(pkt, self.name, val)
+        if val is CBOR_ABSENT:
+            # Bypass any2i so presence sentinel is stored verbatim.
+            pkt.fields[self.name] = CBOR_ABSENT
+            pkt.explicit = 0
+            pkt.raw_packet_cache = None
+            pkt.raw_packet_cache_fields = None
+            pkt.wirelen = None
+            return
+        pkt.setfieldval(self.name, val)
 
     def is_empty(self, pkt):
         # type: (CBOR_Packet) -> bool
-        return getattr(pkt, self.name) is None
+        val = pkt.getfieldval(self.name)
+        return val is None or val is CBOR_ABSENT
+
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        """Return True if the next CBOR item matches this field's outer type."""
+        if not s or cbor_is_break(s):
+            return False
+        try:
+            major_type, _info, _rem = CBOR_decode_head(s)
+        except CBOR_Codec_Decoding_Error:
+            return False
+        tag = self.CBOR_tag
+        if tag is None:
+            return True
+        return major_type == int(tag)
 
     def get_fields_list(self):
-        # type: () -> List[CBORF_field[Any, Any]]
+        # type: () -> List[CBORF_field[Any]]
         return [self]
 
     def __str__(self):
@@ -204,192 +473,395 @@ class CBORF_field(CBORF_element, Generic[_I, _A]):
         return cast(RandField[_I], RandNum(0, 2 ** 32))
 
     def copy(self):
-        # type: () -> CBORF_field[_I, _A]
+        # type: () -> CBORF_field[_I]
         return copy.copy(self)
+
+
+class CBORF_ANY(CBORF_field[Any]):
+    """Represent any well-formed CBOR value, including recursion."""
+    ismutable = True
+    # Treat composites as atomic values so Packet.__iter__/do_build does not
+    # expand a decoded CBOR array into individual generator elements.
+    islist = 1
+
+    def is_empty(self, pkt):
+        # type: (CBOR_Packet) -> bool
+        # Python None is CBOR null; only CBOR_ABSENT means "no item".
+        return pkt.getfieldval(self.name) is CBOR_ABSENT
+
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        try:
+            CBOR_decode_head(s)
+        except CBOR_Codec_Decoding_Error:
+            return False
+        return True
+
+    def do_copy(self, x):  # type: ignore[override]
+        # type: (Any) -> Any
+        if x is CBOR_ABSENT or x is CBOR_UNDEFINED_VALUE or x is CBOR_NO_ITEM:
+            return x
+        # Deep-copy composites so in-place nested mutations invalidate cache.
+        return copy.deepcopy(x)
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        val = pkt.getfieldval(self.name)
+        if val is CBOR_ABSENT:
+            return CBORBuildResult(b"", 0)
+        return CBORBuildResult(self.i2m(pkt, val), 1)
+
+    def m2i(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> Tuple[Any, bytes]
+        obj, remain = CBORcodec_Object.decode_cbor_item(s)
+        return cbor_object_to_python(obj), remain
+
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        if x is CBOR_ABSENT:
+            return b""
+        if isinstance(x, CBOR_Object):
+            x = cbor_object_to_python(x)
+        return CBORcodec_Object.encode_cbor_item(x)
 
 
 #############################
 #    Simple CBOR Fields     #
 #############################
 
-class CBORF_UNSIGNED_INTEGER(CBORF_field[int, CBOR_UNSIGNED_INTEGER]):
+class CBORF_UNSIGNED_INTEGER(CBORF_field[int]):
     """CBOR unsigned integer field (major type 0)."""
     CBOR_tag = CBOR_MajorTypes.UNSIGNED_INTEGER
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_UNSIGNED_INTEGER
-        if isinstance(val, CBOR_UNSIGNED_INTEGER):
-            return val
-        return CBOR_UNSIGNED_INTEGER(int(val))
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> int
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        if x is None:
+            return None  # type: ignore
+        i = int(x)
+        if i < 0 or i > 0xFFFFFFFFFFFFFFFF:
+            raise CBOR_Encoding_Error(
+                "Unsigned integer out of CBOR range: %r" % (i,))
+        return i
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_UNSIGNED_INTEGER, bytes]
-        return CBORcodec_UNSIGNED_INTEGER.dec(s)  # type: ignore
+        # type: (CBOR_Packet, bytes) -> Tuple[int, bytes]
+        obj, remain = CBORcodec_UNSIGNED_INTEGER.dec(s)
+        if not isinstance(obj, CBOR_UNSIGNED_INTEGER):
+            raise CBOR_Type_Mismatch(
+                "Expected unsigned integer, got %r" % obj)
+        return obj.val, remain
 
-    def _encode(self, x):
+    def encode_value(self, x):
         # type: (Any) -> bytes
-        return CBORcodec_UNSIGNED_INTEGER.enc(
-            x if isinstance(x, CBOR_Object) else CBOR_UNSIGNED_INTEGER(int(x))
-        )
+        return CBORcodec_UNSIGNED_INTEGER.enc(int(x))
 
     def randval(self):
         # type: () -> RandNum
         return RandNum(0, 2 ** 64 - 1)
 
 
-class CBORF_NEGATIVE_INTEGER(CBORF_field[int, CBOR_NEGATIVE_INTEGER]):
+class CBORF_NEGATIVE_INTEGER(CBORF_field[int]):
     """CBOR negative integer field (major type 1)."""
     CBOR_tag = CBOR_MajorTypes.NEGATIVE_INTEGER
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_NEGATIVE_INTEGER
-        if isinstance(val, CBOR_NEGATIVE_INTEGER):
-            return val
-        return CBOR_NEGATIVE_INTEGER(int(val))
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> int
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        if x is None:
+            return None  # type: ignore
+        i = int(x)
+        if i >= 0 or i < -(1 << 64):
+            raise CBOR_Encoding_Error(
+                "Negative integer out of CBOR range: %r" % (i,))
+        return i
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_NEGATIVE_INTEGER, bytes]
-        return CBORcodec_NEGATIVE_INTEGER.dec(s)  # type: ignore
+        # type: (CBOR_Packet, bytes) -> Tuple[int, bytes]
+        obj, remain = CBORcodec_NEGATIVE_INTEGER.dec(s)
+        if not isinstance(obj, CBOR_NEGATIVE_INTEGER):
+            raise CBOR_Type_Mismatch(
+                "Expected negative integer, got %r" % obj)
+        return obj.val, remain
 
-    def _encode(self, x):
+    def encode_value(self, x):
         # type: (Any) -> bytes
-        return CBORcodec_NEGATIVE_INTEGER.enc(
-            x if isinstance(x, CBOR_Object) else CBOR_NEGATIVE_INTEGER(int(x))
-        )
+        return CBORcodec_NEGATIVE_INTEGER.enc(int(x))
 
     def randval(self):
         # type: () -> RandNum
         return RandNum(-2 ** 64, -1)
 
 
-class CBORF_INTEGER(CBORF_field[int,
-                                Union[CBOR_UNSIGNED_INTEGER,
-                                      CBOR_NEGATIVE_INTEGER]]):
+class CBORF_INTEGER(CBORF_field[int]):
     """CBOR integer field handling both positive and negative values."""
 
-    def _wrap(self, val):
-        # type: (Any) -> Union[CBOR_UNSIGNED_INTEGER, CBOR_NEGATIVE_INTEGER]
-        if isinstance(val, (CBOR_UNSIGNED_INTEGER, CBOR_NEGATIVE_INTEGER)):
-            return val
-        i = int(val)
-        if i >= 0:
-            return CBOR_UNSIGNED_INTEGER(i)
-        return CBOR_NEGATIVE_INTEGER(i)
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        try:
+            major_type, _info, _rem = CBOR_decode_head(s)
+        except CBOR_Codec_Decoding_Error:
+            return False
+        return major_type in (0, 1)
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> int
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        if x is None:
+            return None  # type: ignore
+        i = int(x)
+        if i < -(1 << 64) or i > 0xFFFFFFFFFFFFFFFF:
+            raise CBOR_Encoding_Error(
+                "Integer out of CBOR range: %r" % (i,))
+        return i
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[Union[CBOR_UNSIGNED_INTEGER, CBOR_NEGATIVE_INTEGER], bytes]  # noqa: E501
+        # type: (CBOR_Packet, bytes) -> Tuple[int, bytes]
         if not s:
             raise CBOR_Decoding_Error("Empty CBOR data")
         major_type = (s[0] >> 5) & 0x7
         if major_type == 0:
-            return CBORcodec_UNSIGNED_INTEGER.dec(s)  # type: ignore
+            obj, remain = CBORcodec_UNSIGNED_INTEGER.dec(s)
+            return obj.val, remain
         elif major_type == 1:
-            return CBORcodec_NEGATIVE_INTEGER.dec(s)  # type: ignore
-        raise CBOR_Decoding_Error(
+            obj, remain = CBORcodec_NEGATIVE_INTEGER.dec(s)
+            return obj.val, remain
+        raise CBOR_Type_Mismatch(
             "Expected integer (major type 0 or 1), got %d" % major_type)
 
-    def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> bytes
-        if x is None:
-            return b""
-        if isinstance(x, CBOR_Object):
-            return x.enc()
+    def encode_value(self, x):
+        # type: (Any) -> bytes
         i = int(x)
         if i >= 0:
-            return CBORcodec_UNSIGNED_INTEGER.enc(CBOR_UNSIGNED_INTEGER(i))
-        return CBORcodec_NEGATIVE_INTEGER.enc(CBOR_NEGATIVE_INTEGER(i))
+            return CBORcodec_UNSIGNED_INTEGER.enc(i)
+        return CBORcodec_NEGATIVE_INTEGER.enc(i)
 
     def randval(self):
         # type: () -> RandNum
         return RandNum(-2 ** 64, 2 ** 64 - 1)
 
 
-class CBORF_BYTE_STRING(CBORF_field[bytes, CBOR_BYTE_STRING]):
+class CBORF_BYTE_STRING(CBORF_field[bytes]):
     """CBOR byte string field (major type 2)."""
     CBOR_tag = CBOR_MajorTypes.BYTE_STRING
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_BYTE_STRING
-        if isinstance(val, CBOR_BYTE_STRING):
-            return val
-        return CBOR_BYTE_STRING(bytes(val))
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[bytes]
+                 definite_only=False,  # type: bool
+                 ):
+        # type: (...) -> None
+        super(CBORF_BYTE_STRING, self).__init__(name, default)
+        self.definite_only = definite_only
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> bytes
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        if x is None:
+            return None  # type: ignore
+        return bytes(x)
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_BYTE_STRING, bytes]
-        return CBORcodec_BYTE_STRING.dec(s)  # type: ignore
+        # type: (CBOR_Packet, bytes) -> Tuple[bytes, bytes]
+        if self.definite_only:
+            try:
+                major_type, length, _rem = CBOR_decode_head(s)
+            except CBOR_Codec_Decoding_Error as e:
+                raise CBOR_Decoding_Error(str(e))
+            if major_type != 2:
+                raise CBOR_Type_Mismatch(
+                    "Expected byte string, got major type %d" % major_type)
+            if length is CBOR_INDEFINITE:
+                raise CBOR_Decoding_Error(
+                    "Indefinite-length byte string not allowed here")
+        obj, remain = CBORcodec_BYTE_STRING.dec(s)
+        if not isinstance(obj, CBOR_BYTE_STRING):
+            raise CBOR_Type_Mismatch(
+                "Expected byte string, got %r" % obj)
+        return obj.val, remain
 
-    def _encode(self, x):
+    def encode_value(self, x):
         # type: (Any) -> bytes
-        return CBORcodec_BYTE_STRING.enc(
-            x if isinstance(x, CBOR_Object) else CBOR_BYTE_STRING(bytes(x))
-        )
+        data = bytes(x)
+        if self.definite_only:
+            # Always emit definite form (codec already does).
+            pass
+        return CBORcodec_BYTE_STRING.enc(data)
 
     def randval(self):
         # type: () -> RandString
         return RandString(RandNum(0, 1000))
 
 
-class CBORF_TEXT_STRING(CBORF_field[str, CBOR_TEXT_STRING]):
+class CBORF_BYTE_STRING_PACKET(CBORF_field[Packet]):
+    """CBOR byte string which wraps another packet field.
+
+    The inner packet may or may not itself be CBOR or CBOR sequence data.
+    """
+    CBOR_tag = CBOR_MajorTypes.BYTE_STRING
+    holds_packets = 1
+
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[Packet]
+                 pkt_cls=None,  # type: Optional[Type[Packet]]
+                 cls_cb=None,  # type: Optional[Callable[[Packet, bytes], Optional[Type[Packet]]]]  # noqa: E501
+                 definite_only=False,  # type: bool
+                 ):
+        # type: (...) -> None
+        if pkt_cls is None and cls_cb is None:
+            raise ValueError('Must give one of pkt_cls or cls_cb')
+        # any2i() needs these during default normalization in super().__init__.
+        self.pkt_cls = pkt_cls
+        self.cls_cb = cls_cb
+        self.definite_only = definite_only
+        super(CBORF_BYTE_STRING_PACKET, self).__init__(name, default)
+
+    def _resolve_packet_class(self, pkt, data):
+        # type: (CBOR_Packet, bytes) -> Tuple[Optional[Type[Packet]], bool]
+        if self.pkt_cls is not None:
+            return self.pkt_cls, True
+        if self.cls_cb is not None:
+            pkt_cls = self.cls_cb(pkt, data)
+            return pkt_cls, pkt_cls is not None
+        return None, False
+
+    def _decode_packet_value(self, pkt, data):
+        # type: (CBOR_Packet, bytes) -> Packet
+        pkt_cls, registered = self._resolve_packet_class(pkt, data)
+        if pkt_cls is None:
+            return _cbor_packet_from_bytes(packet.Raw, data, pkt)
+        try:
+            return _cbor_packet_from_bytes(pkt_cls, data, pkt)
+        except Exception as exc:
+            if registered:
+                raise CBOR_Decoding_Error(
+                    "Failed to decode registered block-type-specific data: %s"
+                    % exc
+                )
+            log_runtime.exception(
+                "Failed to decode byte string content to %s", pkt_cls)
+            return _cbor_packet_from_bytes(packet.Raw, data, pkt)
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> Packet
+        if isinstance(x, CBOR_BYTE_STRING):
+            x = x.val
+        if isinstance(x, (bytes, bytearray)):
+            return self._decode_packet_value(pkt, bytes(x))
+        return _cbor_attach_parent(pkt, x)
+
+    def m2i(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> Tuple[Packet, bytes]
+        if self.definite_only:
+            try:
+                major_type, length, _rem = CBOR_decode_head(s)
+            except CBOR_Codec_Decoding_Error as e:
+                raise CBOR_Decoding_Error(str(e))
+            if major_type != 2:
+                raise CBOR_Type_Mismatch(
+                    "Expected byte string, got major type %d" % major_type)
+            if length is CBOR_INDEFINITE:
+                raise CBOR_Decoding_Error(
+                    "Indefinite-length byte string not allowed here")
+        obj, remain = CBORcodec_BYTE_STRING.dec(s)
+        if not isinstance(obj, CBOR_BYTE_STRING):
+            raise CBOR_Type_Mismatch(
+                "Expected byte string, got %r" % obj)
+        return self._decode_packet_value(pkt, obj.val), remain
+
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        return CBORcodec_BYTE_STRING.enc(bytes(x))
+
+
+class CBORF_TEXT_STRING(CBORF_field[str]):
     """CBOR text string field (major type 3)."""
     CBOR_tag = CBOR_MajorTypes.TEXT_STRING
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_TEXT_STRING
-        if isinstance(val, CBOR_TEXT_STRING):
-            return val
-        return CBOR_TEXT_STRING(str(val))
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> str
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        if x is None:
+            return None  # type: ignore
+        # Reject bytes: str(b"hi") == "b'hi'", which silently corrupts the value.
+        if isinstance(x, (bytes, bytearray, memoryview)):
+            raise TypeError(
+                "CBOR text string field %r requires str, got %s"
+                % (self.name, type(x).__name__)
+            )
+        return str(x)
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_TEXT_STRING, bytes]
-        return CBORcodec_TEXT_STRING.dec(s)  # type: ignore
+        # type: (CBOR_Packet, bytes) -> Tuple[str, bytes]
+        obj, remain = CBORcodec_TEXT_STRING.dec(s)
+        if not isinstance(obj, CBOR_TEXT_STRING):
+            raise CBOR_Type_Mismatch(
+                "Expected text string, got %r" % obj)
+        return obj.val, remain
 
-    def _encode(self, x):
+    def encode_value(self, x):
         # type: (Any) -> bytes
-        return CBORcodec_TEXT_STRING.enc(
-            x if isinstance(x, CBOR_Object) else CBOR_TEXT_STRING(str(x))
-        )
+        return CBORcodec_TEXT_STRING.enc(str(x))
 
     def randval(self):
         # type: () -> RandString
         return RandString(RandNum(0, 1000))
 
 
-class CBORF_BOOLEAN(CBORF_field[bool, Union[CBOR_FALSE, CBOR_TRUE]]):
+class CBORF_BOOLEAN(CBORF_field[bool]):
     """CBOR boolean field (major type 7, simple values 20/21)."""
     CBOR_tag = CBOR_MajorTypes.SIMPLE_AND_FLOAT
 
-    def _wrap(self, val):
-        # type: (Any) -> Union[CBOR_FALSE, CBOR_TRUE]
-        if isinstance(val, (CBOR_FALSE, CBOR_TRUE)):
-            return val
-        return CBOR_TRUE() if val else CBOR_FALSE()
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        ai = s[0] & 0x1f
+        return ((s[0] >> 5) & 0x7) == 7 and ai in (20, 21)
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> bool
+        if x is CBOR_ABSENT:
+            return CBOR_ABSENT  # type: ignore
+        if x is None:
+            return None  # type: ignore
+        if isinstance(x, (CBOR_FALSE, CBOR_TRUE)):
+            return x.val
+        if isinstance(x, CBOR_Object):
+            return bool(x.val)
+        return bool(x)
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[Union[CBOR_FALSE, CBOR_TRUE], bytes]
+        # type: (CBOR_Packet, bytes) -> Tuple[bool, bytes]
         obj, remain = CBORcodec_SIMPLE_AND_FLOAT.dec(s)
         if not isinstance(obj, (CBOR_FALSE, CBOR_TRUE)):
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected boolean (CBOR_FALSE or CBOR_TRUE), got %r" % obj)
-        return obj, remain  # type: ignore
+        return obj.val, remain
 
-    def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> bytes
-        if x is None:
-            return b""
-        if isinstance(x, (CBOR_FALSE, CBOR_TRUE)):
-            return x.enc()
-        return CBORcodec_SIMPLE_AND_FLOAT.enc(
-            CBOR_TRUE() if x else CBOR_FALSE()
-        )
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(bool(x))
 
     def randval(self):
         # type: () -> RandChoice
         return RandChoice(True, False)
 
 
-class CBORF_NULL(CBORF_field[None, CBOR_NULL]):
+class CBORF_NULL(CBORF_field[None]):
     """CBOR null field (major type 7, simple value 22)."""
     CBOR_tag = CBOR_MajorTypes.SIMPLE_AND_FLOAT
+    allows_none = True
 
     def __init__(self,
                  name,  # type: str
@@ -398,30 +870,53 @@ class CBORF_NULL(CBORF_field[None, CBOR_NULL]):
         # type: (...) -> None
         super(CBORF_NULL, self).__init__(name, None)
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_NULL
-        return CBOR_NULL()
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        return s[0] == 0xf6
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> None
+        if x is CBOR_ABSENT:
+            return CBOR_ABSENT  # type: ignore
+        return None
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_NULL, bytes]
+        # type: (CBOR_Packet, bytes) -> Tuple[None, bytes]
         obj, remain = CBORcodec_SIMPLE_AND_FLOAT.dec(s)
         if not isinstance(obj, CBOR_NULL):
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected null, got %r" % obj)
-        return obj, remain  # type: ignore
+        return None, remain
 
-    def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> bytes
+    def encode_value(self, x):
+        # type: (Any) -> bytes
         return CBOR_NULL().enc()
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        if pkt.getfieldval(self.name) is CBOR_ABSENT:
+            return CBORBuildResult(b"", 0)
+        return CBORBuildResult(self.encode_value(None), 1)
 
     def is_empty(self, pkt):
         # type: (CBOR_Packet) -> bool
-        return False
+        return pkt.getfieldval(self.name) is CBOR_ABSENT
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
 
 
-class CBORF_UNDEFINED(CBORF_field[None, CBOR_UNDEFINED]):
+class CBORF_UNDEFINED(CBORF_field[None]):
     """CBOR undefined field (major type 7, simple value 23)."""
     CBOR_tag = CBOR_MajorTypes.SIMPLE_AND_FLOAT
+    allows_none = True
 
     def __init__(self,
                  name,  # type: str
@@ -430,52 +925,110 @@ class CBORF_UNDEFINED(CBORF_field[None, CBOR_UNDEFINED]):
         # type: (...) -> None
         super(CBORF_UNDEFINED, self).__init__(name, None)
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_UNDEFINED
-        return CBOR_UNDEFINED()
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        return s[0] == 0xf7
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> None
+        if x is CBOR_ABSENT:
+            return CBOR_ABSENT  # type: ignore
+        return None
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_UNDEFINED, bytes]
+        # type: (CBOR_Packet, bytes) -> Tuple[None, bytes]
         obj, remain = CBORcodec_SIMPLE_AND_FLOAT.dec(s)
         if not isinstance(obj, CBOR_UNDEFINED):
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected undefined, got %r" % obj)
-        return obj, remain  # type: ignore
+        return None, remain
 
-    def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> bytes
+    def encode_value(self, x):
+        # type: (Any) -> bytes
         return CBOR_UNDEFINED().enc()
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        if pkt.getfieldval(self.name) is CBOR_ABSENT:
+            return CBORBuildResult(b"", 0)
+        return CBORBuildResult(self.encode_value(None), 1)
 
     def is_empty(self, pkt):
         # type: (CBOR_Packet) -> bool
-        return False
+        return pkt.getfieldval(self.name) is CBOR_ABSENT
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
 
 
-class CBORF_FLOAT(CBORF_field[float, CBOR_FLOAT]):
-    """CBOR float field (major type 7, double precision)."""
+class CBORF_FLOAT(CBORF_field[float]):
+    """CBOR float field (major type 7).
+
+    Dissected values retain the received encoding (half / single / double,
+    including NaN payloads) via :class:`~scapy.cbor.cbor.CBORFloatValue`.
+    Assigning a plain ``float`` uses preferred serialization on the next
+    rebuild.
+    """
     CBOR_tag = CBOR_MajorTypes.SIMPLE_AND_FLOAT
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_FLOAT
-        if isinstance(val, CBOR_FLOAT):
-            return val
-        return CBOR_FLOAT(float(val))
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        ai = s[0] & 0x1f
+        return ((s[0] >> 5) & 0x7) == 7 and ai in (25, 26, 27)
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> float
+        from scapy.cbor.cbor import CBORFloatValue
+        if x is CBOR_ABSENT:
+            return CBOR_ABSENT  # type: ignore
+        if x is None:
+            return None  # type: ignore
+        if isinstance(x, CBORFloatValue):
+            return x
+        if isinstance(x, CBOR_FLOAT):
+            return CBORFloatValue(x.val, encoded=x._encoded)
+        if isinstance(x, CBOR_Object):
+            return float(cbor_object_to_python(x))
+        return float(x)
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_FLOAT, bytes]
+        # type: (CBOR_Packet, bytes) -> Tuple[float, bytes]
+        from scapy.cbor.cbor import CBORFloatValue
         obj, remain = CBORcodec_SIMPLE_AND_FLOAT.dec(s)
         if not isinstance(obj, CBOR_FLOAT):
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected float, got %r" % obj)
-        return obj, remain  # type: ignore
+        return CBORFloatValue(obj.val, encoded=obj._encoded), remain
 
-    def i2m(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> bytes
-        if x is None:
-            return b""
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        from scapy.cbor.cbor import CBORFloatValue
         if isinstance(x, CBOR_FLOAT):
             return x.enc()
-        return CBORcodec_SIMPLE_AND_FLOAT.enc(CBOR_FLOAT(float(x)))
+        if isinstance(x, CBORFloatValue) and x.cbor_encoded is not None:
+            return x.cbor_encoded
+        return CBORcodec_SIMPLE_AND_FLOAT.enc(float(x))
+
+    def i2h(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> Any
+        if isinstance(x, CBOR_FLOAT):
+            return x.val
+        return x
+
+    def i2repr(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> str
+        if isinstance(x, CBOR_FLOAT):
+            return repr(x.val)
+        return repr(x)
 
     def randval(self):
         # type: () -> RandFloat
@@ -486,33 +1039,60 @@ class CBORF_FLOAT(CBORF_field[float, CBOR_FLOAT]):
 #    Structured CBOR Fields  #
 ##############################
 
-class CBORF_ARRAY(CBORF_field[List[Any], List[Any]]):
+class CBORF_UNSIGNED_ENUM(CBORF_UNSIGNED_INTEGER):
     """
-    CBOR array with a fixed sequence of named, typed fields (major type 4).
-    Analogous to ASN1F_SEQUENCE: each positional element corresponds to a
-    specific CBORF_field.  The CBOR array count must match the number of
-    declared fields.
-
-    Example::
-
-        class MyCBOR(CBOR_Packet):
-            CBOR_root = CBORF_ARRAY(
-                CBORF_INTEGER("version", 1),
-                CBORF_TEXT_STRING("name", ""),
-            )
+    Display like EnumField, codec like CBORF
     """
-    CBOR_tag = CBOR_MajorTypes.ARRAY
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[int]
+                 enum,  # type: fields._EnumType[int]
+                 ):
+        # type: (...) -> None
+        self._enum = fields.EnumField(name, default, enum, "Q")
+        CBORF_UNSIGNED_INTEGER.__init__(self, name, default)
+
+    def i2repr(self, pkt, x):
+        return self._enum.i2repr(pkt, x)
+
+    def any2i(self, pkt, x):
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        x = self._enum.any2i(pkt, x)
+        return super().any2i(pkt, x)
+
+
+class CBORF_UNSIGNED_FLAGS(CBORF_UNSIGNED_INTEGER):
+    """
+    Display like FlagsField, codec like CBORF
+    """
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Optional[Union[int, fields.FlagValue]]
+                 size,  # type: int
+                 names,  # type: Union[List[str], str, Dict[int, str]]
+                 ):
+        # type: (...) -> None
+        self._flags = fields.FlagsField(name, default, size, names)
+        CBORF_UNSIGNED_INTEGER.__init__(self, name, default)
+
+    def i2repr(self, pkt, x):
+        return self._flags.i2repr(pkt, x)
+
+    def any2i(self, pkt, x):
+        if isinstance(x, CBOR_Object):
+            x = x.val
+        x = self._flags.any2i(pkt, x)
+        return super().any2i(pkt, x)
+
+
+class _CBORF_compound(CBORF_element):
+    """Shared helpers for sequence-like CBOR field containers."""
+    CBOR_tag = None
     holds_packets = 1
 
     def __init__(self, *seq, **kwargs):
         # type: (*Any, **Any) -> None
-        # The array itself is a structural field without its own named slot on
-        # the packet; a placeholder name is used so the base class __init__
-        # stays happy.  Individual element fields are the ones that carry names.
-        name = "_cbor_array"
-        default = [field.default for field in seq]
-        super(CBORF_ARRAY, self).__init__(name, None)
-        self.default = default
         self.seq = seq
         self.islist = len(seq) > 1
 
@@ -525,63 +1105,484 @@ class CBORF_ARRAY(CBORF_field[List[Any], List[Any]]):
         return all(f.is_empty(pkt) for f in self.seq)
 
     def get_fields_list(self):
-        # type: () -> List[CBORF_field[Any, Any]]
-        return reduce(lambda x, y: x + y.get_fields_list(),
-                      self.seq, [])
+        # type: () -> List[CBORF_field[Any]]
+        return [
+            child
+            for field in self.seq
+            for child in field.get_fields_list()
+        ]
 
-    def m2i(self, pkt, s):
-        # type: (Any, bytes) -> Tuple[Any, bytes]
-        """
-        Decode a CBOR array.  Each element is decoded by its corresponding
-        field in ``self.seq``.  The decoded values are set directly on the
-        packet by each field's ``dissect`` call, so this method returns an
-        empty list (which is discarded by ``dissect``).
-        """
-        try:
-            major_type, count, s = CBOR_decode_head(s)
-        except CBOR_Codec_Decoding_Error as e:
-            raise CBOR_Decoding_Error(str(e))
-        if major_type != 4:
-            raise CBOR_Decoding_Error(
-                "Expected major type 4 (array), got %d" % major_type)
-        if count != len(self.seq):
-            raise CBOR_Decoding_Error(
-                "Array length mismatch: expected %d, got %d" %
-                (len(self.seq), count))
-        for obj in self.seq:
+    def _build_children(self, pkt):
+        # type: (CBOR_Packet) -> Tuple[bytes, int]
+        parts = []  # type: List[bytes]
+        total_items = 0
+        for field in self.seq:
+            result = field.build_result(pkt)
+            parts.append(result.data)
+            total_items += result.items
+        return b"".join(parts), total_items
+
+    def _mark_absent(self, pkt, field):
+        # type: (CBOR_Packet, Any) -> None
+        """Record that an optional/conditional field was not present."""
+        if isinstance(field, CBORF_optional):
+            field._field.set_val(pkt, CBOR_ABSENT)
+        elif isinstance(field, CBORF_CONDITIONAL):
+            # Condition false or skipped: leave value untouched.
+            pass
+
+    def _dissect_children(self, pkt, s, count):
+        # type: (CBOR_Packet, bytes, Union[int, CBOR_INDEFINITE]) -> bytes
+        remaining = s
+        if count is CBOR_INDEFINITE:
+            # Count items with a memoryview cursor (no suffix copies / span).
+            if not isinstance(remaining, memoryview):
+                view = memoryview(remaining)
+            else:
+                view = remaining
+            probe = view
+            item_count = 0
+            while probe and not cbor_is_break(probe):
+                _obj, probe = CBORcodec_Object.decode_cbor_item(probe)
+                item_count += 1
+            remaining = self._dissect_children_budgeted(
+                pkt, remaining, item_count
+            )
+            return cbor_consume_break(remaining)
+
+        return self._dissect_children_budgeted(pkt, remaining, count)
+
+    def _dissect_children_budgeted(self, pkt, s, count):
+        # type: (CBOR_Packet, bytes, int) -> bytes
+        remaining = s
+        items_left = count
+        for index, field in enumerate(self.seq):
+            reserved = sum(
+                f.min_items(pkt) for f in self.seq[index + 1:]
+            )
+            available = items_left - reserved
+            needed = field.min_items(pkt)
+            if available < 0:
+                raise CBOR_Decoding_Error("CBOR item count mismatch")
+            if available < needed:
+                raise CBOR_Decoding_Error("CBOR item count mismatch")
+            if available == 0:
+                if needed > 0:
+                    raise CBOR_Decoding_Error("CBOR item count mismatch")
+                # Zero budget: later required fields reserved every remaining
+                # item. Optionals stay absent for reservation, but a *matching*
+                # optional must still be well-formed — otherwise a malformed
+                # present value would silently migrate into a trailing ANY.
+                if (
+                    isinstance(field, CBORF_optional)
+                    and remaining
+                    and field._field.matches_next_item(pkt, remaining)
+                ):
+                    probe = pkt.__class__()
+                    try:
+                        field.dissect_result(probe, remaining)
+                    except CBORF_badsequence:
+                        pass
+                    # CBOR_Decoding_Error / Type_Mismatch propagate.
+                self._mark_absent(pkt, field)
+                continue
             try:
-                s = obj.dissect(pkt, s)
+                if isinstance(field, CBORF_SEQUENCE_OF):
+                    result = field.dissect_result(
+                        pkt, remaining, max_items=available
+                    )
+                elif isinstance(field, CBORF_optional):
+                    if not field._field.matches_next_item(pkt, remaining):
+                        self._mark_absent(pkt, field)
+                        continue
+                    result = field.dissect_result(pkt, remaining)
+                else:
+                    result = field.dissect_result(pkt, remaining)
             except CBORF_badsequence:
-                break
-        return [], s
+                if needed > 0:
+                    raise CBOR_Decoding_Error("CBOR item count mismatch")
+                self._mark_absent(pkt, field)
+                continue
+            if result.items > items_left:
+                raise CBOR_Decoding_Error(
+                    "CBOR field consumed more items than remaining"
+                )
+            if result.items == 0:
+                self._mark_absent(pkt, field)
+            remaining = result.remaining
+            items_left -= result.items
+        if items_left != 0:
+            raise CBOR_Decoding_Error("CBOR item count mismatch")
+        return remaining
 
-    def dissect(self, pkt, s):
-        # type: (Any, bytes) -> bytes
-        _, x = self.m2i(pkt, s)
-        return x
+
+class CBORF_SEQUENCE(_CBORF_compound):
+    """
+    Unframed fixed sequence of named, typed fields (no CBOR array head).
+
+    Unlike :class:`CBORF_ARRAY`, this emits/consumes a stream of top-level
+    CBOR items. Use it when a schema is a field list without a major-type-4
+    envelope (ASN.1 SEQUENCE analogy belongs on :class:`CBORF_ARRAY`).
+
+    Example::
+
+        class MyCBOR(CBOR_Packet):
+            CBOR_root = CBORF_SEQUENCE(
+                CBORF_INTEGER("version", 1),
+                CBORF_TEXT_STRING("name", ""),
+            )
+    """
+
+    def __init__(self, *seq, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(CBORF_SEQUENCE, self).__init__(*seq, **kwargs)
+        self._reject_ambiguous_unbounded_sequences()
+
+    def _reject_ambiguous_unbounded_sequences(self):
+        # type: () -> None
+        CBORF_ARRAY._reject_ambiguous_unbounded_sequences(self)
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        data, total_items = self._build_children(pkt)
+        return CBORBuildResult(data, total_items)
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        # Count only up to this schema's max so trailing CBOR items remain for
+        # a parent (e.g. Raw / Padding), matching definite ARRAY roots.
+        view = memoryview(s) if not isinstance(s, memoryview) else s
+        probe = view
+        item_count = 0
+        max_count = self.max_items(pkt)
+        while probe and not cbor_is_break(probe) and item_count < max_count:
+            _obj, probe = CBORcodec_Object.decode_cbor_item(probe)
+            item_count += 1
+        remaining = self._dissect_children_budgeted(pkt, s, item_count)
+        return CBORParseResult(remaining=remaining, items=item_count)
 
     def build(self, pkt):
         # type: (CBOR_Packet) -> bytes
-        items = b"".join(obj.build(pkt) for obj in self.seq)
-        return CBOR_encode_head(4, len(self.seq)) + items
+        return self.build_result(pkt).data
+
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        return self.dissect_result(pkt, s).remaining
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return sum(f.min_items(pkt) for f in self.seq)
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return sum(f.max_items(pkt) for f in self.seq)
+
+
+class CBORF_ARRAY(_CBORF_compound):
+    """
+    CBOR array with a fixed sequence of named, typed fields (major type 4).
+
+    Analogous to ASN1F_SEQUENCE: each positional element is a
+    :class:`CBORF_field`, wrapped in one definite (or indefinite) CBOR array.
+    Prefer this over :class:`CBORF_SEQUENCE` when the wire form is a single
+    array item.
+
+    Example::
+
+        class MyCBOR(CBOR_Packet):
+            CBOR_root = CBORF_ARRAY(
+                CBORF_INTEGER("version", 1),
+                CBORF_TEXT_STRING("name", ""),
+            )
+    """
+    CBOR_tag = CBOR_MajorTypes.ARRAY
+
+    encode_indefinite = False
+    """Set to true to encode using indefinite length."""
+
+    def __init__(self, *seq, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(CBORF_ARRAY, self).__init__(*seq, **kwargs)
+        self._reject_ambiguous_unbounded_sequences()
+
+    def _reject_ambiguous_unbounded_sequences(self):
+        # type: () -> None
+        def _unbounded(field):
+            # type: (Any) -> bool
+            if isinstance(field, CBORF_optional):
+                return False
+            if isinstance(field, CBORF_CONDITIONAL):
+                return False
+            return (
+                isinstance(field, CBORF_SEQUENCE_OF)
+                or (
+                    hasattr(field, "min_items")
+                    and hasattr(field, "max_items")
+                    and field.min_items(None) == 0  # type: ignore[arg-type]
+                    and field.max_items(None) > 1  # type: ignore[arg-type]
+                )
+            )
+
+        def _skippable(field):
+            # type: (Any) -> bool
+            return isinstance(field, (CBORF_optional, CBORF_CONDITIONAL))
+
+        unbounded_indexes = [
+            index for index, field in enumerate(self.seq) if _unbounded(field)
+        ]
+        for left, right in zip(unbounded_indexes, unbounded_indexes[1:]):
+            # Adjacent unbounded fields, or unbounded fields separated only by
+            # optional/conditional fillers, cannot be partitioned uniquely.
+            if all(_skippable(self.seq[i]) for i in range(left + 1, right)):
+                raise ValueError(
+                    "Ambiguous unbounded CBOR sequences in array schema"
+                )
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        items_data, total_items = self._build_children(pkt)
+        if self.encode_indefinite:
+            data = (
+                CBOR_encode_indefinite_head(int(CBOR_MajorTypes.ARRAY)) +
+                items_data +
+                CBOR_encode_break()
+            )
+        else:
+            data = CBOR_encode_head(int(CBOR_MajorTypes.ARRAY), total_items)
+            data += items_data
+        return CBORBuildResult(data, 1)
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        try:
+            major_type, count, remaining = CBOR_decode_head(s)
+        except CBOR_Codec_Decoding_Error as e:
+            raise CBOR_Decoding_Error(str(e))
+        if major_type != 4:
+            raise CBOR_Type_Mismatch(
+                "Expected major type 4 (array), got %d" % major_type)
+        remaining = self._dissect_children(pkt, remaining, count)
+        return CBORParseResult(remaining=remaining, items=1)
+
+    def build(self, pkt):
+        # type: (CBOR_Packet) -> bytes
+        return self.build_result(pkt).data
+
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        return self.dissect_result(pkt, s).remaining
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+
+class CBORF_ARRAY_INDEFINITE(CBORF_ARRAY):
+    """A field to act as an array but to always encode to indefinite-length."""
+
+    encode_indefinite = True
 
 
 _ARRAY_T = Union[
     'CBOR_Packet',
-    Type[CBORF_field[Any, Any]],
+    Type['CBORF_field[Any]'],
     'CBORF_PACKET',
-    CBORF_field[Any, Any],
+    'CBORF_field[Any]',
 ]
 
 
-class CBORF_ARRAY_OF(CBORF_field[List[_ARRAY_T], List[CBOR_Object[Any]]]):
+class CBORF_SEQUENCE_OF(CBORF_field[List[Any]]):
+    """
+    Unframed sequence of homogeneous elements (no CBOR array head).
+
+    Preferred constructors (ASN1F_SEQUENCE_OF / PacketListField style)::
+
+        CBORF_SEQUENCE_OF("items", [], cls=MyPacket)
+        CBORF_SEQUENCE_OF("items", [], cls=CBORF_UNSIGNED_INTEGER)
+        CBORF_SEQUENCE_OF("items", [], next_cls_cb=choose_next)
+
+    ``pkt_cls`` is accepted as an alias of ``cls`` for PacketListField
+    familiarity. Pass only one of ``cls`` / ``pkt_cls`` / ``next_cls_cb``.
+    """
+    CBOR_tag = None
+    islist = 1
+
+    def __init__(self,
+                 name,  # type: str
+                 default,  # type: Any
+                 cls=None,  # type: _ARRAY_T
+                 pkt_cls=None,  # type: Optional[Type[Packet]]
+                 next_cls_cb=None,  # type: Optional[Callable[..., Optional[Type[Packet]]]]  # noqa: E501
+                 ):
+        # type: (...) -> None
+        self.next_cls_cb = None  # type: Optional[Callable[..., Optional[Type[Packet]]]]
+        self.cls = None
+        self.item_field = None
+        self.holds_packets = 0
+
+        if next_cls_cb is not None:
+            if cls is not None or pkt_cls is not None:
+                raise ValueError(
+                    "Pass only next_cls_cb, or only cls/pkt_cls"
+                )
+            self.next_cls_cb = next_cls_cb
+            self.holds_packets = 1
+        else:
+            if cls is not None and pkt_cls is not None:
+                raise ValueError("Pass only one of cls or pkt_cls")
+            chosen = pkt_cls if pkt_cls is not None else cls
+            if isinstance(chosen, type) and issubclass(chosen, CBORF_field) or \
+                    isinstance(chosen, CBORF_field):
+                if isinstance(chosen, type):
+                    self.item_field = chosen("_item", None)  # type: ignore
+                else:
+                    self.item_field = chosen
+                self.holds_packets = 0
+            elif hasattr(chosen, "CBOR_root") or callable(chosen):
+                self.cls = cast("Type[CBOR_Packet]", chosen)
+                self.holds_packets = 1
+            else:
+                raise ValueError(
+                    "Provide cls, pkt_cls, or next_cls_cb"
+                )
+        super(CBORF_SEQUENCE_OF, self).__init__(name, default)
+
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> List[Any]
+        if x is None:
+            return None  # type: ignore
+        if self.holds_packets:
+            items = list(x)
+            for item in items:
+                _cbor_attach_parent(pkt, item)
+            return items
+        return [self.item_field.any2i(pkt, item) for item in x]
+
+    def _decode_items(self, pkt, data, max_items=None):
+        # type: (CBOR_Packet, bytes, Optional[int]) -> Tuple[List[Any], bytes, int]
+        """Decode zero or more immediate CBOR items; do not consume break."""
+        values = []  # type: List[Any]
+        remaining = data
+        consumed = 0
+        while remaining and not cbor_is_break(remaining):
+            if max_items is not None and consumed >= max_items:
+                break
+            before_len = len(remaining)
+            if self.holds_packets:
+                pkt_cls = self.cls
+                if self.next_cls_cb is not None:
+                    pkt_cls = self.next_cls_cb(
+                        pkt,
+                        values,
+                        values[-1] if values else None,
+                        remaining,
+                    )
+                    if pkt_cls is CBOR_NO_ITEM or pkt_cls is None:
+                        break
+                item_bytes, next_remaining = cbor_item_span(remaining)
+                if len(next_remaining) >= before_len:
+                    raise CBOR_Decoding_Error(
+                        "Sequence decoder did not consume input")
+                try:
+                    child = _cbor_packet_from_bytes(pkt_cls, item_bytes, pkt)
+                except CBOR_Decoding_Error:
+                    raise
+                except Exception as exc:
+                    raise CBOR_Decoding_Error(str(exc))
+                values.append(child)
+                consumed += 1
+                remaining = next_remaining
+            else:
+                result = self.item_field.parse_value(pkt, remaining)
+                if result.items != 1:
+                    raise CBOR_Decoding_Error(
+                        "SEQUENCE_OF element must consume exactly one item"
+                    )
+                if len(result.remaining) >= before_len:
+                    raise CBOR_Decoding_Error(
+                        "Sequence decoder did not consume input")
+                values.append(result.value)
+                consumed += 1
+                remaining = result.remaining
+        return values, remaining, consumed
+
+    def m2i(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> Tuple[List[Any], bytes]
+        values, remaining, _consumed = self._decode_items(pkt, s)
+        return values, remaining
+
+    def dissect_result(self, pkt, s, max_items=None):
+        # type: (CBOR_Packet, bytes, Optional[int]) -> CBORParseResult
+        values, remaining, consumed = self._decode_items(
+            pkt, s, max_items=max_items
+        )
+        self.set_val(pkt, values)
+        return CBORParseResult(remaining=remaining, items=consumed)
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        val = pkt.getfieldval(self.name)
+        if val is None:
+            raise CBOR_Encoding_Error(
+                "Required collection field %r is None" % self.name)
+        parts = []  # type: List[bytes]
+        total_items = 0
+        for item in val:
+            if self.holds_packets:
+                parts.append(
+                    _encode_exactly_one_cbor_item(
+                        item, context="SEQUENCE_OF element"
+                    )
+                )
+                total_items += 1
+            else:
+                result = self.item_field.build_value(pkt, item)
+                if result.items != 1:
+                    raise CBOR_Encoding_Error(
+                        "SEQUENCE_OF element must emit exactly one item"
+                    )
+                parts.append(result.data)
+                total_items += 1
+        return CBORBuildResult(b"".join(parts), total_items)
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 0
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1 << 30
+
+    def i2repr(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> str
+        if self.holds_packets:
+            return repr(x)
+        elif x is None:
+            return "()"
+        else:
+            return "(%s)" % ", ".join(
+                self.item_field.i2repr(pkt, item) for item in x
+            )
+
+    def __repr__(self):
+        # type: () -> str
+        return "<%s %s>" % (self.__class__.__name__, self.name)
+
+
+class CBORF_ARRAY_OF(CBORF_field[List[Any]]):
     """
     CBOR array of homogeneous elements (major type 4).
-    Analogous to ASN1F_SEQUENCE_OF: variable-length array where every
-    element shares the same type, specified by ``cls``.
 
-    ``cls`` may be a :class:`CBORF_field` class/instance (leaf type) or a
-    :class:`CBOR_Packet` subclass (structured type).
+    Preferred constructors::
+
+        CBORF_ARRAY_OF("items", [], cls=MyPacket)
+        CBORF_ARRAY_OF("items", [], cls=CBORF_UNSIGNED_INTEGER)
+
+    ``pkt_cls`` is accepted as an alias of ``cls``. Pass only one of them.
     """
     CBOR_tag = CBOR_MajorTypes.ARRAY
     islist = 1
@@ -589,30 +1590,39 @@ class CBORF_ARRAY_OF(CBORF_field[List[_ARRAY_T], List[CBOR_Object[Any]]]):
     def __init__(self,
                  name,  # type: str
                  default,  # type: Any
-                 cls,  # type: _ARRAY_T
+                 cls=None,  # type: _ARRAY_T
+                 pkt_cls=None,  # type: Optional[Type[Packet]]
                  ):
         # type: (...) -> None
-        if isinstance(cls, type) and issubclass(cls, CBORF_field) or \
-                isinstance(cls, CBORF_field):
-            if isinstance(cls, type):
-                self.fld = cls("_item", None)  # type: ignore
+        if cls is not None and pkt_cls is not None:
+            raise ValueError("Pass only one of cls or pkt_cls")
+        chosen = pkt_cls if pkt_cls is not None else cls
+        if chosen is None:
+            raise ValueError("Provide cls or pkt_cls")
+        if isinstance(chosen, type) and issubclass(chosen, CBORF_field) or \
+                isinstance(chosen, CBORF_field):
+            if isinstance(chosen, type):
+                self.item_field = chosen("_item", None)  # type: ignore
             else:
-                self.fld = cls
-            self._extract_item = lambda s, pkt: self.fld.m2i(pkt, s)
+                self.item_field = chosen
             self.holds_packets = 0
-        elif hasattr(cls, "CBOR_root") or callable(cls):
-            self.cls = cast("Type[CBOR_Packet]", cls)
-            self._extract_item = lambda s, pkt: self.extract_packet(
-                self.cls, s, _underlayer=pkt)
+        elif hasattr(chosen, "CBOR_root") or callable(chosen):
+            self.cls = cast("Type[CBOR_Packet]", chosen)
             self.holds_packets = 1
         else:
             raise ValueError("cls must be a CBORF_field or CBOR_Packet")
-        super(CBORF_ARRAY_OF, self).__init__(name, None)
-        self.default = default
+        super(CBORF_ARRAY_OF, self).__init__(name, default)
 
-    def is_empty(self, pkt):
-        # type: (CBOR_Packet) -> bool
-        return CBORF_field.is_empty(self, pkt)
+    def any2i(self, pkt, x):
+        # type: (CBOR_Packet, Any) -> List[Any]
+        if x is None:
+            return None  # type: ignore
+        if self.holds_packets:
+            items = list(x)
+            for item in items:
+                _cbor_attach_parent(pkt, item)
+            return items
+        return [self.item_field.any2i(pkt, item) for item in x]
 
     def m2i(self, pkt, s):
         # type: (CBOR_Packet, bytes) -> Tuple[List[Any], bytes]
@@ -621,22 +1631,66 @@ class CBORF_ARRAY_OF(CBORF_field[List[_ARRAY_T], List[CBOR_Object[Any]]]):
         except CBOR_Codec_Decoding_Error as e:
             raise CBOR_Decoding_Error(str(e))
         if major_type != 4:
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected major type 4 (array), got %d" % major_type)
-        lst = []
-        for _ in range(count):
-            c, s = self._extract_item(s, pkt)  # type: ignore
-            if c is not None:
-                lst.append(c)
+        lst = []  # type: List[Any]
+
+        def _decode_element():
+            # type: () -> None
+            nonlocal s
+            if self.holds_packets:
+                item_bytes, s = cbor_item_span(s)
+                try:
+                    child = _cbor_packet_from_bytes(self.cls, item_bytes, pkt)
+                except CBOR_Decoding_Error:
+                    raise
+                except Exception as exc:
+                    raise CBOR_Decoding_Error(str(exc))
+                lst.append(child)
+            else:
+                result = self.item_field.parse_value(pkt, s)
+                if result.items != 1:
+                    raise CBOR_Decoding_Error(
+                        "ARRAY_OF element must consume exactly one item"
+                    )
+                lst.append(result.value)
+                s = result.remaining
+
+        if count is CBOR_INDEFINITE:
+            while True:
+                if cbor_is_break(s):
+                    s = cbor_consume_break(s)
+                    break
+                _decode_element()
+        else:
+            for _ in range(count):
+                _decode_element()
         return lst, s
 
-    def build(self, pkt):
-        # type: (CBOR_Packet) -> bytes
-        val = getattr(pkt, self.name)
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        val = pkt.getfieldval(self.name)
         if val is None:
-            val = []
-        items = b"".join(bytes(item) for item in val)
-        return CBOR_encode_head(4, len(val)) + items
+            raise CBOR_Encoding_Error(
+                "Required collection field %r is None" % self.name)
+        parts = []  # type: List[bytes]
+        for item in val:
+            if self.holds_packets:
+                parts.append(
+                    _encode_exactly_one_cbor_item(
+                        item, context="ARRAY_OF element"
+                    )
+                )
+            else:
+                result = self.item_field.build_value(pkt, item)
+                if result.items != 1:
+                    raise CBOR_Encoding_Error(
+                        "ARRAY_OF element must emit exactly one item"
+                    )
+                parts.append(result.data)
+        items = b"".join(parts)
+        data = CBOR_encode_head(4, len(val)) + items
+        return CBORBuildResult(data, 1)
 
     def i2repr(self, pkt, x):
         # type: (CBOR_Packet, Any) -> str
@@ -646,7 +1700,7 @@ class CBORF_ARRAY_OF(CBORF_field[List[_ARRAY_T], List[CBOR_Object[Any]]]):
             return "[]"
         else:
             return "[%s]" % ", ".join(
-                self.fld.i2repr(pkt, item) for item in x  # type: ignore
+                self.item_field.i2repr(pkt, item) for item in x
             )
 
     def __repr__(self):
@@ -654,13 +1708,28 @@ class CBORF_ARRAY_OF(CBORF_field[List[_ARRAY_T], List[CBOR_Object[Any]]]):
         return "<%s %s>" % (self.__class__.__name__, self.name)
 
 
-class CBORF_MAP(CBORF_field[Dict[str, Any], Dict[str, Any]]):
+class CBORF_MAP(CBORF_element):
     """
     CBOR map with a fixed set of named, typed fields (major type 5).
+
+    This is a **JSON-like named-field** schema helper, not a general CBOR map
+    codec: keys must be CBOR text strings (the field ``name``, or unknown
+    extension names). Integer / byte-string / other key types are rejected.
+    Protocols that need arbitrary CBOR map keys should use :class:`CBORF_ANY`
+    or a dedicated field.
 
     Each field in ``seq`` represents one key-value pair.  The key is the
     field's ``name`` encoded as a CBOR text string.  The value is encoded
     and decoded by the corresponding :class:`CBORF_field`.
+
+    On encode, pairs are emitted in RFC 8949 core-deterministic order
+    (sorted by encoded key bytes), independent of declaration order.
+
+    Unknown received key/value pairs are retained on the packet
+    (``_cbor_unknown_map_pairs``) as decoded semantic ``(key, value)`` pairs.
+    While the packet raw cache is valid the exact received bytes are preserved;
+    after any mutation unknown members are re-encoded using core-deterministic
+    CBOR together with known fields.
 
     Example::
 
@@ -672,19 +1741,23 @@ class CBORF_MAP(CBORF_field[Dict[str, Any], Dict[str, Any]]):
     """
     CBOR_tag = CBOR_MajorTypes.MAP
     holds_packets = 1
+    islist = 1
 
     def __init__(self, *seq, **kwargs):
         # type: (*Any, **Any) -> None
-        # The map itself is a structural field without its own named slot on
-        # the packet; a placeholder name is used so the base class __init__
-        # stays happy.  Individual value fields are the ones that carry names
-        # (which also serve as the CBOR text-string keys in the wire encoding).
-        name = "_cbor_map"
-        default = {field.name: field.default for field in seq}
-        super(CBORF_MAP, self).__init__(name, None)
-        self.default = default
         self.seq = seq
-        self.islist = 1
+        field_by_name = {}  # type: Dict[str, Any]
+        encoded_keys = {}  # type: Dict[str, bytes]
+        for fld in seq:
+            name = fld.name
+            if name in field_by_name:
+                raise ValueError(
+                    "Duplicate CBOR map field name: %r" % (name,)
+                )
+            field_by_name[name] = fld
+            encoded_keys[name] = CBORcodec_TEXT_STRING.enc(name)
+        self._field_by_name = field_by_name
+        self._encoded_keys = encoded_keys
 
     def __repr__(self):
         # type: () -> str
@@ -695,66 +1768,182 @@ class CBORF_MAP(CBORF_field[Dict[str, Any], Dict[str, Any]]):
         return all(f.is_empty(pkt) for f in self.seq)
 
     def get_fields_list(self):
-        # type: () -> List[CBORF_field[Any, Any]]
-        return reduce(lambda x, y: x + y.get_fields_list(),
-                      self.seq, [])
+        # type: () -> List[CBORF_field[Any]]
+        return [
+            child
+            for field in self.seq
+            for child in field.get_fields_list()
+        ]
 
-    def m2i(self, pkt, s):
-        # type: (Any, bytes) -> Tuple[Any, bytes]
-        """
-        Decode a CBOR map.  Keys are decoded as CBOR items and matched to
-        fields by name.  Values are decoded by the matching field.  Unknown
-        keys are silently skipped.
-        """
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        # Emit pairs sorted by encoded key bytes (RFC 8949 core deterministic).
+        pairs = []  # type: List[Tuple[bytes, bytes]]
+        for fld in self.seq:
+            value_result = fld.build_result(pkt)
+            if value_result.items == 0:
+                continue
+            if value_result.items != 1:
+                raise CBOR_Encoding_Error(
+                    "CBOR map value for %r must emit exactly one item"
+                    % fld.name
+                )
+            pairs.append((self._encoded_keys[fld.name], value_result.data))
+        unknown = getattr(pkt, "_cbor_unknown_map_pairs", None) or []
+        for key, value in unknown:
+            key_bytes = CBORcodec_TEXT_STRING.enc(key)
+            value_bytes = CBORcodec_Object.encode_cbor_item_deterministic(value)
+            pairs.append((key_bytes, value_bytes))
+        pairs.sort(key=lambda item: item[0])
+        parts = []  # type: List[bytes]
+        for key_bytes, value_bytes in pairs:
+            parts.append(key_bytes)
+            parts.append(value_bytes)
+        data = CBOR_encode_head(5, len(pairs)) + b"".join(parts)
+        return CBORBuildResult(data, 1)
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
         try:
-            major_type, count, s = CBOR_decode_head(s)
+            major_type, count, remaining = CBOR_decode_head(s)
         except CBOR_Codec_Decoding_Error as e:
             raise CBOR_Decoding_Error(str(e))
         if major_type != 5:
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected major type 5 (map), got %d" % major_type)
-        # Build a lookup from field name to field object.
-        field_map = {f.name: f for f in self.seq}
-        for _ in range(count):
-            # Decode the key (any CBOR type; convert to str for lookup).
-            key_obj, s = CBORcodec_Object.decode_cbor_item(s)
-            if isinstance(key_obj, CBOR_Object):
-                key = str(key_obj.val)
-            else:
-                key = str(key_obj)
-            fld = field_map.get(key)
-            if fld is not None:
-                s = fld.dissect(pkt, s)
-            else:
-                # Skip unknown value.
-                _unknown, s = CBORcodec_Object.decode_cbor_item(s)
-        return [], s
 
-    def dissect(self, pkt, s):
-        # type: (Any, bytes) -> bytes
-        _, x = self.m2i(pkt, s)
-        return x
+        field_map = self._field_by_name
+        seen_keys = set()  # type: set[str]
+        seen_fields = set()  # type: set[str]
+        pair_values = {}  # type: Dict[str, bytes]
+        unknown_pairs = []  # type: List[Tuple[str, Any]]
+
+        def _map_text_key(key_obj):
+            # type: (Any) -> str
+            if not isinstance(key_obj, CBOR_TEXT_STRING):
+                raise CBOR_Decoding_Error(
+                    "CBOR map field key must be a text string, got %r"
+                    % (key_obj,)
+                )
+            key = key_obj.val
+            if key in seen_keys:
+                raise CBOR_Decoding_Error(
+                    "Duplicate CBOR map field name: %r" % (key,)
+                )
+            seen_keys.add(key)
+            return key
+
+        def _collect_pair():
+            # type: () -> None
+            nonlocal remaining
+            # Keep encoded key bytes so unknown extensions round-trip exactly.
+            key_bytes, after_key = cbor_item_span(remaining)
+            key_obj, key_rest = CBORcodec_Object.decode_cbor_item(key_bytes)
+            if key_rest:
+                raise CBOR_Decoding_Error(
+                    "CBOR map key did not decode to a single item"
+                )
+            key = _map_text_key(key_obj)
+            val_bytes, remaining = cbor_item_span(after_key)
+            if key in field_map:
+                pair_values[key] = val_bytes
+            else:
+                val_obj, val_rest = CBORcodec_Object.decode_cbor_item(val_bytes)
+                if val_rest:
+                    raise CBOR_Decoding_Error(
+                        "CBOR map value did not decode to a single item"
+                    )
+                unknown_pairs.append(
+                    (key, cbor_object_to_python(val_obj))
+                )
+
+        if count is CBOR_INDEFINITE:
+            while True:
+                if cbor_is_break(remaining):
+                    remaining = cbor_consume_break(remaining)
+                    break
+                _collect_pair()
+        else:
+            for _ in range(count):
+                _collect_pair()
+
+        def _dissect_value_bytes(fld, val_bytes):
+            # type: (Any, bytes) -> None
+            if isinstance(fld, CBORF_optional):
+                value_fld = fld._field
+            elif isinstance(fld, CBORF_CONDITIONAL):
+                value_fld = fld.fld
+            else:
+                value_fld = fld
+            result = value_fld.dissect_result(pkt, val_bytes)
+            if result.items != 1 or result.remaining:
+                raise CBOR_Decoding_Error(
+                    "Map value for %r must contain exactly one item"
+                    % getattr(value_fld, "name", value_fld)
+                )
+            seen_fields.add(value_fld.name)
+
+        # Phase 1: unconditional members (order-independent).
+        for fld in self.seq:
+            if isinstance(fld, CBORF_CONDITIONAL):
+                continue
+            name = fld.name
+            if name not in pair_values:
+                self._mark_map_field_absent(pkt, fld)
+                continue
+            _dissect_value_bytes(fld, pair_values[name])
+
+        # Phase 2: conditionals after discriminators are populated.
+        for fld in self.seq:
+            if not isinstance(fld, CBORF_CONDITIONAL):
+                continue
+            name = fld.fld.name
+            if name not in pair_values:
+                continue
+            if not fld._evalcond(pkt):
+                raise CBOR_Decoding_Error(
+                    "Map field %r present but condition is false" % name
+                )
+            _dissect_value_bytes(fld, pair_values[name])
+
+        for fld in self.seq:
+            if fld.min_items(pkt) > 0 and fld.name not in seen_fields:
+                raise CBOR_Decoding_Error(
+                    "Required map field %r is missing" % fld.name
+                )
+        pkt._cbor_unknown_map_pairs = unknown_pairs  # type: ignore[attr-defined]
+        return CBORParseResult(remaining=remaining, items=1)
+
+    def _mark_map_field_absent(self, pkt, fld):
+        # type: (CBOR_Packet, Any) -> None
+        if isinstance(fld, CBORF_optional):
+            fld._field.set_val(pkt, CBOR_ABSENT)
 
     def build(self, pkt):
         # type: (CBOR_Packet) -> bytes
-        result = CBOR_encode_head(5, len(self.seq))
-        for fld in self.seq:
-            # Encode key as a CBOR text string.
-            result += CBORcodec_TEXT_STRING.enc(CBOR_TEXT_STRING(fld.name))
-            result += fld.build(pkt)
-        return result
+        return self.build_result(pkt).data
+
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        return self.dissect_result(pkt, s).remaining
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 1
 
 
-class CBORF_SEMANTIC_TAG(CBORF_field[Tuple[int, Any],
-                                     CBOR_SEMANTIC_TAG]):
+class CBORF_SEMANTIC_TAG(CBORF_field[int]):
     """
     CBOR semantic tag field (major type 6).
 
     Wraps an ``inner_field`` with the given numeric ``tag_num``.  The inner
     field handles encoding and decoding of the tagged value.  The outer field
-    (named ``name``) stores the :class:`~scapy.cbor.cbor.CBOR_SEMANTIC_TAG`
-    wrapper (tag number + ``None`` placeholder), while the inner field stores
-    its value under its own name on the packet.
+    (named ``name``) stores the tag number, while the inner field stores its
+    value under its own name on the packet.
 
     Example::
 
@@ -764,50 +1953,104 @@ class CBORF_SEMANTIC_TAG(CBORF_field[Tuple[int, Any],
             )
     """
     CBOR_tag = CBOR_MajorTypes.TAG
+    holds_packets = 0
 
     def __init__(self,
                  name,  # type: str
                  default,  # type: Any
                  tag_num,  # type: int
-                 inner_field,  # type: CBORF_field[Any, Any]
+                 inner_field,  # type: CBORF_field[Any]
                  ):
         # type: (...) -> None
         self.tag_num = tag_num
+        if tag_num < 0 or tag_num > 0xFFFFFFFFFFFFFFFF:
+            raise CBOR_Encoding_Error(
+                "Semantic tag number out of uint64 range")
         self.inner_field = inner_field
+        # Honour an explicit default (e.g. CBOR_ABSENT); otherwise the field
+        # stores the configured tag number when present.
+        if default is None:
+            default = tag_num
         super(CBORF_SEMANTIC_TAG, self).__init__(name, default)
 
-    def _wrap(self, val):
-        # type: (Any) -> CBOR_SEMANTIC_TAG
-        if isinstance(val, CBOR_SEMANTIC_TAG):
-            return val
-        return CBOR_SEMANTIC_TAG((self.tag_num, val))
-
-    def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_SEMANTIC_TAG, bytes]
+    def _parse_tag_head(self, s, require_match=True):
+        # type: (bytes, bool) -> Tuple[int, bytes]
         try:
-            major_type, tag_num, s = CBOR_decode_head(s)
+            major_type, tag_num, remaining = CBOR_decode_head(s)
         except CBOR_Codec_Decoding_Error as e:
             raise CBOR_Decoding_Error(str(e))
         if major_type != 6:
-            raise CBOR_Decoding_Error(
+            raise CBOR_Type_Mismatch(
                 "Expected major type 6 (semantic tag), got %d" % major_type)
-        return CBOR_SEMANTIC_TAG((tag_num, None)), s  # type: ignore
+        if require_match and tag_num != self.tag_num:
+            raise CBOR_Type_Mismatch(
+                "Expected tag %d, got %d" % (self.tag_num, tag_num))
+        return tag_num, remaining
+
+    def _encode_tagged(self, inner_data):
+        # type: (bytes) -> bytes
+        return CBOR_encode_head(6, self.tag_num) + inner_data
+
+    def m2i(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> Tuple[int, bytes]
+        return self._parse_tag_head(s, require_match=True)
+
+    def matches_next_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bool
+        if not s or cbor_is_break(s):
+            return False
+        try:
+            major_type, tag_num, _rem = CBOR_decode_head(s)
+        except CBOR_Codec_Decoding_Error:
+            return False
+        return major_type == 6 and tag_num == self.tag_num
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        tag_num, remaining = self._parse_tag_head(s)
+        inner = self.inner_field.dissect_result(pkt, remaining)
+        if inner.items != 1:
+            raise CBOR_Decoding_Error(
+                "Semantic tag content must be exactly one CBOR item")
+        self.set_val(pkt, tag_num)
+        return CBORParseResult(remaining=inner.remaining, items=1)
 
     def dissect(self, pkt, s):
         # type: (CBOR_Packet, bytes) -> bytes
-        tag_obj, s = self.m2i(pkt, s)
-        self.set_val(pkt, tag_obj)
-        # Dissect the tagged content using the inner field.
-        return self.inner_field.dissect(pkt, s)
+        return self.dissect_result(pkt, s).remaining
 
-    def build(self, pkt):
-        # type: (CBOR_Packet) -> bytes
-        inner_bytes = self.inner_field.build(pkt)
-        return CBOR_encode_head(6, self.tag_num) + inner_bytes
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        inner = self.inner_field.build_result(pkt)
+        if inner.items != 1:
+            raise CBOR_Encoding_Error(
+                "Semantic tag content must be exactly one CBOR item")
+        return CBORBuildResult(self._encode_tagged(inner.data), 1)
+
+    def parse_value(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        _tag_num, remaining = self._parse_tag_head(s)
+        inner = self.inner_field.parse_value(pkt, remaining)
+        if inner.items != 1:
+            raise CBOR_Decoding_Error(
+                "Semantic tag content must be exactly one CBOR item")
+        return CBORParseResult(value=inner.value, remaining=inner.remaining, items=1)
+
+    def build_value(self, pkt, value):
+        # type: (CBOR_Packet, Any) -> CBORBuildResult
+        inner = self.inner_field.build_value(pkt, value)
+        if inner.items != 1:
+            raise CBOR_Encoding_Error(
+                "Semantic tag content must be exactly one CBOR item")
+        return CBORBuildResult(data=self._encode_tagged(inner.data), items=1)
 
     def get_fields_list(self):
-        # type: () -> List[CBORF_field[Any, Any]]
+        # type: () -> List[CBORF_field[Any]]
         return [self] + self.inner_field.get_fields_list()
+
+    def is_empty(self, pkt):
+        # type: (CBOR_Packet) -> bool
+        return pkt.getfieldval(self.name) is CBOR_ABSENT
 
 
 ##############################
@@ -818,51 +2061,106 @@ class CBORF_optional(CBORF_element):
     """
     Wrapper making a :class:`CBORF_field` optional.
 
-    During decoding, if the next CBOR item does not match the expected major
-    type, the field value is set to ``None`` and the stream is left unchanged.
+    Absence is recorded as ``CBOR_ABSENT`` on every path (lookahead mismatch,
+    exhausted parent array, missing map key).  If the next item matches but
+    decoding fails, the error propagates (the value is present but malformed).
     """
 
     def __init__(self, field):
-        # type: (CBORF_field[Any, Any]) -> None
+        # type: (CBORF_field[Any]) -> None
         self._field = field
 
     def __getattr__(self, attr):
-        # type: (str) -> Optional[Any]
+        # type: (str) -> Any
         return getattr(self._field, attr)
 
-    def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[Any, bytes]
-        try:
-            return self._field.m2i(pkt, s)
-        except (CBOR_Error, CBORF_badsequence,
-                CBOR_Codec_Decoding_Error):
-            return None, s
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        if pkt.getfieldval(self._field.name) is CBOR_ABSENT:
+            return CBORBuildResult(b"", 0)
+        if self._field.is_empty(pkt):
+            return CBORBuildResult(b"", 0)
+        return self._field.build_result(pkt)
 
-    def dissect(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> bytes
-        try:
-            return self._field.dissect(pkt, s)
-        except (CBOR_Error, CBORF_badsequence,
-                CBOR_Codec_Decoding_Error):
-            self._field.set_val(pkt, None)
-            return s
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        if not self._field.matches_next_item(pkt, s):
+            self._field.set_val(pkt, CBOR_ABSENT)
+            return CBORParseResult(remaining=s, items=0)
+        return self._field.dissect_result(pkt, s)
 
     def build(self, pkt):
         # type: (CBOR_Packet) -> bytes
-        if self._field.is_empty(pkt):
-            return b""
-        return self._field.build(pkt)
+        return self.build_result(pkt).data
 
-    def any2i(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> Any
-        return self._field.any2i(pkt, x)
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        return self.dissect_result(pkt, s).remaining
 
-    def i2repr(self, pkt, x):
-        # type: (CBOR_Packet, Any) -> str
-        return self._field.i2repr(pkt, x)
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return 0
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        return self._field.max_items(pkt)
 
 
-class CBORF_PACKET(CBORF_field['CBOR_Packet', Optional['CBOR_Packet']]):
+class CBORF_CONDITIONAL(CBORF_element, fields.ConditionalField):
+    """
+    Wrapper making a :class:`CBORF_field` conditional on some other packet
+    state.
+    """
+
+    def __init__(self,
+                 fld,  # type: CBORF_field[Any]
+                 cond,  # type: Callable[[Packet], bool]
+                 ):
+        # type: (...) -> None
+        fields.ConditionalField.__init__(self, fld, cond)
+
+    def __repr__(self):
+        # type: () -> str
+        return "<%s%r>" % (self.__class__.__name__, self.fld)
+
+    @property
+    def owners(self):
+        return self.fld.owners
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        if self._evalcond(pkt):
+            return self.fld.build_result(pkt)
+        return CBORBuildResult(b"", 0)
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        if self._evalcond(pkt):
+            return self.fld.dissect_result(pkt, s)
+        return CBORParseResult(remaining=s, items=0)
+
+    def build(self, pkt):
+        # type: (CBOR_Packet) -> bytes
+        return self.build_result(pkt).data
+
+    def dissect(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> bytes
+        return self.dissect_result(pkt, s).remaining
+
+    def min_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        if self._evalcond(pkt):
+            return self.fld.min_items(pkt)
+        return 0
+
+    def max_items(self, pkt):
+        # type: (CBOR_Packet) -> int
+        if self._evalcond(pkt):
+            return self.fld.max_items(pkt)
+        return 0
+
+
+class CBORF_PACKET(CBORF_field['CBOR_Packet']):
     """
     CBOR field that encapsulates a nested :class:`CBOR_Packet`.
 
@@ -878,26 +2176,67 @@ class CBORF_PACKET(CBORF_field['CBOR_Packet', Optional['CBOR_Packet']]):
                  ):
         # type: (...) -> None
         self.cls = cls
-        super(CBORF_PACKET, self).__init__(name, None)
-        self.default = default
+        super(CBORF_PACKET, self).__init__(name, default)
+
+    def _parse_packet_item(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_Packet, bytes]
+        """Decode exactly one CBOR item into a nested packet."""
+        item_bytes, remain = cbor_item_span(s)
+        try:
+            child = _cbor_packet_from_bytes(self.cls, item_bytes, pkt)
+        except CBOR_Decoding_Error:
+            raise
+        except Exception as exc:
+            raise CBOR_Decoding_Error(str(exc))
+        return child, remain
+
+    def _build_packet_item(self, pkt, val):
+        # type: (CBOR_Packet, Any) -> CBORBuildResult
+        """Encode a nested packet and enforce one top-level CBOR item."""
+        if val is None:
+            raise CBOR_Encoding_Error(
+                "Required field %r is None" % self.name)
+        data = _encode_exactly_one_cbor_item(
+            val, context="field %r" % self.name
+        )
+        return CBORBuildResult(data, 1)
 
     def m2i(self, pkt, s):
-        # type: (CBOR_Packet, bytes) -> Tuple[Any, bytes]
-        return self.extract_packet(self.cls, s, _underlayer=pkt)
+        # type: (CBOR_Packet, bytes) -> Tuple[CBOR_Packet, bytes]
+        return self._parse_packet_item(pkt, s)
 
     def i2m(self, pkt, x):
         # type: (CBOR_Packet, Any) -> bytes
         if x is None:
             return b""
-        if isinstance(x, bytes):
-            return x
-        return bytes(x)
+        return self._build_packet_item(pkt, x).data
 
     def any2i(self, pkt, x):
         # type: (CBOR_Packet, Any) -> CBOR_Packet
-        if hasattr(x, "add_underlayer"):
-            x.add_underlayer(pkt)
-        return super(CBORF_PACKET, self).any2i(pkt, x)  # type: ignore
+        return cast('CBOR_Packet', _cbor_attach_parent(pkt, x))
+
+    def encode_value(self, x):
+        # type: (Any) -> bytes
+        return self._build_packet_item(None, x).data  # type: ignore
+
+    def parse_value(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        child, remain = self._parse_packet_item(pkt, s)
+        return CBORParseResult(value=child, remaining=remain, items=1)
+
+    def build_value(self, pkt, value):
+        # type: (CBOR_Packet, Any) -> CBORBuildResult
+        return self._build_packet_item(pkt, value)
+
+    def build_result(self, pkt):
+        # type: (CBOR_Packet) -> CBORBuildResult
+        return self._build_packet_item(pkt, pkt.getfieldval(self.name))
+
+    def dissect_result(self, pkt, s):
+        # type: (CBOR_Packet, bytes) -> CBORParseResult
+        child, remain = self._parse_packet_item(pkt, s)
+        self.set_val(pkt, child)
+        return CBORParseResult(remaining=remain, items=1)
 
     def randval(self):  # type: ignore
         # type: () -> CBOR_Packet

--- a/scapy/cborpacket.py
+++ b/scapy/cborpacket.py
@@ -6,23 +6,23 @@
 CBOR Packet
 
 Packet holding data encoded in Concise Binary Object Representation (CBOR).
-Modelled after scapy/asn1packet.py.
+Modelled after scapy/asn1packet.py, with CBOR-specific raw-cache integration
+for sentinels (``CBOR_ABSENT``), mutable ANY values, and nested item counts.
 """
 
 from scapy.base_classes import Packet_metaclass
 from scapy.packet import Packet
+
+import copy
 
 from typing import (
     Any,
     Dict,
     Tuple,
     Type,
+    Optional,
     cast,
-    TYPE_CHECKING,
 )
-
-if TYPE_CHECKING:
-    from scapy.cbor.cborfields import CBORF_field  # noqa: F401
 
 
 class CBORPacket_metaclass(Packet_metaclass):
@@ -40,26 +40,181 @@ class CBORPacket_metaclass(Packet_metaclass):
         )
 
 
+def _finalize_cbor_raw_cache(pkt, raw, remain, items):
+    # type: (Packet, bytes, bytes, int) -> None
+    """Record raw cache, item count, and mutable-field snapshot after dissect.
+
+    CBOR-specific Packet cache integration: mirrors ``Packet.do_dissect``
+    bookkeeping and also stores ``_cbor_raw_cache_items`` so unframed sequence
+    roots can return the exact received bytes without rebuilding.
+    """
+    from scapy.cbor.cborfields import CBOR_ABSENT
+    pkt.raw_packet_cache = raw[:-len(remain)] if remain else raw
+    pkt._cbor_raw_cache_items = items  # type: ignore[attr-defined]
+    pkt.raw_packet_cache_fields = {}
+    for f in pkt.fields_desc:
+        if f.name not in pkt.fields:
+            continue
+        fval = pkt.fields[f.name]
+        if fval is CBOR_ABSENT:
+            pkt.raw_packet_cache_fields[f.name] = CBOR_ABSENT
+            continue
+        if getattr(f, "isconditional", False) and fval is None:
+            continue
+        if (f.islist or f.holds_packets or getattr(f, "ismutable", False)) \
+                and fval is not None:
+            pkt.raw_packet_cache_fields[f.name] = \
+                pkt._raw_packet_cache_field_value(f, fval, copy=True)
+    pkt.explicit = 1
+
+
+def _cbor_raw_cache_is_valid(pkt):
+    # type: (Packet) -> bool
+    """Return True if ``raw_packet_cache`` still matches nested field state."""
+    if pkt.raw_packet_cache is None or pkt.raw_packet_cache_fields is None:
+        return False
+    for fname, fval in pkt.raw_packet_cache_fields.items():
+        fld, val = pkt.getfield_and_val(fname)
+        if pkt._raw_packet_cache_field_value(fld, val) != fval:
+            pkt.raw_packet_cache = None
+            pkt.raw_packet_cache_fields = None
+            pkt._cbor_raw_cache_items = None  # type: ignore[attr-defined]
+            pkt.wirelen = None
+            return False
+    return True
+
+
 class CBOR_Packet(Packet, metaclass=CBORPacket_metaclass):
-    CBOR_root = cast('CBORF_field[Any, Any]', None)
+    """CBOR packet with root-schema build/dissect and cache integration.
+
+    Field flags (``islist`` / ``ismutable`` / ``holds_packets``) drive
+    Scapy's mutation detection. This class additionally deepens ``ismutable``
+    defaults and stores parsed root item counts for exact-wire rebuilds.
+    """
+
+    CBOR_root = None  # type: Optional[Any]
+
+    def cbor_build_result(self):
+        # type: () -> Any
+        """Return ``CBORBuildResult`` for this packet's root schema.
+
+        When the raw cache is valid, return the exact received bytes together
+        with the dissected top-level item count. Never rebuild an unchanged
+        packet merely to recover cardinality.
+        """
+        from scapy.cbor.cborfields import CBORBuildResult
+        if _cbor_raw_cache_is_valid(self):
+            items = getattr(self, "_cbor_raw_cache_items", None)
+            if items is None:
+                items = 1
+            return CBORBuildResult(self.raw_packet_cache, items)
+        result = self.CBOR_root.build_result(self)
+        self._cbor_raw_cache_items = result.items  # type: ignore[attr-defined]
+        return result
+
+    def do_init_cached_fields(self, for_dissect_only=False):
+        # type: (bool) -> None
+        super(CBOR_Packet, self).do_init_cached_fields(
+            for_dissect_only=for_dissect_only
+        )
+        if for_dissect_only:
+            return
+        # Packet only deep-copies list/dict/set defaults; deepen ismutable.
+        for f in self.fields_desc:
+            if getattr(f, "ismutable", False) and f.name in self.fields:
+                self.fields[f.name] = f.do_copy(self.fields[f.name])
+            # Packet-valued defaults are copied in Packet.__init__ with
+            # parent=None; re-run any2i so this instance becomes the parent.
+            if f.holds_packets and f.name in self.fields:
+                self.fields[f.name] = f.any2i(self, self.fields[f.name])
+
+    def getfield_and_val(self, attr):
+        # type: (str) -> Tuple[Any, Any]
+        if attr not in self.fields and attr in self.default_fields:
+            fld = self.get_field(attr)
+            if fld is not None and (
+                getattr(fld, "ismutable", False) or fld.holds_packets
+            ):
+                val = fld.do_copy(self.default_fields[attr])
+                # Re-run any2i so packet-valued defaults attach this instance
+                # as parent (defaults were normalized with pkt=None).
+                if fld.holds_packets:
+                    val = fld.any2i(self, val)
+                self.fields[attr] = val
+                return fld, self.fields[attr]
+        return super(CBOR_Packet, self).getfield_and_val(attr)
+
+    def getfieldval(self, attr):
+        # type: (str) -> Any
+        if attr not in self.fields and attr in self.default_fields:
+            fld = self.get_field(attr)
+            if fld is not None and (
+                getattr(fld, "ismutable", False) or fld.holds_packets
+            ):
+                val = fld.do_copy(self.default_fields[attr])
+                if fld.holds_packets:
+                    val = fld.any2i(self, val)
+                self.fields[attr] = val
+                return self.fields[attr]
+        return super(CBOR_Packet, self).getfieldval(attr)
 
     def self_build(self):
         # type: () -> bytes
-        """Build this CBOR packet to wire bytes using CBOR_root.
-
-        Returns the raw packet cache when already built, otherwise delegates
-        to CBOR_root.build() which encodes all fields according to the CBOR
-        schema defined for this packet.
-        """
-        if self.raw_packet_cache is not None:
+        if _cbor_raw_cache_is_valid(self):
             return self.raw_packet_cache
         return self.CBOR_root.build(self)
 
+    def do_build(self):
+        # type: () -> bytes
+        # Packet.do_build() expands via __iter__ when explicit=0 (setfieldval).
+        # That would drop CBOR-only packet state such as unknown map pairs.
+        pkt = self.self_build()
+        for t in self.post_transforms:
+            pkt = t(pkt)
+        pay = self.do_build_payload()
+        if self.raw_packet_cache is None:
+            return self.post_build(pkt, pay)
+        return pkt + pay
+
     def do_dissect(self, x):
         # type: (bytes) -> bytes
-        """Dissect CBOR-encoded bytes into packet fields.
+        result = self.CBOR_root.dissect_result(self, x)
+        _finalize_cbor_raw_cache(self, x, result.remaining, result.items)
+        return result.remaining
 
-        Delegates to CBOR_root.dissect() which reads CBOR items from *x*,
-        populates each field on the packet, and returns any unconsumed bytes.
+    def copy(self):
+        # type: () -> Packet
+        """Deep-copy this packet and re-parent embedded CBOR children.
+
+        Generic ``Packet.copy()`` copies packet-valued fields but leaves each
+        child's ``.parent`` pointing at the original owner. CBOR fields rely on
+        ``parent`` for ownership, so reattach after the clone is built.
         """
-        return self.CBOR_root.dissect(self, x)
+        clone = super(CBOR_Packet, self).copy()
+        for attr in (
+            "_cbor_raw_cache_items",
+            "_cbor_unknown_map_pairs",
+            "_crc_content_span",
+        ):
+            if hasattr(self, attr):
+                val = getattr(self, attr)
+                if attr == "_cbor_unknown_map_pairs":
+                    setattr(
+                        clone,
+                        attr,
+                        copy.deepcopy(val),
+                    )
+                else:
+                    setattr(clone, attr, val)
+        from scapy.cbor.cborfields import _cbor_attach_parent
+        for f in clone.fields_desc:
+            if not f.holds_packets or f.name not in clone.fields:
+                continue
+            fval = clone.fields[f.name]
+            if isinstance(fval, Packet):
+                _cbor_attach_parent(clone, fval)
+            elif isinstance(fval, list):
+                for item in fval:
+                    if isinstance(item, Packet):
+                        _cbor_attach_parent(clone, item)
+        return clone

--- a/scapy/contrib/bpv7.py
+++ b/scapy/contrib/bpv7.py
@@ -1,0 +1,1860 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# This file is part of Scapy
+# See https://scapy.net/ for more information
+# Copyright (C) Brian Sipos <brian.sipos@gmail.com>
+
+# scapy.contrib.description = Bundle Protocol Version 7 (BPv7)
+# scapy.contrib.status = loads
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import datetime
+import enum
+from typing import Any, Callable, ClassVar, Optional, Union, cast
+
+from scapy import volatile
+from scapy.cbor.cborcodec import (
+    cbor_is_break,
+    cbor_find_non_deterministic,
+    CBOR_decode_head,
+    CBOR_INDEFINITE,
+)
+from scapy.cbor import (
+    CBORF_field,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_ARRAY,
+    CBORF_ARRAY_INDEFINITE,
+    CBORF_BYTE_STRING,
+    CBORF_CONDITIONAL,
+    CBORF_SEQUENCE_OF,
+    CBORF_PACKET,
+    CBORF_BYTE_STRING_PACKET,
+    CBORF_UNSIGNED_ENUM,
+    CBORF_UNSIGNED_FLAGS,
+    CBORcodec_ARRAY,
+    CBOR_NO_ITEM,
+    CBOR_Encoding_Error,
+)
+from scapy.cbor.cborfields import (
+    CBORBuildResult,
+    cbor_object_to_python,
+)
+from scapy.cborpacket import CBOR_Packet, _cbor_raw_cache_is_valid
+from scapy.error import log_runtime
+from scapy.libs.crc import CRC, CRC_16_X25, CRC_32C
+from scapy.packet import Packet
+
+_MISSING = object()
+
+
+def _as_int(val: Any) -> int:
+    """Coerce a BPv7 numeric field value (always a Python int at rest)."""
+    return int(val)
+
+
+def _require_uint(val: Any, what: str = "unsigned integer") -> int:
+    """Require a RFC 9171 CBOR unsigned integer already normalized to Python.
+
+    Uses ``type(val) is int`` so ``bool`` subclasses of ``int`` are rejected.
+    """
+    if type(val) is not int or val < 0:
+        raise TypeError(
+            "%s must be a CBOR unsigned integer, got %r" % (what, val)
+        )
+    return val
+
+
+def _as_bytes(val: Any) -> bytes:
+    if val is None or val is _MISSING:
+        return b""
+    return cast(bytes, val)
+
+
+class BlockTypeField(CBORF_UNSIGNED_INTEGER):
+    """Canonical block type code; ``None`` means infer from BTSD on build."""
+
+    def build_result(self, pkt):
+        val = pkt.getfieldval(self.name)
+        if val is None:
+            inferred = getattr(pkt, "inferred_type_code", lambda: None)()
+            if inferred is None:
+                raise CBOR_Encoding_Error(
+                    "Block type_code is None and cannot be inferred from BTSD"
+                )
+            val = inferred
+        return CBORBuildResult(self.i2m(pkt, val), 1)
+
+
+class CrcBytesField(CBORF_BYTE_STRING):
+    """CRC content octets; ``None`` means compute automatically on build."""
+
+    def m2i(self, pkt, s):
+        # Record the exact received CRC content span on the owning block.
+        # Kept here (not on generic CBORF_BYTE_STRING) so other definite
+        # byte-string fields cannot overwrite BPv7 CRC bookkeeping.
+        before = len(s)
+        val, remain = super(CrcBytesField, self).m2i(pkt, s)
+        if pkt is not None:
+            pkt._crc_content_span = (  # type: ignore[attr-defined]
+                len(val),
+                len(remain),
+                before - len(remain) - len(val),
+            )
+        return val, remain
+
+    def build_result(self, pkt):
+        override = getattr(pkt, "_cbor_crc_override", _MISSING)
+        if override is not _MISSING:
+            val = override
+        else:
+            val = pkt.getfieldval(self.name)
+            if val is None:
+                # Zero placeholder sized for the selected CRC type.
+                defn = (
+                    pkt._crc_definition()
+                    if hasattr(pkt, "_crc_definition") else None
+                )
+                if defn is None:
+                    raise CBOR_Encoding_Error(
+                        "CRC field present but CRC type is unsupported"
+                    )
+                val = defn.encode(0)
+        return CBORBuildResult(self.i2m(pkt, val), 1)
+
+
+class CrcTypeField(CBORF_UNSIGNED_ENUM):
+    """Human-friendly CRC type enumeration."""
+
+    def any2i(self, pkt, x):
+        # Temporary: accept legacy "CRC32" as CRC-32C (RFC 9171).
+        if x in ("CRC32", b"CRC32"):
+            x = "CRC32C"
+        return super(CrcTypeField, self).any2i(pkt, x)
+
+
+class DtnTimeField(CBORF_UNSIGNED_INTEGER):
+    """A DTN time value representing number of milliseconds from the
+    DTN epoch 2000-01-01T00:00:00Z.
+
+    This value is automatically converted from a
+    :py:class:`datetime.datetime` object and human friendly text in ISO8601
+    format.
+    The special human value "zero" represents the zero value time.
+    """
+
+    DTN_EPOCH = datetime.datetime(2000, 1, 1, 0, 0, 0, 0, datetime.timezone.utc)
+
+    @staticmethod
+    def datetime_to_dtntime(val: Optional[datetime.datetime]) -> int:
+        if val is None:
+            return 0
+        if val.tzinfo is None:
+            raise ValueError("DTN time requires a timezone-aware datetime")
+        val = val.astimezone(datetime.timezone.utc)
+        if val < DtnTimeField.DTN_EPOCH:
+            raise ValueError("DTN time before epoch is not allowed")
+        delta = val - DtnTimeField.DTN_EPOCH
+        return (
+            delta.days * 86400000
+            + delta.seconds * 1000
+            + delta.microseconds // 1000
+        )
+
+    @staticmethod
+    def dtntime_to_datetime(val: Any) -> Optional[datetime.datetime]:
+        if val is None:
+            return None
+        ival = _as_int(val)
+        if ival == 0:
+            return None
+        delta = datetime.timedelta(milliseconds=ival)
+        return delta + DtnTimeField.DTN_EPOCH
+
+    def i2h(self, pkt, x):
+        if x is None:
+            return None
+        if _as_int(x) == 0:
+            return "zero"
+        try:
+            dtval = DtnTimeField.dtntime_to_datetime(x)
+        except OverflowError:
+            return "dtntime:%d" % _as_int(x)
+        if dtval is None:
+            return "zero"
+        return dtval.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    def i2repr(self, pkt, x):
+        return self.i2h(pkt, x)
+
+    def h2i(self, pkt, x):
+        return self.any2i(pkt, x)
+
+    @staticmethod
+    def _parse_text(val: Union[str, bytes]) -> int:
+        if val in ("zero", b"zero"):
+            return 0
+        text = val.decode("ascii") if isinstance(val, bytes) else val
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        dt = datetime.datetime.fromisoformat(text)
+        return DtnTimeField.datetime_to_dtntime(dt)
+
+    def any2i(self, pkt, x):
+        if x is None:
+            return 0
+        if isinstance(x, (str, bytes)):
+            return self._parse_text(x)
+        if isinstance(x, datetime.datetime):
+            return DtnTimeField.datetime_to_dtntime(x)
+        val = _as_int(x)
+        if val < 0:
+            raise ValueError("DTN time must be unsigned")
+        if val > 0xFFFFFFFFFFFFFFFF:
+            raise ValueError("DTN time exceeds uint64")
+        return val
+
+    def randval(self):
+        return volatile.RandNum(0, int(2**16))
+
+
+class BundleTimestamp(CBOR_Packet):
+    """A structured representation of an DTN Timestamp.
+    The timestamp is a two-tuple of (time, sequence number)
+    The creation time portion is automatically converted from a
+    :py:class:`datetime.datetime` object and text.
+    """
+
+    CBOR_root = CBORF_ARRAY(
+        DtnTimeField("dtntime", default=0),
+        CBORF_UNSIGNED_INTEGER("seqno", default=0),
+    )
+
+
+@enum.unique
+class EidScheme(enum.IntEnum):
+    """Handled EID scheme names and values."""
+
+    dtn = 1
+    ipn = 2
+
+
+_DTN_WELL_KNOWN_SSP = {
+    0: "none",
+}
+"""Compressed SSP encoding."""
+
+
+_IPN_LOCALNODE = 0xFFFFFFFF
+# RFC 9758 Table 4: Default Allocator Node Numbers reserved for Private Use.
+_IPN_PRIVATE_USE_NODE_MAX = 0x3FFF
+_IPN_ASCII_DIGITS = frozenset("0123456789")
+
+
+def _parse_ipn_ascii_uint(text: str) -> int:
+    """Parse an RFC 9758 DIGIT (%x30-39) decimal component."""
+    if not text or not _IPN_ASCII_DIGITS.issuperset(text):
+        raise ValueError("Invalid IPN numeric component: %r" % text)
+    if len(text) > 1 and text[0] == "0":
+        raise ValueError("IPN components must not have leading zeros: %r" % text)
+    return int(text, 10)
+
+
+def _dtn_is_vchar(text: str) -> bool:
+    """Return True when *text* is RFC 5234 ``*VCHAR`` (%x21-7E)."""
+    return all(0x21 <= ord(ch) <= 0x7E for ch in text)
+
+
+_DTN_REG_NAME_UNRESERVED = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+)
+_DTN_REG_NAME_SUB_DELIMS = frozenset("!$&'()*+,;=")
+_DTN_REG_NAME_HEXDIG = frozenset("0123456789ABCDEFabcdef")
+
+
+def _dtn_is_reg_name(text: str) -> bool:
+    """Return True when *text* matches RFC 3986 ``reg-name``."""
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "%":
+            if i + 2 >= len(text):
+                return False
+            if (
+                text[i + 1] not in _DTN_REG_NAME_HEXDIG
+                or text[i + 2] not in _DTN_REG_NAME_HEXDIG
+            ):
+                return False
+            i += 3
+        elif ch in _DTN_REG_NAME_UNRESERVED or ch in _DTN_REG_NAME_SUB_DELIMS:
+            i += 1
+        else:
+            return False
+    return True
+
+
+def _parse_dtn_hier_ssp(ssp_text: str) -> tuple[str, str]:
+    """Split a DTN hierarchical SSP into ``(node_name, demux)``.
+
+    RFC 9171: ``dtn-hier-part = "//" node-name "/" demux``.
+    """
+    if not ssp_text.startswith("//"):
+        raise ValueError(
+            "DTN EID must be 'dtn:none' or 'dtn://node-name/demux', "
+            "got 'dtn:%s'" % ssp_text
+        )
+    rest = ssp_text[2:]
+    slash = rest.find("/")
+    if slash < 0:
+        raise ValueError(
+            "DTN hierarchical EID requires '/' after node-name: 'dtn:%s'"
+            % ssp_text
+        )
+    node_name = rest[:slash]
+    demux = rest[slash + 1:]
+    if not node_name:
+        raise ValueError("DTN node-name must not be empty")
+    if not _dtn_is_reg_name(node_name):
+        raise ValueError(
+            "DTN node-name must be an RFC 3986 reg-name: %r" % node_name
+        )
+    if not _dtn_is_vchar(demux):
+        raise ValueError("DTN demux must be *VCHAR: %r" % demux)
+    return node_name, demux
+
+
+def _parse_dtn_composed_ssp(ssp_text: str) -> Union[int, str]:
+    """Validate and normalize a locally composed ``dtn:`` SSP."""
+    for key, val in _DTN_WELL_KNOWN_SSP.items():
+        if ssp_text == val:
+            return key
+    _parse_dtn_hier_ssp(ssp_text)
+    return ssp_text
+
+
+def _known_eid_scheme(scheme: int) -> Optional[EidScheme]:
+    """Return a known :class:`EidScheme` or ``None`` for private-use values."""
+    try:
+        return EidScheme(_as_int(scheme))
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class IpnSsp:
+    """Normalized IPN scheme-specific part.
+
+    Stores the RFC 9758 logical triple ``(allocator, node, service)`` and the
+    CBOR array arity used on the wire. The 2- vs 3-element choice is part of
+    the value: after an EID is first encoded, later decode/re-encode cycles
+    must preserve that element count.
+    """
+
+    allocator: int
+    node: int
+    service: int
+    # 2 = packed [fqnn, service]; 3 = explicit [allocator, node, service]
+    wire_elements: int = 3
+    # When True, allow received allocator=0/node=0/service!=0 (treat as Null).
+    # Newly composed values must not use that form (RFC 9758).
+    allow_invalid_null: bool = field(default=False, compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("allocator", self.allocator),
+            ("node", self.node),
+            ("service", self.service),
+        ):
+            if value < 0:
+                raise ValueError("%s cannot be negative" % name)
+        if self.allocator > 0xFFFFFFFF:
+            raise ValueError("allocator exceeds uint32")
+        if self.node > 0xFFFFFFFF:
+            raise ValueError("node exceeds uint32")
+        if self.service > 0xFFFFFFFFFFFFFFFF:
+            raise ValueError("service exceeds uint64")
+        if self.wire_elements not in (2, 3):
+            raise ValueError("IPN wire element count must be 2 or 3")
+        if (
+            self.allocator == 0
+            and self.node == 0
+            and self.service != 0
+            and not self.allow_invalid_null
+        ):
+            raise ValueError(
+                "Null IPN URI must not be composed with a nonzero service number"
+            )
+
+    @classmethod
+    def from_wire(cls, parts: list[int]) -> IpnSsp:
+        if len(parts) == 2:
+            fqnn, service = parts
+            return cls(
+                fqnn >> 32,
+                fqnn & 0xFFFFFFFF,
+                service,
+                wire_elements=2,
+                allow_invalid_null=True,
+            )
+        if len(parts) == 3:
+            return cls(
+                parts[0],
+                parts[1],
+                parts[2],
+                wire_elements=3,
+                allow_invalid_null=True,
+            )
+        raise ValueError("IPN SSP must be 2 or 3 elements")
+
+    def to_wire(self) -> list[int]:
+        if self.wire_elements == 2:
+            fqnn = (self.allocator << 32) | self.node
+            return [fqnn, self.service]
+        return [self.allocator, self.node, self.service]
+
+    def same_endpoint(self, other: object) -> bool:
+        """Return True when *other* names the same logical IPN endpoint."""
+        if not isinstance(other, IpnSsp):
+            return False
+        # RFC 9758: any allocator=0/node=0 form identifies the Null endpoint,
+        # including received invalid non-zero service numbers.
+        if self.is_null_endpoint() and other.is_null_endpoint():
+            return True
+        return (
+            self.allocator == other.allocator
+            and self.node == other.node
+            and self.service == other.service
+        )
+
+    def is_null_endpoint(self) -> bool:
+        # RFC 9758: allocator 0 and node 0 is the Null Endpoint for any service.
+        return self.allocator == 0 and self.node == 0
+
+    def is_local_node(self) -> bool:
+        """Return True for Default Allocator LocalNode FQNN (RFC 9758)."""
+        return self.allocator == 0 and self.node == _IPN_LOCALNODE
+
+    def is_private_use(self) -> bool:
+        """Return True for Default Allocator Private Use Node Numbers."""
+        return (
+            self.allocator == 0
+            and 1 <= self.node <= _IPN_PRIVATE_USE_NODE_MAX
+        )
+
+    def to_text(self) -> str:
+        # RFC 9758: "!" is the entire FQNN (allocator 0 + LocalNode), never a
+        # lone allocator or service component. Prefer bang for the usual
+        # 2-element wire form; keep an explicit 3-element numeric URI when
+        # that arity was received so text round-trips preserve CBOR shape.
+        if self.allocator == 0 and self.node == _IPN_LOCALNODE:
+            if self.wire_elements == 3:
+                return "ipn:0.%d.%d" % (_IPN_LOCALNODE, self.service)
+            return "ipn:!.%d" % self.service
+        if self.wire_elements == 2 and self.allocator == 0:
+            return "ipn:%d.%d" % (self.node, self.service)
+        return "ipn:%d.%d.%d" % (self.allocator, self.node, self.service)
+
+
+@dataclass(frozen=True)
+class EidStruct:
+    """
+    Internal state for the :class:`BundleEidField` class.
+    """
+
+    scheme: int
+    ssp: Any
+
+    def is_known_scheme(self) -> bool:
+        """Return True when Scapy has semantic support for this scheme."""
+        return _known_eid_scheme(self.scheme) is not None
+
+    @staticmethod
+    def from_text(text: str) -> EidStruct:
+        scheme_name, ssp_text = text.split(":", 1)
+
+        try:
+            scheme = EidScheme[scheme_name.lower()]
+        except KeyError:
+            raise ValueError(f"BP EID scheme {scheme_name} not understood")
+        ssp = None
+        if scheme == EidScheme.dtn:
+            # Local composition rejects syntactically impossible DTN URIs
+            # (RFC 9171). Wire decode via from_cbor() remains permissive.
+            ssp = _parse_dtn_composed_ssp(ssp_text)
+
+        elif scheme == EidScheme.ipn:
+            # RFC 9758: "!" is only the full FQNN form ipn:!.<service>
+            if ssp_text.startswith("!."):
+                service_text = ssp_text[2:]
+                if not service_text or "." in service_text:
+                    raise ValueError("Invalid LocalNode IPN URI: %r" % text)
+                ssp = IpnSsp(
+                    0,
+                    _IPN_LOCALNODE,
+                    _parse_ipn_ascii_uint(service_text),
+                    wire_elements=2,
+                )
+            else:
+                parts = ssp_text.split(".")
+                if len(parts) == 2:
+                    # from_text() is local composition: reject invalid Null+service
+                    # (RFC 9758). Wire decode uses IpnSsp.from_wire() / from_cbor().
+                    ssp = IpnSsp(
+                        0,
+                        _parse_ipn_ascii_uint(parts[0]),
+                        _parse_ipn_ascii_uint(parts[1]),
+                        wire_elements=2,
+                    )
+                elif len(parts) == 3:
+                    ssp = IpnSsp(
+                        _parse_ipn_ascii_uint(parts[0]),
+                        _parse_ipn_ascii_uint(parts[1]),
+                        _parse_ipn_ascii_uint(parts[2]),
+                        wire_elements=3,
+                    )
+                else:
+                    raise ValueError("IPN SSP must be 2 or 3 elements")
+
+        else:
+            raise ValueError("Invalid scheme state")
+
+        return EidStruct(scheme=int(scheme), ssp=ssp)
+
+    def to_text(self) -> str:
+        known = _known_eid_scheme(self.scheme)
+        if known == EidScheme.dtn:
+            if isinstance(self.ssp, int):
+                try:
+                    ssp = _DTN_WELL_KNOWN_SSP[self.ssp]
+                except KeyError:
+                    ssp = "!unknown-ssp-%d" % self.ssp
+            else:
+                ssp = str(self.ssp)
+            return "dtn:" + ssp
+        if known == EidScheme.ipn:
+            if isinstance(self.ssp, IpnSsp):
+                return self.ssp.to_text()
+            return IpnSsp.from_wire(list(self.ssp)).to_text()
+        return "%d:%r" % (self.scheme, self.ssp)
+
+    def is_null_endpoint(self) -> bool:
+        """Return True for the BPv7 Null Endpoint (dtn:none / ipn:0.*)."""
+        known = _known_eid_scheme(self.scheme)
+        if known == EidScheme.dtn:
+            return self.ssp == 0 or self.ssp == "none"
+        if known == EidScheme.ipn:
+            if isinstance(self.ssp, IpnSsp):
+                return self.ssp.is_null_endpoint()
+            return IpnSsp.from_wire(list(self.ssp)).is_null_endpoint()
+        return False
+
+    def _ipn_ssp(self) -> Optional[IpnSsp]:
+        if _known_eid_scheme(self.scheme) != EidScheme.ipn:
+            return None
+        if isinstance(self.ssp, IpnSsp):
+            return self.ssp
+        try:
+            return IpnSsp.from_wire(list(self.ssp))
+        except (TypeError, ValueError):
+            return None
+
+    def is_local_node(self) -> bool:
+        """Return True for an IPN LocalNode EID (``ipn:!.service``)."""
+        ssp = self._ipn_ssp()
+        return ssp is not None and ssp.is_local_node()
+
+    def is_private_use(self) -> bool:
+        """Return True for Default Allocator Private Use IPN EIDs."""
+        ssp = self._ipn_ssp()
+        return ssp is not None and ssp.is_private_use()
+
+    def is_valid(self) -> bool:
+        """Return True when this EID has a RFC-conformant structure.
+
+        Received wire forms may still dissect when ``False``; use this (and
+        :meth:`validate`) to report protocol issues. Local text composition
+        already rejects invalid DTN/IPN forms in :meth:`from_text`.
+
+        Private-use / unknown schemes are not judged invalid merely because
+        Scapy lacks semantic rules for them.
+        """
+        known = _known_eid_scheme(self.scheme)
+        if known is None:
+            return True
+        if known == EidScheme.dtn:
+            if isinstance(self.ssp, int):
+                return self.ssp in _DTN_WELL_KNOWN_SSP
+            if not isinstance(self.ssp, str):
+                return False
+            if self.ssp == "none":
+                return True
+            try:
+                _parse_dtn_hier_ssp(self.ssp)
+            except ValueError:
+                return False
+            return True
+        if known == EidScheme.ipn:
+            if isinstance(self.ssp, IpnSsp):
+                return True
+            try:
+                IpnSsp.from_wire(list(self.ssp))
+            except (TypeError, ValueError):
+                return False
+            return True
+        return False
+
+    def is_node_id(self) -> bool:
+        """Return True when this EID may serve as a BPv7 Node ID.
+
+        - Null endpoint is not a Node ID.
+        - ``dtn:`` Node IDs require an empty demux (``dtn://node-name/``).
+        - RFC 9758: any IPN EID may identify the node named by its FQNN
+          (do not require service number zero).
+        - Unknown/private-use schemes cannot be classified as Node IDs.
+        """
+        if self.is_null_endpoint() or not self.is_known_scheme():
+            return False
+        if not self.is_valid():
+            return False
+        known = _known_eid_scheme(self.scheme)
+        if known == EidScheme.ipn:
+            return True
+        if known == EidScheme.dtn:
+            if isinstance(self.ssp, int):
+                return False
+            try:
+                _node_name, demux = _parse_dtn_hier_ssp(str(self.ssp))
+            except ValueError:
+                return False
+            return demux == ""
+        return False
+
+    def same_endpoint(self, other: object) -> bool:
+        """Return True when *other* denotes the same logical endpoint."""
+        return (
+            isinstance(other, EidStruct)
+            and self.semantic_key() == other.semantic_key()
+        )
+
+    def semantic_key(self) -> tuple[Any, ...]:
+        """Stable logical identity key independent of wire arity / text form."""
+        if self.is_null_endpoint():
+            return ("bpv7-null-endpoint",)
+        known = _known_eid_scheme(self.scheme)
+        if known == EidScheme.dtn:
+            if isinstance(self.ssp, int):
+                return ("dtn", self.ssp)
+            # Normalize well-known text SSP to the compressed code.
+            if self.ssp == "none":
+                return ("dtn", 0)
+            return ("dtn", self.ssp)
+        if known == EidScheme.ipn:
+            if isinstance(self.ssp, IpnSsp):
+                ssp = self.ssp
+            else:
+                ssp = IpnSsp.from_wire(list(self.ssp))
+            return ("ipn", ssp.allocator, ssp.node, ssp.service)
+        return ("unknown-scheme", self.scheme, repr(self.ssp))
+
+    @staticmethod
+    def _wire_parts(ssp_item: Any) -> list[int]:
+        if not isinstance(ssp_item, (list, tuple)):
+            raise TypeError("IPN SSP must be a list, have %r" % (ssp_item,))
+        return [
+            _require_uint(item, "IPN SSP component") for item in ssp_item
+        ]
+
+    @staticmethod
+    def from_cbor(item: Any) -> EidStruct:
+        # Expect Python natives after BundleEidField.m2i normalization.
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            raise TypeError("Need a 2-element EID array, have %r" % (item,))
+        scheme_id, ssp_item = item
+        scheme_num = _require_uint(scheme_id, "EID scheme")
+        known = _known_eid_scheme(scheme_num)
+
+        if known == EidScheme.dtn:
+            if isinstance(ssp_item, int):
+                ssp = _require_uint(ssp_item, "DTN compressed SSP")
+                if ssp not in _DTN_WELL_KNOWN_SSP:
+                    raise ValueError(
+                        "Unknown compressed DTN SSP value: %r" % (ssp,)
+                    )
+            elif isinstance(ssp_item, str):
+                ssp = ssp_item
+            else:
+                raise TypeError("Invalid DTN SSP: %r" % (ssp_item,))
+        elif known == EidScheme.ipn:
+            ssp = IpnSsp.from_wire(EidStruct._wire_parts(ssp_item))
+        else:
+            # Private-use / future schemes: preserve the SSP generically.
+            ssp = ssp_item
+
+        return EidStruct(scheme=scheme_num, ssp=ssp)
+
+    def to_cbor(self) -> list[Any]:
+        known = _known_eid_scheme(self.scheme)
+        if known == EidScheme.dtn:
+            ssp_item = self.ssp
+        elif known == EidScheme.ipn:
+            if isinstance(self.ssp, IpnSsp):
+                ssp_item = self.ssp.to_wire()
+            else:
+                ssp_item = IpnSsp.from_wire(list(self.ssp)).to_wire()
+        else:
+            ssp_item = self.ssp
+
+        return [self.scheme, ssp_item]
+
+
+class BundleEidField(CBORF_field[EidStruct]):
+    """Provide a human-friendly representation of a BP Endpoint ID (EID) as
+    a single field.
+    The EID is a two-item array of (scheme ID, scheme-specific part).
+
+    Internal representation is always :class:`EidStruct`.
+    """
+
+    def i2h(self, _pkt, x):
+        if x is None:
+            return None
+        if not isinstance(x, EidStruct):
+            raise TypeError("EID internal value must be an EidStruct")
+        return x.to_text()
+
+    def h2i(self, _pkt, x):
+        if x is None:
+            return None
+        if isinstance(x, EidStruct):
+            return x
+        if isinstance(x, str):
+            return EidStruct.from_text(x)
+        raise TypeError("Cannot convert %r to an EidStruct" % (x,))
+
+    def any2i(self, pkt, x):
+        return self.h2i(pkt, x)
+
+    def i2repr(self, pkt, x):
+        return self.i2h(pkt, x)
+
+    def encode_value(self, x):
+        if not isinstance(x, EidStruct):
+            raise TypeError("Cannot encode EID value %r" % (x,))
+        return CBORcodec_ARRAY.enc(x.to_cbor())
+
+    def m2i(self, pkt, s):
+        item, remain = CBORcodec_ARRAY.dec(s)
+        return EidStruct.from_cbor(cbor_object_to_python(item)), remain
+
+
+class CrcType(enum.IntEnum):
+    """
+    CRC type values defined in RFC 9171.
+
+    ``CRC32`` is a temporary alias of ``CRC32C`` (Castagnoli); prefer
+    ``CRC32C`` in new code. ``@enum.unique`` is omitted so the alias is valid.
+    """
+
+    NONE = 0
+    CRC16 = 1
+    CRC32C = 2
+    CRC32 = 2
+
+
+@dataclass(frozen=True)
+class CrcInfo:
+    """
+    Processing for a specific :class:`CrcType`
+    """
+
+    cls: type[CRC]
+    width: int
+
+    def encode(self, value: int) -> bytes:
+        return value.to_bytes(self.width, "big")
+
+
+_CRC_DEFN: dict[CrcType, CrcInfo] = {
+    CrcType.CRC16: CrcInfo(cls=CRC_16_X25, width=2),
+    CrcType.CRC32C: CrcInfo(cls=CRC_32C, width=4),
+}
+
+
+def _enum_dict(cls: type[enum.IntEnum]) -> dict[int, str]:
+    return {item.value: item.name for item in cls}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    path: str
+    message: str
+    severity: str = "error"
+
+
+class AbstractBlock:
+    """Represent an abstract block internal interface mixin."""
+
+    _crc_type_name = "crc_type"
+    _crc_value_name = "crc_value"
+
+    def has_crc(self) -> bool:
+        crc_type = self.getfieldval(self._crc_type_name)
+        return _as_int(crc_type) != int(CrcType.NONE)
+
+    def _crc_definition(self) -> Optional[CrcInfo]:
+        value = _as_int(self.getfieldval(self._crc_type_name))
+        try:
+            return _CRC_DEFN[CrcType(value)]
+        except (ValueError, KeyError):
+            return None
+
+    def _build_root_with_crc_value(self, crc_value: bytes) -> bytes:
+        # CrcBytesField reads ``_cbor_crc_override`` instead of mutating fields.
+        self._cbor_crc_override = crc_value  # type: ignore[attr-defined]
+        try:
+            return self.CBOR_root.build(self)
+        finally:
+            try:
+                del self._cbor_crc_override  # type: ignore[attr-defined]
+            except AttributeError:
+                pass
+
+    def cbor_build_result(self):
+        """Return final wire bytes and cardinality in one schema traversal."""
+        return CBORBuildResult(data=self.self_build(), items=1)
+
+    def calculate_crc(self) -> Optional[bytes]:
+        crc_type = _as_int(self.getfieldval(self._crc_type_name))
+        if crc_type == int(CrcType.NONE):
+            return None
+        defn = self._crc_definition()
+        if defn is None:
+            raise CBOR_Encoding_Error(
+                "Unsupported CRC type %d" % crc_type
+            )
+        # Build once with zero placeholder; derive CRC from that buffer.
+        pre_crc = self._build_root_with_crc_value(defn.encode(0))
+        return defn.encode(defn.cls(pre_crc))
+
+    def _self_build_with_crc(self) -> bytes:
+        if _cbor_raw_cache_is_valid(self):
+            return self.raw_packet_cache  # type: ignore[return-value]
+        crc_type = _as_int(self.getfieldval(self._crc_type_name))
+        if crc_type == int(CrcType.NONE):
+            return self.CBOR_root.build(self)
+        crc_value = self.getfieldval(self._crc_value_name)
+        if crc_value is not None and crc_value is not _MISSING:
+            actual = _as_bytes(crc_value)
+            defn = self._crc_definition()
+            if defn is None:
+                raise CBOR_Encoding_Error(
+                    "Unsupported CRC type %d" % crc_type
+                )
+            if len(actual) != defn.width:
+                raise CBOR_Encoding_Error(
+                    "CRC value length %d does not match type %s"
+                    % (len(actual), CrcType(crc_type).name)
+                )
+            return self._build_root_with_crc_value(actual)
+        # None means auto: build once with a zero CRC, then patch.
+        defn = self._crc_definition()
+        if defn is None:
+            raise CBOR_Encoding_Error(
+                "Unsupported CRC type %d" % crc_type
+            )
+        zero = defn.encode(0)
+        pre_crc = self._build_root_with_crc_value(zero)
+        crc_bytes = defn.encode(defn.cls(pre_crc))
+        if len(crc_bytes) != len(zero):
+            raise CBOR_Encoding_Error("CRC width mismatch during patch")
+        # Rebuild with the computed CRC rather than searching for the zero
+        # placeholder (BTSD may contain identical zero sequences).
+        return self._build_root_with_crc_value(crc_bytes)
+
+    def freeze_crc(self) -> None:
+        crc_type = _as_int(self.getfieldval(self._crc_type_name))
+        if crc_type == int(CrcType.NONE):
+            self.setfieldval(self._crc_value_name, None)
+        else:
+            self.setfieldval(self._crc_value_name, self.calculate_crc())
+
+    def _crc_over_received_or_built(self, defn: CrcInfo, actual: bytes) -> bytes:
+        """CRC over exact received bytes when available; else rebuilt form."""
+        # Nested mutations must invalidate a dissected raw cache first.
+        _cbor_raw_cache_is_valid(self)
+        raw = self.raw_packet_cache
+        if raw is not None and actual:
+            span = getattr(self, "_crc_content_span", None)
+            if span is not None:
+                content_len, remain_after, _head_len = span
+                if content_len == len(actual) and remain_after <= len(raw):
+                    start = len(raw) - remain_after - content_len
+                    if start >= 0 and raw[start:start + content_len] == actual:
+                        zeroed = bytearray(raw)
+                        for i in range(content_len):
+                            zeroed[start + i] = 0
+                        return defn.encode(defn.cls(bytes(zeroed)))
+            # Fall back: CRC is the final array element (preferred bstr head
+            # only). Do not rfind overlong heads — BTSD may embed matching
+            # short sequences. Missing span + non-preferred CRC head rebuilds.
+            from scapy.cbor.cborcodec import CBOR_encode_head
+            n = len(actual)
+            head = CBOR_encode_head(2, n)
+            payload = head + actual
+            if raw.endswith(b"\xff"):
+                if not raw.endswith(payload + b"\xff"):
+                    return self.calculate_crc() or b""
+                start = len(raw) - 1 - len(payload)
+            else:
+                if not raw.endswith(payload):
+                    return self.calculate_crc() or b""
+                start = len(raw) - len(payload)
+            zeroed = bytearray(raw)
+            content_off = start + len(head)
+            for i in range(n):
+                zeroed[content_off + i] = 0
+            return defn.encode(defn.cls(bytes(zeroed)))
+        return self.calculate_crc() or b""
+
+    def check_crc(self) -> bool:
+        crc_type = _as_int(self.getfieldval(self._crc_type_name))
+        actual = _as_bytes(self.getfieldval(self._crc_value_name))
+        if crc_type == int(CrcType.NONE):
+            expect = b""
+            valid = actual == b""
+        else:
+            defn = self._crc_definition()
+            if defn is None:
+                return False
+            expect = self._crc_over_received_or_built(defn, actual)
+            valid = actual == expect
+
+        if not valid:
+            log_runtime.warning(
+                "CRC check failed for %s: expected %s, got %s",
+                self.__class__.__name__,
+                expect.hex(),
+                actual.hex(),
+            )
+
+        return valid
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = []
+        crc_type = _as_int(self.getfieldval(self._crc_type_name))
+        crc_value = self.getfieldval(self._crc_value_name)
+        actual = _as_bytes(crc_value)
+        if crc_type == int(CrcType.NONE) and actual:
+            issues.append(
+                ValidationIssue(
+                    "unexpected-crc",
+                    path,
+                    "CRC value present when CRC type is NONE",
+                )
+            )
+        elif crc_type != int(CrcType.NONE):
+            defn = self._crc_definition()
+            if defn is None:
+                issues.append(
+                    ValidationIssue(
+                        "unsupported-crc-type",
+                        path,
+                        "Unsupported CRC type %d" % crc_type,
+                    )
+                )
+            else:
+                expect_len = defn.width
+                if crc_value is None:
+                    # None means "compute on build" — not a protocol error.
+                    pass
+                elif len(actual) != expect_len:
+                    issues.append(
+                        ValidationIssue(
+                            "bad-crc-length",
+                            path,
+                            "CRC value length %d does not match type %s"
+                            % (len(actual), CrcType(crc_type).name),
+                        )
+                    )
+                elif not self.check_crc():
+                    issues.append(
+                        ValidationIssue("crc-mismatch", path, "CRC check failed")
+                    )
+        return issues
+
+
+def _append_non_deterministic_issues(
+    issues: list[ValidationIssue],
+    raw: Optional[bytes],
+    path: str,
+) -> None:
+    """Flag non-shortest encodings and indefinite items in block CBOR.
+
+    RFC 9171 requires definite-length CBOR for primary and canonical blocks
+    (only the outer bundle array is indefinite). Dissection still accepts
+    indefinite block arrays for interop/fuzzing; ``validate()`` reports them.
+    """
+    if not raw:
+        return
+    for offset, message in cbor_find_non_deterministic(
+        raw, allow_indefinite=False
+    ):
+        if message.startswith("Indefinite-length item"):
+            code = "indefinite-length-cbor"
+        else:
+            code = "non-deterministic-cbor"
+        issues.append(
+            ValidationIssue(
+                code,
+                path,
+                "%s at offset %d" % (message, offset),
+            )
+        )
+
+
+class PrimaryBlock(CBOR_Packet, AbstractBlock):
+    """The primary block definition"""
+
+    @enum.unique
+    class Flag(enum.IntFlag):
+        """Bundle processing control flags."""
+
+        REQ_DELETION_REPORT = 0x040000
+        REQ_DELIVERY_REPORT = 0x020000
+        REQ_FORWARDING_REPORT = 0x010000
+        REQ_RECEPTION_REPORT = 0x004000
+        REQ_STATUS_TIME = 0x000040
+        USER_APP_ACK = 0x000020
+        NO_FRAGMENT = 0x000004
+        PAYLOAD_ADMIN = 0x000002
+        IS_FRAGMENT = 0x000001
+
+    def is_fragment(self) -> bool:
+        flags = _as_int(self.getfieldval("bundle_flags"))
+        return bool(flags & PrimaryBlock.Flag.IS_FRAGMENT)
+
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("version", default=7),
+        CBORF_UNSIGNED_FLAGS(
+            "bundle_flags", default=0, size=64, names=_enum_dict(Flag)
+        ),
+        CrcTypeField("crc_type", default=CrcType.NONE, enum=CrcType),
+        BundleEidField("destination", default="dtn:none"),
+        BundleEidField("source", default="dtn:none"),
+        BundleEidField("report_to", default="dtn:none"),
+        CBORF_PACKET("create_ts", default=BundleTimestamp(), cls=BundleTimestamp),
+        CBORF_UNSIGNED_INTEGER("lifetime", default=0),
+        CBORF_CONDITIONAL(
+            CBORF_UNSIGNED_INTEGER("fragment_offset", default=0), cond=is_fragment
+        ),
+        CBORF_CONDITIONAL(
+            CBORF_UNSIGNED_INTEGER("total_app_data_len", default=0), cond=is_fragment
+        ),
+        CBORF_CONDITIONAL(
+            CrcBytesField("crc_value", default=None, definite_only=True),
+            cond=AbstractBlock.has_crc
+        ),
+    )
+
+    def mysummary(self):
+        return self.sprintf(
+            "BPv7 Primary %source% > %destination% crc=%crc_type%"
+        )
+
+    def self_build(self):
+        return self._self_build_with_crc()
+
+    def cbor_build_result(self):
+        return AbstractBlock.cbor_build_result(self)
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = super().validate(path)
+        _append_non_deterministic_issues(
+            issues, self.raw_packet_cache, path
+        )
+        if _as_int(self.getfieldval("version")) != 7:
+            issues.append(
+                ValidationIssue(
+                    "bad-version",
+                    path,
+                    "Primary block version must be 7",
+                )
+            )
+        flags = int(self.getfieldval("bundle_flags") or 0)
+        if (flags & int(PrimaryBlock.Flag.IS_FRAGMENT)) and (
+            flags & int(PrimaryBlock.Flag.NO_FRAGMENT)
+        ):
+            issues.append(
+                ValidationIssue(
+                    "conflicting-fragment-flags",
+                    path,
+                    "IS_FRAGMENT and NO_FRAGMENT must not both be set",
+                )
+            )
+        for fname in ("destination", "source", "report_to"):
+            eid = self.getfieldval(fname)
+            if not isinstance(eid, EidStruct):
+                continue
+            if not eid.is_known_scheme():
+                # Private-use / unallocated schemes stay opaque: Scapy cannot
+                # apply dtn/ipn Node-ID rules, so only warn.
+                issues.append(
+                    ValidationIssue(
+                        "unknown-scheme-eid",
+                        "%s.%s" % (path, fname) if path else fname,
+                        "EID scheme %d is not semantically validated "
+                        "(private-use or unallocated)" % eid.scheme,
+                        severity="warning",
+                    )
+                )
+                continue
+            if not eid.is_valid():
+                issues.append(
+                    ValidationIssue(
+                        "invalid-eid",
+                        "%s.%s" % (path, fname) if path else fname,
+                        "EID is not a valid BPv7 endpoint identifier",
+                    )
+                )
+            elif fname == "source" and (
+                not eid.is_null_endpoint() and not eid.is_node_id()
+            ):
+                issues.append(
+                    ValidationIssue(
+                        "source-not-node-id",
+                        "%s.source" % path if path else "source",
+                        "Source must be the Null endpoint or a Node ID",
+                    )
+                )
+        if self.is_fragment():
+            if self.getfieldval("fragment_offset") is None:
+                issues.append(
+                    ValidationIssue(
+                        "missing-fragment-offset",
+                        path,
+                        "Fragment offset required for fragments",
+                    )
+                )
+            if self.getfieldval("total_app_data_len") is None:
+                issues.append(
+                    ValidationIssue(
+                        "missing-total-app-data-len",
+                        path,
+                        "Total application data length required for fragments",
+                    )
+                )
+            else:
+                offset = self.getfieldval("fragment_offset")
+                total = self.getfieldval("total_app_data_len")
+                if (
+                    offset is not None
+                    and total is not None
+                    and _as_int(offset) > _as_int(total)
+                ):
+                    issues.append(
+                        ValidationIssue(
+                            "fragment-offset-exceeds-total",
+                            path,
+                            "Fragment offset must not exceed total "
+                            "application data length",
+                        )
+                    )
+        return issues
+
+
+class CanonicalBlock(CBOR_Packet, AbstractBlock):
+    """The canonical block definition with a block-type-specific data (BTSD)
+    field containing a dissected Packet.
+    """
+
+    @enum.unique
+    class Flag(enum.IntFlag):
+        """Block processing control flags"""
+
+        REMOVE_IF_NO_PROCESS = 0x10
+        DELETE_IF_NO_PROCESS = 0x04
+        STATUS_IF_NO_PROCESS = 0x02
+        REPLICATE_IN_FRAGMENT = 0x01
+
+    _reg_types: ClassVar[dict[int, type[Packet]]] = {}
+    _reg_codes: ClassVar[dict[type[Packet], int]] = {}
+
+    @classmethod
+    def register_type(cls, type_code: int) -> Callable[[type[Packet]], type[Packet]]:
+        def reg(pkt_cls: type[Packet]) -> type[Packet]:
+            bind_bpv7_block(type_code, pkt_cls)
+            return pkt_cls
+
+        return reg
+
+    def inferred_type_code(self) -> Optional[int]:
+        btsd = self.getfieldval("btsd")
+        if btsd is None:
+            return None
+        return getattr(type(btsd), "BPV7_BLOCK_TYPE", None)
+
+    def _effective_type_code(self) -> Optional[int]:
+        type_code = self.getfieldval("type_code")
+        if type_code is not None:
+            return _as_int(type_code)
+        return self.inferred_type_code()
+
+    def btsd_class(self, data: bytes):
+        type_code = self._effective_type_code()
+        if type_code is not None:
+            try:
+                return self._reg_types[type_code]
+            except KeyError:
+                pass
+        return None
+
+    CBOR_root = CBORF_ARRAY(
+        BlockTypeField("type_code", default=None),
+        CBORF_UNSIGNED_INTEGER("block_num", default=None),
+        CBORF_UNSIGNED_FLAGS("block_flags", default=0, size=64, names=_enum_dict(Flag)),
+        CrcTypeField("crc_type", default=CrcType.NONE, enum=CrcType),
+        CBORF_BYTE_STRING_PACKET(
+            "btsd", default=None, cls_cb=btsd_class, definite_only=True
+        ),
+        CBORF_CONDITIONAL(
+            CrcBytesField("crc_value", default=None, definite_only=True),
+            cond=AbstractBlock.has_crc
+        ),
+    )
+
+    def extract_padding(self, s):
+        return None, s
+
+    def self_build(self):
+        return self._self_build_with_crc()
+
+    def cbor_build_result(self):
+        return AbstractBlock.cbor_build_result(self)
+
+    def mysummary(self):
+        return self.sprintf(
+            "BPv7 Block #%block_num% type=%type_code% crc=%crc_type%"
+        )
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = super().validate(path)
+        effective = self._effective_type_code()
+        if effective is None:
+            issues.append(
+                ValidationIssue("missing-type-code", path, "Block type code is missing")
+            )
+        else:
+            btsd = self.getfieldval("btsd")
+            if btsd is not None:
+                inferred = self.inferred_type_code()
+                if inferred is not None and inferred != effective:
+                    issues.append(
+                        ValidationIssue(
+                            "type-code-mismatch",
+                            path,
+                            "Block type code %d does not match BTSD type %d"
+                            % (effective, inferred),
+                        )
+                    )
+                if hasattr(btsd, "validate"):
+                    issues.extend(btsd.validate(path + ".btsd"))
+        if self.getfieldval("block_num") is None:
+            issues.append(
+                ValidationIssue("missing-block-num", path, "Block number is missing")
+            )
+        if self.getfieldval("btsd") is None:
+            issues.append(ValidationIssue("missing-btsd", path, "BTSD is missing"))
+        _append_non_deterministic_issues(
+            issues, self.raw_packet_cache, path
+        )
+        btsd = self.getfieldval("btsd")
+        # Only scan BTSD contents when the block-type data is itself CBOR.
+        if isinstance(btsd, CBOR_Packet):
+            btsd_raw = getattr(btsd, "raw_packet_cache", None)
+            if not btsd_raw and hasattr(btsd, "original"):
+                btsd_raw = btsd.original
+            # Freshly composed CBOR BTSD may lack a received cache; build it
+            # so deterministic-CBOR checks still cover newly generated data.
+            if not btsd_raw:
+                try:
+                    btsd_raw = bytes(btsd)
+                except Exception:
+                    btsd_raw = None
+            _append_non_deterministic_issues(
+                issues, btsd_raw, path + ".btsd"
+            )
+        return issues
+
+
+def bind_bpv7_block(type_code: int, pkt_cls: type[Packet]) -> type[Packet]:
+    """Register a BTSD packet class for a canonical block type code.
+
+    Analogous to ``bind_layers()``, but for embedded BTSD content rather than
+    Scapy payload stacking.
+    """
+    existing = CanonicalBlock._reg_types.get(type_code)
+    if existing is not None and existing is not pkt_cls:
+        raise ValueError(
+            "Block type code %d already registered to %s"
+            % (type_code, existing.__name__)
+        )
+    prior = CanonicalBlock._reg_codes.get(pkt_cls)
+    if prior is not None and prior != type_code:
+        raise ValueError(
+            "Block class %s already registered as type %d"
+            % (pkt_cls.__name__, prior)
+        )
+    CanonicalBlock._reg_types[type_code] = pkt_cls
+    CanonicalBlock._reg_codes[pkt_cls] = type_code
+    pkt_cls.BPV7_BLOCK_TYPE = type_code
+    return pkt_cls
+
+
+def split_bpv7_block(type_code: int) -> None:
+    """Unregister a previously bound BPv7 block type code."""
+    pkt_cls = CanonicalBlock._reg_types.pop(type_code, None)
+    if pkt_cls is not None:
+        CanonicalBlock._reg_codes.pop(pkt_cls, None)
+        if getattr(pkt_cls, "BPV7_BLOCK_TYPE", None) == type_code:
+            try:
+                delattr(pkt_cls, "BPV7_BLOCK_TYPE")
+            except AttributeError:
+                pass
+
+
+@CanonicalBlock.register_type(6)
+class PreviousNodeBlock(CBOR_Packet):
+    """Block data content from Section 4.4.1 of RFC 9171."""
+
+    CBOR_root = BundleEidField("node", default=None)
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = []  # type: list[ValidationIssue]
+        node = self.getfieldval("node")
+        if node is None:
+            issues.append(
+                ValidationIssue(
+                    "missing-previous-node",
+                    path,
+                    "Previous Node block requires a node ID",
+                )
+            )
+        elif isinstance(node, EidStruct):
+            if not node.is_known_scheme():
+                issues.append(
+                    ValidationIssue(
+                        "unknown-scheme-eid",
+                        path + ".node" if path else "node",
+                        "EID scheme %d is not semantically validated "
+                        "(private-use or unallocated)" % node.scheme,
+                        severity="warning",
+                    )
+                )
+            elif not node.is_valid():
+                issues.append(
+                    ValidationIssue(
+                        "invalid-eid",
+                        path + ".node" if path else "node",
+                        "Previous Node EID is not a valid endpoint identifier",
+                    )
+                )
+            elif not node.is_node_id():
+                issues.append(
+                    ValidationIssue(
+                        "previous-node-not-node-id",
+                        path + ".node" if path else "node",
+                        "Previous Node must contain a Node ID",
+                    )
+                )
+        return issues
+
+
+@CanonicalBlock.register_type(7)
+class BundleAgeBlock(CBOR_Packet):
+    """Block data content from Section 4.4.2 of RFC 9171."""
+
+    CBOR_root = CBORF_UNSIGNED_INTEGER("age", default=None)
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = []  # type: list[ValidationIssue]
+        age = self.getfieldval("age")
+        if age is None:
+            issues.append(
+                ValidationIssue(
+                    "missing-bundle-age",
+                    path,
+                    "Bundle Age block requires an age value",
+                )
+            )
+        elif type(age) is not int or age < 0:
+            issues.append(
+                ValidationIssue(
+                    "bad-bundle-age",
+                    path,
+                    "Bundle Age must be an unsigned integer",
+                )
+            )
+        return issues
+
+
+@CanonicalBlock.register_type(10)
+class HopCountBlock(CBOR_Packet):
+    """Block data content from Section 4.4.3 of RFC 9171."""
+
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("limit", default=None),
+        CBORF_UNSIGNED_INTEGER("count", default=0),
+    )
+
+    def validate(self, path: str = "") -> list[ValidationIssue]:
+        issues = []  # type: list[ValidationIssue]
+        limit = self.getfieldval("limit")
+        count = self.getfieldval("count")
+        if limit is None or _as_int(limit) < 1 or _as_int(limit) > 255:
+            issues.append(
+                ValidationIssue(
+                    "bad-hop-limit",
+                    path,
+                    "Hop Count limit must be in 1..255",
+                )
+            )
+        if count is None:
+            issues.append(
+                ValidationIssue(
+                    "missing-hop-count",
+                    path,
+                    "Hop Count block requires a count value",
+                )
+            )
+        elif limit is not None and _as_int(count) > _as_int(limit):
+            issues.append(
+                ValidationIssue(
+                    "hop-count-exceeds-limit",
+                    path,
+                    "Hop Count count must not exceed limit",
+                )
+            )
+        return issues
+
+
+class BundleV7(CBOR_Packet):
+    """An entire decoded BPv7 bundle (primary block plus canonical blocks)."""
+
+    BLOCK_TYPE_PAYLOAD = 1
+    BLOCK_NUM_PAYLOAD = 1
+    BLOCK_TYPE_PREVIOUS_NODE = 6
+    BLOCK_TYPE_BUNDLE_AGE = 7
+    BLOCK_TYPE_HOP_COUNT = 10
+    STATUS_REPORT_FLAGS = (
+        int(PrimaryBlock.Flag.REQ_DELETION_REPORT)
+        | int(PrimaryBlock.Flag.REQ_DELIVERY_REPORT)
+        | int(PrimaryBlock.Flag.REQ_FORWARDING_REPORT)
+        | int(PrimaryBlock.Flag.REQ_RECEPTION_REPORT)
+    )
+
+    def _block_until_break(self, lst, cur, remain):
+        if cbor_is_break(remain):
+            return CBOR_NO_ITEM
+        return CanonicalBlock
+
+    CBOR_root = CBORF_ARRAY_INDEFINITE(
+        CBORF_PACKET("primary", default=PrimaryBlock(), cls=PrimaryBlock),
+        CBORF_SEQUENCE_OF(
+            "blocks", default=[], next_cls_cb=_block_until_break
+        ),
+    )
+
+    def mysummary(self):
+        nblocks = len(self.blocks or [])
+        return "BPv7 %s > %s (%d blocks)" % (
+            self.primary.source if self.primary else "?",
+            self.primary.destination if self.primary else "?",
+            nblocks,
+        )
+
+    def check_crc(self) -> bool:
+        return self.primary.check_crc() and all(blk.check_crc() for blk in self.blocks)
+
+    def validate(
+        self,
+        primary_integrity_protected: bool = False,
+    ) -> list[ValidationIssue]:
+        issues = []
+        raw = self.raw_packet_cache
+        if raw:
+            try:
+                major_type, count, _ = CBOR_decode_head(raw)
+                if major_type == 4 and count is not CBOR_INDEFINITE:
+                    issues.append(
+                        ValidationIssue(
+                            "bundle-array-must-be-indefinite",
+                            "",
+                            "BPv7 bundle array must use indefinite length",
+                        )
+                    )
+            except Exception:
+                pass
+            # Do not scan the whole bundle here: primary/canonical validates
+            # already cover nested spans and would duplicate diagnostics.
+        primary = self.primary
+        if primary is not None:
+            issues.extend(primary.validate("primary"))
+        else:
+            issues.append(
+                ValidationIssue(
+                    "missing-primary",
+                    "primary",
+                    "Primary block is missing",
+                )
+            )
+
+        flags = 0
+        source_text = ""
+        create_dtntime = 0
+        is_admin = False
+        is_anonymous = False
+        if primary is not None:
+            flags = int(primary.getfieldval("bundle_flags") or 0)
+            crc_type = _as_int(primary.getfieldval("crc_type"))
+            if crc_type == int(CrcType.NONE) and not primary_integrity_protected:
+                issues.append(
+                    ValidationIssue(
+                        "primary-crc-required",
+                        "primary",
+                        "Primary block requires a nonzero CRC type unless a "
+                        "Block Integrity Block protects the primary block",
+                    )
+                )
+            source = primary.getfieldval("source")
+            if isinstance(source, EidStruct):
+                is_anonymous = source.is_null_endpoint()
+                source_text = source.to_text()
+            elif hasattr(source, "to_text"):
+                source_text = source.to_text()
+                is_anonymous = source_text in (
+                    "dtn:none", "ipn:0.0", "ipn:0.0.0"
+                )
+            else:
+                source_text = str(source)
+                try:
+                    is_anonymous = EidStruct.from_text(source_text).is_null_endpoint()
+                except Exception:
+                    is_anonymous = source_text == "dtn:none"
+            is_admin = bool(flags & int(PrimaryBlock.Flag.PAYLOAD_ADMIN))
+            if is_anonymous and not (flags & int(PrimaryBlock.Flag.NO_FRAGMENT)):
+                issues.append(
+                    ValidationIssue(
+                        "anonymous-source-must-not-fragment",
+                        "primary",
+                        "Anonymous source must set must-not-fragment",
+                    )
+                )
+            if is_anonymous and (flags & self.STATUS_REPORT_FLAGS):
+                issues.append(
+                    ValidationIssue(
+                        "anonymous-source-status-flags",
+                        "primary",
+                        "Anonymous source must not request status reports",
+                    )
+                )
+            if is_admin and (flags & self.STATUS_REPORT_FLAGS):
+                issues.append(
+                    ValidationIssue(
+                        "admin-record-status-flags",
+                        "primary",
+                        "Administrative records must not request status reports",
+                    )
+                )
+            create_ts = primary.getfieldval("create_ts")
+            if create_ts is not None:
+                create_dtntime = _as_int(create_ts.getfieldval("dtntime") or 0)
+
+        payload_blocks = []
+        seen_nums: dict[int, int] = {}
+        type_counts: dict[int, int] = {}
+        for index, blk in enumerate(self.blocks):
+            path = "blocks[%d]" % index
+            if not isinstance(blk, CanonicalBlock):
+                issues.append(
+                    ValidationIssue(
+                        "invalid-canonical-block",
+                        path,
+                        "Bundle blocks entry is not a CanonicalBlock",
+                    )
+                )
+                continue
+            issues.extend(blk.validate(path))
+            type_code = blk._effective_type_code()
+            if type_code is not None:
+                type_counts[type_code] = type_counts.get(type_code, 0) + 1
+            block_num = blk.getfieldval("block_num")
+            if block_num is not None:
+                bnum = _as_int(block_num)
+                if bnum == 0:
+                    issues.append(
+                        ValidationIssue(
+                            "canonical-block-uses-primary-number",
+                            path,
+                            "Canonical block number 0 is reserved",
+                        )
+                    )
+                if bnum in seen_nums:
+                    issues.append(
+                        ValidationIssue(
+                            "duplicate-block-num",
+                            path,
+                            "Block number %d already used at blocks[%d]"
+                            % (bnum, seen_nums[bnum]),
+                        )
+                    )
+                else:
+                    seen_nums[bnum] = index
+                if (
+                    type_code != self.BLOCK_TYPE_PAYLOAD
+                    and bnum == self.BLOCK_NUM_PAYLOAD
+                ):
+                    issues.append(
+                        ValidationIssue(
+                            "reserved-payload-block-num",
+                            path,
+                            "Non-payload block must not use block number 1",
+                        )
+                    )
+            if type_code == self.BLOCK_TYPE_PAYLOAD:
+                payload_blocks.append((index, block_num))
+            if isinstance(blk, CanonicalBlock):
+                block_flags = int(blk.getfieldval("block_flags") or 0)
+                if block_flags & int(CanonicalBlock.Flag.STATUS_IF_NO_PROCESS):
+                    if is_anonymous or is_admin:
+                        issues.append(
+                            ValidationIssue(
+                                "forbidden-block-status-report",
+                                path,
+                                "Block status-report flag forbidden for "
+                                "anonymous or administrative bundles",
+                            )
+                        )
+
+        if type_counts.get(self.BLOCK_TYPE_PREVIOUS_NODE, 0) > 1:
+            issues.append(
+                ValidationIssue(
+                    "duplicate-previous-node",
+                    "blocks",
+                    "At most one Previous Node block is allowed",
+                )
+            )
+        age_count = type_counts.get(self.BLOCK_TYPE_BUNDLE_AGE, 0)
+        if create_dtntime == 0 and age_count != 1:
+            issues.append(
+                ValidationIssue(
+                    "bundle-age-required",
+                    "blocks",
+                    "Zero creation time requires exactly one Bundle Age block",
+                )
+            )
+        if age_count > 1:
+            issues.append(
+                ValidationIssue(
+                    "duplicate-bundle-age",
+                    "blocks",
+                    "At most one Bundle Age block is allowed",
+                )
+            )
+        if type_counts.get(self.BLOCK_TYPE_HOP_COUNT, 0) > 1:
+            issues.append(
+                ValidationIssue(
+                    "duplicate-hop-count",
+                    "blocks",
+                    "At most one Hop Count block is allowed",
+                )
+            )
+
+        if not self.blocks:
+            issues.append(
+                ValidationIssue(
+                    "missing-canonical-blocks",
+                    "blocks",
+                    "Bundle has no canonical blocks",
+                )
+            )
+        if len(payload_blocks) == 0:
+            issues.append(
+                ValidationIssue(
+                    "missing-payload",
+                    "blocks",
+                    "Bundle must contain exactly one payload block",
+                )
+            )
+        elif len(payload_blocks) > 1:
+            issues.append(
+                ValidationIssue(
+                    "bad-payload-count",
+                    "blocks",
+                    "Bundle must contain exactly one payload block",
+                )
+            )
+        elif payload_blocks[0][0] != len(self.blocks) - 1:
+            issues.append(
+                ValidationIssue(
+                    "payload-not-last",
+                    "blocks[%d]" % payload_blocks[0][0],
+                    "Payload block must be the last block",
+                )
+            )
+        elif (
+            payload_blocks[0][1] is None
+            or _as_int(payload_blocks[0][1]) != self.BLOCK_NUM_PAYLOAD
+        ):
+            issues.append(
+                ValidationIssue(
+                    "bad-payload-block-num",
+                    "blocks[%d]" % payload_blocks[0][0],
+                    "Payload block number must be 1",
+                )
+            )
+        elif (
+            primary is not None
+            and primary.is_fragment()
+            and primary.getfieldval("fragment_offset") is not None
+            and primary.getfieldval("total_app_data_len") is not None
+        ):
+            # RFC 9171: fragment ADU bytes must fit in [offset, total).
+            offset = _as_int(primary.getfieldval("fragment_offset"))
+            total = _as_int(primary.getfieldval("total_app_data_len"))
+            payload_blk = self.blocks[payload_blocks[0][0]]
+            btsd = payload_blk.getfieldval("btsd")
+            payload_len = None  # type: Optional[int]
+            if btsd is not None:
+                load = getattr(btsd, "load", None)
+                if isinstance(load, (bytes, bytearray)):
+                    payload_len = len(load)
+                else:
+                    raw = getattr(btsd, "raw_packet_cache", None)
+                    if not raw:
+                        try:
+                            raw = bytes(btsd)
+                        except Exception:
+                            raw = None
+                    if raw is not None:
+                        payload_len = len(raw)
+            if payload_len is not None and offset + payload_len > total:
+                issues.append(
+                    ValidationIssue(
+                        "fragment-extends-past-total",
+                        "blocks[%d]" % payload_blocks[0][0],
+                        "Fragment offset plus payload length must not "
+                        "exceed total application data length",
+                    )
+                )
+        return issues
+
+    def validate_lifecycle(
+        self,
+        direction: str = "ingress",
+        crossing_admin_domain: bool = False,
+    ) -> list[ValidationIssue]:
+        """Apply RFC 9758 context-dependent LocalNode / Private Use rules.
+
+        Structural checks remain in :meth:`validate`. This method covers rules
+        that require deployment context:
+
+        - ``direction="ingress"``: externally received LocalNode source,
+          destination, report-to, or Previous Node EIDs are invalid.
+        - ``direction="egress"``: LocalNode source/destination/report-to
+          (and Previous Node) EIDs must not leave the local node.
+        - ``crossing_admin_domain=True``: Private Use IPN EIDs on those
+          fields must not cross administrative domains.
+
+        Call :meth:`assert_valid` with ``lifecycle=`` to combine both.
+        """
+        if direction not in ("ingress", "egress"):
+            raise ValueError(
+                "direction must be 'ingress' or 'egress', got %r" % direction
+            )
+        issues = []  # type: list[ValidationIssue]
+        primary = self.primary
+        if primary is None:
+            return issues
+
+        def _check_eid(eid: Any, path: str) -> None:
+            if not isinstance(eid, EidStruct):
+                return
+            if eid.is_local_node():
+                if direction == "ingress":
+                    issues.append(
+                        ValidationIssue(
+                            "localnode-eid-on-ingress",
+                            path,
+                            "Externally received LocalNode IPN EIDs are invalid",
+                        )
+                    )
+                else:
+                    issues.append(
+                        ValidationIssue(
+                            "localnode-eid-on-egress",
+                            path,
+                            "LocalNode IPN EIDs must not leave the local node",
+                        )
+                    )
+            elif crossing_admin_domain and eid.is_private_use():
+                issues.append(
+                    ValidationIssue(
+                        "private-use-eid-cross-domain",
+                        path,
+                        "Private Use IPN EIDs must not cross administrative "
+                        "domains",
+                    )
+                )
+
+        for fname in ("destination", "source", "report_to"):
+            _check_eid(
+                primary.getfieldval(fname),
+                "primary.%s" % fname,
+            )
+
+        for index, blk in enumerate(self.blocks or []):
+            if not isinstance(blk, CanonicalBlock):
+                continue
+            if blk._effective_type_code() != self.BLOCK_TYPE_PREVIOUS_NODE:
+                continue
+            btsd = blk.getfieldval("btsd")
+            if isinstance(btsd, PreviousNodeBlock):
+                _check_eid(
+                    btsd.getfieldval("node"),
+                    "blocks[%d].btsd.node" % index,
+                )
+        return issues
+
+    def assert_valid(
+        self,
+        primary_integrity_protected: bool = False,
+        lifecycle: Optional[str] = None,
+        crossing_admin_domain: bool = False,
+    ) -> None:
+        """Raise ``ValueError`` when structural (and optional lifecycle) errors exist.
+
+        Warnings (e.g. ``unknown-scheme-eid``) do not fail this check.
+        Pass ``lifecycle="ingress"`` or ``"egress"`` to also enforce
+        :meth:`validate_lifecycle`.
+        """
+        issues = list(
+            self.validate(
+                primary_integrity_protected=primary_integrity_protected
+            )
+        )
+        if lifecycle is not None:
+            issues.extend(
+                self.validate_lifecycle(
+                    direction=lifecycle,
+                    crossing_admin_domain=crossing_admin_domain,
+                )
+            )
+        errors = [issue for issue in issues if issue.severity == "error"]
+        if errors:
+            raise ValueError(
+                "\n".join(
+                    "%s at %s: %s" % (issue.code, issue.path, issue.message)
+                    for issue in errors
+                )
+            )

--- a/test/configs/bsd.utsc
+++ b/test/configs/bsd.utsc
@@ -20,7 +20,8 @@
     "test/contrib/automotive/gm/gmlanutils.uts",
     "test/contrib/isotp_packet.uts",
     "test/contrib/isotpscan.uts",
-    "test/contrib/isotp_soft_socket.uts"
+    "test/contrib/isotp_soft_socket.uts",
+    "test/scapy/layers/cbor_cbor2_interop.uts"
   ],
   "onlyfailed": true,
   "extensions": ["scapy-rpc"],
@@ -36,6 +37,7 @@
     "ipv6",
     "vcan_socket",
     "tun",
-    "tap"
+    "tap",
+    "external_cbor2"
   ]
 }

--- a/test/configs/linux.utsc
+++ b/test/configs/linux.utsc
@@ -16,7 +16,8 @@
   ],
   "remove_testfiles": [
     "test/windows.uts",
-    "test/bpf.uts"
+    "test/bpf.uts",
+    "test/scapy/layers/cbor_cbor2_interop.uts"
   ],
   "breakfailed": true,
   "onlyfailed": true,
@@ -28,6 +29,7 @@
   "kw_ko": [
     "osx",
     "windows",
-    "ipv6"
+    "ipv6",
+    "external_cbor2"
   ]
 }

--- a/test/configs/solaris.utsc
+++ b/test/configs/solaris.utsc
@@ -19,7 +19,8 @@
     "test/windows.uts",
     "test/contrib/automotive/ecu_am.uts",
     "test/contrib/automotive/gm/gmlanutils.uts",
-    "test/contrib/isotpscan.uts"
+    "test/contrib/isotpscan.uts",
+    "test/scapy/layers/cbor_cbor2_interop.uts"
   ],
   "onlyfailed": true,
   "extensions": ["scapy-rpc"],
@@ -35,6 +36,7 @@
     "ipv6",
     "tap",
     "tun",
-    "vcan_socket"
+    "vcan_socket",
+    "external_cbor2"
   ]
 }

--- a/test/configs/windows.utsc
+++ b/test/configs/windows.utsc
@@ -15,7 +15,8 @@
   ],
   "remove_testfiles": [
     "test\\bpf.uts",
-    "test\\linux.uts"
+    "test\\linux.uts",
+    "test\\scapy\\layers\\cbor_cbor2_interop.uts"
   ],
   "breakfailed": true,
   "onlyfailed": true,
@@ -38,6 +39,7 @@
     "tap",
     "tun",
     "vcan_socket",
-    "zstd"
+    "zstd",
+    "external_cbor2"
   ]
 }

--- a/test/configs/windows2.utsc
+++ b/test/configs/windows2.utsc
@@ -13,7 +13,8 @@
   ],
   "remove_testfiles": [
     "bpf.uts",
-    "linux.uts"
+    "linux.uts",
+    "scapy\\layers\\cbor_cbor2_interop.uts"
   ],
   "breakfailed": true,
   "onlyfailed": true,
@@ -37,6 +38,7 @@
     "tcpdump",
     "tap",
     "tun",
-    "tshark"
+    "tshark",
+    "external_cbor2"
   ]
 }

--- a/test/contrib/bpv7.uts
+++ b/test/contrib/bpv7.uts
@@ -1,0 +1,2578 @@
+% Bundle Protocol Version 7 test campaign
+
++ Syntax check
+= Import the BPv7 layer
+from scapy.contrib.bpv7 import *
+
++ EID CODEC
+
+= EID encode
+
+from scapy.cbor import *
+from scapy.contrib.bpv7 import BundleEidField
+
+class TestPkt(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        BundleEidField('eid', default='dtn:none'),
+    )
+
+pkt = TestPkt()
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('820100')
+
+pkt = TestPkt(
+    eid="dtn://n/s"
+)
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('8201652F2F6E2F73')
+
+pkt = TestPkt(
+    eid="ipn:1.2.3"
+)
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('820283010203')
+
+
++ Block CODEC
+
+= Primary default
+from scapy.contrib.bpv7 import *
+pkt = PrimaryBlock()
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('8807000082010082010082010082000000')
+
+= Canonical payload encode
+from scapy.contrib.bpv7 import *
+pkt = CanonicalBlock(
+  type_code=1,
+  block_num=1,
+  btsd=Raw(load=b""),
+)
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('850101000040')
+
+= Canonical with CRC encode
+from scapy.contrib.bpv7 import *
+pkt = CanonicalBlock(
+  type_code=1,
+  block_num=1,
+  crc_type=2,
+  btsd=Raw(load=b"hi"),
+)
+outdata = bytes(pkt)
+assert outdata == bytes.fromhex('8601010002426869441ff585a4')
+
+= Canonical empty decode
+from scapy.contrib.bpv7 import *
+pkt = CanonicalBlock(bytes.fromhex('850101000040'))
+assert pkt.type_code == 1
+
+= Canonical with CRC decode
+from scapy.contrib.bpv7 import *
+pkt = CanonicalBlock(bytes.fromhex('8601010002426869441ff585a4'))
+assert pkt.check_crc()
+
+
++ BPv7 CODEC
+
+= construct default
+from scapy.contrib.bpv7 import *
+pkt = BundleV7()
+assert pkt.primary.crc_type == 0
+outdata = bytes(pkt)
+assert outdata[:1] == b'\x9f'
+assert outdata[-1:] == b'\xff'
+
+= construct only payload
+from scapy.contrib.bpv7 import *
+pkt = BundleV7(
+  primary=PrimaryBlock(
+    crc_type=2,
+    destination='ipn:1.2.3',
+    create_ts=BundleTimestamp(
+      dtntime='2025-11-26T15:00:00Z',
+      seqno=1,
+    ),
+    lifetime=3600000,
+  ),
+  blocks=[
+    CanonicalBlock(
+      type_code=1,
+      block_num=1,
+      crc_type=2,
+      btsd=Raw(b'hi'),
+    ),
+  ]
+)
+outdata = bytes(pkt)
+assert outdata[:1] == b'\x9f'
+assert outdata[-1:] == b'\xff'
+
+= construct with extensions
+
+pkt = BundleV7(
+  primary=PrimaryBlock(
+    crc_type=2,
+    destination='ipn:1.2.3',
+    create_ts=BundleTimestamp(
+      dtntime='2025-11-26T15:00:00Z',
+      seqno=1,
+    ),
+    lifetime=3600000,
+  ),
+  blocks=[
+    CanonicalBlock(
+      block_num=2,
+      crc_type=2,
+      btsd=PreviousNodeBlock(node='ipn:3.2.0'),
+    ),
+    CanonicalBlock(
+      type_code=1,
+      block_num=1,
+      crc_type=2,
+      btsd=Raw(b'hi'),
+    ),
+  ]
+)
+outdata = bytes(pkt)
+assert len(outdata) > 5
+assert outdata[:1] == b'\x9f'
+assert outdata[-1:] == b'\xff'
+
+
+= decoding example from Appendix A.1.1.3 of RFC 9173
+
+from scapy.contrib.bpv7 import *
+data = bytes.fromhex('9f88070000820282010282028202018202820201820018281a000f424085010100005823526561647920746f2067656e657261746520612033322d62797465207061796c6f6164ff')
+pkt = BundleV7(data)
+assert pkt.check_crc()
+assert pkt.primary.source == 'ipn:2.1'
+assert pkt.primary.destination == 'ipn:1.2'
+
+pkt.clear_cache()
+outdata = bytes(pkt)
+assert outdata == data
+
+= decoding example from Appendix A.1.1.4 of RFC 9173
+
+from scapy.contrib.bpv7 import *
+data = bytes.fromhex('9f88070000820282010282028202018202820201820018281a000f424085070200004319012c85010100005823526561647920746f2067656e657261746520612033322d62797465207061796c6f6164ff')
+pkt = BundleV7(data)
+assert pkt.check_crc()
+assert pkt.primary.source == 'ipn:2.1'
+assert pkt.primary.destination == 'ipn:1.2'
+
+pkt.clear_cache()
+outdata = bytes(pkt)
+assert outdata == data
+
+= decoding example from Appendix A.1.4 of RFC 9173
+
+from scapy.contrib.bpv7 import *
+data = bytes.fromhex('9f88070000820282010282028202018202820201820018281a000f4240850b0200005856810101018202820201828201078203008181820158403bdc69b3a34a2b5d3a8554368bd1e808f606219d2a10a846eae3886ae4ecc83c4ee550fdfb1cc636b904e2f1a73e303dcd4b6ccece003e95e8164dcc89a156e185010100005823526561647920746f2067656e657261746520612033322d62797465207061796c6f6164ff')
+pkt = BundleV7(data)
+assert pkt.check_crc()
+assert len(pkt.blocks) == 2
+assert pkt.blocks[0].type_code == 11
+
+pkt.clear_cache()
+outdata = bytes(pkt)
+assert outdata == data
+
+
+= decoding example from Appendix A of draft-dtn-bpsec-cose
+
+from scapy.contrib.bpv7 import *
+data = bytes.fromhex('9f880700008201692f2f6473742f7376638201692f2f7372632f7376638201662f2f7372632f821b000000bd51281400001a000f42408501010000466568656c6c6fff')
+pkt = BundleV7(data)
+assert pkt.check_crc()
+assert pkt.primary.source == 'dtn://src/svc'
+assert pkt.primary.destination == 'dtn://dst/svc'
+assert len(pkt.blocks) == 1
+assert pkt.blocks[0].type_code == 1
+
+pkt.clear_cache()
+outdata = bytes(pkt)
+assert outdata == data
+
+
+= decoding example from Appendix A.1 of draft-dtn-bpsec-cose
+
+from scapy.contrib.bpv7 import *
+data = bytes.fromhex(
+    "9f890700028201692f2f6473742f7376638201692f2f7372632f7376638201662f2f"
+    "7372632f821b000000bd51281400001a000f42404482a081c9850b03000058608101"
+    "03018201662f2f7372632f818205a2000120018181821158458443a10106a1044a45"
+    "78616d706c65412e31f65830ec8260a38a1a00fef2cd4aae063f50f01c5645e84c6c"
+    "4893ca895eed44ef60a5f50f9adf5cc5654499b881e5896378058601010002466568"
+    "656c6c6f444ec359d2ff"
+)
+pkt = BundleV7(data)
+assert pkt.check_crc()
+assert pkt.primary.source == 'dtn://src/svc'
+assert pkt.primary.destination == 'dtn://dst/svc'
+assert len(pkt.blocks) == 2
+assert pkt.blocks[0].type_code == 11
+assert pkt.blocks[1].type_code == 1
+
+
++ BPv7 User API
+
+= bundle flags
+from scapy.contrib.bpv7 import *
+
+pkt = PrimaryBlock(
+    bundle_flags="PAYLOAD_ADMIN",
+)
+assert pkt.bundle_flags == PrimaryBlock.Flag.PAYLOAD_ADMIN
+
+pkt = PrimaryBlock(
+    bundle_flags=0x004002,
+)
+assert pkt.bundle_flags == (
+    PrimaryBlock.Flag.PAYLOAD_ADMIN | PrimaryBlock.Flag.REQ_RECEPTION_REPORT
+)
+
+pkt = PrimaryBlock(
+    bundle_flags="PAYLOAD_ADMIN+REQ_RECEPTION_REPORT",
+)
+assert pkt.bundle_flags == (
+    PrimaryBlock.Flag.PAYLOAD_ADMIN | PrimaryBlock.Flag.REQ_RECEPTION_REPORT
+)
+
+= validate empty bundle
+from scapy.contrib.bpv7 import *
+pkt = BundleV7()
+issues = pkt.validate()
+assert any(issue.code == "missing-payload" for issue in issues)
+assert any(issue.code == "missing-canonical-blocks" for issue in issues)
+try:
+    pkt.assert_valid()
+    assert False, "empty bundle should not validate"
+except ValueError:
+    pass
+
++ Assignment parity
+
+= Post-construction bundle_flags assignment matches constructor
+from scapy.contrib.bpv7 import PrimaryBlock
+
+pkt_ctor = PrimaryBlock(bundle_flags="PAYLOAD_ADMIN")
+pkt_set = PrimaryBlock()
+pkt_set.bundle_flags = "PAYLOAD_ADMIN"
+assert int(pkt_ctor.bundle_flags) == int(pkt_set.bundle_flags) == int(PrimaryBlock.Flag.PAYLOAD_ADMIN)
+assert bytes(pkt_ctor) == bytes(pkt_set)
+
+= Post-construction crc_type assignment matches constructor
+from scapy.contrib.bpv7 import PrimaryBlock, CrcType
+
+pkt_ctor = PrimaryBlock(crc_type="CRC32C")
+pkt_set = PrimaryBlock()
+pkt_set.crc_type = "CRC32C"
+assert pkt_ctor.crc_type == pkt_set.crc_type == CrcType.CRC32C
+# Temporary alias still accepted
+assert PrimaryBlock(crc_type="CRC32").crc_type == CrcType.CRC32C
+assert bytes(pkt_ctor) == bytes(pkt_set)
+
++ Required field omission
+
+= Missing required CanonicalBlock type_code raises instead of shifting positions
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.cbor.cbor import CBOR_Decoding_Error, CBOR_Encoding_Error
+from scapy.packet import Raw
+
+pkt = CanonicalBlock(
+    block_num=1,
+    btsd=Raw(load=b""),
+)
+try:
+    bytes(pkt)
+    assert False
+except (CBOR_Decoding_Error, CBOR_Encoding_Error, ValueError, TypeError):
+    pass
+
++ Import compatibility
+
+= bpv7 module imports on current Python
+import importlib
+mod = importlib.import_module("scapy.contrib.bpv7")
+assert mod.PrimaryBlock is not None
+
+= bpv7 source is import-safe on Python 3.7/3.8
+import sys
+import pathlib
+src = pathlib.Path("scapy/contrib/bpv7.py").read_text()
+header = "\n".join(src.split("\n", 10)[:10])
+if sys.version_info < (3, 9):
+    assert (
+        "from __future__ import annotations" in header
+        or "Dict[" in src and "from typing import" in src
+    )
+else:
+    import scapy.contrib.bpv7  # noqa: F401
+
++ DtnTimeField
+
+= String zero maps to DTN time 0
+from scapy.contrib.bpv7 import DtnTimeField, BundleTimestamp
+
+ts = BundleTimestamp(dtntime="zero")
+assert ts.getfieldval('dtntime') == 0
+
+= bytes ISO timestamp accepted
+import datetime
+from scapy.contrib.bpv7 import BundleTimestamp
+
+ts = BundleTimestamp(dtntime=b"2000-01-01T00:00:01+00:00")
+assert ts.getfieldval('dtntime') == 1000
+
+= Trailing Z ISO8601 accepted
+ts = BundleTimestamp(dtntime="2000-01-01T00:00:01Z")
+assert ts.getfieldval('dtntime') == 1000
+
+= Naive datetime rejected
+try:
+    BundleTimestamp(dtntime=datetime.datetime(2000, 1, 1, 0, 0, 1))
+    assert False
+except ValueError:
+    pass
+
+= Timezone-aware datetime accepted
+ts = BundleTimestamp(dtntime=datetime.datetime(2000, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc))
+assert ts.getfieldval('dtntime') == 1000
+
+= Pre-epoch datetime rejected
+try:
+    BundleTimestamp(dtntime=datetime.datetime(1999, 1, 1, tzinfo=datetime.timezone.utc))
+    assert False
+except ValueError:
+    pass
+
+= DtnTimeField derives from unsigned integer field
+from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
+assert issubclass(DtnTimeField, CBORF_UNSIGNED_INTEGER)
+
++ CRC lifecycle
+
+= CRC recalculated after covered field mutation
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+pkt = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC32C,
+    btsd=Raw(load=b"hi"),
+)
+first = bytes(pkt)
+assert pkt.getfieldval("crc_value") is None
+assert "crc_value" not in pkt.fields
+pkt.btsd = Raw(load=b"bye")
+second = bytes(pkt)
+assert first != second
+assert pkt.getfieldval("crc_value") is None
+assert CanonicalBlock(second).check_crc()
+
+= check_crc with wrong CRC returns False without AttributeError
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+from scapy.cbor import CBOR_BYTE_STRING
+
+pkt = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC32C,
+    btsd=Raw(load=b"hi"),
+)
+bytes(pkt)
+pkt.crc_value = CBOR_BYTE_STRING(b"\x00\x00\x00\x00")
+result = pkt.check_crc()
+assert result is False
+
+= check_crc with missing CRC value returns False
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+pkt = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC32C,
+    btsd=Raw(load=b"hi"),
+)
+assert pkt.check_crc() is False
+
+= freeze_crc stores an explicit CRC
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+pkt = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC32C,
+    btsd=Raw(load=b"hi"),
+)
+pkt.freeze_crc()
+assert pkt.getfieldval("crc_value") is not None
+assert pkt.check_crc() is True
+pkt.crc_value = None
+assert pkt.check_crc() is False
+
++ Import side effects
+
+= Importing bpv7 does not enable global debug_dissector
+from scapy import config
+import importlib
+import sys
+
+modname = "scapy.contrib.bpv7"
+sys.modules.pop(modname, None)
+config.conf.debug_dissector = False
+import scapy.contrib.bpv7 as bpv7_mod  # noqa: F401
+assert config.conf.debug_dissector is False
+importlib.reload(bpv7_mod)
+assert config.conf.debug_dissector is False
+
+= bpv7 source does not call print()
+import pathlib
+src = pathlib.Path("scapy/contrib/bpv7.py").read_text()
+assert "print(" not in src
+
++ Specialized canonical block type codes
+
+= PreviousNodeBlock encodes type code 6 automatically
+from scapy.contrib.bpv7 import CanonicalBlock, PreviousNodeBlock
+
+pkt = CanonicalBlock(
+    block_num=2,
+    btsd=PreviousNodeBlock(node="dtn://n/s"),
+)
+raw = bytes(pkt)
+dec = CanonicalBlock(raw)
+assert dec.getfieldval("type_code") == 6
+assert isinstance(dec.btsd, PreviousNodeBlock)
+
++ BundleV7 semantic validity
+
+= Default BundleV7 without payload block is not protocol-conformant
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bundle = BundleV7(primary=PrimaryBlock())
+assert len(bundle.blocks) == 0
+
++ BPSec scope (deferred)
+
+= BIB block type 11 is not registered
+from scapy.contrib.bpv7 import CanonicalBlock
+assert 11 not in CanonicalBlock._reg_types
+
+= BCB block type 12 is not registered
+assert 12 not in CanonicalBlock._reg_types
+
+= Incomplete BPSec class removed from public API
+import scapy.contrib.bpv7 as bpv7
+assert not hasattr(bpv7, "AbstractSecurityBock")
+assert not hasattr(bpv7, "AbstractSecurityBlock")
+
++ IPN EID normalization
+
+= Two-element and three-element IPN forms name the same logical endpoint
+from scapy.contrib.bpv7 import EidStruct
+
+text_form = EidStruct.from_text("ipn:1.2.3")
+explicit = EidStruct.from_cbor([2, [1, 2, 3]])
+assert text_form == explicit
+assert text_form.ssp.same_endpoint(explicit.ssp)
+
+= Two-element packed form splits allocator from node number
+from scapy.contrib.bpv7 import EidStruct
+
+fqnn = (1 << 32) | 2
+two_elem = EidStruct.from_cbor([2, [fqnn, 3]])
+assert two_elem.ssp.allocator == 1
+assert two_elem.ssp.node == 2
+assert two_elem.ssp.service == 3
+assert two_elem.ssp.wire_elements == 2
+
+= Packed two-element IPN CBOR form is preserved on re-encode
+from scapy.contrib.bpv7 import EidStruct
+
+fqnn = (1 << 32) | 2
+parts = [fqnn, 3]
+eid = EidStruct.from_cbor([2, parts])
+assert eid.to_cbor() == [2, parts]
+assert eid.ssp.to_wire() == parts
+
+= Explicit three-element IPN CBOR form is preserved on re-encode
+from scapy.contrib.bpv7 import EidStruct
+
+parts = [1, 2, 3]
+eid = EidStruct.from_cbor([2, parts])
+assert eid.to_cbor() == [2, parts]
+assert eid.ssp.to_wire() == parts
+
+= Explicit three-element form with allocator zero keeps three wire elements
+from scapy.contrib.bpv7 import EidStruct
+
+parts = [0, 2, 3]
+eid = EidStruct.from_cbor([2, parts])
+assert eid.ssp.wire_elements == 3
+assert eid.to_cbor() == [2, parts]
+assert eid.to_text() == "ipn:0.2.3"
+
+= Packed and explicit forms of the same endpoint compare logically
+from scapy.contrib.bpv7 import EidStruct
+
+fqnn = (1 << 32) | 2
+packed = EidStruct.from_cbor([2, [fqnn, 3]])
+explicit = EidStruct.from_cbor([2, [1, 2, 3]])
+assert packed.ssp.same_endpoint(explicit.ssp)
+assert packed != explicit
+assert packed.to_cbor() != explicit.to_cbor()
+
+= Primary block sizes for fragment and CRC combinations
+from scapy.contrib.bpv7 import *
+
+assert bytes(PrimaryBlock())[0] == 0x88
+assert bytes(PrimaryBlock(crc_type=CrcType.CRC16))[0] == 0x89
+assert bytes(PrimaryBlock(bundle_flags="IS_FRAGMENT"))[0] == 0x8a
+assert bytes(PrimaryBlock(bundle_flags="IS_FRAGMENT", crc_type=CrcType.CRC16))[0] == 0x8b
+
+= Canonical block sizes with and without CRC
+from scapy.contrib.bpv7 import *
+from scapy.packet import Raw
+
+assert bytes(CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=b"")))[0] == 0x85
+assert bytes(CanonicalBlock(type_code=1, block_num=1, crc_type=CrcType.CRC32C, btsd=Raw(load=b"")))[0] == 0x86
+
+= BundleAgeBlock and HopCountBlock infer type codes
+from scapy.contrib.bpv7 import *
+
+age = CanonicalBlock(block_num=2, btsd=BundleAgeBlock(age=100))
+assert CanonicalBlock(bytes(age)).getfieldval("type_code") == 7
+hop = CanonicalBlock(block_num=3, btsd=HopCountBlock(limit=10, count=1))
+assert CanonicalBlock(bytes(hop)).getfieldval("type_code") == 10
+
+= IPN negative allocator rejected
+from scapy.contrib.bpv7 import IpnSsp
+try:
+    IpnSsp(-1, 1, 2)
+    assert False
+except ValueError:
+    pass
+
++ Validation and CRC regressions
+
++ Truncated canonical block
+
+= Canonical block truncated before btsd fails dissection
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock
+
+# [type_code, block_num, flags, crc_type] — missing btsd
+try:
+    CanonicalBlock(b"\x84\x01\x01\x00\x00")
+    assert False
+except CBOR_Decoding_Error:
+    pass
+
++ CRC build context and unsupported types
+
+= freeze_crc uses inferred type code for BundleAgeBlock
+from scapy.contrib.bpv7 import CanonicalBlock, BundleAgeBlock, CrcType
+
+blk = CanonicalBlock(block_num=2, crc_type=CrcType.CRC16, btsd=BundleAgeBlock(age=1))
+blk.freeze_crc()
+assert blk.crc_value is not None
+assert blk.check_crc()
+
+= Unsupported CRC type validates and fails build
+from scapy.cbor.cbor import CBOR_Encoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+blk = CanonicalBlock(type_code=1, block_num=1, crc_type=99, btsd=Raw(load=b""))
+codes = [i.code for i in blk.validate()]
+assert "unsupported-crc-type" in codes
+try:
+    bytes(blk)
+    assert False
+except CBOR_Encoding_Error:
+    pass
+
++ DTN pre-epoch times
+
+= Sub-millisecond pre-epoch DTN times are rejected
+import datetime
+from scapy.contrib.bpv7 import DtnTimeField
+
+for us in (1, 999):
+    pre = datetime.datetime(
+        1999, 12, 31, 23, 59, 59, 1000000 - us, datetime.timezone.utc
+    )
+    try:
+        DtnTimeField.datetime_to_dtntime(pre)
+        assert False
+    except ValueError:
+        pass
+
+= Exact millisecond arithmetic at epoch
+import datetime
+from scapy.contrib.bpv7 import DtnTimeField
+
+assert DtnTimeField.datetime_to_dtntime(DtnTimeField.DTN_EPOCH) == 0
+one_ms = DtnTimeField.DTN_EPOCH + datetime.timedelta(milliseconds=1)
+assert DtnTimeField.datetime_to_dtntime(one_ms) == 1
+
++ EID service and DTN SSP
+
+= IPN service exceeding uint64 is rejected
+from scapy.contrib.bpv7 import IpnSsp
+
+try:
+    IpnSsp(0, 1, 2 ** 64)
+    assert False
+except ValueError:
+    pass
+
+= Unknown compressed DTN SSP is rejected from CBOR
+from scapy.contrib.bpv7 import EidStruct
+
+try:
+    EidStruct.from_cbor([1, 99])
+    assert False
+except ValueError:
+    pass
+
+= Known compressed DTN SSP renders without KeyError
+from scapy.contrib.bpv7 import EidStruct
+
+assert EidStruct.from_cbor([1, 0]).to_text() == "dtn:none"
+
++ Multi-payload validation code
+
+= Multiple payload blocks report bad-payload-count
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, CanonicalBlock
+from scapy.packet import Raw
+
+bundle = BundleV7(
+    primary=PrimaryBlock(),
+    blocks=[
+        CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=b"a")),
+        CanonicalBlock(type_code=1, block_num=2, btsd=Raw(load=b"b")),
+    ],
+)
+codes = [i.code for i in bundle.validate()]
+assert "bad-payload-count" in codes
+
++ Review test helpers
+
+= Define conformant helper blocks used by the validation tests
+from scapy.contrib.bpv7 import (
+    BundleAgeBlock,
+    BundleTimestamp,
+    BundleV7,
+    CanonicalBlock,
+    CrcType,
+    PrimaryBlock,
+)
+from scapy.packet import Raw
+
+def _review_primary(source="ipn:1.1", flags=0, dtntime=1):
+    primary = PrimaryBlock(
+        bundle_flags=flags,
+        crc_type=CrcType.CRC16,
+        destination="ipn:2.1",
+        source=source,
+        report_to="ipn:1.1",
+        create_ts=BundleTimestamp(dtntime=dtntime, seqno=0),
+        lifetime=60000,
+    )
+    primary.freeze_crc()
+    return primary
+
+def _review_block(type_code, block_num, btsd, block_flags=0):
+    block = CanonicalBlock(
+        type_code=type_code,
+        block_num=block_num,
+        block_flags=block_flags,
+        crc_type=CrcType.CRC16,
+        btsd=btsd,
+    )
+    block.freeze_crc()
+    return block
+
+def _review_payload(load=b"payload"):
+    return _review_block(1, 1, Raw(load=load))
+
+def _review_bundle(primary=None, extension_blocks=None):
+    return BundleV7(
+        primary=primary if primary is not None else _review_primary(),
+        blocks=list(extension_blocks or []) + [_review_payload()],
+    )
+
+assert _review_bundle().primary.check_crc()
+assert _review_bundle().blocks[-1].check_crc()
+
+
++ CRC verification over the exact received serialization
+
+= Canonical block CRC16 verifies an indefinite-array wire representation
+import struct
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.libs.crc import CRC_16_X25
+
+# [_ 1, 1, 0, CRC16, h'6869', h'0000' _]
+prefix = b"\x9f\x01\x01\x00\x01\x42\x68\x69\x42"
+zeroed_wire = prefix + b"\x00\x00\xff"
+crc_value = struct.pack(">H", CRC_16_X25(zeroed_wire))
+wire = prefix + crc_value + b"\xff"
+
+block = CanonicalBlock(wire)
+assert block.check_crc(), "CRC must cover the exact indefinite block bytes"
+
+= Canonical block rejects a CRC calculated over Scapy's normalized encoding
+import struct
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.libs.crc import CRC_16_X25
+
+indefinite_prefix = b"\x9f\x01\x01\x00\x01\x42\x68\x69\x42"
+definite_zeroed = b"\x86\x01\x01\x00\x01\x42\x68\x69\x42\x00\x00"
+normalized_crc = struct.pack(">H", CRC_16_X25(definite_zeroed))
+wire = indefinite_prefix + normalized_crc + b"\xff"
+
+block = CanonicalBlock(wire)
+assert not block.check_crc(), (
+    "A CRC over a reconstructed definite array must not validate an "
+    "indefinite wire block"
+)
+
+= Primary block CRC16 verifies an indefinite-array wire representation
+import struct
+from scapy.contrib.bpv7 import PrimaryBlock
+from scapy.libs.crc import CRC_16_X25
+
+# The three EIDs are dtn:none, the creation timestamp is [0, 0], and the
+# lifetime is zero. This test concerns serialization fidelity, not semantics.
+prefix = (
+    b"\x9f"          # indefinite array
+    b"\x07"          # version
+    b"\x00"          # flags
+    b"\x01"          # CRC16
+    b"\x82\x01\x00"  # destination
+    b"\x82\x01\x00"  # source
+    b"\x82\x01\x00"  # report-to
+    b"\x82\x00\x00"  # creation timestamp
+    b"\x00"          # lifetime
+    b"\x42"          # two-byte CRC byte string
+)
+zeroed_wire = prefix + b"\x00\x00\xff"
+crc_value = struct.pack(">H", CRC_16_X25(zeroed_wire))
+wire = prefix + crc_value + b"\xff"
+
+primary = PrimaryBlock(wire)
+assert primary.check_crc(), "Primary CRC must cover its exact received bytes"
+
+
++ Primary-block and bundle semantic validation
+
+= Default construction is either RFC-safe or reports every violated invariant
+from scapy.contrib.bpv7 import BundleV7, CanonicalBlock, CrcType, PrimaryBlock
+from scapy.packet import Raw
+
+primary = PrimaryBlock()
+bundle = BundleV7(
+    primary=primary,
+    blocks=[CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=b"x"))],
+)
+codes = {issue.code for issue in bundle.validate()}
+
+if int(primary.getfieldval("crc_type")) == int(CrcType.NONE):
+    assert "primary-crc-required" in codes
+
+source = primary.getfieldval("source")
+source_text = source.to_text() if hasattr(source, "to_text") else str(source)
+flags = int(primary.getfieldval("bundle_flags"))
+if source_text == "dtn:none" and not (flags & int(PrimaryBlock.Flag.NO_FRAGMENT)):
+    assert "anonymous-source-must-not-fragment" in codes
+
+create_ts = primary.getfieldval("create_ts")
+if int(create_ts.getfieldval("dtntime")) == 0:
+    assert "bundle-age-required" in codes
+
+= A primary block without CRC protection reports primary-crc-required
+from scapy.contrib.bpv7 import BundleTimestamp, CrcType, PrimaryBlock
+
+primary = PrimaryBlock(
+    crc_type=CrcType.NONE,
+    destination="ipn:2.1",
+    source="ipn:1.1",
+    report_to="ipn:1.1",
+    create_ts=BundleTimestamp(dtntime=1, seqno=0),
+    lifetime=60000,
+)
+bundle = _review_bundle(primary=primary)
+codes = {issue.code for issue in bundle.validate()}
+assert "primary-crc-required" in codes
+
+= An anonymous source requires the must-not-fragment flag
+from scapy.contrib.bpv7 import PrimaryBlock
+
+primary = _review_primary(source="dtn:none", flags=0, dtntime=1)
+bundle = _review_bundle(primary=primary)
+codes = {issue.code for issue in bundle.validate()}
+assert "anonymous-source-must-not-fragment" in codes
+
+= An anonymous source cannot request status reports
+from scapy.contrib.bpv7 import PrimaryBlock
+
+flags = int(
+    PrimaryBlock.Flag.NO_FRAGMENT |
+    PrimaryBlock.Flag.REQ_RECEPTION_REPORT
+)
+primary = _review_primary(source="dtn:none", flags=flags, dtntime=1)
+bundle = _review_bundle(primary=primary)
+codes = {issue.code for issue in bundle.validate()}
+assert "anonymous-source-status-flags" in codes
+
+= Zero creation time requires exactly one Bundle Age block
+primary = _review_primary(dtntime=0)
+bundle = _review_bundle(primary=primary)
+codes = {issue.code for issue in bundle.validate()}
+assert "bundle-age-required" in codes
+
+= One Bundle Age block satisfies a zero creation timestamp
+from scapy.contrib.bpv7 import BundleAgeBlock
+
+primary = _review_primary(dtntime=0)
+age = _review_block(7, 2, BundleAgeBlock(age=10))
+bundle = _review_bundle(primary=primary, extension_blocks=[age])
+codes = {issue.code for issue in bundle.validate()}
+assert "bundle-age-required" not in codes
+assert "duplicate-bundle-age" not in codes
+
+= Administrative-record bundles cannot request status reports
+from scapy.contrib.bpv7 import PrimaryBlock
+
+flags = int(
+    PrimaryBlock.Flag.PAYLOAD_ADMIN |
+    PrimaryBlock.Flag.REQ_RECEPTION_REPORT
+)
+primary = _review_primary(flags=flags)
+bundle = _review_bundle(primary=primary)
+codes = {issue.code for issue in bundle.validate()}
+assert "admin-record-status-flags" in codes
+
+= Canonical status-report flags are forbidden for anonymous bundles
+from scapy.contrib.bpv7 import BundleAgeBlock, CanonicalBlock, PrimaryBlock
+
+primary = _review_primary(
+    source="dtn:none",
+    flags=int(PrimaryBlock.Flag.NO_FRAGMENT),
+)
+extension = _review_block(
+    7,
+    2,
+    BundleAgeBlock(age=1),
+    block_flags=int(CanonicalBlock.Flag.STATUS_IF_NO_PROCESS),
+)
+bundle = _review_bundle(primary=primary, extension_blocks=[extension])
+codes = {issue.code for issue in bundle.validate()}
+assert "forbidden-block-status-report" in codes
+
+= Canonical status-report flags are forbidden for administrative bundles
+from scapy.contrib.bpv7 import BundleAgeBlock, CanonicalBlock, PrimaryBlock
+
+primary = _review_primary(flags=int(PrimaryBlock.Flag.PAYLOAD_ADMIN))
+extension = _review_block(
+    7,
+    2,
+    BundleAgeBlock(age=1),
+    block_flags=int(CanonicalBlock.Flag.STATUS_IF_NO_PROCESS),
+)
+bundle = _review_bundle(primary=primary, extension_blocks=[extension])
+codes = {issue.code for issue in bundle.validate()}
+assert "forbidden-block-status-report" in codes
+
+
++ Registered block-type-specific data failures
+
+= Malformed data for a registered block type raises on dissection
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock
+
+# Type 7 is Bundle Age, whose BTSD must be an unsigned integer. The byte
+# string instead contains the CBOR text string "x".
+wire = b"\x85\x07\x02\x00\x00\x42\x61x"
+try:
+    CanonicalBlock(wire)
+except CBOR_Decoding_Error:
+    pass
+else:
+    raise AssertionError(
+        "Malformed registered BTSD was accepted without a decoding error"
+    )
+
+= Data for an unregistered block type remains available as Raw
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.packet import Raw
+
+# [99, 2, 0, NONE, h'616263']
+wire = b"\x85\x18\x63\x02\x00\x00\x43abc"
+block = CanonicalBlock(wire)
+assert isinstance(block.btsd, Raw)
+assert bytes(block.btsd) == b"abc"
+assert "known-btsd-decode-failed" not in {
+    issue.code for issue in block.validate()
+}
+
+
+= Auto CRC build remains correct when BTSD contains zero-byte sequences
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+# Payload deliberately contains CRC16 / CRC32C zero placeholders so a
+# naive rfind(zero) patch would hit the wrong offset.
+for crc_type, zeros in (
+    (CrcType.CRC16, b"\x00\x00"),
+    (CrcType.CRC32C, b"\x00\x00\x00\x00"),
+):
+    block = CanonicalBlock(
+        type_code=1,
+        block_num=1,
+        crc_type=crc_type,
+        btsd=Raw(load=b"pre" + zeros + b"post"),
+    )
+    raw = bytes(block)
+    decoded = CanonicalBlock(raw)
+    assert decoded.check_crc(), (crc_type, raw.hex())
+
+
++ Canonical block-number reservation
+
+= Canonical block number zero is reserved for the primary block
+from scapy.contrib.bpv7 import BundleAgeBlock
+
+extension = _review_block(7, 0, BundleAgeBlock(age=1))
+bundle = _review_bundle(extension_blocks=[extension])
+codes = {issue.code for issue in bundle.validate()}
+assert "canonical-block-uses-primary-number" in codes
+
+
++ Extension-block cardinality and value constraints
+
+= A bundle cannot contain more than one Previous Node block
+from scapy.contrib.bpv7 import PreviousNodeBlock
+
+first = _review_block(6, 2, PreviousNodeBlock(node="ipn:9.1"))
+second = _review_block(6, 3, PreviousNodeBlock(node="ipn:10.1"))
+bundle = _review_bundle(extension_blocks=[first, second])
+codes = {issue.code for issue in bundle.validate()}
+assert "duplicate-previous-node" in codes
+
+= A bundle cannot contain more than one Bundle Age block
+from scapy.contrib.bpv7 import BundleAgeBlock
+
+first = _review_block(7, 2, BundleAgeBlock(age=1))
+second = _review_block(7, 3, BundleAgeBlock(age=2))
+bundle = _review_bundle(extension_blocks=[first, second])
+codes = {issue.code for issue in bundle.validate()}
+assert "duplicate-bundle-age" in codes
+
+= A bundle cannot contain more than one Hop Count block
+from scapy.contrib.bpv7 import HopCountBlock
+
+first = _review_block(10, 2, HopCountBlock(limit=10, count=1))
+second = _review_block(10, 3, HopCountBlock(limit=20, count=2))
+bundle = _review_bundle(extension_blocks=[first, second])
+codes = {issue.code for issue in bundle.validate()}
+assert "duplicate-hop-count" in codes
+
+= Hop Count limit is restricted to the inclusive range 1 through 255
+from scapy.contrib.bpv7 import HopCountBlock
+
+for limit in (0, 256):
+    block = _review_block(10, 2, HopCountBlock(limit=limit, count=0))
+    codes = {issue.code for issue in block.validate()}
+    assert "bad-hop-limit" in codes
+
+= Hop Count accepts boundary limits 1 and 255
+from scapy.contrib.bpv7 import HopCountBlock
+
+for limit in (1, 255):
+    block = _review_block(10, 2, HopCountBlock(limit=limit, count=0))
+    codes = {issue.code for issue in block.validate()}
+    assert "bad-hop-limit" not in codes
+
+
++ BPv7 definite byte strings and CRC lengths
+
+= Canonical BTSD rejects an indefinite-length byte string
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock
+
+# [1, 1, 0, NONE, (_ h'6869' _)]
+wire = b"\x85\x01\x01\x00\x00\x5f\x42hi\xff"
+try:
+    CanonicalBlock(wire)
+    assert False, "BPv7 accepted an indefinite BTSD byte string"
+except CBOR_Decoding_Error:
+    pass
+
+= Canonical CRC rejects an indefinite-length byte string
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock
+
+# [1, 1, 0, CRC16, h'', (_ h'0000' _)]
+wire = b"\x86\x01\x01\x00\x01\x40\x5f\x42\x00\x00\xff"
+try:
+    CanonicalBlock(wire)
+    assert False, "BPv7 accepted an indefinite CRC byte string"
+except CBOR_Decoding_Error:
+    pass
+
+= CRC16 validation reports a byte string that is not exactly two octets
+from scapy.contrib.bpv7 import CanonicalBlock
+
+wire = b"\x86\x01\x01\x00\x01\x40\x43\x00\x00\x00"
+block = CanonicalBlock(wire)
+codes = {issue.code for issue in block.validate()}
+assert "bad-crc-length" in codes
+
+= CRC32C validation reports a byte string that is not exactly four octets
+from scapy.contrib.bpv7 import CanonicalBlock
+
+wire = b"\x86\x01\x01\x00\x02\x40\x42\x00\x00"
+block = CanonicalBlock(wire)
+codes = {issue.code for issue in block.validate()}
+assert "bad-crc-length" in codes
+
+= Primary CRC16 validation reports a byte string that is not two octets
+from scapy.contrib.bpv7 import PrimaryBlock
+
+wire = (
+    b"\x89"
+    b"\x07"
+    b"\x00"
+    b"\x01"
+    b"\x82\x01\x00"
+    b"\x82\x01\x00"
+    b"\x82\x01\x00"
+    b"\x82\x00\x00"
+    b"\x00"
+    b"\x43\x00\x00\x00"
+)
+primary = PrimaryBlock(wire)
+codes = {issue.code for issue in primary.validate()}
+assert "bad-crc-length" in codes
+
+= Building an explicit wrong-length CRC16 value is rejected
+from scapy.cbor.cbor import CBOR_Encoding_Error
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+block = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    crc_value=b"\x00\x00\x00",
+    btsd=Raw(load=b""),
+)
+try:
+    bytes(block)
+    assert False, "Builder emitted a CRC16 value with three octets"
+except CBOR_Encoding_Error:
+    pass
+
+
++ DTN time helper error contract
+
+= Direct naive datetime conversion raises ValueError rather than Python TypeError
+import datetime
+from scapy.contrib.bpv7 import DtnTimeField
+
+naive = datetime.datetime(2000, 1, 1, 0, 0, 1)
+try:
+    DtnTimeField.datetime_to_dtntime(naive)
+    assert False, "Naive datetime was accepted"
+except ValueError:
+    pass
+except TypeError as exc:
+    assert False, "Leaked aware-versus-naive comparison TypeError: %s" % exc
+
+
++ Public documentation contract
+
+= BundleV7 docstring does not promise removed AdminRecord behavior
+from scapy.contrib.bpv7 import BundleV7
+
+assert "AdminRecord" not in (BundleV7.__doc__ or "")
+
+
++ Nested rebuild cache invalidation
+
+= Editing primary fields on a dissected bundle rebuilds fresh wire bytes
+from scapy.contrib.bpv7 import (
+    BundleTimestamp,
+    BundleV7,
+    CanonicalBlock,
+    CrcType,
+    PrimaryBlock,
+)
+from scapy.packet import Raw
+
+primary = PrimaryBlock(
+    bundle_flags=0,
+    crc_type=CrcType.CRC16,
+    destination="ipn:2.1",
+    source="ipn:1.1",
+    report_to="ipn:1.1",
+    create_ts=BundleTimestamp(dtntime=1, seqno=0),
+    lifetime=60000,
+)
+primary.freeze_crc()
+block = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    block_flags=0,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"payload"),
+)
+block.freeze_crc()
+raw = bytes(BundleV7(primary=primary, blocks=[block]))
+pkt = BundleV7(raw)
+assert pkt.raw_packet_cache is not None
+assert pkt.primary.lifetime == 60000
+pkt.primary.lifetime = 1
+pkt.primary.crc_value = None
+pkt.primary.freeze_crc()
+rebuilt = bytes(pkt)
+assert rebuilt != raw
+assert BundleV7(rebuilt).primary.lifetime == 1
+
++ Validator refinements
+
+= BTSD validation errors are emitted exactly once
+from scapy.contrib.bpv7 import HopCountBlock
+
+block = _review_block(10, 2, HopCountBlock(limit=0, count=0))
+bundle = _review_bundle(extension_blocks=[block])
+issues = bundle.validate()
+bad_hop = [issue for issue in issues if issue.code == "bad-hop-limit"]
+assert len(bad_hop) == 1
+assert bad_hop[0].path.endswith(".btsd")
+
+= BIB-protected primary CRC absence is not an unconditional error
+from scapy.contrib.bpv7 import BundleTimestamp, CrcType, PrimaryBlock
+
+primary = PrimaryBlock(
+    crc_type=CrcType.NONE,
+    destination="ipn:2.1",
+    source="ipn:1.1",
+    report_to="ipn:1.1",
+    create_ts=BundleTimestamp(dtntime=1, seqno=0),
+    lifetime=60000,
+)
+bundle = _review_bundle(primary=primary)
+codes_default = {issue.code for issue in bundle.validate()}
+assert "primary-crc-required" in codes_default
+codes_bib = {issue.code for issue in bundle.validate(primary_integrity_protected=True)}
+assert "primary-crc-required" not in codes_bib
+
+= Overlong integer encoding is reported as non-deterministic CBOR
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.libs.crc import CRC_16_X25
+import struct
+
+# Canonical block with overlong type_code encoding: 18 01 instead of 01
+# [_ 18 01, 1, 0, CRC16, h'6869', h'XXXX' _]
+prefix = b"\x9f\x18\x01\x01\x00\x01\x42\x68\x69\x42"
+zeroed = prefix + b"\x00\x00\xff"
+crc_value = struct.pack(">H", CRC_16_X25(zeroed))
+wire = prefix + crc_value + b"\xff"
+block = CanonicalBlock(wire)
+codes = {issue.code for issue in block.validate("blocks[0]")}
+assert "non-deterministic-cbor" in codes
+
++ Shared helpers
+
+= Import follow-up test dependencies and define conformant bundles
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborcodec import CBOR_Codec_Decoding_Error
+from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+from scapy.contrib.bpv7 import (
+    BundleAgeBlock,
+    BundleTimestamp,
+    BundleV7,
+    CanonicalBlock,
+    CrcType,
+    HopCountBlock,
+    PrimaryBlock,
+    ValidationIssue,
+)
+from scapy.packet import Raw
+
+
+def _rr_primary(crc_type=CrcType.CRC16, freeze=True):
+    primary = PrimaryBlock(
+        bundle_flags=0,
+        crc_type=crc_type,
+        destination="ipn:2.1",
+        source="ipn:1.1",
+        report_to="ipn:1.1",
+        create_ts=BundleTimestamp(dtntime=1, seqno=0),
+        lifetime=60000,
+    )
+    if freeze and int(crc_type) != int(CrcType.NONE):
+        primary.freeze_crc()
+    return primary
+
+
+def _rr_block(type_code, block_num, btsd, crc_type=CrcType.CRC16, freeze=True):
+    block = CanonicalBlock(
+        type_code=type_code,
+        block_num=block_num,
+        block_flags=0,
+        crc_type=crc_type,
+        btsd=btsd,
+    )
+    if freeze and int(crc_type) != int(CrcType.NONE):
+        block.freeze_crc()
+    return block
+
+
+def _rr_payload(load=b"payload", crc_type=CrcType.CRC16, freeze=True):
+    return _rr_block(1, 1, Raw(load=load), crc_type=crc_type, freeze=freeze)
+
+
+def _rr_bundle(primary=None, extension_blocks=None, payload=None):
+    return BundleV7(
+        primary=primary if primary is not None else _rr_primary(),
+        blocks=list(extension_blocks or []) + [
+            payload if payload is not None else _rr_payload()
+        ],
+    )
+
+
+def _rr_codes(issues):
+    return [issue.code for issue in issues]
+
+
+def _rr_assert_nondeterministic_rejected_or_reported(packet_cls, wire):
+    try:
+        pkt = packet_cls(wire)
+    except (CBOR_Decoding_Error, CBOR_Codec_Decoding_Error):
+        return
+    issues = pkt.validate()
+    codes = _rr_codes(issues)
+    assert "non-deterministic-cbor" in codes, (
+        "%s silently accepted non-deterministic CBOR: %r; issues=%r"
+        % (packet_cls.__name__, wire, codes)
+    )
+
+
+assert _rr_bundle().check_crc()
+
+
++ Finding 6: BTSD validation issues must not be duplicated
+
+= A Hop Count validation issue appears exactly once in bundle validation
+hop = _rr_block(10, 2, HopCountBlock(limit=0, count=0))
+bundle = _rr_bundle(extension_blocks=[hop])
+issues = [issue for issue in bundle.validate() if issue.code == "bad-hop-limit"]
+assert len(issues) == 1, issues
+assert issues[0].path == "blocks[0].btsd"
+
+= A custom BTSD validation issue appears exactly once with its original path
+class RRValidatedAgeBlock(BundleAgeBlock):
+    def validate(self, path=""):
+        return [ValidationIssue("rr-custom-btsd", path, "custom validation issue")]
+
+age = _rr_block(7, 2, RRValidatedAgeBlock(age=1))
+bundle = _rr_bundle(extension_blocks=[age])
+issues = [issue for issue in bundle.validate() if issue.code == "rr-custom-btsd"]
+assert len(issues) == 1, issues
+assert issues[0].path == "blocks[0].btsd"
+
+
++ Finding 8: primary CRC validation needs BIB protection context
+
+= A CRC-less primary remains invalid when no integrity-protection context is supplied
+bundle = _rr_bundle(primary=_rr_primary(crc_type=CrcType.NONE, freeze=False))
+codes = _rr_codes(bundle.validate())
+assert "primary-crc-required" in codes
+
+= Verified BIB protection suppresses the primary-crc-required issue
+bundle = _rr_bundle(primary=_rr_primary(crc_type=CrcType.NONE, freeze=False))
+issues = bundle.validate(primary_integrity_protected=True)
+assert "primary-crc-required" not in _rr_codes(issues)
+
+= Explicitly absent BIB protection still reports primary-crc-required
+bundle = _rr_bundle(primary=_rr_primary(crc_type=CrcType.NONE, freeze=False))
+issues = bundle.validate(primary_integrity_protected=False)
+assert "primary-crc-required" in _rr_codes(issues)
+
+
++ Finding 9: BPv7 must reject or report non-deterministic CBOR
+
+= Overlong canonical-block scalar encodings are not silently accepted
+wires = (
+    b"\x85\x18\x01\x01\x00\x00\x40",  # type code 1
+    b"\x85\x01\x18\x01\x00\x00\x40",  # block number 1
+    b"\x85\x01\x01\x18\x00\x00\x40",  # flags 0
+    b"\x85\x01\x01\x00\x18\x00\x40",  # CRC type 0
+)
+for wire in wires:
+    _rr_assert_nondeterministic_rejected_or_reported(CanonicalBlock, wire)
+
+= An overlong canonical-block array length is not silently accepted
+_rr_assert_nondeterministic_rejected_or_reported(
+    CanonicalBlock,
+    b"\x98\x05\x01\x01\x00\x00\x40",
+)
+
+= An overlong BTSD byte-string length is not silently accepted
+_rr_assert_nondeterministic_rejected_or_reported(
+    CanonicalBlock,
+    b"\x85\x01\x01\x00\x00\x58\x00",
+)
+
+= An overlong primary-block version is not silently accepted
+wire = bytes(_rr_primary())
+assert wire[1:2] == b"\x07"
+overlong = wire[:1] + b"\x18\x07" + wire[2:]
+_rr_assert_nondeterministic_rejected_or_reported(PrimaryBlock, overlong)
+
+= A non-minimal integer inside registered BTSD is not silently accepted
+_rr_assert_nondeterministic_rejected_or_reported(
+    CanonicalBlock,
+    b"\x85\x07\x02\x00\x00\x42\x18\x01",
+)
+
+= Non-minimal Hop Count content inside BTSD is not silently accepted
+_rr_assert_nondeterministic_rejected_or_reported(
+    CanonicalBlock,
+    b"\x85\x0a\x02\x00\x00\x44\x82\x03\x18\x01",
+)
+
+= A shortest-form canonical block is not reported as non-deterministic
+block = CanonicalBlock(b"\x85\x01\x01\x00\x00\x40")
+assert "non-deterministic-cbor" not in _rr_codes(block.validate())
+
+= BundleV7 construction continues to use the required indefinite outer array
+wire = bytes(_rr_bundle())
+assert wire.startswith(b"\x9f")
+assert wire.endswith(b"\xff")
+
+= A definite outer bundle array is rejected or reported as nonconforming
+wire = bytes(_rr_bundle())
+assert wire.startswith(b"\x9f") and wire.endswith(b"\xff")
+definite = b"\x82" + wire[1:-1]
+try:
+    bundle = BundleV7(definite)
+except (CBOR_Decoding_Error, CBOR_Codec_Decoding_Error):
+    pass
+else:
+    codes = _rr_codes(bundle.validate())
+    assert (
+        "bundle-array-must-be-indefinite" in codes
+        or "non-deterministic-cbor" in codes
+    ), codes
+
+
++ Finding 10: CRC-aware build results must contain final bytes after one traversal
+
+= A canonical block build result contains the same final CRC bytes as bytes(block)
+block = _rr_payload(load=b"x", freeze=False)
+result = block.cbor_build_result()
+assert result.items == 1
+assert result.data == bytes(block)
+assert CanonicalBlock(result.data).check_crc()
+
+= A primary block build result contains the same final CRC bytes as bytes(primary)
+primary = _rr_primary(freeze=False)
+result = primary.cbor_build_result()
+assert result.items == 1
+assert result.data == bytes(primary)
+assert PrimaryBlock(result.data).check_crc()
+
+= CRC32 build results contain final four-byte CRC values
+block = _rr_payload(load=b"crc32", crc_type=CrcType.CRC32C, freeze=False)
+result = block.cbor_build_result()
+assert result.items == 1
+assert result.data == bytes(block)
+parsed = CanonicalBlock(result.data)
+assert len(parsed.crc_value) == 4
+assert parsed.check_crc()
+
+= Building a directly serialized CRC block traverses its root twice for auto-CRC
+block = _rr_payload(load=b"x", freeze=False)
+root = CanonicalBlock.CBOR_root
+original = root.build_result
+calls = {"count": 0}
+
+def _rr_counted_direct_build(pkt):
+    calls["count"] += 1
+    return original(pkt)
+
+root.build_result = _rr_counted_direct_build
+try:
+    wire = bytes(block)
+finally:
+    root.build_result = original
+
+assert CanonicalBlock(wire).check_crc()
+# Auto-CRC builds twice: once with a zero placeholder to compute the CRC,
+# then again with the final CRC value (avoids ambiguous rfind patching).
+assert calls["count"] == 2, calls
+
+= Building a CRC block nested in BundleV7 traverses its root twice for auto-CRC
+payload = _rr_payload(load=b"x", freeze=False)
+bundle = _rr_bundle(payload=payload)
+root = CanonicalBlock.CBOR_root
+original = root.build_result
+calls = {"count": 0}
+
+def _rr_counted_nested_build(pkt):
+    calls["count"] += 1
+    return original(pkt)
+
+root.build_result = _rr_counted_nested_build
+try:
+    wire = bytes(bundle)
+finally:
+    root.build_result = original
+
+assert BundleV7(wire).check_crc()
+assert calls["count"] == 2, calls
+
+
++ Blind spot: parsed CRC checks must observe later nested mutations
+
+= Mutating Raw BTSD invalidates a parsed canonical block CRC
+parsed = CanonicalBlock(bytes(_rr_block(99, 2, Raw(load=b"x"))))
+assert parsed.check_crc()
+parsed.btsd.load = b"y"
+assert not parsed.check_crc()
+
+= Mutating registered structured BTSD invalidates a parsed canonical block CRC
+parsed = CanonicalBlock(bytes(_rr_block(7, 2, BundleAgeBlock(age=1))))
+assert parsed.check_crc()
+parsed.btsd.age = 2
+assert not parsed.check_crc()
+
+= BundleV7 check_crc observes mutation inside a parsed child block
+parsed = BundleV7(
+    bytes(_rr_bundle(extension_blocks=[_rr_block(7, 2, BundleAgeBlock(age=1))]))
+)
+assert parsed.check_crc()
+parsed.blocks[0].btsd.age = 2
+assert not parsed.check_crc()
+
+= freeze_crc after nested mutation restores a valid canonical block
+parsed = CanonicalBlock(bytes(_rr_block(7, 2, BundleAgeBlock(age=1))))
+parsed.btsd.age = 2
+assert not parsed.check_crc()
+parsed.freeze_crc()
+wire = bytes(parsed)
+assert parsed.check_crc()
+assert CanonicalBlock(wire).check_crc()
+
+= Validation reports one CRC mismatch after nested BTSD mutation
+parsed = CanonicalBlock(bytes(_rr_block(7, 2, BundleAgeBlock(age=1))))
+parsed.btsd.age = 2
+issues = [issue for issue in parsed.validate("block") if issue.code == "crc-mismatch"]
+assert len(issues) == 1, issues
+assert issues[0].path == "block"
+
+= Mutating an ordinary canonical scalar also invalidates the parsed CRC
+parsed = CanonicalBlock(bytes(_rr_block(99, 2, Raw(load=b"x"))))
+parsed.block_num = 3
+assert not parsed.check_crc()
+
+
++ Blind spot: registered BTSD conversion must behave consistently on assignment
+
+= Assigning bytes for a registered type constructs the registered BTSD packet
+block = CanonicalBlock(
+    type_code=7,
+    block_num=2,
+    block_flags=0,
+    crc_type=CrcType.NONE,
+)
+block.btsd = b"\x01"
+assert isinstance(block.btsd, BundleAgeBlock)
+assert block.btsd.age == 1
+
+= Assigning malformed bytes for a registered type raises a decoding error
+block = CanonicalBlock(
+    type_code=7,
+    block_num=2,
+    block_flags=0,
+    crc_type=CrcType.NONE,
+)
+try:
+    block.btsd = b"\x61x"
+    assert False, "Malformed registered BTSD assignment became opaque Raw"
+except CBOR_Decoding_Error:
+    pass
+
+= Assigning bytes for an unknown type preserves the data as Raw
+block = CanonicalBlock(
+    type_code=99,
+    block_num=2,
+    block_flags=0,
+    crc_type=CrcType.NONE,
+)
+block.btsd = b"abc"
+assert isinstance(block.btsd, Raw)
+assert bytes(block.btsd) == b"abc"
+
+
++ Blind spot: Hop Count value relationships
+
+= Hop Count count greater than limit is rejected
+hop = _rr_block(10, 2, HopCountBlock(limit=3, count=4))
+bundle = _rr_bundle(extension_blocks=[hop])
+assert "hop-count-exceeds-limit" in _rr_codes(bundle.validate())
+
+= Hop Count count equal to limit is accepted
+hop = _rr_block(10, 2, HopCountBlock(limit=3, count=3))
+bundle = _rr_bundle(extension_blocks=[hop])
+assert "hop-count-exceeds-limit" not in _rr_codes(bundle.validate())
+
+
++ Blind spot: block-type registration integrity and inherited inference
+
+= A subclass of a registered BTSD inherits its BPv7 type code
+class RRBundleAgeSubclass(BundleAgeBlock):
+    pass
+
+block = CanonicalBlock(
+    type_code=None,
+    block_num=2,
+    block_flags=0,
+    crc_type=CrcType.NONE,
+    btsd=RRBundleAgeSubclass(age=5),
+)
+wire = bytes(block)
+parsed = CanonicalBlock(wire)
+assert parsed.type_code == 7
+assert isinstance(parsed.btsd, BundleAgeBlock)
+assert parsed.btsd.age == 5
+
+= A duplicate type-code registration fails atomically
+code = 65010
+
+class RRRegisteredOne(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+class RRRegisteredTwo(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+assert code not in CanonicalBlock._reg_types
+CanonicalBlock.register_type(code)(RRRegisteredOne)
+try:
+    before_types = dict(CanonicalBlock._reg_types)
+    before_codes = dict(CanonicalBlock._reg_codes)
+    try:
+        CanonicalBlock.register_type(code)(RRRegisteredTwo)
+        assert False, "A duplicate BPv7 type code was accepted"
+    except ValueError:
+        pass
+    assert CanonicalBlock._reg_types == before_types
+    assert CanonicalBlock._reg_codes == before_codes
+finally:
+    CanonicalBlock._reg_types.pop(code, None)
+    CanonicalBlock._reg_codes.pop(RRRegisteredOne, None)
+    if "BPV7_BLOCK_TYPE" in RRRegisteredOne.__dict__:
+        delattr(RRRegisteredOne, "BPV7_BLOCK_TYPE")
+
+= Registering one class under a second code fails atomically
+first_code = 65011
+second_code = 65012
+
+class RRRegisteredOnce(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+assert first_code not in CanonicalBlock._reg_types
+assert second_code not in CanonicalBlock._reg_types
+CanonicalBlock.register_type(first_code)(RRRegisteredOnce)
+try:
+    try:
+        CanonicalBlock.register_type(second_code)(RRRegisteredOnce)
+        assert False, "One BTSD class was registered under two type codes"
+    except ValueError:
+        pass
+    assert CanonicalBlock._reg_types[first_code] is RRRegisteredOnce
+    assert second_code not in CanonicalBlock._reg_types
+    assert CanonicalBlock._reg_codes[RRRegisteredOnce] == first_code
+finally:
+    CanonicalBlock._reg_types.pop(first_code, None)
+    CanonicalBlock._reg_types.pop(second_code, None)
+    CanonicalBlock._reg_codes.pop(RRRegisteredOnce, None)
+    if "BPV7_BLOCK_TYPE" in RRRegisteredOnce.__dict__:
+        delattr(RRRegisteredOnce, "BPV7_BLOCK_TYPE")
+
++ Finding 3 - Opaque BTSD must not be interpreted as CBOR
+
+= Payload bytes that resemble non-deterministic CBOR remain opaque
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, CanonicalBlock
+from scapy.packet import Raw
+
+bundle = BundleV7(
+    primary=PrimaryBlock(),
+    blocks=[
+        CanonicalBlock(
+            type_code=1,
+            block_num=1,
+            btsd=Raw(load=b"\x18\x00"),
+        )
+    ],
+)
+issues = bundle.validate(primary_integrity_protected=True)
+assert not any(
+    issue.code == "non-deterministic-cbor" and "btsd" in issue.path
+    for issue in issues
+), issues
+
+= Unknown extension block BTSD is opaque even when it resembles overlong CBOR
+from scapy.contrib.bpv7 import CanonicalBlock
+from scapy.packet import Raw
+
+block = CanonicalBlock(
+    type_code=200,
+    block_num=2,
+    btsd=Raw(load=b"\x18\x00"),
+)
+issues = block.validate(path="block")
+assert not any(
+    issue.code == "non-deterministic-cbor" and "btsd" in issue.path
+    for issue in issues
+), issues
+
+= Arbitrary invalid binary payload never raises a CBOR parser error during validation
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, CanonicalBlock
+from scapy.packet import Raw
+
+for payload in (b"\xff\x00", b"\x1f", b"\x9f\xff\xff", b"\xff" * 8):
+    bundle = BundleV7(
+        primary=PrimaryBlock(),
+        blocks=[CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=payload))],
+    )
+    try:
+        issues = bundle.validate(primary_integrity_protected=True)
+    except Exception as exc:
+        raise AssertionError("opaque payload %r reached CBOR validation: %r" % (payload, exc))
+    assert not any(
+        issue.code == "non-deterministic-cbor" and "btsd" in issue.path
+        for issue in issues
+    ), (payload, issues)
+
+= Registered CBOR BTSD is still checked for deterministic encoding
+from scapy.contrib.bpv7 import CanonicalBlock
+
+# Canonical block type 7 is Bundle Age. Its BTSD is the CBOR item 0x18 0x00,
+# a valid but non-shortest encoding of zero, wrapped in a definite byte string.
+wire = b"\x85\x07\x02\x00\x00\x42\x18\x00"
+block = CanonicalBlock(wire)
+issues = block.validate(path="block")
+assert any(
+    issue.code == "non-deterministic-cbor" and issue.path.endswith(".btsd")
+    for issue in issues
+), issues
+
++ Finding 4 - All BPv7 null EID aliases are anonymous sources
+
+= ipn:0.0 and ipn:0.0.0 trigger anonymous-source validation
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+for source in ("ipn:0.0", "ipn:0.0.0"):
+    bundle = BundleV7(primary=PrimaryBlock(source=source))
+    codes = [issue.code for issue in bundle.validate(primary_integrity_protected=True)]
+    assert "anonymous-source-must-not-fragment" in codes, (source, codes)
+
+= Null IPN aliases also enforce anonymous-source status-report restrictions
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+for source in ("ipn:0.0", "ipn:0.0.0"):
+    flags = int(PrimaryBlock.Flag.NO_FRAGMENT | PrimaryBlock.Flag.REQ_DELIVERY_REPORT)
+    bundle = BundleV7(primary=PrimaryBlock(source=source, bundle_flags=flags))
+    codes = [issue.code for issue in bundle.validate(primary_integrity_protected=True)]
+    assert "anonymous-source-status-flags" in codes, (source, codes)
+
+= IPN node zero with a nonzero service is still the null endpoint
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, EidStruct
+
+# RFC 9758: received allocator 0 + node 0 + nonzero service is Null.
+# Textual/local composition of that form is rejected separately.
+eid = EidStruct.from_cbor([2, [0, 9]])
+assert eid.is_null_endpoint()
+bundle = BundleV7(primary=PrimaryBlock(source=eid))
+codes = [issue.code for issue in bundle.validate(primary_integrity_protected=True)]
+assert "anonymous-source-must-not-fragment" in codes, codes
+
+= Anonymous IPN source forbids canonical-block status-report requests
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, CanonicalBlock
+from scapy.packet import Raw
+
+primary = PrimaryBlock(
+    source="ipn:0.0",
+    bundle_flags=int(PrimaryBlock.Flag.NO_FRAGMENT),
+)
+block = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    block_flags=int(CanonicalBlock.Flag.STATUS_IF_NO_PROCESS),
+    btsd=Raw(load=b"payload"),
+)
+issues = BundleV7(primary=primary, blocks=[block]).validate(
+    primary_integrity_protected=True
+)
+assert any(issue.code == "forbidden-block-status-report" for issue in issues), issues
+
++ Additional RFC 9758 IPN blind spots
+
+= LocalNode exclamation syntax parses and is semantically equal to its numeric form
+from scapy.contrib.bpv7 import EidStruct
+
+local = EidStruct.from_text("ipn:!.7")
+numeric = EidStruct.from_text("ipn:4294967295.7")
+assert local.to_text() == "ipn:!.7"
+assert local.ssp.same_endpoint(numeric.ssp)
+
+= IPN textual forms reject decimal components with leading zeros
+from scapy.contrib.bpv7 import EidStruct
+
+for text in ("ipn:01.2", "ipn:0.01.2", "ipn:1.02"):
+    try:
+        EidStruct.from_text(text)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("non-canonical IPN text was accepted: %s" % text)
+
+= Two- and three-element IPN wire forms round-trip while denoting the same endpoint
+from scapy.contrib.bpv7 import BundleEidField
+from scapy.cborpacket import CBOR_Packet
+
+class EidPacket(CBOR_Packet):
+    CBOR_root = BundleEidField("eid", None)
+
+two_wire = b"\x82\x02\x82\x00\x00"
+three_wire = b"\x82\x02\x83\x00\x00\x00"
+two = EidPacket(two_wire)
+three = EidPacket(three_wire)
+assert bytes(two) == two_wire
+assert bytes(three) == three_wire
+assert two.getfieldval("eid").ssp.same_endpoint(three.getfieldval("eid").ssp)
+
++ Finding 5 - PrimaryBlock EID defaults use the normal internal representation
+
+= Default EIDs are directly readable and render as dtn:none
+from scapy.contrib.bpv7 import PrimaryBlock
+
+primary = PrimaryBlock()
+assert primary.destination == "dtn:none"
+assert primary.source == "dtn:none"
+assert primary.report_to == "dtn:none"
+assert "dtn:none" in primary.show(dump=True)
+
+= Default EIDs are normalized to EidStruct internally and survive Packet.copy
+from scapy.contrib.bpv7 import EidStruct, PrimaryBlock
+
+primary = PrimaryBlock()
+for name in ("destination", "source", "report_to"):
+    assert isinstance(primary.getfieldval(name), EidStruct), (name, primary.getfieldval(name))
+
+clone = primary.copy()
+for name in ("destination", "source", "report_to"):
+    assert isinstance(clone.getfieldval(name), EidStruct), (name, clone.getfieldval(name))
+
+assert bytes(clone) == bytes(primary)
+
++ Finding 6 - Deterministic-CBOR validation covers floats and map order without duplicates
+
+= Deterministic scanner detects non-shortest floats and non-canonical map-key order
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+
+# 1.5 is exactly representable as binary16. Binary16 is deterministic, while
+# binary32 and binary64 encodings of the same value are not.
+assert not cbor_find_non_deterministic(b"\xf9\x3e\x00")
+assert cbor_find_non_deterministic(b"\xfa\x3f\xc0\x00\x00")
+assert cbor_find_non_deterministic(b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00")
+
+# Infinities also have an exact half-precision representation.
+assert not cbor_find_non_deterministic(b"\xf9\x7c\x00")
+assert cbor_find_non_deterministic(b"\xfa\x7f\x80\x00\x00")
+
+# RFC 8949 deterministic map ordering compares encoded keys bytewise.
+assert not cbor_find_non_deterministic(b"\xa2\x61a\x02\x61b\x01")
+assert cbor_find_non_deterministic(b"\xa2\x61b\x01\x61a\x02")
+
+# Indefinite maps must obey the same key-order rule (RFC 9171 / RFC 8949).
+assert not cbor_find_non_deterministic(bytes.fromhex("bf616101616202ff"))
+assert cbor_find_non_deterministic(bytes.fromhex("bf616201616102ff"))
+
+# Large binary64 values must not crash the scanner (RFC 8949 1.0e+300).
+assert cbor_find_non_deterministic(bytes.fromhex("fb7e37e43c8800759c")) == []
+
+= Bundle validation does not duplicate the same deterministic-CBOR wire issue
+from scapy.cbor.cborcodec import CBOR_decode_head
+from scapy.contrib.bpv7 import BundleV7
+
+bundle = BundleV7()
+raw = bytes(bundle)
+assert raw[:1] == b"\x9f", raw.hex()
+
+# Locate the version item structurally: the bundle's indefinite-array marker is
+# followed by the primary block. Decode only the primary-array header to find
+# the exact version offset, rather than searching for a coincidental 0x07 byte.
+primary_major, _primary_len, after_primary_head = CBOR_decode_head(raw[1:])
+assert primary_major == 4
+primary_head_len = len(raw[1:]) - len(after_primary_head)
+version_pos = 1 + primary_head_len
+assert raw[version_pos:version_pos + 1] == b"\x07", raw.hex()
+mutated = raw[:version_pos] + b"\x18\x07" + raw[version_pos + 1:]
+parsed = BundleV7(mutated)
+nd = [
+    i for i in parsed.validate(primary_integrity_protected=True)
+    if i.code == "non-deterministic-cbor"
+]
+assert len(nd) == 1, [(i.path, i.message) for i in nd]
+
++ Finding 7 - CRC verification uses the exact received CRC-value span
+
+= CRC16 verifies when CRC byte-string length header is valid but non-shortest
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.libs.crc import CRC_16_X25
+from scapy.packet import Raw
+
+base = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"payload"),
+)
+wire = bytes(base)
+parsed = CanonicalBlock(wire)
+crc = parsed.getfieldval("crc_value")
+assert isinstance(crc, bytes) and len(crc) == 2
+
+needle = b"\x42" + crc
+idx = wire.rfind(needle)
+assert idx >= 0
+zero_wire = wire[:idx] + b"\x58\x02\x00\x00" + wire[idx + len(needle):]
+new_crc = CRC_16_X25(zero_wire).to_bytes(2, "big")
+nonpreferred = wire[:idx] + b"\x58\x02" + new_crc + wire[idx + len(needle):]
+received = CanonicalBlock(nonpreferred)
+assert received.getfieldval("crc_value") == new_crc
+assert received.check_crc() is True
+
+= CRC32C also verifies against a non-shortest received CRC byte-string header
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.libs.crc import CRC_32C
+from scapy.packet import Raw
+
+base = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC32C,
+    btsd=Raw(load=b"payload"),
+)
+wire = bytes(base)
+parsed = CanonicalBlock(wire)
+crc = parsed.getfieldval("crc_value")
+assert isinstance(crc, bytes) and len(crc) == 4
+
+needle = b"\x44" + crc
+idx = wire.rfind(needle)
+assert idx >= 0
+zero_wire = wire[:idx] + b"\x58\x04\x00\x00\x00\x00" + wire[idx + len(needle):]
+new_crc = CRC_32C(zero_wire).to_bytes(4, "big")
+nonpreferred = wire[:idx] + b"\x58\x04" + new_crc + wire[idx + len(needle):]
+received = CanonicalBlock(nonpreferred)
+assert received.getfieldval("crc_value") == new_crc
+assert received.check_crc() is True
+
++ Finding 9 - Full uint64 DTN time domain is display-safe
+
+= Maximum uint64 DTN time can be parsed, copied, and represented without OverflowError
+from scapy.contrib.bpv7 import BundleTimestamp
+
+max_dtntime = (1 << 64) - 1
+pkt = BundleTimestamp(dtntime=max_dtntime, seqno=0)
+assert pkt.getfieldval("dtntime") == max_dtntime
+_ = pkt.dtntime
+text = pkt.show(dump=True)
+assert str(max_dtntime) in text or "dtntime" in text
+
+wire = bytes(pkt)
+parsed = BundleTimestamp(wire)
+assert parsed.getfieldval("dtntime") == max_dtntime
+_ = parsed.dtntime
+assert parsed.copy().getfieldval("dtntime") == max_dtntime
+
+= DTN time display remains safe immediately above Python datetime's range
+import datetime
+from scapy.contrib.bpv7 import BundleTimestamp, DtnTimeField
+
+max_datetime = datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
+last_ms = DtnTimeField.datetime_to_dtntime(max_datetime)
+assert DtnTimeField.dtntime_to_datetime(last_ms) is not None
+
+overflow_ms = last_ms + 1
+pkt = BundleTimestamp(dtntime=overflow_ms, seqno=0)
+assert pkt.getfieldval("dtntime") == overflow_ms
+_ = pkt.dtntime
+assert pkt.show(dump=True)
+
++ Additional BPv7 validation regressions
+
+= Primary CRC exception is contextual and only suppressed when integrity protection is known
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bundle = BundleV7(primary=PrimaryBlock())
+without_context = [issue.code for issue in bundle.validate()]
+with_context = [
+    issue.code for issue in bundle.validate(primary_integrity_protected=True)
+]
+assert "primary-crc-required" in without_context
+assert "primary-crc-required" not in with_context
+
+= Hop Count reports count greater than limit exactly once
+from scapy.contrib.bpv7 import HopCountBlock
+
+issues = HopCountBlock(limit=3, count=4).validate(path="hop")
+matching = [issue for issue in issues if issue.code == "hop-count-exceeds-limit"]
+assert len(matching) == 1, issues
+assert matching[0].path == "hop"
+
+= Null IPN two- and three-element encodings have identical anonymous-source semantics
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock, BundleEidField
+from scapy.cborpacket import CBOR_Packet
+
+class NullEidPacket(CBOR_Packet):
+    CBOR_root = BundleEidField("eid", None)
+
+for wire in (b"\x82\x02\x82\x00\x00", b"\x82\x02\x83\x00\x00\x00"):
+    eid = NullEidPacket(wire).getfieldval("eid")
+    bundle = BundleV7(primary=PrimaryBlock(source=eid))
+    codes = [issue.code for issue in bundle.validate(primary_integrity_protected=True)]
+    assert "anonymous-source-must-not-fragment" in codes, (wire.hex(), codes)
+
++ Latest review - RFC 9758 IPN "!" grammar and Null composition
+
+= Reject malformed "!" placements and non-ASCII digits
+from scapy.contrib.bpv7 import EidStruct
+
+for text in (
+    "ipn:!.1.2",
+    "ipn:1.!",
+    "ipn:0.1.!",
+    "ipn:!.!",
+    "ipn:\u0661.2",
+):
+    try:
+        EidStruct.from_text(text)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("accepted invalid IPN text: %r" % text)
+
+= LocalNode formats only as the full FQNN bang form
+from scapy.contrib.bpv7 import EidStruct, IpnSsp
+
+assert EidStruct.from_text("ipn:!.7").to_text() == "ipn:!.7"
+assert IpnSsp(5, 0xffffffff, 7).to_text() == "ipn:5.4294967295.7"
+assert IpnSsp(0xffffffff, 1, 7).to_text() == "ipn:4294967295.1.7"
+
+= Null IPN with nonzero service is receivable but not composable
+from scapy.contrib.bpv7 import IpnSsp
+
+try:
+    IpnSsp(0, 0, 7)
+except ValueError:
+    pass
+else:
+    raise AssertionError("composed invalid Null IPN with nonzero service")
+
+received = IpnSsp.from_wire([0, 0, 7])
+assert received.is_null_endpoint()
+assert received.service == 7
+
++ RFC 9758 invalid Null-IPN composition
+
+= Invalid Null-IPN plus nonzero service cannot be composed from text
+from scapy.contrib.bpv7 import EidStruct
+
+for text in ("ipn:0.9", "ipn:0.0.9"):
+    try:
+        EidStruct.from_text(text)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "RFC 9758 invalid Null-IPN service form was locally composed: %s"
+            % text
+        )
+
+= Invalid Null-IPN plus nonzero service received from wire is still decoded as Null
+from scapy.contrib.bpv7 import EidStruct
+
+for parts in ([0, 9], [0, 0, 9]):
+    eid = EidStruct.from_cbor([2, parts])
+    assert eid.is_null_endpoint()
+    assert eid.to_cbor() == [2, parts]
+
+= PrimaryBlock rejects locally composed invalid Null-IPN source text
+from scapy.contrib.bpv7 import PrimaryBlock
+
+for source in ("ipn:0.9", "ipn:0.0.9"):
+    try:
+        PrimaryBlock(source=source)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "PrimaryBlock accepted an RFC 9758 invalid composed source: %s"
+            % source
+        )
+
++ BundleV7 validation robustness
+
+= BundleV7 validate reports a non-CanonicalBlock entry instead of crashing
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+from scapy.packet import Raw
+
+bundle = BundleV7(
+    primary=PrimaryBlock(),
+    blocks=[Raw(load=b"not-a-canonical-block")],
+)
+try:
+    issues = bundle.validate(primary_integrity_protected=True)
+except Exception as exc:
+    raise AssertionError(
+        "BundleV7.validate() crashed on a malformed blocks entry: %r" % exc
+    )
+
+assert any(
+    issue.code == "invalid-canonical-block" and issue.path == "blocks[0]"
+    for issue in issues
+), [(issue.code, issue.path, issue.message) for issue in issues]
+
++ RFC 9758 Null endpoint semantic identity
+
+= Received invalid Null-IPN service forms have canonical Null semantic identity
+from scapy.contrib.bpv7 import EidStruct
+
+canonical_two = EidStruct.from_text("ipn:0.0")
+canonical_three = EidStruct.from_text("ipn:0.0.0")
+received_two = EidStruct.from_cbor([2, [0, 9]])
+received_three = EidStruct.from_cbor([2, [0, 0, 9]])
+
+for received in (received_two, received_three):
+    assert received.is_null_endpoint()
+    assert received.same_endpoint(canonical_two)
+    assert canonical_two.same_endpoint(received)
+    assert received.same_endpoint(canonical_three)
+    assert canonical_three.same_endpoint(received)
+    assert received.semantic_key() == canonical_two.semantic_key()
+    assert received.semantic_key() == canonical_three.semantic_key()
+
+
+# Preserve the received wire representation even though semantic identity is
+# normalized to the Null endpoint.
+assert received_two.to_cbor() == [2, [0, 9]]
+assert received_three.to_cbor() == [2, [0, 0, 9]]
+
+
+= dtn:none and both canonical IPN Null forms identify the same BPv7 endpoint
+from scapy.contrib.bpv7 import EidStruct
+
+dtn_null = EidStruct.from_text("dtn:none")
+ipn_null_two = EidStruct.from_text("ipn:0.0")
+ipn_null_three = EidStruct.from_text("ipn:0.0.0")
+
+for ipn_null in (ipn_null_two, ipn_null_three):
+    assert dtn_null.is_null_endpoint()
+    assert ipn_null.is_null_endpoint()
+    assert dtn_null.same_endpoint(ipn_null)
+    assert ipn_null.same_endpoint(dtn_null)
+    assert dtn_null.semantic_key() == ipn_null.semantic_key()
+
+
+# The two textual/wire IPN forms remain distinguishable for rendering even
+# though they denote the same endpoint.
+assert ipn_null_two.to_text() == "ipn:0.0"
+assert ipn_null_three.to_text() == "ipn:0.0.0"
+
++ DTN EID syntax and Node-ID validation
+
+= Local DTN composition rejects syntactically invalid URIs
+from scapy.contrib.bpv7 import EidStruct
+
+for text in ("dtn:garbage", "dtn://nodemux", "dtn:///svc"):
+    try:
+        EidStruct.from_text(text)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid DTN text was accepted: %s" % text)
+
+= Hierarchical DTN forms parse; only empty demux is a Node ID
+from scapy.contrib.bpv7 import EidStruct
+
+node = EidStruct.from_text("dtn://node/")
+svc = EidStruct.from_text("dtn://node/svc")
+assert node.is_valid() and node.is_node_id()
+assert svc.is_valid() and not svc.is_node_id()
+assert not EidStruct.from_text("dtn:none").is_node_id()
+
+= IPN EIDs with nonzero service remain Node IDs under RFC 9758
+from scapy.contrib.bpv7 import EidStruct
+
+eid = EidStruct.from_text("ipn:1.2.3")
+assert eid.is_valid() and eid.is_node_id()
+
+= Primary source with a non-empty DTN demux is reported by validate()
+from scapy.contrib.bpv7 import PrimaryBlock
+
+codes = {i.code for i in PrimaryBlock(source="dtn://src/svc").validate()}
+assert "source-not-node-id" in codes, codes
+
+= PreviousNodeBlock.validate requires a Node ID
+from scapy.contrib.bpv7 import PreviousNodeBlock
+
+bad = PreviousNodeBlock(node="dtn://n/s")
+good = PreviousNodeBlock(node="dtn://n/")
+assert "previous-node-not-node-id" in {i.code for i in bad.validate()}
+assert not {i.code for i in good.validate()}
+
+= Fresh CBOR BTSD without a received cache is scanned via bytes(btsd)
+from scapy.cbor.cborfields import CBORF_FLOAT
+from scapy.cborpacket import CBOR_Packet
+from scapy.contrib.bpv7 import CanonicalBlock
+
+class StickyNonPrefFloat(CBOR_Packet):
+    CBOR_root = CBORF_FLOAT("value", 1.5)
+    def self_build(self):
+        # Intentionally emit non-preferred binary64 for 1.5.
+        return b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00"
+
+btsd = StickyNonPrefFloat(value=1.5)
+btsd.raw_packet_cache = None
+btsd.raw_packet_cache_fields = None
+btsd.original = None
+block = CanonicalBlock(block_num=2, type_code=99, btsd=btsd)
+assert "non-deterministic-cbor" in {i.code for i in block.validate()}, [
+    (i.code, i.message) for i in block.validate()
+]
+
+= Freshly composed preferred float BTSD is not reported as non-deterministic
+from scapy.cbor.cborfields import CBORF_FLOAT
+from scapy.cborpacket import CBOR_Packet
+from scapy.contrib.bpv7 import CanonicalBlock
+
+class PrefFloatBtsd(CBOR_Packet):
+    CBOR_root = CBORF_FLOAT("value", 1.5)
+
+block = CanonicalBlock(block_num=2, type_code=99, btsd=PrefFloatBtsd(value=1.5))
+assert bytes(block.btsd) == b"\xf9\x3e\x00"
+assert "non-deterministic-cbor" not in {i.code for i in block.validate()}
+
+= Received non-preferred float BTSD remains detectable via its raw cache
+from scapy.cbor.cborfields import CBORF_FLOAT
+from scapy.cborpacket import CBOR_Packet
+from scapy.contrib.bpv7 import CanonicalBlock
+
+class FloatBtsd(CBOR_Packet):
+    CBOR_root = CBORF_FLOAT("value", 0.0)
+
+nonpref = FloatBtsd(b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00")
+block = CanonicalBlock(block_num=2, type_code=99, btsd=nonpref)
+assert "non-deterministic-cbor" in {i.code for i in block.validate()}
+
++ private-use EIDs and DTN reg-name grammar
+
+= Private-use EID scheme 65536 dissects and round-trips without aborting the bundle
+from scapy.contrib.bpv7 import BundleV7, CanonicalBlock, EidStruct, PrimaryBlock
+from scapy.packet import Raw
+
+private = EidStruct.from_cbor([65536, b"private"])
+primary = PrimaryBlock()
+primary.setfieldval("source", private)
+primary.setfieldval("destination", EidStruct.from_text("dtn:none"))
+primary.setfieldval("report_to", EidStruct.from_text("dtn:none"))
+bundle = BundleV7(
+    primary=primary,
+    blocks=[CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=b"payload"))],
+)
+wire = bytes(bundle)
+decoded = BundleV7(wire)
+assert decoded.primary.getfieldval("source").scheme == 65536
+assert decoded.primary.getfieldval("source").ssp == b"private"
+assert decoded.primary.getfieldval("source").to_cbor() == [65536, b"private"]
+assert len(decoded.blocks) == 1
+assert not decoded.primary.getfieldval("source").is_known_scheme()
+assert "invalid-eid" not in {i.code for i in decoded.primary.validate()}
+assert "unknown-scheme-eid" in {i.code for i in decoded.primary.validate()}
+assert all(
+    i.severity == "warning"
+    for i in decoded.primary.validate()
+    if i.code == "unknown-scheme-eid"
+)
+
+= DTN node-name accepts RFC 3986 reg-name and rejects illegal gen-delimiters
+from scapy.contrib.bpv7 import EidStruct
+
+assert EidStruct.from_text("dtn://node%20/svc").is_valid()
+assert EidStruct.from_text("dtn://node!$/service").is_valid()
+
+for text in (
+    "dtn://node?foo/svc",
+    "dtn://node#foo/svc",
+    "dtn://node@foo/svc",
+    "dtn://node:foo/svc",
+    "dtn://node%ZZ/svc",
+    "dtn://node%/svc",
+):
+    try:
+        EidStruct.from_text(text)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid DTN reg-name was accepted: %s" % text)
+
++ EID wire CBOR type enforcement
+
+= EID scheme rejects non-unsigned CBOR integer types
+from scapy.contrib.bpv7 import EidStruct
+
+for scheme in (-1, True, "1", 1.0):
+    try:
+        EidStruct.from_cbor([scheme, b"private"])
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("malformed EID scheme accepted: %r" % scheme)
+
+= IPN SSP components reject non-unsigned CBOR integer types
+from scapy.contrib.bpv7 import EidStruct
+
+for bad in (True, "1", 1.0, -1):
+    try:
+        EidStruct.from_cbor([2, [bad, 1]])
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("malformed IPN SSP component accepted: %r" % bad)
+
+= Valid unsigned EID scheme and IPN SSP still decode
+from scapy.contrib.bpv7 import EidStruct
+
+assert EidStruct.from_cbor([65536, b"private"]).scheme == 65536
+assert EidStruct.from_cbor([2, [1, 2, 3]]).to_text() == "ipn:1.2.3"
+
+= BundleAgeBlock.validate reports a missing age value
+from scapy.contrib.bpv7 import BundleAgeBlock
+
+codes = {i.code for i in BundleAgeBlock().validate()}
+assert "missing-bundle-age" in codes, codes
+assert not BundleAgeBlock(age=0).validate()
+assert not BundleAgeBlock(age=100).validate()
+
++ RFC 9758 contextual lifecycle validation
+
+= LocalNode and Private Use EID helpers classify RFC 9758 special FQNNs
+from scapy.contrib.bpv7 import EidStruct
+
+local = EidStruct.from_text("ipn:!.7")
+priv = EidStruct.from_text("ipn:100.1")
+normal = EidStruct.from_text("ipn:16384.1")
+assert local.is_local_node() and not local.is_private_use()
+assert priv.is_private_use() and not priv.is_local_node()
+assert not normal.is_local_node() and not normal.is_private_use()
+
+= Ingress rejects LocalNode source or destination EIDs
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bundle = BundleV7(primary=PrimaryBlock(source="ipn:!.1", destination="ipn:1.1"))
+codes = {i.code for i in bundle.validate_lifecycle(direction="ingress")}
+assert "localnode-eid-on-ingress" in codes, codes
+
+bundle = BundleV7(primary=PrimaryBlock(source="ipn:1.1", destination="ipn:!.2"))
+codes = {i.code for i in bundle.validate_lifecycle(direction="ingress")}
+assert "localnode-eid-on-ingress" in codes, codes
+
+= Egress rejects LocalNode source or destination EIDs
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bundle = BundleV7(primary=PrimaryBlock(source="ipn:!.1"))
+codes = {i.code for i in bundle.validate_lifecycle(direction="egress")}
+assert "localnode-eid-on-egress" in codes, codes
+
+= Crossing administrative domains rejects Private Use IPN EIDs
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bundle = BundleV7(primary=PrimaryBlock(source="ipn:100.1", destination="ipn:200.1"))
+assert not bundle.validate_lifecycle(direction="egress", crossing_admin_domain=False)
+codes = {i.code for i in bundle.validate_lifecycle(
+    direction="egress", crossing_admin_domain=True
+)}
+assert "private-use-eid-cross-domain" in codes, codes
+
+= Egress rejects LocalNode Previous Node EIDs
+from scapy.contrib.bpv7 import (
+    BundleV7, CanonicalBlock, PreviousNodeBlock, PrimaryBlock,
+)
+from scapy.packet import Raw
+
+bundle = BundleV7(
+    primary=PrimaryBlock(source="ipn:1.1", destination="ipn:2.1"),
+    blocks=[
+        CanonicalBlock(
+            block_num=2,
+            btsd=PreviousNodeBlock(node="ipn:!.0"),
+        ),
+        CanonicalBlock(type_code=1, block_num=1, btsd=Raw(load=b"x")),
+    ],
+)
+codes = {i.code for i in bundle.validate_lifecycle(direction="egress")}
+assert "localnode-eid-on-egress" in codes, codes
+ingress = {i.code for i in bundle.validate_lifecycle(direction="ingress")}
+assert "localnode-eid-on-ingress" in ingress, ingress
+
+= LocalNode three-element CBOR preserves arity through text
+from scapy.contrib.bpv7 import EidStruct
+
+eid = EidStruct.from_cbor([2, [0, 0xFFFFFFFF, 7]])
+assert eid.ssp.wire_elements == 3
+assert eid.to_text() == "ipn:0.4294967295.7"
+roundtrip = EidStruct.from_text(eid.to_text())
+assert roundtrip.ssp.wire_elements == 3
+assert roundtrip.to_cbor() == [2, [0, 0xFFFFFFFF, 7]]
+assert EidStruct.from_text("ipn:!.7").ssp.wire_elements == 2
+
+= Indefinite-length primary and canonical arrays are reported by validate
+import struct
+from scapy.contrib.bpv7 import CanonicalBlock, PrimaryBlock
+from scapy.libs.crc import CRC_16_X25
+
+# [_ 1, 1, 0, CRC16, h'6869', h'0000' _] with CRC over indefinite wire
+prefix = b"\x9f\x01\x01\x00\x01\x42\x68\x69\x42"
+zeroed_wire = prefix + b"\x00\x00\xff"
+crc_value = struct.pack(">H", CRC_16_X25(zeroed_wire))
+wire = prefix + crc_value + b"\xff"
+block = CanonicalBlock(wire)
+assert block.check_crc()
+assert "indefinite-length-cbor" in {i.code for i in block.validate()}, [
+    (i.code, i.message) for i in block.validate()
+]
+
+primary_prefix = (
+    b"\x9f"          # indefinite array
+    b"\x07"          # version
+    b"\x00"          # flags
+    b"\x01"          # CRC16
+    b"\x82\x01\x00"  # destination
+    b"\x82\x01\x00"  # source
+    b"\x82\x01\x00"  # report-to
+    b"\x82\x00\x00"  # creation timestamp
+    b"\x00"          # lifetime
+    b"\x42"          # two-byte CRC byte string
+)
+primary_zeroed = primary_prefix + b"\x00\x00\xff"
+pcrc = struct.pack(">H", CRC_16_X25(primary_zeroed))
+pwire = primary_prefix + pcrc + b"\xff"
+primary = PrimaryBlock(pwire)
+assert primary.check_crc()
+assert "indefinite-length-cbor" in {i.code for i in primary.validate()}, [
+    (i.code, i.message) for i in primary.validate()
+]
+
+= Fragment offset exceeding total length is reported
+from scapy.contrib.bpv7 import PrimaryBlock
+
+primary = PrimaryBlock(
+    destination="ipn:1.1",
+    source="ipn:2.1",
+    report_to="ipn:2.1",
+    bundle_flags=int(PrimaryBlock.Flag.IS_FRAGMENT),
+    fragment_offset=100,
+    total_app_data_len=50,
+)
+assert "fragment-offset-exceeds-total" in {i.code for i in primary.validate()}
+
+= assert_valid optionally includes lifecycle checks
+from scapy.contrib.bpv7 import BundleV7, PrimaryBlock
+
+bad = BundleV7(primary=PrimaryBlock(source="ipn:!.1", destination="ipn:2.1"))
+try:
+    bad.assert_valid()
+except ValueError as exc:
+    assert "localnode-eid-on-ingress" not in str(exc), exc
+else:
+    # Structurally incomplete bundles may still raise; LocalNode alone must not.
+    pass
+
+try:
+    bad.assert_valid(lifecycle="ingress")
+except ValueError as exc:
+    assert "localnode-eid-on-ingress" in str(exc), exc
+else:
+    raise AssertionError("assert_valid ignored lifecycle LocalNode")
+
+= HopCountBlock.validate reports a missing count value
+from scapy.contrib.bpv7 import HopCountBlock
+
+codes = {i.code for i in HopCountBlock(limit=5, count=None).validate()}
+assert "missing-hop-count" in codes, codes
+assert not HopCountBlock(limit=5, count=0).validate()
+
+= CRC check without span uses only a final preferred-length CRC bstr
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.packet import Raw
+
+block = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"payload"),
+)
+wire = bytes(block)
+parsed = CanonicalBlock(wire)
+assert parsed.check_crc()
+assert hasattr(parsed, "_crc_content_span")
+del parsed._crc_content_span
+assert parsed.check_crc(), (
+    "preferred CRC at end of definite array must verify via fallback"
+)
+
+= CRC fallback does not match an embedded preferred bstr inside BTSD
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.libs.crc import CRC_16_X25
+from scapy.packet import Raw
+
+# Build a block, then craft BTSD that embeds the same preferred CRC bstr
+# earlier in the array so a naive rfind would zero the wrong region.
+base = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"xx"),
+)
+wire = bytes(base)
+parsed = CanonicalBlock(wire)
+crc = parsed.getfieldval("crc_value")
+assert len(crc) == 2
+# Replace BTSD with bytes that contain \x42||crc as a decoy payload, keep CRC.
+# Canonical layout: [type, num, flags, crc_type, btsd, crc]
+# Use dissect with span cleared after embedding decoy in load.
+decoy = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"\x42" + crc + b"tail"),
+)
+decoy_wire = bytes(decoy)
+decoy_parsed = CanonicalBlock(decoy_wire)
+assert decoy_parsed.check_crc()
+del decoy_parsed._crc_content_span
+assert decoy_parsed.check_crc(), (
+    "fallback must use the final CRC field, not an embedded bstr in BTSD"
+)
+
+= Non-preferred CRC header still verifies with span but not after span loss
+from scapy.contrib.bpv7 import CanonicalBlock, CrcType
+from scapy.libs.crc import CRC_16_X25
+from scapy.packet import Raw
+
+base = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"payload"),
+)
+wire = bytes(base)
+crc = CanonicalBlock(wire).getfieldval("crc_value")
+needle = b"\x42" + crc
+idx = wire.rfind(needle)
+zero_wire = wire[:idx] + b"\x58\x02\x00\x00" + wire[idx + len(needle):]
+new_crc = CRC_16_X25(zero_wire).to_bytes(2, "big")
+nonpreferred = wire[:idx] + b"\x58\x02" + new_crc + wire[idx + len(needle):]
+received = CanonicalBlock(nonpreferred)
+assert received.check_crc() is True
+del received._crc_content_span
+assert received.check_crc() is False, (
+    "without span, non-preferred CRC head must not use unsafe rfind fallback"
+)
+
+= IS_FRAGMENT and NO_FRAGMENT together is reported
+from scapy.contrib.bpv7 import PrimaryBlock
+
+flags = int(PrimaryBlock.Flag.IS_FRAGMENT | PrimaryBlock.Flag.NO_FRAGMENT)
+primary = PrimaryBlock(
+    destination="ipn:1.1",
+    source="ipn:2.1",
+    report_to="ipn:2.1",
+    bundle_flags=flags,
+    fragment_offset=0,
+    total_app_data_len=10,
+)
+assert "conflicting-fragment-flags" in {i.code for i in primary.validate()}
+
+= Fragment offset plus payload must not exceed total ADU length
+from scapy.contrib.bpv7 import (
+    BundleV7,
+    CanonicalBlock,
+    CrcType,
+    PrimaryBlock,
+    BundleTimestamp,
+)
+from scapy.packet import Raw
+
+primary = PrimaryBlock(
+    bundle_flags=int(PrimaryBlock.Flag.IS_FRAGMENT),
+    crc_type=CrcType.CRC16,
+    destination="ipn:1.1",
+    source="ipn:2.1",
+    report_to="ipn:2.1",
+    create_ts=BundleTimestamp(dtntime=1, seqno=0),
+    lifetime=60000,
+    fragment_offset=10,
+    total_app_data_len=20,
+)
+primary.freeze_crc()
+payload = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"abcdefghijkl"),  # 12 bytes: 10+12 > 20
+)
+payload.freeze_crc()
+bundle = BundleV7(primary=primary, blocks=[payload])
+codes = {i.code for i in bundle.validate()}
+assert "fragment-extends-past-total" in codes, codes
+
+# Boundary fit is accepted.
+ok_payload = CanonicalBlock(
+    type_code=1,
+    block_num=1,
+    crc_type=CrcType.CRC16,
+    btsd=Raw(load=b"abcdefghij"),  # 10 bytes: 10+10 == 20
+)
+ok_payload.freeze_crc()
+ok = BundleV7(primary=primary, blocks=[ok_payload])
+assert "fragment-extends-past-total" not in {i.code for i in ok.validate()}
+
+= Previous Node unknown-scheme EID emits a warning
+from scapy.contrib.bpv7 import EidStruct, PreviousNodeBlock
+
+pn = PreviousNodeBlock(node=EidStruct.from_cbor([65536, b"private"]))
+issues = pn.validate()
+assert any(
+    i.code == "unknown-scheme-eid" and i.severity == "warning"
+    for i in issues
+), [(i.code, i.severity) for i in issues]
+assert not any(i.severity == "error" for i in issues)

--- a/test/fields.uts
+++ b/test/fields.uts
@@ -2357,3 +2357,15 @@ p
 assert p.indent == 0xf
 assert p.pcount == 4
 assert [p.x for p in p.plist] == [0x41, 0x42, 0x43, 0x44]
+
+############
+############
++ ConditionalField __getattr__
+
+= ConditionalField __getattr__ has no try/except AttributeError wrapper
+~ core field
+import inspect
+from scapy import fields
+
+src = inspect.getsource(fields.ConditionalField.__getattr__)
+assert "except AttributeError" not in src

--- a/test/scapy/layers/cbor.uts
+++ b/test/scapy/layers/cbor.uts
@@ -4,9 +4,9 @@
 # Try me with:
 # bash test/run_tests -t test/scapy/layers/cbor.uts -F
 #
-# NOTE: Interoperability tests require cbor2 (test-only dependency):
-# pip install cbor2
-# cbor2 is used ONLY in tests, NOT in the scapy CBOR implementation
+# Interoperability / cbor2 differential tests live in:
+#   test/scapy/layers/cbor_cbor2_interop.uts
+# (requires: pip install -r test/scapy/layers/requirements-cbor2.txt)
 
 ########### CBOR Basic Types #######################################
 
@@ -143,9 +143,24 @@ isinstance(obj, CBOR_UNDEFINED) and remainder == b''
 
 + CBOR Float
 
-= Encode double precision float
+= Encode preferred (shortest) float for exact half-precision values
 obj = CBOR_FLOAT(1.5)
-bytes(obj) == b'\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00'
+bytes(obj) == b'\xf9\x3e\x00'
+
+= Encode double precision when shorter widths cannot preserve the value
+obj = CBOR_FLOAT(1.0e300)
+bytes(obj) == b'\xfb\x7e\x37\xe4\x3c\x88\x00\x75\x9c'
+
+= Decoded floats preserve their exact received encoding on rebuild
+obj, rem = CBOR_Codecs.CBOR.dec(b'\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00')
+abs(obj.val - 1.5) < 0.0001 and rem == b'' and bytes(obj) == b'\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00'
+
+= CBOR_Object equality compares type and value
+from scapy.cbor import CBOR_UNSIGNED_INTEGER, CBOR_TRUE
+assert CBOR_UNSIGNED_INTEGER(1) == CBOR_UNSIGNED_INTEGER(1)
+assert CBOR_UNSIGNED_INTEGER(1) != CBOR_UNSIGNED_INTEGER(2)
+assert CBOR_UNSIGNED_INTEGER(1) != CBOR_TRUE()
+assert CBOR_UNSIGNED_INTEGER(1) != 1
 
 = Decode double precision float
 obj, remainder = CBOR_Codecs.CBOR.dec(b'\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00')
@@ -268,6 +283,10 @@ isinstance(obj, CBOR_MAP) and remainder == b''
 obj, remainder = CBOR_Codecs.CBOR.safedec(b'\xff\xff\xff')
 isinstance(obj, CBOR_DECODING_ERROR)
 
+= Safe decode of a truncated nested array wraps only the outer error
+obj, remainder = CBOR_Codecs.CBOR.safedec(b'\x82\x01')
+isinstance(obj, CBOR_DECODING_ERROR) and remainder == b''
+
 = Decode with insufficient bytes for length
 try:
     obj, remainder = CBOR_Codecs.CBOR.dec(b'\x18')
@@ -282,3670 +301,2694 @@ try:
 except:
     True
 
-########### CBOR Interoperability Tests with cbor2 #################
-# These tests verify interoperability between scapy's CBOR implementation
-# and the standard cbor2 library. cbor2 is ONLY used in tests, not in
-# the scapy implementation.
-#
-# NOTE: These tests require cbor2 to be installed: pip install cbor2
++ CBORF_SEQUENCE_OF packet item cardinality
 
-+ CBOR Interoperability - Basic Types (Scapy encode, cbor2 decode)
+= CBORF_SEQUENCE_OF rejects a packet element that consumes two top-level items
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import (
+    CBORF_SEQUENCE,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
 
-= Check cbor2 availability
+class TwoItemSequenceDecodeElement(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_UNSIGNED_INTEGER("first", 0),
+        CBORF_UNSIGNED_INTEGER("second", 0),
+    )
+
+class PacketSequenceDecode(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF(
+        "elements",
+        [],
+        TwoItemSequenceDecodeElement,
+    )
+
 try:
-    import cbor2
-    cbor2_available = True
-except ImportError:
-    cbor2_available = False
-
-cbor2_available
-
-= Interop: Scapy encode unsigned integer, cbor2 decode
-import cbor2
-obj = CBOR_UNSIGNED_INTEGER(42)
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded == 42
-
-= Interop: Scapy encode negative integer, cbor2 decode
-obj = CBOR_NEGATIVE_INTEGER(-100)
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded == -100
-
-= Interop: Scapy encode text string, cbor2 decode
-obj = CBOR_TEXT_STRING("Hello, World!")
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded == "Hello, World!"
-
-= Interop: Scapy encode UTF-8 text string, cbor2 decode
-obj = CBOR_TEXT_STRING("Café ☕")
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded == "Café ☕"
-
-= Interop: Scapy encode byte string, cbor2 decode
-obj = CBOR_BYTE_STRING(b'\x01\x02\x03\x04\x05')
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded == b'\x01\x02\x03\x04\x05'
-
-= Interop: Scapy encode true, cbor2 decode
-obj = CBOR_TRUE()
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded is True
-
-= Interop: Scapy encode false, cbor2 decode
-obj = CBOR_FALSE()
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded is False
-
-= Interop: Scapy encode null, cbor2 decode
-obj = CBOR_NULL()
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-decoded is None
-
-= Interop: Scapy encode undefined, cbor2 decode
-obj = CBOR_UNDEFINED()
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-from cbor2 import undefined
-decoded is undefined
-
-= Interop: Scapy encode float, cbor2 decode
-obj = CBOR_FLOAT(3.14159)
-encoded = bytes(obj)
-decoded = cbor2.loads(encoded)
-abs(decoded - 3.14159) < 0.0001
-
-+ CBOR Interoperability - Collections (Scapy encode, cbor2 decode)
-
-= Interop: Scapy encode array, cbor2 decode
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-encoded = CBORcodec_ARRAY.enc([1, 2, 3, 4, 5])
-decoded = cbor2.loads(encoded)
-decoded == [1, 2, 3, 4, 5]
-
-= Interop: Scapy encode nested array, cbor2 decode
-encoded = CBORcodec_ARRAY.enc([1, [2, 3], [4, [5, 6]]])
-decoded = cbor2.loads(encoded)
-decoded == [1, [2, 3], [4, [5, 6]]]
-
-= Interop: Scapy encode map, cbor2 decode
-from scapy.cbor.cborcodec import CBORcodec_MAP
-encoded = CBORcodec_MAP.enc({"a": 1, "b": 2, "c": 3})
-decoded = cbor2.loads(encoded)
-decoded == {"a": 1, "b": 2, "c": 3}
-
-= Interop: Scapy encode complex map, cbor2 decode
-data = {"name": "Alice", "age": 30, "active": True, "tags": ["user", "admin"]}
-encoded = CBORcodec_MAP.enc(data)
-decoded = cbor2.loads(encoded)
-decoded == data
-
-= Interop: Scapy encode mixed array, cbor2 decode
-encoded = CBORcodec_ARRAY.enc([42, "hello", True, None, 3.14, [1, 2]])
-decoded = cbor2.loads(encoded)
-len(decoded) == 6 and decoded[0] == 42 and decoded[1] == "hello"
-
-+ CBOR Interoperability - Basic Types (cbor2 encode, Scapy decode)
-
-= Interop: cbor2 encode unsigned integer, Scapy decode
-encoded = cbor2.dumps(42)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == 42 and isinstance(obj, CBOR_UNSIGNED_INTEGER)
-
-= Interop: cbor2 encode negative integer, Scapy decode
-encoded = cbor2.dumps(-100)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == -100 and isinstance(obj, CBOR_NEGATIVE_INTEGER)
-
-= Interop: cbor2 encode text string, Scapy decode
-encoded = cbor2.dumps("Hello, World!")
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == "Hello, World!" and isinstance(obj, CBOR_TEXT_STRING)
-
-= Interop: cbor2 encode UTF-8 text string, Scapy decode
-encoded = cbor2.dumps("Café ☕")
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == "Café ☕" and isinstance(obj, CBOR_TEXT_STRING)
-
-= Interop: cbor2 encode byte string, Scapy decode
-encoded = cbor2.dumps(b'\x01\x02\x03\x04\x05')
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == b'\x01\x02\x03\x04\x05' and isinstance(obj, CBOR_BYTE_STRING)
-
-= Interop: cbor2 encode true, Scapy decode
-encoded = cbor2.dumps(True)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val is True and isinstance(obj, CBOR_TRUE)
-
-= Interop: cbor2 encode false, Scapy decode
-encoded = cbor2.dumps(False)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val is False and isinstance(obj, CBOR_FALSE)
-
-= Interop: cbor2 encode null, Scapy decode
-encoded = cbor2.dumps(None)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-obj.val is None and isinstance(obj, CBOR_NULL)
-
-= Interop: cbor2 encode undefined, Scapy decode
-from cbor2 import CBORSimpleValue, undefined
-encoded = cbor2.dumps(undefined)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_UNDEFINED)
-
-= Interop: cbor2 encode float, Scapy decode
-encoded = cbor2.dumps(3.14159)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-abs(obj.val - 3.14159) < 0.0001 and isinstance(obj, CBOR_FLOAT)
-
-+ CBOR Interoperability - Collections (cbor2 encode, Scapy decode)
-
-= Interop: cbor2 encode array, Scapy decode
-encoded = cbor2.dumps([1, 2, 3, 4, 5])
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 5
-
-= Interop: cbor2 encode nested array, Scapy decode
-encoded = cbor2.dumps([1, [2, 3], [4, [5, 6]]])
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 3
-
-= Interop: cbor2 encode map, Scapy decode
-encoded = cbor2.dumps({"a": 1, "b": 2, "c": 3})
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_MAP) and len(obj.val) == 3
-
-= Interop: cbor2 encode complex map, Scapy decode
-data = {"name": "Alice", "age": 30, "active": True}
-encoded = cbor2.dumps(data)
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_MAP) and "name" in obj.val
-
-= Interop: cbor2 encode mixed array, Scapy decode
-encoded = cbor2.dumps([42, "hello", True, None, 3.14])
-obj, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 5
-
-+ CBOR Interoperability - Roundtrip Tests
-
-= Interop roundtrip: integer through cbor2
-original_val = 12345
-scapy_obj = CBOR_UNSIGNED_INTEGER(original_val)
-scapy_encoded = bytes(scapy_obj)
-cbor2_decoded = cbor2.loads(scapy_encoded)
-cbor2_encoded = cbor2.dumps(cbor2_decoded)
-scapy_decoded, _ = CBOR_Codecs.CBOR.dec(cbor2_encoded)
-scapy_decoded.val == original_val
-
-= Interop roundtrip: string through cbor2
-original_val = "Test String 测试"
-scapy_obj = CBOR_TEXT_STRING(original_val)
-scapy_encoded = bytes(scapy_obj)
-cbor2_decoded = cbor2.loads(scapy_encoded)
-cbor2_encoded = cbor2.dumps(cbor2_decoded)
-scapy_decoded, _ = CBOR_Codecs.CBOR.dec(cbor2_encoded)
-scapy_decoded.val == original_val
-
-= Interop roundtrip: array through cbor2
-original_val = [1, "two", 3.0, True, None]
-scapy_encoded = CBORcodec_ARRAY.enc(original_val)
-cbor2_decoded = cbor2.loads(scapy_encoded)
-cbor2_encoded = cbor2.dumps(cbor2_decoded)
-scapy_decoded, _ = CBOR_Codecs.CBOR.dec(cbor2_encoded)
-isinstance(scapy_decoded, CBOR_ARRAY) and len(scapy_decoded.val) == 5
-
-= Interop roundtrip: map through cbor2
-original_val = {"int": 42, "str": "value", "bool": True, "null": None}
-scapy_encoded = CBORcodec_MAP.enc(original_val)
-cbor2_decoded = cbor2.loads(scapy_encoded)
-cbor2_encoded = cbor2.dumps(cbor2_decoded)
-scapy_decoded, _ = CBOR_Codecs.CBOR.dec(cbor2_encoded)
-isinstance(scapy_decoded, CBOR_MAP) and len(scapy_decoded.val) == 4
-
-+ CBOR Interoperability - Edge Cases
-
-= Interop: Large unsigned integer
-large_int = 18446744073709551615  # 2^64 - 1
-encoded = cbor2.dumps(large_int)
-obj, _ = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == large_int
-
-= Interop: Very negative integer
-neg_int = -18446744073709551616  # -(2^64)
-encoded = cbor2.dumps(neg_int)
-obj, _ = CBOR_Codecs.CBOR.dec(encoded)
-obj.val == neg_int
-
-= Interop: Empty collections
-empty_array = cbor2.dumps([])
-obj1, _ = CBOR_Codecs.CBOR.dec(empty_array)
-empty_map = cbor2.dumps({})
-obj2, _ = CBOR_Codecs.CBOR.dec(empty_map)
-isinstance(obj1, CBOR_ARRAY) and len(obj1.val) == 0 and isinstance(obj2, CBOR_MAP) and len(obj2.val) == 0
-
-= Interop: Deeply nested structure
-deep = {"level1": {"level2": {"level3": {"level4": [1, 2, 3]}}}}
-encoded = cbor2.dumps(deep)
-obj, _ = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(obj, CBOR_MAP)
-
-= Interop: Special float values (infinity)
-import math
-pos_inf_encoded = cbor2.dumps(math.inf)
-pos_inf_obj, _ = CBOR_Codecs.CBOR.dec(pos_inf_encoded)
-neg_inf_encoded = cbor2.dumps(-math.inf)
-neg_inf_obj, _ = CBOR_Codecs.CBOR.dec(neg_inf_encoded)
-math.isinf(pos_inf_obj.val) and math.isinf(neg_inf_obj.val)
-
-= Interop: Special float value (NaN)
-nan_encoded = cbor2.dumps(math.nan)
-nan_obj, _ = CBOR_Codecs.CBOR.dec(nan_encoded)
-math.isnan(nan_obj.val)
-
-= Interop: Zero values
-zero_int = cbor2.dumps(0)
-zero_float = cbor2.dumps(0.0)
-obj1, _ = CBOR_Codecs.CBOR.dec(zero_int)
-obj2, _ = CBOR_Codecs.CBOR.dec(zero_float)
-obj1.val == 0 and obj2.val == 0.0
-
-########### Additional Tests Adapted from PR #4875 ###################
-# These tests verify specific encoding sizes and edge cases
-
-+ CBOR Encoding Sizes - Unsigned Integers
-
-= uint encoding size 0 (argument in initial byte)
-obj = CBOR_UNSIGNED_INTEGER(0x12)
-data = bytes(obj)
-data == bytes.fromhex('12')
-
-= uint encoding size 1 (1-byte argument follows)
-obj = CBOR_UNSIGNED_INTEGER(0x34)
-data = bytes(obj)
-data == bytes.fromhex('1834')
-
-= uint encoding size 2 (2-byte argument follows)
-obj = CBOR_UNSIGNED_INTEGER(0x1234)
-data = bytes(obj)
-data == bytes.fromhex('191234')
-
-= uint encoding size 4 (4-byte argument follows)
-obj = CBOR_UNSIGNED_INTEGER(0x12345678)
-data = bytes(obj)
-data == bytes.fromhex('1a12345678')
-
-= uint encoding size 8 (8-byte argument follows)
-obj = CBOR_UNSIGNED_INTEGER(0x1234567812345678)
-data = bytes(obj)
-data == bytes.fromhex('1b1234567812345678')
-
-= uint decoding size 0
-data = bytes.fromhex('12')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 18 and remainder == b''
-
-= uint decoding size 1
-data = bytes.fromhex('1834')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 0x34 and remainder == b''
-
-= uint decoding size 2
-data = bytes.fromhex('191234')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 0x1234 and remainder == b''
-
-= uint decoding size 4
-data = bytes.fromhex('1a12345678')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 0x12345678 and remainder == b''
-
-= uint decoding size 8
-data = bytes.fromhex('1b1234567812345678')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 0x1234567812345678 and remainder == b''
-
-+ CBOR Encoding Sizes - Negative Integers
-
-= nint encoding size 0
-obj = CBOR_NEGATIVE_INTEGER(-0x13)
-data = bytes(obj)
-data == bytes.fromhex('32')
-
-= nint decoding size 0
-data = bytes.fromhex('32')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == -0x13 and isinstance(obj, CBOR_NEGATIVE_INTEGER) and remainder == b''
-
-= nint decoding size 2
-data = bytes.fromhex('391234')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == (-0x1234 - 1) and isinstance(obj, CBOR_NEGATIVE_INTEGER) and remainder == b''
-
-+ CBOR Byte String Edge Cases
-
-= bstr encoding with specific content
-obj = CBOR_BYTE_STRING(b'hi')
-data = bytes(obj)
-data == bytes.fromhex('426869')
-
-= bstr decoding with specific content
-data = bytes.fromhex('426869')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == b'hi' and isinstance(obj, CBOR_BYTE_STRING) and remainder == b''
-
-= bstr longer content (24 bytes)
-content = b'longlonglonglonglonglong'
-obj = CBOR_BYTE_STRING(content)
-data = bytes(obj)
-# Should use 1-byte length encoding (0x58 = major type 2, additional info 24)
-data[:2] == bytes.fromhex('5818') and data[2:] == content
-
-= bstr decoding longer content
-data = bytes.fromhex('58186c6f6e676c6f6e676c6f6e676c6f6e676c6f6e676c6f6e67')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == b'longlonglonglonglonglong' and remainder == b''
-
-+ CBOR Text String Edge Cases
-
-= tstr encoding with specific content
-obj = CBOR_TEXT_STRING('hi')
-data = bytes(obj)
-data == bytes.fromhex('626869')
-
-= tstr decoding with specific content
-data = bytes.fromhex('626869')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 'hi' and isinstance(obj, CBOR_TEXT_STRING) and remainder == b''
-
-= tstr longer content (24 chars)
-content = 'longlonglonglonglonglong'
-obj = CBOR_TEXT_STRING(content)
-data = bytes(obj)
-# Should use 1-byte length encoding (0x78 = major type 3, additional info 24)
-data[:2] == bytes.fromhex('7818') and data[2:] == content.encode('utf8')
-
-= tstr decoding longer content
-data = bytes.fromhex('78186c6f6e676c6f6e676c6f6e676c6f6e676c6f6e676c6f6e67')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-obj.val == 'longlonglonglonglonglong' and remainder == b''
-
-+ CBOR Array Specific Encodings
-
-= array encoding with mixed integer types
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-# Array with positive 10 and negative 20
-encoded = CBORcodec_ARRAY.enc([10, -20])
-decoded, _ = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and len(decoded.val) == 2
-
-= array decoding specific encoding
-data = bytes.fromhex('820A33')  # array(2): [10, -20]
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 2 and remainder == b''
-
-+ CBOR Map Specific Encodings
-
-= map encoding with integer keys
-from scapy.cbor.cborcodec import CBORcodec_MAP
-encoded = CBORcodec_MAP.enc({10: -20})
-decoded, _ = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and len(decoded.val) == 1
-
-= map decoding specific encoding
-data = bytes.fromhex('A10A33')  # map(1): {10: -20}
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_MAP) and len(obj.val) == 1 and remainder == b''
-
-+ CBOR Float Specific Encodings
-
-= float64 encoding specific value
-obj = CBOR_FLOAT(1.5e20)
-data = bytes(obj)
-data == bytes.fromhex('FB442043561A882930')
-
-= float64 decoding specific value
-data = bytes.fromhex('FB442043561A882930')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 1.5e20 and remainder == b''
-
-+ CBOR Multiple Item Decoding
-
-= decode multiple items in sequence
-data = bytes.fromhex('010203')  # Three unsigned integers: 1, 2, 3
-obj1, remainder1 = CBOR_Codecs.CBOR.dec(data)
-obj2, remainder2 = CBOR_Codecs.CBOR.dec(remainder1)
-obj3, remainder3 = CBOR_Codecs.CBOR.dec(remainder2)
-obj1.val == 1 and obj2.val == 2 and obj3.val == 3 and remainder3 == b''
-
-= decode nested array with specific encoding
-data = bytes.fromhex('8201820203')  # array(2): [1, array(2): [2, 3]]
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 2 and remainder == b'' and isinstance(obj.val[1], CBOR_ARRAY)
-
-+ CBOR Boundary Value Tests
-
-= encode maximum value that fits in each size
-# Maximum for size 0 (0-23)
-obj = CBOR_UNSIGNED_INTEGER(23)
-bytes(obj) == bytes.fromhex('17')
-
-= encode minimum value needing size 1
-obj = CBOR_UNSIGNED_INTEGER(24)
-bytes(obj) == bytes.fromhex('1818')
-
-= encode maximum value for size 1
-obj = CBOR_UNSIGNED_INTEGER(255)
-bytes(obj) == bytes.fromhex('18ff')
-
-= encode minimum value needing size 2
-obj = CBOR_UNSIGNED_INTEGER(256)
-bytes(obj) == bytes.fromhex('190100')
-
-= negative integer boundary at -24
-obj = CBOR_NEGATIVE_INTEGER(-24)
-bytes(obj) == bytes.fromhex('37')
-
-= negative integer boundary at -25
-obj = CBOR_NEGATIVE_INTEGER(-25)
-bytes(obj) == bytes.fromhex('3818')
-
-+ CBOR Empty Container Tests
-
-= encode empty array
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-encoded = CBORcodec_ARRAY.enc([])
-decoded, _ = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and len(decoded.val) == 0
-
-= encode empty map
-from scapy.cbor.cborcodec import CBORcodec_MAP
-encoded = CBORcodec_MAP.enc({})
-decoded, _ = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and len(decoded.val) == 0
-
-= encode empty byte string
-obj = CBOR_BYTE_STRING(b'')
-data = bytes(obj)
-data == bytes.fromhex('40')
-
-= encode empty text string
-obj = CBOR_TEXT_STRING('')
-data = bytes(obj)
-data == bytes.fromhex('60')
-
-########### CBOR Fuzzing / Random Object Tests ####################
-
-+ CBOR Random Object Generation
-
-= Create RandCBORObject
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-isinstance(rand, RandCBORObject)
-
-= Generate random CBOR unsigned integer
-from scapy.cbor import RandCBORObject, CBOR_UNSIGNED_INTEGER
-rand = RandCBORObject(objlist=[CBOR_UNSIGNED_INTEGER])
-obj = rand._fix()
-isinstance(obj, CBOR_UNSIGNED_INTEGER) and isinstance(obj.val, int) and obj.val >= 0
-
-= Generate random CBOR negative integer
-from scapy.cbor import RandCBORObject, CBOR_NEGATIVE_INTEGER
-rand = RandCBORObject(objlist=[CBOR_NEGATIVE_INTEGER])
-obj = rand._fix()
-isinstance(obj, CBOR_NEGATIVE_INTEGER) and isinstance(obj.val, int) and obj.val < 0
-
-= Generate random CBOR byte string
-from scapy.cbor import RandCBORObject, CBOR_BYTE_STRING
-rand = RandCBORObject(objlist=[CBOR_BYTE_STRING])
-obj = rand._fix()
-isinstance(obj, CBOR_BYTE_STRING) and isinstance(obj.val, bytes)
-
-= Generate random CBOR text string
-from scapy.cbor import RandCBORObject, CBOR_TEXT_STRING
-rand = RandCBORObject(objlist=[CBOR_TEXT_STRING])
-obj = rand._fix()
-isinstance(obj, CBOR_TEXT_STRING) and isinstance(obj.val, str) and len(obj.val) > 0
-
-= Generate random CBOR array
-from scapy.cbor import RandCBORObject, CBOR_ARRAY
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-isinstance(obj, CBOR_ARRAY) and isinstance(obj.val, list)
-
-= Generate random CBOR map
-from scapy.cbor import RandCBORObject, CBOR_MAP
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-isinstance(obj, CBOR_MAP) and isinstance(obj.val, dict)
-
-= Generate random CBOR boolean (false)
-from scapy.cbor import RandCBORObject, CBOR_FALSE
-rand = RandCBORObject(objlist=[CBOR_FALSE])
-obj = rand._fix()
-isinstance(obj, CBOR_FALSE) and obj.val == False
-
-= Generate random CBOR boolean (true)
-from scapy.cbor import RandCBORObject, CBOR_TRUE
-rand = RandCBORObject(objlist=[CBOR_TRUE])
-obj = rand._fix()
-isinstance(obj, CBOR_TRUE) and obj.val == True
-
-= Generate random CBOR null
-from scapy.cbor import RandCBORObject, CBOR_NULL
-rand = RandCBORObject(objlist=[CBOR_NULL])
-obj = rand._fix()
-isinstance(obj, CBOR_NULL) and obj.val is None
-
-= Generate random CBOR undefined
-from scapy.cbor import RandCBORObject, CBOR_UNDEFINED
-rand = RandCBORObject(objlist=[CBOR_UNDEFINED])
-obj = rand._fix()
-isinstance(obj, CBOR_UNDEFINED) and obj.val is None
-
-= Generate random CBOR float
-from scapy.cbor import RandCBORObject, CBOR_FLOAT
-rand = RandCBORObject(objlist=[CBOR_FLOAT])
-obj = rand._fix()
-isinstance(obj, CBOR_FLOAT) and isinstance(obj.val, float)
-
-+ CBOR Random Object Encoding/Decoding
-
-= Encode and decode random unsigned integer
-from scapy.cbor import RandCBORObject, CBOR_UNSIGNED_INTEGER, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_UNSIGNED_INTEGER])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_UNSIGNED_INTEGER) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random text string
-from scapy.cbor import RandCBORObject, CBOR_TEXT_STRING, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_TEXT_STRING])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_TEXT_STRING) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random byte string
-from scapy.cbor import RandCBORObject, CBOR_BYTE_STRING, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_BYTE_STRING])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_BYTE_STRING) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random array
-from scapy.cbor import RandCBORObject, CBOR_ARRAY, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and remainder == b'' and len(decoded.val) == len(obj.val)
-
-= Encode and decode random map
-from scapy.cbor import RandCBORObject, CBOR_MAP, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and remainder == b'' and len(decoded.val) == len(obj.val)
-
-= Encode and decode random float
-from scapy.cbor import RandCBORObject, CBOR_FLOAT, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_FLOAT])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_FLOAT) and remainder == b''
-
-+ CBOR Random Mixed Types
-
-= Generate multiple random objects of different types
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-objects = [rand._fix() for _ in range(10)]
-len(objects) == 10 and all(hasattr(obj, 'val') for obj in objects)
-
-= Encode and decode multiple random objects
-from scapy.cbor import RandCBORObject, CBOR_Codecs
-rand = RandCBORObject()
-success_count = 0
-for _ in range(20):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-        if remainder == b'':
-            success_count += 1
-    except:
-        pass
-
-success_count >= 18
-
-= Random nested arrays encode/decode correctly
-from scapy.cbor import RandCBORObject, CBOR_ARRAY, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and remainder == b''
-
-= Random nested maps encode/decode correctly
-from scapy.cbor import RandCBORObject, CBOR_MAP, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and remainder == b''
-
-+ CBOR Fuzzing Stress Tests
-
-= Generate 100 random objects without errors
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-objects = []
-for _ in range(100):
-    obj = None
-    try:
-        obj = rand._fix()
-    except:
-        pass
-    if obj is not None:
-        objects.append(obj)
-
-len(objects) >= 95
-
-= Encode 50 random objects without errors
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-encoded_count = 0
-for _ in range(50):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        if len(encoded) > 0:
-            encoded_count += 1
-    except:
-        pass
-
-encoded_count >= 45
-
-= Roundtrip 50 random objects
-from scapy.cbor import RandCBORObject, CBOR_Codecs
-rand = RandCBORObject()
-roundtrip_count = 0
-for _ in range(50):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-        if remainder == b'':
-            roundtrip_count += 1
-    except:
-        pass
-
-roundtrip_count >= 45
-
-########### CBOR Fields ###########################################
-
-+ CBORF scalar fields - CBORF_UNSIGNED_INTEGER
-
-= CBORF_UNSIGNED_INTEGER basic encode/decode
-from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
+    PacketSequenceDecode(b"\x01\x02")
+    assert False, "SEQUENCE_OF accepted two CBOR items as one packet element"
+except CBOR_Decoding_Error:
+    pass
+
++ Optional lookahead distinguishes absence from malformed presence
+
+= An outer major-type mismatch means that an optional semantic tag is absent
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
 from scapy.cborpacket import CBOR_Packet
 
-class PktUInt(CBOR_Packet):
-    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 42)
+class OptionalTaggedThenFallback(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", None),
+            )
+        ),
+        CBORF_ANY("fallback", None),
+    )
 
-pkt = PktUInt()
-assert pkt.value.val == 42
-raw_data = bytes(pkt)
-pkt2 = PktUInt(raw_data)
-assert pkt2.value.val == 42
+pkt = OptionalTaggedThenFallback(b"\x81\x07")
+from scapy.cbor.cborfields import CBOR_ABSENT
+assert pkt.tag_number is CBOR_ABSENT
+assert pkt.tagged_value is None or pkt.tagged_value is CBOR_ABSENT
+assert pkt.fallback == 7
 
-= CBORF_UNSIGNED_INTEGER zero value
-from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
+= A matching optional semantic tag with the wrong inner type is malformed
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import (
+    CBORF_SEQUENCE,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
 from scapy.cborpacket import CBOR_Packet
 
-class PktUIntZero(CBOR_Packet):
+class OptionalTaggedUnsigned(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", None),
+            )
+        )
+    )
+
+pkt = OptionalTaggedUnsigned()
+try:
+    OptionalTaggedUnsigned.CBOR_root.dissect_result(
+        pkt,
+        b"\xc1\x61x",
+    )
+    assert False, "A present tag with malformed content was treated as absent"
+except CBOR_Decoding_Error:
+    pass
+
+= A matching optional semantic tag with truncated content is malformed
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import (
+    CBORF_SEQUENCE,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalTruncatedTaggedUnsigned(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", None),
+            )
+        )
+    )
+
+pkt = OptionalTruncatedTaggedUnsigned()
+try:
+    OptionalTruncatedTaggedUnsigned.CBOR_root.dissect_result(pkt, b"\xc1")
+    assert False, "A truncated present tag was treated as an absent field"
+except CBOR_Decoding_Error:
+    pass
+
+= Zero-budget optional stays absent so a trailing CBORF_ANY can consume the item
+# Finding 2: when the optional has available==0 because a required trailing
+# field reserved the only item, mark the optional absent if the item does not
+# match the optional type. A *matching* but malformed optional must still
+# raise (see "Malformed optional semantic tag does not migrate...").
+from scapy.cbor.cborfields import (
+    CBOR_ABSENT,
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalTaggedBeforeAny(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", None),
+            )
+        ),
+        CBORF_ANY("fallback", None),
+    )
+
+# Tag 2 does not match optional tag 1 → absent; ANY consumes the item.
+pkt = OptionalTaggedBeforeAny(b"\x81\xc2\x01")
+assert pkt.getfieldval("tag_number") is CBOR_ABSENT
+assert pkt.getfieldval("fallback") is not None
+assert pkt.getfieldval("fallback") is not CBOR_ABSENT
+
++ Optional CBOR null presence
+
+= Optional CBORF_ANY preserves a present null after another field is mutated
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalAnyWithTail(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_ANY("value", None)),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = OptionalAnyWithTail(b"\x82\xf6\x01")
+assert pkt.value is None
+assert pkt.tail == 1
+
+# Mutating another field invalidates Scapy's raw-packet cache. The rebuilt
+# packet must still contain the explicitly present CBOR null item.
+pkt.tail = 2
+assert bytes(pkt) == b"\x82\xf6\x02"
+
++ Nested CBOR packet dissection lifecycle
+
+= CBORF_PACKET runs child dissection hooks and retains the exact child bytes
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_PACKET,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class LifecycleDirectChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(CBORF_UNSIGNED_INTEGER("value", 0))
+    events = []
+    def pre_dissect(self, data):
+        type(self).events.append("pre")
+        return data
+    def do_dissect(self, data):
+        type(self).events.append("do")
+        return super().do_dissect(data)
+    def post_dissect(self, data):
+        type(self).events.append("post")
+        return data
+
+class LifecycleDirectParent(CBOR_Packet):
+    CBOR_root = CBORF_PACKET("child", None, LifecycleDirectChild)
+
+LifecycleDirectChild.events[:] = []
+pkt = LifecycleDirectParent(b"\x81\x01\xff")
+child = pkt.child
+assert LifecycleDirectChild.events == ["pre", "do", "post"]
+assert child.original == b"\x81\x01"
+assert child.raw_packet_cache == b"\x81\x01"
+
+= Packet-valued CBORF_ARRAY_OF runs child hooks and retains each item span
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_ARRAY_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class LifecycleArrayChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(CBORF_UNSIGNED_INTEGER("value", 0))
+    events = []
+    def pre_dissect(self, data):
+        type(self).events.append("pre")
+        return data
+    def do_dissect(self, data):
+        type(self).events.append("do")
+        return super().do_dissect(data)
+    def post_dissect(self, data):
+        type(self).events.append("post")
+        return data
+
+class LifecycleArrayParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("items", [], LifecycleArrayChild)
+
+LifecycleArrayChild.events[:] = []
+pkt = LifecycleArrayParent(b"\x81\x81\x01")
+child = pkt.items[0]
+assert LifecycleArrayChild.events == ["pre", "do", "post"]
+assert child.original == b"\x81\x01"
+assert child.raw_packet_cache == b"\x81\x01"
+
+= Packet-valued CBORF_SEQUENCE_OF runs child hooks and retains each item span
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class LifecycleSequenceChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(CBORF_UNSIGNED_INTEGER("value", 0))
+    events = []
+    def pre_dissect(self, data):
+        type(self).events.append("pre")
+        return data
+    def do_dissect(self, data):
+        type(self).events.append("do")
+        return super().do_dissect(data)
+    def post_dissect(self, data):
+        type(self).events.append("post")
+        return data
+
+class LifecycleSequenceParent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF("items", [], LifecycleSequenceChild)
+
+LifecycleSequenceChild.events[:] = []
+pkt = LifecycleSequenceParent(b"\x81\x01")
+child = pkt.items[0]
+assert LifecycleSequenceChild.events == ["pre", "do", "post"]
+assert child.original == b"\x81\x01"
+assert child.raw_packet_cache == b"\x81\x01"
+
+= Nested field edits invalidate parent raw_packet_cache on rebuild
+from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_PACKET
+from scapy.cborpacket import CBOR_Packet
+
+class CacheChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(CBORF_INTEGER("val", 0))
+
+class CacheParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(CBORF_PACKET("child", None, CacheChild))
+
+raw = bytes(CacheParent(child=CacheChild(val=7)))
+pkt = CacheParent(raw)
+assert pkt.raw_packet_cache is not None
+assert pkt.child.val == 7
+pkt.child.val = 9
+assert pkt.child.raw_packet_cache is None
+rebuilt = bytes(pkt)
+assert rebuilt != raw
+assert CacheParent(rebuilt).child.val == 9
+
++ Fixed-map conditional field ordering
+
+= A fixed map decodes conditional members independently of wire key order
+from scapy.cbor.cborfields import (
+    CBORF_CONDITIONAL,
+    CBORF_MAP,
+    CBORF_TEXT_STRING,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class ConditionalMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("kind", 0),
+        CBORF_CONDITIONAL(
+            CBORF_TEXT_STRING("name", None),
+            lambda pkt: pkt.getfieldval("kind") == 1,
+        ),
+    )
+
+kind_first = b"\xa2\x64kind\x01\x64name\x61x"
+name_first = b"\xa2\x64name\x61x\x64kind\x01"
+
+first = ConditionalMap(kind_first)
+second = ConditionalMap(name_first)
+assert first.kind == second.kind == 1
+assert first.getfieldval("name") == second.getfieldval("name") == "x"
+
++ Generic CBOR map key identity
+
+= Generic CBOR maps preserve integer 1 and boolean true as distinct keys
+from scapy.cbor import CBOR_Codecs
+
+wire = b"\xa2\x01\x61a\xf5\x61b"
+obj, remaining = CBOR_Codecs.CBOR.dec(wire)
+assert remaining == b""
+assert obj.enc() == wire
+
+= Generic CBOR maps round-trip a map-valued key
+from scapy.cbor import CBOR_Codecs
+
+wire = b"\xa1\xa1\x01\x02\x03"
+obj, remaining = CBOR_Codecs.CBOR.dec(wire)
+assert remaining == b""
+assert obj.enc() == wire
+
+= Generic CBOR maps still reject duplicate data-item keys
+from scapy.cbor import CBOR_Codecs
+from scapy.cbor.cborcodec import CBOR_Codec_Decoding_Error
+
+try:
+    CBOR_Codecs.CBOR.dec(b"\xa2\x01\x00\x01\x01")
+    assert False, "A generic map accepted a duplicate integer key"
+except CBOR_Codec_Decoding_Error:
+    pass
+
++ CBORF_ANY map identity and mutability
+
+= Empty CBORF_ANY map survives sibling mutation as a map
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_UNSIGNED_INTEGER, CBOR_ABSENT
+from scapy.cbor.cbor import CBORMapData
+from scapy.cborpacket import CBOR_Packet
+
+class AnyMapPkt(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("a", None),
+        CBORF_UNSIGNED_INTEGER("b", 0),
+    )
+
+pkt = AnyMapPkt(b"\x82\xa0\x00")
+assert isinstance(pkt.a, CBORMapData)
+assert len(pkt.a) == 0
+pkt.b = 1
+assert bytes(pkt) == b"\x82\xa0\x01"
+
+= Non-empty CBORF_ANY map survives sibling mutation
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_UNSIGNED_INTEGER
+from scapy.cbor.cbor import CBORMapData
+from scapy.cborpacket import CBOR_Packet
+
+class AnyMapPkt2(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("a", None),
+        CBORF_UNSIGNED_INTEGER("b", 0),
+    )
+
+pkt = AnyMapPkt2(b"\x82\xa1\x01\x02\x00")
+assert isinstance(pkt.a, CBORMapData)
+assert pkt.a[1] == 2
+pkt.b = 1
+assert bytes(pkt) == b"\x82\xa1\x01\x02\x01"
+
+= In-place mutation of CBORF_ANY list invalidates raw cache
+from scapy.cbor.cborfields import CBORF_ANY
+from scapy.cborpacket import CBOR_Packet
+
+class AnyRoot(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", None)
+
+pkt = AnyRoot(b"\x82\x01\x02")
+assert pkt.raw_packet_cache == b"\x82\x01\x02"
+pkt.value.append(3)
+assert bytes(pkt) == b"\x83\x01\x02\x03"
+
+= Typed map lookup distinguishes integer 1 from boolean True
+from scapy.cbor import CBOR_Codecs
+from scapy.cbor.cbor import CBORMapData
+
+wire = b"\xa2\x01\x61a\xf5\x61b"
+obj, remaining = CBOR_Codecs.CBOR.dec(wire)
+assert remaining == b""
+assert isinstance(obj.val, CBORMapData)
+assert obj.val[1].val == "a"
+assert obj.val[True].val == "b"
+assert obj.val[1] is not obj.val[True]
+
+= CBORMapData equality with dict keeps True and 1 distinct
+from scapy.cbor.cbor import CBORMapData, CBOR_TRUE, CBOR_UNSIGNED_INTEGER
+
+m = CBORMapData([(CBOR_TRUE(), "a"), (CBOR_UNSIGNED_INTEGER(1), "b")])
+# Python dict cannot hold both True and 1; equality must not collapse them.
+assert m != {True: "b"}
+assert m != {1: "b"}
+assert m != {True: "a"}
+assert m == CBORMapData([(CBOR_TRUE(), "a"), (CBOR_UNSIGNED_INTEGER(1), "b")])
+assert len(dict(m.items())) == 1
+
++ optional major-type-7 lookahead and absence
+
+= Optional boolean leaves a required float for the next field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_FLOAT,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptBoolFloat(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_BOOLEAN("flag", None)),
+        CBORF_FLOAT("num", 0.0),
+    )
+
+pkt = OptBoolFloat(b"\x81\xf9\x3e\x00")  # [1.5] as float16
+assert pkt.flag is CBOR_ABSENT
+assert abs(pkt.num - 1.5) < 1e-6
+
+= Optional boolean leaves a required null for the next field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_NULL,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptBoolNull(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_BOOLEAN("flag", None)),
+        CBORF_NULL("nil"),
+    )
+
+pkt = OptBoolNull(b"\x81\xf6")
+assert pkt.flag is CBOR_ABSENT
+assert pkt.nil is None
+
+= Optional null leaves a required boolean for the next field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_NULL,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptNullBool(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_NULL("nil")),
+        CBORF_BOOLEAN("flag", False),
+    )
+
+pkt = OptNullBool(b"\x81\xf5")
+assert pkt.nil is CBOR_ABSENT
+assert pkt.flag is True
+
+= Optional undefined leaves a required float for the next field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_FLOAT,
+    CBORF_UNDEFINED,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptUndefFloat(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_UNDEFINED("u")),
+        CBORF_FLOAT("num", 0.0),
+    )
+
+pkt = OptUndefFloat(b"\x81\xf9\x3e\x00")
+assert pkt.u is CBOR_ABSENT
+assert abs(pkt.num - 1.5) < 1e-6
+
+= Optional float leaves a required boolean for the next field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_FLOAT,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptFloatBool(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_FLOAT("num", None)),
+        CBORF_BOOLEAN("flag", False),
+    )
+
+pkt = OptFloatBool(b"\x81\xf4")
+assert pkt.num is CBOR_ABSENT
+assert pkt.flag is False
+
+= Absent optional ANY stays absent after cache invalidation
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptAnyTail(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("n", 0),
+        CBORF_optional(CBORF_ANY("extra", None)),
+    )
+
+pkt = OptAnyTail(b"\x81\x00")
+assert pkt.extra is CBOR_ABSENT
+pkt.n = 1
+assert bytes(pkt) == b"\x81\x01"
+
+= Absent optional map members stay absent after rebuild
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_INTEGER,
+    CBORF_MAP,
+    CBORF_NULL,
+    CBORF_SEMANTIC_TAG,
+    CBORF_TEXT_STRING,
+    CBORF_UNDEFINED,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptMapPkt(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_INTEGER("n", 0),
+        CBORF_optional(CBORF_ANY("any", None)),
+        CBORF_optional(CBORF_NULL("nil")),
+        CBORF_optional(CBORF_UNDEFINED("u")),
+        CBORF_optional(CBORF_SEMANTIC_TAG("tag", None, 1, CBORF_INTEGER("ts", 0))),
+        CBORF_optional(CBORF_TEXT_STRING("endpoint", "default")),
+    )
+
+pkt = OptMapPkt(b"\xa1\x61n\x00")
+assert pkt.any is CBOR_ABSENT
+assert pkt.nil is CBOR_ABSENT
+assert pkt.u is CBOR_ABSENT
+assert pkt.tag is CBOR_ABSENT
+assert pkt.endpoint is CBOR_ABSENT
+pkt.n = 1
+assert bytes(pkt) == b"\xa1\x61n\x01"
+
++ array item reservation
+
+= Nonterminal SEQUENCE_OF reserves items for a later required field
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class SeqThenReq(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_SEQUENCE_OF("vals", [], CBORF_UNSIGNED_INTEGER),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = SeqThenReq(b"\x83\x01\x02\x03")
+assert pkt.vals == [1, 2]
+assert pkt.tail == 3
+
+= Optional same-type scalar reserves the sole item for a required tail
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptThenReq(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_UNSIGNED_INTEGER("opt", None)),
+        CBORF_UNSIGNED_INTEGER("req", 0),
+    )
+
+pkt = OptThenReq(b"\x81\x07")
+assert pkt.opt is CBOR_ABSENT
+assert pkt.req == 7
+
+= Indefinite array reserves SEQUENCE_OF items for a required tail
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY_INDEFINITE,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class IndefSeqThenReq(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_INDEFINITE(
+        CBORF_SEQUENCE_OF("vals", [], CBORF_UNSIGNED_INTEGER),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = IndefSeqThenReq(b"\x9f\x01\x02\x03\xff")
+assert pkt.vals == [1, 2]
+assert pkt.tail == 3
+
++ Shared helpers
+
+= Import follow-up test dependencies
+from scapy.cbor import CBOR_Codecs
+from scapy.cbor.cbor import (
+    CBOR_Decoding_Error,
+    CBOR_Encoding_Error,
+    CBORMapData,
+    CBOR_UNSIGNED_INTEGER,
+    CBOR_TEXT_STRING,
+    CBOR_FALSE,
+    CBOR_TRUE,
+    CBOR_FLOAT,
+    CBORTagValue,
+    CBORSimpleValue,
+)
+from scapy.cbor.cborcodec import (
+    CBOR_Codec_Decoding_Error,
+    CBORcodec_ARRAY,
+)
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_ARRAY_INDEFINITE,
+    CBORF_ARRAY_OF,
+    CBORF_BOOLEAN,
+    CBORF_CONDITIONAL,
+    CBORF_FLOAT,
+    CBORF_MAP,
+    CBORF_NULL,
+    CBORF_PACKET,
+    CBORF_SEMANTIC_TAG,
+    CBORF_SEQUENCE,
+    CBORF_SEQUENCE_OF,
+    CBORF_TEXT_STRING,
+    CBORF_UNDEFINED,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
+from scapy.cborpacket import CBOR_Packet
+
+_RR_FLOAT_1_5 = b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00"
+
+
++ Finding 1: CBORF_ANY must preserve map identity
+
+= A non-empty CBORF_ANY map remains a map after a sibling field changes
+class RRAnyNonEmptyMap(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\x82\xa1\x01\x02\x00"
+pkt = RRAnyNonEmptyMap(wire)
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xa1\x01\x02\x01"
+
+= An empty CBORF_ANY map never silently becomes an empty array
+class RRAnyEmptyMap(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = RRAnyEmptyMap(b"\x82\xa0\x00")
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xa0\x01"
+
+= A map nested in a CBORF_ANY array retains major type 5 on rebuild
+class RRAnyNestedMap(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\x82\x81\xa1\x01\x02\x00"
+pkt = RRAnyNestedMap(wire)
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\x81\xa1\x01\x02\x01"
+
+= A map nested in a semantic tag retains map identity on rebuild
+class RRAnyTaggedMap(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\x82\xd8\x2a\xa1\x01\x02\x00"
+pkt = RRAnyTaggedMap(wire)
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xd8\x2a\xa1\x01\x02\x01"
+
+= A CBORF_ANY map with a compound array key round-trips faithfully
+class RRAnyCompoundMapKey(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\x82\xa1\x81\x01\x02\x00"
+pkt = RRAnyCompoundMapKey(wire)
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xa1\x81\x01\x02\x01"
+
+= A CBORF_ANY map preserves integer 1 and Boolean true as distinct keys
+class RRAnyTypedMapKeys(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\x82\xa2\x01\x61i\xf5\x61b\x00"
+pkt = RRAnyTypedMapKeys(wire)
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xa2\x01\x61i\xf5\x61b\x01"
+
+
++ Finding 2: optional major-type-7 lookahead must be exact
+
+= Optional Boolean does not consume a following floating-point value
+class RROptionalBooleanThenFloat(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_FLOAT("value", None),
+    )
+
+pkt = RROptionalBooleanThenFloat(_RR_FLOAT_1_5)
+assert pkt.value == 1.5
+
+= Optional Boolean does not consume a following null
+class RROptionalBooleanThenNull(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_NULL("value"),
+    )
+
+pkt = RROptionalBooleanThenNull(b"\xf6")
+assert bytes(pkt) == b"\xf6"
+
+= Optional null does not consume a following Boolean
+class RROptionalNullThenBoolean(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_NULL("maybe")),
+        CBORF_BOOLEAN("value", None),
+    )
+
+pkt = RROptionalNullThenBoolean(b"\xf5")
+assert pkt.value is True
+
+= Optional undefined does not consume a following float
+class RROptionalUndefinedThenFloat(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_UNDEFINED("maybe")),
+        CBORF_FLOAT("value", None),
+    )
+
+pkt = RROptionalUndefinedThenFloat(_RR_FLOAT_1_5)
+assert pkt.value == 1.5
+
+= Optional float does not consume a following Boolean
+class RROptionalFloatThenBoolean(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_FLOAT("maybe", None)),
+        CBORF_BOOLEAN("value", None),
+    )
+
+pkt = RROptionalFloatThenBoolean(b"\xf4")
+assert pkt.value is False
+
+= Exact major-type-7 matches are still consumed by optional fields
+class RROptionalBooleanPresent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_UNSIGNED_INTEGER("tail", None),
+    )
+
+class RROptionalFloatPresent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_FLOAT("maybe", None)),
+        CBORF_UNSIGNED_INTEGER("tail", None),
+    )
+
+boolean_pkt = RROptionalBooleanPresent(b"\xf5\x07")
+assert boolean_pkt.maybe is True
+assert boolean_pkt.tail == 7
+
+float_pkt = RROptionalFloatPresent(_RR_FLOAT_1_5 + b"\x07")
+assert float_pkt.maybe == 1.5
+assert float_pkt.tail == 7
+
+= Optional Boolean lookahead recognizes half and single precision floats
+for wire in (b"\xf9\x3e\x00", b"\xfa\x3f\xc0\x00\x00"):
+    pkt = RROptionalBooleanThenFloat(wire)
+    assert pkt.value == 1.5
+
+= Optional Boolean leaves direct and extended simple values for CBORF_ANY
+class RROptionalBooleanThenAny(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_ANY("value", None),
+    )
+
+for wire, expected in ((b"\xf0", 16), (b"\xf8\x20", 32)):
+    pkt = RROptionalBooleanThenAny(wire)
+    assert isinstance(pkt.value, CBORSimpleValue)
+    assert pkt.value.value == expected
+
+= Optional null and undefined do not consume each other's wire values
+class RROptionalNullThenUndefined(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_NULL("maybe")),
+        CBORF_UNDEFINED("value"),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+class RROptionalUndefinedThenNull(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_UNDEFINED("maybe")),
+        CBORF_NULL("value"),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+undefined_pkt = RROptionalNullThenUndefined(b"\xf7\x00")
+undefined_pkt.tail = 1
+assert bytes(undefined_pkt) == b"\xf7\x01"
+
+null_pkt = RROptionalUndefinedThenNull(b"\xf6\x00")
+null_pkt.tail = 1
+assert bytes(null_pkt) == b"\xf6\x01"
+
+
++ Finding 3: optional absence must be represented on every decode path
+
+= Definite-array exhaustion marks a trailing optional CBORF_ANY absent
+class RRAbsentAnyDefinite(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(CBORF_ANY("value", None)),
+    )
+
+pkt = RRAbsentAnyDefinite(b"\x81\x00")
+pkt.head = 1
+assert bytes(pkt) == b"\x81\x01"
+
+= Indefinite-array break marks a trailing optional CBORF_ANY absent
+class RRAbsentAnyIndefinite(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_INDEFINITE(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(CBORF_ANY("value", None)),
+    )
+
+pkt = RRAbsentAnyIndefinite(b"\x9f\x00\xff")
+pkt.head = 1
+assert bytes(pkt) == b"\x9f\x01\xff"
+
+= A missing optional fixed-map member remains omitted after rebuild
+class RRAbsentAnyMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+        CBORF_optional(CBORF_ANY("b", None)),
+    )
+
+pkt = RRAbsentAnyMap(b"\xa1\x61a\x00")
+pkt.a = 1
+assert bytes(pkt) == b"\xa1\x61a\x01"
+
+= Optional null undefined and semantic-tag fields stay absent at array end
+class RRAbsentNull(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(CBORF_NULL("value")),
+    )
+
+class RRAbsentUndefined(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(CBORF_UNDEFINED("value")),
+    )
+
+class RRAbsentTag(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", 7),
+            )
+        ),
+    )
+
+for packet_cls in (RRAbsentNull, RRAbsentUndefined, RRAbsentTag):
+    pkt = packet_cls(b"\x81\x00")
+    pkt.head = 1
+    assert bytes(pkt) == b"\x81\x01", packet_cls.__name__
+
+= An absent optional scalar does not reappear from a non-None declared default
+class RRAbsentDefaultScalar(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(CBORF_UNSIGNED_INTEGER("value", 9)),
+    )
+
+pkt = RRAbsentDefaultScalar(b"\x81\x00")
+pkt.head = 1
+assert bytes(pkt) == b"\x81\x01"
+
+= An absent optional packet does not reappear from its packet default
+class RRAbsentPacketChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 9)
+
+class RRAbsentPacketParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("head", 0),
+        CBORF_optional(
+            CBORF_PACKET(
+                "child",
+                RRAbsentPacketChild(value=9),
+                RRAbsentPacketChild,
+            )
+        ),
+    )
+
+pkt = RRAbsentPacketParent(b"\x81\x00")
+pkt.head = 1
+assert bytes(pkt) == b"\x81\x01"
+
+= A missing optional fixed-map scalar does not reappear from its default
+class RRAbsentDefaultMapScalar(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+        CBORF_optional(CBORF_UNSIGNED_INTEGER("b", 9)),
+    )
+
+pkt = RRAbsentDefaultMapScalar(b"\xa1\x61a\x00")
+pkt.a = 1
+assert bytes(pkt) == b"\xa1\x61a\x01"
+
+= A present optional CBOR null remains present after cache invalidation
+class RRPresentOptionalNull(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_ANY("value", None)),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = RRPresentOptionalNull(b"\x82\xf6\x00")
+pkt.tail = 1
+assert bytes(pkt) == b"\x82\xf6\x01"
+
+
++ Finding 4: positional arrays must reserve items for later required fields
+
+= Definite arrays reserve the final item after a nonterminal SEQUENCE_OF
+class RRSequenceThenTail(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_SEQUENCE_OF(
+            "values",
+            [],
+            CBORF_UNSIGNED_INTEGER("item", None),
+        ),
+        CBORF_UNSIGNED_INTEGER("tail", None),
+    )
+
+pkt = RRSequenceThenTail(b"\x83\x01\x02\x03")
+assert pkt.values == [1, 2]
+assert pkt.tail == 3
+
+= Indefinite arrays reserve the final item after a nonterminal SEQUENCE_OF
+class RRIndefiniteSequenceThenTail(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_INDEFINITE(
+        CBORF_SEQUENCE_OF(
+            "values",
+            [],
+            CBORF_UNSIGNED_INTEGER("item", None),
+        ),
+        CBORF_UNSIGNED_INTEGER("tail", None),
+    )
+
+pkt = RRIndefiniteSequenceThenTail(b"\x9f\x01\x02\x03\xff")
+assert pkt.values == [1, 2]
+assert pkt.tail == 3
+
+= An optional scalar yields a sole item to a required scalar of the same type
+class RROptionalThenRequiredUnsigned(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_UNSIGNED_INTEGER("optional_value", None)),
+        CBORF_UNSIGNED_INTEGER("required_value", None),
+    )
+
+pkt = RROptionalThenRequiredUnsigned(b"\x81\x07")
+assert pkt.required_value == 7
+pkt.required_value = 8
+assert bytes(pkt) == b"\x81\x08"
+
+= An optional packet yields a sole item to a required packet
+class RRBudgetChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", None)
+
+class RROptionalThenRequiredPacket(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_PACKET("optional_child", None, RRBudgetChild)),
+        CBORF_PACKET("required_child", None, RRBudgetChild),
+    )
+
+pkt = RROptionalThenRequiredPacket(b"\x81\x07")
+assert pkt.required_child.value == 7
+
+= A SEQUENCE_OF reserves an item for a later required conditional field
+class RRSequenceThenConditionalTail(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("flag", 0),
+        CBORF_SEQUENCE_OF(
+            "values",
+            [],
+            CBORF_UNSIGNED_INTEGER("item", None),
+        ),
+        CBORF_CONDITIONAL(
+            CBORF_UNSIGNED_INTEGER("tail", None),
+            lambda pkt: pkt.getfieldval("flag") == 1,
+        ),
+    )
+
+pkt = RRSequenceThenConditionalTail(b"\x83\x01\x02\x03")
+assert pkt.flag == 1
+assert pkt.values == [2]
+assert pkt.tail == 3
+
+
++ Finding 5: recursive CBORF_ANY mutations must invalidate the raw cache
+
+= Appending to a decoded root CBORF_ANY array changes serialized bytes
+class RRMutableAnyRoot(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", None)
+
+pkt = RRMutableAnyRoot(b"\x82\x01\x02")
+pkt.value.append(3)
+assert bytes(pkt) == b"\x83\x01\x02\x03"
+
+= Mutating a nested CBORF_ANY array changes serialized bytes
+class RRMutableAnyNested(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = RRMutableAnyNested(b"\x82\x82\x01\x02\x00")
+pkt.value.append(3)
+assert bytes(pkt) == b"\x82\x83\x01\x02\x03\x00"
+
+= Mutating the list inside a decoded semantic tag changes serialized bytes
+pkt = RRMutableAnyRoot(b"\xd8\x2a\x82\x01\x02")
+assert isinstance(pkt.value, CBORTagValue)
+pkt.value.value.append(3)
+assert bytes(pkt) == b"\xd8\x2a\x83\x01\x02\x03"
+
+= Mutating a decoded semantic tag number changes serialized bytes
+pkt = RRMutableAnyRoot(b"\xd8\x2a\x01")
+assert isinstance(pkt.value, CBORTagValue)
+pkt.value.tag = 43
+assert bytes(pkt) == b"\xd8\x2b\x01"
+
+= Mutating a decoded extended simple value changes serialized bytes
+pkt = RRMutableAnyRoot(b"\xf8\x20")
+assert isinstance(pkt.value, CBORSimpleValue)
+pkt.value.value = 33
+assert bytes(pkt) == b"\xf8\x21"
+
+= Mutating an array value inside a decoded map changes serialized bytes
+pkt = RRMutableAnyRoot(b"\xa1\x61a\x81\x01")
+assert isinstance(pkt.value, CBORMapData)
+pkt.value["a"].append(2)
+assert bytes(pkt) == b"\xa1\x61a\x82\x01\x02"
+
+
++ Finding 7: generic map lookup must use typed CBOR key identity
+
+= Typed lookup distinguishes unsigned integer 1 from Boolean true
+obj, remaining = CBOR_Codecs.CBOR.dec(b"\xa2\x01\x61i\xf5\x61b")
+assert remaining == b""
+map_data = obj.val
+assert map_data[CBOR_UNSIGNED_INTEGER(1)].val == "i"
+assert map_data[CBOR_TRUE()].val == "b"
+
+= Typed lookup distinguishes unsigned integer 0 from Boolean false
+obj, remaining = CBOR_Codecs.CBOR.dec(b"\xa2\x00\x61i\xf4\x61b")
+assert remaining == b""
+map_data = obj.val
+assert map_data[CBOR_UNSIGNED_INTEGER(0)].val == "i"
+assert map_data[CBOR_FALSE()].val == "b"
+
+= Typed lookup distinguishes unsigned integer 1 from floating-point 1.0
+obj, remaining = CBOR_Codecs.CBOR.dec(
+    b"\xa2\x01\x61i\xfb\x3f\xf0\x00\x00\x00\x00\x00\x00\x61f"
+)
+assert remaining == b""
+map_data = obj.val
+assert map_data[CBOR_UNSIGNED_INTEGER(1)].val == "i"
+assert map_data[CBOR_FLOAT(1.0)].val == "f"
+
+
++ Finding 10: nested packet builds must traverse each child schema once
+
+= CBORF_PACKET builds a child root exactly once
+class RRCountingArray(CBORF_ARRAY):
+    calls = 0
+    def build_result(self, pkt):
+        type(self).calls += 1
+        return super().build_result(pkt)
+
+class RRCountedChild(CBOR_Packet):
+    CBOR_root = RRCountingArray(CBORF_UNSIGNED_INTEGER("value", 1))
+
+class RRCountedDirectParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_PACKET("child", None, RRCountedChild)
+    )
+
+RRCountingArray.calls = 0
+bytes(RRCountedDirectParent(child=RRCountedChild(value=1)))
+assert RRCountingArray.calls == 1
+
+= Packet-valued CBORF_ARRAY_OF builds each child root exactly once
+class RRCountedArrayParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("children", [], RRCountedChild)
+
+RRCountingArray.calls = 0
+bytes(RRCountedArrayParent(children=[RRCountedChild(value=1)]))
+assert RRCountingArray.calls == 1
+
+= Packet-valued CBORF_SEQUENCE_OF builds each child root exactly once
+class RRCountedSequenceParent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF("children", [], RRCountedChild)
+
+RRCountingArray.calls = 0
+bytes(RRCountedSequenceParent(children=[RRCountedChild(value=1)]))
+assert RRCountingArray.calls == 1
+
+
++ Finding 11: decoder internals must not repeatedly copy unread suffixes
+
+= Decoding a flat array has linear rather than quadratic suffix-copy volume
+class RRSliceCountingBytes(bytes):
+    copied = 0
+    slices = 0
+    def __getitem__(self, key):
+        result = super().__getitem__(key)
+        if isinstance(key, slice) and isinstance(result, bytes):
+            type(self).copied += len(result)
+            type(self).slices += 1
+            return type(self)(result)
+        return result
+
+wire = CBORcodec_ARRAY.enc([0] * 1024) + b"\x01"
+RRSliceCountingBytes.copied = 0
+RRSliceCountingBytes.slices = 0
+obj, remaining = CBOR_Codecs.CBOR.dec(RRSliceCountingBytes(wire))
+assert len(obj.val) == 1024
+assert remaining == b"\x01"
+assert RRSliceCountingBytes.copied <= len(wire) * 8, (
+    "decoder copied %d bytes while consuming %d bytes"
+    % (RRSliceCountingBytes.copied, len(wire))
+)
+
+
++ Additional blind spots: fixed maps, mutable defaults, and simple values
+
+= A fixed map skips an unknown nested indefinite value and decodes later keys
+class RRKnownMapMember(CBOR_Packet):
+    CBOR_root = CBORF_MAP(CBORF_UNSIGNED_INTEGER("a", None))
+
+wire = (
+    b"\xa2"
+    b"\x61x"
+    b"\x9f\x01\xbf\x61k\x02\xff\xff"
+    b"\x61a\x07"
+)
+pkt = RRKnownMapMember(wire)
+assert pkt.a == 7
+
+= A malformed unknown fixed-map value is not silently skipped
+try:
+    RRKnownMapMember(b"\xa1\x61x\x9f\x01")
+    assert False, "Malformed unknown map content was silently accepted"
+except (CBOR_Decoding_Error, CBOR_Codec_Decoding_Error):
+    pass
+
+= Duplicate fixed-map schema names are rejected at class construction
+try:
+    CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("duplicate", 0),
+        CBORF_TEXT_STRING("duplicate", ""),
+    )
+    assert False, "Duplicate fixed-map field names were accepted"
+except ValueError:
+    pass
+
+= Nested mutable CBORF_ANY defaults are isolated between packet instances
+class RRNestedMutableDefault(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", [[0]])
+
+a = RRNestedMutableDefault()
+b = RRNestedMutableDefault()
+a.value[0].append(1)
+assert b.value == [[0]]
+
+= Mutable semantic-tag defaults are isolated between packet instances
+class RRMutableTagDefault(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", CBORTagValue(1, []))
+
+a = RRMutableTagDefault()
+b = RRMutableTagDefault()
+a.value.value.append(1)
+assert b.value == CBORTagValue(1, [])
+
+= Semantically duplicate map keys are rejected despite different encodings
+try:
+    CBOR_Codecs.CBOR.dec(b"\xa2\x01\x00\x18\x01\x01")
+    assert False, "Equivalent unsigned-integer map keys were accepted twice"
+except CBOR_Codec_Decoding_Error:
+    pass
+
+= Two adjacent unbounded positional sequences are rejected as ambiguous
+try:
+    CBORF_ARRAY(
+        CBORF_SEQUENCE_OF(
+            "left",
+            [],
+            CBORF_UNSIGNED_INTEGER("left_item", None),
+        ),
+        CBORF_SEQUENCE_OF(
+            "right",
+            [],
+            CBORF_UNSIGNED_INTEGER("right_item", None),
+        ),
+    )
+    assert False, "An inherently ambiguous array schema was accepted"
+except ValueError:
+    pass
+
+= A false conditional with a non-None default stays absent after rebuild
+class RRConditionalDefaultAbsent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("flag", 0),
+        CBORF_CONDITIONAL(
+            CBORF_UNSIGNED_INTEGER("conditional_value", 9),
+            lambda pkt: pkt.getfieldval("flag") == 1,
+        ),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+pkt = RRConditionalDefaultAbsent(b"\x82\x00\x07")
+pkt.tail = 8
+assert bytes(pkt) == b"\x82\x00\x08"
+
+= A false conditional fixed-map member stays absent after rebuild
+class RRConditionalDefaultMapAbsent(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("flag", 0),
+        CBORF_CONDITIONAL(
+            CBORF_UNSIGNED_INTEGER("conditional_value", 9),
+            lambda pkt: pkt.getfieldval("flag") == 1,
+        ),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+wire = b"\xa2\x64flag\x00\x64tail\x07"
+pkt = RRConditionalDefaultMapAbsent(wire)
+pkt.tail = 8
+assert bytes(pkt) == b"\xa2\x64flag\x00\x64tail\x08"
+
+= Mutable CBORMapData defaults are isolated between packet instances
+class RRMutableMapDefault(CBOR_Packet):
+    CBOR_root = CBORF_ANY(
+        "value",
+        CBORMapData([(CBOR_TEXT_STRING("a"), [])]),
+    )
+
+a = RRMutableMapDefault()
+b = RRMutableMapDefault()
+a.value["a"].append(1)
+assert b.value["a"] == []
+
+= Direct and extended simple values round-trip through CBORF_ANY
+for wire in (b"\xf0", b"\xf8\x20", b"\xf8\xff"):
+    pkt = RRMutableAnyRoot(wire)
+    assert bytes(pkt) == wire
+
++ Finding 1 - CBOR sentinel identity survives Scapy copying
+
+= CBOR_ABSENT and CBOR_UNDEFINED_VALUE survive Packet.copy and deepcopy
+import copy
+from scapy.cbor import CBOR_UNDEFINED_VALUE
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_optional, CBOR_ABSENT
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalAnyCopy(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_ANY("value", CBOR_ABSENT)),
+    )
+
+class UndefinedAnyCopy(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", CBOR_UNDEFINED_VALUE)
+
+absent = OptionalAnyCopy(b"\x80")
+assert absent.getfieldval("value") is CBOR_ABSENT
+assert absent.copy().getfieldval("value") is CBOR_ABSENT
+assert copy.deepcopy(absent).getfieldval("value") is CBOR_ABSENT
+assert bytes(absent.copy()) == b"\x80"
+
+undefined = UndefinedAnyCopy(b"\xf7")
+assert undefined.getfieldval("value") is CBOR_UNDEFINED_VALUE
+assert undefined.copy().getfieldval("value") is CBOR_UNDEFINED_VALUE
+assert copy.deepcopy(undefined).getfieldval("value") is CBOR_UNDEFINED_VALUE
+assert bytes(undefined.copy()) == b"\xf7"
+
+= CBOR structural sentinels preserve singleton identity under copy operations
+import copy
+from scapy.cbor import CBOR_NO_ITEM, CBOR_UNDEFINED_VALUE
+from scapy.cbor.cborfields import CBOR_ABSENT
+
+for sentinel in (CBOR_ABSENT, CBOR_UNDEFINED_VALUE, CBOR_NO_ITEM):
+    assert copy.copy(sentinel) is sentinel
+    assert copy.deepcopy(sentinel) is sentinel
+
+= Fresh optional ANY default is absent before any dissection occurs
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_optional, CBOR_ABSENT
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalAnyFreshDefault(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_ANY("value", CBOR_ABSENT)),
+    )
+
+fresh = OptionalAnyFreshDefault()
+assert fresh.getfieldval("value") is CBOR_ABSENT
+assert bytes(fresh) == b"\x80"
+assert fresh.copy().getfieldval("value") is CBOR_ABSENT
+assert bytes(fresh.copy()) == b"\x80"
+
+= Undefined values nested in a generic map survive packet copies
+from scapy.cbor import CBOR_UNDEFINED_VALUE
+from scapy.cbor.cborfields import CBORF_ANY
+from scapy.cborpacket import CBOR_Packet
+
+class AnyUndefinedMap(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", None)
+
+wire = b"\xa1\x61u\xf7"
+pkt = AnyUndefinedMap(wire)
+assert pkt.value["u"] is CBOR_UNDEFINED_VALUE
+clone = pkt.copy()
+assert clone.value["u"] is CBOR_UNDEFINED_VALUE
+assert bytes(clone) == wire
+
++ Finding 2 - Positional reservation must protect trailing required fields
+
+= Zero-budget optional does not consume an item reserved for trailing CBORF_ANY
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_SEQUENCE,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalBoolThenAnyArray(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_ANY("required", CBOR_ABSENT),
+    )
+
+class OptionalBoolThenAnySequence(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_ANY("required", CBOR_ABSENT),
+    )
+
+# One item is available and the required trailing field needs exactly one item.
+# Therefore the optional Boolean must be absent even though the item is Boolean.
+arr = OptionalBoolThenAnyArray(b"\x81\xf5")
+assert arr.getfieldval("maybe") is CBOR_ABSENT
+assert arr.required is True
+assert bytes(arr) == b"\x81\xf5"
+
+seq = OptionalBoolThenAnySequence(b"\xf5")
+assert seq.getfieldval("maybe") is CBOR_ABSENT
+assert seq.required is True
+assert bytes(seq) == b"\xf5"
+
+= Indefinite arrays reserve the final item for a required ANY field
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY_INDEFINITE,
+    CBORF_BOOLEAN,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalBoolThenAnyIndefinite(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_INDEFINITE(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_ANY("required", CBOR_ABSENT),
+    )
+
+pkt = OptionalBoolThenAnyIndefinite(b"\x9f\xf5\xff")
+assert pkt.getfieldval("maybe") is CBOR_ABSENT
+assert pkt.required is True
+assert bytes(pkt) == b"\x9f\xf5\xff"
+
+= Optional ANY does not consume an item required by a trailing typed field
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_SEQUENCE,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalAnyThenBoolArray(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_ANY("maybe", CBOR_ABSENT)),
+        CBORF_BOOLEAN("required", None),
+    )
+
+class OptionalAnyThenBoolSequence(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_optional(CBORF_ANY("maybe", CBOR_ABSENT)),
+        CBORF_BOOLEAN("required", None),
+    )
+
+arr = OptionalAnyThenBoolArray(b"\x81\xf5")
+assert arr.getfieldval("maybe") is CBOR_ABSENT
+assert arr.required is True
+
+seq = OptionalAnyThenBoolSequence(b"\xf5")
+assert seq.getfieldval("maybe") is CBOR_ABSENT
+assert seq.required is True
+
+= Optional packet does not consume an item reserved for a trailing required ANY
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_PACKET,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class BooleanChild(CBOR_Packet):
+    CBOR_root = CBORF_BOOLEAN("value", None)
+
+class OptionalPacketThenAny(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_PACKET("child", None, BooleanChild)),
+        CBORF_ANY("required", CBOR_ABSENT),
+    )
+
+pkt = OptionalPacketThenAny(b"\x81\xf5")
+assert pkt.getfieldval("child") is CBOR_ABSENT
+assert pkt.required is True
+
+= Nonterminal SEQUENCE_OF stops at a typed delimiter in an unframed sequence
+from scapy.cbor.cborfields import (
+    CBORF_SEQUENCE,
+    CBORF_SEQUENCE_OF,
+    CBORF_TEXT_STRING,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class IntSequenceThenText(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_SEQUENCE_OF("items", [], CBORF_UNSIGNED_INTEGER),
+        CBORF_TEXT_STRING("tail", ""),
+    )
+
+pkt = IntSequenceThenText(b"\x01\x02\x61x")
+assert pkt.items == [1, 2]
+assert pkt.tail == "x"
+assert bytes(pkt) == b"\x01\x02\x61x"
+
+= Ambiguous unbounded array schema is rejected even with an optional field between sequences
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+)
+
+try:
+    CBORF_ARRAY(
+        CBORF_SEQUENCE_OF("left", [], CBORF_UNSIGNED_INTEGER),
+        CBORF_optional(CBORF_BOOLEAN("middle", None)),
+        CBORF_SEQUENCE_OF("right", [], CBORF_UNSIGNED_INTEGER),
+    )
+except ValueError:
+    pass
+else:
+    raise AssertionError("ambiguous separated unbounded sequences were accepted")
+
++ Finding 8 - Nested cbor_build_result must preserve a valid child raw cache
+
+= Parent rebuild preserves untouched child wire representation
+from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_PACKET, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class OverlongUintChild(CBOR_Packet):
     CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
 
-pkt = PktUIntZero()
-raw_data = bytes(pkt)
-assert raw_data == b'\x00'
-pkt2 = PktUIntZero(raw_data)
-assert pkt2.value.val == 0
+class ParentWithRawCachedChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+        CBORF_PACKET("child", None, OverlongUintChild),
+    )
 
-= CBORF_UNSIGNED_INTEGER large value roundtrip
+# 0x18 0x01 is a valid but non-preferred encoding of integer 1.
+wire = b"\x82\x00\x18\x01"
+pkt = ParentWithRawCachedChild(wire)
+assert bytes(pkt.child) == b"\x18\x01"
+
+# Rebuilding the parent after changing only a sibling must not normalize the
+# untouched nested child from 0x18 0x01 to 0x01.
+pkt.sibling = 1
+assert bytes(pkt) == b"\x82\x01\x18\x01"
+assert pkt.child.cbor_build_result().data == bytes(pkt.child)
+
+= Parent rebuild preserves an untouched child encoded as an indefinite array
+from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_PACKET, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class IndefiniteArrayChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("value", 0),
+    )
+
+class ParentWithIndefiniteChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+        CBORF_PACKET("child", None, IndefiniteArrayChild),
+    )
+
+wire = b"\x82\x00\x9f\x01\xff"
+pkt = ParentWithIndefiniteChild(wire)
+assert bytes(pkt.child) == b"\x9f\x01\xff"
+pkt.sibling = 1
+assert bytes(pkt) == b"\x82\x01\x9f\x01\xff"
+
+= SEQUENCE_OF preserves raw representations of untouched packet children
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_SEQUENCE_OF,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class SequenceArrayChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("value", 0),
+    )
+
+class ParentWithChildSequence(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+        CBORF_SEQUENCE_OF("children", [], SequenceArrayChild),
+    )
+
+wire = b"\x83\x00\x9f\x01\xff\x81\x02"
+pkt = ParentWithChildSequence(wire)
+assert bytes(pkt.children[0]) == b"\x9f\x01\xff"
+assert bytes(pkt.children[1]) == b"\x81\x02"
+pkt.sibling = 1
+assert bytes(pkt) == b"\x83\x01\x9f\x01\xff\x81\x02"
+
+= Mutating a nested child invalidates the parent cache and rebuilds the child
+from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_PACKET, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class MutableUintChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+class ParentWithMutableChild(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+        CBORF_PACKET("child", None, MutableUintChild),
+    )
+
+pkt = ParentWithMutableChild(b"\x82\x00\x18\x01")
+pkt.child.value = 2
+assert bytes(pkt) == b"\x82\x00\x02"
+
++ Additional CBOR API blind spots
+
+= Optional semantic tag honors an absent default instead of forcing tag presence
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalSemanticTagDefault(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag",
+                CBOR_ABSENT,
+                1,
+                CBORF_UNSIGNED_INTEGER("value", 0),
+            )
+        )
+    )
+
+pkt = OptionalSemanticTagDefault()
+assert pkt.getfieldval("tag") is CBOR_ABSENT
+assert bytes(pkt) == b"\x80"
+
+= Fixed-schema maps reject duplicate known keys instead of silently taking the last value
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cborpacket import CBOR_Packet
+
+class OneKeyMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("x", 0),
+    )
+
+try:
+    OneKeyMap(b"\xa2\x61x\x01\x61x\x02")
+except CBOR_Decoding_Error:
+    pass
+else:
+    raise AssertionError("duplicate fixed-map key was silently accepted")
+
++ Finding 10 - Indefinite arrays should scale linearly without repeated suffix pre-decodes
+
+= Indefinite array span work remains linear in the input size
+import scapy.cbor.cborfields as cborfields
+from scapy.cbor.cborfields import CBORF_ARRAY_INDEFINITE, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+many_fields = [CBORF_UNSIGNED_INTEGER("v%d" % i, 0) for i in range(64)]
+
+class IndefiniteManyInts(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_INDEFINITE(*many_fields)
+
+orig_span = cborfields.cbor_item_span
+span_input_sizes = []
+
+def counted_span(data):
+    span_input_sizes.append(len(data))
+    return orig_span(data)
+
+wire = b"\x9f" + (b"\x00" * 64) + b"\xff"
+cborfields.cbor_item_span = counted_span
+try:
+    pkt = IndefiniteManyInts(wire)
+    assert pkt.v0 == 0
+    assert pkt.v63 == 0
+finally:
+    cborfields.cbor_item_span = orig_span
+
+# Repeatedly handing cbor_item_span() the complete shrinking suffix is
+# quadratic. Exact-item spans or a shared cursor keep aggregate scanned input
+# proportional to the original wire size. The 4x allowance avoids constraining
+# the exact implementation while still rejecting an O(n^2) pre-scan.
+assert sum(span_input_sizes) <= len(wire) * 4, span_input_sizes
+
++ Additional regressions for recently fixed generic-CBOR behavior
+
+= Optional major-type-7 fields discriminate Boolean, null, undefined, and float exactly
+from scapy.cbor.cborfields import (
+    CBORF_ARRAY,
+    CBORF_BOOLEAN,
+    CBORF_FLOAT,
+    CBORF_NULL,
+    CBORF_UNDEFINED,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalBoolThenFloat(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_BOOLEAN("maybe", None)),
+        CBORF_FLOAT("required", 0.0),
+    )
+
+class OptionalNullThenBool(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_NULL("maybe")),
+        CBORF_BOOLEAN("required", None),
+    )
+
+class OptionalUndefinedThenBool(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(CBORF_UNDEFINED("maybe")),
+        CBORF_BOOLEAN("required", None),
+    )
+
+# Half-precision 1.5 is a float, not a Boolean even though both are major type 7.
+pkt = OptionalBoolThenFloat(b"\x81\xf9\x3e\x00")
+assert pkt.getfieldval("maybe") is CBOR_ABSENT
+assert pkt.required == 1.5
+
+pkt = OptionalNullThenBool(b"\x81\xf5")
+assert pkt.getfieldval("maybe") is CBOR_ABSENT
+assert pkt.required is True
+
+pkt = OptionalUndefinedThenBool(b"\x81\xf4")
+assert pkt.getfieldval("maybe") is CBOR_ABSENT
+assert pkt.required is False
+
+= Generic ANY preserves CBOR map identity when an unrelated sibling is changed
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class AnyMapWithSibling(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+    )
+
+wire = b"\x82\xa1\x01\x02\x00"
+pkt = AnyMapWithSibling(wire)
+assert pkt.value[1] == 2
+pkt.sibling = 1
+assert bytes(pkt) == b"\x82\xa1\x01\x02\x01"
+
+= In-place mutation of a generic ANY array invalidates the packet raw cache
+from scapy.cbor.cborfields import CBORF_ANY, CBORF_ARRAY, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class AnyArrayWithSibling(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", None),
+        CBORF_UNSIGNED_INTEGER("sibling", 0),
+    )
+
+pkt = AnyArrayWithSibling(b"\x82\x82\x01\x02\x00")
+pkt.value.append(3)
+assert bytes(pkt) == b"\x82\x83\x01\x02\x03\x00"
+
+= Generic map lookup keeps integer 1 and Boolean true as distinct CBOR keys
+from scapy.cbor.cborfields import CBORF_ANY
+from scapy.cborpacket import CBOR_Packet
+
+class TypedKeyMap(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", None)
+
+pkt = TypedKeyMap(b"\xa2\x01\x61i\xf5\x61b")
+assert pkt.value[1] == "i"
+assert pkt.value[True] == "b"
+assert len(pkt.value.cbor_pairs()) == 2
+assert bytes(pkt) == b"\xa2\x01\x61i\xf5\x61b"
+
++ Deterministic CBOR and float edge cases
+
++ Deterministic CBOR: large binary64 and indefinite map key order
+
+= Large binary64 values do not crash the deterministic scanner
+import struct
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+
+# RFC 8949 Appendix A example: 1.0e+300 as binary64
+wire = bytes.fromhex("fb7e37e43c8800759c")
+assert cbor_find_non_deterministic(wire) == []
+
+wire = struct.pack(">B", 0xfb) + struct.pack(">d", -1e300)
+assert cbor_find_non_deterministic(wire) == []
+
+= Indefinite maps require bytewise lexicographic key order
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+
+assert not cbor_find_non_deterministic(bytes.fromhex("bf616101616202ff"))
+assert cbor_find_non_deterministic(bytes.fromhex("bf616201616102ff"))
+
+= NaN preferred width uses the original payload bit pattern
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+
+# binary64 NaN with a low payload bit cannot shorten to binary16/32
+assert cbor_find_non_deterministic(bytes.fromhex("fb7ff8000000000001")) == []
+
+# binary64 quiet NaN with only top significand bits set prefers binary16
+assert cbor_find_non_deterministic(bytes.fromhex("fb7ffc000000000000"))
+
+
++ Cache item counts and packet-field cardinality
+
++ Cached unframed packets preserve exact bytes and item counts
+
+= Unframed SEQUENCE cache returns exact bytes without rebuild
+from scapy.cbor.cborfields import (
+    CBORF_PACKET,
+    CBORF_SEQUENCE,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cbor.cbor import CBOR_Encoding_Error
+from scapy.cborpacket import CBOR_Packet
+
+class SeqChild(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+        CBORF_UNSIGNED_INTEGER("b", 0),
+    )
+
+# Overlong encoding of 1, then 2: two top-level items
+overlong = b"\x18\x01\x02"
+child = SeqChild(overlong)
+assert child.raw_packet_cache == overlong
+assert child._cbor_raw_cache_items == 2
+result = child.cbor_build_result()
+assert result.data == overlong
+assert result.items == 2
+assert result.data == bytes(child)
+
+# CBORF_PACKET represents exactly one CBOR item: embedding a multi-item
+# SEQUENCE child must fail (do not put this child in a CBORF_PACKET parent
+# and expect serialization to succeed).
+fld = CBORF_PACKET("x", None, cls=SeqChild)
+try:
+    fld.build_value(None, child)
+    assert False, "multi-item child must be rejected by CBORF_PACKET"
+except CBOR_Encoding_Error:
+    pass
+
+= CBORF_PACKET build_value enforces one-item cardinality like build_result
+from scapy.cbor.cborfields import (
+    CBORF_PACKET,
+    CBORF_SEQUENCE,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cbor.cbor import CBOR_Encoding_Error
+from scapy.cborpacket import CBOR_Packet
+
+class TwoItemChild(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_UNSIGNED_INTEGER("a", 1),
+        CBORF_UNSIGNED_INTEGER("b", 2),
+    )
+
+class OneItemChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("a", 1)
+
+fld = CBORF_PACKET("x", None, cls=OneItemChild)
+ok = fld.build_value(None, OneItemChild(a=7))
+assert ok.items == 1
+
+fld2 = CBORF_PACKET("x", None, cls=TwoItemChild)
+try:
+    fld2.build_value(None, TwoItemChild())
+    assert False, "multi-item child must be rejected by build_value"
+except CBOR_Encoding_Error:
+    pass
+
+= CBORF_PACKET rejects non-CBOR Packet/bytes that are not exactly one item
+from scapy.cbor.cborfields import CBORF_PACKET
+from scapy.cbor.cbor import CBOR_Encoding_Error
+from scapy.cborpacket import CBOR_Packet
+from scapy.packet import Raw
+
+fld = CBORF_PACKET("x", None, cls=CBOR_Packet)
+
+# Two valid CBOR integers must not be reported as one item
+try:
+    fld.build_value(None, Raw(b"\x01\x02"))
+    assert False, "two CBOR items must be rejected"
+except CBOR_Encoding_Error:
+    pass
+
+# Illegal standalone break
+try:
+    fld.build_value(None, Raw(b"\xff"))
+    assert False, "bare break must be rejected"
+except CBOR_Encoding_Error:
+    pass
+
+# Truncated CBOR
+try:
+    fld.build_value(None, Raw(b"\x18"))
+    assert False, "truncated CBOR must be rejected"
+except CBOR_Encoding_Error:
+    pass
+
+# Exactly one valid item is accepted via the Raw fallback
+ok = fld.build_value(None, Raw(b"\x01"))
+assert ok.items == 1
+assert ok.data == b"\x01"
+
+
++ Scapy-native packet ownership
+
+= CBORF_PACKET construction uses parent ownership, not protocol underlayer
+from scapy.cbor.cborfields import CBORF_PACKET, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
+
+class OwnedChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+class DirectParent(CBOR_Packet):
+    CBOR_root = CBORF_PACKET("child", None, OwnedChild)
+
+child = OwnedChild(value=1)
+parent = DirectParent(child=child)
+assert parent.child is child
+assert child.parent is parent
+assert child.underlayer is None
+
+= CBORF_PACKET assignment preserves an existing protocol underlayer
+from scapy.packet import Raw
+
+child = OwnedChild(value=1)
+real_underlayer = Raw(load=b"lower")
+child.add_underlayer(real_underlayer)
+parent = DirectParent(child=child)
+assert child.parent is parent
+assert child.underlayer is real_underlayer
+
+= CBORF_PACKET dissection uses parent ownership, not protocol underlayer
+parent = DirectParent(b"\x01")
+assert isinstance(parent.child, OwnedChild)
+assert parent.child.parent is parent
+assert parent.child.underlayer is None
+assert bytes(parent) == b"\x01"
+
+= CBORF_BYTE_STRING_PACKET uses parent ownership on construction and dissection
+from scapy.cbor.cborfields import CBORF_BYTE_STRING_PACKET
+from scapy.packet import Raw
+
+class ByteStringParent(CBOR_Packet):
+    CBOR_root = CBORF_BYTE_STRING_PACKET("child", None, pkt_cls=Raw)
+
+child = Raw(load=b"x")
+parent = ByteStringParent(child=child)
+assert parent.child is child
+assert child.parent is parent
+assert child.underlayer is None
+assert bytes(parent) == b"\x41x"
+
+parsed = ByteStringParent(b"\x41x")
+assert isinstance(parsed.child, Raw)
+assert parsed.child.load == b"x"
+assert parsed.child.parent is parsed
+assert parsed.child.underlayer is None
+
++ packet-valued collection ownership
+
+= CBORF_ARRAY_OF construction attaches every packet child to parent
+from scapy.cbor.cborfields import CBORF_ARRAY_OF
+
+class ArrayParent(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("children", [], OwnedChild)
+
+children = [OwnedChild(value=1), OwnedChild(value=2)]
+parent = ArrayParent(children=children)
+assert parent.children == children
+for child in parent.children:
+    assert child.parent is parent
+    assert child.underlayer is None
+
+assert bytes(parent) == b"\x82\x01\x02"
+
+= CBORF_ARRAY_OF dissection attaches every packet child to parent
+parent = ArrayParent(b"\x82\x01\x02")
+assert [child.value for child in parent.children] == [1, 2]
+for child in parent.children:
+    assert child.parent is parent
+    assert child.underlayer is None
+
+assert bytes(parent) == b"\x82\x01\x02"
+
+= CBORF_SEQUENCE_OF construction attaches every packet child to parent
+from scapy.cbor.cborfields import CBORF_SEQUENCE_OF
+
+class SequenceParent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF("children", [], OwnedChild)
+
+children = [OwnedChild(value=1), OwnedChild(value=2)]
+parent = SequenceParent(children=children)
+assert parent.children == children
+for child in parent.children:
+    assert child.parent is parent
+    assert child.underlayer is None
+
+assert bytes(parent) == b"\x01\x02"
+
+= CBORF_SEQUENCE_OF dissection attaches every packet child to parent
+parent = SequenceParent(b"\x01\x02")
+assert [child.value for child in parent.children] == [1, 2]
+for child in parent.children:
+    assert child.parent is parent
+    assert child.underlayer is None
+
+assert bytes(parent) == b"\x01\x02"
+
++ deterministic fixed-schema maps
+
+= CBORF_MAP emits deterministic encoded-key order independent of declaration order
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+from scapy.cbor.cborfields import CBORF_MAP
+
+class ReverseDeclaredMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("b", 1),
+        CBORF_UNSIGNED_INTEGER("a", 2),
+    )
+
+wire = bytes(ReverseDeclaredMap())
+# RFC 8949 deterministic ordering sorts by the encoded key bytes, so "a"
+# precedes "b" even though the fields were declared in the opposite order.
+assert wire == b"\xa2\x61a\x02\x61b\x01"
+assert cbor_find_non_deterministic(wire) == []
+
+########### Scapy-native conversion pipeline #################
+
++ Field defaults and i2m / RawVal
+
+= Field defaults are normalized through any2i like native Scapy
 from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class PktUIntLarge(CBOR_Packet):
-    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 1000000)
+class DefaultNormPkt(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", "12")
 
-pkt = PktUIntLarge()
-raw_data = bytes(pkt)
-pkt2 = PktUIntLarge(raw_data)
-assert pkt2.value.val == 1000000
+assert DefaultNormPkt().value == 12
+assert DefaultNormPkt(value="34").value == 34
+assert bytes(DefaultNormPkt()) == b"\x0c"
 
-+ CBORF scalar fields - CBORF_NEGATIVE_INTEGER
-
-= CBORF_NEGATIVE_INTEGER basic encode/decode
-from scapy.cbor.cborfields import CBORF_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class PktNInt(CBOR_Packet):
-    CBOR_root = CBORF_NEGATIVE_INTEGER("value", -1)
-
-pkt = PktNInt()
-assert pkt.value.val == -1
-raw_data = bytes(pkt)
-pkt2 = PktNInt(raw_data)
-assert pkt2.value.val == -1
-
-= CBORF_NEGATIVE_INTEGER -100 roundtrip
-from scapy.cbor.cborfields import CBORF_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class PktNInt100(CBOR_Packet):
-    CBOR_root = CBORF_NEGATIVE_INTEGER("value", -100)
-
-pkt = PktNInt100()
-raw_data = bytes(pkt)
-pkt2 = PktNInt100(raw_data)
-assert pkt2.value.val == -100
-
-+ CBORF scalar fields - CBORF_INTEGER
-
-= CBORF_INTEGER positive value
-from scapy.cbor.cborfields import CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class PktInt(CBOR_Packet):
-    CBOR_root = CBORF_INTEGER("value", 7)
-
-pkt = PktInt()
-raw_data = bytes(pkt)
-pkt2 = PktInt(raw_data)
-assert pkt2.value.val == 7
-
-= CBORF_INTEGER negative value
-from scapy.cbor.cborfields import CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class PktIntNeg(CBOR_Packet):
-    CBOR_root = CBORF_INTEGER("value", -5)
-
-pkt = PktIntNeg()
-raw_data = bytes(pkt)
-pkt2 = PktIntNeg(raw_data)
-assert pkt2.value.val == -5
-
-+ CBORF scalar fields - CBORF_BYTE_STRING
-
-= CBORF_BYTE_STRING basic encode/decode
-from scapy.cbor.cborfields import CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class PktBStr(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING("data", b"hello")
-
-pkt = PktBStr()
-assert pkt.data.val == b"hello"
-raw_data = bytes(pkt)
-pkt2 = PktBStr(raw_data)
-assert pkt2.data.val == b"hello"
-
-= CBORF_BYTE_STRING empty bytes
-from scapy.cbor.cborfields import CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class PktBStrEmpty(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING("data", b"")
-
-pkt = PktBStrEmpty()
-raw_data = bytes(pkt)
-assert raw_data == b'\x40'
-pkt2 = PktBStrEmpty(raw_data)
-assert pkt2.data.val == b""
-
-+ CBORF scalar fields - CBORF_TEXT_STRING
-
-= CBORF_TEXT_STRING basic encode/decode
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class PktTStr(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING("title", "hello")
-
-pkt = PktTStr()
-assert pkt.title.val == "hello"
-raw_data = bytes(pkt)
-pkt2 = PktTStr(raw_data)
-assert pkt2.title.val == "hello"
-
-= CBORF_TEXT_STRING empty string
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class PktTStrEmpty(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING("title", "")
-
-pkt = PktTStrEmpty()
-raw_data = bytes(pkt)
-assert raw_data == b'\x60'
-pkt2 = PktTStrEmpty(raw_data)
-assert pkt2.title.val == ""
-
-+ CBORF scalar fields - CBORF_BOOLEAN
-
-= CBORF_BOOLEAN true value
-from scapy.cbor.cborfields import CBORF_BOOLEAN
-from scapy.cbor.cbor import CBOR_TRUE
-from scapy.cborpacket import CBOR_Packet
-
-class PktBool(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN("flag", True)
-
-pkt = PktBool()
-assert isinstance(pkt.flag, CBOR_TRUE)
-raw_data = bytes(pkt)
-assert raw_data == b'\xf5'
-pkt2 = PktBool(raw_data)
-assert isinstance(pkt2.flag, CBOR_TRUE)
-
-= CBORF_BOOLEAN false value
-from scapy.cbor.cborfields import CBORF_BOOLEAN
-from scapy.cbor.cbor import CBOR_FALSE
-from scapy.cborpacket import CBOR_Packet
-
-class PktBoolFalse(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN("flag", False)
-
-pkt = PktBoolFalse()
-raw_data = bytes(pkt)
-assert raw_data == b'\xf4'
-pkt2 = PktBoolFalse(raw_data)
-assert isinstance(pkt2.flag, CBOR_FALSE)
-
-+ CBORF scalar fields - CBORF_FLOAT
-
-= CBORF_FLOAT encode/decode
-from scapy.cbor.cborfields import CBORF_FLOAT
-from scapy.cborpacket import CBOR_Packet
-
-class PktFloat(CBOR_Packet):
-    CBOR_root = CBORF_FLOAT("value", 1.5)
-
-pkt = PktFloat()
-raw_data = bytes(pkt)
-pkt2 = PktFloat(raw_data)
-assert abs(pkt2.value.val - 1.5) < 1e-9
-
-= CBORF_NULL encode/decode
-from scapy.cbor.cborfields import CBORF_NULL
-from scapy.cbor.cbor import CBOR_NULL
-from scapy.cborpacket import CBOR_Packet
-
-class PktNull(CBOR_Packet):
-    CBOR_root = CBORF_NULL("nothing")
-
-pkt = PktNull()
-raw_data = bytes(pkt)
-assert raw_data == b'\xf6'
-pkt2 = PktNull(raw_data)
-assert isinstance(pkt2.nothing, CBOR_NULL)
-
-+ CBORF scalar fields - CBORF_UNDEFINED
-
-= CBORF_UNDEFINED encode/decode
-from scapy.cbor.cborfields import CBORF_UNDEFINED
-from scapy.cbor.cbor import CBOR_UNDEFINED
-from scapy.cborpacket import CBOR_Packet
-
-class PktUndef(CBOR_Packet):
-    CBOR_root = CBORF_UNDEFINED("undef")
-
-pkt = PktUndef()
-raw_data = bytes(pkt)
-assert raw_data == b'\xf7'
-pkt2 = PktUndef(raw_data)
-assert isinstance(pkt2.undef, CBOR_UNDEFINED)
-
-+ CBORF structured fields - CBORF_ARRAY
-
-= CBORF_ARRAY two-field encode/decode
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class MyCBOR(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER("version", 1),
-        CBORF_TEXT_STRING("title", "test"),
-    )
-
-pkt = MyCBOR()
-assert pkt.version.val == 1
-assert pkt.title.val == "test"
-raw_data = bytes(pkt)
-pkt2 = MyCBOR(raw_data)
-assert pkt2.version.val == 1
-assert pkt2.title.val == "test"
-
-= CBORF_ARRAY three-field encode/decode
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BOOLEAN
-from scapy.cborpacket import CBOR_Packet
-
-class Multi(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER("id", 99),
-        CBORF_TEXT_STRING("label", "x"),
-        CBORF_BOOLEAN("active", True),
-    )
-
-pkt = Multi()
-raw_data = bytes(pkt)
-pkt2 = Multi(raw_data)
-assert pkt2.id.val == 99
-assert pkt2.label.val == "x"
-
-= CBORF_ARRAY single integer roundtrip
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class Single(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_UNSIGNED_INTEGER("count", 5),
-    )
-
-pkt = Single()
-raw_data = bytes(pkt)
-pkt2 = Single(raw_data)
-assert pkt2.count.val == 5
-
-+ CBORF structured fields - CBORF_ARRAY_OF
-
-= CBORF_ARRAY_OF with CBORF_INTEGER elements
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_INTEGER
-from scapy.cbor.cbor import CBOR_UNSIGNED_INTEGER, CBOR_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class ArrOfInt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF("items", [], CBORF_INTEGER)
-
-pkt = ArrOfInt()
-pkt.items = [CBOR_UNSIGNED_INTEGER(1), CBOR_UNSIGNED_INTEGER(2), CBOR_UNSIGNED_INTEGER(3)]
-raw_data = bytes(pkt)
-pkt2 = ArrOfInt(raw_data)
-assert len(pkt2.items) == 3
-assert pkt2.items[0].val == 1
-assert pkt2.items[2].val == 3
-
-+ CBORF structured fields - CBORF_MAP
-
-= CBORF_MAP basic encode/decode
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class MyMap(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER("version", 2),
-        CBORF_TEXT_STRING("title", "cbor"),
-    )
-
-pkt = MyMap()
-assert pkt.version.val == 2
-assert pkt.title.val == "cbor"
-raw_data = bytes(pkt)
-pkt2 = MyMap(raw_data)
-assert pkt2.version.val == 2
-assert pkt2.title.val == "cbor"
-
-= CBORF_MAP byte string value
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class BinMap(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_BYTE_STRING("data", b"\xde\xad\xbe\xef"),
-    )
-
-pkt = BinMap()
-raw_data = bytes(pkt)
-pkt2 = BinMap(raw_data)
-assert pkt2.data.val == b"\xde\xad\xbe\xef"
-
-+ CBORF complex fields - CBORF_optional
-
-= CBORF_optional present field
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class OptPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER("version", 1),
-        CBORF_optional(CBORF_TEXT_STRING("title", "")),
-    )
-
-pkt = OptPkt()
-raw_data = bytes(pkt)
-pkt2 = OptPkt(raw_data)
-assert pkt2.version.val == 1
-assert pkt2.title.val == ""
-
-+ CBORF_PACKET nested packet
-
-= CBORF_PACKET basic nesting
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class Inner(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER("x", 10),
-    )
-
-class Outer(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_TEXT_STRING("label", "outer"),
-        CBORF_PACKET("inner", None, Inner),
-    )
-
-inner = Inner()
-outer = Outer()
-outer.label = outer.label  # keep default
-outer.inner = inner
-raw_data = bytes(outer)
-outer2 = Outer(raw_data)
-assert outer2.label.val == "outer"
-
-+ CBORF_SEMANTIC_TAG
-
-= CBORF_SEMANTIC_TAG encode with inner integer
-from scapy.cbor.cborfields import CBORF_SEMANTIC_TAG, CBORF_INTEGER
-from scapy.cbor.cbor import CBOR_SEMANTIC_TAG as CBOR_SEM
-from scapy.cborpacket import CBOR_Packet
-
-class TaggedPkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG("tag_info", None, 1, CBORF_INTEGER("ts", 0))
-
-pkt = TaggedPkt()
-# Build encodes tag 1 + inner field default
-raw_data = bytes(pkt)
-# Major type 6 (tag), tag number 1 => 0xc1
-assert raw_data[0:1] == b'\xc1'
-
-+ CBOR_Packet / CBORF field integration
-
-= CBOR_Packet fields_desc built from CBORF_ARRAY
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_UNSIGNED_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class Demo(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_UNSIGNED_INTEGER("id", 1),
-        CBORF_TEXT_STRING("desc", "demo"),
-    )
-
-# fields_desc should contain both fields
-field_names = [f.name for f in Demo.fields_desc]
-assert "id" in field_names
-assert "desc" in field_names
-
-= CBOR_Packet roundtrip preserves raw bytes
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class Simple(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER("a", 3),
-        CBORF_INTEGER("b", 7),
-    )
-
-pkt = Simple()
-raw_data = bytes(pkt)
-pkt2 = Simple(raw_data)
-assert bytes(pkt2) == raw_data
-
-########### Additional Unit Tests ####################################
-
-+ CBOR Simple Values
-
-= Decode CBOR simple value 0
-data = bytes.fromhex('e0')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-from scapy.cbor.cbor import CBOR_SIMPLE_VALUE
-isinstance(obj, CBOR_SIMPLE_VALUE) and obj.val == 0 and remainder == b''
-
-= Decode CBOR simple value 16
-data = bytes.fromhex('f0')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_SIMPLE_VALUE) and obj.val == 16 and remainder == b''
-
-= Decode CBOR simple value 255 (1-byte extended)
-data = bytes.fromhex('f8ff')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_SIMPLE_VALUE) and obj.val == 255 and remainder == b''
-
-+ CBOR Float Encodings - RFC 8949 Test Vectors
-
-= Half-precision: positive zero (0xf90000)
-import math
-data = bytes.fromhex('f90000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 0.0 and remainder == b''
-
-= Half-precision: negative zero (0xf98000)
-data = bytes.fromhex('f98000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == -0.0 and math.copysign(1, obj.val) == -1.0 and remainder == b''
-
-= Half-precision: 1.0 (0xf93c00)
-data = bytes.fromhex('f93c00')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 1.0 and remainder == b''
-
-= Half-precision: 1.5 (0xf93e00)
-data = bytes.fromhex('f93e00')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 1.5 and remainder == b''
-
-= Half-precision: max (65504.0) (0xf97bff)
-data = bytes.fromhex('f97bff')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 65504.0 and remainder == b''
-
-= Half-precision: smallest subnormal (0xf90001)
-data = bytes.fromhex('f90001')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and abs(obj.val - 5.960464477539063e-8) < 1e-15 and remainder == b''
-
-= Half-precision: smallest normal (0xf90400)
-data = bytes.fromhex('f90400')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and abs(obj.val - 6.103515625e-5) < 1e-12 and remainder == b''
-
-= Half-precision: positive infinity (0xf97c00)
-data = bytes.fromhex('f97c00')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isinf(obj.val) and obj.val > 0 and remainder == b''
-
-= Half-precision: negative infinity (0xf9fc00)
-data = bytes.fromhex('f9fc00')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isinf(obj.val) and obj.val < 0 and remainder == b''
-
-= Half-precision: NaN (0xf97e00)
-data = bytes.fromhex('f97e00')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isnan(obj.val) and remainder == b''
-
-= Single-precision: 100000.0 (0xfa47c35000)
-data = bytes.fromhex('fa47c35000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 100000.0 and remainder == b''
-
-= Single-precision: max float32 (0xfa7f7fffff)
-data = bytes.fromhex('fa7f7fffff')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and abs(obj.val - 3.4028234663852886e+38) < 1e30 and remainder == b''
-
-= Single-precision: positive infinity (0xfa7f800000)
-data = bytes.fromhex('fa7f800000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isinf(obj.val) and obj.val > 0 and remainder == b''
-
-= Single-precision: NaN (0xfa7fc00000)
-data = bytes.fromhex('fa7fc00000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isnan(obj.val) and remainder == b''
-
-= Double-precision: 1.1 (0xfb3ff199999999999a)
-data = bytes.fromhex('fb3ff199999999999a')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and abs(obj.val - 1.1) < 1e-10 and remainder == b''
-
-= Double-precision: 1.0e+300 (0xfb7e37e43c8800759c)
-data = bytes.fromhex('fb7e37e43c8800759c')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and abs(obj.val - 1.0e+300) / 1.0e+300 < 1e-10 and remainder == b''
-
-= Double-precision: NaN (0xfb7ff8000000000000)
-data = bytes.fromhex('fb7ff8000000000000')
-obj, remainder = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isnan(obj.val) and remainder == b''
-
-+ CBOR Integer Encoding - RFC 8949 Test Vectors
-
-= RFC 8949: encode 0
-obj = CBOR_UNSIGNED_INTEGER(0)
-bytes(obj) == bytes.fromhex('00')
-
-= RFC 8949: encode 1
-obj = CBOR_UNSIGNED_INTEGER(1)
-bytes(obj) == bytes.fromhex('01')
-
-= RFC 8949: encode 10
-obj = CBOR_UNSIGNED_INTEGER(10)
-bytes(obj) == bytes.fromhex('0a')
-
-= RFC 8949: encode 23
-obj = CBOR_UNSIGNED_INTEGER(23)
-bytes(obj) == bytes.fromhex('17')
-
-= RFC 8949: encode 24
-obj = CBOR_UNSIGNED_INTEGER(24)
-bytes(obj) == bytes.fromhex('1818')
-
-= RFC 8949: encode 25
-obj = CBOR_UNSIGNED_INTEGER(25)
-bytes(obj) == bytes.fromhex('1819')
-
-= RFC 8949: encode 100
-obj = CBOR_UNSIGNED_INTEGER(100)
-bytes(obj) == bytes.fromhex('1864')
-
-= RFC 8949: encode 1000
-obj = CBOR_UNSIGNED_INTEGER(1000)
-bytes(obj) == bytes.fromhex('1903e8')
-
-= RFC 8949: encode 1000000
-obj = CBOR_UNSIGNED_INTEGER(1000000)
-bytes(obj) == bytes.fromhex('1a000f4240')
-
-= RFC 8949: encode 1000000000000
-obj = CBOR_UNSIGNED_INTEGER(1000000000000)
-bytes(obj) == bytes.fromhex('1b000000e8d4a51000')
-
-= RFC 8949: encode 18446744073709551615 (2^64-1)
-obj = CBOR_UNSIGNED_INTEGER(18446744073709551615)
-bytes(obj) == bytes.fromhex('1bffffffffffffffff')
-
-= RFC 8949: encode -1
-obj = CBOR_NEGATIVE_INTEGER(-1)
-bytes(obj) == bytes.fromhex('20')
-
-= RFC 8949: encode -10
-obj = CBOR_NEGATIVE_INTEGER(-10)
-bytes(obj) == bytes.fromhex('29')
-
-= RFC 8949: encode -100
-obj = CBOR_NEGATIVE_INTEGER(-100)
-bytes(obj) == bytes.fromhex('3863')
-
-= RFC 8949: encode -1000
-obj = CBOR_NEGATIVE_INTEGER(-1000)
-bytes(obj) == bytes.fromhex('3903e7')
-
-= RFC 8949: decode 0
-obj, remainder = CBOR_Codecs.CBOR.dec(bytes.fromhex('00'))
-obj.val == 0 and remainder == b''
-
-= RFC 8949: decode 23
-obj, remainder = CBOR_Codecs.CBOR.dec(bytes.fromhex('17'))
-obj.val == 23 and remainder == b''
-
-= RFC 8949: decode 24
-obj, remainder = CBOR_Codecs.CBOR.dec(bytes.fromhex('1818'))
-obj.val == 24 and remainder == b''
-
-= RFC 8949: decode 1000000000000
-obj, remainder = CBOR_Codecs.CBOR.dec(bytes.fromhex('1b000000e8d4a51000'))
-obj.val == 1000000000000 and remainder == b''
-
-= RFC 8949: decode -1000
-obj, remainder = CBOR_Codecs.CBOR.dec(bytes.fromhex('3903e7'))
-obj.val == -1000 and remainder == b''
-
-+ CBOR Byte String with All Byte Values
-
-= CBOR_BYTE_STRING: encode/decode all 256 byte values
-all_bytes = bytes(range(256))
-obj = CBOR_BYTE_STRING(all_bytes)
-enc = bytes(obj)
-dec, remainder = CBOR_Codecs.CBOR.dec(enc)
-dec.val == all_bytes and remainder == b''
-
-= CBOR_BYTE_STRING: cbor2 interop with all 256 byte values
-import cbor2
-all_bytes = bytes(range(256))
-obj = CBOR_BYTE_STRING(all_bytes)
-enc = bytes(obj)
-dec = cbor2.loads(enc)
-dec == all_bytes
-
-+ CBOR Map with Integer Keys
-
-= Decode map with integer keys (cbor2 encode, Scapy decode)
-import cbor2
-enc = cbor2.dumps({1: 'one', 2: 'two', -1: 'minus_one'})
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_MAP) and obj.val.get(1) is not None and obj.val[1].val == 'one' and remainder == b''
-
-= Encode map with integer keys (Scapy encode, cbor2 decode)
-from scapy.cbor.cborcodec import CBORcodec_MAP
-enc = CBORcodec_MAP.enc({1: 'one', 2: 'two'})
-dec = cbor2.loads(enc)
-dec == {1: 'one', 2: 'two'}
-
-= Map with mixed key types roundtrip
-enc = cbor2.dumps({'str_key': 42, 1: 'int_key'})
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_MAP) and len(obj.val) == 2 and remainder == b''
-
-+ CBOR Multiple Items in Stream
-
-= Decode three integers from a single byte stream
-data = bytes.fromhex('01') + bytes.fromhex('0a') + bytes.fromhex('17')
-obj1, rest1 = CBOR_Codecs.CBOR.dec(data)
-obj2, rest2 = CBOR_Codecs.CBOR.dec(rest1)
-obj3, rest3 = CBOR_Codecs.CBOR.dec(rest2)
-obj1.val == 1 and obj2.val == 10 and obj3.val == 23 and rest3 == b''
-
-= Decode integer followed by string
-data = bytes.fromhex('1864') + bytes.fromhex('626869')
-obj1, rest1 = CBOR_Codecs.CBOR.dec(data)
-obj2, rest2 = CBOR_Codecs.CBOR.dec(rest1)
-obj1.val == 100 and obj2.val == 'hi' and rest2 == b''
-
-+ CBOR Nested Structures Unit Tests
-
-= Encode and decode doubly nested array
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-enc = CBORcodec_ARRAY.enc([[1, 2], [3, 4], [5, 6]])
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 3 and len(obj.val[0].val) == 2 and remainder == b''
-
-= Encode and decode map containing arrays
-from scapy.cbor.cborcodec import CBORcodec_MAP, CBORcodec_ARRAY
-enc = CBORcodec_MAP.enc({'nums': [1, 2, 3], 'strs': ['a', 'b']})
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_MAP) and 'nums' in obj.val and isinstance(obj.val['nums'], CBOR_ARRAY) and remainder == b''
-
-= Encode and decode array containing maps
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-enc = CBORcodec_ARRAY.enc([{'id': 1}, {'id': 2}])
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 2 and isinstance(obj.val[0], CBOR_MAP) and remainder == b''
-
-########### Extended Interoperability Tests with cbor2 ################
-
-+ CBOR Interoperability - RFC 8949 Appendix B (Scapy encode, cbor2 decode)
-
-= RFC 8949 Appendix B: 0
-import cbor2
-obj = CBOR_UNSIGNED_INTEGER(0)
-cbor2.loads(bytes(obj)) == 0
-
-= RFC 8949 Appendix B: 1
-obj = CBOR_UNSIGNED_INTEGER(1)
-cbor2.loads(bytes(obj)) == 1
-
-= RFC 8949 Appendix B: 10
-obj = CBOR_UNSIGNED_INTEGER(10)
-cbor2.loads(bytes(obj)) == 10
-
-= RFC 8949 Appendix B: 23
-obj = CBOR_UNSIGNED_INTEGER(23)
-cbor2.loads(bytes(obj)) == 23
-
-= RFC 8949 Appendix B: 24
-obj = CBOR_UNSIGNED_INTEGER(24)
-cbor2.loads(bytes(obj)) == 24
-
-= RFC 8949 Appendix B: 1000
-obj = CBOR_UNSIGNED_INTEGER(1000)
-cbor2.loads(bytes(obj)) == 1000
-
-= RFC 8949 Appendix B: 1000000000000
-obj = CBOR_UNSIGNED_INTEGER(1000000000000)
-cbor2.loads(bytes(obj)) == 1000000000000
-
-= RFC 8949 Appendix B: 18446744073709551615 (max u64)
-obj = CBOR_UNSIGNED_INTEGER(18446744073709551615)
-cbor2.loads(bytes(obj)) == 18446744073709551615
-
-= RFC 8949 Appendix B: -1
-obj = CBOR_NEGATIVE_INTEGER(-1)
-cbor2.loads(bytes(obj)) == -1
-
-= RFC 8949 Appendix B: -1000
-obj = CBOR_NEGATIVE_INTEGER(-1000)
-cbor2.loads(bytes(obj)) == -1000
-
-= RFC 8949 Appendix B: false
-obj = CBOR_FALSE()
-cbor2.loads(bytes(obj)) is False
-
-= RFC 8949 Appendix B: true
-obj = CBOR_TRUE()
-cbor2.loads(bytes(obj)) is True
-
-= RFC 8949 Appendix B: null
-obj = CBOR_NULL()
-cbor2.loads(bytes(obj)) is None
-
-= RFC 8949 Appendix B: undefined
-obj = CBOR_UNDEFINED()
-decoded = cbor2.loads(bytes(obj))
-from cbor2 import undefined
-decoded is undefined
-
-= RFC 8949 Appendix B: empty byte string
-obj = CBOR_BYTE_STRING(b'')
-cbor2.loads(bytes(obj)) == b''
-
-= RFC 8949 Appendix B: byte string b'\x01\x02\x03\x04'
-obj = CBOR_BYTE_STRING(b'\x01\x02\x03\x04')
-cbor2.loads(bytes(obj)) == b'\x01\x02\x03\x04'
-
-= RFC 8949 Appendix B: empty text string
-obj = CBOR_TEXT_STRING('')
-cbor2.loads(bytes(obj)) == ''
-
-= RFC 8949 Appendix B: 'a'
-obj = CBOR_TEXT_STRING('a')
-cbor2.loads(bytes(obj)) == 'a'
-
-= RFC 8949 Appendix B: 'IETF'
-obj = CBOR_TEXT_STRING('IETF')
-cbor2.loads(bytes(obj)) == 'IETF'
-
-= RFC 8949 Appendix B: u00fc (ü)
-obj = CBOR_TEXT_STRING('\u00fc')
-cbor2.loads(bytes(obj)) == '\u00fc'
-
-= RFC 8949 Appendix B: u6c34 (water in Chinese)
-obj = CBOR_TEXT_STRING('\u6c34')
-cbor2.loads(bytes(obj)) == '\u6c34'
-
-= RFC 8949 Appendix B: empty array
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-enc = CBORcodec_ARRAY.enc([])
-cbor2.loads(enc) == []
-
-= RFC 8949 Appendix B: [1, 2, 3]
-enc = CBORcodec_ARRAY.enc([1, 2, 3])
-cbor2.loads(enc) == [1, 2, 3]
-
-= RFC 8949 Appendix B: [1, [2, 3], [4, 5]]
-enc = CBORcodec_ARRAY.enc([1, [2, 3], [4, 5]])
-cbor2.loads(enc) == [1, [2, 3], [4, 5]]
-
-= RFC 8949 Appendix B: empty map
-from scapy.cbor.cborcodec import CBORcodec_MAP
-enc = CBORcodec_MAP.enc({})
-cbor2.loads(enc) == {}
-
-= RFC 8949 Appendix B: {1: 2, 3: 4}
-enc = CBORcodec_MAP.enc({1: 2, 3: 4})
-cbor2.loads(enc) == {1: 2, 3: 4}
-
-= RFC 8949 Appendix B: {"a": 1, "b": [2, 3]}
-enc = CBORcodec_MAP.enc({"a": 1, "b": [2, 3]})
-cbor2.loads(enc) == {"a": 1, "b": [2, 3]}
-
-+ CBOR Interoperability - RFC 8949 Appendix B (cbor2 encode, Scapy decode)
-
-= RFC 8949 Appendix B decode: 0
-import cbor2
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(0))
-obj.val == 0 and isinstance(obj, CBOR_UNSIGNED_INTEGER)
-
-= RFC 8949 Appendix B decode: 23
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(23))
-obj.val == 23 and isinstance(obj, CBOR_UNSIGNED_INTEGER)
-
-= RFC 8949 Appendix B decode: 24
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(24))
-obj.val == 24 and isinstance(obj, CBOR_UNSIGNED_INTEGER)
-
-= RFC 8949 Appendix B decode: -1
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(-1))
-obj.val == -1 and isinstance(obj, CBOR_NEGATIVE_INTEGER)
-
-= RFC 8949 Appendix B decode: -1000
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(-1000))
-obj.val == -1000 and isinstance(obj, CBOR_NEGATIVE_INTEGER)
-
-= RFC 8949 Appendix B decode: false
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(False))
-isinstance(obj, CBOR_FALSE) and obj.val is False
-
-= RFC 8949 Appendix B decode: true
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(True))
-isinstance(obj, CBOR_TRUE) and obj.val is True
-
-= RFC 8949 Appendix B decode: null
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(None))
-isinstance(obj, CBOR_NULL) and obj.val is None
-
-= RFC 8949 Appendix B decode: empty string
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(''))
-isinstance(obj, CBOR_TEXT_STRING) and obj.val == ''
-
-= RFC 8949 Appendix B decode: 'IETF'
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps('IETF'))
-isinstance(obj, CBOR_TEXT_STRING) and obj.val == 'IETF'
-
-= RFC 8949 Appendix B decode: u00fc
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps('\u00fc'))
-isinstance(obj, CBOR_TEXT_STRING) and obj.val == '\u00fc'
-
-= RFC 8949 Appendix B decode: b'\x01\x02\x03\x04'
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps(b'\x01\x02\x03\x04'))
-isinstance(obj, CBOR_BYTE_STRING) and obj.val == b'\x01\x02\x03\x04'
-
-= RFC 8949 Appendix B decode: [1, 2, 3]
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps([1, 2, 3]))
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 3 and obj.val[0].val == 1
-
-= RFC 8949 Appendix B decode: [1, [2, 3], [4, 5]]
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps([1, [2, 3], [4, 5]]))
-isinstance(obj, CBOR_ARRAY) and len(obj.val) == 3 and isinstance(obj.val[1], CBOR_ARRAY)
-
-= RFC 8949 Appendix B decode: {"a": 1, "b": [2, 3]}
-obj, _ = CBOR_Codecs.CBOR.dec(cbor2.dumps({"a": 1, "b": [2, 3]}))
-isinstance(obj, CBOR_MAP) and obj.val['a'].val == 1 and isinstance(obj.val['b'], CBOR_ARRAY)
-
-+ CBOR Interoperability - Byte-exact Comparison
-
-= Scapy and cbor2 produce identical bytes for integer 0
-import cbor2
-bytes(CBOR_UNSIGNED_INTEGER(0)) == cbor2.dumps(0)
-
-= Scapy and cbor2 produce identical bytes for integer 255
-bytes(CBOR_UNSIGNED_INTEGER(255)) == cbor2.dumps(255)
-
-= Scapy and cbor2 produce identical bytes for -1
-bytes(CBOR_NEGATIVE_INTEGER(-1)) == cbor2.dumps(-1)
-
-= Scapy and cbor2 produce identical bytes for -1000
-bytes(CBOR_NEGATIVE_INTEGER(-1000)) == cbor2.dumps(-1000)
-
-= Scapy and cbor2 produce identical bytes for empty byte string
-bytes(CBOR_BYTE_STRING(b'')) == cbor2.dumps(b'')
-
-= Scapy and cbor2 produce identical bytes for 'hello'
-bytes(CBOR_TEXT_STRING('hello')) == cbor2.dumps('hello')
-
-= Scapy and cbor2 produce identical bytes for true
-bytes(CBOR_TRUE()) == cbor2.dumps(True)
-
-= Scapy and cbor2 produce identical bytes for false
-bytes(CBOR_FALSE()) == cbor2.dumps(False)
-
-= Scapy and cbor2 produce identical bytes for null
-bytes(CBOR_NULL()) == cbor2.dumps(None)
-
-= Scapy and cbor2 produce identical bytes for undefined
-from cbor2 import undefined
-bytes(CBOR_UNDEFINED()) == cbor2.dumps(undefined)
-
-= Scapy and cbor2 produce identical bytes for empty array
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-CBORcodec_ARRAY.enc([]) == cbor2.dumps([])
-
-= Scapy and cbor2 produce identical bytes for empty map
-from scapy.cbor.cborcodec import CBORcodec_MAP
-CBORcodec_MAP.enc({}) == cbor2.dumps({})
-
-= Scapy and cbor2 produce identical bytes for [1, 2, 3]
-CBORcodec_ARRAY.enc([1, 2, 3]) == cbor2.dumps([1, 2, 3])
-
-= Scapy and cbor2 produce identical bytes for {'a': 1}
-CBORcodec_MAP.enc({'a': 1}) == cbor2.dumps({'a': 1})
-
-+ CBOR Interoperability - Semantic Tags
-
-= Scapy encode semantic tag (tag 42), cbor2 decode
-import cbor2
-obj = CBOR_SEMANTIC_TAG((42, CBOR_TEXT_STRING('test-content')))
-enc = bytes(obj)
-dec = cbor2.loads(enc)
-isinstance(dec, cbor2.CBORTag) and dec.tag == 42 and dec.value == 'test-content'
-
-= cbor2 encode semantic tag (tag 42), Scapy decode
-enc = cbor2.dumps(cbor2.CBORTag(42, 'test-content'))
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_SEMANTIC_TAG) and obj.val[0] == 42 and obj.val[1].val == 'test-content' and remainder == b''
-
-= Scapy and cbor2 produce identical bytes for semantic tag 42
-import cbor2
-scapy_enc = bytes(CBOR_SEMANTIC_TAG((42, CBOR_TEXT_STRING('test-content'))))
-cbor2_enc = cbor2.dumps(cbor2.CBORTag(42, 'test-content'))
-scapy_enc == cbor2_enc
-
-= cbor2 encode epoch-based datetime tag (tag 1), Scapy decode
-enc = cbor2.dumps(cbor2.CBORTag(1, 1363896240))
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_SEMANTIC_TAG) and obj.val[0] == 1 and obj.val[1].val == 1363896240 and remainder == b''
-
-= cbor2 encode integer-tagged byte string, Scapy decode
-enc = cbor2.dumps(cbor2.CBORTag(100, b'\xde\xad\xbe\xef'))
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_SEMANTIC_TAG) and obj.val[0] == 100 and obj.val[1].val == b'\xde\xad\xbe\xef' and remainder == b''
-
-+ CBOR Interoperability - Half-Precision Floats (RFC 8949 vectors)
-
-= Half-precision from RFC 8949: 0.0
-import cbor2
-data = bytes.fromhex('f90000')
-obj, _ = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 0.0
-
-= Half-precision from RFC 8949: 1.0
-data = bytes.fromhex('f93c00')
-obj, _ = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 1.0
-
-= Half-precision from RFC 8949: 1.5
-data = bytes.fromhex('f93e00')
-obj, _ = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and obj.val == 1.5
-
-= Half-precision from RFC 8949: positive infinity
-import math
-data = bytes.fromhex('f97c00')
-obj, _ = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isinf(obj.val) and obj.val > 0
-
-= Half-precision from RFC 8949: NaN
-data = bytes.fromhex('f97e00')
-obj, _ = CBOR_Codecs.CBOR.dec(data)
-isinstance(obj, CBOR_FLOAT) and math.isnan(obj.val)
-
-= Scapy decode half-precision 1.5 agrees with cbor2 decode of double 1.5
-import cbor2
-half_data = bytes.fromhex('f93e00')
-scapy_obj, _ = CBOR_Codecs.CBOR.dec(half_data)
-double_data = bytes.fromhex('fb3ff8000000000000')
-cbor2_val = cbor2.loads(double_data)
-scapy_obj.val == cbor2_val
-
-+ CBOR Interoperability - Large Integers
-
-= Large uint 18446744073709551615 bytes match cbor2
-import cbor2
-max_u64 = 18446744073709551615
-bytes(CBOR_UNSIGNED_INTEGER(max_u64)) == cbor2.dumps(max_u64)
-
-= Large uint roundtrip Scapy to cbor2 to Scapy
-max_u64 = 18446744073709551615
-scapy_enc = bytes(CBOR_UNSIGNED_INTEGER(max_u64))
-cbor2_val = cbor2.loads(scapy_enc)
-cbor2_enc = cbor2.dumps(cbor2_val)
-scapy_dec, _ = CBOR_Codecs.CBOR.dec(cbor2_enc)
-scapy_dec.val == max_u64
-
-= Large negative int -18446744073709551616 roundtrip via cbor2
-neg_max = -18446744073709551616
-cbor2_enc = cbor2.dumps(neg_max)
-scapy_dec, _ = CBOR_Codecs.CBOR.dec(cbor2_enc)
-scapy_dec.val == neg_max
-
-+ CBOR Interoperability - Complex Nested Structures
-
-= cbor2 deeply nested map: 3 levels, Scapy decode
-import cbor2
-deep = {"level1": {"level2": {"level3": [1, 2, 3]}}}
-enc = cbor2.dumps(deep)
-obj, _ = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_MAP) and 'level1' in obj.val
-
-= Scapy deeply nested array, cbor2 decode
-from scapy.cbor.cborcodec import CBORcodec_ARRAY
-enc = CBORcodec_ARRAY.enc([[1, [2, [3, [4]]]], 5])
-dec = cbor2.loads(enc)
-dec == [[1, [2, [3, [4]]]], 5]
-
-= cbor2 complex mixed structure: Scapy decodes it
-import cbor2
-data = {
-    "name": "Alice",
-    "scores": [100, 95, 87],
-    "active": True,
-    "meta": {"created": 12345, "tag": "user"},
-}
-enc = cbor2.dumps(data)
-obj, _ = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_MAP) and 'name' in obj.val and 'scores' in obj.val
-
-= Scapy encode complex structure, cbor2 decode, values match
-from scapy.cbor.cborcodec import CBORcodec_MAP, CBORcodec_ARRAY
-enc = CBORcodec_MAP.enc({
-    "items": [1, 2, 3],
-    "count": 3,
-    "valid": True,
-})
-dec = cbor2.loads(enc)
-dec["items"] == [1, 2, 3] and dec["count"] == 3 and dec["valid"] is True
-
-########### CBORF Fields Interoperability Tests with cbor2 ############
-
-+ CBORF Fields - Interop: CBORF_ARRAY packet to cbor2
-
-= CBORF_ARRAY packet to cbor2 list (version info)
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_UNSIGNED_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class VersionInfo(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_UNSIGNED_INTEGER('major', 1),
-        CBORF_UNSIGNED_INTEGER('minor', 2),
-        CBORF_UNSIGNED_INTEGER('patch', 3),
-    )
-
-pkt = VersionInfo()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-isinstance(dec, list) and dec == [1, 2, 3]
-
-= cbor2 list to CBORF_ARRAY packet
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class VersionInfo2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_UNSIGNED_INTEGER('major', 0),
-        CBORF_UNSIGNED_INTEGER('minor', 0),
-        CBORF_UNSIGNED_INTEGER('patch', 0),
-    )
-
-cbor2_data = cbor2.dumps([4, 5, 6])
-pkt = VersionInfo2(cbor2_data)
-pkt.major.val == 4 and pkt.minor.val == 5 and pkt.patch.val == 6
-
-= CBORF_ARRAY packet roundtrip through cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class MsgPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('code', 200),
-        CBORF_TEXT_STRING('status', 'ok'),
-    )
-
-pkt = MsgPkt()
-raw = bytes(pkt)
-cbor2_dec = cbor2.loads(raw)
-cbor2_re_enc = cbor2.dumps(cbor2_dec)
-pkt2 = MsgPkt(cbor2_re_enc)
-pkt2.code.val == 200 and pkt2.status.val == 'ok'
-
-= CBORF_ARRAY with boolean and null fields to cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_BOOLEAN, CBORF_NULL, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class FlagPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('id', 7),
-        CBORF_BOOLEAN('active', True),
-        CBORF_NULL('reserved'),
-    )
-
-pkt = FlagPkt()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-dec[0] == 7 and dec[1] is True and dec[2] is None
-
-= cbor2 list with mixed types to CBORF_ARRAY packet
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_BOOLEAN, CBORF_NULL
-from scapy.cborpacket import CBOR_Packet
-
-class Mixed(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('num', 0),
-        CBORF_BOOLEAN('flag', False),
-        CBORF_NULL('nval'),
-    )
-
-cbor2_data = cbor2.dumps([42, False, None])
-pkt = Mixed(cbor2_data)
-pkt.num.val == 42
-
-+ CBORF Fields - Interop: CBORF_MAP packet to cbor2
-
-= CBORF_MAP packet to cbor2 dict
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class ClaimSet(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('iss', 'scapy'),
-        CBORF_INTEGER('exp', 9999999),
-    )
-
-pkt = ClaimSet()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-isinstance(dec, dict) and dec.get('iss') == 'scapy' and dec.get('exp') == 9999999
-
-= cbor2 dict to CBORF_MAP packet
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class Claims(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('iss', ''),
-        CBORF_INTEGER('exp', 0),
-    )
-
-cbor2_data = cbor2.dumps({'iss': 'myapp', 'exp': 12345})
-pkt = Claims(cbor2_data)
-pkt.iss.val == 'myapp' and pkt.exp.val == 12345
-
-= CBORF_MAP packet roundtrip through cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class BinHeader(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('alg', 'ES256'),
-        CBORF_BYTE_STRING('kid', b'\x01\x02\x03\x04'),
-    )
-
-pkt = BinHeader()
-raw = bytes(pkt)
-cbor2_dec = cbor2.loads(raw)
-cbor2_re_enc = cbor2.dumps(cbor2_dec)
-pkt2 = BinHeader(cbor2_re_enc)
-pkt2.alg.val == 'ES256' and pkt2.kid.val == b'\x01\x02\x03\x04'
-
-= CBORF_MAP with boolean values to cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_BOOLEAN, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class Flags(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_BOOLEAN('enabled', True),
-        CBORF_INTEGER('count', 5),
-    )
-
-pkt = Flags()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-dec.get('enabled') is True and dec.get('count') == 5
-
-= cbor2 dict with unknown keys: CBORF_MAP skips them
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class SimpleMap(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('known', 'default'),
-    )
-
-cbor2_data = cbor2.dumps({'known': 'value', 'unknown': 'extra'})
-pkt = SimpleMap(cbor2_data)
-pkt.known.val == 'value'
-
-+ CBORF Fields - Interop: CBORF_ARRAY_OF packet to cbor2
-
-= CBORF_ARRAY_OF with integer elements to cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_INTEGER
-from scapy.cbor.cbor import CBOR_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_INTEGER)
-
-pkt = IntList()
-pkt.items = [CBOR_UNSIGNED_INTEGER(10), CBOR_UNSIGNED_INTEGER(20), CBOR_UNSIGNED_INTEGER(30)]
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-isinstance(dec, list) and dec == [10, 20, 30]
-
-= cbor2 list to CBORF_ARRAY_OF
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntList2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_INTEGER)
-
-cbor2_data = cbor2.dumps([100, 200, 300])
-pkt = IntList2(cbor2_data)
-len(pkt.items) == 3 and pkt.items[0].val == 100 and pkt.items[2].val == 300
-
-+ CBORF Fields - Interop: CBORF_SEMANTIC_TAG to cbor2
-
-= CBORF_SEMANTIC_TAG packet to cbor2 CBORTag
-import cbor2
-from scapy.cbor.cborfields import CBORF_SEMANTIC_TAG, CBORF_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class TimestampPkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag_info', None, 1, CBORF_UNSIGNED_INTEGER('ts', 1363896240))
-
-pkt = TimestampPkt()
-raw = bytes(pkt)
-import datetime
-dec = cbor2.loads(raw)
-isinstance(dec, (cbor2.CBORTag, datetime.datetime, datetime.date))
-
-= cbor2 CBORTag (tag 42) decoded by Scapy CBOR_SEMANTIC_TAG
-import cbor2
-enc = cbor2.dumps(cbor2.CBORTag(42, 'tagged-value'))
-obj, remainder = CBOR_Codecs.CBOR.dec(enc)
-isinstance(obj, CBOR_SEMANTIC_TAG) and obj.val[0] == 42 and obj.val[1].val == 'tagged-value' and remainder == b''
-
-= CBORF_SEMANTIC_TAG bytes identical to cbor2 CBORTag bytes
-import cbor2
-scapy_enc = bytes(CBOR_SEMANTIC_TAG((42, CBOR_TEXT_STRING('tagged-value'))))
-cbor2_enc = cbor2.dumps(cbor2.CBORTag(42, 'tagged-value'))
-scapy_enc == cbor2_enc
-
-+ CBORF Fields - Interop: CBORF_UNSIGNED_INTEGER with cbor2
-
-= CBORF_UNSIGNED_INTEGER boundary values - Scapy encode, cbor2 decode
-import cbor2
+= RawVal injects exact CBOR wire bytes through i2m
 from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
+from scapy.fields import RawVal
+from scapy.cbor.cbor import CBOR_Encoding_Error
 
-class UIntPkt(CBOR_Packet):
-    CBOR_root = CBORF_UNSIGNED_INTEGER('n', 0)
+class RawValPkt(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
 
-results = []
-for val in [0, 23, 24, 255, 256, 65535, 65536, 4294967295, 4294967296, 18446744073709551615]:
-    pkt = UIntPkt()
-    pkt.n.val = val
-    dec = cbor2.loads(bytes(pkt))
-    results.append(dec == val)
+assert bytes(RawValPkt(value=RawVal(b"\x18\x64"))) == b"\x18\x64"
 
-all(results)
+try:
+    bytes(RawValPkt(value=RawVal(b"\x01\x02")))
+    assert False, "multi-item RawVal must be rejected"
+except CBOR_Encoding_Error:
+    pass
 
-= CBORF_UNSIGNED_INTEGER boundary values - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class UIntPkt2(CBOR_Packet):
-    CBOR_root = CBORF_UNSIGNED_INTEGER('n', 0)
-
-results = []
-for val in [0, 23, 24, 255, 256, 65535, 65536, 4294967295, 4294967296]:
-    pkt = UIntPkt2(cbor2.dumps(val))
-    results.append(pkt.n.val == val)
-
-all(results)
-
-= CBORF_UNSIGNED_INTEGER byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_UNSIGNED_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class UIntExact(CBOR_Packet):
-    CBOR_root = CBORF_UNSIGNED_INTEGER('n', 0)
-
-results = []
-for val in [0, 1, 10, 23, 24, 255, 256, 65535, 65536, 4294967295]:
-    pkt = UIntExact()
-    pkt.n.val = val
-    results.append(bytes(pkt) == cbor2.dumps(val))
-
-all(results)
-
-+ CBORF Fields - Interop: CBORF_NEGATIVE_INTEGER with cbor2
-
-= CBORF_NEGATIVE_INTEGER boundary values - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class NIntPkt(CBOR_Packet):
-    CBOR_root = CBORF_NEGATIVE_INTEGER('n', -1)
-
-results = []
-for val in [-1, -24, -25, -256, -257, -65536, -65537, -4294967296, -4294967297]:
-    pkt = NIntPkt()
-    pkt.n.val = val
-    dec = cbor2.loads(bytes(pkt))
-    results.append(dec == val)
-
-all(results)
-
-= CBORF_NEGATIVE_INTEGER boundary values - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class NIntPkt2(CBOR_Packet):
-    CBOR_root = CBORF_NEGATIVE_INTEGER('n', -1)
-
-results = []
-for val in [-1, -24, -25, -256, -257, -65536, -4294967296]:
-    pkt = NIntPkt2(cbor2.dumps(val))
-    results.append(pkt.n.val == val)
-
-all(results)
-
-= CBORF_NEGATIVE_INTEGER byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_NEGATIVE_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class NIntExact(CBOR_Packet):
-    CBOR_root = CBORF_NEGATIVE_INTEGER('n', -1)
-
-results = []
-for val in [-1, -10, -24, -25, -256, -257, -65536, -65537]:
-    pkt = NIntExact()
-    pkt.n.val = val
-    results.append(bytes(pkt) == cbor2.dumps(val))
-
-all(results)
-
-+ CBORF Fields - Interop: CBORF_INTEGER with cbor2
-
-= CBORF_INTEGER positive values - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntPkt(CBOR_Packet):
-    CBOR_root = CBORF_INTEGER('n', 0)
-
-results = []
-for val in [0, 1, 42, 100, 1000, 1000000]:
-    pkt = IntPkt()
-    pkt.n.val = val
-    dec = cbor2.loads(bytes(pkt))
-    results.append(dec == val)
-
-all(results)
-
-= CBORF_INTEGER negative values - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntNegPkt(CBOR_Packet):
-    CBOR_root = CBORF_INTEGER('n', -1)
-
-results = []
-for val in [-1, -10, -100, -1000, -1000000]:
-    pkt = IntNegPkt()
-    pkt.n.val = val
-    dec = cbor2.loads(bytes(pkt))
-    results.append(dec == val)
-
-all(results)
-
-= CBORF_INTEGER - cbor2 encode positive and negative, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntPkt2(CBOR_Packet):
-    CBOR_root = CBORF_INTEGER('n', 0)
-
-results = []
-for val in [0, 42, -1, -42, 255, -256, 65536, -65537]:
-    pkt = IntPkt2(cbor2.dumps(val))
-    results.append(pkt.n.val == val)
-
-all(results)
-
-+ CBORF Fields - Interop: CBORF_BYTE_STRING with cbor2
-
-= CBORF_BYTE_STRING empty bytes - Scapy encode, cbor2 decode
-import cbor2
+= Byte-string internals remain encoded (bytes is not a wire bypass)
 from scapy.cbor.cborfields import CBORF_BYTE_STRING
 from scapy.cborpacket import CBOR_Packet
 
-class BytePkt(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING('data', b'')
+class BstrPkt(CBOR_Packet):
+    CBOR_root = CBORF_BYTE_STRING("blob", b"ABC")
 
-pkt = BytePkt()
-dec = cbor2.loads(bytes(pkt))
-dec == b''
+assert BstrPkt().blob == b"ABC"
+assert bytes(BstrPkt()) == b"\x43" + b"ABC"
 
-= CBORF_BYTE_STRING all 256 byte values - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_BYTE_STRING
+= BundleEidField defaults and assignments are always EidStruct
+from scapy.contrib.bpv7 import BundleEidField, EidStruct, PrimaryBlock
 from scapy.cborpacket import CBOR_Packet
 
-class ByteAllPkt(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING('data', b'')
+class EidPkt(CBOR_Packet):
+    CBOR_root = BundleEidField("eid", "dtn:none")
 
-pkt = ByteAllPkt()
-pkt.data.val = bytes(range(256))
-dec = cbor2.loads(bytes(pkt))
-dec == bytes(range(256))
+# Internal representation (getfieldval) is always EidStruct; attribute access
+# returns the human form via i2h(), matching native Scapy Field semantics.
+assert isinstance(EidPkt().getfieldval("eid"), EidStruct)
+assert EidPkt().eid == "dtn:none"
+assert isinstance(PrimaryBlock().getfieldval("source"), EidStruct)
+assert PrimaryBlock().source == "dtn:none"
 
-= CBORF_BYTE_STRING - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_BYTE_STRING
++ CBORF_BYTE_STRING_PACKET default normalization
+
+= CBORF_BYTE_STRING_PACKET normalizes byte defaults after packet-class state is initialized
+from scapy.cbor.cborfields import CBORF_BYTE_STRING_PACKET
+from scapy.cborpacket import CBOR_Packet
+from scapy.packet import Raw
+
+class ByteStringDefaultParent(CBOR_Packet):
+    CBOR_root = CBORF_BYTE_STRING_PACKET(
+        "child",
+        b"abc",
+        pkt_cls=Raw,
+    )
+
+pkt = ByteStringDefaultParent()
+assert isinstance(pkt.child, Raw)
+assert pkt.child.load == b"abc"
+assert pkt.child.parent is pkt
+assert bytes(pkt) == b"\x43abc"
+
+
++ PacketListField-style next_cls_cb semantics
+
+= CBORF_SEQUENCE_OF next_cls_cb selects packet classes dynamically
+from scapy.cbor.cborfields import CBORF_SEQUENCE_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class BytePkt3(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING('data', b'')
+class DynamicSequenceChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
 
-for raw_val in [b'', b'\xde\xad\xbe\xef', bytes(range(256))]:
-    pkt = BytePkt3(cbor2.dumps(raw_val))
-    assert pkt.data.val == raw_val
+NextClsCalls = []
+def choose_dynamic_child(pkt, lst, cur, remain):
+    NextClsCalls.append(len(lst))
+    return DynamicSequenceChild
 
-True
+class DynamicSequenceParent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF(
+        "children",
+        [],
+        next_cls_cb=choose_dynamic_child,
+    )
 
-= CBORF_BYTE_STRING byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_BYTE_STRING
+pkt = DynamicSequenceParent(b"\x01")
+assert NextClsCalls == [0]
+assert len(pkt.children) == 1
+assert isinstance(pkt.children[0], DynamicSequenceChild)
+assert pkt.children[0].parent is pkt
+
+= CBORF_SEQUENCE_OF rejects combining next_cls_cb with cls/pkt_cls
+from scapy.cbor.cborfields import CBORF_SEQUENCE_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class ByteExact(CBOR_Packet):
-    CBOR_root = CBORF_BYTE_STRING('data', b'')
+class FixedSequenceChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
 
-results = []
-for raw_val in [b'', b'\x00', b'\xff', b'\xde\xad\xbe\xef', b'hello']:
-    pkt = ByteExact()
-    pkt.data.val = raw_val
-    results.append(bytes(pkt) == cbor2.dumps(raw_val))
+try:
+    CBORF_SEQUENCE_OF(
+        "children",
+        [],
+        pkt_cls=FixedSequenceChild,
+        next_cls_cb=lambda *a: FixedSequenceChild,
+    )
+except ValueError:
+    pass
+else:
+    raise AssertionError("conflicting SEQUENCE_OF selectors accepted")
 
-all(results)
 
-+ CBORF Fields - Interop: CBORF_TEXT_STRING with cbor2
++ TypeError must not be used for callback signature probing
 
-= CBORF_TEXT_STRING empty string - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
+= CBORF_SEQUENCE_OF does not retry next_cls_cb when the callback itself raises TypeError
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import CBORF_SEQUENCE_OF
 from scapy.cborpacket import CBOR_Packet
 
-class TextPkt(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING('txt', '')
+BrokenNextClsCalls = []
+def broken_next_cls(*args):
+    BrokenNextClsCalls.append(len(args))
+    raise TypeError("intentional next_cls_cb failure")
 
-pkt = TextPkt()
-dec = cbor2.loads(bytes(pkt))
-dec == ''
+class BrokenCallbackParent(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE_OF(
+        "children",
+        [],
+        next_cls_cb=broken_next_cls,
+    )
 
-= CBORF_TEXT_STRING ASCII string - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
+try:
+    BrokenCallbackParent(b"\x01")
+except TypeError as exc:
+    assert str(exc) == "intentional next_cls_cb failure"
+except CBOR_Decoding_Error as exc:
+    raise AssertionError(
+        "next_cls_cb TypeError was unexpectedly translated: %r" % (exc,)
+    )
+else:
+    raise AssertionError("next_cls_cb TypeError was swallowed")
+
+assert BrokenNextClsCalls == [4], BrokenNextClsCalls
+
+
+= Nested packet construction is not retried when the child constructor raises TypeError
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import CBORF_PACKET, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class TextPkt2(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING('txt', '')
+class TypeErrorChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+    init_calls = []
+    def __init__(self, *args, **kwargs):
+        type(self).init_calls.append("_parent" in kwargs)
+        raise TypeError("intentional nested packet failure")
 
-pkt = TextPkt2()
-pkt.txt.val = 'Hello, World!'
-dec = cbor2.loads(bytes(pkt))
-dec == 'Hello, World!'
+class TypeErrorParent(CBOR_Packet):
+    CBOR_root = CBORF_PACKET("child", None, TypeErrorChild)
 
-= CBORF_TEXT_STRING unicode string - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
+TypeErrorChild.init_calls[:] = []
+try:
+    TypeErrorParent(b"\x01")
+except CBOR_Decoding_Error as exc:
+    assert "intentional nested packet failure" in str(exc)
+else:
+    raise AssertionError("nested packet TypeError was unexpectedly swallowed")
+
+assert TypeErrorChild.init_calls == [True], TypeErrorChild.init_calls
+
+
++ fixed-map unknown member preservation
+
+= CBORF_MAP preserves an unknown member when a known field is mutated
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class TextUniPkt(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING('txt', '')
+class ExtensibleMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+    )
 
-pkt = TextUniPkt()
-pkt.txt.val = u'Hello, \u4e16\u754c'
-dec = cbor2.loads(bytes(pkt))
-dec == u'Hello, \u4e16\u754c'
+# {"x": 1, "a": 7}
+wire = b"\xa2\x61x\x01\x61a\x07"
+pkt = ExtensibleMap(wire)
+assert pkt.a == 7
+# Exact received bytes are retained while the packet is untouched.
+assert bytes(pkt) == wire
 
-= CBORF_TEXT_STRING - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
+# Mutation invalidates Scapy's raw packet cache.  Rebuilding must not silently
+# discard the unknown extension member.  Fixed maps build deterministically,
+# therefore "a" sorts before "x".
+pkt.a = 8
+assert bytes(pkt) == b"\xa2\x61a\x08\x61x\x01"
+
+
+= CBORF_MAP preserves an unknown nested value after a known-field mutation
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class TextPkt3(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING('txt', '')
+class ExtensibleNestedMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+    )
 
-for s in ['', 'hello', 'Hello, World!', u'caf\u00e9', u'\u4e16\u754c']:
-    pkt = TextPkt3(cbor2.dumps(s))
-    assert pkt.txt.val == s
+# Indefinite input map: {"x": [1, {"k": 2}], "a": 7}
+# The unknown value is itself indefinite/nested, exercising preservation of
+# the complete encoded value rather than only simple Python-native values.
+wire = (
+    b"\xbf"
+    b"\x61x"
+    b"\x9f\x01\xbf\x61k\x02\xff\xff"
+    b"\x61a\x07"
+    b"\xff"
+)
+pkt = ExtensibleNestedMap(wire)
+assert pkt.a == 7
+pkt.a = 8
 
-True
+# CBORF_MAP's normal rebuild is definite and deterministic; unknown members
+# are re-encoded canonically after mutation (not as the original wire spans).
+assert bytes(pkt) == (
+    b"\xa2"
+    b"\x61a\x08"
+    b"\x61x\x82\x01\xa1\x61k\x02"
+)
 
-= CBORF_TEXT_STRING byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_TEXT_STRING
++ CBOR_Packet.copy re-parents embedded children
+
+= Copied CBOR packet children point at the clone, not the original
+from scapy.cbor.cborfields import CBORF_PACKET, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class TextExact(CBOR_Packet):
-    CBOR_root = CBORF_TEXT_STRING('txt', '')
+class CopyChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("n", 0)
 
-results = []
-for s in ['', 'a', 'hello', 'IETF', u'\u6c34']:
-    pkt = TextExact()
-    pkt.txt.val = s
-    results.append(bytes(pkt) == cbor2.dumps(s))
+class CopyParent(CBOR_Packet):
+    CBOR_root = CBORF_PACKET("child", None, cls=CopyChild)
 
-all(results)
+a = CopyParent(child=CopyChild(n=1))
+assert a.child.parent is a
+b = a.copy()
+assert b.child is not a.child
+assert b.child.parent is b, b.child.parent
+assert a.child.parent is a
+assert b.child.n == 1
 
-+ CBORF Fields - Interop: CBORF_BOOLEAN with cbor2
 
-= CBORF_BOOLEAN true - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_BOOLEAN
++ CBORF_MAP deterministic unknown rebuild
+
+= CBORF_MAP re-encodes non-preferred unknown members after a known-field mutation
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class BoolPkt(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN('flag', True)
+class DeterministicUnknownMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("z", 0),
+    )
 
-pkt = BoolPkt()
-dec = cbor2.loads(bytes(pkt))
-dec is True
+# known "z":1, unknown "a":1 with non-preferred key (78 01 61) and value (18 01)
+wire = b"\xa2\x61z\x01\x78\x01\x61\x18\x01"
+pkt = DeterministicUnknownMap(wire)
+assert bytes(pkt) == wire
+pkt.z = 2
+assert bytes(pkt) == b"\xa2\x61a\x01\x61z\x02"
 
-= CBORF_BOOLEAN false - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_BOOLEAN
+
+= CBORF_MAP recursively determinizes nested unknown map keys after mutation
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class BoolFalsePkt(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN('flag', False)
+class NestedUnknownMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("z", 0),
+    )
 
-pkt = BoolFalsePkt()
-dec = cbor2.loads(bytes(pkt))
-dec is False
+# known z:1, unknown x:{b:1,a:2} with nested keys out of deterministic order
+wire = b"\xa2\x61z\x01\x61x\xa2\x61b\x01\x61a\x02"
+pkt = NestedUnknownMap(wire)
+assert bytes(pkt) == wire
+pkt.z = 2
+assert bytes(pkt) == b"\xa2\x61x\xa2\x61a\x02\x61b\x01\x61z\x02"
 
-= CBORF_BOOLEAN - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_BOOLEAN
+
+= CBORF_MAP copy isolates nested unknown extension values from the original packet
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class BoolPkt2(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN('flag', False)
+class MapCopyIsolation(CBOR_Packet):
+    CBOR_root = CBORF_MAP(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+    )
 
-pkt_true = BoolPkt2(cbor2.dumps(True))
-pkt_false = BoolPkt2(cbor2.dumps(False))
-pkt_true.flag.val is True and pkt_false.flag.val is False
+wire = (
+    b"\xbf"
+    b"\x61x"
+    b"\x9f\x01\xbf\x61k\x02\xff\xff"
+    b"\x61a\x07"
+    b"\xff"
+)
+orig = MapCopyIsolation(wire)
+clone = orig.copy()
+assert clone._cbor_unknown_map_pairs is not orig._cbor_unknown_map_pairs
+assert clone._cbor_unknown_map_pairs[0][1] is not orig._cbor_unknown_map_pairs[0][1]
+clone._cbor_unknown_map_pairs[0][1].append(3)
+assert len(orig._cbor_unknown_map_pairs[0][1]) == 2
+assert clone._cbor_unknown_map_pairs[0][1] == [1, {"k": 2}, 3]
 
-= CBORF_BOOLEAN byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_BOOLEAN
+
++ CBORF_ARRAY_OF indefinite decoding
+
+= CBORF_ARRAY_OF decodes indefinite-length scalar arrays
+from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class BoolExactTrue(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN('flag', True)
+class IndefUIntArray(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("values", [], cls=CBORF_UNSIGNED_INTEGER)
 
-class BoolExactFalse(CBOR_Packet):
-    CBOR_root = CBORF_BOOLEAN('flag', False)
+wire = b"\x9f\x01\x02\x03\xff"
+pkt = IndefUIntArray(wire)
+assert pkt.values == [1, 2, 3]
+assert bytes(pkt) == wire
 
-pkt_t = BoolExactTrue()
-pkt_f = BoolExactFalse()
-bytes(pkt_t) == cbor2.dumps(True) and bytes(pkt_f) == cbor2.dumps(False)
 
-+ CBORF Fields - Interop: CBORF_NULL with cbor2
-
-= CBORF_NULL - Scapy encode, cbor2 decode gives None
-import cbor2
-from scapy.cbor.cborfields import CBORF_NULL
+= CBORF_ARRAY_OF decodes indefinite-length packet arrays
+from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
-class NullPkt(CBOR_Packet):
-    CBOR_root = CBORF_NULL('n')
+class IndefChild(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("n", 0)
 
-pkt = NullPkt()
-dec = cbor2.loads(bytes(pkt))
-dec is None
+class IndefPacketArray(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("children", [], pkt_cls=IndefChild)
 
-= CBORF_NULL byte-exact comparison with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_NULL
-from scapy.cborpacket import CBOR_Packet
+wire = b"\x9f\x01\x02\xff"
+pkt = IndefPacketArray(wire)
+assert len(pkt.children) == 2
+assert pkt.children[0].n == 1
+assert pkt.children[0].parent is pkt
+assert pkt.children[1].parent is pkt
 
-class NullExact(CBOR_Packet):
-    CBOR_root = CBORF_NULL('n')
++ Medium-severity review follow-ups
 
-pkt = NullExact()
-bytes(pkt) == cbor2.dumps(None)
-
-= CBORF_NULL - cbor2 None encode, Scapy decode gives CBOR_NULL
-import cbor2
-from scapy.cbor.cbor import CBOR_NULL
-from scapy.cbor.cborfields import CBORF_NULL
-from scapy.cborpacket import CBOR_Packet
-
-class NullPkt2(CBOR_Packet):
-    CBOR_root = CBORF_NULL('n')
-
-pkt = NullPkt2(cbor2.dumps(None))
-isinstance(pkt.n, CBOR_NULL)
-
-+ CBORF Fields - Interop: CBORF_FLOAT with cbor2
-
-= CBORF_FLOAT basic values - Scapy encode, cbor2 decode
-import cbor2
+= CBORF_FLOAT preserves received half-float wire after cache clear
+from scapy.cbor.cbor import CBORFloatValue
 from scapy.cbor.cborfields import CBORF_FLOAT
 from scapy.cborpacket import CBOR_Packet
 
 class FloatPkt(CBOR_Packet):
-    CBOR_root = CBORF_FLOAT('f', 0.0)
+    CBOR_root = CBORF_FLOAT("value", 0.0)
 
-results = []
-for val in [0.0, 1.0, -1.0, 3.14159, 1e10, -2.5]:
-    pkt = FloatPkt()
-    pkt.f.val = val
-    dec = cbor2.loads(bytes(pkt))
-    results.append(dec == val)
+wire = b"\xf9\x3e\x00"  # 1.5 as half
+pkt = FloatPkt(wire)
+assert isinstance(pkt.value, CBORFloatValue)
+assert abs(pkt.value - 1.5) < 1e-6
+assert pkt.value.cbor_encoded == wire
+pkt.raw_packet_cache = None
+pkt.raw_packet_cache_fields = None
+assert bytes(pkt) == wire
+pkt.value = 1.5
+assert bytes(pkt) == wire  # preferred half for 1.5
 
-all(results)
+= Unframed CBORF_SEQUENCE leaves trailing CBOR items
+from scapy.cbor.cborfields import CBORF_SEQUENCE, CBORF_UNSIGNED_INTEGER
+from scapy.cborpacket import CBOR_Packet
 
-= CBORF_FLOAT special values (NaN, Inf, -Inf) - Scapy encode, cbor2 decode
-import cbor2, math
+class TwoInts(CBOR_Packet):
+    CBOR_root = CBORF_SEQUENCE(
+        CBORF_UNSIGNED_INTEGER("a", 0),
+        CBORF_UNSIGNED_INTEGER("b", 0),
+    )
+
+pkt = TwoInts(b"\x01\x02\x03")
+assert pkt.a == 1 and pkt.b == 2
+assert isinstance(pkt.payload, Raw) or pkt.original.endswith(b"\x03")
+# Remaining third item is not consumed by the schema
+remain = TwoInts.CBOR_root.dissect_result(TwoInts(), b"\x01\x02\x03").remaining
+assert remain == b"\x03"
+
+= CBORF_SEMANTIC_TAG.m2i rejects the wrong tag number
+from scapy.cbor.cborfields import (
+    CBORF_SEMANTIC_TAG, CBORF_INTEGER, CBOR_Type_Mismatch,
+)
+
+fld = CBORF_SEMANTIC_TAG("tag", None, 1, CBORF_INTEGER("ts", 0))
+try:
+    fld.m2i(None, b"\xc2\x00")  # tag 2
+except CBOR_Type_Mismatch:
+    pass
+else:
+    raise AssertionError("wrong tag accepted by m2i")
+
+= Deterministic encoder accepts CBOR_Object wrappers
+from scapy.cbor.cbor import CBOR_UNSIGNED_INTEGER, CBOR_TEXT_STRING, CBOR_MAP, CBORMapData
+from scapy.cbor.cborcodec import CBORcodec_Object
+
+obj = CBOR_MAP(CBORMapData([
+    (CBOR_TEXT_STRING("b"), CBOR_UNSIGNED_INTEGER(1)),
+    (CBOR_TEXT_STRING("a"), CBOR_UNSIGNED_INTEGER(2)),
+]))
+wire = CBORcodec_Object.encode_cbor_item_deterministic(obj)
+assert wire == b"\xa2\x61a\x02\x61b\x01"
+
+= Non-determinism scanner reports bare break and short simples
+from scapy.cbor.cborcodec import cbor_find_non_deterministic
+
+issues = cbor_find_non_deterministic(b"\xff")
+assert issues and "break" in issues[0][1].lower()
+issues = cbor_find_non_deterministic(b"\xf8\x14")  # simple 20 via AI=24
+assert issues and "simple" in issues[0][1].lower()
+
+= CBORMapData lookup distinguishes +0.0 from -0.0 map keys
+from scapy.cbor import CBOR_Codecs
+
+# {+0.0: 1, -0.0: 2} as half floats
+wire = b"\xa2\xf9\x00\x00\x01\xf9\x80\x00\x02"
+obj, remaining = CBOR_Codecs.CBOR.dec(wire)
+assert remaining == b""
+md = obj.val
+assert md[0.0].val == 1
+assert md[-0.0].val == 2
+assert md[0.0] is not md[-0.0]
+
+= Malformed optional semantic tag does not migrate into trailing CBORF_ANY
+from scapy.cbor.cbor import CBOR_Decoding_Error
+from scapy.cbor.cborfields import (
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_SEMANTIC_TAG,
+    CBORF_UNSIGNED_INTEGER,
+    CBORF_optional,
+    CBOR_ABSENT,
+)
+from scapy.cborpacket import CBOR_Packet
+
+class OptionalTaggedBeforeAny(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_optional(
+            CBORF_SEMANTIC_TAG(
+                "tag_number",
+                None,
+                1,
+                CBORF_UNSIGNED_INTEGER("tagged_value", None),
+            )
+        ),
+        CBORF_ANY("fallback", None),
+    )
+
+try:
+    OptionalTaggedBeforeAny(b"\x81\xc1\x61x")
+except CBOR_Decoding_Error:
+    pass
+else:
+    raise AssertionError("Malformed tagged data migrated into the fallback field")
+
+# Matching well-formed optional still yields to reserved trailing ANY.
+ok = OptionalTaggedBeforeAny(b"\x81\xc1\x01")
+assert ok.getfieldval("tag_number") is CBOR_ABSENT
+assert ok.fallback is not None
+
+= CBORF_MAP rejects non-text map keys
+from scapy.cbor.cborfields import CBORF_MAP, CBORF_UNSIGNED_INTEGER, CBOR_Decoding_Error
+from scapy.cborpacket import CBOR_Packet
+
+class NamedMap(CBOR_Packet):
+    CBOR_root = CBORF_MAP(CBORF_UNSIGNED_INTEGER("a", 0))
+
+# {1: 2} — integer key is not allowed for schema maps
+try:
+    NamedMap(b"\xa1\x01\x02")
+except CBOR_Decoding_Error:
+    pass
+else:
+    raise AssertionError("CBORF_MAP accepted an integer key")
+
+= Indefinite text rejects a UTF-8 code point split across chunks
+from scapy.cbor import CBOR_Codecs
+from scapy.cbor.cborcodec import CBOR_Codec_Decoding_Error
+
+# U+00E4 is UTF-8 C3 A4; RFC 8949 forbids splitting a code point across chunks.
+wire = b"\x7f\x61\xc3\x61\xa4\xff"
+try:
+    CBOR_Codecs.CBOR.dec(wire)
+except CBOR_Codec_Decoding_Error:
+    pass
+else:
+    raise AssertionError("split UTF-8 code point across chunks was accepted")
+
+# Valid split on a code-point boundary still works.
+obj, rem = CBOR_Codecs.CBOR.dec(b"\x7f\x62\xc3\xa4\x61\x61\xff")
+assert rem == b"" and obj.val == "äa"
+
+= CBORF_FLOAT preserves non-preferred NaN payload wire after cache clear
+from scapy.cbor.cbor import CBORFloatValue
 from scapy.cbor.cborfields import CBORF_FLOAT
 from scapy.cborpacket import CBOR_Packet
 
-class FloatSpecialPkt(CBOR_Packet):
-    CBOR_root = CBORF_FLOAT('f', 0.0)
+class FloatPkt(CBOR_Packet):
+    CBOR_root = CBORF_FLOAT("value", 0.0)
 
-pkt_nan = FloatSpecialPkt()
-pkt_nan.f.val = float('nan')
-raw_nan = bytes(pkt_nan)
-pkt_inf = FloatSpecialPkt()
-pkt_inf.f.val = float('inf')
-raw_inf = bytes(pkt_inf)
-pkt_ninf = FloatSpecialPkt()
-pkt_ninf.f.val = float('-inf')
-raw_ninf = bytes(pkt_ninf)
-math.isnan(cbor2.loads(raw_nan)) and math.isinf(cbor2.loads(raw_inf)) and cbor2.loads(raw_ninf) == float('-inf')
+# binary64 NaN with a low payload bit (preferred width stays binary64)
+wire = bytes.fromhex("fb7ff8000000000001")
+pkt = FloatPkt(wire)
+assert isinstance(pkt.value, CBORFloatValue)
+assert pkt.value != pkt.value  # NaN
+assert pkt.value.cbor_encoded == wire
+pkt.raw_packet_cache = None
+pkt.raw_packet_cache_fields = None
+assert bytes(pkt) == wire
 
-= CBORF_FLOAT special values - cbor2 encode, Scapy decode
-import cbor2, math
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_FLOAT
+= CBORF_TEXT_STRING rejects bytes values instead of str(bytes) corruption
+from scapy.cbor.cborfields import CBORF_TEXT_STRING
 from scapy.cborpacket import CBOR_Packet
 
-class FloatArrPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_FLOAT('nan_val', 0.0),
-        CBORF_FLOAT('inf_val', 0.0),
-        CBORF_FLOAT('ninf_val', 0.0),
-    )
+class TextPkt(CBOR_Packet):
+    CBOR_root = CBORF_TEXT_STRING("label", "")
 
-pkt = FloatArrPkt(cbor2.dumps([float('nan'), float('inf'), float('-inf')]))
-math.isnan(pkt.nan_val.val) and math.isinf(pkt.inf_val.val) and pkt.ninf_val.val == float('-inf')
+pkt = TextPkt()
+try:
+    pkt.label = b"hi"
+except TypeError:
+    pass
+else:
+    raise AssertionError("bytes were coerced via str(bytes)")
 
-= CBORF_FLOAT - cbor2 encode, Scapy decode roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_FLOAT
+= CBORF_ANY preserves non-preferred float wire after cache clear
+from scapy.cbor.cbor import CBORFloatValue
+from scapy.cbor.cborfields import CBORF_ANY
 from scapy.cborpacket import CBOR_Packet
 
-class FloatPkt2(CBOR_Packet):
-    CBOR_root = CBORF_FLOAT('f', 0.0)
-
-results = []
-for val in [0.0, 1.0, -1.0, 2.5, 100.0]:
-    pkt = FloatPkt2(cbor2.dumps(val))
-    results.append(pkt.f.val == val)
-
-all(results)
-
-+ CBORF Fields - Interop: CBORF_ARRAY with cbor2
-
-= CBORF_ARRAY with integer fields - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class PointPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('x', 10),
-        CBORF_INTEGER('y', 20),
-        CBORF_INTEGER('z', 30),
-    )
-
-pkt = PointPkt()
-dec = cbor2.loads(bytes(pkt))
-dec == [10, 20, 30]
-
-= CBORF_ARRAY with mixed types - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BOOLEAN
-from scapy.cborpacket import CBOR_Packet
-
-class MixedPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('id', 99),
-        CBORF_TEXT_STRING('label', 'test'),
-        CBORF_BOOLEAN('active', True),
-    )
-
-pkt = MixedPkt()
-dec = cbor2.loads(bytes(pkt))
-dec[0] == 99 and dec[1] == 'test' and dec[2] is True
-
-= CBORF_ARRAY - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class RecordPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('code', 0),
-        CBORF_TEXT_STRING('msg', ''),
-    )
-
-pkt = RecordPkt(cbor2.dumps([200, 'OK']))
-pkt.code.val == 200 and pkt.msg.val == 'OK'
-
-= CBORF_ARRAY roundtrip through cbor2 - multiple encode/decode cycles
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class RTPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('seq', 1),
-        CBORF_TEXT_STRING('data', 'payload'),
-    )
-
-pkt = RTPkt()
-raw = bytes(pkt)
-cbor2_dec = cbor2.loads(raw)
-re_enc = cbor2.dumps(cbor2_dec)
-pkt2 = RTPkt(re_enc)
-pkt2.seq.val == 1 and pkt2.data.val == 'payload'
-
-= CBORF_ARRAY with null elements - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_NULL
-from scapy.cborpacket import CBOR_Packet
-
-class NullArrPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('id', 5),
-        CBORF_NULL('opt'),
-    )
-
-pkt = NullArrPkt()
-dec = cbor2.loads(bytes(pkt))
-dec[0] == 5 and dec[1] is None
-
-+ CBORF Fields - Interop: CBORF_ARRAY_OF with cbor2
-
-= CBORF_ARRAY_OF with text strings - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cbor import CBOR_TEXT_STRING
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class TextListPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_TEXT_STRING)
-
-pkt = TextListPkt(cbor2.dumps(['hello', 'world', 'foo']))
-len(pkt.items) == 3 and pkt.items[0].val == 'hello' and pkt.items[2].val == 'foo'
-
-= CBORF_ARRAY_OF with text strings - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cbor import CBOR_TEXT_STRING
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class TextListPkt2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_TEXT_STRING)
-
-pkt = TextListPkt2()
-pkt.items = [CBOR_TEXT_STRING('abc'), CBOR_TEXT_STRING('def'), CBOR_TEXT_STRING('ghi')]
-dec = cbor2.loads(bytes(pkt))
-dec == ['abc', 'def', 'ghi']
-
-= CBORF_ARRAY_OF with text strings roundtrip through cbor2
-import cbor2
-from scapy.cbor.cbor import CBOR_TEXT_STRING
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class TextListRT(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_TEXT_STRING)
-
-pkt = TextListRT()
-pkt.items = [CBOR_TEXT_STRING('x'), CBOR_TEXT_STRING('y'), CBOR_TEXT_STRING('z')]
-raw = bytes(pkt)
-re_enc = cbor2.dumps(cbor2.loads(raw))
-pkt2 = TextListRT(re_enc)
-len(pkt2.items) == 3 and pkt2.items[1].val == 'y'
-
-= CBORF_ARRAY_OF with byte strings - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cbor import CBOR_BYTE_STRING
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class ByteListPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_BYTE_STRING)
-
-pkt = ByteListPkt(cbor2.dumps([b'\x01\x02', b'\x03\x04', b'\x05\x06']))
-len(pkt.items) == 3 and pkt.items[0].val == b'\x01\x02' and pkt.items[2].val == b'\x05\x06'
-
-= CBORF_ARRAY_OF with byte strings - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cbor import CBOR_BYTE_STRING
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class ByteListPkt2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_BYTE_STRING)
-
-pkt = ByteListPkt2()
-pkt.items = [CBOR_BYTE_STRING(b'\xaa\xbb'), CBOR_BYTE_STRING(b'\xcc\xdd')]
-dec = cbor2.loads(bytes(pkt))
-dec == [b'\xaa\xbb', b'\xcc\xdd']
-
-= CBORF_ARRAY_OF integers - large list cbor2 roundtrip
-import cbor2
-from scapy.cbor.cbor import CBOR_UNSIGNED_INTEGER
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class BigIntList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_INTEGER)
-
-cbor2_data = cbor2.dumps(list(range(50)))
-pkt = BigIntList(cbor2_data)
-len(pkt.items) == 50 and pkt.items[0].val == 0 and pkt.items[49].val == 49
-
-= CBORF_ARRAY_OF integers - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cbor import CBOR_UNSIGNED_INTEGER
-from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class IntListPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], CBORF_INTEGER)
-
-pkt = IntListPkt()
-pkt.items = [CBOR_UNSIGNED_INTEGER(i) for i in [10, 20, 30, 40, 50]]
-dec = cbor2.loads(bytes(pkt))
-dec == [10, 20, 30, 40, 50]
-
-+ CBORF Fields - Interop: CBORF_MAP with cbor2
-
-= CBORF_MAP with text string values - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class HeaderPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('alg', 'ES256'),
-        CBORF_TEXT_STRING('typ', 'JWT'),
-        CBORF_INTEGER('ver', 1),
-    )
-
-pkt = HeaderPkt()
-dec = cbor2.loads(bytes(pkt))
-isinstance(dec, dict) and dec.get('alg') == 'ES256' and dec.get('typ') == 'JWT' and dec.get('ver') == 1
-
-= CBORF_MAP - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER, CBORF_BOOLEAN
-from scapy.cborpacket import CBOR_Packet
-
-class CredPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('sub', ''),
-        CBORF_INTEGER('iat', 0),
-        CBORF_BOOLEAN('admin', False),
-    )
-
-pkt = CredPkt(cbor2.dumps({'sub': 'user42', 'iat': 1700000000, 'admin': True}))
-pkt.sub.val == 'user42' and pkt.iat.val == 1700000000 and pkt.admin.val is True
-
-= CBORF_MAP roundtrip through cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_BYTE_STRING, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class CoseHeaderPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('alg', 'ES256'),
-        CBORF_BYTE_STRING('kid', b'\x01\x02\x03\x04'),
-        CBORF_INTEGER('crit', 1),
-    )
-
-pkt = CoseHeaderPkt()
-raw = bytes(pkt)
-re_enc = cbor2.dumps(cbor2.loads(raw))
-pkt2 = CoseHeaderPkt(re_enc)
-pkt2.alg.val == 'ES256' and pkt2.kid.val == b'\x01\x02\x03\x04' and pkt2.crit.val == 1
-
-= CBORF_MAP with null value - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_NULL
-from scapy.cborpacket import CBOR_Packet
-
-class OptionalPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('id', 7),
-        CBORF_NULL('optional_data'),
-    )
-
-pkt = OptionalPkt()
-dec = cbor2.loads(bytes(pkt))
-dec.get('id') == 7 and dec.get('optional_data') is None
-
-= CBORF_MAP with boolean values roundtrip with cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_BOOLEAN, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class FlagsPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_BOOLEAN('active', True),
-        CBORF_BOOLEAN('verified', False),
-        CBORF_INTEGER('level', 3),
-        CBORF_TEXT_STRING('role', 'admin'),
-    )
-
-pkt = FlagsPkt()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-re_enc = cbor2.dumps(dec)
-pkt2 = FlagsPkt(re_enc)
-pkt2.active.val is True and pkt2.verified.val is False and pkt2.level.val == 3 and pkt2.role.val == 'admin'
-
-= CBORF_MAP skip unknown keys from cbor2
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER
-from scapy.cborpacket import CBOR_Packet
-
-class KnownKeysPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('known', 'default'),
-        CBORF_INTEGER('count', 0),
-    )
-
-pkt = KnownKeysPkt(cbor2.dumps({'known': 'found', 'count': 42, 'extra': 'ignored'}))
-pkt.known.val == 'found' and pkt.count.val == 42
-
-+ CBORF Fields - Interop: CBOR_Packet complex structures with cbor2
-
-= CBOR_Packet CBORF_ARRAY with multiple field types - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BOOLEAN
-from scapy.cborpacket import CBOR_Packet
-
-class SensorReading(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('sensor_id', 42),
-        CBORF_TEXT_STRING('unit', 'fahrenheit'),
-        CBORF_INTEGER('value', 98),
-        CBORF_BOOLEAN('alarm', True),
-    )
-
-pkt = SensorReading()
-dec = cbor2.loads(bytes(pkt))
-dec[0] == 42 and dec[1] == 'fahrenheit' and dec[2] == 98 and dec[3] is True
-
-= CBOR_Packet with CBORF_MAP multiple field types - Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BOOLEAN, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class DeviceInfo(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('id', 0),
-        CBORF_TEXT_STRING('label', ''),
-        CBORF_BOOLEAN('online', False),
-        CBORF_BYTE_STRING('hwaddr', b''),
-    )
-
-pkt = DeviceInfo(cbor2.dumps({'id': 1001, 'label': 'device-01', 'online': True, 'hwaddr': b'\x00\x11\x22\x33\x44\x55'}))
-dec = cbor2.loads(bytes(pkt))
-dec.get('id') == 1001 and dec.get('label') == 'device-01' and dec.get('online') is True and dec.get('hwaddr') == b'\x00\x11\x22\x33\x44\x55'
-
-= CBOR_Packet CBORF_MAP full cbor2 roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BOOLEAN
-from scapy.cborpacket import CBOR_Packet
-
-class ClaimsPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('iss', ''),
-        CBORF_TEXT_STRING('sub', ''),
-        CBORF_INTEGER('exp', 0),
-        CBORF_BOOLEAN('admin', False),
-    )
-
-pkt = ClaimsPkt(cbor2.dumps({'iss': 'auth.example.com', 'sub': 'user99', 'exp': 9999999, 'admin': False}))
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-dec.get('iss') == 'auth.example.com' and dec.get('sub') == 'user99' and dec.get('exp') == 9999999 and dec.get('admin') is False
-
-= CBOR_Packet CBORF_MAP with negative integer - cbor2 encode, Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class OffsetPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('name', ''),
-        CBORF_INTEGER('offset', 0),
-        CBORF_INTEGER('count', 0),
-    )
-
-pkt = OffsetPkt(cbor2.dumps({'name': 'delta', 'offset': -1024, 'count': 512}))
-pkt.name.val == 'delta' and pkt.offset.val == -1024 and pkt.count.val == 512
-
-+ CBOR_Packet - nested CBORF_PACKET structures
-
-= CBORF_PACKET three levels deep: Outer(ARRAY) -> Middle(ARRAY) -> Inner(ARRAY)
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class NestInner(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('x', 0),
-        CBORF_INTEGER('y', 0),
-    )
-
-class NestMiddle(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_TEXT_STRING('zone', ''),
-        CBORF_PACKET('point', None, NestInner),
-    )
-
-class NestOuter(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('version', 0),
-        CBORF_PACKET('region', None, NestMiddle),
-    )
-
-inner = NestInner(cbor2.dumps([30, 40]))
-mid = NestMiddle()
-mid.zone.val = 'north'
-mid.point = inner
-outer = NestOuter()
-outer.version.val = 2
-outer.region = mid
-raw = bytes(outer)
-outer2 = NestOuter(raw)
-outer2.version.val == 2 and outer2.region.zone.val == 'north' and outer2.region.point.x.val == 30 and outer2.region.point.y.val == 40
-
-= CBORF_PACKET three-level nesting cbor2 interop
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class NestInner2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('x', 0),
-        CBORF_INTEGER('y', 0),
-    )
-
-class NestMiddle2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_TEXT_STRING('zone', ''),
-        CBORF_PACKET('point', None, NestInner2),
-    )
-
-class NestOuter2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('version', 0),
-        CBORF_PACKET('region', None, NestMiddle2),
-    )
-
-inner = NestInner2(cbor2.dumps([10, 20]))
-mid = NestMiddle2()
-mid.zone.val = 'south'
-mid.point = inner
-outer = NestOuter2()
-outer.version.val = 1
-outer.region = mid
-dec = cbor2.loads(bytes(outer))
-dec == [1, ['south', [10, 20]]]
-
-= CBORF_PACKET inside CBORF_MAP: cbor2 decode matches field values
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_MAP, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class MapInner(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('px', 0),
-        CBORF_INTEGER('py', 0),
-    )
-
-class MapWithNestedPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('label', ''),
-        CBORF_PACKET('coords', None, MapInner),
-    )
-
-inner = MapInner(cbor2.dumps([5, 7]))
-pkt = MapWithNestedPkt()
-pkt.label.val = 'origin'
-pkt.coords = inner
-dec = cbor2.loads(bytes(pkt))
-dec.get('label') == 'origin' and dec.get('coords') == [5, 7]
-
-= CBORF_PACKET inside CBORF_MAP: Scapy decode roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_MAP, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class CoordsInner(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('px', 0),
-        CBORF_INTEGER('py', 0),
-    )
-
-class CoordsOuter(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('label', ''),
-        CBORF_PACKET('coords', None, CoordsInner),
-    )
-
-inner = CoordsInner(cbor2.dumps([5, 7]))
-pkt = CoordsOuter()
-pkt.label.val = 'origin'
-pkt.coords = inner
-pkt2 = CoordsOuter(bytes(pkt))
-pkt2.label.val == 'origin' and pkt2.coords.px.val == 5 and pkt2.coords.py.val == 7
-
-= CBORF_PACKET: nested MAP-in-MAP via CBORF_PACKET (Document/Metadata)
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_BYTE_STRING, CBORF_INTEGER, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class DocMeta(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('creator', ''),
-        CBORF_INTEGER('version', 0),
-    )
-
-class DocPacket(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('title', ''),
-        CBORF_BYTE_STRING('body', b''),
-        CBORF_PACKET('metadata', None, DocMeta),
-    )
-
-meta = DocMeta()
-meta.creator.val = 'alice'
-meta.version.val = 3
-doc = DocPacket()
-doc.title.val = 'My Document'
-doc.body.val = b'hello world'
-doc.metadata = meta
-raw = bytes(doc)
-dec = cbor2.loads(raw)
-dec.get('title') == 'My Document' and dec.get('body') == b'hello world' and dec.get('metadata') == {'creator': 'alice', 'version': 3}
-
-= CBORF_PACKET: nested MAP-in-MAP Scapy roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_BYTE_STRING, CBORF_INTEGER, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class DocMeta2(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('creator', ''),
-        CBORF_INTEGER('version', 0),
-    )
-
-class DocPacket2(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('title', ''),
-        CBORF_BYTE_STRING('body', b''),
-        CBORF_PACKET('metadata', None, DocMeta2),
-    )
-
-meta = DocMeta2()
-meta.creator.val = 'bob'
-meta.version.val = 7
-doc = DocPacket2()
-doc.title.val = 'Report'
-doc.body.val = b'\x01\x02\x03'
-doc.metadata = meta
-raw = bytes(doc)
-doc2 = DocPacket2(raw)
-doc2.title.val == 'Report' and doc2.body.val == b'\x01\x02\x03' and doc2.metadata.creator.val == 'bob' and doc2.metadata.version.val == 7
-
-+ CBOR_Packet - CBORF_ARRAY_OF with CBOR_Packet elements
-
-= CBORF_ARRAY_OF with CBOR_Packet class: cbor2 list of lists → Scapy decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF
-from scapy.cborpacket import CBOR_Packet
-
-class StatusItem(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('code', 0),
-        CBORF_TEXT_STRING('msg', ''),
-    )
-
-class StatusList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('statuses', [], StatusItem)
-
-raw = cbor2.dumps([[200, 'OK'], [201, 'Created'], [204, 'No Content']])
-pkt = StatusList(raw)
-len(pkt.statuses) == 3 and pkt.statuses[0].code.val == 200 and pkt.statuses[1].msg.val == 'Created' and pkt.statuses[2].code.val == 204
-
-= CBORF_ARRAY_OF with CBOR_Packet class: Scapy encode → cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF
-from scapy.cborpacket import CBOR_Packet
-
-class ErrItem(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('code', 0),
-        CBORF_TEXT_STRING('msg', ''),
-    )
-
-class ErrList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('errors', [], ErrItem)
-
-pkt = ErrList()
-pkt.errors = [ErrItem(cbor2.dumps([404, 'Not Found'])), ErrItem(cbor2.dumps([500, 'Server Error']))]
-dec = cbor2.loads(bytes(pkt))
-dec == [[404, 'Not Found'], [500, 'Server Error']]
-
-= CBORF_ARRAY_OF with CBOR_Packet class: roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF
-from scapy.cborpacket import CBOR_Packet
-
-class MsgItem(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('id', 0),
-        CBORF_TEXT_STRING('txt', ''),
-    )
-
-class MsgList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('messages', [], MsgItem)
-
-raw = cbor2.dumps([[1, 'hello'], [2, 'world'], [3, 'foo']])
-pkt = MsgList(raw)
-raw2 = bytes(pkt)
-pkt2 = MsgList(raw2)
-len(pkt2.messages) == 3 and pkt2.messages[2].id.val == 3 and pkt2.messages[2].txt.val == 'foo'
-
-= CBORF_ARRAY_OF with CBOR_Packet class: empty list
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF
-from scapy.cborpacket import CBOR_Packet
-
-class EmptyItem(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('val', 0),
-    )
-
-class EmptyItemList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('items', [], EmptyItem)
-
-pkt = EmptyItemList()
-raw = bytes(pkt)
-dec = cbor2.loads(raw)
-dec == [] and len(EmptyItemList(raw).items) == 0
-
-= CBORF_ARRAY_OF with CBOR_Packet class inside CBORF_MAP
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF, CBORF_MAP, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class EventItem(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_TEXT_STRING('evt', ''),
-        CBORF_INTEGER('ts', 0),
-    )
-
-class EventLog(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('events', [], EventItem)
-
-class Report(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('source', ''),
-        CBORF_INTEGER('count', 0),
-        CBORF_PACKET('log', None, EventLog),
-    )
-
-log = EventLog()
-log.events = [EventItem(cbor2.dumps(['boot', 1000])), EventItem(cbor2.dumps(['login', 2000]))]
-rpt = Report()
-rpt.source.val = 'sensor-1'
-rpt.count.val = 2
-rpt.log = log
-raw = bytes(rpt)
-dec = cbor2.loads(raw)
-dec.get('source') == 'sensor-1' and dec.get('count') == 2 and dec.get('log') == [['boot', 1000], ['login', 2000]]
-
-+ CBOR_Packet - CBORF_optional extended tests
-
-= CBORF_optional: type mismatch in CBORF_ARRAY sets field to None
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class TwoFieldPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('version', 0),
-        CBORF_optional(CBORF_TEXT_STRING('description', 'none')),
-    )
-
-raw = cbor2.dumps([7, 99])
-pkt = TwoFieldPkt(raw)
-pkt.version.val == 7 and pkt.description is None
-
-= CBORF_optional: correct type present is decoded normally
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class OptPresentPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('version', 0),
-        CBORF_optional(CBORF_TEXT_STRING('description', '')),
-    )
-
-raw = cbor2.dumps([3, 'hello world'])
-pkt = OptPresentPkt(raw)
-pkt.version.val == 3 and pkt.description.val == 'hello world'
-
-= CBORF_optional: encode and decode roundtrip with present field
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class OptRTPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('version', 1),
-        CBORF_optional(CBORF_TEXT_STRING('title', '')),
-    )
-
-pkt = OptRTPkt()
-pkt.title.val = 'test title'
-raw = bytes(pkt)
-pkt2 = OptRTPkt(raw)
-pkt2.version.val == 1 and pkt2.title.val == 'test title'
-
-= CBORF_optional: cbor2 interop - optional present
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class OptInteropPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('seq', 0),
-        CBORF_optional(CBORF_TEXT_STRING('note', '')),
-    )
-
-pkt = OptInteropPkt()
-pkt.note.val = 'cbor2 interop'
-dec = cbor2.loads(bytes(pkt))
-dec == [0, 'cbor2 interop']
-
-= CBORF_optional inside CBORF_MAP: key present in cbor2 dict is decoded
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class ConfigWithOpt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('timeout', 30),
-        CBORF_optional(CBORF_TEXT_STRING('endpoint', '')),
-        CBORF_INTEGER('retries', 3),
-    )
-
-pkt = ConfigWithOpt(cbor2.dumps({'timeout': 60, 'endpoint': 'https://example.com', 'retries': 5}))
-pkt.timeout.val == 60 and pkt.endpoint.val == 'https://example.com' and pkt.retries.val == 5
-
-= CBORF_optional inside CBORF_MAP: missing key stays at default
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_optional
-from scapy.cborpacket import CBOR_Packet
-
-class ConfigNoOpt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('timeout', 30),
-        CBORF_optional(CBORF_TEXT_STRING('endpoint', '')),
-        CBORF_INTEGER('retries', 3),
-    )
-
-pkt = ConfigNoOpt(cbor2.dumps({'timeout': 15, 'retries': 2}))
-pkt.timeout.val == 15 and pkt.retries.val == 2
-
-+ CBOR_Packet - CBORF_SEMANTIC_TAG extended tests
-
-= CBORF_SEMANTIC_TAG with TEXT_STRING inner: Scapy encode, cbor2 decode as datetime
-import cbor2, datetime
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_TEXT_STRING, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class DatetimePkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag', None, 0, CBORF_TEXT_STRING('dt', ''))
-
-pkt = DatetimePkt()
-pkt.dt.val = '2023-01-15T12:00:00Z'
-dec = cbor2.loads(bytes(pkt))
-isinstance(dec, datetime.datetime)
-
-= CBORF_SEMANTIC_TAG with INTEGER inner: Scapy encode, cbor2 decode as datetime
-import cbor2, datetime
-from scapy.cbor.cborfields import CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class UnixTimePkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0))
-
-pkt = UnixTimePkt()
-pkt.ts.val = 1700000000
-dec = cbor2.loads(bytes(pkt))
-isinstance(dec, datetime.datetime)
-
-= CBORF_SEMANTIC_TAG roundtrip: Scapy encode → Scapy decode preserves inner value
-import cbor2
-from scapy.cbor.cborfields import CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class TagRTPkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0))
-
-pkt = TagRTPkt()
-pkt.ts.val = 1700000000
-raw = bytes(pkt)
-pkt2 = TagRTPkt(raw)
-pkt2.ts.val == 1700000000
-
-= CBORF_SEMANTIC_TAG: tag byte matches CBOR major type 6 encoding
-import cbor2
-from scapy.cbor.cborfields import CBORF_BYTE_STRING, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class TagBigNum(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag', None, 2, CBORF_BYTE_STRING('n', b''))
-
-pkt = TagBigNum()
-pkt.n.val = b'\x01\x00\x00\x00\x00\x00\x00\x00\x00'
-raw = bytes(pkt)
-raw[0:1] == b'\xc2'
-
-= CBORF_SEMANTIC_TAG: byte-exact comparison with cbor2 CBORTag
-import cbor2
-from scapy.cbor.cborfields import CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class TagCmpPkt(CBOR_Packet):
-    CBOR_root = CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0))
-
-pkt = TagCmpPkt()
-pkt.ts.val = 9999999
-bytes(pkt) == cbor2.dumps(cbor2.CBORTag(1, 9999999))
-
-= CBORF_SEMANTIC_TAG inside CBORF_MAP: Scapy encode, cbor2 decode
-import cbor2, datetime
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class EventPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('event_type', ''),
-        CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0)),
-    )
-
-pkt = EventPkt()
-pkt.event_type.val = 'login'
-pkt.ts.val = 9999999
-dec = cbor2.loads(bytes(pkt))
-isinstance(dec, dict) and dec.get('event_type') == 'login' and isinstance(dec.get('tag'), datetime.datetime)
-
-= CBORF_SEMANTIC_TAG inside CBORF_MAP: Scapy roundtrip preserves inner value
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_TEXT_STRING, CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class EventRTPkt(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_TEXT_STRING('event_type', ''),
-        CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0)),
-    )
-
-pkt = EventRTPkt()
-pkt.event_type.val = 'logout'
-pkt.ts.val = 1234567890
-raw = bytes(pkt)
-pkt2 = EventRTPkt(raw)
-pkt2.event_type.val == 'logout' and pkt2.ts.val == 1234567890
-
-= CBORF_SEMANTIC_TAG inside CBORF_ARRAY: Scapy encode, cbor2 decode
-import cbor2, datetime
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_TEXT_STRING, CBORF_INTEGER, CBORF_SEMANTIC_TAG
-from scapy.cborpacket import CBOR_Packet
-
-class TimedEventArr(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_TEXT_STRING('evt', ''),
-        CBORF_SEMANTIC_TAG('tag', None, 1, CBORF_INTEGER('ts', 0)),
-    )
-
-pkt = TimedEventArr()
-pkt.evt.val = 'start'
-pkt.ts.val = 1700000000
-dec = cbor2.loads(bytes(pkt))
-dec[0] == 'start' and isinstance(dec[1], datetime.datetime)
-
-+ CBOR_Packet - realistic models
-
-= Realistic model: EAT-like attestation token
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class EATToken(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('nonce', 0),
-        CBORF_TEXT_STRING('ueid', ''),
-        CBORF_BYTE_STRING('boot_seed', b''),
-        CBORF_INTEGER('hwver', 0),
-    )
-
-raw = cbor2.dumps({'nonce': 12345, 'ueid': 'device-abc', 'boot_seed': b'\x00' * 16, 'hwver': 3})
-pkt = EATToken(raw)
-pkt.nonce.val == 12345 and pkt.ueid.val == 'device-abc' and pkt.boot_seed.val == b'\x00' * 16 and pkt.hwver.val == 3
-
-= Realistic model: EAT-like token Scapy encode, cbor2 decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class EATToken2(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('nonce', 0),
-        CBORF_TEXT_STRING('ueid', ''),
-        CBORF_BYTE_STRING('boot_seed', b''),
-        CBORF_INTEGER('hwver', 0),
-    )
-
-pkt = EATToken2()
-pkt.nonce.val = 99999
-pkt.ueid.val = 'iot-sensor-01'
-pkt.boot_seed.val = b'\xde\xad\xbe\xef' * 4
-pkt.hwver.val = 5
-dec = cbor2.loads(bytes(pkt))
-dec.get('nonce') == 99999 and dec.get('ueid') == 'iot-sensor-01' and dec.get('boot_seed') == b'\xde\xad\xbe\xef' * 4 and dec.get('hwver') == 5
-
-= Realistic model: SensorReport with CBORF_PACKET inner reading
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_FLOAT, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class SensorData(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('sensor_id', 0),
-        CBORF_FLOAT('temperature', 0.0),
-    )
-
-class SensorReport(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('station', 0),
-        CBORF_TEXT_STRING('unit', ''),
-        CBORF_PACKET('reading', None, SensorData),
-    )
-
-reading = SensorData()
-reading.sensor_id.val = 3
-reading.temperature.val = 98.6
-rpt = SensorReport()
-rpt.station.val = 5
-rpt.unit.val = 'fahrenheit'
-rpt.reading = reading
-dec = cbor2.loads(bytes(rpt))
-dec.get('station') == 5 and dec.get('unit') == 'fahrenheit' and dec.get('reading') == [3, 98.6]
-
-= Realistic model: SensorReport Scapy roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_FLOAT, CBORF_PACKET
-from scapy.cborpacket import CBOR_Packet
-
-class SensorData2(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('sensor_id', 0),
-        CBORF_FLOAT('temperature', 0.0),
-    )
-
-class SensorReport2(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('station', 0),
-        CBORF_TEXT_STRING('unit', ''),
-        CBORF_PACKET('reading', None, SensorData2),
-    )
-
-raw = cbor2.dumps({'station': 9, 'unit': 'celsius', 'reading': [7, 36.5]})
-pkt = SensorReport2(raw)
-pkt2 = SensorReport2(bytes(pkt))
-pkt2.station.val == 9 and pkt2.unit.val == 'celsius' and pkt2.reading.sensor_id.val == 7
-
-= Realistic model: StatusList (CBORF_ARRAY_OF of CBOR_Packets) encode and decode
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_ARRAY_OF
-from scapy.cborpacket import CBOR_Packet
-
-class HttpStatus(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('code', 0),
-        CBORF_TEXT_STRING('phrase', ''),
-    )
-
-class HttpStatusList(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF('statuses', [], HttpStatus)
-
-raw = cbor2.dumps([[200, 'OK'], [201, 'Created'], [404, 'Not Found']])
-pkt = HttpStatusList(raw)
-raw2 = bytes(pkt)
-dec = cbor2.loads(raw2)
-dec == [[200, 'OK'], [201, 'Created'], [404, 'Not Found']]
-
-= Realistic model: HTTP response header map
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class HttpResponse(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('status', 0),
-        CBORF_TEXT_STRING('content_type', ''),
-        CBORF_INTEGER('content_length', 0),
-        CBORF_BYTE_STRING('body', b''),
-    )
-
-pkt = HttpResponse()
-pkt.status.val = 200
-pkt.content_type.val = 'application/cbor'
-pkt.content_length.val = 4
-pkt.body.val = b'\x01\x02\x03\x04'
-dec = cbor2.loads(bytes(pkt))
-dec.get('status') == 200 and dec.get('content_type') == 'application/cbor' and dec.get('body') == b'\x01\x02\x03\x04'
-
-= Realistic model: HTTP response header cbor2 → Scapy roundtrip
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class HttpResponse2(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('status', 0),
-        CBORF_TEXT_STRING('content_type', ''),
-        CBORF_INTEGER('content_length', 0),
-        CBORF_BYTE_STRING('body', b''),
-    )
-
-raw = cbor2.dumps({'status': 404, 'content_type': 'text/plain', 'content_length': 9, 'body': b'Not Found'})
-pkt = HttpResponse2(raw)
-pkt2 = HttpResponse2(bytes(pkt))
-pkt2.status.val == 404 and pkt2.content_type.val == 'text/plain' and pkt2.body.val == b'Not Found'
-
-= Realistic model: COSE-like header map with integer algorithm
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_BYTE_STRING, CBORF_TEXT_STRING
-from scapy.cborpacket import CBOR_Packet
-
-class CoseHeader(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('alg', 0),
-        CBORF_TEXT_STRING('kid', ''),
-        CBORF_BYTE_STRING('x5t', b''),
-    )
-
-pkt = CoseHeader(cbor2.dumps({'alg': -7, 'kid': 'key-42', 'x5t': b'\xaa\xbb\xcc\xdd'}))
-dec = cbor2.loads(bytes(pkt))
-dec.get('alg') == -7 and dec.get('kid') == 'key-42' and dec.get('x5t') == b'\xaa\xbb\xcc\xdd'
-
-= Realistic model: CBOR_Packet fields_desc populated for complex structures
-import cbor2
-from scapy.cbor.cborfields import CBORF_MAP, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING, CBORF_FLOAT
-from scapy.cborpacket import CBOR_Packet
-
-class FullRecord(CBOR_Packet):
-    CBOR_root = CBORF_MAP(
-        CBORF_INTEGER('seq', 0),
-        CBORF_TEXT_STRING('source', ''),
-        CBORF_FLOAT('score', 0.0),
-        CBORF_BYTE_STRING('checksum', b''),
-    )
-
-field_names = [f.name for f in FullRecord.fields_desc]
-'seq' in field_names and 'source' in field_names and 'score' in field_names and 'checksum' in field_names
-
-= Realistic model: multi-field packet encoding is byte-for-byte reproducible
-import cbor2
-from scapy.cbor.cborfields import CBORF_ARRAY, CBORF_INTEGER, CBORF_TEXT_STRING, CBORF_BYTE_STRING, CBORF_FLOAT
-from scapy.cborpacket import CBOR_Packet
-
-class MeasurementPkt(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY(
-        CBORF_INTEGER('seq', 0),
-        CBORF_TEXT_STRING('sensor', ''),
-        CBORF_FLOAT('value', 0.0),
-        CBORF_BYTE_STRING('raw', b''),
-    )
-
-pkt = MeasurementPkt()
-pkt.seq.val = 42
-pkt.sensor.val = 'temp-01'
-pkt.value.val = 23.5
-pkt.raw.val = b'\x01\x02'
-raw1 = bytes(pkt)
-raw2 = bytes(MeasurementPkt(raw1))
-raw1 == raw2
-
-########### CBOR Fuzzing / Random Object Tests ####################
-
-+ CBOR Random Object Generation
-
-= Create RandCBORObject
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-isinstance(rand, RandCBORObject)
-
-= Generate random CBOR unsigned integer
-from scapy.cbor import RandCBORObject, CBOR_UNSIGNED_INTEGER
-rand = RandCBORObject(objlist=[CBOR_UNSIGNED_INTEGER])
-obj = rand._fix()
-isinstance(obj, CBOR_UNSIGNED_INTEGER) and isinstance(obj.val, int) and obj.val >= 0
-
-= Generate random CBOR negative integer
-from scapy.cbor import RandCBORObject, CBOR_NEGATIVE_INTEGER
-rand = RandCBORObject(objlist=[CBOR_NEGATIVE_INTEGER])
-obj = rand._fix()
-isinstance(obj, CBOR_NEGATIVE_INTEGER) and isinstance(obj.val, int) and obj.val < 0
-
-= Generate random CBOR byte string
-from scapy.cbor import RandCBORObject, CBOR_BYTE_STRING
-rand = RandCBORObject(objlist=[CBOR_BYTE_STRING])
-obj = rand._fix()
-isinstance(obj, CBOR_BYTE_STRING) and isinstance(obj.val, bytes)
-
-= Generate random CBOR text string
-from scapy.cbor import RandCBORObject, CBOR_TEXT_STRING
-rand = RandCBORObject(objlist=[CBOR_TEXT_STRING])
-obj = rand._fix()
-isinstance(obj, CBOR_TEXT_STRING) and isinstance(obj.val, str) and len(obj.val) > 0
-
-= Generate random CBOR array
-from scapy.cbor import RandCBORObject, CBOR_ARRAY
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-isinstance(obj, CBOR_ARRAY) and isinstance(obj.val, list)
-
-= Generate random CBOR map
-from scapy.cbor import RandCBORObject, CBOR_MAP
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-isinstance(obj, CBOR_MAP) and isinstance(obj.val, dict)
-
-= Generate random CBOR boolean (false)
-from scapy.cbor import RandCBORObject, CBOR_FALSE
-rand = RandCBORObject(objlist=[CBOR_FALSE])
-obj = rand._fix()
-isinstance(obj, CBOR_FALSE) and obj.val == False
-
-= Generate random CBOR boolean (true)
-from scapy.cbor import RandCBORObject, CBOR_TRUE
-rand = RandCBORObject(objlist=[CBOR_TRUE])
-obj = rand._fix()
-isinstance(obj, CBOR_TRUE) and obj.val == True
-
-= Generate random CBOR null
-from scapy.cbor import RandCBORObject, CBOR_NULL
-rand = RandCBORObject(objlist=[CBOR_NULL])
-obj = rand._fix()
-isinstance(obj, CBOR_NULL) and obj.val is None
-
-= Generate random CBOR undefined
-from scapy.cbor import RandCBORObject, CBOR_UNDEFINED
-rand = RandCBORObject(objlist=[CBOR_UNDEFINED])
-obj = rand._fix()
-isinstance(obj, CBOR_UNDEFINED) and obj.val is None
-
-= Generate random CBOR float
-from scapy.cbor import RandCBORObject, CBOR_FLOAT
-rand = RandCBORObject(objlist=[CBOR_FLOAT])
-obj = rand._fix()
-isinstance(obj, CBOR_FLOAT) and isinstance(obj.val, float)
-
-+ CBOR Random Object Encoding/Decoding
-
-= Encode and decode random unsigned integer
-from scapy.cbor import RandCBORObject, CBOR_UNSIGNED_INTEGER, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_UNSIGNED_INTEGER])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_UNSIGNED_INTEGER) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random text string
-from scapy.cbor import RandCBORObject, CBOR_TEXT_STRING, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_TEXT_STRING])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_TEXT_STRING) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random byte string
-from scapy.cbor import RandCBORObject, CBOR_BYTE_STRING, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_BYTE_STRING])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_BYTE_STRING) and remainder == b'' and decoded.val == obj.val
-
-= Encode and decode random array
-from scapy.cbor import RandCBORObject, CBOR_ARRAY, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and remainder == b'' and len(decoded.val) == len(obj.val)
-
-= Encode and decode random map
-from scapy.cbor import RandCBORObject, CBOR_MAP, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and remainder == b'' and len(decoded.val) == len(obj.val)
-
-= Encode and decode random float
-from scapy.cbor import RandCBORObject, CBOR_FLOAT, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_FLOAT])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_FLOAT) and remainder == b''
-
-+ CBOR Random Mixed Types
-
-= Generate multiple random objects of different types
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-objects = [rand._fix() for _ in range(10)]
-len(objects) == 10 and all(hasattr(obj, 'val') for obj in objects)
-
-= Encode and decode multiple random objects
-from scapy.cbor import RandCBORObject, CBOR_Codecs
-rand = RandCBORObject()
-success_count = 0
-for _ in range(20):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-        if remainder == b'':
-            success_count += 1
-    except:
-        pass
-
-success_count >= 18
-
-= Random nested arrays encode/decode correctly
-from scapy.cbor import RandCBORObject, CBOR_ARRAY, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_ARRAY])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_ARRAY) and remainder == b''
-
-= Random nested maps encode/decode correctly
-from scapy.cbor import RandCBORObject, CBOR_MAP, CBOR_Codecs
-rand = RandCBORObject(objlist=[CBOR_MAP])
-obj = rand._fix()
-encoded = bytes(obj)
-decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-isinstance(decoded, CBOR_MAP) and remainder == b''
-
-+ CBOR Fuzzing Stress Tests
-
-= Generate 100 random objects without errors
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-objects = []
-for _ in range(100):
-    obj = None
-    try:
-        obj = rand._fix()
-    except:
-        pass
-    if obj is not None:
-        objects.append(obj)
-
-len(objects) >= 95
-
-= Encode 50 random objects without errors
-from scapy.cbor import RandCBORObject
-rand = RandCBORObject()
-encoded_count = 0
-for _ in range(50):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        if len(encoded) > 0:
-            encoded_count += 1
-    except:
-        pass
-
-encoded_count >= 45
-
-= Roundtrip 50 random objects
-from scapy.cbor import RandCBORObject, CBOR_Codecs
-rand = RandCBORObject()
-roundtrip_count = 0
-for _ in range(50):
-    obj = rand._fix()
-    try:
-        encoded = bytes(obj)
-        decoded, remainder = CBOR_Codecs.CBOR.dec(encoded)
-        if remainder == b'':
-            roundtrip_count += 1
-    except:
-        pass
-
-roundtrip_count >= 45
+class AnyFloatPkt(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", None)
+
+# binary64 NaN with a low payload bit
+wire = bytes.fromhex("fb7ff8000000000001")
+pkt = AnyFloatPkt(wire)
+assert isinstance(pkt.value, CBORFloatValue)
+assert pkt.value != pkt.value  # NaN
+assert pkt.value.cbor_encoded == wire
+pkt.raw_packet_cache = None
+pkt.raw_packet_cache_fields = None
+assert bytes(pkt) == wire
+
+= RandCBORObject generates encodable objects including nested containers
+import random
+from scapy.cbor.cbor import (
+    RandCBORObject,
+    CBOR_UNSIGNED_INTEGER,
+    CBOR_ARRAY,
+    CBOR_MAP,
+    CBOR_TEXT_STRING,
+    CBOR_NULL,
+)
+
+random.seed(42)
+obj = RandCBORObject()._fix()
+assert bytes(obj)  # encodable
+# Custom list forces deep recursion fallbacks and array/map nesting.
+nested = RandCBORObject(objlist=[CBOR_ARRAY, CBOR_MAP])._fix(n=0)
+assert isinstance(nested, (CBOR_ARRAY, CBOR_MAP))
+assert bytes(nested)
+# Depth cap strips recursive types.
+leaf = RandCBORObject(objlist=[CBOR_ARRAY, CBOR_MAP])._fix(n=10)
+assert not isinstance(leaf, (CBOR_ARRAY, CBOR_MAP))
+assert bytes(leaf)
+# Only recursive types at high depth still yields a leaf via fallback.
+only_recursive = RandCBORObject(objlist=[CBOR_ARRAY])._fix(n=10)
+assert isinstance(only_recursive, CBOR_UNSIGNED_INTEGER)
+simple = RandCBORObject(objlist=[CBOR_TEXT_STRING, CBOR_NULL])._fix()
+assert bytes(simple)
+
+= CBOR object display helpers and decoding-error repr
+import copy
+from scapy.cbor.cbor import (
+    CBOR_ARRAY,
+    CBOR_BYTE_STRING,
+    CBOR_DECODING_ERROR,
+    CBOR_Error,
+    CBOR_FALSE,
+    CBOR_FLOAT,
+    CBOR_MAP,
+    CBOR_NULL,
+    CBORMapData,
+    CBOR_Object,
+    CBOR_TRUE,
+    CBORSimpleValue,
+    CBORTagValue,
+    CBOR_UNDEFINED_VALUE,
+    CBOR_UNSIGNED_INTEGER,
+)
+
+assert "h'6162'" in repr(CBOR_BYTE_STRING(b"ab"))
+assert "CBOR_ARRAY" in CBOR_ARRAY([CBOR_UNSIGNED_INTEGER(1), 2]).strshow()
+assert "CBOR_MAP" in CBOR_MAP(CBORMapData([(1, CBOR_TRUE())])).strshow()
+assert "CBOR_MAP" in CBOR_MAP({1: CBOR_FALSE()}).strshow()
+assert "CBORMapData" in repr(CBORMapData([(b"k", 1)]))
+assert "CBORTagValue" in repr(CBORTagValue(1, "x"))
+assert "CBORSimpleValue" in repr(CBORSimpleValue(41))
+assert repr(CBOR_UNDEFINED_VALUE) == "CBOR_UNDEFINED"
+assert not CBOR_UNDEFINED_VALUE
+assert copy.copy(CBOR_UNDEFINED_VALUE) is CBOR_UNDEFINED_VALUE
+assert copy.deepcopy(CBOR_UNDEFINED_VALUE) is CBOR_UNDEFINED_VALUE
+bad = bytes.fromhex("ff")
+err = CBOR_DECODING_ERROR(bad, exc=ValueError("boom"))
+assert "boom" in repr(err)
+assert err.enc() == bad
+assert CBOR_DECODING_ERROR(CBOR_NULL()).enc() == bytes(CBOR_NULL())
+untagged_ok = False
+try:
+    CBOR_Object(None).enc()
+except CBOR_Error:
+    untagged_ok = True
+
+assert untagged_ok
+assert CBOR_TRUE() == CBOR_TRUE()
+assert CBOR_TRUE() != CBOR_FALSE()
+encoded = bytes.fromhex("fa3fc00000")
+assert CBOR_FLOAT(1.5, encoded=encoded).enc() == encoded
+True

--- a/test/scapy/layers/cbor.uts
+++ b/test/scapy/layers/cbor.uts
@@ -2167,7 +2167,7 @@ assert result.data == bytes(child)
 # CBORF_PACKET represents exactly one CBOR item: embedding a multi-item
 # SEQUENCE child must fail (do not put this child in a CBORF_PACKET parent
 # and expect serialization to succeed).
-fld = CBORF_PACKET("x", None, cls=SeqChild)
+fld = CBORF_PACKET("x", None, pkt_cls=SeqChild)
 try:
     fld.build_value(None, child)
     assert False, "multi-item child must be rejected by CBORF_PACKET"
@@ -2192,11 +2192,11 @@ class TwoItemChild(CBOR_Packet):
 class OneItemChild(CBOR_Packet):
     CBOR_root = CBORF_UNSIGNED_INTEGER("a", 1)
 
-fld = CBORF_PACKET("x", None, cls=OneItemChild)
+fld = CBORF_PACKET("x", None, pkt_cls=OneItemChild)
 ok = fld.build_value(None, OneItemChild(a=7))
 assert ok.items == 1
 
-fld2 = CBORF_PACKET("x", None, cls=TwoItemChild)
+fld2 = CBORF_PACKET("x", None, pkt_cls=TwoItemChild)
 try:
     fld2.build_value(None, TwoItemChild())
     assert False, "multi-item child must be rejected by build_value"
@@ -2209,7 +2209,7 @@ from scapy.cbor.cbor import CBOR_Encoding_Error
 from scapy.cborpacket import CBOR_Packet
 from scapy.packet import Raw
 
-fld = CBORF_PACKET("x", None, cls=CBOR_Packet)
+fld = CBORF_PACKET("x", None, pkt_cls=CBOR_Packet)
 
 # Two valid CBOR integers must not be reported as one item
 try:
@@ -2403,20 +2403,6 @@ class BstrPkt(CBOR_Packet):
 assert BstrPkt().blob == b"ABC"
 assert bytes(BstrPkt()) == b"\x43" + b"ABC"
 
-= BundleEidField defaults and assignments are always EidStruct
-from scapy.contrib.bpv7 import BundleEidField, EidStruct, PrimaryBlock
-from scapy.cborpacket import CBOR_Packet
-
-class EidPkt(CBOR_Packet):
-    CBOR_root = BundleEidField("eid", "dtn:none")
-
-# Internal representation (getfieldval) is always EidStruct; attribute access
-# returns the human form via i2h(), matching native Scapy Field semantics.
-assert isinstance(EidPkt().getfieldval("eid"), EidStruct)
-assert EidPkt().eid == "dtn:none"
-assert isinstance(PrimaryBlock().getfieldval("source"), EidStruct)
-assert PrimaryBlock().source == "dtn:none"
-
 + CBORF_BYTE_STRING_PACKET default normalization
 
 = CBORF_BYTE_STRING_PACKET normalizes byte defaults after packet-class state is initialized
@@ -2465,7 +2451,7 @@ assert len(pkt.children) == 1
 assert isinstance(pkt.children[0], DynamicSequenceChild)
 assert pkt.children[0].parent is pkt
 
-= CBORF_SEQUENCE_OF rejects combining next_cls_cb with cls/pkt_cls
+= CBORF_SEQUENCE_OF rejects combining next_cls_cb with pkt_cls
 from scapy.cbor.cborfields import CBORF_SEQUENCE_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
@@ -2610,7 +2596,7 @@ class CopyChild(CBOR_Packet):
     CBOR_root = CBORF_UNSIGNED_INTEGER("n", 0)
 
 class CopyParent(CBOR_Packet):
-    CBOR_root = CBORF_PACKET("child", None, cls=CopyChild)
+    CBOR_root = CBORF_PACKET("child", None, pkt_cls=CopyChild)
 
 a = CopyParent(child=CopyChild(n=1))
 assert a.child.parent is a
@@ -2689,7 +2675,7 @@ from scapy.cbor.cborfields import CBORF_ARRAY_OF, CBORF_UNSIGNED_INTEGER
 from scapy.cborpacket import CBOR_Packet
 
 class IndefUIntArray(CBOR_Packet):
-    CBOR_root = CBORF_ARRAY_OF("values", [], cls=CBORF_UNSIGNED_INTEGER)
+    CBOR_root = CBORF_ARRAY_OF("values", [], pkt_cls=CBORF_UNSIGNED_INTEGER)
 
 wire = b"\x9f\x01\x02\x03\xff"
 pkt = IndefUIntArray(wire)

--- a/test/scapy/layers/cbor_cbor2_interop.uts
+++ b/test/scapy/layers/cbor_cbor2_interop.uts
@@ -1,0 +1,1465 @@
+% CBOR interoperability and differential tests using cbor2 6.1.4
+
++ Shared cbor2 oracle helpers
+
+= Import cbor2 and define differential-test helpers ~ external_cbor2
+import io
+import math
+import random
+import re
+import struct
+from collections.abc import Mapping
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from email.mime.text import MIMEText
+from fractions import Fraction
+from importlib.metadata import version as distribution_version
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
+from uuid import UUID
+
+import cbor2
+
+from scapy.cbor import CBOR_Codecs
+from scapy.cbor.cbor import (
+    CBOR_DECODING_ERROR,
+    CBOR_Decoding_Error,
+    CBORMapData,
+    CBOR_ARRAY,
+    CBOR_BYTE_STRING,
+    CBOR_FALSE,
+    CBOR_FLOAT,
+    CBOR_MAP,
+    CBOR_NEGATIVE_INTEGER,
+    CBOR_NULL,
+    CBOR_Object,
+    CBOR_SEMANTIC_TAG,
+    CBOR_SIMPLE_VALUE,
+    CBOR_TEXT_STRING,
+    CBOR_TRUE,
+    CBOR_UNDEFINED,
+    CBOR_UNDEFINED_VALUE,
+    CBOR_UNSIGNED_INTEGER,
+    CBORSimpleValue,
+    CBORTagValue,
+)
+from scapy.cbor.cborcodec import (
+    CBOR_Codec_Decoding_Error,
+    CBORcodec_Object,
+    MAX_CBOR_NESTING,
+)
+from scapy.cbor.cborfields import (
+    CBOR_ABSENT,
+    CBORF_ANY,
+    CBORF_ARRAY,
+    CBORF_ARRAY_OF,
+    CBORF_BOOLEAN,
+    CBORF_BYTE_STRING,
+    CBORF_FLOAT,
+    CBORF_NEGATIVE_INTEGER,
+    CBORF_NULL,
+    CBORF_SEMANTIC_TAG,
+    CBORF_TEXT_STRING,
+    CBORF_UNDEFINED,
+    CBORF_UNSIGNED_INTEGER,
+)
+from scapy.cborpacket import CBOR_Packet
+
+_RR_CBOR2_VERSION = distribution_version("cbor2")
+_RR_SCAPY_DECODE_ERRORS = (CBOR_Decoding_Error, CBOR_Codec_Decoding_Error)
+
+
+def _rr_float(value):
+    value = float(value)
+    if math.isnan(value):
+        return ("float", "nan")
+    if math.isinf(value):
+        return ("float", "+inf" if value > 0 else "-inf")
+    if value == 0.0:
+        return ("float", "-0" if math.copysign(1.0, value) < 0 else "+0")
+    return ("float", struct.pack(">d", value).hex())
+
+
+def _rr_map(pairs, norm):
+    normalized = [(norm(key), norm(value)) for key, value in pairs]
+    return ("map", tuple(sorted(normalized, key=repr)))
+
+
+def rr_norm_scapy(obj):
+    if isinstance(obj, CBOR_FALSE):
+        return ("bool", False)
+    if isinstance(obj, CBOR_TRUE):
+        return ("bool", True)
+    if isinstance(obj, CBOR_NULL):
+        return ("null",)
+    if isinstance(obj, CBOR_UNDEFINED):
+        return ("undefined",)
+    if isinstance(obj, CBOR_UNSIGNED_INTEGER):
+        return ("uint", obj.val)
+    if isinstance(obj, CBOR_NEGATIVE_INTEGER):
+        return ("nint", obj.val)
+    if isinstance(obj, CBOR_BYTE_STRING):
+        return ("bytes", obj.val)
+    if isinstance(obj, CBOR_TEXT_STRING):
+        return ("text", obj.val)
+    if isinstance(obj, CBOR_FLOAT):
+        return _rr_float(obj.val)
+    if isinstance(obj, CBOR_SIMPLE_VALUE):
+        return ("simple", obj.val)
+    if isinstance(obj, CBOR_ARRAY):
+        return ("array", tuple(rr_norm_scapy(item) for item in obj.val))
+    if isinstance(obj, CBOR_MAP):
+        if isinstance(obj.val, CBORMapData):
+            pairs = obj.val.cbor_pairs()
+        elif isinstance(obj.val, Mapping):
+            pairs = list(obj.val.items())
+        else:
+            pairs = list(obj.val)
+        return _rr_map(pairs, rr_norm_scapy)
+    if isinstance(obj, CBOR_SEMANTIC_TAG):
+        tag, value = obj.val
+        return ("tag", tag, rr_norm_scapy(value))
+    if isinstance(obj, CBOR_Object):
+        return ("scapy-object", type(obj).__name__, repr(obj.val))
+    return rr_norm_native(obj)
+
+
+def rr_norm_cbor2(value):
+    if value is cbor2.undefined:
+        return ("undefined",)
+    if isinstance(value, cbor2.CBORSimpleValue):
+        return ("simple", value.value)
+    if isinstance(value, cbor2.CBORTag):
+        return ("tag", value.tag, rr_norm_cbor2(value.value))
+    if isinstance(value, bool):
+        return ("bool", value)
+    if value is None:
+        return ("null",)
+    if isinstance(value, int):
+        return ("uint" if value >= 0 else "nint", value)
+    if isinstance(value, float):
+        return _rr_float(value)
+    if isinstance(value, bytes):
+        return ("bytes", value)
+    if isinstance(value, str):
+        return ("text", value)
+    if isinstance(value, Mapping):
+        return _rr_map(list(value.items()), rr_norm_cbor2)
+    if isinstance(value, (list, tuple)):
+        return ("array", tuple(rr_norm_cbor2(item) for item in value))
+    return ("python", type(value).__module__, type(value).__qualname__, repr(value))
+
+
+def rr_norm_native(value):
+    if value is CBOR_UNDEFINED_VALUE:
+        return ("undefined",)
+    if isinstance(value, CBORSimpleValue):
+        return ("simple", value.value)
+    if isinstance(value, CBORTagValue):
+        return ("tag", value.tag, rr_norm_native(value.value))
+    if isinstance(value, CBORMapData):
+        return _rr_map(value.cbor_pairs(), rr_norm_native)
+    if isinstance(value, bool):
+        return ("bool", value)
+    if value is None:
+        return ("null",)
+    if isinstance(value, int):
+        return ("uint" if value >= 0 else "nint", value)
+    if isinstance(value, float):
+        return _rr_float(value)
+    if isinstance(value, bytes):
+        return ("bytes", value)
+    if isinstance(value, str):
+        return ("text", value)
+    if isinstance(value, Mapping):
+        return _rr_map(list(value.items()), rr_norm_native)
+    if isinstance(value, (list, tuple)):
+        return ("array", tuple(rr_norm_native(item) for item in value))
+    if isinstance(value, CBOR_Object):
+        return rr_norm_scapy(value)
+    return ("python", type(value).__module__, type(value).__qualname__, repr(value))
+
+
+def rr_cbor2_load(wire, **kwargs):
+    kwargs.setdefault("immutable", True)
+    return cbor2.loads(wire, **kwargs)
+
+
+def rr_scapy_decode(wire):
+    obj, remainder = CBOR_Codecs.CBOR.dec(wire)
+    assert remainder == b"", (wire.hex(), remainder.hex())
+    return obj
+
+
+def rr_assert_cbor2_value(value, *, canonical=False,
+                          indefinite_containers=False, exact=False):
+    wire = cbor2.dumps(
+        value,
+        canonical=canonical,
+        indefinite_containers=indefinite_containers,
+    )
+    expected = rr_norm_cbor2(rr_cbor2_load(wire))
+    obj = rr_scapy_decode(wire)
+    actual = rr_norm_scapy(obj)
+    assert actual == expected, (wire.hex(), expected, actual)
+    rebuilt = obj.enc()
+    if exact:
+        assert rebuilt == wire, (wire.hex(), rebuilt.hex())
+    assert rr_norm_cbor2(rr_cbor2_load(rebuilt)) == expected
+    return wire, obj
+
+
+def rr_assert_extension_wire(value, **dump_kwargs):
+    wire = cbor2.dumps(value, **dump_kwargs)
+    obj = rr_scapy_decode(wire)
+    rebuilt = obj.enc()
+    assert rebuilt == wire, (wire.hex(), rebuilt.hex())
+    expected = cbor2.loads(wire)
+    actual = cbor2.loads(rebuilt)
+    if isinstance(expected, float) and math.isnan(expected):
+        assert isinstance(actual, float) and math.isnan(actual)
+    else:
+        assert actual == expected
+    return wire, obj
+
+
+def rr_to_scapy_native(value):
+    if value is cbor2.undefined:
+        return CBOR_UNDEFINED_VALUE
+    if isinstance(value, cbor2.CBORSimpleValue):
+        return CBORSimpleValue(value.value)
+    if isinstance(value, cbor2.CBORTag):
+        return CBORTagValue(value.tag, rr_to_scapy_native(value.value))
+    if isinstance(value, Mapping):
+        return {
+            rr_to_scapy_native(key): rr_to_scapy_native(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [rr_to_scapy_native(item) for item in value]
+    return value
+
+
+def rr_assert_scapy_native(value):
+    native = rr_to_scapy_native(value)
+    wire = CBORcodec_Object.encode_cbor_item(native)
+    expected = rr_norm_native(native)
+    actual = rr_norm_cbor2(rr_cbor2_load(wire))
+    assert actual == expected, (wire.hex(), expected, actual)
+    return wire
+
+
+def rr_clear_cache(pkt):
+    pkt.raw_packet_cache = None
+    pkt.raw_packet_cache_fields = None
+    pkt.wirelen = None
+
+
+def rr_scapy_reject(wire):
+    try:
+        CBOR_Codecs.CBOR.dec(wire)
+    except _RR_SCAPY_DECODE_ERRORS:
+        return
+    raise AssertionError("Scapy accepted malformed CBOR: %s" % wire.hex())
+
+
+def rr_cbor2_reject(wire, **kwargs):
+    try:
+        cbor2.loads(wire, **kwargs)
+    except cbor2.CBORDecodeError:
+        return
+    raise AssertionError("cbor2 accepted malformed CBOR: %s" % wire.hex())
+
+
+def rr_both_reject(wire, **cbor2_kwargs):
+    rr_cbor2_reject(wire, **cbor2_kwargs)
+    rr_scapy_reject(wire)
+
+
+def rr_scapy_sequence(wire):
+    values = []
+    remainder = wire
+    while remainder:
+        before = len(remainder)
+        obj, remainder = CBOR_Codecs.CBOR.dec(remainder)
+        assert len(remainder) < before
+        values.append(rr_norm_scapy(obj))
+    return values
+
+
+def rr_cbor2_sequence(wire, count):
+    stream = io.BytesIO(wire)
+    decoder = cbor2.CBORDecoder(stream)
+    return [rr_norm_cbor2(decoder.decode(immutable=True)) for _ in range(count)]
+
+
+def rr_random_key(rng):
+    kind = rng.randrange(3)
+    if kind == 0:
+        return rng.randint(-100000, 100000)
+    if kind == 1:
+        return bytes(rng.randrange(256) for _ in range(rng.randrange(0, 8)))
+    alphabet = "abcXYZ012-_ä"
+    return "".join(rng.choice(alphabet) for _ in range(rng.randrange(0, 8)))
+
+
+def rr_random_value(rng, depth=0, include_float=True):
+    scalar_kinds = ["uint", "nint", "bytes", "text", "bool", "null",
+                    "undefined", "simple", "tag"]
+    if include_float:
+        scalar_kinds.append("float")
+    kinds = list(scalar_kinds)
+    if depth < 4:
+        kinds.extend(["array", "map"])
+    kind = rng.choice(kinds)
+    if kind == "uint":
+        return rng.randrange(0, 1 << rng.choice((4, 8, 16, 32, 64)))
+    if kind == "nint":
+        return -1 - rng.randrange(0, 1 << rng.choice((4, 8, 16, 32, 63)))
+    if kind == "bytes":
+        return bytes(rng.randrange(256) for _ in range(rng.randrange(0, 32)))
+    if kind == "text":
+        alphabet = "abcXYZ012-_ä€𐍈\x00"
+        return "".join(rng.choice(alphabet) for _ in range(rng.randrange(0, 24)))
+    if kind == "bool":
+        return bool(rng.getrandbits(1))
+    if kind == "null":
+        return None
+    if kind == "undefined":
+        return cbor2.undefined
+    if kind == "simple":
+        return cbor2.CBORSimpleValue(rng.choice((0, 1, 16, 19, 32, 64, 127, 255)))
+    if kind == "float":
+        special = rng.randrange(12)
+        if special == 0:
+            return -0.0
+        if special == 1:
+            return float("inf")
+        if special == 2:
+            return float("-inf")
+        if special == 3:
+            return float("nan")
+        return rng.uniform(-1.0e12, 1.0e12)
+    if kind == "tag":
+        return cbor2.CBORTag(
+            60000 + rng.randrange(1000),
+            rr_random_value(rng, depth + 1, include_float=include_float),
+        )
+    if kind == "array":
+        return [
+            rr_random_value(rng, depth + 1, include_float=include_float)
+            for _ in range(rng.randrange(0, 6))
+        ]
+    mapping = {}
+    target = rng.randrange(0, 6)
+    while len(mapping) < target:
+        mapping[rr_random_key(rng)] = rr_random_value(
+            rng, depth + 1, include_float=include_float
+        )
+    return mapping
+
+
+class RRCbor2AnyRoot(CBOR_Packet):
+    CBOR_root = CBORF_ANY("value", CBOR_ABSENT)
+
+
+class RRCbor2AnyEnvelope(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY(
+        CBORF_ANY("value", CBOR_ABSENT),
+        CBORF_UNSIGNED_INTEGER("tail", 0),
+    )
+
+
+class RRCbor2UInt(CBOR_Packet):
+    CBOR_root = CBORF_UNSIGNED_INTEGER("value", 0)
+
+
+class RRCbor2NInt(CBOR_Packet):
+    CBOR_root = CBORF_NEGATIVE_INTEGER("value", -1)
+
+
+class RRCbor2Bytes(CBOR_Packet):
+    CBOR_root = CBORF_BYTE_STRING("value", b"")
+
+
+class RRCbor2DefiniteBytes(CBOR_Packet):
+    CBOR_root = CBORF_BYTE_STRING("value", b"", definite_only=True)
+
+
+class RRCbor2Text(CBOR_Packet):
+    CBOR_root = CBORF_TEXT_STRING("value", "")
+
+
+class RRCbor2Bool(CBOR_Packet):
+    CBOR_root = CBORF_BOOLEAN("value", False)
+
+
+class RRCbor2Null(CBOR_Packet):
+    CBOR_root = CBORF_NULL("value")
+
+
+class RRCbor2Undefined(CBOR_Packet):
+    CBOR_root = CBORF_UNDEFINED("value")
+
+
+class RRCbor2Float(CBOR_Packet):
+    CBOR_root = CBORF_FLOAT("value", 0.0)
+
+
+class RRCbor2UIntArray(CBOR_Packet):
+    CBOR_root = CBORF_ARRAY_OF("values", [], CBORF_UNSIGNED_INTEGER)
+
+
+class RRCbor2TaggedText(CBOR_Packet):
+    CBOR_root = CBORF_SEMANTIC_TAG(
+        "tag_number", None, 60000, CBORF_TEXT_STRING("value", "")
+    )
+
++ Oracle version and API assumptions
+
+= The differential suite is pinned to cbor2 6.1.4 ~ external_cbor2
+assert _RR_CBOR2_VERSION == "6.1.4", _RR_CBOR2_VERSION
+
+= cbor2 exposes canonical and indefinite-container encoders ~ external_cbor2
+canonical = cbor2.dumps({"long": 1, "x": 2}, canonical=True)
+indefinite = cbor2.dumps([1, 2], indefinite_containers=True)
+assert cbor2.loads(canonical) == {"long": 1, "x": 2}
+assert cbor2.loads(indefinite) == [1, 2]
+assert indefinite[0] == 0x9f and indefinite[-1] == 0xff
+
+= cbor2 strict decoder options provide independent negative controls ~ external_cbor2
+wire = cbor2.dumps([1, 2], indefinite_containers=True)
+rr_cbor2_reject(wire, allow_indefinite=False)
+duplicate = b"\xa2\x01\x00\x01\x01"
+rr_cbor2_reject(duplicate, allow_duplicate_keys=False)
+
++ Integer boundary vectors generated by cbor2
+
+= Unsigned integer boundaries decode and re-encode exactly ~ external_cbor2
+values = [0, 1, 10, 23, 24, 25, 255, 256, 65535, 65536,
+          (1 << 32) - 1, 1 << 32, (1 << 64) - 1]
+
+for value in values:
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Unsigned integer additional-information transitions match cbor2 ~ external_cbor2
+expected = {
+    23: b"\x17",
+    24: b"\x18\x18",
+    255: b"\x18\xff",
+    256: b"\x19\x01\x00",
+    65535: b"\x19\xff\xff",
+    65536: b"\x1a\x00\x01\x00\x00",
+    (1 << 32) - 1: b"\x1a\xff\xff\xff\xff",
+    1 << 32: b"\x1b\x00\x00\x00\x01\x00\x00\x00\x00",
+}
+for value, wire in expected.items():
+    assert cbor2.dumps(value, canonical=True) == wire
+    assert rr_scapy_decode(wire).enc() == wire
+
+= Negative integer boundaries decode and re-encode exactly ~ external_cbor2
+values = [-1, -10, -24, -25, -256, -257, -65536, -65537,
+          -(1 << 32), -(1 << 32) - 1, -(1 << 64)]
+
+for value in values:
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Negative integer additional-information transitions match cbor2 ~ external_cbor2
+values = [-24, -25, -256, -257, -65536, -65537, -(1 << 32), -(1 << 32) - 1]
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert isinstance(obj, CBOR_NEGATIVE_INTEGER)
+    assert obj.val == value
+    assert obj.enc() == wire
+
+= Positive bignums generated by cbor2 remain wire-faithful through Scapy ~ external_cbor2
+for value in (1 << 64, 1 << 80, 1 << 128, (1 << 521) - 1):
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert isinstance(obj, CBOR_SEMANTIC_TAG)
+    assert obj.enc() == wire
+    assert cbor2.loads(obj.enc()) == value
+
+= Negative bignums generated by cbor2 remain wire-faithful through Scapy ~ external_cbor2
+for value in (-(1 << 64) - 1, -(1 << 80), -(1 << 128), -(1 << 521)):
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert isinstance(obj, CBOR_SEMANTIC_TAG)
+    assert obj.enc() == wire
+    assert cbor2.loads(obj.enc()) == value
+
++ Byte and text string vectors generated by cbor2
+
+= Byte-string length boundaries decode and re-encode exactly ~ external_cbor2
+for length in (0, 1, 22, 23, 24, 25, 254, 255, 256, 65535, 65536):
+    value = bytes((index * 17) & 0xff for index in range(length))
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Text-string ASCII length boundaries decode and re-encode exactly ~ external_cbor2
+for length in (0, 1, 22, 23, 24, 25, 254, 255, 256, 65535, 65536):
+    value = "x" * length
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Text-string length headers use UTF-8 byte length rather than characters ~ external_cbor2
+values = [
+    "ä" * 11 + "x",       # 23 UTF-8 bytes
+    "ä" * 12,             # 24 UTF-8 bytes
+    "€" * 8,              # 24 UTF-8 bytes
+    "𐍈" * 6,              # 24 UTF-8 bytes
+    "e\u0301" * 12,       # combining sequence
+]
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert obj.val == value
+    assert obj.enc() == wire
+
+= Unicode and embedded-NUL strings interoperate in both directions ~ external_cbor2
+values = ["Grüße", "€uro", "𐍈", "e\u0301", "a\x00b", "日本語", "🙂"]
+for value in values:
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+    rr_assert_scapy_native(value)
+
+= Indefinite byte strings assembled from cbor2 chunks decode semantically ~ external_cbor2
+wire = b"\x5f" + cbor2.dumps(b"ab") + cbor2.dumps(b"") + cbor2.dumps(b"cd") + b"\xff"
+assert cbor2.loads(wire) == b"abcd"
+obj = rr_scapy_decode(wire)
+assert obj.val == b"abcd"
+assert cbor2.loads(obj.enc()) == b"abcd"
+
+= Indefinite text strings assembled from cbor2 chunks decode semantically ~ external_cbor2
+wire = b"\x7f" + cbor2.dumps("Grü") + cbor2.dumps("") + cbor2.dumps("ße") + b"\xff"
+assert cbor2.loads(wire) == "Grüße"
+obj = rr_scapy_decode(wire)
+assert obj.val == "Grüße"
+assert cbor2.loads(obj.enc()) == "Grüße"
+
+= Many cbor2-generated byte-string chunks concatenate correctly ~ external_cbor2
+chunks = [bytes([index & 0xff]) for index in range(1024)]
+wire = b"\x5f" + b"".join(cbor2.dumps(chunk) for chunk in chunks) + b"\xff"
+expected = b"".join(chunks)
+assert cbor2.loads(wire) == expected
+obj = rr_scapy_decode(wire)
+assert obj.val == expected
+assert cbor2.loads(obj.enc()) == expected
+
+= Many Unicode text chunks concatenate correctly ~ external_cbor2
+chunks = ["ä", "€", "𐍈", "x"] * 256
+wire = b"\x7f" + b"".join(cbor2.dumps(chunk) for chunk in chunks) + b"\xff"
+expected = "".join(chunks)
+assert cbor2.loads(wire) == expected
+obj = rr_scapy_decode(wire)
+assert obj.val == expected
+assert cbor2.loads(obj.enc()) == expected
+
++ Simple values, tags, and standard cbor2 extensions
+
+= Boolean, null, and undefined values agree between cbor2 and Scapy ~ external_cbor2
+for value in (False, True, None, cbor2.undefined):
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+    rr_assert_scapy_native(value)
+
+= Direct and extended simple values agree between cbor2 and Scapy ~ external_cbor2
+for number in (0, 1, 16, 19, 32, 64, 127, 255):
+    value = cbor2.CBORSimpleValue(number)
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+    rr_assert_scapy_native(value)
+
+= Unknown semantic-tag number boundaries round-trip exactly ~ external_cbor2
+for tag in (0, 23, 24, 255, 256, 65535, 65536,
+            (1 << 32) - 1, 1 << 32, (1 << 64) - 1):
+    # Scapy preserves the generic tag structure even when cbor2 assigns semantics.
+    wire = cbor2.dumps(cbor2.CBORTag(tag, "payload"), canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert isinstance(obj, CBOR_SEMANTIC_TAG)
+    assert obj.val[0] == tag
+    assert obj.enc() == wire
+
+= Nested unknown semantic tags preserve structure and bytes ~ external_cbor2
+value = cbor2.CBORTag(60000, cbor2.CBORTag(60001, [1, "x", b"y"]))
+rr_assert_cbor2_value(value, canonical=True, exact=True)
+rr_assert_scapy_native(value)
+
+= Decimal extension encodings generated by cbor2 are wire-faithful ~ external_cbor2
+for value in (Decimal("0"), Decimal("-1.25"), Decimal("1E+100")):
+    rr_assert_extension_wire(value, canonical=True)
+
+= Fraction extension encodings generated by cbor2 are wire-faithful ~ external_cbor2
+for value in (Fraction(1, 3), Fraction(-22, 7), Fraction(0, 1)):
+    rr_assert_extension_wire(value, canonical=True)
+
+= Timezone-aware datetime extension encodings are wire-faithful ~ external_cbor2
+values = [
+    datetime(1970, 1, 1, tzinfo=timezone.utc),
+    datetime(2026, 8, 29, 12, 34, 56, 123456, tzinfo=timezone.utc),
+]
+for value in values:
+    rr_assert_extension_wire(value, canonical=True)
+
+= Date extension encodings are wire-faithful ~ external_cbor2
+for value in (date(1970, 1, 1), date(2026, 8, 29), date(9999, 12, 31)):
+    rr_assert_extension_wire(value, canonical=True)
+
+= UUID extension encodings are wire-faithful ~ external_cbor2
+for value in (UUID(int=0), UUID("12345678-1234-5678-1234-567812345678")):
+    rr_assert_extension_wire(value, canonical=True)
+
+= Set extension encodings are wire-faithful ~ external_cbor2
+for value in (frozenset(), frozenset({1, 2, 3}), frozenset({"b", "a"})):
+    rr_assert_extension_wire(value, canonical=True)
+
+= Complex-number extension encodings remain semantically equivalent ~ external_cbor2
+for value in (0j, 1 + 2j, complex(-1.5, 2.25), complex(1.0e100, -1.0e-100)):
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    rebuilt = obj.enc()
+    assert cbor2.loads(rebuilt) == value
+    assert rr_norm_scapy(obj)[0] == "tag"
+
+= Regular-expression extension encodings preserve their pattern ~ external_cbor2
+for value in (re.compile(r"a+"), re.compile(r"(?i)^[a-z0-9_]+$")):
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert obj.enc() == wire
+    expected = cbor2.loads(wire)
+    actual = cbor2.loads(obj.enc())
+    assert isinstance(actual, re.Pattern)
+    assert actual.pattern == expected.pattern == value.pattern
+
+= IPv4 and IPv6 extension encodings are wire-faithful ~ external_cbor2
+values = [
+    IPv4Address("192.0.2.1"),
+    IPv4Network("192.0.2.0/24"),
+    IPv4Interface("192.0.2.1/24"),
+    IPv6Address("2001:db8::1"),
+    IPv6Network("2001:db8::/64"),
+    IPv6Interface("2001:db8::1/64"),
+]
+for value in values:
+    rr_assert_extension_wire(value, canonical=True)
+
+= MIME text extension encodings remain semantically equivalent ~ external_cbor2
+message = MIMEText("Grüße from CBOR", "plain", "utf-8")
+message["Subject"] = "cbor2 interoperability"
+wire = cbor2.dumps(message, canonical=True)
+obj = rr_scapy_decode(wire)
+assert obj.enc() == wire
+expected = cbor2.loads(wire)
+actual = cbor2.loads(obj.enc())
+assert actual.as_bytes() == expected.as_bytes()
+assert actual.get_payload() == expected.get_payload()
+
+= Self-described CBOR tag is retained by Scapy and ignored by cbor2 ~ external_cbor2
+value = {"self-described": [1, 2, 3], "ok": True}
+wire = cbor2.dumps(cbor2.CBORTag(55799, value), canonical=True)
+obj = rr_scapy_decode(wire)
+assert isinstance(obj, CBOR_SEMANTIC_TAG)
+assert obj.val[0] == 55799
+assert obj.enc() == wire
+# cbor2 may decode tag 55799 into frozendict/tuple; compare semantically.
+assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == rr_norm_cbor2(value)
+
+= bytearray and tuple encoder inputs produce ordinary CBOR values ~ external_cbor2
+cases = [
+    (bytearray(b"mutable bytes"), b"mutable bytes"),
+    ((1, "two", b"three"), [1, "two", b"three"]),
+]
+for value, expected in cases:
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert cbor2.loads(obj.enc()) == expected
+    assert obj.enc() == wire
+
+= cbor2 value-sharing tags survive generic Scapy decoding ~ external_cbor2
+shared = [1, 2, 3]
+value = [shared, shared]
+wire = cbor2.dumps(value, value_sharing=True)
+obj = rr_scapy_decode(wire)
+assert obj.enc() == wire
+actual = cbor2.loads(obj.enc())
+assert actual == value
+assert actual[0] is actual[1]
+
+= cbor2 cyclic shared-reference data remains a finite generic CBOR tree ~ external_cbor2
+value = []
+value.append(value)
+wire = cbor2.dumps(value, value_sharing=True)
+obj = rr_scapy_decode(wire)
+assert obj.enc() == wire
+actual = cbor2.loads(obj.enc())
+assert actual[0] is actual
+
+= cbor2 string-reference tags survive generic Scapy decoding ~ external_cbor2
+value = ["repeated-value", "repeated-value", {"repeated-value": "repeated-value"}]
+wire = cbor2.dumps(value, string_referencing=True)
+obj = rr_scapy_decode(wire)
+assert obj.enc() == wire
+assert cbor2.loads(obj.enc()) == value
+
++ Valid non-preferred serializations accepted and normalized
+
+= Overlong integer arguments decode like cbor2 and rebuild minimally ~ external_cbor2
+cases = [
+    (b"\x18\x00", 0),
+    (b"\x19\x00\x17", 23),
+    (b"\x1a\x00\x00\x00\x18", 24),
+    (b"\x38\x00", -1),
+    (b"\x39\x00\x17", -24),
+    (b"\x3a\x00\x00\x00\x18", -25),
+]
+for wire, expected in cases:
+    assert cbor2.loads(wire) == expected
+    obj = rr_scapy_decode(wire)
+    assert obj.val == expected
+    assert obj.enc() == cbor2.dumps(expected, canonical=True)
+
+= Overlong string and container lengths rebuild in shortest form ~ external_cbor2
+cases = [
+    (b"\x58\x01x", b"x"),
+    (b"\x78\x01x", "x"),
+    (b"\x98\x01\x00", [0]),
+    (b"\xb8\x01\x00\x01", {0: 1}),
+]
+for wire, expected in cases:
+    assert cbor2.loads(wire) == expected
+    obj = rr_scapy_decode(wire)
+    assert obj.enc() == cbor2.dumps(expected, canonical=True)
+    assert cbor2.loads(obj.enc()) == expected
+
+= An overlong semantic-tag header rebuilds in shortest form ~ external_cbor2
+wire = b"\xda\x00\x00\xea\x60\x00"  # tag 60000 around integer 0
+expected = cbor2.CBORTag(60000, 0)
+assert cbor2.loads(wire) == expected
+obj = rr_scapy_decode(wire)
+canonical = cbor2.dumps(expected, canonical=True)
+assert obj.enc() == canonical
+assert cbor2.loads(obj.enc()) == expected
+
+= Mixed non-preferred headers normalize recursively ~ external_cbor2
+wire = (
+    b"\x98\x03"          # array(3), overlong length
+    b"\x18\x01"          # uint 1, overlong
+    b"\x78\x01x"        # text length 1, overlong
+    b"\xb8\x01\x18\x02\x18\x03"  # {2: 3}, all overlong
+)
+expected = [1, "x", {2: 3}]
+assert cbor2.loads(wire) == expected
+obj = rr_scapy_decode(wire)
+assert obj.enc() == cbor2.dumps(expected, canonical=True)
+assert cbor2.loads(obj.enc()) == expected
+
++ Floating-point vectors generated and validated by cbor2
+
+= Canonical cbor2 chooses half, single, and double float widths ~ external_cbor2
+cases = [(1.5, 0xf9), (100000.0, 0xfa), (1.1, 0xfb)]
+for value, initial in cases:
+    wire = cbor2.dumps(value, canonical=True)
+    assert wire[0] == initial, (value, wire.hex())
+    rr_assert_cbor2_value(value, canonical=True, exact=False)
+
+= Positive and negative zero retain their sign across implementations ~ external_cbor2
+for value in (0.0, -0.0):
+    wire, obj = rr_assert_cbor2_value(value, canonical=True, exact=False)
+    assert math.copysign(1.0, obj.val) == math.copysign(1.0, value)
+    rebuilt = obj.enc()
+    assert math.copysign(1.0, cbor2.loads(rebuilt)) == math.copysign(1.0, value)
+
+= Positive and negative infinity interoperate ~ external_cbor2
+for value in (float("inf"), float("-inf")):
+    rr_assert_cbor2_value(value, canonical=True, exact=False)
+    rr_assert_scapy_native(value)
+
+= NaN remains NaN across width normalization ~ external_cbor2
+wire = cbor2.dumps(float("nan"), canonical=True)
+obj = rr_scapy_decode(wire)
+assert math.isnan(obj.val)
+assert math.isnan(cbor2.loads(obj.enc()))
+
+= Half, single, and double subnormal values interoperate ~ external_cbor2
+for value in (2.0 ** -24, 2.0 ** -149, 2.0 ** -1074):
+    wire = cbor2.dumps(value, canonical=True)
+    expected = cbor2.loads(wire)
+    obj = rr_scapy_decode(wire)
+    assert _rr_float(obj.val) == _rr_float(expected)
+    assert _rr_float(cbor2.loads(obj.enc())) == _rr_float(expected)
+
+= Explicit half, single, and double encodings decode identically ~ external_cbor2
+wires = [
+    b"\xf9\x3e\x00",
+    b"\xfa\x3f\xc0\x00\x00",
+    b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00",
+]
+for wire in wires:
+    assert cbor2.loads(wire) == 1.5
+    obj = rr_scapy_decode(wire)
+    assert obj.val == 1.5
+    assert cbor2.loads(obj.enc()) == 1.5
+
+= Scapy preferred float encodings are accepted by cbor2 for finite floats ~ external_cbor2
+values = [-1.0e300, -123.5, -0.0, 0.0, 1.5, 1.1, 1.0e300]
+for value in values:
+    wire = rr_assert_scapy_native(value)
+    # Preferred serialization may use half/single/double; cbor2 must accept it.
+    assert wire[0] in (0xf9, 0xfa, 0xfb), wire.hex()
+    loaded = cbor2.loads(wire)
+    assert loaded == value or (
+        math.copysign(1.0, loaded) == math.copysign(1.0, value)
+        and loaded == 0.0 and value == 0.0
+    )
+= Different NaN payloads remain semantic NaNs after Scapy re-encoding ~ external_cbor2
+for wire in (b"\xf9\x7e\x00", b"\xfa\x7f\xc0\x00\x01",
+             b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x01"):
+    assert math.isnan(cbor2.loads(wire))
+    obj = rr_scapy_decode(wire)
+    assert math.isnan(obj.val)
+    assert math.isnan(cbor2.loads(obj.enc()))
+
++ Arrays, maps, nesting, and canonical ordering
+
+= Array length boundaries generated by cbor2 decode and re-encode exactly ~ external_cbor2
+for length in (0, 1, 22, 23, 24, 25, 254, 255, 256, 4096):
+    value = [index & 0x17 for index in range(length)]
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Large array 16-bit to 32-bit length transition interoperates ~ external_cbor2
+for length in (65535, 65536):
+    value = [None] * length
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert len(obj.val) == length
+    assert obj.enc() == wire
+
+= Map length boundaries generated by cbor2 decode and re-encode exactly ~ external_cbor2
+for length in (0, 1, 22, 23, 24, 25, 254, 255, 256):
+    value = {index: index + 1 for index in range(length)}
+    rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Deep heterogeneous containers agree semantically and exactly ~ external_cbor2
+value = {
+    "array": [1, -2, b"three", "four", None, True, cbor2.undefined],
+    "map": {"nested": [{"x": 1}, {"y": 2}]},
+    "tag": cbor2.CBORTag(60000, [1, {"z": b"q"}]),
+}
+rr_assert_cbor2_value(value, canonical=True, exact=True)
+
+= Canonical map order emitted by cbor2 is retained by Scapy ~ external_cbor2
+value = {"aa": 1, "b": 2, b"": 3, 10: 4, -1: 5}
+wire = cbor2.dumps(value, canonical=True)
+obj = rr_scapy_decode(wire)
+assert obj.enc() == wire
+assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= A compound array-valued map key generated by cbor2 round-trips ~ external_cbor2
+value = {(1, "x", b"y"): "compound-key"}
+wire = cbor2.dumps(value, canonical=True)
+obj = rr_scapy_decode(wire)
+assert isinstance(obj, CBOR_MAP)
+assert obj.enc() == wire
+assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= A map-valued map key validated by immutable cbor2 round-trips ~ external_cbor2
+key_wire = cbor2.dumps({"inner": 1}, canonical=True)
+wire = b"\xa1" + key_wire + cbor2.dumps("map-key", canonical=True)
+decoded = cbor2.loads(wire, immutable=True)
+assert len(decoded) == 1
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 1
+assert isinstance(pairs[0][0], CBOR_MAP)
+assert obj.enc() == wire
+
+= A semantic-tag-valued map key round-trips exactly ~ external_cbor2
+key_wire = cbor2.dumps(cbor2.CBORTag(60000, "key"), canonical=True)
+wire = b"\xa1" + key_wire + cbor2.dumps("tag-key", canonical=True)
+cbor2.loads(wire, immutable=True)
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 1
+assert isinstance(pairs[0][0], CBOR_SEMANTIC_TAG)
+assert obj.enc() == wire
+
+= CBOR integer 1 and floating-point 1.0 remain distinct map keys ~ external_cbor2
+wire = (
+    b"\xa2" + cbor2.dumps(1) + cbor2.dumps("integer") +
+    cbor2.dumps(1.0) + cbor2.dumps("float")
+)
+cbor2.loads(wire, immutable=True)
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 2
+assert isinstance(pairs[0][0], CBOR_UNSIGNED_INTEGER)
+assert isinstance(pairs[1][0], CBOR_FLOAT)
+assert obj.enc() == wire
+
+= Positive and negative floating zero remain distinct encoded map keys ~ external_cbor2
+wire = (
+    b"\xa2" + cbor2.dumps(0.0) + cbor2.dumps("positive") +
+    cbor2.dumps(-0.0) + cbor2.dumps("negative")
+)
+cbor2.loads(wire, immutable=True)
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 2
+assert isinstance(pairs[0][0], CBOR_FLOAT)
+assert isinstance(pairs[1][0], CBOR_FLOAT)
+assert math.copysign(1.0, pairs[0][0].val) == 1.0
+assert math.copysign(1.0, pairs[1][0].val) == -1.0
+assert obj.enc() == wire
+
+= Distinct double-precision NaN payloads survive as separate map keys ~ external_cbor2
+first_nan = b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x01"
+second_nan = b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x02"
+wire = b"\xa2" + first_nan + cbor2.dumps(1) + second_nan + cbor2.dumps(2)
+cbor2.loads(wire, immutable=True)
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 2
+assert all(isinstance(key, CBOR_FLOAT) and math.isnan(key.val) for key, _ in pairs)
+assert obj.enc() == wire
+
+= CBOR integer 1 and Boolean true remain distinct map keys in Scapy ~ external_cbor2
+wire = (
+    b"\xa2" + cbor2.dumps(1) + cbor2.dumps("integer") +
+    cbor2.dumps(True) + cbor2.dumps("boolean")
+)
+# cbor2 validates the complete wire, even though a Python mapping cannot
+# faithfully expose these two Python-equal keys at the same time.
+cbor2.loads(wire)
+obj = rr_scapy_decode(wire)
+pairs = obj.val.cbor_pairs()
+assert len(pairs) == 2
+assert isinstance(pairs[0][0], CBOR_UNSIGNED_INTEGER)
+assert isinstance(pairs[1][0], CBOR_TRUE)
+assert obj.enc() == wire
+
+= Indefinite arrays generated by cbor2 normalize semantically in Scapy ~ external_cbor2
+for value in ([], [1], [1, "two", [3, 4]], [{"x": 1}, {"y": 2}]):
+    wire = cbor2.dumps(value, indefinite_containers=True)
+    assert wire[0] == 0x9f and wire[-1] == 0xff
+    rr_assert_cbor2_value(value, indefinite_containers=True, exact=False)
+
+= Indefinite maps generated by cbor2 normalize semantically in Scapy ~ external_cbor2
+for value in ({}, {"x": 1}, {"x": [1, 2], "y": {"z": 3}}):
+    wire = cbor2.dumps(value, indefinite_containers=True)
+    assert wire[0] == 0xbf and wire[-1] == 0xff
+    rr_assert_cbor2_value(value, indefinite_containers=True, exact=False)
+
+= Mixed nested indefinite containers generated by cbor2 interoperate ~ external_cbor2
+value = [{"a": [1, 2]}, {"b": {"c": [3, 4]}}]
+rr_assert_cbor2_value(value, indefinite_containers=True, exact=False)
+
+= Scapy accepts the maximum configured nesting depth from cbor2 ~ external_cbor2
+value = 0
+for _ in range(MAX_CBOR_NESTING):
+    value = [value]
+
+wire = cbor2.dumps(value)
+rr_scapy_decode(wire)
+assert cbor2.loads(wire, max_depth=MAX_CBOR_NESTING + 2) == value
+
+= Scapy rejects one level beyond its configured nesting depth ~ external_cbor2
+value = 0
+for _ in range(MAX_CBOR_NESTING + 1):
+    value = [value]
+
+wire = cbor2.dumps(value)
+assert cbor2.loads(wire, max_depth=MAX_CBOR_NESTING + 2) == value
+rr_scapy_reject(wire)
+
++ CBOR sequence and remainder interoperability
+
+= Scapy leaves the exact cbor2-generated suffix after one decoded item ~ external_cbor2
+first = cbor2.dumps({"first": [1, 2]}, canonical=True)
+second = cbor2.dumps(cbor2.CBORTag(60000, "second"), canonical=True)
+obj, remainder = CBOR_Codecs.CBOR.dec(first + second)
+assert obj.enc() == first
+assert remainder == second
+
+= A heterogeneous cbor2 sequence decodes item-by-item in Scapy ~ external_cbor2
+values = [0, -1, b"x", "y", [1, 2], {"z": 3}, True, None,
+          cbor2.undefined, cbor2.CBORTag(60000, 4)]
+
+wire = b"".join(cbor2.dumps(value, canonical=True) for value in values)
+expected = [rr_norm_cbor2(rr_cbor2_load(cbor2.dumps(value, canonical=True)))
+            for value in values]
+
+assert rr_scapy_sequence(wire) == expected
+assert rr_cbor2_sequence(wire, len(values)) == expected
+
+= cbor2 decodes a sequence produced by Scapy native encoders ~ external_cbor2
+values = [0, -1, b"x", "y", [1, 2], {"z": 3}, True, None,
+          CBOR_UNDEFINED_VALUE, CBORTagValue(60000, 4)]
+
+wire = b"".join(CBORcodec_Object.encode_cbor_item(value) for value in values)
+expected = [rr_norm_native(value) for value in values]
+assert rr_cbor2_sequence(wire, len(values)) == expected
+assert rr_scapy_sequence(wire) == expected
+
+= A 100-item deterministic sequence makes forward progress in both decoders ~ external_cbor2
+rng = random.Random(0xCB020001)
+values = [rr_random_value(rng, include_float=False) for _ in range(100)]
+wire = b"".join(cbor2.dumps(value, canonical=True) for value in values)
+expected = [rr_norm_cbor2(rr_cbor2_load(cbor2.dumps(value, canonical=True)))
+            for value in values]
+
+assert rr_scapy_sequence(wire) == expected
+assert rr_cbor2_sequence(wire, len(values)) == expected
+
++ Typed CBOR packet fields with cbor2-generated wire data
+
+= CBORF_UNSIGNED_INTEGER accepts all cbor2 uint64 boundaries ~ external_cbor2
+for value in (0, 23, 24, 255, 256, 65535, 65536, (1 << 64) - 1):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2UInt(wire)
+    assert pkt.value == value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_NEGATIVE_INTEGER accepts all cbor2 int64 boundaries ~ external_cbor2
+for value in (-1, -24, -25, -256, -257, -65536, -65537, -(1 << 64)):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2NInt(wire)
+    assert pkt.value == value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_BYTE_STRING accepts definite strings generated by cbor2 ~ external_cbor2
+for value in (b"", b"x", bytes(range(256)), b"z" * 65536):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2Bytes(wire)
+    assert pkt.value == value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_BYTE_STRING accepts a valid indefinite string and rebuilds definite ~ external_cbor2
+wire = b"\x5f" + cbor2.dumps(b"ab") + cbor2.dumps(b"cd") + b"\xff"
+pkt = RRCbor2Bytes(wire)
+assert pkt.value == b"abcd"
+rr_clear_cache(pkt)
+assert bytes(pkt) == cbor2.dumps(b"abcd")
+
+= CBORF_BYTE_STRING definite-only mode accepts cbor2 definite data ~ external_cbor2
+for value in (b"", b"x", bytes(range(32)), b"z" * 256):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2DefiniteBytes(wire)
+    assert pkt.value == value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_BYTE_STRING definite-only mode rejects an oracle-valid indefinite value ~ external_cbor2
+wire = b"\x5f" + cbor2.dumps(b"ab") + cbor2.dumps(b"cd") + b"\xff"
+assert cbor2.loads(wire) == b"abcd"
+try:
+    RRCbor2DefiniteBytes(wire)
+except CBOR_Decoding_Error:
+    pass
+else:
+    raise AssertionError("definite-only byte field accepted an indefinite string")
+
+= CBORF_TEXT_STRING accepts Unicode strings generated by cbor2 ~ external_cbor2
+for value in ("", "hello", "Grüße", "𐍈" * 100, "a\x00b"):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2Text(wire)
+    assert pkt.value == value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_TEXT_STRING accepts a valid indefinite string and rebuilds definite ~ external_cbor2
+wire = b"\x7f" + cbor2.dumps("Grü") + cbor2.dumps("ße") + b"\xff"
+pkt = RRCbor2Text(wire)
+assert pkt.value == "Grüße"
+rr_clear_cache(pkt)
+assert bytes(pkt) == cbor2.dumps("Grüße")
+
+= CBORF_BOOLEAN agrees with cbor2 for both Boolean values ~ external_cbor2
+for value in (False, True):
+    wire = cbor2.dumps(value)
+    pkt = RRCbor2Bool(wire)
+    assert pkt.value is value
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_NULL agrees with cbor2 null ~ external_cbor2
+wire = cbor2.dumps(None)
+pkt = RRCbor2Null(wire)
+assert pkt.value is None
+rr_clear_cache(pkt)
+assert bytes(pkt) == wire
+
+= CBORF_UNDEFINED agrees with cbor2 undefined ~ external_cbor2
+wire = cbor2.dumps(cbor2.undefined)
+pkt = RRCbor2Undefined(wire)
+assert pkt.value is None
+rr_clear_cache(pkt)
+assert bytes(pkt) == wire
+
+= CBORF_FLOAT accepts every cbor2 float width and rebuilds valid double ~ external_cbor2
+for wire in (b"\xf9\x3e\x00", b"\xfa\x3f\xc0\x00\x00",
+             b"\xfb\x3f\xf8\x00\x00\x00\x00\x00\x00"):
+    expected = cbor2.loads(wire)
+    pkt = RRCbor2Float(wire)
+    assert _rr_float(pkt.value) == _rr_float(expected)
+    rr_clear_cache(pkt)
+    assert _rr_float(cbor2.loads(bytes(pkt))) == _rr_float(expected)
+
+= CBORF_ARRAY_OF decodes homogeneous cbor2 arrays at length boundaries ~ external_cbor2
+for length in (0, 1, 23, 24, 255, 256):
+    values = list(range(length))
+    wire = cbor2.dumps(values, canonical=True)
+    pkt = RRCbor2UIntArray(wire)
+    assert pkt.values == values
+    rr_clear_cache(pkt)
+    assert bytes(pkt) == wire
+
+= CBORF_ARRAY_OF decodes indefinite cbor2 arrays ~ external_cbor2
+wire = cbor2.dumps([1, 2, 3], indefinite_containers=True)
+pkt = RRCbor2UIntArray(wire)
+assert pkt.values == [1, 2, 3]
+assert bytes(pkt) == wire
+
+= CBORF_SEMANTIC_TAG decodes and rebuilds a cbor2-generated tag ~ external_cbor2
+value = cbor2.CBORTag(60000, "tagged")
+wire = cbor2.dumps(value, canonical=True)
+pkt = RRCbor2TaggedText(wire)
+assert pkt.tag_number == 60000
+assert pkt.value == "tagged"
+rr_clear_cache(pkt)
+assert bytes(pkt) == wire
+
+= Typed packet mutation produces wire accepted by cbor2 ~ external_cbor2
+pkt = RRCbor2UInt(cbor2.dumps(23))
+pkt.value = 65536
+wire = bytes(pkt)
+assert cbor2.loads(wire) == 65536
+assert wire == cbor2.dumps(65536)
+
++ CBORF_ANY differential packet tests
+
+= CBORF_ANY scalar values generated by cbor2 rebuild semantically ~ external_cbor2
+values = [0, (1 << 64) - 1, -1, -(1 << 64), b"bytes", "text",
+          False, True, None, cbor2.undefined, cbor2.CBORSimpleValue(32),
+          1.5, cbor2.CBORTag(60000, "tag")]
+
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2AnyRoot(wire)
+    rr_clear_cache(pkt)
+    rebuilt = bytes(pkt)
+    assert rr_norm_cbor2(rr_cbor2_load(rebuilt)) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= CBORF_ANY nested arrays generated by cbor2 survive sibling mutation ~ external_cbor2
+value = [1, [2, [3]], "four"]
+wire = cbor2.dumps([value, 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+pkt.tail = 1
+assert cbor2.loads(bytes(pkt)) == [value, 1]
+
+= CBORF_ANY non-empty maps remain maps after sibling mutation ~ external_cbor2
+value = {"a": 1, "b": [2, 3]}
+wire = cbor2.dumps([value, 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+pkt.tail = 1
+assert cbor2.loads(bytes(pkt)) == [value, 1]
+
+= CBORF_ANY empty maps do not become arrays after sibling mutation ~ external_cbor2
+wire = cbor2.dumps([{}, 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+pkt.tail = 1
+actual = cbor2.loads(bytes(pkt))
+assert actual == [{}, 1]
+assert isinstance(actual[0], dict)
+
+= CBORF_ANY unknown nested tags remain tags after rebuild ~ external_cbor2
+value = cbor2.CBORTag(60000, [cbor2.CBORTag(60001, {"x": 1})])
+wire = cbor2.dumps(value, canonical=True)
+pkt = RRCbor2AnyRoot(wire)
+rr_clear_cache(pkt)
+assert rr_norm_cbor2(rr_cbor2_load(bytes(pkt))) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= CBORF_ANY preserves simple values and undefined distinctly ~ external_cbor2
+for value in (cbor2.CBORSimpleValue(0), cbor2.CBORSimpleValue(255), cbor2.undefined):
+    wire = cbor2.dumps(value)
+    pkt = RRCbor2AnyRoot(wire)
+    rr_clear_cache(pkt)
+    assert rr_norm_cbor2(rr_cbor2_load(bytes(pkt))) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= CBORF_ANY accepts cbor2 indefinite arrays and rebuilds equivalent data ~ external_cbor2
+value = [1, {"x": [2, 3]}]
+wire = cbor2.dumps(value, indefinite_containers=True)
+pkt = RRCbor2AnyRoot(wire)
+rr_clear_cache(pkt)
+assert cbor2.loads(bytes(pkt)) == value
+
+= CBORF_ANY accepts cbor2 indefinite maps and rebuilds a map ~ external_cbor2
+value = {"x": [1, 2], "y": {"z": 3}}
+wire = cbor2.dumps(value, indefinite_containers=True)
+pkt = RRCbor2AnyRoot(wire)
+rr_clear_cache(pkt)
+actual = cbor2.loads(bytes(pkt))
+assert actual == value
+assert isinstance(actual, dict)
+
+= CBORF_ANY bignums rebuild to the original mathematical integer ~ external_cbor2
+for value in (1 << 100, -(1 << 100)):
+    wire = cbor2.dumps(value, canonical=True)
+    pkt = RRCbor2AnyRoot(wire)
+    rr_clear_cache(pkt)
+    assert cbor2.loads(bytes(pkt)) == value
+
+= In-place mutation of a CBORF_ANY outer list invalidates cached bytes ~ external_cbor2
+wire = cbor2.dumps([[1, 2], 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+pkt.value.append(3)
+assert cbor2.loads(bytes(pkt)) == [[1, 2, 3], 0]
+
+= In-place mutation of a nested CBORF_ANY list invalidates cached bytes ~ external_cbor2
+wire = cbor2.dumps([[[1]], 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+pkt.value[0].append(2)
+assert cbor2.loads(bytes(pkt)) == [[[1, 2]], 0]
+
+= CBORF_ANY map-value mutation invalidates cached bytes ~ external_cbor2
+wire = cbor2.dumps([{"x": [1]}, 0], canonical=True)
+pkt = RRCbor2AnyEnvelope(wire)
+# The fixed representation must expose a mutable map while retaining major type 5.
+map_value = pkt.value
+if isinstance(map_value, CBORMapData):
+    stored = map_value["x"]
+elif isinstance(map_value, dict):
+    stored = map_value["x"]
+else:
+    stored = dict(map_value)["x"]
+
+stored.append(2)
+assert cbor2.loads(bytes(pkt)) == [{"x": [1, 2]}, 0]
+
++ Seeded randomized differential corpora
+
+= 256 canonical non-float values are byte-identical through generic Scapy ~ external_cbor2
+rng = random.Random(0xCB020101)
+for index in range(256):
+    value = rr_random_value(rng, include_float=False)
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    rebuilt = obj.enc()
+    assert rebuilt == wire, (index, wire.hex(), rebuilt.hex(), value)
+    assert rr_norm_cbor2(rr_cbor2_load(rebuilt)) == rr_norm_cbor2(rr_cbor2_load(wire))
+
+= 256 default cbor2 values including floats agree semantically with Scapy ~ external_cbor2
+rng = random.Random(0xCB020102)
+for index in range(256):
+    value = rr_random_value(rng, include_float=True)
+    wire = cbor2.dumps(value)
+    obj = rr_scapy_decode(wire)
+    expected = rr_norm_cbor2(rr_cbor2_load(wire))
+    actual = rr_norm_scapy(obj)
+    assert actual == expected, (index, wire.hex(), expected, actual, value)
+    assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == expected
+
+= 128 cbor2 indefinite-container values agree semantically with Scapy ~ external_cbor2
+rng = random.Random(0xCB020103)
+for index in range(128):
+    value = rr_random_value(rng, include_float=True)
+    wire = cbor2.dumps(value, indefinite_containers=True)
+    obj = rr_scapy_decode(wire)
+    expected = rr_norm_cbor2(rr_cbor2_load(wire))
+    actual = rr_norm_scapy(obj)
+    assert actual == expected, (index, wire.hex(), expected, actual, value)
+    assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == expected
+
+= 256 Scapy-native randomized values are accepted by cbor2 ~ external_cbor2
+rng = random.Random(0xCB020104)
+for index in range(256):
+    value = rr_random_value(rng, include_float=True)
+    native = rr_to_scapy_native(value)
+    wire = CBORcodec_Object.encode_cbor_item(native)
+    expected = rr_norm_native(native)
+    actual = rr_norm_cbor2(rr_cbor2_load(wire))
+    assert actual == expected, (index, wire.hex(), expected, actual, value)
+
+= 128 randomized canonical maps retain cbor2 canonical key order ~ external_cbor2
+rng = random.Random(0xCB020105)
+for index in range(128):
+    value = {}
+    while len(value) < rng.randrange(0, 12):
+        value[rr_random_key(rng)] = rr_random_value(rng, 2, include_float=False)
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert obj.enc() == wire, (index, wire.hex(), obj.enc().hex(), value)
+
+= 128 randomized unknown-tag trees remain byte-identical ~ external_cbor2
+rng = random.Random(0xCB020106)
+for index in range(128):
+    value = cbor2.CBORTag(
+        60000 + index,
+        rr_random_value(rng, include_float=False),
+    )
+    wire = cbor2.dumps(value, canonical=True)
+    obj = rr_scapy_decode(wire)
+    assert obj.enc() == wire, (index, wire.hex(), obj.enc().hex())
+
++ Malformed-input differential tests
+
+= Every proper prefix of cbor2-generated composite values is rejected ~ external_cbor2
+values = [
+    b"x" * 32,
+    "Grüße" * 8,
+    [1, 2, [3, 4]],
+    {"a": 1, "b": [2, 3]},
+    cbor2.CBORTag(60000, {"x": [1, 2]}),
+    1.5,
+]
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    for cut in range(len(wire)):
+        rr_both_reject(wire[:cut])
+
+= Invalid UTF-8 text is rejected by both implementations ~ external_cbor2
+for wire in (b"\x61\xff", b"\x62\xc0\x80", b"\x63\xed\xa0\x80"):
+    rr_both_reject(wire)
+
+= Exact duplicate map keys are rejected by both strict decoders ~ external_cbor2
+wire = b"\xa2" + cbor2.dumps(1) + cbor2.dumps(0) + cbor2.dumps(1) + cbor2.dumps(1)
+rr_cbor2_reject(wire, allow_duplicate_keys=False)
+rr_scapy_reject(wire)
+
+= Semantically duplicate shortest and overlong map keys are rejected ~ external_cbor2
+wire = b"\xa2\x01\x00\x18\x01\x01"
+assert cbor2.loads(wire) == {1: 1}
+rr_cbor2_reject(wire, allow_duplicate_keys=False)
+rr_scapy_reject(wire)
+
+= Standalone and misplaced break bytes are rejected by Scapy ~ external_cbor2
+# cbor2 6.1.4 decodes a bare/misplaced break as a sentinel object; Scapy must
+# still reject these as non-well-formed top-level / container items.
+for wire in (b"\xff", b"\x81\xff", b"\xa1\xff\x00"):
+    rr_scapy_reject(wire)
+
+= Reserved additional-information values are rejected by both ~ external_cbor2
+for major in range(8):
+    for additional in (28, 29, 30):
+        rr_both_reject(bytes([(major << 5) | additional]))
+
+= Non-well-formed two-byte simple values below 32 are rejected ~ external_cbor2
+for number in range(32):
+    rr_both_reject(b"\xf8" + bytes([number]))
+
+= Indefinite byte strings reject text-string chunks ~ external_cbor2
+wire = b"\x5f" + cbor2.dumps("wrong chunk type") + b"\xff"
+rr_both_reject(wire)
+
+= Indefinite text strings reject byte-string chunks ~ external_cbor2
+wire = b"\x7f" + cbor2.dumps(b"wrong chunk type") + b"\xff"
+rr_both_reject(wire)
+
+= Indefinite byte strings reject nested indefinite chunks ~ external_cbor2
+wire = b"\x5f\x5f" + cbor2.dumps(b"nested") + b"\xff\xff"
+rr_both_reject(wire)
+
+= Indefinite text strings reject nested indefinite chunks ~ external_cbor2
+wire = b"\x7f\x7f" + cbor2.dumps("nested") + b"\xff\xff"
+rr_both_reject(wire)
+
+= A UTF-8 code point split across text chunks is rejected ~ external_cbor2
+# U+00E4 is UTF-8 C3 A4, but each chunk must independently be valid UTF-8.
+wire = b"\x7f\x61\xc3\x61\xa4\xff"
+rr_both_reject(wire)
+
+= Indefinite strings reject a break before a chunk payload completes ~ external_cbor2
+for wire in (b"\x5f\x42a\xff", b"\x7f\x62a\xff"):
+    rr_both_reject(wire)
+
+= Indefinite maps reject a key without a value ~ external_cbor2
+wire = b"\xbf" + cbor2.dumps("key") + b"\xff"
+rr_both_reject(wire)
+
+= Semantic tags reject a missing tagged data item ~ external_cbor2
+wire = cbor2.dumps(cbor2.CBORTag(60000, 0), canonical=True)
+# Strip the complete encoded value, retaining only the cbor2-generated tag head.
+tag_only = wire[:-1]
+rr_both_reject(tag_only)
+
+= Truncated half, single, and double floats are rejected by both ~ external_cbor2
+for value in (1.5, 100000.0, 1.1):
+    wire = cbor2.dumps(value, canonical=True)
+    for cut in range(1, len(wire)):
+        rr_both_reject(wire[:cut])
+
+= Scapy safedec wraps every cbor2-rejected truncation ~ external_cbor2
+wire = cbor2.dumps({"a": [1, 2, 3], "b": "text"}, canonical=True)
+for cut in range(len(wire)):
+    prefix = wire[:cut]
+    rr_cbor2_reject(prefix)
+    result, remainder = CBOR_Codecs.CBOR.safedec(prefix)
+    assert isinstance(result, CBOR_DECODING_ERROR)
+    assert remainder == b""
+
+= cbor2 strict mode rejects indefinite data that generic Scapy accepts ~ external_cbor2
+values = [[], [1, 2], {}, {"x": 1}]
+for value in values:
+    wire = cbor2.dumps(value, indefinite_containers=True)
+    rr_cbor2_reject(wire, allow_indefinite=False)
+    obj = rr_scapy_decode(wire)
+    assert rr_norm_cbor2(rr_cbor2_load(obj.enc())) == rr_norm_cbor2(rr_cbor2_load(wire))
+
++ Canonicalization and encode/decode idempotence
+
+= A broad canonical cbor2 corpus is byte-identical in generic Scapy ~ external_cbor2
+values = [
+    0, 23, 24, (1 << 64) - 1, -1, -(1 << 64), b"", b"x" * 256,
+    "", "Grüße", False, True, None, cbor2.undefined,
+    cbor2.CBORSimpleValue(255), [1, "x", b"y"],
+    {"b": 2, "a": 1}, cbor2.CBORTag(60000, {"x": [1, 2]}),
+]
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    assert rr_scapy_decode(wire).enc() == wire
+
+= Scapy generic encoding is idempotent after cbor2 input ~ external_cbor2
+rng = random.Random(0xCB020201)
+for index in range(256):
+    value = rr_random_value(rng, include_float=True)
+    original = cbor2.dumps(value)
+    first = rr_scapy_decode(original).enc()
+    second = rr_scapy_decode(first).enc()
+    assert second == first, (index, original.hex(), first.hex(), second.hex())
+
+= Scapy-normalized indefinite data remains stable on a second build ~ external_cbor2
+rng = random.Random(0xCB020202)
+for index in range(128):
+    value = rr_random_value(rng, include_float=True)
+    indefinite = cbor2.dumps(value, indefinite_containers=True)
+    first = rr_scapy_decode(indefinite).enc()
+    second = rr_scapy_decode(first).enc()
+    assert second == first, (index, indefinite.hex(), first.hex(), second.hex())
+
+= cbor2 canonicalization of Scapy output preserves semantics ~ external_cbor2
+rng = random.Random(0xCB020203)
+for index in range(256):
+    value = rr_random_value(rng, include_float=True)
+    native = rr_to_scapy_native(value)
+    scapy_wire = CBORcodec_Object.encode_cbor_item(native)
+    decoded = cbor2.loads(scapy_wire)
+    canonical = cbor2.dumps(decoded, canonical=True)
+    assert rr_norm_cbor2(rr_cbor2_load(canonical)) == rr_norm_native(native), index
+
+= cbor2 length-header transitions remain exact after Scapy decoding ~ external_cbor2
+values = [
+    b"x" * 23, b"x" * 24, b"x" * 255, b"x" * 256,
+    "x" * 23, "x" * 24, "x" * 255, "x" * 256,
+    [None] * 23, [None] * 24, [None] * 255, [None] * 256,
+    {index: None for index in range(23)},
+    {index: None for index in range(24)},
+    {index: None for index in range(255)},
+    {index: None for index in range(256)},
+]
+for value in values:
+    wire = cbor2.dumps(value, canonical=True)
+    assert rr_scapy_decode(wire).enc() == wire

--- a/test/scapy/layers/generate_cbor2_corpus.py
+++ b/test/scapy/layers/generate_cbor2_corpus.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate a reproducible CBOR corpus with cbor2 6.1.4.
+
+The UTS campaign performs live differential checks. This helper freezes the
+same style of independently generated vectors into JSON for debugging,
+minimization, or CI systems that prefer checked-in fixtures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+from typing import Any
+
+import cbor2
+
+VERSION = "6.1.4"
+DEFAULT_SEED = 0xCB020301
+
+
+def random_key(rng: random.Random) -> Any:
+    kind = rng.randrange(3)
+    if kind == 0:
+        return rng.randint(-100000, 100000)
+    if kind == 1:
+        return bytes(rng.randrange(256) for _ in range(rng.randrange(8)))
+    alphabet = "abcXYZ012-_ä"
+    return "".join(rng.choice(alphabet) for _ in range(rng.randrange(8)))
+
+
+def random_value(rng: random.Random, depth: int = 0) -> Any:
+    kinds = [
+        "uint", "nint", "bytes", "text", "bool", "null", "undefined",
+        "simple", "float", "tag",
+    ]
+    if depth < 4:
+        kinds.extend(("array", "map"))
+    kind = rng.choice(kinds)
+    if kind == "uint":
+        return rng.randrange(0, 1 << rng.choice((4, 8, 16, 32, 64)))
+    if kind == "nint":
+        return -1 - rng.randrange(0, 1 << rng.choice((4, 8, 16, 32, 63)))
+    if kind == "bytes":
+        return bytes(rng.randrange(256) for _ in range(rng.randrange(32)))
+    if kind == "text":
+        alphabet = "abcXYZ012-_ä€𐍈\x00"
+        return "".join(rng.choice(alphabet) for _ in range(rng.randrange(24)))
+    if kind == "bool":
+        return bool(rng.getrandbits(1))
+    if kind == "null":
+        return None
+    if kind == "undefined":
+        return cbor2.undefined
+    if kind == "simple":
+        return cbor2.CBORSimpleValue(rng.choice((0, 1, 16, 19, 32, 64, 127, 255)))
+    if kind == "float":
+        special = rng.randrange(12)
+        if special == 0:
+            return -0.0
+        if special == 1:
+            return float("inf")
+        if special == 2:
+            return float("-inf")
+        if special == 3:
+            return float("nan")
+        return rng.uniform(-1.0e12, 1.0e12)
+    if kind == "tag":
+        return cbor2.CBORTag(60000 + rng.randrange(1000), random_value(rng, depth + 1))
+    if kind == "array":
+        return [random_value(rng, depth + 1) for _ in range(rng.randrange(6))]
+
+    result: dict[Any, Any] = {}
+    target = rng.randrange(6)
+    while len(result) < target:
+        result[random_key(rng)] = random_value(rng, depth + 1)
+    return result
+
+
+def json_repr(value: Any) -> Any:
+    if value is cbor2.undefined:
+        return {"type": "undefined"}
+    if isinstance(value, cbor2.CBORSimpleValue):
+        return {"type": "simple", "value": value.value}
+    if isinstance(value, cbor2.CBORTag):
+        return {"type": "tag", "tag": value.tag, "value": json_repr(value.value)}
+    if isinstance(value, bytes):
+        return {"type": "bytes", "hex": value.hex()}
+    if isinstance(value, float):
+        if math.isnan(value):
+            return {"type": "float", "value": "nan"}
+        if math.isinf(value):
+            return {"type": "float", "value": "+inf" if value > 0 else "-inf"}
+        if value == 0.0 and math.copysign(1.0, value) < 0:
+            return {"type": "float", "value": "-0"}
+        return value
+    if isinstance(value, dict):
+        return {
+            "type": "map",
+            "pairs": [[json_repr(key), json_repr(item)] for key, item in value.items()],
+        }
+    if isinstance(value, (list, tuple)):
+        return [json_repr(item) for item in value]
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--seed", type=lambda value: int(value, 0), default=DEFAULT_SEED)
+    parser.add_argument("--count", type=int, default=512)
+    args = parser.parse_args()
+
+    actual_version = distribution_version("cbor2")
+    if actual_version != VERSION:
+        parser.error(f"expected cbor2 {VERSION}, found {actual_version}")
+
+    rng = random.Random(args.seed)
+    vectors = []
+    for index in range(args.count):
+        value = random_value(rng)
+        default_wire = cbor2.dumps(value)
+        canonical_wire = cbor2.dumps(value, canonical=True)
+        indefinite_wire = cbor2.dumps(value, indefinite_containers=True)
+        vectors.append({
+            "index": index,
+            "value": json_repr(value),
+            "default_hex": default_wire.hex(),
+            "canonical_hex": canonical_wire.hex(),
+            "indefinite_hex": indefinite_wire.hex(),
+        })
+
+    document = {
+        "generator": "cbor2",
+        "generator_version": actual_version,
+        "seed": args.seed,
+        "count": args.count,
+        "vectors": vectors,
+    }
+    args.output.write_text(
+        json.dumps(document, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scapy/layers/requirements-cbor2.txt
+++ b/test/scapy/layers/requirements-cbor2.txt
@@ -1,0 +1,3 @@
+# Optional interoperability-test dependency. Not required by Scapy itself.
+# cbor2 6.1.4 requires Python 3.10 or newer.
+cbor2==6.1.4

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps =
        cryptography
        coverage[toml]
        python-can
-       cbor2
        scapy-rpc
        # disabled on windows because they require c++ dependencies
        # brotli 1.1.0 broken https://github.com/google/brotli/issues/1072
@@ -99,6 +98,17 @@ deps = sphinx
        cryptography
 commands =
   sphinx-apidoc -f --no-toc -d 1 --separate --module-first --templatedir=_templates --output-dir api ../../scapy ../../scapy/modules/voip.py ../../scapy/modules/krack/ ../../scapy/libs/winpcapy.py ../../scapy/libs/ethertypes.py ../../scapy/libs/bluetoothids.py ../../scapy/libs/m*.py ../../scapy/libs/structures.py ../../scapy/libs/test_pyx.py ../../scapy/tools/ ../../scapy/arch/ ../../scapy/contrib/scada/* ../../scapy/contrib/igmp.py ../../scapy/contrib/igmpv3.py ../../scapy/layers/msrpce/raw/ ../../scapy/layers/msrpce/all.py ../../scapy/all.py ../../scapy/layers/all.py ../../scapy/compat.py
+
+
+[testenv:cbor2]
+description = "CBOR differential tests against pinned cbor2 6.1.4 (Python >= 3.10)"
+basepython = python3.12
+deps =
+       cbor2==6.1.4
+       coverage[toml]
+commands =
+  {envpython} {env:DISABLE_COVERAGE:-m coverage run} -m scapy.tools.UTscapy \
+      -t test/scapy/layers/cbor_cbor2_interop.uts -N {posargs}
 
 
 [testenv:mypy]


### PR DESCRIPTION
## Summary
- Add BPv7 primary/canonical blocks, EID handling, and CRC verification
- RFC 9171 / 9758 validation (fragments, Previous Node, lifecycle, etc.)

## Stack
PR 3 of 3. Depends on #5124 (CRC) and the CBOR PR. Includes the stacked foundations plus `scapy/contrib/bpv7.py` and UTS.

## Test plan
- [ ] `./test/run_tests -t test/contrib/bpv7.uts -N`
- [ ] flake8 / mypy on `scapy/contrib/bpv7.py`