### PR TITLE
utils: restore TLS settings when a pcapng reader closes

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -1657,6 +1657,7 @@ class RawPcapNgReader(RawPcapReader):
         }
         self.endian = "!"  # Will be overwritten by first SHB
         self.process_information = []  # type: List[Dict[str, Any]]
+        self._tls_state = None  # type: Optional[Tuple[Dict[str, bytes], bool]]
 
         if magic != b"\x0a\x0d\x0d\x0a":  # PcapNg:
             raise Scapy_Exception(
@@ -2016,10 +2017,22 @@ class RawPcapNgReader(RawPcapReader):
                 else:
                     # Note: these attributes are only available when the TLS
                     #       layer is loaded.
+                    if self._tls_state is None:
+                        self._tls_state = (
+                            conf.tls_nss_keys,
+                            conf.tls_session_enable,
+                        )
                     conf.tls_nss_keys = keys
                     conf.tls_session_enable = True
         else:
             warning("PcapNg: Unknown DSB secrets type (0x%x)!", secrets_type)
+
+    def close(self):
+        # type: () -> None
+        if self._tls_state is not None:
+            conf.tls_nss_keys, conf.tls_session_enable = self._tls_state
+            self._tls_state = None
+        RawPcapReader.close(self)
 
     def _read_block_pib(self, block, _):
         # type: (bytes, int) -> None

--- a/test/scapy/layers/tls/tls.uts
+++ b/test/scapy/layers/tls/tls.uts
@@ -1633,6 +1633,42 @@ if shutil.which("editcap"):
     assert b"BEGIN PRIVATE KEY" in packets[28].inner.msg[0].data
     conf = bck_conf
 
+= pcapng Decryption Secrets Block state follows the reader lifecycle
+
+import io
+import struct
+
+def pcapng_block(block_type, body):
+    body += b"\x00" * (-len(body) % 4)
+    length = 12 + len(body)
+    return (
+        struct.pack("<II", block_type, length)
+        + body
+        + struct.pack("<I", length)
+    )
+
+old_keys = conf.tls_nss_keys
+old_session_enable = conf.tls_session_enable
+previous_keys = {"EXISTING": {b"identifier": b"secret"}}
+conf.tls_nss_keys = previous_keys
+conf.tls_session_enable = False
+key_log_path = scapy_path("doc/notebooks/tls/raw_data/tls_nss_example.keys.txt")
+with open(key_log_path, "rb") as key_log_file:
+    key_log = key_log_file.read()
+
+section = bytes.fromhex("4d3c2b1a") + struct.pack("<HHq", 1, 0, -1)
+secrets = struct.pack("<II", 0x544c534b, len(key_log)) + key_log
+capture = pcapng_block(0x0a0d0d0a, section) + pcapng_block(10, secrets)
+reader = PcapReader(io.BytesIO(capture))
+assert len(reader.read_all()) == 0
+assert conf.tls_nss_keys is not previous_keys
+assert conf.tls_session_enable is True
+reader.close()
+assert conf.tls_nss_keys is previous_keys
+assert conf.tls_session_enable is False
+conf.tls_nss_keys = old_keys
+conf.tls_session_enable = old_session_enable
+
 = pcapng file with a non-UTF-8 Decryption Secrets Block
 
 # GH3936


### PR DESCRIPTION
When a pcapng capture carries a Decryption Secrets Block, Scapy loads the keys and switches on TLS
session processing so the encrypted traffic in that file can be read
([`scapy/utils.py:1994-2016`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/utils.py#L1994-L2016)).
Both are process-global settings on `conf`.

Closing the reader restores neither. `rdpcap()` closes it (`scapy/utils.py:1303-1314`), but the
inherited close only closes the file. The keys and the enable flag outlive the capture that supplied
them, so a later unrelated capture is read with the first file's keys still installed. A
key-carrying capture with no packets in it, read first, was enough to make a second encrypted
capture decrypt.

The change remembers the previous values the first time a reader installs keys, and puts them back
when it closes:

```diff
+        self._tls_state = None  # type: Optional[Tuple[Dict[str, bytes], bool]]
...
+                    if self._tls_state is None:
+                        self._tls_state = (
+                            conf.tls_nss_keys,
+                            conf.tls_session_enable,
+                        )
...
+    def close(self):
+        # type: () -> None
+        if self._tls_state is not None:
+            conf.tls_nss_keys, conf.tls_session_enable = self._tls_state
+            self._tls_state = None
+        RawPcapReader.close(self)
```

Settings the operator configured themselves are preserved: only what this reader changed is undone.
Decryption within the capture that carries the keys is unaffected.

The added regression reads a key-carrying capture, closes it, and asserts `conf.tls_nss_keys` and
`conf.tls_session_enable` are back to what they were. Without the source change it fails.

Performance was measured on one computer, before and after the fix: reading a capture took
1,668.8 ns before and 1,808.2 ns after. Repeat runs of this test moved by about 7%, which is wide
enough that only a large change would show — this is not one.
