### PR TITLE
http: return one Content-Length message per packet

### DIFF
--- a/scapy/layers/http.py
+++ b/scapy/layers/http.py
@@ -694,7 +694,8 @@ class HTTP(Packet):
                 # Subtract the length of the "HTTP*" layer
                 elif http_packet.payload.payload or length == 0:
                     http_length = len(data) - http_packet.payload._original_len
-                    detect_end = lambda dat: len(dat) - http_length >= length
+                    metadata["http_end"] = http_end = http_length + length
+                    detect_end = lambda dat: len(dat) >= http_end
                 else:
                     # The HTTP layer isn't fully received.
                     if metadata.get("tcp_end", False):
@@ -738,9 +739,15 @@ class HTTP(Packet):
                     metadata["detect_unknown"] = True
             metadata["detect_end"] = detect_end
             if detect_end(data):
+                http_end = metadata.get("http_end")
+                if http_end is not None and len(data) > http_end:
+                    return cls(data[:http_end]) / conf.padding_layer(data[http_end:])
                 return http_packet
         else:
             if detect_end(data):
+                http_end = metadata.get("http_end")
+                if http_end is not None and len(data) > http_end:
+                    return cls(data[:http_end]) / conf.padding_layer(data[http_end:])
                 http_packet = cls(data)
                 return http_packet
 

--- a/test/scapy/layers/http.uts
+++ b/test/scapy/layers/http.uts
@@ -272,6 +272,21 @@ pkt.clear_cache()
 bytes(pkt)
 assert bytes(pkt) == b'HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=ISO-8859-1\r\nDate: Tue, 16 Jun 2026 17:47:46 GMT\r\nExpires: -1\r\nTransfer-Encoding: chunked\r\nVary: Accept-Encoding\r\n\r\n14\r\n00000000000000000000\r\n0\r\n\r\n'
 
+= TCPSession separates coalesced HTTP messages with Content-Length
+~ http
+
+from scapy.layers.http import HTTP, HTTPRequest
+from scapy.sessions import TCPSession
+
+first_bytes = b"GET /first HTTP/1.1\r\nHost: example\r\nContent-Length: 0\r\n\r\n"
+second_bytes = b"POST /second HTTP/1.1\r\nHost: example\r\nContent-Length: 0\r\n\r\n"
+session = TCPSession(app=True)
+first = session.process(first_bytes + second_bytes, cls=HTTP)
+second = session.process(b"", cls=HTTP)
+
+assert first[HTTPRequest].Path == b"/first"
+assert second[HTTPRequest].Path == b"/second"
+
 = Test chunked with gzip
 
 conf.contribs["http"]["auto_compression"] = False


### PR DESCRIPTION
Scapy's HTTP stream session accumulates bytes until a message is complete, then returns it. For a
message with `Content-Length`, completeness is decided at
[`scapy/layers/http.py:665-745`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/http.py#L665-L745)
by comparing the buffer length against the header length plus the declared body length.

The test is correct, but the packet returned is built from the *whole* accumulated buffer. If one
socket read carried two complete requests, the extra bytes ride along inside the first packet.
`ForwardMachine` then calls its policy callback once and forwards the serialisation of everything it
was given, so the second request crosses without ever being offered to the callback.

The change records where the message actually ends and represents the remainder as padding:

```diff
-                    detect_end = lambda dat: len(dat) - http_length >= length
+                    metadata["http_end"] = http_end = http_length + length
+                    detect_end = lambda dat: len(dat) >= http_end
...
             if detect_end(data):
+                http_end = metadata.get("http_end")
+                if http_end is not None and len(data) > http_end:
+                    return cls(data[:http_end]) / conf.padding_layer(data[http_end:])
                 return http_packet
```

The stream session already carries padding forward to the next message, so the second request is
returned on the following iteration and gets its own callback. No `ForwardMachine`-specific parsing
is added.

The added regression feeds two complete requests in one read and asserts the callback sees both.
Without the source change it fails.

Performance was measured on one computer, before and after the fix: a forwarded request took
32.5 µs before and 32.0 µs after. Repeat runs of this test moved by about 7%, which is wide enough
that only a large change would show — this is not one.
