### PR TITLE
utils: fall back to the writer linktype for unbound layers

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -2211,9 +2211,12 @@ class GenericPcapWriter(object):
         ifname = getattr(packet, "sniffed_on", None)
         direction = getattr(packet, "direction", None)
         if not isinstance(packet, bytes):
-            linktype: int = conf.l2types.layer2num[
-                packet.__class__
-            ]
+            # The class may not be bound to any linktype (e.g. conf.raw_layer),
+            # in which case fall back to the one write_header() settled on.
+            linktype: int = conf.l2types.layer2num.get(
+                packet.__class__,
+                self.linktype,
+            )
         else:
             linktype = self.linktype
         if ifname is not None:

--- a/test/regression.uts
+++ b/test/regression.uts
@@ -2779,6 +2779,21 @@ with RawPcapWriter(fd) as w:
     w.write(b"test")
     assert w.linktype == 1
 
+= Check PcapWriter with a layer that is not bound to any linktype
+~ pcap
+
+from io import BytesIO
+
+f = BytesIO()
+w = PcapWriter(f, linktype=DLT_RAW, sync=True)
+w.write(Raw(b"test"))
+assert w.linktype == DLT_RAW
+
+f.seek(0) or None
+r = RawPcapReader(f)
+assert r.linktype == DLT_RAW
+assert [x for (x, y) in r] == [b"test"]
+
 = Check tcpdump()
 ~ tcpdump
 from io import BytesIO


### PR DESCRIPTION
<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->

Prevent KeyError exceptions on unbound packets such as RAW packets.