### PR TITLE
fix(inet6): stop IP6ListField parsing on a truncated trailing address

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -268,6 +268,11 @@ class IP6ListField(StrField):
                 if c <= 0:
                     break
                 c -= 1
+            if len(remain) < 16:
+                # not enough bytes for a full IPv6 address: a truncated or
+                # misaligned list. Leave the remainder for the next layer
+                # instead of feeding a short buffer to inet_ntop().
+                break
             addr = inet_ntop(socket.AF_INET6, remain[:16])
             lst.append(addr)
             remain = remain[16:]

--- a/test/scapy/layers/dhcp6.uts
+++ b/test/scapy/layers/dhcp6.uts
@@ -618,6 +618,13 @@ raw(DHCP6OptDNSServers(dnsservers = ["2001:db8::1", "2001:db8::2"] )) == b'\x00\
 a = DHCP6OptDNSServers(b'\x00\x17\x00  \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02')
 a.optcode == 23 and a.optlen == 32 and len(a.dnsservers) == 2 and a.dnsservers[0] == "2001:db8::1" and a.dnsservers[1] == "2001:db8::2"
 
+= DHCP6OptDNSServers - Dissection with a truncated trailing address (regression)
+# optlen=20: one full IPv6 address plus 4 stray bytes. IP6ListField used to raise
+# ValueError ("invalid length of packed IP address string") on the short final
+# chunk; it must stop and leave the extra bytes to the next layer instead.
+a = DHCP6OptDNSServers(b'\x00\x17\x00\x14 \x01\r\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xde\xad\xbe\xef')
+a.optcode == 23 and a.dnsservers == ["2001:db8::1"]
+
 
 ############
 ############


### PR DESCRIPTION
Fixes a crash in `IP6ListField`: a truncated or misaligned IPv6 address list raises
`ValueError: invalid length of packed IP address string` instead of stopping, so the
dissector aborts and the layer falls back to `Raw`.

The loop ran `while remain:` and always passed `remain[:16]` to `inet_ntop()`. When the
final address is short (1..15 bytes left), inet_ntop rejects it. The field is shared by
~17 dissectors, e.g. the DHCPv6 DNS/SIP/NIS options, ICMPv6 RDNSS and address-list
options, and IPv6 Segment Routing.

Repro on master:

```python
from scapy.all import DHCP6OptDNSServers
# DNS-servers option, declared length 20 = one IPv6 addr + 4 trailing bytes
DHCP6OptDNSServers(bytes.fromhex("0017001420010db8000000000000000000000001deadbeef"))
# ValueError: invalid length of packed IP address string
```

Fix: stop when fewer than 16 bytes remain and leave them to the next layer, the way
Scapy handles truncation elsewhere. Well-formed lists are unchanged; added a regression
test in dhcp6.uts.

Not a security issue (it degrades to `Raw`, per SECURITY.md). The same
inet_ntop-on-short-buffer pattern also exists in `IP6Field.m2i`, `BGPFieldIPv6.m2i` and
the EDNS0 client-subnet field; can follow up on those.

AI-Assisted: yes (Claude Code)
