### PR TITLE
fix(bgp): don't crash on a truncated IPv6/IPv4 NLRI prefix

### DIFF
--- a/scapy/contrib/bgp.py
+++ b/scapy/contrib/bgp.py
@@ -130,7 +130,7 @@ class BGPFieldIPv4(Field):
     def m2i(self, pkt, m):
         mask = m[0]
         mask2iplen_res = self.mask2iplen(mask)
-        ip = b"".join(m[i + 1:i + 2] if i < mask2iplen_res else b"\x00" for i in range(4))  # noqa: E501
+        ip = b"".join(m[i + 1:i + 2] if i < mask2iplen_res and i + 1 < len(m) else b"\x00" for i in range(4))  # noqa: E501
         return (mask, socket.inet_ntoa(ip))
 
 
@@ -173,7 +173,14 @@ class BGPFieldIPv6(Field):
 
     def m2i(self, pkt, m):
         mask = m[0]
-        ip = b"".join(m[i + 1:i + 2] if i < self.mask2iplen(mask) else b"\x00" for i in range(16))  # noqa: E501
+        # zero-fill missing prefix bytes in place: a truncated NLRI has fewer
+        # than mask2iplen(mask) bytes, and inet_ntop() needs exactly 16.
+        ip = b"".join(
+            m[i + 1:i + 2]
+            if i < self.mask2iplen(mask) and i + 1 < len(m)
+            else b"\x00"
+            for i in range(16)
+        )
         return (mask, pton_ntop.inet_ntop(socket.AF_INET6, ip))
 
 

--- a/test/contrib/bgp.uts
+++ b/test/contrib/bgp.uts
@@ -30,6 +30,11 @@ nlri = BGPNLRI_IPv4(b'\x18\xc0\x00\x02')
 nlri.prefix == '192.0.2.0/24'
 
 
+= BGPNLRI_IPv4 - Dissection of a truncated prefix does not crash (regression)
+nlri = BGPNLRI_IPv4(b'\x20\x0a')
+nlri.prefix == '10.0.0.0/32'
+
+
 ################################ BGPNLRI_IPv6 ################################
 + BGPNLRI_IPv6 class tests
 
@@ -49,6 +54,11 @@ nlri.prefix == '::/0'
 = BGPNLRI_IPv6 - Dissection with specific values
 nlri = BGPNLRI_IPv6(b'  \x01\r\xb8')
 nlri.prefix == '2001:db8::/32'
+
+
+= BGPNLRI_IPv6 - Dissection of a truncated prefix does not crash (regression)
+nlri = BGPNLRI_IPv6(b'\x80\x20\x01\x0d\xb8')
+nlri.prefix == '2001:db8::/128'
 
 
 #################################### BGP #####################################


### PR DESCRIPTION
Fixes a crash when dissecting a truncated BGP NLRI. `BGPFieldIPv6.m2i` and
`BGPFieldIPv4.m2i` rebuild the address from `mask2iplen(mask)` bytes and hand it to
`inet_ntop()` / `inet_ntoa()`. If the prefix on the wire is shorter than the mask
claims, the buffer is under length and the call raises (`invalid length of packed IP
address string` for v6, `packed IP wrong length` for v4), so the dissector aborts.

Repro on master:

```python
from scapy.all import load_contrib
load_contrib("bgp")
from scapy.contrib.bgp import BGPNLRI_IPv6, BGPNLRI_IPv4
BGPNLRI_IPv6(b"\x80\x20\x01\x0d\xb8")   # mask 128 wants 16 bytes, 4 present
BGPNLRI_IPv4(b"\x20\x0a")               # mask 32 wants 4 bytes, 1 present
```

Fix: zero-fill the missing prefix bytes in place so the packed address is always full
length. Well-formed NLRIs are unchanged; added regression tests for both.

Same class as #5149 (inet_ntop on a short buffer).

AI-Assisted: yes (Claude Code)
