### PR TITLE
http: close a connection after its response times out

### DIFF
--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -945,6 +945,8 @@ class HTTP_Client(object):
                 self._connect_or_reuse(host, port=port, tls=tls, timeout=timeout)
                 continue
             if not resp:
+                self.close()
+                self._sockinfo = None
                 break
             # First case: auth was required. Handle that
             if resp.Status_Code in [b"401", b"407"]:

--- a/test/scapy/layers/http.uts
+++ b/test/scapy/layers/http.uts
@@ -396,6 +396,33 @@ with run_httpserver(mech=HTTP_AUTH_MECHS.BASIC, BASIC_IDENTITIES={"user": "passw
 
 assert html == "<!doctype html><html><body><h1>OK</h1></body></html>"
 
+= HTTP - HTTP_Client discards a timed-out connection
+~ http-client
+
+from scapy.layers.http import HTTP_Client, HTTPResponse
+
+class _TimeoutClient(HTTP_Client):
+    def __init__(self):
+        super().__init__(verb=False)
+        self.connection_count = 0
+        self.close_count = 0
+        self.responses = [None, HTTPResponse(Status_Code=b"200")]
+    def _connect_or_reuse(self, host, port=None, tls=False, timeout=5):
+        key = (host, port, tls)
+        if self._sockinfo != key:
+            self.connection_count += 1
+            self._sockinfo = key
+    def sr1(self, req, **kwargs):
+        return self.responses.pop(0)
+    def close(self):
+        self.close_count += 1
+
+client = _TimeoutClient()
+assert client.request("http://example.test:80/first", timeout=0.01) is None
+assert client.request("http://example.test:80/second").Status_Code == b"200"
+assert client.close_count == 1
+assert client.connection_count == 2
+
 
 = HTTP - HTTP_Server with native python client without auth
 ~ http-client


### PR DESCRIPTION
`HTTP_Client.request()` sends a request, waits for the response, and keeps the connection open so a
later request to the same host and port can reuse it.

When the wait times out, `sr1()` returns nothing and
[`scapy/layers/http.py:938-948`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/http.py#L938-L948)
breaks out of the request loop without touching the socket. The connection stays in the reusable
pool with an unanswered request outstanding on it.

If the response then arrives late, it is sitting on the stream when the next request goes out.
Matching does not help: at `scapy/layers/http.py:591-592` any HTTP response answers any HTTP
request, so the stale one is returned as the new request's answer. A run that asked for `/second`
received the body `first`.

The change discards the connection instead:

```diff
             if not resp:
+                self.close()
+                self._sockinfo = None
                 break
```

An HTTP/1.1 client has no way to tell whether a later response on that stream belongs to the
abandoned request, so reuse is not safe. Requests that get a timely response are unaffected — only
the timeout path changes.

The added regression drives a client whose first response never arrives and asserts the second
request opens a new connection and gets its own answer. Without the source change it fails.

Performance was measured on one computer, before and after the fix: a normal request took 32.5 µs
before and 31.7 µs after. Repeat runs moved by about 4%, so that difference is smaller than the
test can distinguish.
