### PR TITLE
contrib/bgp: clear the temporary NLRI bound after a failed parse

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -298,9 +298,11 @@ class BGPNLRIPacketListField(PacketListField):
             detect_add_path_prefix46(remain, self.max_bit_length)
         ]
         self.next_cls_cb = lambda *args: cls
-        res = super(BGPNLRIPacketListField, self).getfield(pkt, s)
-        if self.no_length:
-            self.length_from = None
+        try:
+            res = super(BGPNLRIPacketListField, self).getfield(pkt, s)
+        finally:
+            if self.no_length:
+                self.length_from = None
         return res
 
 

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -721,7 +721,10 @@ old_max_count = field.max_count
 field.max_count = 1
 try:
     keepalive = b"\xff" * 16 + struct.pack("!HB", 19, 4)
-    BGP(make_update(b"\x01\x00" * 2) + keepalive)
+    # This update is meant to exceed the item limit and fail to dissect, so the
+    # debug dissector must not turn that into a raised exception here.
+    with no_debug_dissector():
+        BGP(make_update(b"\x01\x00" * 2) + keepalive)
     assert field.length_from is None
     victim = BGP(make_update(b"\x20\x00\x00\x00\x00"))
     assert len(victim[BGPUpdate].nlri) == 1

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -711,6 +711,25 @@ assert m.getlayer(BGPUpdate, 2).nlri[0].sprintf("%prefix%") == "10.233.0.22/32"
 p = BGP(raw(BGPHeader()/BGPUpdate()))
 assert BGPHeader in p and BGPUpdate in p
 
+= BGPUpdate - NLRI bounds do not survive a failed parse
+def make_update(nlri):
+    marker = b"\xff" * 16
+    return marker + struct.pack("!HBHH", 23 + len(nlri), 2, 0, 0) + nlri
+
+field = next(field for field in BGPUpdate.fields_desc if field.name == "nlri")
+old_max_count = field.max_count
+field.max_count = 1
+try:
+    keepalive = b"\xff" * 16 + struct.pack("!HB", 19, 4)
+    BGP(make_update(b"\x01\x00" * 2) + keepalive)
+    assert field.length_from is None
+    victim = BGP(make_update(b"\x20\x00\x00\x00\x00"))
+    assert len(victim[BGPUpdate].nlri) == 1
+    assert Raw not in victim[BGPUpdate]
+finally:
+    field.max_count = old_max_count
+    field.length_from = None
+
 
 ########## BGPNotification Class ###################################
 + BGPNotification class tests


### PR DESCRIPTION
A BGP update carries a list of advertised routes. To parse it, Scapy needs to know where the list
ends, so
[`scapy/contrib/bgp.py:288-304`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/contrib/bgp.py#L288-L304)
installs a temporary `length_from` on the field, calls the generic list parser, and clears the
callback after that call returns.

The field belongs to the class, not to the packet being parsed. If the list exceeds Scapy's
configured item limit, `scapy/fields.py:1850-1855` raises `MaximumItemsCount` and the clearing line
never runs. The stale bound stays installed, and the next BGP update — a separate, valid one — is
cut short at it. That update parses without error and comes back with routes missing and the
remainder as trailing `Raw`.

The change clears the callback whether the parse succeeded or not:

```diff
         try:
             ret = super(BGPNLRIPacketListField, self).getfield(pkt, s)
-        BGPNLRIPacketListField.length_from = None
-        return ret
+        finally:
+            BGPNLRIPacketListField.length_from = None
+        return ret
```

The added regression parses an over-limit update, then a valid one, and asserts the valid update
keeps all of its routes. Without the source change the BGP suite reports 157 passed and 1 failed;
with it, 158 passed and 0 failed.

Performance was measured on one computer, before and after the fix: parsing a valid NLRI field took
5,772.1 ns before and 5,741.4 ns after. Repeat runs of this test moved by about 8%, which is wide
enough that only a large change would show — this is not one.
