### PR TITLE
bluetooth: Normalize bd_addr fields to Core spec

### DIFF
--- a/scapy/layers/bluetooth.py
+++ b/scapy/layers/bluetooth.py
@@ -970,10 +970,11 @@ class SM_Identity_Information(Packet):
 class SM_Identity_Address_Information(Packet):
     name = "Identity Address Information"
     fields_desc = [ByteEnumField("addr_type", 0, {0: "public"}),
-                   LEMACField("addr", None), ]
+                   LEMACField("bd_addr", None), ]
     deprecated_fields = {
         "atype": ("addr_type", "2.7.0"),
-        "address": ("addr", "2.7.0"),
+        "address": ("bd_addr", "2.7.0"),
+        "addr": ("bd_addr", "2.8.0"),
     }
 
 
@@ -2526,7 +2527,7 @@ class HCI_Event_Inquiry_Result(Packet):
     name = "HCI_Inquiry_Result"
     fields_desc = [
         ByteField("num_response", 0x00),
-        FieldListField("addr", None, LEMACField("addr", None),
+        FieldListField("bd_addr", None, LEMACField("", None),
                        count_from=lambda p: p.num_response),
         FieldListField("page_scan_repetition_mode", None,
                        ByteField("page_scan_repetition_mode", 0),
@@ -2538,6 +2539,7 @@ class HCI_Event_Inquiry_Result(Packet):
         FieldListField("clock_offset", None, LEShortField("clock_offset", 0),
                        count_from=lambda p: p.num_response)
     ]
+    deprecated_fields = {"addr": ("bd_addr", "2.8.0")}
 
 
 class HCI_Event_Connection_Complete(Packet):
@@ -2906,7 +2908,8 @@ class HCI_Cmd_Complete_Read_BD_Addr(Packet):
     7.4.6 Read BD_ADDR command complete
     """
     name = "Read BD Addr"
-    fields_desc = [LEMACField("addr", None), ]
+    fields_desc = [LEMACField("bd_addr", None), ]
+    deprecated_fields = {"addr": ("bd_addr", "2.8.0")}
 
 
 class HCI_Cmd_Complete_LE_Read_White_List_Size(Packet):

--- a/test/scapy/layers/bluetooth.uts
+++ b/test/scapy/layers/bluetooth.uts
@@ -359,10 +359,30 @@ assert evt_pkt[HCI_Event_Inquiry_Complete].status == 0
 evt_pkt = HCI_Event_Inquiry_Result(b'\x01\xcb\x7f\xdbn\x8c\x9c\x01\x00\x00<\x04\x08\x8di')
 assert HCI_Event_Inquiry_Result in evt_pkt
 assert evt_pkt[HCI_Event_Inquiry_Result].num_response == 1
-assert evt_pkt[HCI_Event_Inquiry_Result].addr[0] == '9c:8c:6e:db:7f:cb'
+assert evt_pkt[HCI_Event_Inquiry_Result].bd_addr[0] == '9c:8c:6e:db:7f:cb'
 assert evt_pkt[HCI_Event_Inquiry_Result].page_scan_repetition_mode[0] == 1
 assert evt_pkt[HCI_Event_Inquiry_Result].device_class[0] == 0x8043c
 assert evt_pkt[HCI_Event_Inquiry_Result].clock_offset[0] == 27021
+
+
+= Deprecated 'addr' alias still resolves to bd_addr (backward compat)
+try:
+    import warnings
+    inq = HCI_Event_Inquiry_Result(b'\x01\xcb\x7f\xdbn\x8c\x9c\x01\x00\x00<\x04\x08\x8di')
+    ref = raw(HCI_Cmd_Complete_Read_BD_Addr(bd_addr="11:22:33:44:55:66"))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rd = HCI_Cmd_Complete_Read_BD_Addr(addr="11:22:33:44:55:66")
+        assert rd.bd_addr == "11:22:33:44:55:66"
+        assert raw(rd) == ref
+        sm = SM_Identity_Address_Information(addr="a1:b2:c3:d4:e5:f6")
+        assert sm.bd_addr == "a1:b2:c3:d4:e5:f6"
+        assert SM_Identity_Address_Information(address="a1:b2:c3:d4:e5:f6").bd_addr == "a1:b2:c3:d4:e5:f6"
+        assert inq.addr[0] == '9c:8c:6e:db:7f:cb'
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+except DeprecationWarning:
+    # -Werror is used
+    pass
 
 
 = Connection Complete
@@ -919,7 +939,7 @@ assert raw(p[EIR_ServiceData16BitUUID].payload) == hex_bytes("e6c2")
 
 = Basic L2CAP dissect
 a = L2CAP_Hdr(b'\x08\x00\x06\x00\t\x00\xf6\xe5\xd4\xc3\xb2\xa1')
-assert a[SM_Identity_Address_Information].addr == 'a1:b2:c3:d4:e5:f6'
+assert a[SM_Identity_Address_Information].bd_addr == 'a1:b2:c3:d4:e5:f6'
 assert a[SM_Identity_Address_Information].addr_type == 0
 a.show()
 


### PR DESCRIPTION
AI-Assisted: yes (Claude Opus 5)

<!-- Hi there ! First of all thanks a lot for contributing to Scapy ! We're really grateful for contributions and for the time people spend contributing back. Please note that due to the amount of contributions, we have to impose quality standards for PRs.

Here is a small checklist of actions to get you started with this PR. You may remove this entire section once you're done. Please note that if you don't follow the guidelines detailed here, we might end up closing the PR :( When in doubt, ask !

Checklist :

- Check the contribution guide at https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md (esp. section submitting-pull-requests)
- Have good commit hygiene. They must have the `AI-Assisted` tag as explained in the contributing guide. Please squash commits that belong together, and split commits that contain multiple features.
- AI: You must make sure that you understood the internal concepts of Scapy and have good test coverage (like >90%). Please review ALL the code you generated.
- Add unit tests or explain why they are not relevant.
- If the PR is still not finished, please create a **Draft Pull Request**
- If this PR contains more than 500 lines of code (excluding unit tests), consider splitting it.
- New protocols: I considered interoperability tests with existing packages or utilities to ensure conformity of a newly generated protocol

Please read the output of the tests if they fail ! In rare cases, some tests might fail for reasons unrelated to your PR, sorry about that ! Just explain it and we'll relaunch them.
-->

### Description

<!-- brief description what this PR will do, e.g. fixes broken dissection of XXX -->

<!-- if required - short explanation why you fixed something in a way that may look more complicated as it actually is -->

<!-- if required - outline impacts on other parts of the library -->

<!-- (add issue number here if appropriate, else remove this line) -->
