### PR TITLE
hsrp, bluetooth, kerberos: fix three dissection crashes found by fuzzing

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -2697,17 +2697,17 @@ class HCI_Event_Inquiry_Result_With_Rssi(Packet):
     name = "HCI_Inquiry_Result_with_RSSI"
     fields_desc = [
         ByteField("num_response", 0x00),
-        FieldListField("bd_addr", None, LEMACField,
+        FieldListField("bd_addr", None, LEMACField("", None),
                        count_from=lambda p: p.num_response),
-        FieldListField("page_scan_repetition_mode", None, ByteField,
+        FieldListField("page_scan_repetition_mode", None, ByteField("", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("reserved", None, LEShortField,
+        FieldListField("reserved", None, LEShortField("", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("device_class", None, XLE3BytesField,
+        FieldListField("device_class", None, XLE3BytesField("", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("clock_offset", None, LEShortField,
+        FieldListField("clock_offset", None, LEShortField("", 0),
                        count_from=lambda p: p.num_response),
-        FieldListField("rssi", None, SignedByteField,
+        FieldListField("rssi", None, SignedByteField("", 0),
                        count_from=lambda p: p.num_response)
     ]
 

--- a/scapy/layers/hsrp.py
+++ b/scapy/layers/hsrp.py
@@ -88,10 +88,13 @@ class HSRP(Packet):
         return HSRP
 
     def guess_payload_class(self, payload):
-        if self.underlayer.len > 28:
+        if (
+            self.underlayer is not None
+            and getattr(self.underlayer, "len", None) is not None
+            and self.underlayer.len > 28
+        ):
             return HSRPmd5
-        else:
-            return Packet.guess_payload_class(self, payload)
+        return Packet.guess_payload_class(self, payload)
 
 
 class HSRPAdvertise(Packet):

--- a/scapy/layers/kerberos.py
+++ b/scapy/layers/kerberos.py
@@ -2520,7 +2520,9 @@ class KRB_InnerToken(Packet):
         PacketField(
             "root",
             KRB_AP_REQ(),
-            lambda x, _parent: _InitialContextTokens[_parent.TOK_ID](x),
+            lambda x, _parent: _InitialContextTokens.get(
+                _parent.TOK_ID, conf.raw_layer
+            )(x),
         ),
     ]
 

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -1284,3 +1284,12 @@ assert p.num_sets == 1
 assert len(p.sets) == 1
 assert p.sets[0].handle == 1
 assert raw(p) == hex_bytes("010101640005")
+
+= HCI_Event_Inquiry_Result_With_Rssi dissection
+
+p = HCI_Event_Inquiry_Result_With_Rssi(hex_bytes("011122334455660100000000000000c0"))
+assert p.num_response == 1
+assert p.bd_addr == ["66:55:44:33:22:11"]
+assert p.page_scan_repetition_mode == [1]
+assert p.rssi == [-64]
+assert raw(p) == hex_bytes("011122334455660100000000000000c0")

--- a/test/scapy/layers/hsrp.uts
+++ b/test/scapy/layers/hsrp.uts
@@ -51,3 +51,8 @@ assert pkt[HSRPv2].ipVer == 6 and pkt[HSRPv2].padding == None
 assert pkt[HSRPv2].version == 2 and pkt[HSRPv2].opcode == 0 and pkt[HSRPv2].state == 16
 assert pkt[HSRPv2].hellotime == 3000 and pkt[HSRPv2].holdtime == 10000
 assert pkt[HSRPv2TextAuth].type == 3 and pkt[HSRPv2TextAuth].auth == b"cisco\x00\x00\x00"
+
+= HSRP without underlayer does not crash
+pkt = HSRP(b"\x00\x01" + b"\x00" * 26 + b"\x41" * 20)
+assert pkt.version == 0 and pkt.opcode == 1
+assert Raw in pkt and pkt[Raw].load.endswith(b"A" * 20)

--- a/test/scapy/layers/kerberos.uts
+++ b/test/scapy/layers/kerberos.uts
@@ -2169,3 +2169,9 @@ with KrbRandomPatcher():
     )
 
 assert negState == 0
+= KRB_InnerToken with an unknown TOK_ID does not crash
+
+p = KRB_InnerToken(hex_bytes("ead5") + b"\x00" * 30)
+assert p.TOK_ID == b"\xea\xd5"
+assert isinstance(p.root, conf.raw_layer)
+assert p.root.load == b"\x00" * 30


### PR DESCRIPTION
Three independent dissection crashes found by running random bytes through the default layers. Each commit is self-contained with its UTScapy test; no existing behavior changes.

**1. hsrp**

`HSRP.guess_payload_class` read `self.underlayer.len` unconditionally:

```python
>>> HSRP(b"\x00\x01" + b"\x00" * 26 + b"A" * 20)
AttributeError: 'NoneType' object has no attribute 'len'
```

Same class as #5089 (MQTTPublish). The HSRPmd5 selection is unchanged when the underlayer is present.

**2. bluetooth**

The six `FieldListField` entries of `HCI_Event_Inquiry_Result_With_Rssi` were given field *classes* instead of instances, so the event could never be dissected with `num_response >= 1`:

```python
>>> HCI_Event_Inquiry_Result_With_Rssi(bytes.fromhex("011122334455660100000000000000c0"))
TypeError: Field.getfield() missing 1 required positional argument: 's'
```

Fixed by passing instances; the test campaign now round-trips a full inquiry result.

**3. kerberos**

`KRB_InnerToken` indexed `_InitialContextTokens[_parent.TOK_ID]` directly, so any TOK_ID outside the implemented set aborted the dissection with a `KeyError`. Fall back to `conf.raw_layer` (consistent with the existing `mysummary()` fallback), keeping the body as raw bytes. Known TOK_IDs are unaffected.