### PR TITLE
dns: stop recording unknown names in the answering machine

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -13,7 +13,6 @@ This implements:
 """
 
 import abc
-import collections
 import operator
 import itertools
 import socket
@@ -1674,7 +1673,7 @@ class DNS_am(AnsweringMachine):
                 k += b"."
             return k
 
-        self.match = collections.defaultdict(lambda: (joker, joker6))
+        self.match = {}
         if match:
             if isinstance(match, (list, set)):
                 self.match.update({normk(k): (None, None) for k in match})
@@ -1808,7 +1807,10 @@ class DNS_am(AnsweringMachine):
                 # A or AAAA
                 if rq.qtype == 28:
                     # AAAA
-                    rdata = self.match[rqname][1]
+                    try:
+                        rdata = self.match[rqname][1]
+                    except KeyError:
+                        rdata = self.joker6
                     if rdata is None and not self.relay:
                         # 'None' resolves to the default IPv6
                         iface = resolve_iface(self.optsniff.get("iface", conf.iface))
@@ -1824,7 +1826,10 @@ class DNS_am(AnsweringMachine):
                         resp[IPv6].src = rdata
                 elif rq.qtype == 1:
                     # A
-                    rdata = self.match[rqname][0]
+                    try:
+                        rdata = self.match[rqname][0]
+                    except KeyError:
+                        rdata = self.joker
                     if rdata is None and not self.relay:
                         # 'None' resolves to the default IPv4
                         iface = resolve_iface(self.optsniff.get("iface", conf.iface))

--- a/test/answering_machines.uts
+++ b/test/answering_machines.uts
@@ -137,6 +137,18 @@ assert DNS_am().make_reply(
     Ether()/IP()/UDP()/DNS(b'q\xa04\x00\x00\xa0\x01\x00\xf3\x00\x01\x04\x01y')
 ) is None
 
+def check_DNS_am_unknown_names_not_cached(qtypes):
+    am = DNS_am(joker=False)
+    for i, qtype in enumerate(qtypes):
+        am.make_reply(
+            Ether()/IP()/UDP()/DNS(
+                qd=DNSQR(qname="unknown-%d.example" % i, qtype=qtype)
+            )
+        )
+    assert not am.match
+
+check_DNS_am_unknown_names_not_cached(("A", "AAAA"))
+
 = LLMNR_am
 def check_LLMNR_am_am_reply(packet):
     # assert packet[Ether].src == get_if_hwaddr(conf.iface)


### PR DESCRIPTION
`DNS_am` answers queries from a `match` mapping of name to address, falling back to the documented
`joker` and `joker6` values for anything not configured.

That mapping is a `defaultdict` built at
[`scapy/layers/dns.py:1677`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/dns.py#L1677),
and the A and AAAA paths reach the fallback by indexing it (`:1811`, `:1827`). Indexing a
`defaultdict` with a missing key inserts it. Every query for a name the operator never configured
therefore adds an entry, and the mapping grows for as long as the machine runs, driven entirely by
what arrives. `LLMNR_am` inherits the same behaviour.

The change uses a plain dictionary and handles the missing key without writing to it:

```diff
-        self.match = collections.defaultdict(lambda: (joker, joker6))
+        self.match = {}
...
-                    rdata = self.match[rqname][0]
+                    try:
+                        rdata = self.match[rqname][0]
+                    except KeyError:
+                        rdata = self.joker
```

Configured names resolve as before and both jokers keep their documented behaviour; the only change
is that an unknown name is no longer recorded.

The added regressions cover A and AAAA and assert the mapping is still empty after answering a
series of unknown names. Without the source change they fail.

Performance was measured on one computer, before and after the fix: answering a configured name
took 84.5 ns before and 86.8 ns after, a difference of 2.3 ns. Repeat runs moved by about 2%, which
is the same size as the difference, so the test cannot separate them.
