### PR TITLE
Restrict AI-Assisted CI check to PR commits on merge checkouts

### DIFF
--- a/.config/ci/check_commits.sh
+++ b/.config/ci/check_commits.sh
@@ -6,7 +6,14 @@
 # We copy Wireshark's contributing guide, thanks to them for the idea !
 # This script is inspired by https://gitlab.com/wireshark/wireshark/-/blob/master/.gitlab-ci.yml
 
-commits=$(git rev-list --no-merges --after="2026-01-00T00:00:00" --max-count=$((PR_FETCH_DEPTH - 1)) HEAD)
+# On pull_request, actions/checkout creates a merge of the PR into the base
+# branch (HEAD^1=base tip, HEAD^2=PR tip). Restrict the check to PR commits
+# so base-branch history is not false-failed for missing trailers.
+if git rev-parse -q --verify HEAD^2 >/dev/null 2>&1; then
+    commits=$(git rev-list --no-merges HEAD^1..HEAD^2)
+else
+    commits=$(git rev-list --no-merges --after="2026-01-00T00:00:00" --max-count=$((PR_FETCH_DEPTH - 1)) HEAD)
+fi
 if [ -z "$commits" ]; then
     echo "No commit to check in PR. OK."
     exit 0


### PR DESCRIPTION
## Summary
- On `pull_request`, `actions/checkout` builds a merge of the PR into the base branch (`HEAD^1` = base tip, `HEAD^2` = PR tip).
- `check_commits.sh` previously walked `rev-list` from `HEAD`, so it also validated base-branch tips and false-failed when those commits lacked an `AI-Assisted` trailer.
- Restrict the check to `HEAD^1..HEAD^2` when that merge topology is present; keep the existing dated/`PR_FETCH_DEPTH` fallback otherwise.

Split out of #5050 so the ASN.1 work stays independent of this CI fix.

## Test plan
- [ ] Confirm CI `check_commits` passes on a PR whose tip commits all have `AI-Assisted` trailers even if master tip lacks one
- [ ] Confirm local / non-merge checkout still uses the dated `rev-list` fallback