### PR TITLE
automotive: scope UDS_WDBIEnumerator writes to the state that read them

### DIFF
--- a/scapy/contrib/automotive/scanner/enumerator.py
+++ b/scapy/contrib/automotive/scanner/enumerator.py
@@ -262,7 +262,7 @@ class ServiceEnumerator(AutomotiveTestCase, metaclass=abc.ABCMeta):
         # type: (EcuState, Any) -> Iterable[Packet]
         if state not in self._request_iterators:
             self._request_iterators[state] = iter(
-                self._get_initial_requests(**kwargs))
+                self._get_initial_requests(state=state, **kwargs))
 
         return self._request_iterators[state]
 

--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -575,6 +575,7 @@ class UDS_WDBIEnumerator(UDS_Enumerator):
         # type: (Any) -> Iterable[Packet]
         scan_range = kwargs.pop("scan_range", range(0x10000))
         rdbi_enumerator = kwargs.pop("rdbi_enumerator", None)
+        state = kwargs.pop("state", None)
 
         if rdbi_enumerator is None:
             log_automotive.debug("Use entire scan range")
@@ -584,7 +585,8 @@ class UDS_WDBIEnumerator(UDS_Enumerator):
             return (UDS() / UDS_WDBI(dataIdentifier=t.resp.dataIdentifier) /
                     Raw(load=bytes(t.resp)[3:])
                     for t in rdbi_enumerator.results_with_positive_response
-                    if len(bytes(t.resp)) >= 3)
+                    if len(bytes(t.resp)) >= 3 and
+                    (state is None or t.state == state))
         else:
             raise Scapy_Exception("rdbi_enumerator has to be an instance "
                                   "of UDS_RDBIEnumerator")

--- a/test/contrib/automotive/scanner/uds_scanner.uts
+++ b/test/contrib/automotive/scanner/uds_scanner.uts
@@ -775,6 +775,37 @@ assert 2 in ids
 assert 3 in ids
 assert 0xff in ids
 
+= UDS_WDBIEnumerator keeps read data in its ECU state
+
+class StateWriteSocket:
+    def __init__(self):
+        self.writes = []
+    def sr1(self, request, **kwargs):
+        self.writes.append(bytes(request)[3:])
+        return UDS()/UDS_WDBIPR(dataIdentifier=request.dataIdentifier)
+
+reader = UDS_RDBIEnumerator()
+reader._store_result(
+    EcuState(session=1),
+    UDS()/UDS_RDBI(identifiers=[1]),
+    UDS()/UDS_RDBIPR(dataIdentifier=1)/Raw(b"session-one"),
+)
+reader._store_result(
+    EcuState(session=3),
+    UDS()/UDS_RDBI(identifiers=[1]),
+    UDS()/UDS_RDBIPR(dataIdentifier=1)/Raw(b"session-three"),
+)
+write_socket = StateWriteSocket()
+writer = UDS_WDBIEnumerator()
+writer.execute(
+    write_socket,
+    EcuState(session=3),
+    rdbi_enumerator=reader,
+    count=1,
+)
+
+assert write_socket.writes == [b"session-three"]
+
 
 = UDS_TPEnumerator
 


### PR DESCRIPTION
Opening this as a pull request at @polybassa's request, from a report on the security tab
(GHSA-6f3r-46w9-ch5q). He read it as a correctness bug rather than a vulnerability, and that is how
it is described here.

### What the code does

`UDS_WDBIEnumerator` scans an ECU for data identifiers it will accept a *write* to. Writing needs a
plausible value, so instead of inventing one it reuses what a previous read scan saw: pass it a
`UDS_RDBIEnumerator` and it replays each value that identifier returned
(`scapy/contrib/automotive/uds_scan.py:585`).

A UDS ECU answers differently depending on the diagnostic session it is in, so the scanner visits
each session in turn and both enumerators keep their results tagged with the state they were
collected in.

### The bug

The generator at `scapy/contrib/automotive/uds_scan.py:585` iterates
`rdbi_enumerator.results_with_positive_response` — every result the reader ever recorded, in every
state. The write scan for one session therefore writes back values that were read in a different
session.

Where an identifier reads back differently per session, the scanner writes the wrong session's
content into the ECU. The result it then records is a write that succeeded with data the ECU never
reported for the session under test.

The requests are also built once and cached per state at
`scapy/contrib/automotive/scanner/enumerator.py:265`, so whichever session is scanned first fixes
the list, and the cache hides the mismatch from anyone comparing two runs.

### The change

`_get_initial_request_iterator` already knows the state it is building requests for; it now passes
it to `_get_initial_requests`. `UDS_WDBIEnumerator` takes that state and skips read results that
came from another one. Enumerators that do not care about the state ignore the keyword, and passing
no state keeps the previous behaviour, so nothing else in the scanner changes.

The test drives a reader holding one identifier read in two sessions, runs the write enumerator
against the second, and asserts the value written is the one read in that session. It fails on
master.
