### PR TITLE
fwdmachine: build server TLS contexts with PROTOCOL_TLS_SERVER

### DIFF
--- a/scapy/fwdmachine.py
+++ b/scapy/fwdmachine.py
@@ -433,7 +433,7 @@ class ForwardMachine:
                     password = self.keyfilepwd
                     certfile = self.crtfile
                     keyfile = self.keyfile
-                sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+                sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
                 sslcontext.check_hostname = False
                 sslcontext.verify_mode = ssl.CERT_NONE  # note: server side
                 sslcontext.load_cert_chain(certfile, keyfile, password=password)
@@ -443,7 +443,7 @@ class ForwardMachine:
                 return None  # Continue
 
             # Server SSL context
-            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             sslcontext.sni_callback = cb_sni
             try:
                 sock = sslcontext.wrap_socket(sock, server_side=True)


### PR DESCRIPTION
`ForwardMachine` builds two server-side TLS contexts with `ssl.PROTOCOL_TLSv1_2`
(`scapy/fwdmachine.py:436` and `:446`). Python deprecated that constant in 3.10, and builds against
OpenSSL 4 no longer define it at all, so on those interpreters the attribute lookup raises before
any socket is touched:

```
AttributeError: module 'ssl' has no attribute 'PROTOCOL_TLSv1_2'.
Did you mean: 'PROTOCOL_TLS'?
```

@evverx hit this on Fedora Rawhide in #5141, where a test added by that PR is the first thing in the
suite to reach the code. The failure is not in the test — `ForwardMachine.handler()` cannot run at
all on such a build.

Both call sites make a context for the listening side: the one at `:436` loads the certificate chain
served to the intercepted client, and the one at `:446` wraps the accepted socket with
`server_side=True`. `ssl.PROTOCOL_TLS_SERVER` is the supported spelling for both, and it is the
constant CPython's own deprecation notice points at. The client-side context two functions up
already uses its counterpart, `ssl.PROTOCOL_TLS_CLIENT` (`scapy/fwdmachine.py:381`).

One behaviour change comes with it. `PROTOCOL_TLSv1_2` pinned the listener to exactly TLS 1.2;
`PROTOCOL_TLS_SERVER` negotiates the highest version both sides support, so a client that requires
TLS 1.3 can now complete a handshake with the forwarding machine instead of failing. The explicit
`check_hostname` and `verify_mode` assignments are left in place — they are already the defaults for
this protocol, and reading them at the call site is worth the two lines.

Relevant: python/cpython#152714.
