### PR TITLE
bluetooth: Normalize HCI connection_handle field names to be accordin…

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -297,9 +297,10 @@ class HCI_Hdr(Packet):
 
 class HCI_ACL_Hdr(Packet):
     name = "HCI ACL header"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [BitField("BC", 0, 2, tot_size=-2),
                    BitField("PB", 0, 2),
-                   BitField("handle", 0, 12, end_tot_size=-2),
+                   BitField("connection_handle", 0, 12, end_tot_size=-2),
                    LEShortField("len", None), ]
 
     def post_build(self, p, pay):
@@ -1804,7 +1805,8 @@ class HCI_Cmd_Disconnect(Packet):
     7.1.6 Disconnect command
     """
     name = "HCI_Disconnect"
-    fields_desc = [XLEShortField("handle", 0),
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [XLEShortField("connection_handle", 0),
                    ByteField("reason", 0x13), ]
 
 
@@ -1883,7 +1885,8 @@ class HCI_Cmd_Authentication_Requested(Packet):
     7.1.15 Authentication Requested command
     """
     name = "HCI_Authentication_Requested"
-    fields_desc = [LEShortField("handle", 0)]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0)]
 
 
 class HCI_Cmd_Set_Connection_Encryption(Packet):
@@ -1891,7 +1894,9 @@ class HCI_Cmd_Set_Connection_Encryption(Packet):
     7.1.16 Set Connection Encryption command
     """
     name = "HCI_Set_Connection_Encryption"
-    fields_desc = [LEShortField("handle", 0), ByteField("encryption_enable", 0)]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0),
+                   ByteField("encryption_enable", 0)]
 
 
 class HCI_Cmd_Change_Connection_Link_Key(Packet):
@@ -1899,7 +1904,8 @@ class HCI_Cmd_Change_Connection_Link_Key(Packet):
     7.1.17 Change Connection Link Key command
     """
     name = "HCI_Change_Connection_Link_Key"
-    fields_desc = [LEShortField("handle", 0), ]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0), ]
 
 
 class HCI_Cmd_Link_Key_Selection(Packet):
@@ -2119,12 +2125,14 @@ class HCI_Cmd_Read_BD_Addr(Packet):
 
 class HCI_Cmd_Read_Link_Quality(Packet):
     name = "HCI_Read_Link_Quality"
-    fields_desc = [LEShortField("handle", 0)]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0)]
 
 
 class HCI_Cmd_Read_RSSI(Packet):
     name = "HCI_Read_RSSI"
-    fields_desc = [LEShortField("handle", 0)]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0)]
 
 
 # 7.6 TESTING COMMANDS, the OGF is defined as 0x06
@@ -2463,7 +2471,8 @@ class HCI_Cmd_LE_Remove_Device_From_Filter_Accept_List(HCI_Cmd_LE_Add_Device_To_
 
 class HCI_Cmd_LE_Connection_Update(Packet):
     name = "HCI_LE_Connection_Update"
-    fields_desc = [XLEShortField("handle", 0),
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [XLEShortField("connection_handle", 0),
                    XLEShortField("min_interval", 0),
                    XLEShortField("max_interval", 0),
                    XLEShortField("latency", 0),
@@ -2474,12 +2483,14 @@ class HCI_Cmd_LE_Connection_Update(Packet):
 
 class HCI_Cmd_LE_Read_Remote_Features(Packet):
     name = "HCI_LE_Read_Remote_Features"
-    fields_desc = [LEShortField("handle", 64)]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 64)]
 
 
 class HCI_Cmd_LE_Enable_Encryption(Packet):
     name = "HCI_LE_Enable_Encryption"
-    fields_desc = [LEShortField("handle", 0),
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0),
                    StrFixedLenField("rand", None, 8),
                    XLEShortField("ediv", 0),
                    StrFixedLenField("ltk", b'\x00' * 16, 16), ]
@@ -2487,13 +2498,15 @@ class HCI_Cmd_LE_Enable_Encryption(Packet):
 
 class HCI_Cmd_LE_Long_Term_Key_Request_Reply(Packet):
     name = "HCI_LE_Long_Term_Key_Request_Reply"
-    fields_desc = [LEShortField("handle", 0),
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0),
                    StrFixedLenField("ltk", b'\x00' * 16, 16), ]
 
 
 class HCI_Cmd_LE_Long_Term_Key_Request_Negative_Reply(Packet):
     name = "HCI_LE_Long_Term_Key_Request _Negative_Reply"
-    fields_desc = [LEShortField("handle", 0), ]
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0), ]
 
 
 class HCI_Event_Hdr(Packet):
@@ -2545,8 +2558,9 @@ class HCI_Event_Connection_Complete(Packet):
     7.7.3 Connection Complete event
     """
     name = "HCI_Connection_Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField('status', 0, _bluetooth_error_codes),
-                   LEShortField("handle", 0x0100),
+                   LEShortField("connection_handle", 0x0100),
                    LEMACField("bd_addr", None),
                    ByteEnumField("link_type", 0, {0: "SCO connection",
                                                   1: "ACL connection", }),
@@ -2572,8 +2586,9 @@ class HCI_Event_Disconnection_Complete(Packet):
     7.7.5 Disconnection Complete event
     """
     name = "HCI_Disconnection_Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField("status", 0, _bluetooth_error_codes),
-                   LEShortField("handle", 0),
+                   LEShortField("connection_handle", 0),
                    XByteField("reason", 0), ]
 
 
@@ -2592,8 +2607,9 @@ class HCI_Event_Encryption_Change(Packet):
     7.7.8 Encryption Change event
     """
     name = "HCI_Encryption_Change"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField("status", 0, {0: "change has occurred"}),
-                   LEShortField("handle", 0),
+                   LEShortField("connection_handle", 0),
                    ByteEnumField("enabled", 0, {0: "OFF", 1: "ON (LE)", 2: "ON (BR/EDR)"}), ]  # noqa: E501
 
 
@@ -2602,9 +2618,10 @@ class HCI_Event_Read_Remote_Supported_Features_Complete(Packet):
     7.7.11 Read Remote Supported Features Complete event
     """
     name = "HCI_Read_Remote_Supported_Features_Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [
         ByteEnumField('status', 0, _bluetooth_error_codes),
-        LEShortField('handle', 0),
+        LEShortField('connection_handle', 0),
         FlagsField('lmp_features', 0, -64, _bluetooth_features)
     ]
 
@@ -2625,9 +2642,10 @@ class HCI_Event_Read_Remote_Version_Information_Complete(Packet):
     7.7.12 Read Remote Version Information Complete event
     """
     name = "HCI_Read_Remote_Version_Information"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [
         ByteEnumField('status', 0, _bluetooth_error_codes),
-        LEShortField('handle', 0),
+        LEShortField('connection_handle', 0),
         ByteField('version', 0x00),
         LEShortField('manufacturer_name', 0x0000),
         LEShortField('subversion', 0x0000)
@@ -2717,9 +2735,10 @@ class HCI_Event_Read_Remote_Extended_Features_Complete(Packet):
     7.7.34 Read Remote Extended Features Complete event
     """
     name = "HCI_Read_Remote_Extended_Features_Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [
         ByteEnumField('status', 0, _bluetooth_error_codes),
-        LEShortField('handle', 0),
+        LEShortField('connection_handle', 0),
         ByteField('page', 0x00),
         ByteField('max_page', 0x00),
         XLELongField('extended_features', 0)
@@ -2918,7 +2937,7 @@ class HCI_Cmd_Complete_LE_Read_White_List_Size(Packet):
 class HCI_LE_Meta_Connection_Complete(Packet):
     name = "Connection Complete"
     fields_desc = [ByteEnumField("status", 0, {0: "success"}),
-                   LEShortField("handle", 0),
+                   LEShortField("connection_handle", 0),
                    ByteEnumField("role", 0, {0: "master"}),
                    ByteEnumField("peer_addr_type", 0, {0: "public", 1: "random"}),
                    LEMACField("peer_addr", None),
@@ -2927,6 +2946,7 @@ class HCI_LE_Meta_Connection_Complete(Packet):
                    LEShortField("supervision", 42),
                    XByteField("master_clock_accuracy", 5)]
     deprecated_fields = {
+        "handle": ("connection_handle", "2.8.0"),
         "patype": ("peer_addr_type", "2.7.0"),
         "paddr": ("peer_addr", "2.7.0"),
         "clock_latency": ("master_clock_accuracy", "2.7.0"),
@@ -2946,8 +2966,9 @@ class HCI_LE_Meta_Connection_Complete(Packet):
 
 class HCI_LE_Meta_Enhanced_Connection_Complete(Packet):
     name = 'LE Enhanced Connection Complete'
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField('status', 0, {0: 'success'}),
-                   LEShortField('handle', 0),
+                   LEShortField('connection_handle', 0),
                    ByteEnumField('role', 0, {0: 'master', 1: 'slave'}),
                    ByteEnumField('peer_addr_type', 0, {
                        0: 'public',
@@ -2975,8 +2996,9 @@ class HCI_LE_Meta_Enhanced_Connection_Complete(Packet):
 
 class HCI_LE_Meta_Connection_Update_Complete(Packet):
     name = "Connection Update Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField("status", 0, {0: "success"}),
-                   LEShortField("handle", 0),
+                   LEShortField("connection_handle", 0),
                    LEShortField("interval", 54),
                    LEShortField("latency", 0),
                    LEShortField("timeout", 42), ]
@@ -2984,8 +3006,9 @@ class HCI_LE_Meta_Connection_Update_Complete(Packet):
 
 class HCI_LE_Meta_LE_Read_Remote_Features_Complete(Packet):
     name = "LE Read Remote Features Complete"
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
     fields_desc = [ByteEnumField("status", 0, _bluetooth_error_codes),
-                   LEShortField("handle", 0),
+                   LEShortField("connection_handle", 0),
                    XLELongField("le_features", 0)]
 
 
@@ -3014,7 +3037,8 @@ class HCI_LE_Meta_Advertising_Reports(Packet):
 
 class HCI_LE_Meta_Long_Term_Key_Request(Packet):
     name = "Long Term Key Request"
-    fields_desc = [LEShortField("handle", 0),
+    deprecated_fields = {"handle": ("connection_handle", "2.8.0")}
+    fields_desc = [LEShortField("connection_handle", 0),
                    StrFixedLenField("rand", None, 8),
                    XLEShortField("ediv", 0), ]
 

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -178,7 +178,7 @@ assert cmd[HCI_Cmd_Create_Connection].allow_role_switch == 1
 
 cmd = HCI_Hdr(hex_bytes("011104020001"))
 assert HCI_Cmd_Authentication_Requested in cmd
-assert cmd[HCI_Cmd_Authentication_Requested].handle == 256
+assert cmd[HCI_Cmd_Authentication_Requested].connection_handle == 256
 
 = Link Key Request Reply
 
@@ -191,7 +191,7 @@ assert cmd[HCI_Cmd_Link_Key_Request_Reply].link_key == 0x6c9016a48a009180086a392
 
 cmd = HCI_Hdr(hex_bytes("01130403000101"))
 assert HCI_Cmd_Set_Connection_Encryption in cmd
-assert cmd[HCI_Cmd_Set_Connection_Encryption].handle == 256
+assert cmd[HCI_Cmd_Set_Connection_Encryption].connection_handle == 256
 assert cmd[HCI_Cmd_Set_Connection_Encryption].encryption_enable == 1
 
 = Remote Name Request
@@ -335,16 +335,35 @@ for p in (
 
 = Disconnect
 expected_cmd_raw_data = hex_bytes("01060403341213")
-cmd_raw_data = raw(HCI_Hdr() / HCI_Command_Hdr() / HCI_Cmd_Disconnect(handle=0x1234))
+cmd_raw_data = raw(HCI_Hdr() / HCI_Command_Hdr() / HCI_Cmd_Disconnect(connection_handle=0x1234))
 assert expected_cmd_raw_data == cmd_raw_data
 
 = LE Connection Update Command
 expected_cmd_raw_data = hex_bytes("0113200e47000a00140001003c000100ffff")
 cmd_raw_data = raw(
     HCI_Hdr() / HCI_Command_Hdr() / HCI_Cmd_LE_Connection_Update(
-        handle=0x47, min_interval=10, max_interval=20, latency=1, timeout=60,
+        connection_handle=0x47, min_interval=10, max_interval=20, latency=1, timeout=60,
         min_ce=1, max_ce=0xffff))
 assert expected_cmd_raw_data == cmd_raw_data
+
+= Deprecated 'handle' alias still resolves to connection_handle (backward compat)
+# The Connection_Handle field was renamed handle -> connection_handle; the old
+# name stays usable via deprecated_fields (construct kwarg + attribute read),
+# emitting a DeprecationWarning.
+try:
+    import warnings
+    ref = raw(HCI_Command_Hdr() / HCI_Cmd_Disconnect(connection_handle=0x1234))
+    evt = HCI_Event_Disconnection_Complete(connection_handle=0x0040)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cmd = HCI_Cmd_Disconnect(handle=0x1234)
+        assert cmd.connection_handle == 0x1234
+        assert raw(HCI_Command_Hdr() / cmd) == ref
+        assert evt.handle == 0x0040
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+except DeprecationWarning:
+    # -Werror is used
+    pass
 
 
 + HCI Events
@@ -370,7 +389,7 @@ evt_raw_data = hex_bytes("04030b000b00093491e5b7540100")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Connection_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Connection_Complete].status == 0
-assert evt_pkt[HCI_Event_Connection_Complete].handle == 0x000b
+assert evt_pkt[HCI_Event_Connection_Complete].connection_handle == 0x000b
 assert evt_pkt[HCI_Event_Connection_Complete].bd_addr == "54:b7:e5:91:34:09"
 assert evt_pkt[HCI_Event_Connection_Complete].link_type == 1
 assert evt_pkt[HCI_Event_Connection_Complete].encryption_enabled == 0
@@ -403,7 +422,7 @@ evt_raw_data = hex_bytes("04050400400016")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Disconnection_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Disconnection_Complete].status == 0
-assert evt_pkt[HCI_Event_Disconnection_Complete].handle == 0x0040
+assert evt_pkt[HCI_Event_Disconnection_Complete].connection_handle == 0x0040
 assert evt_pkt[HCI_Event_Disconnection_Complete].reason == 0x16
 
 = Remote Name Request Complete
@@ -419,7 +438,7 @@ evt_raw_data = hex_bytes("040804000b0001")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Encryption_Change in evt_pkt
 assert evt_pkt[HCI_Event_Encryption_Change].status == 0
-assert evt_pkt[HCI_Event_Encryption_Change].handle == 0x000b
+assert evt_pkt[HCI_Event_Encryption_Change].connection_handle == 0x000b
 assert evt_pkt[HCI_Event_Encryption_Change].enabled == 1
 
 = Read Remote Supported Features Complete
@@ -427,7 +446,7 @@ evt_raw_data = hex_bytes("040b0b000b00fffe8ffedbff5b87")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Read_Remote_Supported_Features_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Read_Remote_Supported_Features_Complete].status == 0
-assert evt_pkt[HCI_Event_Read_Remote_Supported_Features_Complete].handle == 0x000b
+assert evt_pkt[HCI_Event_Read_Remote_Supported_Features_Complete].connection_handle == 0x000b
 assert evt_pkt[HCI_Event_Read_Remote_Supported_Features_Complete].lmp_features == 0x875bffdbfe8ffeff
 
 = Remote Host Supported Features Notification
@@ -447,7 +466,7 @@ evt_raw_data = hex_bytes("040c080002000bb0022c04")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Read_Remote_Version_Information_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].status == 0
-assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].handle == 0x0002
+assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].connection_handle == 0x0002
 assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].version == 0x0b
 assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].manufacturer_name == 0x02b0
 assert evt_pkt[HCI_Event_Read_Remote_Version_Information_Complete].subversion == 1068
@@ -502,7 +521,7 @@ evt_raw_data = hex_bytes("04230d000b0001020300000000000000")
 evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_Event_Read_Remote_Extended_Features_Complete in evt_pkt
 assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].status == 0
-assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].handle == 0x000b
+assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].connection_handle == 0x000b
 assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].page == 1
 assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].max_page == 2
 assert evt_pkt[HCI_Event_Read_Remote_Extended_Features_Complete].extended_features == 0x0000000000000003
@@ -574,7 +593,7 @@ assert evt_pkt[HCI_Event_Hdr].len == 31
 assert HCI_LE_Meta_Enhanced_Connection_Complete in evt_pkt
 evt = evt_pkt[HCI_LE_Meta_Enhanced_Connection_Complete]
 assert evt.status == 0
-assert evt.handle == 16
+assert evt.connection_handle == 16
 assert evt.role == 0
 assert evt.peer_addr_type == 1
 assert evt.peer_addr == "ff:ee:dd:cc:bb:aa"
@@ -588,7 +607,7 @@ assert evt.master_clock_accuracy == 0x0
 = LE Connection Update Event
 evt_raw_data = hex_bytes("043e0a03004800140001003c00")
 evt_pkt =  HCI_Hdr(evt_raw_data)
-assert evt_pkt[HCI_LE_Meta_Connection_Update_Complete].handle == 0x48
+assert evt_pkt[HCI_LE_Meta_Connection_Update_Complete].connection_handle == 0x48
 assert evt_pkt[HCI_LE_Meta_Connection_Update_Complete].interval == 20
 assert evt_pkt[HCI_LE_Meta_Connection_Update_Complete].latency == 1
 assert evt_pkt[HCI_LE_Meta_Connection_Update_Complete].timeout == 60
@@ -601,7 +620,7 @@ evt_pkt = HCI_Hdr(evt_raw_data)
 assert HCI_LE_Meta_LE_Read_Remote_Features_Complete in evt_pkt
 evt = evt_pkt[HCI_LE_Meta_LE_Read_Remote_Features_Complete]
 assert evt.status == 0
-assert evt.handle == 0x0040
+assert evt.connection_handle == 0x0040
 assert evt.le_features == 0x000000000000001f
 assert raw(evt_pkt) == evt_raw_data
 
@@ -924,7 +943,7 @@ assert a[SM_Identity_Address_Information].addr_type == 0
 a.show()
 
 = Basic HCI_ACL_Hdr build & dissect
-a = HCI_Hdr()/HCI_ACL_Hdr(handle=0xf4c, PB=2, BC=2, len=20)/L2CAP_Hdr(len=16)/L2CAP_CmdHdr(code=8, len=12)/L2CAP_EchoReq(data="AAAAAAAAAAAA")
+a = HCI_Hdr()/HCI_ACL_Hdr(connection_handle=0xf4c, PB=2, BC=2, len=20)/L2CAP_Hdr(len=16)/L2CAP_CmdHdr(code=8, len=12)/L2CAP_EchoReq(data="AAAAAAAAAAAA")
 assert raw(a) == b'\x02L\xaf\x14\x00\x10\x00\x05\x00\x08\x01\x0c\x00AAAAAAAAAAAA'
 b = HCI_Hdr(raw(a))
 assert a == b


### PR DESCRIPTION
…g spec.

Add deprecation warnings for backwards compat.

AI-Assisted: yes (Claude Opus 5)

<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
