### PR TITLE
msrpce: commit only an accepted presentation context

### DIFF
--- a/scapy/layers/msrpce/rpcserver.py
+++ b/scapy/layers/msrpce/rpcserver.py
@@ -18,6 +18,7 @@ from scapy.data import MTU
 from scapy.volatile import RandShort
 
 from scapy.layers.dcerpc import (
+    COM_INTERFACES,
     CommonAuthVerifier,
     DCE_RPC_INTERFACES,
     DCERPC_Transport,
@@ -248,6 +249,8 @@ class DCERPC_Server(metaclass=_DCERPC_Server_metaclass):
             pad = req[conf.padding_layer].load
             req[conf.padding_layer].underlayer.remove_payload()
         # Ask the DCE/RPC session to process it (match interface, etc.)
+        previous_interface = self.session.rpc_bind_interface
+        previous_interface_is_com = self.session.rpc_bind_is_com
         req = self.session.in_pkt(req)
         hdr = DceRpc5(
             endian=req.endian,
@@ -325,6 +328,7 @@ class DCERPC_Server(metaclass=_DCERPC_Server_metaclass):
 
                 # Process bind contexts and answer to them
                 results = []
+                accepted_context = None
                 for ctx in req.context_elem:
                     # Get name
                     name = ctx.transfer_syntaxes[0].sprintf("%if_uuid%")
@@ -336,6 +340,7 @@ class DCERPC_Server(metaclass=_DCERPC_Server_metaclass):
                         (name == "NDR 2.0" and not self.ndr64)
                     ):
                         # Acceptance
+                        accepted_context = ctx
                         results.append(
                             DceRpc5Result(
                                 result=0,
@@ -404,6 +409,18 @@ class DCERPC_Server(metaclass=_DCERPC_Server_metaclass):
                             + ("NDR64" if self.ndr64 else "NDR32")
                         )
                     )
+                if accepted_context is None:
+                    self.session.rpc_bind_interface = previous_interface
+                    self.session.rpc_bind_is_com = previous_interface_is_com
+                elif len(req.context_elem) > 1:
+                    abstract_syntax = accepted_context.abstract_syntax
+                    interface = DCE_RPC_INTERFACES.get(
+                        (abstract_syntax.if_uuid, abstract_syntax.if_version)
+                    )
+                    self.session.rpc_bind_interface = interface or COM_INTERFACES.get(
+                        abstract_syntax.if_uuid
+                    )
+                    self.session.rpc_bind_is_com = interface is None
         elif DceRpc5Request in req:
             if self.verb:
                 print(

--- a/test/scapy/layers/dcerpc.uts
+++ b/test/scapy/layers/dcerpc.uts
@@ -976,6 +976,11 @@ rpcserver.close()
 
 = A rejected presentation context cannot select an RPC interface
 
+from scapy.layers.msrpce.raw.ept import (
+    ept_lookup_handle_free_Request,
+    ept_lookup_handle_free_Response,
+)
+
 class PresentationContextServer(DCERPC_Server):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/test/scapy/layers/dcerpc.uts
+++ b/test/scapy/layers/dcerpc.uts
@@ -974,6 +974,58 @@ except OSError:
 
 rpcserver.close()
 
+= A rejected presentation context cannot select an RPC interface
+
+class PresentationContextServer(DCERPC_Server):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.handler_calls = 0
+    @DCERPC_Server.answer(ept_lookup_handle_free_Request)
+    def operation(self, request):
+        self.handler_calls += 1
+        return ept_lookup_handle_free_Response(status=0, ndr64=False)
+
+def drive_presentation_context(transfer_syntax):
+    interface = find_dcerpc_interface("ept")
+    syntax = next(
+        syntax
+        for syntax, name in DCE_RPC_TRANSFER_SYNTAXES.items()
+        if name == transfer_syntax
+    )
+    context = DceRpc5Context(
+        abstract_syntax=DceRpc5AbstractSyntax(
+            if_uuid=interface.uuid,
+            if_version=interface.if_version,
+        ),
+        transfer_syntaxes=[
+            DceRpc5TransferSyntax(
+                if_uuid=syntax,
+                if_version=2 if transfer_syntax == "NDR 2.0" else 0,
+            )
+        ],
+    )
+    server = PresentationContextServer(
+        DCERPC_Transport.NCACN_IP_TCP,
+        verb=False,
+        port=12345,
+    )
+    server.recv(bytes(DceRpc5(call_id=1) / DceRpc5Bind(context_elem=[context])))
+    result = int(server.get_response().results[0].result)
+    try:
+        server.recv(
+            bytes(
+                DceRpc5(call_id=2)
+                / DceRpc5Request(opnum=4)
+                / ept_lookup_handle_free_Request(ndr64=False)
+            )
+        )
+    except AttributeError:
+        pass
+    return result, server.handler_calls
+
+assert drive_presentation_context("NULL") == (2, 0)
+assert drive_presentation_context("NDR 2.0") == (0, 1)
+
 + Cleanup
 
 = Restore conf.debug_dissector

--- a/test/scapy/layers/dcerpc.uts
+++ b/test/scapy/layers/dcerpc.uts
@@ -976,10 +976,12 @@ rpcserver.close()
 
 = A rejected presentation context cannot select an RPC interface
 
-from scapy.layers.msrpce.raw.ept import (
-    ept_lookup_handle_free_Request,
-    ept_lookup_handle_free_Response,
-)
+# Take the classes from the registry rather than from the module. A second
+# import of an already-registered interface returns before binding opnum and
+# intf, so the module-level names are not always the registered objects.
+_ept_free = find_dcerpc_interface("ept").opnums[4]
+ept_lookup_handle_free_Request = _ept_free.request
+ept_lookup_handle_free_Response = _ept_free.response
 
 class PresentationContextServer(DCERPC_Server):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
A DCE/RPC bind proposes one or more presentation contexts, each naming an interface (the abstract
syntax) and an encoding (the transfer syntax). The server accepts or rejects each one independently
and says so in its response.

Scapy selects the session's interface from the bind contexts at
[`scapy/layers/dcerpc.py:2847-2864`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/dcerpc.py#L2847-L2864)
without regard to the transfer syntax, while
[`scapy/layers/msrpce/rpcserver.py:326-372`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/msrpce/rpcserver.py#L326-L372)
decides acceptance separately. A bind proposing an unsupported transfer syntax is answered with a
provider rejection, and the interface it named is nonetheless left selected on the session — so a
following request reaches that interface's registered handler.

The change tracks which context was actually accepted and commits only that one, restoring the
previous interface when none was:

```diff
+        previous_interface = self.session.rpc_bind_interface
+        previous_interface_is_com = self.session.rpc_bind_is_com
...
+                if accepted_context is None:
+                    self.session.rpc_bind_interface = previous_interface
+                    self.session.rpc_bind_is_com = previous_interface_is_com
```

A bind that proposes a supported transfer syntax behaves exactly as before; the regression keeps the
ordinary NDR 2.0 path as its control.

The added regression sends a bind with an unsupported transfer syntax, asserts the rejection, then
sends a request and asserts the handler is not reached. Without the source change it fails.

Performance was measured on one computer, before and after the fix: a normal bind and call took
116.1 µs before and 116.4 µs after. Repeat runs moved by about 2%, so that difference is smaller
than the test can distinguish.
