### PR TITLE
snmp: keep printing results after an ICMP answer

### DIFF
--- a/scapy/layers/snmp.py
+++ b/scapy/layers/snmp.py
@@ -308,7 +308,7 @@ def snmpget(dst, oid="1.0.8802.1.1.1.1.1.2.1.2.29", community="public"):
     for r in ans:
         if ICMP in r.answer:
             print(repr(r.answer))
-            return
+            continue
         print("[%-10s] %-40s: %r" % (
             r.query.dst,
             r.answer[SNMPvarbind].oid.val,

--- a/test/scapy/layers/snmp.uts
+++ b/test/scapy/layers/snmp.uts
@@ -38,6 +38,34 @@ assert SNMP in z
 x = UDP()/SNMP()
 assert x.sport == x.dport == 161
 
+= snmpget continues after an ICMP result
+~ SNMP ASN1
+
+from types import SimpleNamespace
+from scapy.layers import snmp as snmp_module
+
+query_one = IP(dst="192.0.2.1")/UDP()/SNMP()
+query_two = IP(dst="192.0.2.2")/UDP()/SNMP()
+icmp_answer = IP(src="192.0.2.1")/ICMP(type=3, code=3)
+snmp_answer = IP(src="192.0.2.2")/UDP()/SNMP(
+    PDU=SNMPresponse(
+        varbindlist=[SNMPvarbind(oid=ASN1_OID("1.4"), value=ASN1_STRING(b"two"))],
+    ),
+)
+answers = [
+    SimpleNamespace(query=query_one, answer=icmp_answer),
+    SimpleNamespace(query=query_two, answer=snmp_answer),
+]
+saved_sr = snmp_module.sr
+snmp_module.sr = lambda *args, **kwargs: (answers, [])
+try:
+    with ContextManagerCaptureOutput() as output:
+        snmp_module.snmpget(["192.0.2.1", "192.0.2.2"])
+finally:
+    snmp_module.sr = saved_sr
+
+assert "192.0.2.2" in output.get_output()
+
 = Basic SNMPvarbind build
 ~ SNMP ASN1
 x = SNMPvarbind(oid=ASN1_OID("1.3.6.1.2.1.1.4.0"), value=RandBin())


### PR DESCRIPTION
`snmpget()` can query several targets in one call and prints what each returns. Some answers are
not SNMP at all: Scapy matches an ICMP error to the probe that provoked it, so an unreachable host
or router appears in the answered set.

The result loop at
[`scapy/layers/snmp.py:290-317`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/snmp.py#L290-L317)
prints that error and then returns from the function rather than moving to the next answer.
Everything before the ICMP answer in the iteration has already printed; everything after it is
discarded. The results were collected — they are simply never shown.

The change continues instead of returning:

```diff
         if ICMP in r.answer:
             print("%s: %s" % (r.answer.src, r.answer.sprintf("%ICMP.type%")))
-            return
+            continue
```

The diagnostic still prints, so nothing about the error case is lost.

The added regression builds a multi-target result set with an ICMP answer ahead of a valid SNMP
answer and asserts both appear in the output. Restoring the `return` makes it fail.

Performance was measured on one computer, before and after the fix: a representative call took
113.5 µs before and 114.3 µs after. Repeat runs moved by about 2%, so that difference is smaller
than the test can distinguish.
