### PR TITLE
inet: choose the payload class from reassembled fragments

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,169 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "filing-scapy"
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   deno
+#   elixir                 elm                    erlang                 fortran                fsharp
+#   gdscript               gleam                  go                     groovy                 haskell
+#   haxe                   hlsl                   html                   java                   json
+#   julia                  julia_fatou            kotlin                 latex                  lean4
+#   lua                    luau                   markdown               matlab                 msl
+#   nextflow               nix                    ocaml                  pascal                 perl
+#   php                    php_phpactor           php_phpantom           powershell             python
+#   python_basedpyright    python_jedi            python_pyrefly         python_ty              qml
+#   r                      rego                   ruby                   ruby_solargraph        rust
+#   scala                  scss                   solidity               svelte                 swift
+#   systemverilog          terraform              toml                   typescript             typescript_vts
+#   vue                    wolfram                yaml                   zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of the LanguageServerId enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For Deno projects, use deno (serves the same .ts/.js files as typescript; requires the deno CLI on PATH)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1493,13 +1493,13 @@ def _defrag_ip_pkt(pkt, frags):
                 raise BadFragments(frags=badfrags)
             # re-build initial packet without fragmentation
             p = curfrags[0][0].copy()
-            pay_class = p[IP].payload.__class__
+            pay_class = p[IP].guess_payload_class(data)
             p[IP].flags.MF = False
             p[IP].remove_payload()
             p[IP].len = None
             p[IP].chksum = None
             # append defragmented payload
-            p /= pay_class(data)
+            p[IP].add_payload(pay_class(data))
             # cleanup
             del frags[uid]
             return True, p

--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -1498,8 +1498,16 @@ def _defrag_ip_pkt(pkt, frags):
             p[IP].remove_payload()
             p[IP].len = None
             p[IP].chksum = None
-            # append defragmented payload
-            p[IP].add_payload(pay_class(data))
+            # append defragmented payload. The reassembled bytes may still fail
+            # to dissect, and that has to fall back the way dissection itself
+            # does rather than escape into the caller's sniff loop.
+            try:
+                payload = pay_class(data)
+            except Exception:
+                if conf.debug_dissector:
+                    raise
+                payload = conf.raw_layer(load=data)
+            p[IP].add_payload(payload)
             # cleanup
             del frags[uid]
             return True, p

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -604,6 +604,28 @@ with no_debug_dissector(reverse=True):
 
 split_layers(TCP, CustomPacket, sport=12345)
 
+= TCPSession parses application data after IPv4 defragmentation
+~ http
+
+load_layer("http")
+
+def fragmented_http_response(fragsize):
+    payload = b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nBODY"
+    packet = (
+        IP(src="192.0.2.1", dst="192.0.2.2", id=1234) /
+        TCP(sport=80, dport=2345, seq=1, flags="PA") /
+        Raw(payload)
+    )
+    fragments = [IP(raw(pkt)) for pkt in fragment(packet, fragsize)]
+    return sniff(offline=fragments, session=TCPSession)
+
+with no_debug_dissector():
+    for fragsize in (8, 24):
+        packets = fragmented_http_response(fragsize)
+        assert len(packets) == 1
+        assert HTTPResponse in packets[0]
+        assert packets[0][Raw].load == b"BODY"
+
 
 = Layer binding
 

--- a/test/scapy/layers/inet.uts
+++ b/test/scapy/layers/inet.uts
@@ -626,6 +626,24 @@ with no_debug_dissector():
         assert HTTPResponse in packets[0]
         assert packets[0][Raw].load == b"BODY"
 
+= Fragments reassembling to less than their protocol's header keep sniffing
+
+# The reassembled payload is shorter than a TCP header, so dissecting it fails.
+# That must not escape: IPSession would close the socket and end the capture.
+# no_debug_dissector() is required rather than incidental -- the campaign runs
+# with conf.debug_dissector on, where dissection failures raise either way.
+
+with no_debug_dissector():
+    short = [
+        Ether() / IP(src="192.0.2.1", dst="192.0.2.2", id=99, proto=6,
+                     flags="MF", frag=0) / Raw(b"A" * 8),
+        Ether() / IP(src="192.0.2.1", dst="192.0.2.2", id=99, proto=6,
+                     frag=1) / Raw(b"B" * 4),
+    ]
+    short = [Ether(raw(pkt)) for pkt in short]
+    assert defragment([pkt[IP] for pkt in short])[0][Raw].load == b"A" * 8 + b"B" * 4
+    assert len(sniff(offline=short, session=IPSession)) == 1
+
 
 = Layer binding
 


### PR DESCRIPTION
`_defrag_ip_pkt()` puts a fragmented IPv4 datagram back together and then has to decide what the
reassembled bytes are. At
[`scapy/layers/inet.py:1467-1505`](https://github.com/secdev/scapy/blob/1f870205baae8baf1718bc20700d0d9ffc0e4324/scapy/layers/inet.py#L1467-L1505)
it reuses the class Scapy guessed for the *first fragment's* payload:

```python
pay_class = p[IP].payload.__class__
```

The first fragment is often too short to classify correctly — with a small enough first fragment
Scapy has not seen a complete TCP header, so the guess is whatever it managed from those bytes. The
complete datagram is then forced into that class regardless of what the assembled bytes actually
are. Through `TCPSession`, an HTTP response that arrived in valid ordered fragments comes back
without its application layer, while the byte-identical unfragmented response comes back correctly.

The change asks the reassembled IP layer to classify the complete bytes, the same way ordinary
dissection does:

```diff
-            pay_class = p[IP].payload.__class__
+            pay_class = p[IP].guess_payload_class(data)
...
-            p /= pay_class(data)
+            p[IP].add_payload(pay_class(data))
```

Every valid fragment layout is still reassembled; what changes is that the result is classified from
what was actually received.

The added regression reassembles the same HTTP response at two fragment sizes, including one whose
first fragment is too small to classify, and asserts the response body is delivered in both. Without
the source change it fails.

Performance was measured on one computer, before and after the fix: reassembling a valid ordered
datagram took 232.0 µs before and 176.3 µs after — **24% faster**. Repeat runs moved by less than
that, so it is a real difference. Dispatching normally avoids the work the old path spent forcing
bytes into a class that could not parse them.
