### PR TITLE
ms_nrtp: bound NRBF string lengths to 31 bits

### DIFF
--- a/scapy/layers/ms_nrtp.py
+++ b/scapy/layers/ms_nrtp.py
@@ -17,6 +17,7 @@ import struct
 
 from scapy.automaton import Automaton, ATMT
 from scapy.config import conf
+from scapy.error import Scapy_Exception
 from scapy.main import interact
 from scapy.fields import (
     ByteEnumField,
@@ -336,6 +337,11 @@ class MSBExtendedFieldLen(MSBExtendedField):
     def __init__(self, name, default, length_of=None):
         FieldLenField.__init__(self, name, default, length_of=length_of)
         super(MSBExtendedFieldLen, self).__init__(name, default)
+
+    def getfield(self, pkt, s):
+        if len(s) >= 5 and min(s[:4]) >= 0x80 and s[4] > 0x07:
+            raise Scapy_Exception("NRBF string length exceeds 31 bits")
+        return super(MSBExtendedFieldLen, self).getfield(pkt, s)
 
     i2m = FieldLenField.i2m
 

--- a/test/scapy/layers/msnrtp.uts
+++ b/test/scapy/layers/msnrtp.uts
@@ -39,6 +39,17 @@ assert pkt.records[3].Values == b"TRIMMED"
 
 assert isinstance(pkt.records[4], NRBFMessageEnd)
 
+= [MS-NRBF] reject a string length wider than 31 bits
+
+# The over-wide length is meant to be rejected and fall back to Raw, so the
+# debug dissector must not turn that rejection into a raised exception.
+with no_debug_dissector():
+    pkt = NRBF(b"\x0c\x01\x00\x00\x00" + b"\x81" * 5)
+    assert isinstance(pkt.records[0], Raw)
+
+maximum = NRBFLengthPrefixedString(b"\xff\xff\xff\xff\x07")
+assert maximum.Length == 0x7fffffff
+
 = [MS-NRBF] build .NET Binary Format
 
 pkt = NRBF(


### PR DESCRIPTION
NRTP reassembly decodes an `application/octet-stream` body as .NET Remoting Binary Format. NRBF
encodes a string's length as a variable-length integer, seven bits per byte, and the format caps it
at five bytes and 31 bits.

[`scapy/layers/ms_nrtp.py:333-350`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/ms_nrtp.py#L333-L350)
uses the generic extended-integer decoder for that field, and the generic decoder has no cap. It
keeps consuming continuation bytes and shifting a Python integer that grows with the input, so the
work is quadratic in the number of bytes supplied — all before it looks for the string data, which
does not exist.

The change enforces the limit the format already defines, in the NRBF-specific field, before the
generic decoder runs:

```diff
+    def getfield(self, pkt, s):
+        if len(s) >= 5 and min(s[:4]) >= 0x80 and s[4] > 0x07:
+            raise Scapy_Exception("NRBF string length exceeds 31 bits")
+        return super(MSBExtendedFieldLen, self).getfield(pkt, s)
```

The largest valid encoding, `ff ff ff ff 07`, is still accepted; only encodings the format does not
permit are rejected.

The added regression parses that maximum encoding and then an over-wide one, asserting the first is
accepted and the second raises. Without the source change the NRTP suite reports 2 passed and 1
failed; with it, 3 passed and 0 failed.

Performance was measured on one computer, before and after the fix: parsing a valid NRBF body took
4,430.4 ns before and 4,598.5 ns after. Repeat runs of this test moved by about 9%, which is wide
enough that only a large change would show — this is not one.
